### PR TITLE
Code improvements in System.Linq.Queryable

### DIFF
--- a/src/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
@@ -15,42 +15,42 @@ namespace System.Linq
 
         public static MethodInfo Aggregate_TSource_2(Type TSource) =>
              (s_Aggregate_TSource_2 ??
-             (s_Aggregate_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, object, object>>, object>(Queryable.Aggregate<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Aggregate_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, object, object>>, object>(Queryable.Aggregate).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Aggregate_TSource_TAccumulate_3;
 
         public static MethodInfo Aggregate_TSource_TAccumulate_3(Type TSource, Type TAccumulate) =>
              (s_Aggregate_TSource_TAccumulate_3 ??
-             (s_Aggregate_TSource_TAccumulate_3 = new Func<IQueryable<object>, object, Expression<Func<object, object, object>>, object>(Queryable.Aggregate<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Aggregate_TSource_TAccumulate_3 = new Func<IQueryable<object>, object, Expression<Func<object, object, object>>, object>(Queryable.Aggregate).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TAccumulate);
 
         private static MethodInfo s_Aggregate_TSource_TAccumulate_TResult_4;
 
         public static MethodInfo Aggregate_TSource_TAccumulate_TResult_4(Type TSource, Type TAccumulate, Type TResult) =>
              (s_Aggregate_TSource_TAccumulate_TResult_4 ??
-             (s_Aggregate_TSource_TAccumulate_TResult_4 = new Func<IQueryable<object>, object, Expression<Func<object, object, object>>, Expression<Func<object, object>>, object>(Queryable.Aggregate<object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Aggregate_TSource_TAccumulate_TResult_4 = new Func<IQueryable<object>, object, Expression<Func<object, object, object>>, Expression<Func<object, object>>, object>(Queryable.Aggregate).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TAccumulate, TResult);
 
         private static MethodInfo s_All_TSource_2;
 
         public static MethodInfo All_TSource_2(Type TSource) =>
              (s_All_TSource_2 ??
-             (s_All_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, bool>(Queryable.All<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_All_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, bool>(Queryable.All).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Any_TSource_1;
 
         public static MethodInfo Any_TSource_1(Type TSource) =>
              (s_Any_TSource_1 ??
-             (s_Any_TSource_1 = new Func<IQueryable<object>, bool>(Queryable.Any<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Any_TSource_1 = new Func<IQueryable<object>, bool>(Queryable.Any).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Any_TSource_2;
 
         public static MethodInfo Any_TSource_2(Type TSource) =>
              (s_Any_TSource_2 ??
-             (s_Any_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, bool>(Queryable.Any<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Any_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, bool>(Queryable.Any).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_AsQueryable_1;
@@ -63,7 +63,7 @@ namespace System.Linq
 
         public static MethodInfo AsQueryable_TElement_1(Type TElement) =>
              (s_AsQueryable_TElement_1 ??
-             (s_AsQueryable_TElement_1 = new Func<IEnumerable<object>, IQueryable<object>>(Queryable.AsQueryable<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_AsQueryable_TElement_1 = new Func<IEnumerable<object>, IQueryable<object>>(Queryable.AsQueryable).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TElement);
 
         private static MethodInfo s_Average_Int32_1;
@@ -130,70 +130,70 @@ namespace System.Linq
 
         public static MethodInfo Average_Int32_TSource_2(Type TSource) =>
              (s_Average_Int32_TSource_2 ??
-             (s_Average_Int32_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int>>, double>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Average_Int32_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int>>, double>(Queryable.Average).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_NullableInt32_TSource_2;
 
         public static MethodInfo Average_NullableInt32_TSource_2(Type TSource) =>
              (s_Average_NullableInt32_TSource_2 ??
-             (s_Average_NullableInt32_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int?>>, double?>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Average_NullableInt32_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int?>>, double?>(Queryable.Average).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_Single_TSource_2;
 
         public static MethodInfo Average_Single_TSource_2(Type TSource) =>
              (s_Average_Single_TSource_2 ??
-             (s_Average_Single_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, float>>, float>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Average_Single_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, float>>, float>(Queryable.Average).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_NullableSingle_TSource_2;
 
         public static MethodInfo Average_NullableSingle_TSource_2(Type TSource) =>
              (s_Average_NullableSingle_TSource_2 ??
-             (s_Average_NullableSingle_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, float?>>, float?>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Average_NullableSingle_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, float?>>, float?>(Queryable.Average).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_Int64_TSource_2;
 
         public static MethodInfo Average_Int64_TSource_2(Type TSource) =>
              (s_Average_Int64_TSource_2 ??
-             (s_Average_Int64_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, long>>, double>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Average_Int64_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, long>>, double>(Queryable.Average).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_NullableInt64_TSource_2;
 
         public static MethodInfo Average_NullableInt64_TSource_2(Type TSource) =>
              (s_Average_NullableInt64_TSource_2 ??
-             (s_Average_NullableInt64_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, long?>>, double?>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Average_NullableInt64_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, long?>>, double?>(Queryable.Average).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_Double_TSource_2;
 
         public static MethodInfo Average_Double_TSource_2(Type TSource) =>
              (s_Average_Double_TSource_2 ??
-             (s_Average_Double_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, double>>, double>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Average_Double_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, double>>, double>(Queryable.Average).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_NullableDouble_TSource_2;
 
         public static MethodInfo Average_NullableDouble_TSource_2(Type TSource) =>
              (s_Average_NullableDouble_TSource_2 ??
-             (s_Average_NullableDouble_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, double?>>, double?>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Average_NullableDouble_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, double?>>, double?>(Queryable.Average).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_Decimal_TSource_2;
 
         public static MethodInfo Average_Decimal_TSource_2(Type TSource) =>
              (s_Average_Decimal_TSource_2 ??
-             (s_Average_Decimal_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, decimal>>, decimal>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Average_Decimal_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, decimal>>, decimal>(Queryable.Average).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_NullableDecimal_TSource_2;
 
         public static MethodInfo Average_NullableDecimal_TSource_2(Type TSource) =>
              (s_Average_NullableDecimal_TSource_2 ??
-             (s_Average_NullableDecimal_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, decimal?>>, decimal?>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Average_NullableDecimal_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, decimal?>>, decimal?>(Queryable.Average).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Cast_TResult_1;
@@ -207,287 +207,287 @@ namespace System.Linq
 
         public static MethodInfo Concat_TSource_2(Type TSource) =>
              (s_Concat_TSource_2 ??
-             (s_Concat_TSource_2 = new Func<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Concat<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Concat_TSource_2 = new Func<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Concat).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Contains_TSource_2;
 
         public static MethodInfo Contains_TSource_2(Type TSource) =>
              (s_Contains_TSource_2 ??
-             (s_Contains_TSource_2 = new Func<IQueryable<object>, object, bool>(Queryable.Contains<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Contains_TSource_2 = new Func<IQueryable<object>, object, bool>(Queryable.Contains).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Contains_TSource_3;
 
         public static MethodInfo Contains_TSource_3(Type TSource) =>
              (s_Contains_TSource_3 ??
-             (s_Contains_TSource_3 = new Func<IQueryable<object>, object, IEqualityComparer<object>, bool>(Queryable.Contains<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Contains_TSource_3 = new Func<IQueryable<object>, object, IEqualityComparer<object>, bool>(Queryable.Contains).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Count_TSource_1;
 
         public static MethodInfo Count_TSource_1(Type TSource) =>
              (s_Count_TSource_1 ??
-             (s_Count_TSource_1 = new Func<IQueryable<object>, int>(Queryable.Count<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Count_TSource_1 = new Func<IQueryable<object>, int>(Queryable.Count).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Count_TSource_2;
 
         public static MethodInfo Count_TSource_2(Type TSource) =>
              (s_Count_TSource_2 ??
-             (s_Count_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, int>(Queryable.Count<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Count_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, int>(Queryable.Count).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_DefaultIfEmpty_TSource_1;
 
         public static MethodInfo DefaultIfEmpty_TSource_1(Type TSource) =>
              (s_DefaultIfEmpty_TSource_1 ??
-             (s_DefaultIfEmpty_TSource_1 = new Func<IQueryable<object>, IQueryable<object>>(Queryable.DefaultIfEmpty<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_DefaultIfEmpty_TSource_1 = new Func<IQueryable<object>, IQueryable<object>>(Queryable.DefaultIfEmpty).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_DefaultIfEmpty_TSource_2;
 
         public static MethodInfo DefaultIfEmpty_TSource_2(Type TSource) =>
              (s_DefaultIfEmpty_TSource_2 ??
-             (s_DefaultIfEmpty_TSource_2 = new Func<IQueryable<object>, object, IQueryable<object>>(Queryable.DefaultIfEmpty<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_DefaultIfEmpty_TSource_2 = new Func<IQueryable<object>, object, IQueryable<object>>(Queryable.DefaultIfEmpty).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Distinct_TSource_1;
 
         public static MethodInfo Distinct_TSource_1(Type TSource) =>
              (s_Distinct_TSource_1 ??
-             (s_Distinct_TSource_1 = new Func<IQueryable<object>, IQueryable<object>>(Queryable.Distinct<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Distinct_TSource_1 = new Func<IQueryable<object>, IQueryable<object>>(Queryable.Distinct).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Distinct_TSource_2;
 
         public static MethodInfo Distinct_TSource_2(Type TSource) =>
              (s_Distinct_TSource_2 ??
-             (s_Distinct_TSource_2 = new Func<IQueryable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Distinct<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Distinct_TSource_2 = new Func<IQueryable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Distinct).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_ElementAt_TSource_2;
 
         public static MethodInfo ElementAt_TSource_2(Type TSource) =>
              (s_ElementAt_TSource_2 ??
-             (s_ElementAt_TSource_2 = new Func<IQueryable<object>, int, object>(Queryable.ElementAt<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_ElementAt_TSource_2 = new Func<IQueryable<object>, int, object>(Queryable.ElementAt).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_ElementAtOrDefault_TSource_2;
 
         public static MethodInfo ElementAtOrDefault_TSource_2(Type TSource) =>
              (s_ElementAtOrDefault_TSource_2 ??
-             (s_ElementAtOrDefault_TSource_2 = new Func<IQueryable<object>, int, object>(Queryable.ElementAtOrDefault<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_ElementAtOrDefault_TSource_2 = new Func<IQueryable<object>, int, object>(Queryable.ElementAtOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Except_TSource_2;
 
         public static MethodInfo Except_TSource_2(Type TSource) =>
              (s_Except_TSource_2 ??
-             (s_Except_TSource_2 = new Func<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Except<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Except_TSource_2 = new Func<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Except).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Except_TSource_3;
 
         public static MethodInfo Except_TSource_3(Type TSource) =>
              (s_Except_TSource_3 ??
-             (s_Except_TSource_3 = new Func<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Except<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Except_TSource_3 = new Func<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Except).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_First_TSource_1;
 
         public static MethodInfo First_TSource_1(Type TSource) =>
              (s_First_TSource_1 ??
-             (s_First_TSource_1 = new Func<IQueryable<object>, object>(Queryable.First<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_First_TSource_1 = new Func<IQueryable<object>, object>(Queryable.First).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_First_TSource_2;
 
         public static MethodInfo First_TSource_2(Type TSource) =>
              (s_First_TSource_2 ??
-             (s_First_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.First<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_First_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.First).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_FirstOrDefault_TSource_1;
 
         public static MethodInfo FirstOrDefault_TSource_1(Type TSource) =>
              (s_FirstOrDefault_TSource_1 ??
-             (s_FirstOrDefault_TSource_1 = new Func<IQueryable<object>, object>(Queryable.FirstOrDefault<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_FirstOrDefault_TSource_1 = new Func<IQueryable<object>, object>(Queryable.FirstOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_FirstOrDefault_TSource_2;
 
         public static MethodInfo FirstOrDefault_TSource_2(Type TSource) =>
              (s_FirstOrDefault_TSource_2 ??
-             (s_FirstOrDefault_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.FirstOrDefault<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_FirstOrDefault_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.FirstOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_GroupBy_TSource_TKey_2;
 
         public static MethodInfo GroupBy_TSource_TKey_2(Type TSource, Type TKey) =>
              (s_GroupBy_TSource_TKey_2 ??
-             (s_GroupBy_TSource_TKey_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_GroupBy_TSource_TKey_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_GroupBy_TSource_TKey_3;
 
         public static MethodInfo GroupBy_TSource_TKey_3(Type TSource, Type TKey) =>
              (s_GroupBy_TSource_TKey_3 ??
-             (s_GroupBy_TSource_TKey_3 = new Func<IQueryable<object>, Expression<Func<object, object>>, IEqualityComparer<object>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_GroupBy_TSource_TKey_3 = new Func<IQueryable<object>, Expression<Func<object, object>>, IEqualityComparer<object>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_GroupBy_TSource_TKey_TElement_3;
 
         public static MethodInfo GroupBy_TSource_TKey_TElement_3(Type TSource, Type TKey, Type TElement) =>
              (s_GroupBy_TSource_TKey_TElement_3 ??
-             (s_GroupBy_TSource_TKey_TElement_3 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy<object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_GroupBy_TSource_TKey_TElement_3 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey, TElement);
 
         private static MethodInfo s_GroupBy_TSource_TKey_TElement_4;
 
         public static MethodInfo GroupBy_TSource_TKey_TElement_4(Type TSource, Type TKey, Type TElement) =>
              (s_GroupBy_TSource_TKey_TElement_4 ??
-             (s_GroupBy_TSource_TKey_TElement_4 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, IEqualityComparer<object>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy<object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_GroupBy_TSource_TKey_TElement_4 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, IEqualityComparer<object>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey, TElement);
 
         private static MethodInfo s_GroupBy_TSource_TKey_TResult_3;
 
         public static MethodInfo GroupBy_TSource_TKey_TResult_3(Type TSource, Type TKey, Type TResult) =>
              (s_GroupBy_TSource_TKey_TResult_3 ??
-             (s_GroupBy_TSource_TKey_TResult_3 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IQueryable<object>>(Queryable.GroupBy<object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_GroupBy_TSource_TKey_TResult_3 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IQueryable<object>>(Queryable.GroupBy).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey, TResult);
 
         private static MethodInfo s_GroupBy_TSource_TKey_TResult_4;
 
         public static MethodInfo GroupBy_TSource_TKey_TResult_4(Type TSource, Type TKey, Type TResult) =>
              (s_GroupBy_TSource_TKey_TResult_4 ??
-             (s_GroupBy_TSource_TKey_TResult_4 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.GroupBy<object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_GroupBy_TSource_TKey_TResult_4 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.GroupBy).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey, TResult);
 
         private static MethodInfo s_GroupBy_TSource_TKey_TElement_TResult_4;
 
         public static MethodInfo GroupBy_TSource_TKey_TElement_TResult_4(Type TSource, Type TKey, Type TElement, Type TResult) =>
              (s_GroupBy_TSource_TKey_TElement_TResult_4 ??
-             (s_GroupBy_TSource_TKey_TElement_TResult_4 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IQueryable<object>>(Queryable.GroupBy<object, object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_GroupBy_TSource_TKey_TElement_TResult_4 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IQueryable<object>>(Queryable.GroupBy).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey, TElement, TResult);
 
         private static MethodInfo s_GroupBy_TSource_TKey_TElement_TResult_5;
 
         public static MethodInfo GroupBy_TSource_TKey_TElement_TResult_5(Type TSource, Type TKey, Type TElement, Type TResult) =>
              (s_GroupBy_TSource_TKey_TElement_TResult_5 ??
-             (s_GroupBy_TSource_TKey_TElement_TResult_5 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.GroupBy<object, object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_GroupBy_TSource_TKey_TElement_TResult_5 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.GroupBy).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey, TElement, TResult);
 
         private static MethodInfo s_GroupJoin_TOuter_TInner_TKey_TResult_5;
 
         public static MethodInfo GroupJoin_TOuter_TInner_TKey_TResult_5(Type TOuter, Type TInner, Type TKey, Type TResult) =>
              (s_GroupJoin_TOuter_TInner_TKey_TResult_5 ??
-             (s_GroupJoin_TOuter_TInner_TKey_TResult_5 = new Func<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IQueryable<object>>(Queryable.GroupJoin<object, object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_GroupJoin_TOuter_TInner_TKey_TResult_5 = new Func<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IQueryable<object>>(Queryable.GroupJoin).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TOuter, TInner, TKey, TResult);
 
         private static MethodInfo s_GroupJoin_TOuter_TInner_TKey_TResult_6;
 
         public static MethodInfo GroupJoin_TOuter_TInner_TKey_TResult_6(Type TOuter, Type TInner, Type TKey, Type TResult) =>
              (s_GroupJoin_TOuter_TInner_TKey_TResult_6 ??
-             (s_GroupJoin_TOuter_TInner_TKey_TResult_6 = new Func<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.GroupJoin<object, object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_GroupJoin_TOuter_TInner_TKey_TResult_6 = new Func<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.GroupJoin).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TOuter, TInner, TKey, TResult);
 
         private static MethodInfo s_Intersect_TSource_2;
 
         public static MethodInfo Intersect_TSource_2(Type TSource) =>
              (s_Intersect_TSource_2 ??
-             (s_Intersect_TSource_2 = new Func<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Intersect<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Intersect_TSource_2 = new Func<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Intersect).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Intersect_TSource_3;
 
         public static MethodInfo Intersect_TSource_3(Type TSource) =>
              (s_Intersect_TSource_3 ??
-             (s_Intersect_TSource_3 = new Func<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Intersect<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Intersect_TSource_3 = new Func<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Intersect).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Join_TOuter_TInner_TKey_TResult_5;
 
         public static MethodInfo Join_TOuter_TInner_TKey_TResult_5(Type TOuter, Type TInner, Type TKey, Type TResult) =>
              (s_Join_TOuter_TInner_TKey_TResult_5 ??
-             (s_Join_TOuter_TInner_TKey_TResult_5 = new Func<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.Join<object, object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Join_TOuter_TInner_TKey_TResult_5 = new Func<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.Join).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TOuter, TInner, TKey, TResult);
 
         private static MethodInfo s_Join_TOuter_TInner_TKey_TResult_6;
 
         public static MethodInfo Join_TOuter_TInner_TKey_TResult_6(Type TOuter, Type TInner, Type TKey, Type TResult) =>
              (s_Join_TOuter_TInner_TKey_TResult_6 ??
-             (s_Join_TOuter_TInner_TKey_TResult_6 = new Func<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, object, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Join<object, object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Join_TOuter_TInner_TKey_TResult_6 = new Func<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, object, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Join).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TOuter, TInner, TKey, TResult);
 
         private static MethodInfo s_Last_TSource_1;
 
         public static MethodInfo Last_TSource_1(Type TSource) =>
              (s_Last_TSource_1 ??
-             (s_Last_TSource_1 = new Func<IQueryable<object>, object>(Queryable.Last<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Last_TSource_1 = new Func<IQueryable<object>, object>(Queryable.Last).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Last_TSource_2;
 
         public static MethodInfo Last_TSource_2(Type TSource) =>
              (s_Last_TSource_2 ??
-             (s_Last_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.Last<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Last_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.Last).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_LastOrDefault_TSource_1;
 
         public static MethodInfo LastOrDefault_TSource_1(Type TSource) =>
              (s_LastOrDefault_TSource_1 ??
-             (s_LastOrDefault_TSource_1 = new Func<IQueryable<object>, object>(Queryable.LastOrDefault<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_LastOrDefault_TSource_1 = new Func<IQueryable<object>, object>(Queryable.LastOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_LastOrDefault_TSource_2;
 
         public static MethodInfo LastOrDefault_TSource_2(Type TSource) =>
              (s_LastOrDefault_TSource_2 ??
-             (s_LastOrDefault_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.LastOrDefault<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_LastOrDefault_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.LastOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_LongCount_TSource_1;
 
         public static MethodInfo LongCount_TSource_1(Type TSource) =>
              (s_LongCount_TSource_1 ??
-             (s_LongCount_TSource_1 = new Func<IQueryable<object>, long>(Queryable.LongCount<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_LongCount_TSource_1 = new Func<IQueryable<object>, long>(Queryable.LongCount).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_LongCount_TSource_2;
 
         public static MethodInfo LongCount_TSource_2(Type TSource) =>
              (s_LongCount_TSource_2 ??
-             (s_LongCount_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, long>(Queryable.LongCount<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_LongCount_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, long>(Queryable.LongCount).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Max_TSource_1;
 
         public static MethodInfo Max_TSource_1(Type TSource) =>
              (s_Max_TSource_1 ??
-             (s_Max_TSource_1 = new Func<IQueryable<object>, object>(Queryable.Max<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Max_TSource_1 = new Func<IQueryable<object>, object>(Queryable.Max).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Max_TSource_TResult_2;
 
         public static MethodInfo Max_TSource_TResult_2(Type TSource, Type TResult) =>
              (s_Max_TSource_TResult_2 ??
-             (s_Max_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, object>(Queryable.Max<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Max_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, object>(Queryable.Max).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TResult);
 
         private static MethodInfo s_Min_TSource_1;
 
         public static MethodInfo Min_TSource_1(Type TSource) =>
              (s_Min_TSource_1 ??
-             (s_Min_TSource_1 = new Func<IQueryable<object>, object>(Queryable.Min<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Min_TSource_1 = new Func<IQueryable<object>, object>(Queryable.Min).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Min_TSource_TResult_2;
 
         public static MethodInfo Min_TSource_TResult_2(Type TSource, Type TResult) =>
              (s_Min_TSource_TResult_2 ??
-             (s_Min_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, object>(Queryable.Min<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Min_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, object>(Queryable.Min).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TResult);
 
         private static MethodInfo s_OfType_TResult_1;
@@ -501,140 +501,140 @@ namespace System.Linq
 
         public static MethodInfo OrderBy_TSource_TKey_2(Type TSource, Type TKey) =>
              (s_OrderBy_TSource_TKey_2 ??
-             (s_OrderBy_TSource_TKey_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.OrderBy<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_OrderBy_TSource_TKey_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.OrderBy).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_OrderBy_TSource_TKey_3;
 
         public static MethodInfo OrderBy_TSource_TKey_3(Type TSource, Type TKey) =>
              (s_OrderBy_TSource_TKey_3 ??
-             (s_OrderBy_TSource_TKey_3 = new Func<IQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.OrderBy<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_OrderBy_TSource_TKey_3 = new Func<IQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.OrderBy).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_OrderByDescending_TSource_TKey_2;
 
         public static MethodInfo OrderByDescending_TSource_TKey_2(Type TSource, Type TKey) =>
              (s_OrderByDescending_TSource_TKey_2 ??
-             (s_OrderByDescending_TSource_TKey_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.OrderByDescending<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_OrderByDescending_TSource_TKey_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.OrderByDescending).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_OrderByDescending_TSource_TKey_3;
 
         public static MethodInfo OrderByDescending_TSource_TKey_3(Type TSource, Type TKey) =>
              (s_OrderByDescending_TSource_TKey_3 ??
-             (s_OrderByDescending_TSource_TKey_3 = new Func<IQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.OrderByDescending<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_OrderByDescending_TSource_TKey_3 = new Func<IQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.OrderByDescending).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_Reverse_TSource_1;
 
         public static MethodInfo Reverse_TSource_1(Type TSource) =>
              (s_Reverse_TSource_1 ??
-             (s_Reverse_TSource_1 = new Func<IQueryable<object>, IQueryable<object>>(Queryable.Reverse<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Reverse_TSource_1 = new Func<IQueryable<object>, IQueryable<object>>(Queryable.Reverse).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Select_TSource_TResult_2;
 
         public static MethodInfo Select_TSource_TResult_2(Type TSource, Type TResult) =>
              (s_Select_TSource_TResult_2 ??
-             (s_Select_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, IQueryable<object>>(Queryable.Select<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Select_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, IQueryable<object>>(Queryable.Select).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TResult);
 
         private static MethodInfo s_Select_Index_TSource_TResult_2;
 
         public static MethodInfo Select_Index_TSource_TResult_2(Type TSource, Type TResult) =>
              (s_Select_Index_TSource_TResult_2 ??
-             (s_Select_Index_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, int, object>>, IQueryable<object>>(Queryable.Select<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Select_Index_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, int, object>>, IQueryable<object>>(Queryable.Select).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TResult);
 
         private static MethodInfo s_SelectMany_TSource_TResult_2;
 
         public static MethodInfo SelectMany_TSource_TResult_2(Type TSource, Type TResult) =>
              (s_SelectMany_TSource_TResult_2 ??
-             (s_SelectMany_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, IEnumerable<object>>>, IQueryable<object>>(Queryable.SelectMany<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_SelectMany_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, IEnumerable<object>>>, IQueryable<object>>(Queryable.SelectMany).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TResult);
 
         private static MethodInfo s_SelectMany_Index_TSource_TResult_2;
 
         public static MethodInfo SelectMany_Index_TSource_TResult_2(Type TSource, Type TResult) =>
              (s_SelectMany_Index_TSource_TResult_2 ??
-             (s_SelectMany_Index_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, int, IEnumerable<object>>>, IQueryable<object>>(Queryable.SelectMany<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_SelectMany_Index_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, int, IEnumerable<object>>>, IQueryable<object>>(Queryable.SelectMany).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TResult);
 
         private static MethodInfo s_SelectMany_Index_TSource_TCollection_TResult_3;
 
         public static MethodInfo SelectMany_Index_TSource_TCollection_TResult_3(Type TSource, Type TCollection, Type TResult) =>
              (s_SelectMany_Index_TSource_TCollection_TResult_3 ??
-             (s_SelectMany_Index_TSource_TCollection_TResult_3 = new Func<IQueryable<object>, Expression<Func<object, int, IEnumerable<object>>>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.SelectMany<object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_SelectMany_Index_TSource_TCollection_TResult_3 = new Func<IQueryable<object>, Expression<Func<object, int, IEnumerable<object>>>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.SelectMany).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TCollection, TResult);
 
         private static MethodInfo s_SelectMany_TSource_TCollection_TResult_3;
 
         public static MethodInfo SelectMany_TSource_TCollection_TResult_3(Type TSource, Type TCollection, Type TResult) =>
              (s_SelectMany_TSource_TCollection_TResult_3 ??
-             (s_SelectMany_TSource_TCollection_TResult_3 = new Func<IQueryable<object>, Expression<Func<object, IEnumerable<object>>>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.SelectMany<object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_SelectMany_TSource_TCollection_TResult_3 = new Func<IQueryable<object>, Expression<Func<object, IEnumerable<object>>>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.SelectMany).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TCollection, TResult);
 
         private static MethodInfo s_SequenceEqual_TSource_2;
 
         public static MethodInfo SequenceEqual_TSource_2(Type TSource) =>
              (s_SequenceEqual_TSource_2 ??
-             (s_SequenceEqual_TSource_2 = new Func<IQueryable<object>, IEnumerable<object>, bool>(Queryable.SequenceEqual<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_SequenceEqual_TSource_2 = new Func<IQueryable<object>, IEnumerable<object>, bool>(Queryable.SequenceEqual).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_SequenceEqual_TSource_3;
 
         public static MethodInfo SequenceEqual_TSource_3(Type TSource) =>
              (s_SequenceEqual_TSource_3 ??
-             (s_SequenceEqual_TSource_3 = new Func<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, bool>(Queryable.SequenceEqual<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_SequenceEqual_TSource_3 = new Func<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, bool>(Queryable.SequenceEqual).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Single_TSource_1;
 
         public static MethodInfo Single_TSource_1(Type TSource) =>
              (s_Single_TSource_1 ??
-             (s_Single_TSource_1 = new Func<IQueryable<object>, object>(Queryable.Single<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Single_TSource_1 = new Func<IQueryable<object>, object>(Queryable.Single).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Single_TSource_2;
 
         public static MethodInfo Single_TSource_2(Type TSource) =>
              (s_Single_TSource_2 ??
-             (s_Single_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.Single<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Single_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.Single).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_SingleOrDefault_TSource_1;
 
         public static MethodInfo SingleOrDefault_TSource_1(Type TSource) =>
              (s_SingleOrDefault_TSource_1 ??
-             (s_SingleOrDefault_TSource_1 = new Func<IQueryable<object>, object>(Queryable.SingleOrDefault<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_SingleOrDefault_TSource_1 = new Func<IQueryable<object>, object>(Queryable.SingleOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_SingleOrDefault_TSource_2;
 
         public static MethodInfo SingleOrDefault_TSource_2(Type TSource) =>
              (s_SingleOrDefault_TSource_2 ??
-             (s_SingleOrDefault_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.SingleOrDefault<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_SingleOrDefault_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.SingleOrDefault).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Skip_TSource_2;
 
         public static MethodInfo Skip_TSource_2(Type TSource) =>
              (s_Skip_TSource_2 ??
-             (s_Skip_TSource_2 = new Func<IQueryable<object>, int, IQueryable<object>>(Queryable.Skip<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Skip_TSource_2 = new Func<IQueryable<object>, int, IQueryable<object>>(Queryable.Skip).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_SkipWhile_TSource_2;
 
         public static MethodInfo SkipWhile_TSource_2(Type TSource) =>
              (s_SkipWhile_TSource_2 ??
-             (s_SkipWhile_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, IQueryable<object>>(Queryable.SkipWhile<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_SkipWhile_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, IQueryable<object>>(Queryable.SkipWhile).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_SkipWhile_Index_TSource_2;
 
         public static MethodInfo SkipWhile_Index_TSource_2(Type TSource) =>
              (s_SkipWhile_Index_TSource_2 ??
-             (s_SkipWhile_Index_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int, bool>>, IQueryable<object>>(Queryable.SkipWhile<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_SkipWhile_Index_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int, bool>>, IQueryable<object>>(Queryable.SkipWhile).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_Int32_1;
@@ -701,154 +701,154 @@ namespace System.Linq
 
         public static MethodInfo Sum_NullableDecimal_TSource_2(Type TSource) =>
              (s_Sum_NullableDecimal_TSource_2 ??
-             (s_Sum_NullableDecimal_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, decimal?>>, decimal?>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Sum_NullableDecimal_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, decimal?>>, decimal?>(Queryable.Sum).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_Int32_TSource_2;
 
         public static MethodInfo Sum_Int32_TSource_2(Type TSource) =>
              (s_Sum_Int32_TSource_2 ??
-             (s_Sum_Int32_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int>>, int>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Sum_Int32_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int>>, int>(Queryable.Sum).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_NullableInt32_TSource_2;
 
         public static MethodInfo Sum_NullableInt32_TSource_2(Type TSource) =>
              (s_Sum_NullableInt32_TSource_2 ??
-             (s_Sum_NullableInt32_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int?>>, int?>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Sum_NullableInt32_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int?>>, int?>(Queryable.Sum).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_Int64_TSource_2;
 
         public static MethodInfo Sum_Int64_TSource_2(Type TSource) =>
              (s_Sum_Int64_TSource_2 ??
-             (s_Sum_Int64_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, long>>, long>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Sum_Int64_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, long>>, long>(Queryable.Sum).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_NullableInt64_TSource_2;
 
         public static MethodInfo Sum_NullableInt64_TSource_2(Type TSource) =>
              (s_Sum_NullableInt64_TSource_2 ??
-             (s_Sum_NullableInt64_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, long?>>, long?>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Sum_NullableInt64_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, long?>>, long?>(Queryable.Sum).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_Single_TSource_2;
 
         public static MethodInfo Sum_Single_TSource_2(Type TSource) =>
              (s_Sum_Single_TSource_2 ??
-             (s_Sum_Single_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, float>>, float>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Sum_Single_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, float>>, float>(Queryable.Sum).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_NullableSingle_TSource_2;
 
         public static MethodInfo Sum_NullableSingle_TSource_2(Type TSource) =>
              (s_Sum_NullableSingle_TSource_2 ??
-             (s_Sum_NullableSingle_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, float?>>, float?>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Sum_NullableSingle_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, float?>>, float?>(Queryable.Sum).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_Double_TSource_2;
 
         public static MethodInfo Sum_Double_TSource_2(Type TSource) =>
              (s_Sum_Double_TSource_2 ??
-             (s_Sum_Double_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, double>>, double>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Sum_Double_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, double>>, double>(Queryable.Sum).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_NullableDouble_TSource_2;
 
         public static MethodInfo Sum_NullableDouble_TSource_2(Type TSource) =>
              (s_Sum_NullableDouble_TSource_2 ??
-             (s_Sum_NullableDouble_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, double?>>, double?>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Sum_NullableDouble_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, double?>>, double?>(Queryable.Sum).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_Decimal_TSource_2;
 
         public static MethodInfo Sum_Decimal_TSource_2(Type TSource) =>
              (s_Sum_Decimal_TSource_2 ??
-             (s_Sum_Decimal_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, decimal>>, decimal>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Sum_Decimal_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, decimal>>, decimal>(Queryable.Sum).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Take_TSource_2;
 
         public static MethodInfo Take_TSource_2(Type TSource) =>
              (s_Take_TSource_2 ??
-             (s_Take_TSource_2 = new Func<IQueryable<object>, int, IQueryable<object>>(Queryable.Take<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Take_TSource_2 = new Func<IQueryable<object>, int, IQueryable<object>>(Queryable.Take).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_TakeWhile_TSource_2;
 
         public static MethodInfo TakeWhile_TSource_2(Type TSource) =>
              (s_TakeWhile_TSource_2 ??
-             (s_TakeWhile_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, IQueryable<object>>(Queryable.TakeWhile<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_TakeWhile_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, IQueryable<object>>(Queryable.TakeWhile).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_TakeWhile_Index_TSource_2;
 
         public static MethodInfo TakeWhile_Index_TSource_2(Type TSource) =>
              (s_TakeWhile_Index_TSource_2 ??
-             (s_TakeWhile_Index_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int, bool>>, IQueryable<object>>(Queryable.TakeWhile<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_TakeWhile_Index_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int, bool>>, IQueryable<object>>(Queryable.TakeWhile).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_ThenBy_TSource_TKey_2;
 
         public static MethodInfo ThenBy_TSource_TKey_2(Type TSource, Type TKey) =>
              (s_ThenBy_TSource_TKey_2 ??
-             (s_ThenBy_TSource_TKey_2 = new Func<IOrderedQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.ThenBy<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_ThenBy_TSource_TKey_2 = new Func<IOrderedQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.ThenBy).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_ThenBy_TSource_TKey_3;
 
         public static MethodInfo ThenBy_TSource_TKey_3(Type TSource, Type TKey) =>
              (s_ThenBy_TSource_TKey_3 ??
-             (s_ThenBy_TSource_TKey_3 = new Func<IOrderedQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.ThenBy<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_ThenBy_TSource_TKey_3 = new Func<IOrderedQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.ThenBy).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_ThenByDescending_TSource_TKey_2;
 
         public static MethodInfo ThenByDescending_TSource_TKey_2(Type TSource, Type TKey) =>
              (s_ThenByDescending_TSource_TKey_2 ??
-             (s_ThenByDescending_TSource_TKey_2 = new Func<IOrderedQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.ThenByDescending<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_ThenByDescending_TSource_TKey_2 = new Func<IOrderedQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.ThenByDescending).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_ThenByDescending_TSource_TKey_3;
 
         public static MethodInfo ThenByDescending_TSource_TKey_3(Type TSource, Type TKey) =>
              (s_ThenByDescending_TSource_TKey_3 ??
-             (s_ThenByDescending_TSource_TKey_3 = new Func<IOrderedQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.ThenByDescending<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_ThenByDescending_TSource_TKey_3 = new Func<IOrderedQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.ThenByDescending).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_Union_TSource_2;
 
         public static MethodInfo Union_TSource_2(Type TSource) =>
              (s_Union_TSource_2 ??
-             (s_Union_TSource_2 = new Func<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Union<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Union_TSource_2 = new Func<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Union).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Union_TSource_3;
 
         public static MethodInfo Union_TSource_3(Type TSource) =>
              (s_Union_TSource_3 ??
-             (s_Union_TSource_3 = new Func<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Union<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Union_TSource_3 = new Func<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Union).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Where_TSource_2;
 
         public static MethodInfo Where_TSource_2(Type TSource) =>
              (s_Where_TSource_2 ??
-             (s_Where_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, IQueryable<object>>(Queryable.Where<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Where_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, IQueryable<object>>(Queryable.Where).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Where_Index_TSource_2;
 
         public static MethodInfo Where_Index_TSource_2(Type TSource) =>
              (s_Where_Index_TSource_2 ??
-             (s_Where_Index_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int, bool>>, IQueryable<object>>(Queryable.Where<object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Where_Index_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int, bool>>, IQueryable<object>>(Queryable.Where).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Zip_TFirst_TSecond_TResult_3;
 
         public static MethodInfo Zip_TFirst_TSecond_TResult_3(Type TFirst, Type TSecond, Type TResult) =>
              (s_Zip_TFirst_TSecond_TResult_3 ??
-             (s_Zip_TFirst_TSecond_TResult_3 = new Func<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.Zip<object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
+             (s_Zip_TFirst_TSecond_TResult_3 = new Func<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.Zip).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TFirst, TSecond, TResult);
 
     }

--- a/src/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -52,19 +51,6 @@ namespace System.Linq
              (s_Any_TSource_2 ??
              (s_Any_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, bool>(Queryable.Any).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
-
-        private static MethodInfo s_AsQueryable_1;
-
-        public static MethodInfo AsQueryable_1 =>
-             s_AsQueryable_1 ??
-            (s_AsQueryable_1 = new Func<IEnumerable, IQueryable>(Queryable.AsQueryable).GetMethodInfo());
-
-        private static MethodInfo s_AsQueryable_TElement_1;
-
-        public static MethodInfo AsQueryable_TElement_1(Type TElement) =>
-             (s_AsQueryable_TElement_1 ??
-             (s_AsQueryable_TElement_1 = new Func<IEnumerable<object>, IQueryable<object>>(Queryable.AsQueryable).GetMethodInfo().GetGenericMethodDefinition()))
-              .MakeGenericMethod(TElement);
 
         private static MethodInfo s_Average_Int32_1;
 

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableExecutor.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableExecutor.cs
@@ -30,10 +30,7 @@ namespace System.Linq
             _expression = expression;
         }
 
-        internal override object ExecuteBoxed()
-        {
-            return Execute();
-        }
+        internal override object ExecuteBoxed() => Execute();
 
         internal T Execute()
         {

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableExecutor.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableExecutor.cs
@@ -15,7 +15,7 @@ namespace System.Linq
         internal static EnumerableExecutor Create(Expression expression)
         {
             Type execType = typeof(EnumerableExecutor<>).MakeGenericType(expression.Type);
-            return (EnumerableExecutor)Activator.CreateInstance(execType, new object[] { expression });
+            return (EnumerableExecutor)Activator.CreateInstance(execType, expression);
         }
     }
 

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableExecutor.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableExecutor.cs
@@ -22,7 +22,7 @@ namespace System.Linq
     // Must remain public for Silverlight
     public class EnumerableExecutor<T> : EnumerableExecutor
     {
-        private Expression _expression;
+        private readonly Expression _expression;
 
         // Must remain public for Silverlight
         public EnumerableExecutor(Expression expression)

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableExecutor.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableExecutor.cs
@@ -32,7 +32,7 @@ namespace System.Linq
 
         internal override object ExecuteBoxed()
         {
-            return this.Execute();
+            return Execute();
         }
 
         internal T Execute()

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableQuery.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableQuery.cs
@@ -47,25 +47,13 @@ namespace System.Linq
             _expression = expression;
         }
 
-        internal override Expression Expression
-        {
-            get { return _expression; }
-        }
+        internal override Expression Expression => _expression;
 
-        internal override IEnumerable Enumerable
-        {
-            get { return _enumerable; }
-        }
+        internal override IEnumerable Enumerable => _enumerable;
 
-        Expression IQueryable.Expression
-        {
-            get { return _expression; }
-        }
+        Expression IQueryable.Expression => _expression;
 
-        Type IQueryable.ElementType
-        {
-            get { return typeof(T); }
-        }
+        Type IQueryable.ElementType => typeof(T);
 
         IQueryable IQueryProvider.CreateQuery(Expression expression)
         {
@@ -112,15 +100,9 @@ namespace System.Linq
             return new EnumerableExecutor<TElement>(expression).Execute();
         }
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        IEnumerator<T> IEnumerable<T>.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
 
         private IEnumerator<T> GetEnumerator()
         {

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableQuery.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableQuery.cs
@@ -105,7 +105,6 @@ namespace System.Linq
         {
             if (expression == null)
                 throw Error.ArgumentNull(nameof(expression));
-            Type execType = typeof(EnumerableExecutor<>).MakeGenericType(expression.Type);
             return EnumerableExecutor.Create(expression).ExecuteBoxed();
         }
 

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableQuery.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableQuery.cs
@@ -16,13 +16,13 @@ namespace System.Linq
         internal static IQueryable Create(Type elementType, IEnumerable sequence)
         {
             Type seqType = typeof(EnumerableQuery<>).MakeGenericType(elementType);
-            return (IQueryable)Activator.CreateInstance(seqType, new object[] { sequence });
+            return (IQueryable)Activator.CreateInstance(seqType, sequence);
         }
 
         internal static IQueryable Create(Type elementType, Expression expression)
         {
             Type seqType = typeof(EnumerableQuery<>).MakeGenericType(elementType);
-            return (IQueryable)Activator.CreateInstance(seqType, new object[] { expression });
+            return (IQueryable)Activator.CreateInstance(seqType, expression);
         }
     }
 

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableQuery.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableQuery.cs
@@ -29,7 +29,7 @@ namespace System.Linq
     // Must remain public for Silverlight
     public class EnumerableQuery<T> : EnumerableQuery, IOrderedQueryable<T>, IQueryable, IQueryProvider, IEnumerable<T>, IEnumerable
     {
-        private Expression _expression;
+        private readonly Expression _expression;
         private IEnumerable<T> _enumerable;
 
         IQueryProvider IQueryable.Provider

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableQuery.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableQuery.cs
@@ -27,18 +27,12 @@ namespace System.Linq
     }
 
     // Must remain public for Silverlight
-    public class EnumerableQuery<T> : EnumerableQuery, IOrderedQueryable<T>, IQueryable, IQueryProvider, IEnumerable<T>, IEnumerable
+    public class EnumerableQuery<T> : EnumerableQuery, IOrderedQueryable<T>, IQueryProvider
     {
         private readonly Expression _expression;
         private IEnumerable<T> _enumerable;
 
-        IQueryProvider IQueryable.Provider
-        {
-            get
-            {
-                return (IQueryProvider)this;
-            }
-        }
+        IQueryProvider IQueryable.Provider => this;
 
         // Must remain public for Silverlight
         public EnumerableQuery(IEnumerable<T> enumerable)
@@ -80,18 +74,18 @@ namespace System.Linq
             Type iqType = TypeHelper.FindGenericType(typeof(IQueryable<>), expression.Type);
             if (iqType == null)
                 throw Error.ArgumentNotValid(nameof(expression));
-            return EnumerableQuery.Create(iqType.GetGenericArguments()[0], expression);
+            return Create(iqType.GetGenericArguments()[0], expression);
         }
 
-        IQueryable<S> IQueryProvider.CreateQuery<S>(Expression expression)
+        IQueryable<TElement> IQueryProvider.CreateQuery<TElement>(Expression expression)
         {
             if (expression == null)
                 throw Error.ArgumentNull(nameof(expression));
-            if (!typeof(IQueryable<S>).IsAssignableFrom(expression.Type))
+            if (!typeof(IQueryable<TElement>).IsAssignableFrom(expression.Type))
             {
                 throw Error.ArgumentNotValid(nameof(expression));
             }
-            return new EnumerableQuery<S>(expression);
+            return new EnumerableQuery<TElement>(expression);
         }
 
         // Baselining as Safe for Mix demo so that interface can be transparent. Marking this
@@ -109,23 +103,23 @@ namespace System.Linq
         }
 
         // see above
-        S IQueryProvider.Execute<S>(Expression expression)
+        TElement IQueryProvider.Execute<TElement>(Expression expression)
         {
             if (expression == null)
                 throw Error.ArgumentNull(nameof(expression));
-            if (!typeof(S).IsAssignableFrom(expression.Type))
+            if (!typeof(TElement).IsAssignableFrom(expression.Type))
                 throw Error.ArgumentNotValid(nameof(expression));
-            return new EnumerableExecutor<S>(expression).Execute();
+            return new EnumerableExecutor<TElement>(expression).Execute();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return this.GetEnumerator();
+            return GetEnumerator();
         }
 
         IEnumerator<T> IEnumerable<T>.GetEnumerator()
         {
-            return this.GetEnumerator();
+            return GetEnumerator();
         }
 
         private IEnumerator<T> GetEnumerator()

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
@@ -73,10 +73,8 @@ namespace System.Linq
                             newArgs.Add(argList[j]);
                         }
                     }
-                    if (newArgs != null)
-                    {
-                        newArgs.Add(arg);
-                    }
+
+                    newArgs?.Add(arg);
                 }
                 if (newArgs != null)
                     argList = newArgs.AsReadOnly();

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
@@ -21,7 +21,7 @@ namespace System.Linq
 
         protected override Expression VisitMethodCall(MethodCallExpression m)
         {
-            Expression obj = this.Visit(m.Object);
+            Expression obj = Visit(m.Object);
             ReadOnlyCollection<Expression> args = Visit(m.Arguments);
 
             // check for args changed
@@ -40,14 +40,14 @@ namespace System.Linq
                 {
                     // convert Queryable method to Enumerable method
                     MethodInfo seqMethod = FindEnumerableMethod(mInfo.Name, args, typeArgs);
-                    args = this.FixupQuotedArgs(seqMethod, args);
+                    args = FixupQuotedArgs(seqMethod, args);
                     return Expression.Call(obj, seqMethod, args);
                 }
                 else
                 {
                     // rebind to new method
                     MethodInfo method = FindMethod(mInfo.DeclaringType, mInfo.Name, args, typeArgs);
-                    args = this.FixupQuotedArgs(method, args);
+                    args = FixupQuotedArgs(method, args);
                     return Expression.Call(obj, method, args);
                 }
             }
@@ -103,7 +103,7 @@ namespace System.Linq
                     List<Expression> exprs = new List<Expression>(na.Expressions.Count);
                     for (int i = 0, n = na.Expressions.Count; i < n; i++)
                     {
-                        exprs.Add(this.FixupQuotedExpression(elementType, na.Expressions[i]));
+                        exprs.Add(FixupQuotedExpression(elementType, na.Expressions[i]));
                     }
                     expression = Expression.NewArrayInit(elementType, exprs);
                 }

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
@@ -171,16 +171,25 @@ namespace System.Linq
                 }
                 if (equiv == null)
                 {
-                    var interfacesWithInfo = info.ImplementedInterfaces.Select(i => new { Type = i, Info = i.GetTypeInfo() }).ToArray();
+                    var interfacesWithInfo = info.ImplementedInterfaces.Select(IntrospectionExtensions.GetTypeInfo).ToArray();
                     var singleTypeGenInterfacesWithGetType = interfacesWithInfo
-                        .Where(i => i.Info.IsGenericType && i.Info.GenericTypeArguments.Length == 1)
-                        .Select(i => new { Type = i.Type, Info = i.Info, GenType = i.Info.GetGenericTypeDefinition() });
-                    Type typeArg = singleTypeGenInterfacesWithGetType.Where(i => i.GenType == typeof(IOrderedQueryable<>) || i.GenType == typeof(IOrderedEnumerable<>)).Select(i => i.Info.GenericTypeArguments[0]).Distinct().SingleOrDefault();
+                        .Where(i => i.IsGenericType && i.GenericTypeArguments.Length == 1)
+                        .Select(i => new {Info = i, GenType = i.GetGenericTypeDefinition() })
+                        .ToArray();
+                    Type typeArg = singleTypeGenInterfacesWithGetType
+                        .Where(i => i.GenType == typeof(IOrderedQueryable<>) || i.GenType == typeof(IOrderedEnumerable<>))
+                        .Select(i => i.Info.GenericTypeArguments[0])
+                        .Distinct()
+                        .SingleOrDefault();
                     if (typeArg != null)
                         equiv = typeof(IOrderedEnumerable<>).MakeGenericType(typeArg);
                     else
                     {
-                        typeArg = singleTypeGenInterfacesWithGetType.Where(i => i.GenType == typeof(IQueryable<>) || i.GenType == typeof(IEnumerable<>)).Select(i => i.Info.GenericTypeArguments[0]).Distinct().Single();
+                        typeArg = singleTypeGenInterfacesWithGetType
+                            .Where(i => i.GenType == typeof(IQueryable<>) || i.GenType == typeof(IEnumerable<>))
+                            .Select(i => i.Info.GenericTypeArguments[0])
+                            .Distinct()
+                            .Single();
                         equiv = typeof(IEnumerable<>).MakeGenericType(typeArg);
                     }
                 }

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
@@ -111,10 +111,7 @@ namespace System.Linq
             return expression;
         }
 
-        protected override Expression VisitLambda<T>(Expression<T> node)
-        {
-            return node;
-        }
+        protected override Expression VisitLambda<T>(Expression<T> node) => node;
 
         private static Type GetPublicType(Type t)
         {

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
@@ -315,7 +315,6 @@ namespace System.Linq
                 return Expression.Condition(test, ifTrue, ifFalse, trueType);
             if (falseType.IsAssignableFrom(trueType))
                 return Expression.Condition(test, ifTrue, ifFalse, falseType);
-            TypeInfo info = type.GetTypeInfo();
             return Expression.Condition(test, ifTrue, ifFalse, GetEquivalentType(type));
         }
 

--- a/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
@@ -210,7 +210,7 @@ namespace System.Linq
 
 
 
-        private static volatile ILookup<string, MethodInfo> s_seqMethods;
+        private static ILookup<string, MethodInfo> s_seqMethods;
         private static MethodInfo FindEnumerableMethod(string name, ReadOnlyCollection<Expression> args, params Type[] typeArgs)
         {
             if (s_seqMethods == null)

--- a/src/System.Linq.Queryable/src/System/Linq/Error.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/Error.cs
@@ -4,7 +4,7 @@
 
 namespace System.Linq
 {
-    internal class Error
+    internal static class Error
     {
         internal static Exception ArgumentNull(string message)
         {

--- a/src/System.Linq.Queryable/src/System/Linq/Error.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/Error.cs
@@ -6,39 +6,24 @@ namespace System.Linq
 {
     internal static class Error
     {
-        internal static Exception ArgumentNull(string message)
-        {
-            return new ArgumentNullException(message);
-        }
+        internal static Exception ArgumentNull(string message) => new ArgumentNullException(message);
 
-        internal static Exception ArgumentNotIEnumerableGeneric(string message)
-        {
-            return new ArgumentException(Strings.ArgumentNotIEnumerableGeneric(message));
-        }
+        internal static Exception ArgumentNotIEnumerableGeneric(string message) =>
+            new ArgumentException(Strings.ArgumentNotIEnumerableGeneric(message));
 
-        internal static Exception ArgumentNotValid(string message)
-        {
-            return new ArgumentException(Strings.ArgumentNotValid(message));
-        }
+        internal static Exception ArgumentNotValid(string message) =>
+            new ArgumentException(Strings.ArgumentNotValid(message));
 
-        internal static Exception ArgumentOutOfRange(string message)
-        {
-            return new ArgumentOutOfRangeException(message);
-        }
+        internal static Exception ArgumentOutOfRange(string message) =>
+            new ArgumentOutOfRangeException(message);
 
-        internal static Exception NoMethodOnType(string name, object type)
-        {
-            return new InvalidOperationException(Strings.NoMethodOnType(name, type));
-        }
+        internal static Exception NoMethodOnType(string name, object type) =>
+            new InvalidOperationException(Strings.NoMethodOnType(name, type));
 
-        internal static Exception NoMethodOnTypeMatchingArguments(string name, object type)
-        {
-            return new InvalidOperationException(Strings.NoMethodOnTypeMatchingArguments(name, type));
-        }
+        internal static Exception NoMethodOnTypeMatchingArguments(string name, object type) =>
+            new InvalidOperationException(Strings.NoMethodOnTypeMatchingArguments(name, type));
 
-        internal static Exception EnumeratingNullEnumerableExpression()
-        {
-            return new InvalidOperationException(Strings.EnumeratingNullEnumerableExpression());
-        }
+        internal static Exception EnumeratingNullEnumerableExpression() =>
+            new InvalidOperationException(Strings.EnumeratingNullEnumerableExpression());
     }
 }

--- a/src/System.Linq.Queryable/src/System/Linq/Queryable.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/Queryable.cs
@@ -65,9 +65,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.OfType_TResult_1(typeof(TResult)),
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.OfType_TResult_1(typeof(TResult)), source.Expression));
         }
 
         public static IQueryable<TResult> Cast<TResult>(this IQueryable source)
@@ -77,9 +75,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Cast_TResult_1(typeof(TResult)),
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Cast_TResult_1(typeof(TResult)), source.Expression));
         }
 
         public static IQueryable<TResult> Select<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector)
@@ -192,15 +188,7 @@ namespace System.Linq
             return outer.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Join_TOuter_TInner_TKey_TResult_5(typeof(TOuter), typeof(TInner), typeof(TKey), typeof(TResult)),
-                    new Expression[] {
-                        outer.Expression,
-                        GetSourceExpression(inner),
-                        Expression.Quote(outerKeySelector),
-                        Expression.Quote(innerKeySelector),
-                        Expression.Quote(resultSelector)
-                        }
-                    ));
+                    CachedReflectionInfo.Join_TOuter_TInner_TKey_TResult_5(typeof(TOuter), typeof(TInner), typeof(TKey), typeof(TResult)), outer.Expression, GetSourceExpression(inner), Expression.Quote(outerKeySelector), Expression.Quote(innerKeySelector), Expression.Quote(resultSelector)));
         }
 
         public static IQueryable<TResult> Join<TOuter, TInner, TKey, TResult>(this IQueryable<TOuter> outer, IEnumerable<TInner> inner, Expression<Func<TOuter, TKey>> outerKeySelector, Expression<Func<TInner, TKey>> innerKeySelector, Expression<Func<TOuter, TInner, TResult>> resultSelector, IEqualityComparer<TKey> comparer)
@@ -218,16 +206,7 @@ namespace System.Linq
             return outer.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Join_TOuter_TInner_TKey_TResult_6(typeof(TOuter), typeof(TInner), typeof(TKey), typeof(TResult)),
-                    new Expression[] {
-                        outer.Expression,
-                        GetSourceExpression(inner),
-                        Expression.Quote(outerKeySelector),
-                        Expression.Quote(innerKeySelector),
-                        Expression.Quote(resultSelector),
-                        Expression.Constant(comparer, typeof(IEqualityComparer<TKey>))
-                        }
-                    ));
+                    CachedReflectionInfo.Join_TOuter_TInner_TKey_TResult_6(typeof(TOuter), typeof(TInner), typeof(TKey), typeof(TResult)), outer.Expression, GetSourceExpression(inner), Expression.Quote(outerKeySelector), Expression.Quote(innerKeySelector), Expression.Quote(resultSelector), Expression.Constant(comparer, typeof(IEqualityComparer<TKey>))));
         }
 
         public static IQueryable<TResult> GroupJoin<TOuter, TInner, TKey, TResult>(this IQueryable<TOuter> outer, IEnumerable<TInner> inner, Expression<Func<TOuter, TKey>> outerKeySelector, Expression<Func<TInner, TKey>> innerKeySelector, Expression<Func<TOuter, IEnumerable<TInner>, TResult>> resultSelector)
@@ -245,14 +224,7 @@ namespace System.Linq
             return outer.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.GroupJoin_TOuter_TInner_TKey_TResult_5(typeof(TOuter), typeof(TInner), typeof(TKey), typeof(TResult)),
-                    new Expression[] {
-                        outer.Expression,
-                        GetSourceExpression(inner),
-                        Expression.Quote(outerKeySelector),
-                        Expression.Quote(innerKeySelector),
-                        Expression.Quote(resultSelector) }
-                    ));
+                    CachedReflectionInfo.GroupJoin_TOuter_TInner_TKey_TResult_5(typeof(TOuter), typeof(TInner), typeof(TKey), typeof(TResult)), outer.Expression, GetSourceExpression(inner), Expression.Quote(outerKeySelector), Expression.Quote(innerKeySelector), Expression.Quote(resultSelector)));
         }
 
         public static IQueryable<TResult> GroupJoin<TOuter, TInner, TKey, TResult>(this IQueryable<TOuter> outer, IEnumerable<TInner> inner, Expression<Func<TOuter, TKey>> outerKeySelector, Expression<Func<TInner, TKey>> innerKeySelector, Expression<Func<TOuter, IEnumerable<TInner>, TResult>> resultSelector, IEqualityComparer<TKey> comparer)
@@ -270,15 +242,7 @@ namespace System.Linq
             return outer.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.GroupJoin_TOuter_TInner_TKey_TResult_6(typeof(TOuter), typeof(TInner), typeof(TKey), typeof(TResult)),
-                    new Expression[] {
-                        outer.Expression,
-                        GetSourceExpression(inner),
-                        Expression.Quote(outerKeySelector),
-                        Expression.Quote(innerKeySelector),
-                        Expression.Quote(resultSelector),
-                        Expression.Constant(comparer, typeof(IEqualityComparer<TKey>)) }
-                    ));
+                    CachedReflectionInfo.GroupJoin_TOuter_TInner_TKey_TResult_6(typeof(TOuter), typeof(TInner), typeof(TKey), typeof(TResult)), outer.Expression, GetSourceExpression(inner), Expression.Quote(outerKeySelector), Expression.Quote(innerKeySelector), Expression.Quote(resultSelector), Expression.Constant(comparer, typeof(IEqualityComparer<TKey>))));
         }
 
         public static IOrderedQueryable<TSource> OrderBy<TSource, TKey>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector)
@@ -528,9 +492,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<IGrouping<TKey, TElement>>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.GroupBy_TSource_TKey_TElement_4(typeof(TSource), typeof(TKey), typeof(TElement)),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Quote(elementSelector), Expression.Constant(comparer, typeof(IEqualityComparer<TKey>)) }
-                    ));
+                    CachedReflectionInfo.GroupBy_TSource_TKey_TElement_4(typeof(TSource), typeof(TKey), typeof(TElement)), source.Expression, Expression.Quote(keySelector), Expression.Quote(elementSelector), Expression.Constant(comparer, typeof(IEqualityComparer<TKey>))));
         }
 
         public static IQueryable<TResult> GroupBy<TSource, TKey, TElement, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector, Expression<Func<TSource, TElement>> elementSelector, Expression<Func<TKey, IEnumerable<TElement>, TResult>> resultSelector)
@@ -546,9 +508,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.GroupBy_TSource_TKey_TElement_TResult_4(typeof(TSource), typeof(TKey), typeof(TElement), typeof(TResult)),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Quote(elementSelector), Expression.Quote(resultSelector) }
-                    ));
+                    CachedReflectionInfo.GroupBy_TSource_TKey_TElement_TResult_4(typeof(TSource), typeof(TKey), typeof(TElement), typeof(TResult)), source.Expression, Expression.Quote(keySelector), Expression.Quote(elementSelector), Expression.Quote(resultSelector)));
         }
 
         public static IQueryable<TResult> GroupBy<TSource, TKey, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector, Expression<Func<TKey, IEnumerable<TSource>, TResult>> resultSelector)
@@ -578,9 +538,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.GroupBy_TSource_TKey_TResult_4(typeof(TSource), typeof(TKey), typeof(TResult)),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Quote(resultSelector), Expression.Constant(comparer, typeof(IEqualityComparer<TKey>)) }
-                    ));
+                    CachedReflectionInfo.GroupBy_TSource_TKey_TResult_4(typeof(TSource), typeof(TKey), typeof(TResult)), source.Expression, Expression.Quote(keySelector), Expression.Quote(resultSelector), Expression.Constant(comparer, typeof(IEqualityComparer<TKey>))));
         }
 
         public static IQueryable<TResult> GroupBy<TSource, TKey, TElement, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> keySelector, Expression<Func<TSource, TElement>> elementSelector, Expression<Func<TKey, IEnumerable<TElement>, TResult>> resultSelector, IEqualityComparer<TKey> comparer)
@@ -596,9 +554,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.GroupBy_TSource_TKey_TElement_TResult_5(typeof(TSource), typeof(TKey), typeof(TElement), typeof(TResult)),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Quote(elementSelector), Expression.Quote(resultSelector), Expression.Constant(comparer, typeof(IEqualityComparer<TKey>)) }
-                    ));
+                    CachedReflectionInfo.GroupBy_TSource_TKey_TElement_TResult_5(typeof(TSource), typeof(TKey), typeof(TElement), typeof(TResult)), source.Expression, Expression.Quote(keySelector), Expression.Quote(elementSelector), Expression.Quote(resultSelector), Expression.Constant(comparer, typeof(IEqualityComparer<TKey>))));
         }
 
         public static IQueryable<TSource> Distinct<TSource>(this IQueryable<TSource> source)
@@ -608,9 +564,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Distinct_TSource_1(typeof(TSource)),
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Distinct_TSource_1(typeof(TSource)), source.Expression));
         }
 
         public static IQueryable<TSource> Distinct<TSource>(this IQueryable<TSource> source, IEqualityComparer<TSource> comparer)
@@ -758,9 +712,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.First_TSource_1(typeof(TSource)),
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.First_TSource_1(typeof(TSource)), source.Expression));
         }
 
         public static TSource First<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
@@ -784,9 +736,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.FirstOrDefault_TSource_1(typeof(TSource)),
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.FirstOrDefault_TSource_1(typeof(TSource)), source.Expression));
         }
 
         public static TSource FirstOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
@@ -810,9 +760,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Last_TSource_1(typeof(TSource)),
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Last_TSource_1(typeof(TSource)), source.Expression));
         }
 
         public static TSource Last<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
@@ -836,9 +784,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.LastOrDefault_TSource_1(typeof(TSource)),
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.LastOrDefault_TSource_1(typeof(TSource)), source.Expression));
         }
 
         public static TSource LastOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
@@ -862,9 +808,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Single_TSource_1(typeof(TSource)),
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Single_TSource_1(typeof(TSource)), source.Expression));
         }
 
         public static TSource Single<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
@@ -888,9 +832,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.SingleOrDefault_TSource_1(typeof(TSource)),
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.SingleOrDefault_TSource_1(typeof(TSource)), source.Expression));
         }
 
         public static TSource SingleOrDefault<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
@@ -940,9 +882,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.DefaultIfEmpty_TSource_1(typeof(TSource)),
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.DefaultIfEmpty_TSource_1(typeof(TSource)), source.Expression));
         }
 
         public static IQueryable<TSource> DefaultIfEmpty<TSource>(this IQueryable<TSource> source, TSource defaultValue)
@@ -988,9 +928,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Reverse_TSource_1(typeof(TSource)),
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Reverse_TSource_1(typeof(TSource)), source.Expression));
         }
 
         public static bool SequenceEqual<TSource>(this IQueryable<TSource> source1, IEnumerable<TSource> source2)
@@ -1032,9 +970,7 @@ namespace System.Linq
             return source.Provider.Execute<bool>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Any_TSource_1(typeof(TSource)),
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Any_TSource_1(typeof(TSource)), source.Expression));
         }
 
         public static bool Any<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
@@ -1072,9 +1008,7 @@ namespace System.Linq
             return source.Provider.Execute<int>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Count_TSource_1(typeof(TSource)),
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Count_TSource_1(typeof(TSource)), source.Expression));
         }
 
         public static int Count<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
@@ -1098,9 +1032,7 @@ namespace System.Linq
             return source.Provider.Execute<long>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.LongCount_TSource_1(typeof(TSource)),
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.LongCount_TSource_1(typeof(TSource)), source.Expression));
         }
 
         public static long LongCount<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
@@ -1124,9 +1056,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Min_TSource_1(typeof(TSource)),
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Min_TSource_1(typeof(TSource)), source.Expression));
         }
 
         public static TResult Min<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector)
@@ -1150,9 +1080,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Max_TSource_1(typeof(TSource)),
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Max_TSource_1(typeof(TSource)), source.Expression));
         }
 
         public static TResult Max<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector)
@@ -1176,9 +1104,7 @@ namespace System.Linq
             return source.Provider.Execute<int>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Sum_Int32_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Sum_Int32_1, source.Expression));
         }
 
         public static int? Sum(this IQueryable<int?> source)
@@ -1188,9 +1114,7 @@ namespace System.Linq
             return source.Provider.Execute<int?>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Sum_NullableInt32_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Sum_NullableInt32_1, source.Expression));
         }
 
         public static long Sum(this IQueryable<long> source)
@@ -1200,9 +1124,7 @@ namespace System.Linq
             return source.Provider.Execute<long>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Sum_Int64_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Sum_Int64_1, source.Expression));
         }
 
         public static long? Sum(this IQueryable<long?> source)
@@ -1212,9 +1134,7 @@ namespace System.Linq
             return source.Provider.Execute<long?>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Sum_NullableInt64_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Sum_NullableInt64_1, source.Expression));
         }
 
         public static float Sum(this IQueryable<float> source)
@@ -1224,9 +1144,7 @@ namespace System.Linq
             return source.Provider.Execute<float>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Sum_Single_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Sum_Single_1, source.Expression));
         }
 
         public static float? Sum(this IQueryable<float?> source)
@@ -1236,9 +1154,7 @@ namespace System.Linq
             return source.Provider.Execute<float?>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Sum_NullableSingle_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Sum_NullableSingle_1, source.Expression));
         }
 
         public static double Sum(this IQueryable<double> source)
@@ -1248,9 +1164,7 @@ namespace System.Linq
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Sum_Double_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Sum_Double_1, source.Expression));
         }
 
         public static double? Sum(this IQueryable<double?> source)
@@ -1260,9 +1174,7 @@ namespace System.Linq
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Sum_NullableDouble_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Sum_NullableDouble_1, source.Expression));
         }
 
         public static decimal Sum(this IQueryable<decimal> source)
@@ -1272,9 +1184,7 @@ namespace System.Linq
             return source.Provider.Execute<decimal>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Sum_Decimal_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Sum_Decimal_1, source.Expression));
         }
 
         public static decimal? Sum(this IQueryable<decimal?> source)
@@ -1284,9 +1194,7 @@ namespace System.Linq
             return source.Provider.Execute<decimal?>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Sum_NullableDecimal_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Sum_NullableDecimal_1, source.Expression));
         }
 
         public static int Sum<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int>> selector)
@@ -1436,9 +1344,7 @@ namespace System.Linq
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Average_Int32_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Average_Int32_1, source.Expression));
         }
 
         public static double? Average(this IQueryable<int?> source)
@@ -1448,9 +1354,7 @@ namespace System.Linq
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Average_NullableInt32_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Average_NullableInt32_1, source.Expression));
         }
 
         public static double Average(this IQueryable<long> source)
@@ -1460,9 +1364,7 @@ namespace System.Linq
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Average_Int64_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Average_Int64_1, source.Expression));
         }
 
         public static double? Average(this IQueryable<long?> source)
@@ -1472,9 +1374,7 @@ namespace System.Linq
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Average_NullableInt64_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Average_NullableInt64_1, source.Expression));
         }
 
         public static float Average(this IQueryable<float> source)
@@ -1484,9 +1384,7 @@ namespace System.Linq
             return source.Provider.Execute<float>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Average_Single_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Average_Single_1, source.Expression));
         }
 
         public static float? Average(this IQueryable<float?> source)
@@ -1496,9 +1394,7 @@ namespace System.Linq
             return source.Provider.Execute<float?>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Average_NullableSingle_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Average_NullableSingle_1, source.Expression));
         }
 
         public static double Average(this IQueryable<double> source)
@@ -1508,9 +1404,7 @@ namespace System.Linq
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Average_Double_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Average_Double_1, source.Expression));
         }
 
         public static double? Average(this IQueryable<double?> source)
@@ -1520,9 +1414,7 @@ namespace System.Linq
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Average_NullableDouble_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Average_NullableDouble_1, source.Expression));
         }
 
         public static decimal Average(this IQueryable<decimal> source)
@@ -1532,9 +1424,7 @@ namespace System.Linq
             return source.Provider.Execute<decimal>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Average_Decimal_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Average_Decimal_1, source.Expression));
         }
 
         public static decimal? Average(this IQueryable<decimal?> source)
@@ -1544,9 +1434,7 @@ namespace System.Linq
             return source.Provider.Execute<decimal?>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Average_NullableDecimal_1,
-                    new Expression[] { source.Expression }
-                    ));
+                    CachedReflectionInfo.Average_NullableDecimal_1, source.Expression));
         }
 
         public static double Average<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int>> selector)
@@ -1728,9 +1616,7 @@ namespace System.Linq
             return source.Provider.Execute<TResult>(
                 Expression.Call(
                     null,
-                    CachedReflectionInfo.Aggregate_TSource_TAccumulate_TResult_4(typeof(TSource), typeof(TAccumulate), typeof(TResult)),
-                    new Expression[] { source.Expression, Expression.Constant(seed), Expression.Quote(func), Expression.Quote(selector) }
-                    ));
+                    CachedReflectionInfo.Aggregate_TSource_TAccumulate_TResult_4(typeof(TSource), typeof(TAccumulate), typeof(TResult)), source.Expression, Expression.Constant(seed), Expression.Quote(func), Expression.Quote(selector)));
         }
     }
 }

--- a/src/System.Linq.Queryable/src/System/Linq/Queryable.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/Queryable.cs
@@ -40,7 +40,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Where_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(predicate) }
+                    source.Expression, Expression.Quote(predicate)
                     ));
         }
 
@@ -54,7 +54,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Where_Index_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(predicate) }
+                    source.Expression, Expression.Quote(predicate)
                     ));
         }
 
@@ -88,7 +88,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Select_TSource_TResult_2(typeof(TSource), typeof(TResult)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -102,7 +102,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Select_Index_TSource_TResult_2(typeof(TSource), typeof(TResult)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -116,7 +116,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.SelectMany_TSource_TResult_2(typeof(TSource), typeof(TResult)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -130,7 +130,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.SelectMany_Index_TSource_TResult_2(typeof(TSource), typeof(TResult)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -146,7 +146,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.SelectMany_Index_TSource_TCollection_TResult_3(typeof(TSource), typeof(TCollection), typeof(TResult)),
-                    new Expression[] { source.Expression, Expression.Quote(collectionSelector), Expression.Quote(resultSelector) }
+                    source.Expression, Expression.Quote(collectionSelector), Expression.Quote(resultSelector)
                     ));
         }
 
@@ -162,7 +162,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.SelectMany_TSource_TCollection_TResult_3(typeof(TSource), typeof(TCollection), typeof(TResult)),
-                    new Expression[] { source.Expression, Expression.Quote(collectionSelector), Expression.Quote(resultSelector) }
+                    source.Expression, Expression.Quote(collectionSelector), Expression.Quote(resultSelector)
                     ));
         }
 
@@ -255,7 +255,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.OrderBy_TSource_TKey_2(typeof(TSource), typeof(TKey)),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector) }
+                    source.Expression, Expression.Quote(keySelector)
                     ));
         }
 
@@ -269,7 +269,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.OrderBy_TSource_TKey_3(typeof(TSource), typeof(TKey)),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Constant(comparer, typeof(IComparer<TKey>)) }
+                    source.Expression, Expression.Quote(keySelector), Expression.Constant(comparer, typeof(IComparer<TKey>))
                     ));
         }
 
@@ -283,7 +283,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.OrderByDescending_TSource_TKey_2(typeof(TSource), typeof(TKey)),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector) }
+                    source.Expression, Expression.Quote(keySelector)
                     ));
         }
 
@@ -297,7 +297,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.OrderByDescending_TSource_TKey_3(typeof(TSource), typeof(TKey)),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Constant(comparer, typeof(IComparer<TKey>)) }
+                    source.Expression, Expression.Quote(keySelector), Expression.Constant(comparer, typeof(IComparer<TKey>))
                     ));
         }
 
@@ -311,7 +311,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.ThenBy_TSource_TKey_2(typeof(TSource), typeof(TKey)),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector) }
+                    source.Expression, Expression.Quote(keySelector)
                     ));
         }
 
@@ -325,7 +325,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.ThenBy_TSource_TKey_3(typeof(TSource), typeof(TKey)),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Constant(comparer, typeof(IComparer<TKey>)) }
+                    source.Expression, Expression.Quote(keySelector), Expression.Constant(comparer, typeof(IComparer<TKey>))
                     ));
         }
 
@@ -339,7 +339,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.ThenByDescending_TSource_TKey_2(typeof(TSource), typeof(TKey)),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector) }
+                    source.Expression, Expression.Quote(keySelector)
                     ));
         }
 
@@ -353,7 +353,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.ThenByDescending_TSource_TKey_3(typeof(TSource), typeof(TKey)),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Constant(comparer, typeof(IComparer<TKey>)) }
+                    source.Expression, Expression.Quote(keySelector), Expression.Constant(comparer, typeof(IComparer<TKey>))
                     ));
         }
 
@@ -365,7 +365,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Take_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Constant(count) }
+                    source.Expression, Expression.Constant(count)
                     ));
         }
 
@@ -379,7 +379,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.TakeWhile_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(predicate) }
+                    source.Expression, Expression.Quote(predicate)
                     ));
         }
 
@@ -393,7 +393,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.TakeWhile_Index_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(predicate) }
+                    source.Expression, Expression.Quote(predicate)
                     ));
         }
 
@@ -405,7 +405,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Skip_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Constant(count) }
+                    source.Expression, Expression.Constant(count)
                     ));
         }
 
@@ -419,7 +419,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.SkipWhile_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(predicate) }
+                    source.Expression, Expression.Quote(predicate)
                     ));
         }
 
@@ -433,7 +433,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.SkipWhile_Index_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(predicate) }
+                    source.Expression, Expression.Quote(predicate)
                     ));
         }
 
@@ -447,7 +447,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.GroupBy_TSource_TKey_2(typeof(TSource), typeof(TKey)),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector) }
+                    source.Expression, Expression.Quote(keySelector)
                     ));
         }
 
@@ -463,7 +463,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.GroupBy_TSource_TKey_TElement_3(typeof(TSource), typeof(TKey), typeof(TElement)),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Quote(elementSelector) }
+                    source.Expression, Expression.Quote(keySelector), Expression.Quote(elementSelector)
                     ));
         }
 
@@ -477,7 +477,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.GroupBy_TSource_TKey_3(typeof(TSource), typeof(TKey)),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Constant(comparer, typeof(IEqualityComparer<TKey>)) }
+                    source.Expression, Expression.Quote(keySelector), Expression.Constant(comparer, typeof(IEqualityComparer<TKey>))
                     ));
         }
 
@@ -523,7 +523,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.GroupBy_TSource_TKey_TResult_3(typeof(TSource), typeof(TKey), typeof(TResult)),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Quote(resultSelector) }
+                    source.Expression, Expression.Quote(keySelector), Expression.Quote(resultSelector)
                     ));
         }
 
@@ -575,7 +575,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Distinct_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Constant(comparer, typeof(IEqualityComparer<TSource>)) }
+                    source.Expression, Expression.Constant(comparer, typeof(IEqualityComparer<TSource>))
                     ));
         }
 
@@ -589,7 +589,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Concat_TSource_2(typeof(TSource)),
-                    new Expression[] { source1.Expression, GetSourceExpression(source2) }
+                    source1.Expression, GetSourceExpression(source2)
                     ));
         }
 
@@ -605,7 +605,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Zip_TFirst_TSecond_TResult_3(typeof(TFirst), typeof(TSecond), typeof(TResult)),
-                    new Expression[] { source1.Expression, GetSourceExpression(source2), Expression.Quote(resultSelector) }
+                    source1.Expression, GetSourceExpression(source2), Expression.Quote(resultSelector)
                     ));
         }
 
@@ -619,7 +619,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Union_TSource_2(typeof(TSource)),
-                    new Expression[] { source1.Expression, GetSourceExpression(source2) }
+                    source1.Expression, GetSourceExpression(source2)
                     ));
         }
 
@@ -633,11 +633,9 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Union_TSource_3(typeof(TSource)),
-                    new Expression[] {
-                        source1.Expression,
-                        GetSourceExpression(source2),
-                        Expression.Constant(comparer, typeof(IEqualityComparer<TSource>))
-                        }
+                    source1.Expression,
+                    GetSourceExpression(source2),
+                    Expression.Constant(comparer, typeof(IEqualityComparer<TSource>))
                     ));
         }
 
@@ -651,7 +649,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Intersect_TSource_2(typeof(TSource)),
-                    new Expression[] { source1.Expression, GetSourceExpression(source2) }
+                    source1.Expression, GetSourceExpression(source2)
                     ));
         }
 
@@ -665,11 +663,9 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Intersect_TSource_3(typeof(TSource)),
-                    new Expression[] {
-                        source1.Expression,
-                        GetSourceExpression(source2),
-                        Expression.Constant(comparer, typeof(IEqualityComparer<TSource>))
-                        }
+                    source1.Expression,
+                    GetSourceExpression(source2),
+                    Expression.Constant(comparer, typeof(IEqualityComparer<TSource>))
                     ));
         }
 
@@ -683,7 +679,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Except_TSource_2(typeof(TSource)),
-                    new Expression[] { source1.Expression, GetSourceExpression(source2) }
+                    source1.Expression, GetSourceExpression(source2)
                     ));
         }
 
@@ -697,11 +693,9 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Except_TSource_3(typeof(TSource)),
-                    new Expression[] {
-                        source1.Expression,
-                        GetSourceExpression(source2),
-                        Expression.Constant(comparer, typeof(IEqualityComparer<TSource>))
-                        }
+                    source1.Expression,
+                    GetSourceExpression(source2),
+                    Expression.Constant(comparer, typeof(IEqualityComparer<TSource>))
                     ));
         }
 
@@ -725,7 +719,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.First_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(predicate) }
+                    source.Expression, Expression.Quote(predicate)
                     ));
         }
 
@@ -749,7 +743,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.FirstOrDefault_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(predicate) }
+                    source.Expression, Expression.Quote(predicate)
                     ));
         }
 
@@ -773,7 +767,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Last_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(predicate) }
+                    source.Expression, Expression.Quote(predicate)
                     ));
         }
 
@@ -797,7 +791,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.LastOrDefault_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(predicate) }
+                    source.Expression, Expression.Quote(predicate)
                     ));
         }
 
@@ -821,7 +815,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Single_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(predicate) }
+                    source.Expression, Expression.Quote(predicate)
                     ));
         }
 
@@ -845,7 +839,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.SingleOrDefault_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(predicate) }
+                    source.Expression, Expression.Quote(predicate)
                     ));
         }
 
@@ -859,7 +853,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.ElementAt_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Constant(index) }
+                    source.Expression, Expression.Constant(index)
                     ));
         }
 
@@ -871,7 +865,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.ElementAtOrDefault_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Constant(index) }
+                    source.Expression, Expression.Constant(index)
                     ));
         }
 
@@ -893,7 +887,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.DefaultIfEmpty_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Constant(defaultValue, typeof(TSource)) }
+                    source.Expression, Expression.Constant(defaultValue, typeof(TSource))
                     ));
         }
 
@@ -905,7 +899,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Contains_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Constant(item, typeof(TSource)) }
+                    source.Expression, Expression.Constant(item, typeof(TSource))
                     ));
         }
 
@@ -917,7 +911,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Contains_TSource_3(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Constant(item, typeof(TSource)), Expression.Constant(comparer, typeof(IEqualityComparer<TSource>)) }
+                    source.Expression, Expression.Constant(item, typeof(TSource)), Expression.Constant(comparer, typeof(IEqualityComparer<TSource>))
                     ));
         }
 
@@ -941,7 +935,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.SequenceEqual_TSource_2(typeof(TSource)),
-                    new Expression[] { source1.Expression, GetSourceExpression(source2) }
+                    source1.Expression, GetSourceExpression(source2)
                     ));
         }
 
@@ -955,11 +949,9 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.SequenceEqual_TSource_3(typeof(TSource)),
-                    new Expression[] {
-                        source1.Expression,
-                        GetSourceExpression(source2),
-                        Expression.Constant(comparer, typeof(IEqualityComparer<TSource>))
-                        }
+                    source1.Expression,
+                    GetSourceExpression(source2),
+                    Expression.Constant(comparer, typeof(IEqualityComparer<TSource>))
                     ));
         }
 
@@ -983,7 +975,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Any_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(predicate) }
+                    source.Expression, Expression.Quote(predicate)
                     ));
         }
 
@@ -997,7 +989,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.All_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(predicate) }
+                    source.Expression, Expression.Quote(predicate)
                     ));
         }
 
@@ -1021,7 +1013,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Count_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(predicate) }
+                    source.Expression, Expression.Quote(predicate)
                     ));
         }
 
@@ -1045,7 +1037,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.LongCount_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(predicate) }
+                    source.Expression, Expression.Quote(predicate)
                     ));
         }
 
@@ -1069,7 +1061,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Min_TSource_TResult_2(typeof(TSource), typeof(TResult)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1093,7 +1085,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Max_TSource_TResult_2(typeof(TSource), typeof(TResult)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1207,7 +1199,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Sum_Int32_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1221,7 +1213,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Sum_NullableInt32_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1235,7 +1227,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Sum_Int64_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1249,7 +1241,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Sum_NullableInt64_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1263,7 +1255,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Sum_Single_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1277,7 +1269,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Sum_NullableSingle_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1291,7 +1283,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Sum_Double_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1305,7 +1297,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Sum_NullableDouble_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1319,7 +1311,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Sum_Decimal_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1333,7 +1325,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Sum_NullableDecimal_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1447,7 +1439,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Average_Int32_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1461,7 +1453,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Average_NullableInt32_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1475,7 +1467,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Average_Single_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1489,7 +1481,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Average_NullableSingle_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1503,7 +1495,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Average_Int64_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1517,7 +1509,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Average_NullableInt64_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1531,7 +1523,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Average_Double_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1545,7 +1537,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Average_NullableDouble_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1559,7 +1551,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Average_Decimal_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1573,7 +1565,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Average_NullableDecimal_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
+                    source.Expression, Expression.Quote(selector)
                     ));
         }
 
@@ -1587,7 +1579,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Aggregate_TSource_2(typeof(TSource)),
-                    new Expression[] { source.Expression, Expression.Quote(func) }
+                    source.Expression, Expression.Quote(func)
                     ));
         }
 
@@ -1601,7 +1593,7 @@ namespace System.Linq
                 Expression.Call(
                     null,
                     CachedReflectionInfo.Aggregate_TSource_TAccumulate_3(typeof(TSource), typeof(TAccumulate)),
-                    new Expression[] { source.Expression, Expression.Constant(seed), Expression.Quote(func) }
+                    source.Expression, Expression.Constant(seed), Expression.Quote(func)
                     ));
         }
 

--- a/src/System.Linq.Queryable/src/System/Linq/Queryable.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/Queryable.cs
@@ -169,8 +169,7 @@ namespace System.Linq
         private static Expression GetSourceExpression<TSource>(IEnumerable<TSource> source)
         {
             IQueryable<TSource> q = source as IQueryable<TSource>;
-            if (q != null) return q.Expression;
-            return Expression.Constant(source, typeof(IEnumerable<TSource>));
+            return q != null ? q.Expression : Expression.Constant(source, typeof(IEnumerable<TSource>));
         }
 
         public static IQueryable<TResult> Join<TOuter, TInner, TKey, TResult>(this IQueryable<TOuter> outer, IEnumerable<TInner> inner, Expression<Func<TOuter, TKey>> outerKeySelector, Expression<Func<TInner, TKey>> innerKeySelector, Expression<Func<TOuter, TInner, TResult>> resultSelector)

--- a/src/System.Linq.Queryable/src/System/Linq/Strings.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/Strings.cs
@@ -9,29 +9,18 @@ namespace System.Linq
     /// </summary>
     internal static class Strings
     {
-        internal static string ArgumentNotIEnumerableGeneric(string message)
-        {
-            return SR.Format(SR.ArgumentNotIEnumerableGeneric, message);
-        }
+        internal static string ArgumentNotIEnumerableGeneric(string message) =>
+            SR.Format(SR.ArgumentNotIEnumerableGeneric, message);
 
-        internal static string ArgumentNotValid(string message)
-        {
-            return SR.Format(SR.ArgumentNotValid, message);
-        }
+        internal static string ArgumentNotValid(string message) =>
+            SR.Format(SR.ArgumentNotValid, message);
 
-        internal static string NoMethodOnType(string name, object type)
-        {
-            return SR.Format(SR.NoMethodOnType, name, type);
-        }
+        internal static string NoMethodOnType(string name, object type) =>
+            SR.Format(SR.NoMethodOnType, name, type);
 
-        internal static string NoMethodOnTypeMatchingArguments(string name, object type)
-        {
-            return SR.Format(SR.NoMethodOnTypeMatchingArguments, name, type);
-        }
+        internal static string NoMethodOnTypeMatchingArguments(string name, object type) =>
+            SR.Format(SR.NoMethodOnTypeMatchingArguments, name, type);
 
-        internal static string EnumeratingNullEnumerableExpression()
-        {
-            return SR.EnumeratingNullEnumerableExpression;
-        }
+        internal static string EnumeratingNullEnumerableExpression() => SR.EnumeratingNullEnumerableExpression;
     }
 }

--- a/src/System.Linq.Queryable/src/System/Linq/TypeHelper.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/TypeHelper.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Reflection;
-using System.Linq.Expressions;
 
 namespace System.Linq
 {

--- a/src/System.Linq.Queryable/src/System/Linq/TypeHelper.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/TypeHelper.cs
@@ -33,20 +33,6 @@ namespace System.Linq
             return null;
         }
 
-        internal static bool IsAssignableFrom(this Type source, Type destination)
-        {
-            return source.GetTypeInfo().IsAssignableFrom(destination.GetTypeInfo());
-        }
-
-        internal static Type[] GetGenericArguments(this Type type)
-        {
-            // Note that TypeInfo distinguishes between the type parameters of definitions 
-            // and the type arguments of instantiations, but we want to mimic the behavior
-            // of the old Type.GetGenericArguments() here.
-            TypeInfo t = type.GetTypeInfo();
-            return t.IsGenericTypeDefinition ? t.GenericTypeParameters : t.GenericTypeArguments;
-        }
-
         internal static IEnumerable<MethodInfo> GetStaticMethods(this Type type)
         {
             return type.GetRuntimeMethods().Where(m => m.IsStatic);

--- a/src/System.Linq.Queryable/tests/AggregateTests.cs
+++ b/src/System.Linq.Queryable/tests/AggregateTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq.Expressions;
 using Xunit;
 

--- a/src/System.Linq.Queryable/tests/AllTests.cs
+++ b/src/System.Linq.Queryable/tests/AllTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq.Expressions;
 using Xunit;
 

--- a/src/System.Linq.Queryable/tests/AnyTests.cs
+++ b/src/System.Linq.Queryable/tests/AnyTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq.Expressions;
 using Xunit;
 

--- a/src/System.Linq.Queryable/tests/AverageTests.cs
+++ b/src/System.Linq.Queryable/tests/AverageTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq.Expressions;
 using Xunit;
 

--- a/src/System.Linq.Queryable/tests/CastTests.cs
+++ b/src/System.Linq.Queryable/tests/CastTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Tests

--- a/src/System.Linq.Queryable/tests/ConcatTests.cs
+++ b/src/System.Linq.Queryable/tests/ConcatTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Tests

--- a/src/System.Linq.Queryable/tests/ContainsTests.cs
+++ b/src/System.Linq.Queryable/tests/ContainsTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/System.Linq.Queryable/tests/CountTests.cs
+++ b/src/System.Linq.Queryable/tests/CountTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq.Expressions;
 using Xunit;
 

--- a/src/System.Linq.Queryable/tests/DefaultIfEmptyTests.cs
+++ b/src/System.Linq.Queryable/tests/DefaultIfEmptyTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Tests

--- a/src/System.Linq.Queryable/tests/DistinctTests.cs
+++ b/src/System.Linq.Queryable/tests/DistinctTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/System.Linq.Queryable/tests/ElementAtOrDefaultTests.cs
+++ b/src/System.Linq.Queryable/tests/ElementAtOrDefaultTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Tests

--- a/src/System.Linq.Queryable/tests/ElementAtTests.cs
+++ b/src/System.Linq.Queryable/tests/ElementAtTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Tests

--- a/src/System.Linq.Queryable/tests/EnumerableQueryTests.cs
+++ b/src/System.Linq.Queryable/tests/EnumerableQueryTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections;
 using System.Linq.Expressions;

--- a/src/System.Linq.Queryable/tests/EnumerableTests.cs
+++ b/src/System.Linq.Queryable/tests/EnumerableTests.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using System.Collections.Generic;
-using Xunit;
-using Xunit.Extensions;
 
 namespace System.Linq.Tests
 {

--- a/src/System.Linq.Queryable/tests/ExceptTests.cs
+++ b/src/System.Linq.Queryable/tests/ExceptTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/System.Linq.Queryable/tests/FirstOrDefaultTests.cs
+++ b/src/System.Linq.Queryable/tests/FirstOrDefaultTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq.Expressions;
 using Xunit;
 

--- a/src/System.Linq.Queryable/tests/FirstTests.cs
+++ b/src/System.Linq.Queryable/tests/FirstTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq.Expressions;
 using Xunit;
 

--- a/src/System.Linq.Queryable/tests/GroupByTests.cs
+++ b/src/System.Linq.Queryable/tests/GroupByTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Xunit;

--- a/src/System.Linq.Queryable/tests/GroupJoinTests.cs
+++ b/src/System.Linq.Queryable/tests/GroupJoinTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Xunit;

--- a/src/System.Linq.Queryable/tests/IntersectTests.cs
+++ b/src/System.Linq.Queryable/tests/IntersectTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/System.Linq.Queryable/tests/JoinTests.cs
+++ b/src/System.Linq.Queryable/tests/JoinTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Xunit;

--- a/src/System.Linq.Queryable/tests/LastOrDefaultTests.cs
+++ b/src/System.Linq.Queryable/tests/LastOrDefaultTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq.Expressions;
 using Xunit;
 

--- a/src/System.Linq.Queryable/tests/LastTests.cs
+++ b/src/System.Linq.Queryable/tests/LastTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq.Expressions;
 using Xunit;
 

--- a/src/System.Linq.Queryable/tests/LongCountTests.cs
+++ b/src/System.Linq.Queryable/tests/LongCountTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq.Expressions;
 using Xunit;
 

--- a/src/System.Linq.Queryable/tests/OfTypeTests.cs
+++ b/src/System.Linq.Queryable/tests/OfTypeTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Tests

--- a/src/System.Linq.Queryable/tests/OrderByDescendingTests.cs
+++ b/src/System.Linq.Queryable/tests/OrderByDescendingTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Xunit;

--- a/src/System.Linq.Queryable/tests/OrderByTests.cs
+++ b/src/System.Linq.Queryable/tests/OrderByTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Xunit;

--- a/src/System.Linq.Queryable/tests/QueryFromExpressionTests.cs
+++ b/src/System.Linq.Queryable/tests/QueryFromExpressionTests.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Tests

--- a/src/System.Linq.Queryable/tests/SelectManyTests.cs
+++ b/src/System.Linq.Queryable/tests/SelectManyTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Xunit;

--- a/src/System.Linq.Queryable/tests/SequenceEqualTests.cs
+++ b/src/System.Linq.Queryable/tests/SequenceEqualTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/System.Linq.Queryable/tests/SingleOrDefaultTests.cs
+++ b/src/System.Linq.Queryable/tests/SingleOrDefaultTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq.Expressions;
 using Xunit;
 

--- a/src/System.Linq.Queryable/tests/SumTests.cs
+++ b/src/System.Linq.Queryable/tests/SumTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Linq.Expressions;
 using Xunit;
 

--- a/src/System.Linq.Queryable/tests/TakeTests.cs
+++ b/src/System.Linq.Queryable/tests/TakeTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Tests

--- a/src/System.Linq.Queryable/tests/ThenByTests.cs
+++ b/src/System.Linq.Queryable/tests/ThenByTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Xunit;

--- a/src/System.Linq.Queryable/tests/ZipTests.cs
+++ b/src/System.Linq.Queryable/tests/ZipTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq.Expressions;
 using Xunit;
 


### PR DESCRIPTION
Some cutting out paths or otherwise giving a practical improvement, some just style.

**Improvements first**:

Remove method calls where value is unused.

Remove explicit array on params calls. In most cases this results in picking a lighter overload.

Remove unnecessary volatility. If racing threads compete on reading or writing s_seqMethods the
result either way is they use a valid lookup correctly. Avoid the cost of volatile reads subsequently.

Make init-only fields readonly and static-only class static. Null-propagate.

Cache enumerable likely to be enumerated twice in a list.

**More stylistic than impacting**:

Remove redundant this.

Remove redundant class name on static.

Name type parameter according to convention (and interface implemented)

Remove redundant cast.

Simple properties to expression bodies.

Remove redundant interface supertypes

Remove redundant name in anonymous.