### PR TITLE
Implement HandleCount on Unix systems

### DIFF
--- a/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
+++ b/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
@@ -18,6 +18,7 @@ internal static partial class Interop
         internal const string ProcUptimeFilePath = RootPath + "uptime";
         private const string StatFileName = "/stat";
         private const string MapsFileName = "/maps";
+        private const string FileDescriptorDirectoryName = "/fd/";
         private const string TaskDirectoryName = "/task/";
 
         internal struct ParsedStat
@@ -92,6 +93,11 @@ internal static partial class Interop
         internal static string GetTaskDirectoryPathForProcess(int pid)
         {
             return RootPath + pid.ToString(CultureInfo.InvariantCulture) + TaskDirectoryName;
+        }
+
+        internal static string GetFileDescriptorDirectoryPathForProcess(int pid)
+        {
+            return RootPath + pid.ToString(CultureInfo.InvariantCulture) + FileDescriptorDirectoryName;
         }
 
         internal static IEnumerable<ParsedMapsModule> ParseMapsModules(int pid)

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
@@ -87,10 +87,16 @@ namespace System.Diagnostics
         {
             if (_processInfo.HandleCount <= 0 && _haveProcessId)
             {
-                string path = "/proc/" + _processId.ToString() + "/fd";
+                string path = Interop.procfs.GetFileDescriptorDirectoryPathForProcess(_processId);
                 if (Directory.Exists(path))
                 {
-                    _processInfo.HandleCount = Directory.GetFiles(path, "*", SearchOption.TopDirectoryOnly).Length;
+                    try
+                    {
+                        _processInfo.HandleCount = Directory.GetFiles(path, "*", SearchOption.TopDirectoryOnly).Length;
+                    }
+                    catch (DirectoryNotFoundException) // Occurs when the process is deleted between the Exists check and the GetFiles call.
+                    {
+                    }
                 }
             }
         }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
@@ -83,6 +83,18 @@ namespace System.Diagnostics
             }
         }
 
+        partial void EnsureHandleCountPopulated()
+        {
+            if (_processInfo.HandleCount <= 0 && _haveProcessId)
+            {
+                string path = "/proc/" + _processId.ToString() + "/fd";
+                if (Directory.Exists(path))
+                {
+                    _processInfo.HandleCount = Directory.GetFiles(path, "*", SearchOption.TopDirectoryOnly).Length;
+                }
+            }
+        }
+
         /// <summary>
         /// Gets or sets which processors the threads in this process can be scheduled to run on.
         /// </summary>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -604,10 +604,12 @@ namespace System.Diagnostics
             get
             {
                 EnsureState(State.HaveProcessInfo);
+                EnsureHandleCountPopulated();
                 return _processInfo.HandleCount;
             }
         }
 
+        partial void EnsureHandleCountPopulated();
 
         public long VirtualMemorySize64
         {

--- a/src/System.Diagnostics.Process/tests/ProcessTests.netstandard1.7.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.netstandard1.7.cs
@@ -42,19 +42,19 @@ namespace System.Diagnostics.Tests
             RemoteInvoke(() =>
             {
                 Process p = Process.GetCurrentProcess();
-                int firstHandleCount = p.HandleCount;
-                var fs1 = File.Open(Path.Combine(Path.GetTempPath(), Path.GetTempFileName()), FileMode.OpenOrCreate);
-                var fs2 = File.Open(Path.Combine(Path.GetTempPath(), Path.GetTempFileName()), FileMode.OpenOrCreate);
-                var fs3 = File.Open(Path.Combine(Path.GetTempPath(), Path.GetTempFileName()), FileMode.OpenOrCreate);
-                p.Refresh();
-                int secondHandleCount = p.HandleCount;
-                Assert.True(firstHandleCount < secondHandleCount);
-                fs1.Dispose();
-                fs2.Dispose();
-                fs3.Dispose();
+                int handleCount = p.HandleCount;
+                using (var fs1 = File.Open(Path.Combine(Path.GetTempPath(), Path.GetTempFileName()), FileMode.OpenOrCreate))
+                using (var fs2 = File.Open(Path.Combine(Path.GetTempPath(), Path.GetTempFileName()), FileMode.OpenOrCreate))
+                using (var fs3 = File.Open(Path.Combine(Path.GetTempPath(), Path.GetTempFileName()), FileMode.OpenOrCreate))
+                {
+                    p.Refresh();
+                    int secondHandleCount = p.HandleCount;
+                    Assert.True(handleCount < secondHandleCount);
+                    handleCount = secondHandleCount;
+                }
                 p.Refresh();
                 int thirdHandleCount = p.HandleCount;
-                Assert.True(thirdHandleCount < secondHandleCount);
+                Assert.True(thirdHandleCount < handleCount);
                 return SuccessExitCode;
             }).Dispose();
         }


### PR DESCRIPTION
HandleCount is implemented on Linux by doing an on-demand enumeration of /proc/pid/fd. On OSX it is done by enumerating /dev/fd which is equivalent to /proc/self/fd. The HandleCount test is also enabled for all platforms.

I went back and forth on whether to add caching to the directory enumeration. Adding it would more closely mirror the Windows behavior, but since we're getting the HandleCount on-demand anyways I'm not certain it's worthwhile.

resolves https://github.com/dotnet/corefx/issues/12793


@stephentoub 