### PR TITLE
Use cached reflection for Queryable methods

### DIFF
--- a/src/System.Linq.Queryable/src/System.Linq.Queryable.csproj
+++ b/src/System.Linq.Queryable/src/System.Linq.Queryable.csproj
@@ -16,6 +16,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+    <Compile Include="System\Linq\CachedReflection.cs" />
     <Compile Include="System\Linq\EnumerableExecutor.cs" />
     <Compile Include="System\Linq\EnumerableQuery.cs" />
     <Compile Include="System\Linq\EnumerableRewriter.cs" />

--- a/src/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
@@ -1,0 +1,862 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace System.Linq
+{
+    internal static class CachedReflectionInfo
+    {
+        private static MethodInfo s_Aggregate_TSource_2;
+
+        public static MethodInfo Aggregate_TSource_2(Type TSource) =>
+             (s_Aggregate_TSource_2 ??
+             (s_Aggregate_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object, object>>, object>(Queryable.Aggregate<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Aggregate_TSource_TAccumulate_3;
+
+        public static MethodInfo Aggregate_TSource_TAccumulate_3(Type TSource, Type TAccumulate) =>
+             (s_Aggregate_TSource_TAccumulate_3 ??
+             (s_Aggregate_TSource_TAccumulate_3 = GetMethodInfoOf<IQueryable<object>, object, Expression<Func<object, object, object>>, object>(Queryable.Aggregate<object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TAccumulate);
+
+        private static MethodInfo s_Aggregate_TSource_TAccumulate_TResult_4;
+
+        public static MethodInfo Aggregate_TSource_TAccumulate_TResult_4(Type TSource, Type TAccumulate, Type TResult) =>
+             (s_Aggregate_TSource_TAccumulate_TResult_4 ??
+             (s_Aggregate_TSource_TAccumulate_TResult_4 = GetMethodInfoOf<IQueryable<object>, object, Expression<Func<object, object, object>>, Expression<Func<object, object>>, object>(Queryable.Aggregate<object, object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TAccumulate, TResult);
+
+        private static MethodInfo s_All_TSource_2;
+
+        public static MethodInfo All_TSource_2(Type TSource) =>
+             (s_All_TSource_2 ??
+             (s_All_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, bool>(Queryable.All<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Any_TSource_1;
+
+        public static MethodInfo Any_TSource_1(Type TSource) =>
+             (s_Any_TSource_1 ??
+             (s_Any_TSource_1 = GetMethodInfoOf<IQueryable<object>, bool>(Queryable.Any<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Any_TSource_2;
+
+        public static MethodInfo Any_TSource_2(Type TSource) =>
+             (s_Any_TSource_2 ??
+             (s_Any_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, bool>(Queryable.Any<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_AsQueryable_1;
+
+        public static MethodInfo AsQueryable_1 =>
+             s_AsQueryable_1 ??
+            (s_AsQueryable_1 = GetMethodInfoOf<IEnumerable, IQueryable>(Queryable.AsQueryable));
+
+        private static MethodInfo s_AsQueryable_TElement_1;
+
+        public static MethodInfo AsQueryable_TElement_1(Type TElement) =>
+             (s_AsQueryable_TElement_1 ??
+             (s_AsQueryable_TElement_1 = GetMethodInfoOf<IEnumerable<object>, IQueryable<object>>(Queryable.AsQueryable<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TElement);
+
+        private static MethodInfo s_Average_Int32_1;
+
+        public static MethodInfo Average_Int32_1 =>
+             s_Average_Int32_1 ??
+            (s_Average_Int32_1 = GetMethodInfoOf<IQueryable<int>, double>(Queryable.Average));
+
+        private static MethodInfo s_Average_NullableInt32_1;
+
+        public static MethodInfo Average_NullableInt32_1 =>
+             s_Average_NullableInt32_1 ??
+            (s_Average_NullableInt32_1 = GetMethodInfoOf<IQueryable<int?>, double?>(Queryable.Average));
+
+        private static MethodInfo s_Average_Int64_1;
+
+        public static MethodInfo Average_Int64_1 =>
+             s_Average_Int64_1 ??
+            (s_Average_Int64_1 = GetMethodInfoOf<IQueryable<long>, double>(Queryable.Average));
+
+        private static MethodInfo s_Average_NullableInt64_1;
+
+        public static MethodInfo Average_NullableInt64_1 =>
+             s_Average_NullableInt64_1 ??
+            (s_Average_NullableInt64_1 = GetMethodInfoOf<IQueryable<long?>, double?>(Queryable.Average));
+
+        private static MethodInfo s_Average_Single_1;
+
+        public static MethodInfo Average_Single_1 =>
+             s_Average_Single_1 ??
+            (s_Average_Single_1 = GetMethodInfoOf<IQueryable<float>, float>(Queryable.Average));
+
+        private static MethodInfo s_Average_NullableSingle_1;
+
+        public static MethodInfo Average_NullableSingle_1 =>
+             s_Average_NullableSingle_1 ??
+            (s_Average_NullableSingle_1 = GetMethodInfoOf<IQueryable<float?>, float?>(Queryable.Average));
+
+        private static MethodInfo s_Average_Double_1;
+
+        public static MethodInfo Average_Double_1 =>
+             s_Average_Double_1 ??
+            (s_Average_Double_1 = GetMethodInfoOf<IQueryable<double>, double>(Queryable.Average));
+
+        private static MethodInfo s_Average_NullableDouble_1;
+
+        public static MethodInfo Average_NullableDouble_1 =>
+             s_Average_NullableDouble_1 ??
+            (s_Average_NullableDouble_1 = GetMethodInfoOf<IQueryable<double?>, double?>(Queryable.Average));
+
+        private static MethodInfo s_Average_Decimal_1;
+
+        public static MethodInfo Average_Decimal_1 =>
+             s_Average_Decimal_1 ??
+            (s_Average_Decimal_1 = GetMethodInfoOf<IQueryable<decimal>, decimal>(Queryable.Average));
+
+        private static MethodInfo s_Average_NullableDecimal_1;
+
+        public static MethodInfo Average_NullableDecimal_1 =>
+             s_Average_NullableDecimal_1 ??
+            (s_Average_NullableDecimal_1 = GetMethodInfoOf<IQueryable<decimal?>, decimal?>(Queryable.Average));
+
+        private static MethodInfo s_Average_Int32_TSource_2;
+
+        public static MethodInfo Average_Int32_TSource_2(Type TSource) =>
+             (s_Average_Int32_TSource_2 ??
+             (s_Average_Int32_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int>>, double>(Queryable.Average<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Average_NullableInt32_TSource_2;
+
+        public static MethodInfo Average_NullableInt32_TSource_2(Type TSource) =>
+             (s_Average_NullableInt32_TSource_2 ??
+             (s_Average_NullableInt32_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int?>>, double?>(Queryable.Average<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Average_Single_TSource_2;
+
+        public static MethodInfo Average_Single_TSource_2(Type TSource) =>
+             (s_Average_Single_TSource_2 ??
+             (s_Average_Single_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, float>>, float>(Queryable.Average<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Average_NullableSingle_TSource_2;
+
+        public static MethodInfo Average_NullableSingle_TSource_2(Type TSource) =>
+             (s_Average_NullableSingle_TSource_2 ??
+             (s_Average_NullableSingle_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, float?>>, float?>(Queryable.Average<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Average_Int64_TSource_2;
+
+        public static MethodInfo Average_Int64_TSource_2(Type TSource) =>
+             (s_Average_Int64_TSource_2 ??
+             (s_Average_Int64_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, long>>, double>(Queryable.Average<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Average_NullableInt64_TSource_2;
+
+        public static MethodInfo Average_NullableInt64_TSource_2(Type TSource) =>
+             (s_Average_NullableInt64_TSource_2 ??
+             (s_Average_NullableInt64_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, long?>>, double?>(Queryable.Average<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Average_Double_TSource_2;
+
+        public static MethodInfo Average_Double_TSource_2(Type TSource) =>
+             (s_Average_Double_TSource_2 ??
+             (s_Average_Double_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, double>>, double>(Queryable.Average<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Average_NullableDouble_TSource_2;
+
+        public static MethodInfo Average_NullableDouble_TSource_2(Type TSource) =>
+             (s_Average_NullableDouble_TSource_2 ??
+             (s_Average_NullableDouble_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, double?>>, double?>(Queryable.Average<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Average_Decimal_TSource_2;
+
+        public static MethodInfo Average_Decimal_TSource_2(Type TSource) =>
+             (s_Average_Decimal_TSource_2 ??
+             (s_Average_Decimal_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, decimal>>, decimal>(Queryable.Average<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Average_NullableDecimal_TSource_2;
+
+        public static MethodInfo Average_NullableDecimal_TSource_2(Type TSource) =>
+             (s_Average_NullableDecimal_TSource_2 ??
+             (s_Average_NullableDecimal_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, decimal?>>, decimal?>(Queryable.Average<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Cast_TResult_1;
+
+        public static MethodInfo Cast_TResult_1(Type TResult) =>
+             (s_Cast_TResult_1 ??
+             (s_Cast_TResult_1 = GetMethodInfoOf<IQueryable, IQueryable<object>>(Queryable.Cast<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TResult);
+
+        private static MethodInfo s_Concat_TSource_2;
+
+        public static MethodInfo Concat_TSource_2(Type TSource) =>
+             (s_Concat_TSource_2 ??
+             (s_Concat_TSource_2 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Concat<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Contains_TSource_2;
+
+        public static MethodInfo Contains_TSource_2(Type TSource) =>
+             (s_Contains_TSource_2 ??
+             (s_Contains_TSource_2 = GetMethodInfoOf<IQueryable<object>, object, bool>(Queryable.Contains<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Contains_TSource_3;
+
+        public static MethodInfo Contains_TSource_3(Type TSource) =>
+             (s_Contains_TSource_3 ??
+             (s_Contains_TSource_3 = GetMethodInfoOf<IQueryable<object>, object, IEqualityComparer<object>, bool>(Queryable.Contains<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Count_TSource_1;
+
+        public static MethodInfo Count_TSource_1(Type TSource) =>
+             (s_Count_TSource_1 ??
+             (s_Count_TSource_1 = GetMethodInfoOf<IQueryable<object>, int>(Queryable.Count<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Count_TSource_2;
+
+        public static MethodInfo Count_TSource_2(Type TSource) =>
+             (s_Count_TSource_2 ??
+             (s_Count_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, int>(Queryable.Count<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_DefaultIfEmpty_TSource_1;
+
+        public static MethodInfo DefaultIfEmpty_TSource_1(Type TSource) =>
+             (s_DefaultIfEmpty_TSource_1 ??
+             (s_DefaultIfEmpty_TSource_1 = GetMethodInfoOf<IQueryable<object>, IQueryable<object>>(Queryable.DefaultIfEmpty<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_DefaultIfEmpty_TSource_2;
+
+        public static MethodInfo DefaultIfEmpty_TSource_2(Type TSource) =>
+             (s_DefaultIfEmpty_TSource_2 ??
+             (s_DefaultIfEmpty_TSource_2 = GetMethodInfoOf<IQueryable<object>, object, IQueryable<object>>(Queryable.DefaultIfEmpty<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Distinct_TSource_1;
+
+        public static MethodInfo Distinct_TSource_1(Type TSource) =>
+             (s_Distinct_TSource_1 ??
+             (s_Distinct_TSource_1 = GetMethodInfoOf<IQueryable<object>, IQueryable<object>>(Queryable.Distinct<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Distinct_TSource_2;
+
+        public static MethodInfo Distinct_TSource_2(Type TSource) =>
+             (s_Distinct_TSource_2 ??
+             (s_Distinct_TSource_2 = GetMethodInfoOf<IQueryable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Distinct<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_ElementAt_TSource_2;
+
+        public static MethodInfo ElementAt_TSource_2(Type TSource) =>
+             (s_ElementAt_TSource_2 ??
+             (s_ElementAt_TSource_2 = GetMethodInfoOf<IQueryable<object>, int, object>(Queryable.ElementAt<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_ElementAtOrDefault_TSource_2;
+
+        public static MethodInfo ElementAtOrDefault_TSource_2(Type TSource) =>
+             (s_ElementAtOrDefault_TSource_2 ??
+             (s_ElementAtOrDefault_TSource_2 = GetMethodInfoOf<IQueryable<object>, int, object>(Queryable.ElementAtOrDefault<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Except_TSource_2;
+
+        public static MethodInfo Except_TSource_2(Type TSource) =>
+             (s_Except_TSource_2 ??
+             (s_Except_TSource_2 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Except<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Except_TSource_3;
+
+        public static MethodInfo Except_TSource_3(Type TSource) =>
+             (s_Except_TSource_3 ??
+             (s_Except_TSource_3 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Except<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_First_TSource_1;
+
+        public static MethodInfo First_TSource_1(Type TSource) =>
+             (s_First_TSource_1 ??
+             (s_First_TSource_1 = GetMethodInfoOf<IQueryable<object>, object>(Queryable.First<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_First_TSource_2;
+
+        public static MethodInfo First_TSource_2(Type TSource) =>
+             (s_First_TSource_2 ??
+             (s_First_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.First<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_FirstOrDefault_TSource_1;
+
+        public static MethodInfo FirstOrDefault_TSource_1(Type TSource) =>
+             (s_FirstOrDefault_TSource_1 ??
+             (s_FirstOrDefault_TSource_1 = GetMethodInfoOf<IQueryable<object>, object>(Queryable.FirstOrDefault<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_FirstOrDefault_TSource_2;
+
+        public static MethodInfo FirstOrDefault_TSource_2(Type TSource) =>
+             (s_FirstOrDefault_TSource_2 ??
+             (s_FirstOrDefault_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.FirstOrDefault<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_GroupBy_TSource_TKey_2;
+
+        public static MethodInfo GroupBy_TSource_TKey_2(Type TSource, Type TKey) =>
+             (s_GroupBy_TSource_TKey_2 ??
+             (s_GroupBy_TSource_TKey_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy<object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TKey);
+
+        private static MethodInfo s_GroupBy_TSource_TKey_3;
+
+        public static MethodInfo GroupBy_TSource_TKey_3(Type TSource, Type TKey) =>
+             (s_GroupBy_TSource_TKey_3 ??
+             (s_GroupBy_TSource_TKey_3 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, IEqualityComparer<object>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy<object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TKey);
+
+        private static MethodInfo s_GroupBy_TSource_TKey_TElement_3;
+
+        public static MethodInfo GroupBy_TSource_TKey_TElement_3(Type TSource, Type TKey, Type TElement) =>
+             (s_GroupBy_TSource_TKey_TElement_3 ??
+             (s_GroupBy_TSource_TKey_TElement_3 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy<object, object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TKey, TElement);
+
+        private static MethodInfo s_GroupBy_TSource_TKey_TElement_4;
+
+        public static MethodInfo GroupBy_TSource_TKey_TElement_4(Type TSource, Type TKey, Type TElement) =>
+             (s_GroupBy_TSource_TKey_TElement_4 ??
+             (s_GroupBy_TSource_TKey_TElement_4 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, IEqualityComparer<object>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy<object, object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TKey, TElement);
+
+        private static MethodInfo s_GroupBy_TSource_TKey_TResult_3;
+
+        public static MethodInfo GroupBy_TSource_TKey_TResult_3(Type TSource, Type TKey, Type TResult) =>
+             (s_GroupBy_TSource_TKey_TResult_3 ??
+             (s_GroupBy_TSource_TKey_TResult_3 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IQueryable<object>>(Queryable.GroupBy<object, object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TKey, TResult);
+
+        private static MethodInfo s_GroupBy_TSource_TKey_TResult_4;
+
+        public static MethodInfo GroupBy_TSource_TKey_TResult_4(Type TSource, Type TKey, Type TResult) =>
+             (s_GroupBy_TSource_TKey_TResult_4 ??
+             (s_GroupBy_TSource_TKey_TResult_4 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.GroupBy<object, object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TKey, TResult);
+
+        private static MethodInfo s_GroupBy_TSource_TKey_TElement_TResult_4;
+
+        public static MethodInfo GroupBy_TSource_TKey_TElement_TResult_4(Type TSource, Type TKey, Type TElement, Type TResult) =>
+             (s_GroupBy_TSource_TKey_TElement_TResult_4 ??
+             (s_GroupBy_TSource_TKey_TElement_TResult_4 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IQueryable<object>>(Queryable.GroupBy<object, object, object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TKey, TElement, TResult);
+
+        private static MethodInfo s_GroupBy_TSource_TKey_TElement_TResult_5;
+
+        public static MethodInfo GroupBy_TSource_TKey_TElement_TResult_5(Type TSource, Type TKey, Type TElement, Type TResult) =>
+             (s_GroupBy_TSource_TKey_TElement_TResult_5 ??
+             (s_GroupBy_TSource_TKey_TElement_TResult_5 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.GroupBy<object, object, object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TKey, TElement, TResult);
+
+        private static MethodInfo s_GroupJoin_TOuter_TInner_TKey_TResult_5;
+
+        public static MethodInfo GroupJoin_TOuter_TInner_TKey_TResult_5(Type TOuter, Type TInner, Type TKey, Type TResult) =>
+             (s_GroupJoin_TOuter_TInner_TKey_TResult_5 ??
+             (s_GroupJoin_TOuter_TInner_TKey_TResult_5 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IQueryable<object>>(Queryable.GroupJoin<object, object, object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TOuter, TInner, TKey, TResult);
+
+        private static MethodInfo s_GroupJoin_TOuter_TInner_TKey_TResult_6;
+
+        public static MethodInfo GroupJoin_TOuter_TInner_TKey_TResult_6(Type TOuter, Type TInner, Type TKey, Type TResult) =>
+             (s_GroupJoin_TOuter_TInner_TKey_TResult_6 ??
+             (s_GroupJoin_TOuter_TInner_TKey_TResult_6 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.GroupJoin<object, object, object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TOuter, TInner, TKey, TResult);
+
+        private static MethodInfo s_Intersect_TSource_2;
+
+        public static MethodInfo Intersect_TSource_2(Type TSource) =>
+             (s_Intersect_TSource_2 ??
+             (s_Intersect_TSource_2 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Intersect<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Intersect_TSource_3;
+
+        public static MethodInfo Intersect_TSource_3(Type TSource) =>
+             (s_Intersect_TSource_3 ??
+             (s_Intersect_TSource_3 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Intersect<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Join_TOuter_TInner_TKey_TResult_5;
+
+        public static MethodInfo Join_TOuter_TInner_TKey_TResult_5(Type TOuter, Type TInner, Type TKey, Type TResult) =>
+             (s_Join_TOuter_TInner_TKey_TResult_5 ??
+             (s_Join_TOuter_TInner_TKey_TResult_5 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.Join<object, object, object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TOuter, TInner, TKey, TResult);
+
+        private static MethodInfo s_Join_TOuter_TInner_TKey_TResult_6;
+
+        public static MethodInfo Join_TOuter_TInner_TKey_TResult_6(Type TOuter, Type TInner, Type TKey, Type TResult) =>
+             (s_Join_TOuter_TInner_TKey_TResult_6 ??
+             (s_Join_TOuter_TInner_TKey_TResult_6 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, object, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Join<object, object, object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TOuter, TInner, TKey, TResult);
+
+        private static MethodInfo s_Last_TSource_1;
+
+        public static MethodInfo Last_TSource_1(Type TSource) =>
+             (s_Last_TSource_1 ??
+             (s_Last_TSource_1 = GetMethodInfoOf<IQueryable<object>, object>(Queryable.Last<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Last_TSource_2;
+
+        public static MethodInfo Last_TSource_2(Type TSource) =>
+             (s_Last_TSource_2 ??
+             (s_Last_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.Last<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_LastOrDefault_TSource_1;
+
+        public static MethodInfo LastOrDefault_TSource_1(Type TSource) =>
+             (s_LastOrDefault_TSource_1 ??
+             (s_LastOrDefault_TSource_1 = GetMethodInfoOf<IQueryable<object>, object>(Queryable.LastOrDefault<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_LastOrDefault_TSource_2;
+
+        public static MethodInfo LastOrDefault_TSource_2(Type TSource) =>
+             (s_LastOrDefault_TSource_2 ??
+             (s_LastOrDefault_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.LastOrDefault<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_LongCount_TSource_1;
+
+        public static MethodInfo LongCount_TSource_1(Type TSource) =>
+             (s_LongCount_TSource_1 ??
+             (s_LongCount_TSource_1 = GetMethodInfoOf<IQueryable<object>, long>(Queryable.LongCount<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_LongCount_TSource_2;
+
+        public static MethodInfo LongCount_TSource_2(Type TSource) =>
+             (s_LongCount_TSource_2 ??
+             (s_LongCount_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, long>(Queryable.LongCount<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Max_TSource_1;
+
+        public static MethodInfo Max_TSource_1(Type TSource) =>
+             (s_Max_TSource_1 ??
+             (s_Max_TSource_1 = GetMethodInfoOf<IQueryable<object>, object>(Queryable.Max<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Max_TSource_TResult_2;
+
+        public static MethodInfo Max_TSource_TResult_2(Type TSource, Type TResult) =>
+             (s_Max_TSource_TResult_2 ??
+             (s_Max_TSource_TResult_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, object>(Queryable.Max<object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TResult);
+
+        private static MethodInfo s_Min_TSource_1;
+
+        public static MethodInfo Min_TSource_1(Type TSource) =>
+             (s_Min_TSource_1 ??
+             (s_Min_TSource_1 = GetMethodInfoOf<IQueryable<object>, object>(Queryable.Min<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Min_TSource_TResult_2;
+
+        public static MethodInfo Min_TSource_TResult_2(Type TSource, Type TResult) =>
+             (s_Min_TSource_TResult_2 ??
+             (s_Min_TSource_TResult_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, object>(Queryable.Min<object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TResult);
+
+        private static MethodInfo s_OfType_TResult_1;
+
+        public static MethodInfo OfType_TResult_1(Type TResult) =>
+             (s_OfType_TResult_1 ??
+             (s_OfType_TResult_1 = GetMethodInfoOf<IQueryable, IQueryable<object>>(Queryable.OfType<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TResult);
+
+        private static MethodInfo s_OrderBy_TSource_TKey_2;
+
+        public static MethodInfo OrderBy_TSource_TKey_2(Type TSource, Type TKey) =>
+             (s_OrderBy_TSource_TKey_2 ??
+             (s_OrderBy_TSource_TKey_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.OrderBy<object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TKey);
+
+        private static MethodInfo s_OrderBy_TSource_TKey_3;
+
+        public static MethodInfo OrderBy_TSource_TKey_3(Type TSource, Type TKey) =>
+             (s_OrderBy_TSource_TKey_3 ??
+             (s_OrderBy_TSource_TKey_3 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.OrderBy<object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TKey);
+
+        private static MethodInfo s_OrderByDescending_TSource_TKey_2;
+
+        public static MethodInfo OrderByDescending_TSource_TKey_2(Type TSource, Type TKey) =>
+             (s_OrderByDescending_TSource_TKey_2 ??
+             (s_OrderByDescending_TSource_TKey_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.OrderByDescending<object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TKey);
+
+        private static MethodInfo s_OrderByDescending_TSource_TKey_3;
+
+        public static MethodInfo OrderByDescending_TSource_TKey_3(Type TSource, Type TKey) =>
+             (s_OrderByDescending_TSource_TKey_3 ??
+             (s_OrderByDescending_TSource_TKey_3 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.OrderByDescending<object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TKey);
+
+        private static MethodInfo s_Reverse_TSource_1;
+
+        public static MethodInfo Reverse_TSource_1(Type TSource) =>
+             (s_Reverse_TSource_1 ??
+             (s_Reverse_TSource_1 = GetMethodInfoOf<IQueryable<object>, IQueryable<object>>(Queryable.Reverse<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Select_TSource_TResult_2;
+
+        public static MethodInfo Select_TSource_TResult_2(Type TSource, Type TResult) =>
+             (s_Select_TSource_TResult_2 ??
+             (s_Select_TSource_TResult_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, IQueryable<object>>(Queryable.Select<object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TResult);
+
+        private static MethodInfo s_Select_Index_TSource_TResult_2;
+
+        public static MethodInfo Select_Index_TSource_TResult_2(Type TSource, Type TResult) =>
+             (s_Select_Index_TSource_TResult_2 ??
+             (s_Select_Index_TSource_TResult_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int, object>>, IQueryable<object>>(Queryable.Select<object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TResult);
+
+        private static MethodInfo s_SelectMany_TSource_TResult_2;
+
+        public static MethodInfo SelectMany_TSource_TResult_2(Type TSource, Type TResult) =>
+             (s_SelectMany_TSource_TResult_2 ??
+             (s_SelectMany_TSource_TResult_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, IEnumerable<object>>>, IQueryable<object>>(Queryable.SelectMany<object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TResult);
+
+        private static MethodInfo s_SelectMany_Index_TSource_TResult_2;
+
+        public static MethodInfo SelectMany_Index_TSource_TResult_2(Type TSource, Type TResult) =>
+             (s_SelectMany_Index_TSource_TResult_2 ??
+             (s_SelectMany_Index_TSource_TResult_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int, IEnumerable<object>>>, IQueryable<object>>(Queryable.SelectMany<object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TResult);
+
+        private static MethodInfo s_SelectMany_Index_TSource_TCollection_TResult_3;
+
+        public static MethodInfo SelectMany_Index_TSource_TCollection_TResult_3(Type TSource, Type TCollection, Type TResult) =>
+             (s_SelectMany_Index_TSource_TCollection_TResult_3 ??
+             (s_SelectMany_Index_TSource_TCollection_TResult_3 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int, IEnumerable<object>>>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.SelectMany<object, object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TCollection, TResult);
+
+        private static MethodInfo s_SelectMany_TSource_TCollection_TResult_3;
+
+        public static MethodInfo SelectMany_TSource_TCollection_TResult_3(Type TSource, Type TCollection, Type TResult) =>
+             (s_SelectMany_TSource_TCollection_TResult_3 ??
+             (s_SelectMany_TSource_TCollection_TResult_3 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, IEnumerable<object>>>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.SelectMany<object, object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TCollection, TResult);
+
+        private static MethodInfo s_SequenceEqual_TSource_2;
+
+        public static MethodInfo SequenceEqual_TSource_2(Type TSource) =>
+             (s_SequenceEqual_TSource_2 ??
+             (s_SequenceEqual_TSource_2 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, bool>(Queryable.SequenceEqual<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_SequenceEqual_TSource_3;
+
+        public static MethodInfo SequenceEqual_TSource_3(Type TSource) =>
+             (s_SequenceEqual_TSource_3 ??
+             (s_SequenceEqual_TSource_3 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, bool>(Queryable.SequenceEqual<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Single_TSource_1;
+
+        public static MethodInfo Single_TSource_1(Type TSource) =>
+             (s_Single_TSource_1 ??
+             (s_Single_TSource_1 = GetMethodInfoOf<IQueryable<object>, object>(Queryable.Single<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Single_TSource_2;
+
+        public static MethodInfo Single_TSource_2(Type TSource) =>
+             (s_Single_TSource_2 ??
+             (s_Single_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.Single<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_SingleOrDefault_TSource_1;
+
+        public static MethodInfo SingleOrDefault_TSource_1(Type TSource) =>
+             (s_SingleOrDefault_TSource_1 ??
+             (s_SingleOrDefault_TSource_1 = GetMethodInfoOf<IQueryable<object>, object>(Queryable.SingleOrDefault<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_SingleOrDefault_TSource_2;
+
+        public static MethodInfo SingleOrDefault_TSource_2(Type TSource) =>
+             (s_SingleOrDefault_TSource_2 ??
+             (s_SingleOrDefault_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.SingleOrDefault<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Skip_TSource_2;
+
+        public static MethodInfo Skip_TSource_2(Type TSource) =>
+             (s_Skip_TSource_2 ??
+             (s_Skip_TSource_2 = GetMethodInfoOf<IQueryable<object>, int, IQueryable<object>>(Queryable.Skip<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_SkipWhile_TSource_2;
+
+        public static MethodInfo SkipWhile_TSource_2(Type TSource) =>
+             (s_SkipWhile_TSource_2 ??
+             (s_SkipWhile_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, IQueryable<object>>(Queryable.SkipWhile<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_SkipWhile_Index_TSource_2;
+
+        public static MethodInfo SkipWhile_Index_TSource_2(Type TSource) =>
+             (s_SkipWhile_Index_TSource_2 ??
+             (s_SkipWhile_Index_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int, bool>>, IQueryable<object>>(Queryable.SkipWhile<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Sum_Int32_1;
+
+        public static MethodInfo Sum_Int32_1 =>
+             s_Sum_Int32_1 ??
+            (s_Sum_Int32_1 = GetMethodInfoOf<IQueryable<int>, int>(Queryable.Sum));
+
+        private static MethodInfo s_Sum_NullableInt32_1;
+
+        public static MethodInfo Sum_NullableInt32_1 =>
+             s_Sum_NullableInt32_1 ??
+            (s_Sum_NullableInt32_1 = GetMethodInfoOf<IQueryable<int?>, int?>(Queryable.Sum));
+
+        private static MethodInfo s_Sum_Int64_1;
+
+        public static MethodInfo Sum_Int64_1 =>
+             s_Sum_Int64_1 ??
+            (s_Sum_Int64_1 = GetMethodInfoOf<IQueryable<long>, long>(Queryable.Sum));
+
+        private static MethodInfo s_Sum_NullableInt64_1;
+
+        public static MethodInfo Sum_NullableInt64_1 =>
+             s_Sum_NullableInt64_1 ??
+            (s_Sum_NullableInt64_1 = GetMethodInfoOf<IQueryable<long?>, long?>(Queryable.Sum));
+
+        private static MethodInfo s_Sum_Single_1;
+
+        public static MethodInfo Sum_Single_1 =>
+             s_Sum_Single_1 ??
+            (s_Sum_Single_1 = GetMethodInfoOf<IQueryable<float>, float>(Queryable.Sum));
+
+        private static MethodInfo s_Sum_NullableSingle_1;
+
+        public static MethodInfo Sum_NullableSingle_1 =>
+             s_Sum_NullableSingle_1 ??
+            (s_Sum_NullableSingle_1 = GetMethodInfoOf<IQueryable<float?>, float?>(Queryable.Sum));
+
+        private static MethodInfo s_Sum_Double_1;
+
+        public static MethodInfo Sum_Double_1 =>
+             s_Sum_Double_1 ??
+            (s_Sum_Double_1 = GetMethodInfoOf<IQueryable<double>, double>(Queryable.Sum));
+
+        private static MethodInfo s_Sum_NullableDouble_1;
+
+        public static MethodInfo Sum_NullableDouble_1 =>
+             s_Sum_NullableDouble_1 ??
+            (s_Sum_NullableDouble_1 = GetMethodInfoOf<IQueryable<double?>, double?>(Queryable.Sum));
+
+        private static MethodInfo s_Sum_Decimal_1;
+
+        public static MethodInfo Sum_Decimal_1 =>
+             s_Sum_Decimal_1 ??
+            (s_Sum_Decimal_1 = GetMethodInfoOf<IQueryable<decimal>, decimal>(Queryable.Sum));
+
+        private static MethodInfo s_Sum_NullableDecimal_1;
+
+        public static MethodInfo Sum_NullableDecimal_1 =>
+             s_Sum_NullableDecimal_1 ??
+            (s_Sum_NullableDecimal_1 = GetMethodInfoOf<IQueryable<decimal?>, decimal?>(Queryable.Sum));
+
+        private static MethodInfo s_Sum_NullableDecimal_TSource_2;
+
+        public static MethodInfo Sum_NullableDecimal_TSource_2(Type TSource) =>
+             (s_Sum_NullableDecimal_TSource_2 ??
+             (s_Sum_NullableDecimal_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, decimal?>>, decimal?>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Sum_Int32_TSource_2;
+
+        public static MethodInfo Sum_Int32_TSource_2(Type TSource) =>
+             (s_Sum_Int32_TSource_2 ??
+             (s_Sum_Int32_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int>>, int>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Sum_NullableInt32_TSource_2;
+
+        public static MethodInfo Sum_NullableInt32_TSource_2(Type TSource) =>
+             (s_Sum_NullableInt32_TSource_2 ??
+             (s_Sum_NullableInt32_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int?>>, int?>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Sum_Int64_TSource_2;
+
+        public static MethodInfo Sum_Int64_TSource_2(Type TSource) =>
+             (s_Sum_Int64_TSource_2 ??
+             (s_Sum_Int64_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, long>>, long>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Sum_NullableInt64_TSource_2;
+
+        public static MethodInfo Sum_NullableInt64_TSource_2(Type TSource) =>
+             (s_Sum_NullableInt64_TSource_2 ??
+             (s_Sum_NullableInt64_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, long?>>, long?>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Sum_Single_TSource_2;
+
+        public static MethodInfo Sum_Single_TSource_2(Type TSource) =>
+             (s_Sum_Single_TSource_2 ??
+             (s_Sum_Single_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, float>>, float>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Sum_NullableSingle_TSource_2;
+
+        public static MethodInfo Sum_NullableSingle_TSource_2(Type TSource) =>
+             (s_Sum_NullableSingle_TSource_2 ??
+             (s_Sum_NullableSingle_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, float?>>, float?>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Sum_Double_TSource_2;
+
+        public static MethodInfo Sum_Double_TSource_2(Type TSource) =>
+             (s_Sum_Double_TSource_2 ??
+             (s_Sum_Double_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, double>>, double>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Sum_NullableDouble_TSource_2;
+
+        public static MethodInfo Sum_NullableDouble_TSource_2(Type TSource) =>
+             (s_Sum_NullableDouble_TSource_2 ??
+             (s_Sum_NullableDouble_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, double?>>, double?>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Sum_Decimal_TSource_2;
+
+        public static MethodInfo Sum_Decimal_TSource_2(Type TSource) =>
+             (s_Sum_Decimal_TSource_2 ??
+             (s_Sum_Decimal_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, decimal>>, decimal>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Take_TSource_2;
+
+        public static MethodInfo Take_TSource_2(Type TSource) =>
+             (s_Take_TSource_2 ??
+             (s_Take_TSource_2 = GetMethodInfoOf<IQueryable<object>, int, IQueryable<object>>(Queryable.Take<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_TakeWhile_TSource_2;
+
+        public static MethodInfo TakeWhile_TSource_2(Type TSource) =>
+             (s_TakeWhile_TSource_2 ??
+             (s_TakeWhile_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, IQueryable<object>>(Queryable.TakeWhile<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_TakeWhile_Index_TSource_2;
+
+        public static MethodInfo TakeWhile_Index_TSource_2(Type TSource) =>
+             (s_TakeWhile_Index_TSource_2 ??
+             (s_TakeWhile_Index_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int, bool>>, IQueryable<object>>(Queryable.TakeWhile<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_ThenBy_TSource_TKey_2;
+
+        public static MethodInfo ThenBy_TSource_TKey_2(Type TSource, Type TKey) =>
+             (s_ThenBy_TSource_TKey_2 ??
+             (s_ThenBy_TSource_TKey_2 = GetMethodInfoOf<IOrderedQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.ThenBy<object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TKey);
+
+        private static MethodInfo s_ThenBy_TSource_TKey_3;
+
+        public static MethodInfo ThenBy_TSource_TKey_3(Type TSource, Type TKey) =>
+             (s_ThenBy_TSource_TKey_3 ??
+             (s_ThenBy_TSource_TKey_3 = GetMethodInfoOf<IOrderedQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.ThenBy<object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TKey);
+
+        private static MethodInfo s_ThenByDescending_TSource_TKey_2;
+
+        public static MethodInfo ThenByDescending_TSource_TKey_2(Type TSource, Type TKey) =>
+             (s_ThenByDescending_TSource_TKey_2 ??
+             (s_ThenByDescending_TSource_TKey_2 = GetMethodInfoOf<IOrderedQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.ThenByDescending<object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TKey);
+
+        private static MethodInfo s_ThenByDescending_TSource_TKey_3;
+
+        public static MethodInfo ThenByDescending_TSource_TKey_3(Type TSource, Type TKey) =>
+             (s_ThenByDescending_TSource_TKey_3 ??
+             (s_ThenByDescending_TSource_TKey_3 = GetMethodInfoOf<IOrderedQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.ThenByDescending<object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource, TKey);
+
+        private static MethodInfo s_Union_TSource_2;
+
+        public static MethodInfo Union_TSource_2(Type TSource) =>
+             (s_Union_TSource_2 ??
+             (s_Union_TSource_2 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Union<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Union_TSource_3;
+
+        public static MethodInfo Union_TSource_3(Type TSource) =>
+             (s_Union_TSource_3 ??
+             (s_Union_TSource_3 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Union<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Where_TSource_2;
+
+        public static MethodInfo Where_TSource_2(Type TSource) =>
+             (s_Where_TSource_2 ??
+             (s_Where_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, IQueryable<object>>(Queryable.Where<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Where_Index_TSource_2;
+
+        public static MethodInfo Where_Index_TSource_2(Type TSource) =>
+             (s_Where_Index_TSource_2 ??
+             (s_Where_Index_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int, bool>>, IQueryable<object>>(Queryable.Where<object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TSource);
+
+        private static MethodInfo s_Zip_TFirst_TSecond_TResult_3;
+
+        public static MethodInfo Zip_TFirst_TSecond_TResult_3(Type TFirst, Type TSecond, Type TResult) =>
+             (s_Zip_TFirst_TSecond_TResult_3 ??
+             (s_Zip_TFirst_TSecond_TResult_3 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.Zip<object, object, object>).GetGenericMethodDefinition()))
+              .MakeGenericMethod(TFirst, TSecond, TResult);
+
+        private static MethodInfo GetMethodInfoOf<T1, R>(Func<T1, R> f) => GetMethodInfoOf((Delegate)f);
+        private static MethodInfo GetMethodInfoOf<T1, T2, R>(Func<T1, T2, R> f) => GetMethodInfoOf((Delegate)f);
+        private static MethodInfo GetMethodInfoOf<T1, T2, T3, R>(Func<T1, T2, T3, R> f) => GetMethodInfoOf((Delegate)f);
+        private static MethodInfo GetMethodInfoOf<T1, T2, T3, T4, R>(Func<T1, T2, T3, T4, R> f) => GetMethodInfoOf((Delegate)f);
+        private static MethodInfo GetMethodInfoOf<T1, T2, T3, T4, T5, R>(Func<T1, T2, T3, T4, T5, R> f) => GetMethodInfoOf((Delegate)f);
+        private static MethodInfo GetMethodInfoOf<T1, T2, T3, T4, T5, T6, R>(Func<T1, T2, T3, T4, T5, T6, R> f) => GetMethodInfoOf((Delegate)f);
+        private static MethodInfo GetMethodInfoOf(Delegate f) => f.GetMethodInfo();
+    }
+}

--- a/src/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/CachedReflection.cs
@@ -15,848 +15,841 @@ namespace System.Linq
 
         public static MethodInfo Aggregate_TSource_2(Type TSource) =>
              (s_Aggregate_TSource_2 ??
-             (s_Aggregate_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object, object>>, object>(Queryable.Aggregate<object>).GetGenericMethodDefinition()))
+             (s_Aggregate_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, object, object>>, object>(Queryable.Aggregate<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Aggregate_TSource_TAccumulate_3;
 
         public static MethodInfo Aggregate_TSource_TAccumulate_3(Type TSource, Type TAccumulate) =>
              (s_Aggregate_TSource_TAccumulate_3 ??
-             (s_Aggregate_TSource_TAccumulate_3 = GetMethodInfoOf<IQueryable<object>, object, Expression<Func<object, object, object>>, object>(Queryable.Aggregate<object, object>).GetGenericMethodDefinition()))
+             (s_Aggregate_TSource_TAccumulate_3 = new Func<IQueryable<object>, object, Expression<Func<object, object, object>>, object>(Queryable.Aggregate<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TAccumulate);
 
         private static MethodInfo s_Aggregate_TSource_TAccumulate_TResult_4;
 
         public static MethodInfo Aggregate_TSource_TAccumulate_TResult_4(Type TSource, Type TAccumulate, Type TResult) =>
              (s_Aggregate_TSource_TAccumulate_TResult_4 ??
-             (s_Aggregate_TSource_TAccumulate_TResult_4 = GetMethodInfoOf<IQueryable<object>, object, Expression<Func<object, object, object>>, Expression<Func<object, object>>, object>(Queryable.Aggregate<object, object, object>).GetGenericMethodDefinition()))
+             (s_Aggregate_TSource_TAccumulate_TResult_4 = new Func<IQueryable<object>, object, Expression<Func<object, object, object>>, Expression<Func<object, object>>, object>(Queryable.Aggregate<object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TAccumulate, TResult);
 
         private static MethodInfo s_All_TSource_2;
 
         public static MethodInfo All_TSource_2(Type TSource) =>
              (s_All_TSource_2 ??
-             (s_All_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, bool>(Queryable.All<object>).GetGenericMethodDefinition()))
+             (s_All_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, bool>(Queryable.All<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Any_TSource_1;
 
         public static MethodInfo Any_TSource_1(Type TSource) =>
              (s_Any_TSource_1 ??
-             (s_Any_TSource_1 = GetMethodInfoOf<IQueryable<object>, bool>(Queryable.Any<object>).GetGenericMethodDefinition()))
+             (s_Any_TSource_1 = new Func<IQueryable<object>, bool>(Queryable.Any<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Any_TSource_2;
 
         public static MethodInfo Any_TSource_2(Type TSource) =>
              (s_Any_TSource_2 ??
-             (s_Any_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, bool>(Queryable.Any<object>).GetGenericMethodDefinition()))
+             (s_Any_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, bool>(Queryable.Any<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_AsQueryable_1;
 
         public static MethodInfo AsQueryable_1 =>
              s_AsQueryable_1 ??
-            (s_AsQueryable_1 = GetMethodInfoOf<IEnumerable, IQueryable>(Queryable.AsQueryable));
+            (s_AsQueryable_1 = new Func<IEnumerable, IQueryable>(Queryable.AsQueryable).GetMethodInfo());
 
         private static MethodInfo s_AsQueryable_TElement_1;
 
         public static MethodInfo AsQueryable_TElement_1(Type TElement) =>
              (s_AsQueryable_TElement_1 ??
-             (s_AsQueryable_TElement_1 = GetMethodInfoOf<IEnumerable<object>, IQueryable<object>>(Queryable.AsQueryable<object>).GetGenericMethodDefinition()))
+             (s_AsQueryable_TElement_1 = new Func<IEnumerable<object>, IQueryable<object>>(Queryable.AsQueryable<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TElement);
 
         private static MethodInfo s_Average_Int32_1;
 
         public static MethodInfo Average_Int32_1 =>
              s_Average_Int32_1 ??
-            (s_Average_Int32_1 = GetMethodInfoOf<IQueryable<int>, double>(Queryable.Average));
+            (s_Average_Int32_1 = new Func<IQueryable<int>, double>(Queryable.Average).GetMethodInfo());
 
         private static MethodInfo s_Average_NullableInt32_1;
 
         public static MethodInfo Average_NullableInt32_1 =>
              s_Average_NullableInt32_1 ??
-            (s_Average_NullableInt32_1 = GetMethodInfoOf<IQueryable<int?>, double?>(Queryable.Average));
+            (s_Average_NullableInt32_1 = new Func<IQueryable<int?>, double?>(Queryable.Average).GetMethodInfo());
 
         private static MethodInfo s_Average_Int64_1;
 
         public static MethodInfo Average_Int64_1 =>
              s_Average_Int64_1 ??
-            (s_Average_Int64_1 = GetMethodInfoOf<IQueryable<long>, double>(Queryable.Average));
+            (s_Average_Int64_1 = new Func<IQueryable<long>, double>(Queryable.Average).GetMethodInfo());
 
         private static MethodInfo s_Average_NullableInt64_1;
 
         public static MethodInfo Average_NullableInt64_1 =>
              s_Average_NullableInt64_1 ??
-            (s_Average_NullableInt64_1 = GetMethodInfoOf<IQueryable<long?>, double?>(Queryable.Average));
+            (s_Average_NullableInt64_1 = new Func<IQueryable<long?>, double?>(Queryable.Average).GetMethodInfo());
 
         private static MethodInfo s_Average_Single_1;
 
         public static MethodInfo Average_Single_1 =>
              s_Average_Single_1 ??
-            (s_Average_Single_1 = GetMethodInfoOf<IQueryable<float>, float>(Queryable.Average));
+            (s_Average_Single_1 = new Func<IQueryable<float>, float>(Queryable.Average).GetMethodInfo());
 
         private static MethodInfo s_Average_NullableSingle_1;
 
         public static MethodInfo Average_NullableSingle_1 =>
              s_Average_NullableSingle_1 ??
-            (s_Average_NullableSingle_1 = GetMethodInfoOf<IQueryable<float?>, float?>(Queryable.Average));
+            (s_Average_NullableSingle_1 = new Func<IQueryable<float?>, float?>(Queryable.Average).GetMethodInfo());
 
         private static MethodInfo s_Average_Double_1;
 
         public static MethodInfo Average_Double_1 =>
              s_Average_Double_1 ??
-            (s_Average_Double_1 = GetMethodInfoOf<IQueryable<double>, double>(Queryable.Average));
+            (s_Average_Double_1 = new Func<IQueryable<double>, double>(Queryable.Average).GetMethodInfo());
 
         private static MethodInfo s_Average_NullableDouble_1;
 
         public static MethodInfo Average_NullableDouble_1 =>
              s_Average_NullableDouble_1 ??
-            (s_Average_NullableDouble_1 = GetMethodInfoOf<IQueryable<double?>, double?>(Queryable.Average));
+            (s_Average_NullableDouble_1 = new Func<IQueryable<double?>, double?>(Queryable.Average).GetMethodInfo());
 
         private static MethodInfo s_Average_Decimal_1;
 
         public static MethodInfo Average_Decimal_1 =>
              s_Average_Decimal_1 ??
-            (s_Average_Decimal_1 = GetMethodInfoOf<IQueryable<decimal>, decimal>(Queryable.Average));
+            (s_Average_Decimal_1 = new Func<IQueryable<decimal>, decimal>(Queryable.Average).GetMethodInfo());
 
         private static MethodInfo s_Average_NullableDecimal_1;
 
         public static MethodInfo Average_NullableDecimal_1 =>
              s_Average_NullableDecimal_1 ??
-            (s_Average_NullableDecimal_1 = GetMethodInfoOf<IQueryable<decimal?>, decimal?>(Queryable.Average));
+            (s_Average_NullableDecimal_1 = new Func<IQueryable<decimal?>, decimal?>(Queryable.Average).GetMethodInfo());
 
         private static MethodInfo s_Average_Int32_TSource_2;
 
         public static MethodInfo Average_Int32_TSource_2(Type TSource) =>
              (s_Average_Int32_TSource_2 ??
-             (s_Average_Int32_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int>>, double>(Queryable.Average<object>).GetGenericMethodDefinition()))
+             (s_Average_Int32_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int>>, double>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_NullableInt32_TSource_2;
 
         public static MethodInfo Average_NullableInt32_TSource_2(Type TSource) =>
              (s_Average_NullableInt32_TSource_2 ??
-             (s_Average_NullableInt32_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int?>>, double?>(Queryable.Average<object>).GetGenericMethodDefinition()))
+             (s_Average_NullableInt32_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int?>>, double?>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_Single_TSource_2;
 
         public static MethodInfo Average_Single_TSource_2(Type TSource) =>
              (s_Average_Single_TSource_2 ??
-             (s_Average_Single_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, float>>, float>(Queryable.Average<object>).GetGenericMethodDefinition()))
+             (s_Average_Single_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, float>>, float>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_NullableSingle_TSource_2;
 
         public static MethodInfo Average_NullableSingle_TSource_2(Type TSource) =>
              (s_Average_NullableSingle_TSource_2 ??
-             (s_Average_NullableSingle_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, float?>>, float?>(Queryable.Average<object>).GetGenericMethodDefinition()))
+             (s_Average_NullableSingle_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, float?>>, float?>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_Int64_TSource_2;
 
         public static MethodInfo Average_Int64_TSource_2(Type TSource) =>
              (s_Average_Int64_TSource_2 ??
-             (s_Average_Int64_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, long>>, double>(Queryable.Average<object>).GetGenericMethodDefinition()))
+             (s_Average_Int64_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, long>>, double>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_NullableInt64_TSource_2;
 
         public static MethodInfo Average_NullableInt64_TSource_2(Type TSource) =>
              (s_Average_NullableInt64_TSource_2 ??
-             (s_Average_NullableInt64_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, long?>>, double?>(Queryable.Average<object>).GetGenericMethodDefinition()))
+             (s_Average_NullableInt64_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, long?>>, double?>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_Double_TSource_2;
 
         public static MethodInfo Average_Double_TSource_2(Type TSource) =>
              (s_Average_Double_TSource_2 ??
-             (s_Average_Double_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, double>>, double>(Queryable.Average<object>).GetGenericMethodDefinition()))
+             (s_Average_Double_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, double>>, double>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_NullableDouble_TSource_2;
 
         public static MethodInfo Average_NullableDouble_TSource_2(Type TSource) =>
              (s_Average_NullableDouble_TSource_2 ??
-             (s_Average_NullableDouble_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, double?>>, double?>(Queryable.Average<object>).GetGenericMethodDefinition()))
+             (s_Average_NullableDouble_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, double?>>, double?>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_Decimal_TSource_2;
 
         public static MethodInfo Average_Decimal_TSource_2(Type TSource) =>
              (s_Average_Decimal_TSource_2 ??
-             (s_Average_Decimal_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, decimal>>, decimal>(Queryable.Average<object>).GetGenericMethodDefinition()))
+             (s_Average_Decimal_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, decimal>>, decimal>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Average_NullableDecimal_TSource_2;
 
         public static MethodInfo Average_NullableDecimal_TSource_2(Type TSource) =>
              (s_Average_NullableDecimal_TSource_2 ??
-             (s_Average_NullableDecimal_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, decimal?>>, decimal?>(Queryable.Average<object>).GetGenericMethodDefinition()))
+             (s_Average_NullableDecimal_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, decimal?>>, decimal?>(Queryable.Average<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Cast_TResult_1;
 
         public static MethodInfo Cast_TResult_1(Type TResult) =>
              (s_Cast_TResult_1 ??
-             (s_Cast_TResult_1 = GetMethodInfoOf<IQueryable, IQueryable<object>>(Queryable.Cast<object>).GetGenericMethodDefinition()))
+             (s_Cast_TResult_1 = new Func<IQueryable, IQueryable<object>>(Queryable.Cast<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TResult);
 
         private static MethodInfo s_Concat_TSource_2;
 
         public static MethodInfo Concat_TSource_2(Type TSource) =>
              (s_Concat_TSource_2 ??
-             (s_Concat_TSource_2 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Concat<object>).GetGenericMethodDefinition()))
+             (s_Concat_TSource_2 = new Func<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Concat<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Contains_TSource_2;
 
         public static MethodInfo Contains_TSource_2(Type TSource) =>
              (s_Contains_TSource_2 ??
-             (s_Contains_TSource_2 = GetMethodInfoOf<IQueryable<object>, object, bool>(Queryable.Contains<object>).GetGenericMethodDefinition()))
+             (s_Contains_TSource_2 = new Func<IQueryable<object>, object, bool>(Queryable.Contains<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Contains_TSource_3;
 
         public static MethodInfo Contains_TSource_3(Type TSource) =>
              (s_Contains_TSource_3 ??
-             (s_Contains_TSource_3 = GetMethodInfoOf<IQueryable<object>, object, IEqualityComparer<object>, bool>(Queryable.Contains<object>).GetGenericMethodDefinition()))
+             (s_Contains_TSource_3 = new Func<IQueryable<object>, object, IEqualityComparer<object>, bool>(Queryable.Contains<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Count_TSource_1;
 
         public static MethodInfo Count_TSource_1(Type TSource) =>
              (s_Count_TSource_1 ??
-             (s_Count_TSource_1 = GetMethodInfoOf<IQueryable<object>, int>(Queryable.Count<object>).GetGenericMethodDefinition()))
+             (s_Count_TSource_1 = new Func<IQueryable<object>, int>(Queryable.Count<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Count_TSource_2;
 
         public static MethodInfo Count_TSource_2(Type TSource) =>
              (s_Count_TSource_2 ??
-             (s_Count_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, int>(Queryable.Count<object>).GetGenericMethodDefinition()))
+             (s_Count_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, int>(Queryable.Count<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_DefaultIfEmpty_TSource_1;
 
         public static MethodInfo DefaultIfEmpty_TSource_1(Type TSource) =>
              (s_DefaultIfEmpty_TSource_1 ??
-             (s_DefaultIfEmpty_TSource_1 = GetMethodInfoOf<IQueryable<object>, IQueryable<object>>(Queryable.DefaultIfEmpty<object>).GetGenericMethodDefinition()))
+             (s_DefaultIfEmpty_TSource_1 = new Func<IQueryable<object>, IQueryable<object>>(Queryable.DefaultIfEmpty<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_DefaultIfEmpty_TSource_2;
 
         public static MethodInfo DefaultIfEmpty_TSource_2(Type TSource) =>
              (s_DefaultIfEmpty_TSource_2 ??
-             (s_DefaultIfEmpty_TSource_2 = GetMethodInfoOf<IQueryable<object>, object, IQueryable<object>>(Queryable.DefaultIfEmpty<object>).GetGenericMethodDefinition()))
+             (s_DefaultIfEmpty_TSource_2 = new Func<IQueryable<object>, object, IQueryable<object>>(Queryable.DefaultIfEmpty<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Distinct_TSource_1;
 
         public static MethodInfo Distinct_TSource_1(Type TSource) =>
              (s_Distinct_TSource_1 ??
-             (s_Distinct_TSource_1 = GetMethodInfoOf<IQueryable<object>, IQueryable<object>>(Queryable.Distinct<object>).GetGenericMethodDefinition()))
+             (s_Distinct_TSource_1 = new Func<IQueryable<object>, IQueryable<object>>(Queryable.Distinct<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Distinct_TSource_2;
 
         public static MethodInfo Distinct_TSource_2(Type TSource) =>
              (s_Distinct_TSource_2 ??
-             (s_Distinct_TSource_2 = GetMethodInfoOf<IQueryable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Distinct<object>).GetGenericMethodDefinition()))
+             (s_Distinct_TSource_2 = new Func<IQueryable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Distinct<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_ElementAt_TSource_2;
 
         public static MethodInfo ElementAt_TSource_2(Type TSource) =>
              (s_ElementAt_TSource_2 ??
-             (s_ElementAt_TSource_2 = GetMethodInfoOf<IQueryable<object>, int, object>(Queryable.ElementAt<object>).GetGenericMethodDefinition()))
+             (s_ElementAt_TSource_2 = new Func<IQueryable<object>, int, object>(Queryable.ElementAt<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_ElementAtOrDefault_TSource_2;
 
         public static MethodInfo ElementAtOrDefault_TSource_2(Type TSource) =>
              (s_ElementAtOrDefault_TSource_2 ??
-             (s_ElementAtOrDefault_TSource_2 = GetMethodInfoOf<IQueryable<object>, int, object>(Queryable.ElementAtOrDefault<object>).GetGenericMethodDefinition()))
+             (s_ElementAtOrDefault_TSource_2 = new Func<IQueryable<object>, int, object>(Queryable.ElementAtOrDefault<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Except_TSource_2;
 
         public static MethodInfo Except_TSource_2(Type TSource) =>
              (s_Except_TSource_2 ??
-             (s_Except_TSource_2 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Except<object>).GetGenericMethodDefinition()))
+             (s_Except_TSource_2 = new Func<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Except<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Except_TSource_3;
 
         public static MethodInfo Except_TSource_3(Type TSource) =>
              (s_Except_TSource_3 ??
-             (s_Except_TSource_3 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Except<object>).GetGenericMethodDefinition()))
+             (s_Except_TSource_3 = new Func<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Except<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_First_TSource_1;
 
         public static MethodInfo First_TSource_1(Type TSource) =>
              (s_First_TSource_1 ??
-             (s_First_TSource_1 = GetMethodInfoOf<IQueryable<object>, object>(Queryable.First<object>).GetGenericMethodDefinition()))
+             (s_First_TSource_1 = new Func<IQueryable<object>, object>(Queryable.First<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_First_TSource_2;
 
         public static MethodInfo First_TSource_2(Type TSource) =>
              (s_First_TSource_2 ??
-             (s_First_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.First<object>).GetGenericMethodDefinition()))
+             (s_First_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.First<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_FirstOrDefault_TSource_1;
 
         public static MethodInfo FirstOrDefault_TSource_1(Type TSource) =>
              (s_FirstOrDefault_TSource_1 ??
-             (s_FirstOrDefault_TSource_1 = GetMethodInfoOf<IQueryable<object>, object>(Queryable.FirstOrDefault<object>).GetGenericMethodDefinition()))
+             (s_FirstOrDefault_TSource_1 = new Func<IQueryable<object>, object>(Queryable.FirstOrDefault<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_FirstOrDefault_TSource_2;
 
         public static MethodInfo FirstOrDefault_TSource_2(Type TSource) =>
              (s_FirstOrDefault_TSource_2 ??
-             (s_FirstOrDefault_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.FirstOrDefault<object>).GetGenericMethodDefinition()))
+             (s_FirstOrDefault_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.FirstOrDefault<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_GroupBy_TSource_TKey_2;
 
         public static MethodInfo GroupBy_TSource_TKey_2(Type TSource, Type TKey) =>
              (s_GroupBy_TSource_TKey_2 ??
-             (s_GroupBy_TSource_TKey_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy<object, object>).GetGenericMethodDefinition()))
+             (s_GroupBy_TSource_TKey_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_GroupBy_TSource_TKey_3;
 
         public static MethodInfo GroupBy_TSource_TKey_3(Type TSource, Type TKey) =>
              (s_GroupBy_TSource_TKey_3 ??
-             (s_GroupBy_TSource_TKey_3 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, IEqualityComparer<object>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy<object, object>).GetGenericMethodDefinition()))
+             (s_GroupBy_TSource_TKey_3 = new Func<IQueryable<object>, Expression<Func<object, object>>, IEqualityComparer<object>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_GroupBy_TSource_TKey_TElement_3;
 
         public static MethodInfo GroupBy_TSource_TKey_TElement_3(Type TSource, Type TKey, Type TElement) =>
              (s_GroupBy_TSource_TKey_TElement_3 ??
-             (s_GroupBy_TSource_TKey_TElement_3 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy<object, object, object>).GetGenericMethodDefinition()))
+             (s_GroupBy_TSource_TKey_TElement_3 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy<object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey, TElement);
 
         private static MethodInfo s_GroupBy_TSource_TKey_TElement_4;
 
         public static MethodInfo GroupBy_TSource_TKey_TElement_4(Type TSource, Type TKey, Type TElement) =>
              (s_GroupBy_TSource_TKey_TElement_4 ??
-             (s_GroupBy_TSource_TKey_TElement_4 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, IEqualityComparer<object>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy<object, object, object>).GetGenericMethodDefinition()))
+             (s_GroupBy_TSource_TKey_TElement_4 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, IEqualityComparer<object>, IQueryable<IGrouping<object, object>>>(Queryable.GroupBy<object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey, TElement);
 
         private static MethodInfo s_GroupBy_TSource_TKey_TResult_3;
 
         public static MethodInfo GroupBy_TSource_TKey_TResult_3(Type TSource, Type TKey, Type TResult) =>
              (s_GroupBy_TSource_TKey_TResult_3 ??
-             (s_GroupBy_TSource_TKey_TResult_3 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IQueryable<object>>(Queryable.GroupBy<object, object, object>).GetGenericMethodDefinition()))
+             (s_GroupBy_TSource_TKey_TResult_3 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IQueryable<object>>(Queryable.GroupBy<object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey, TResult);
 
         private static MethodInfo s_GroupBy_TSource_TKey_TResult_4;
 
         public static MethodInfo GroupBy_TSource_TKey_TResult_4(Type TSource, Type TKey, Type TResult) =>
              (s_GroupBy_TSource_TKey_TResult_4 ??
-             (s_GroupBy_TSource_TKey_TResult_4 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.GroupBy<object, object, object>).GetGenericMethodDefinition()))
+             (s_GroupBy_TSource_TKey_TResult_4 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.GroupBy<object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey, TResult);
 
         private static MethodInfo s_GroupBy_TSource_TKey_TElement_TResult_4;
 
         public static MethodInfo GroupBy_TSource_TKey_TElement_TResult_4(Type TSource, Type TKey, Type TElement, Type TResult) =>
              (s_GroupBy_TSource_TKey_TElement_TResult_4 ??
-             (s_GroupBy_TSource_TKey_TElement_TResult_4 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IQueryable<object>>(Queryable.GroupBy<object, object, object, object>).GetGenericMethodDefinition()))
+             (s_GroupBy_TSource_TKey_TElement_TResult_4 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IQueryable<object>>(Queryable.GroupBy<object, object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey, TElement, TResult);
 
         private static MethodInfo s_GroupBy_TSource_TKey_TElement_TResult_5;
 
         public static MethodInfo GroupBy_TSource_TKey_TElement_TResult_5(Type TSource, Type TKey, Type TElement, Type TResult) =>
              (s_GroupBy_TSource_TKey_TElement_TResult_5 ??
-             (s_GroupBy_TSource_TKey_TElement_TResult_5 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.GroupBy<object, object, object, object>).GetGenericMethodDefinition()))
+             (s_GroupBy_TSource_TKey_TElement_TResult_5 = new Func<IQueryable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.GroupBy<object, object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey, TElement, TResult);
 
         private static MethodInfo s_GroupJoin_TOuter_TInner_TKey_TResult_5;
 
         public static MethodInfo GroupJoin_TOuter_TInner_TKey_TResult_5(Type TOuter, Type TInner, Type TKey, Type TResult) =>
              (s_GroupJoin_TOuter_TInner_TKey_TResult_5 ??
-             (s_GroupJoin_TOuter_TInner_TKey_TResult_5 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IQueryable<object>>(Queryable.GroupJoin<object, object, object, object>).GetGenericMethodDefinition()))
+             (s_GroupJoin_TOuter_TInner_TKey_TResult_5 = new Func<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IQueryable<object>>(Queryable.GroupJoin<object, object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TOuter, TInner, TKey, TResult);
 
         private static MethodInfo s_GroupJoin_TOuter_TInner_TKey_TResult_6;
 
         public static MethodInfo GroupJoin_TOuter_TInner_TKey_TResult_6(Type TOuter, Type TInner, Type TKey, Type TResult) =>
              (s_GroupJoin_TOuter_TInner_TKey_TResult_6 ??
-             (s_GroupJoin_TOuter_TInner_TKey_TResult_6 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.GroupJoin<object, object, object, object>).GetGenericMethodDefinition()))
+             (s_GroupJoin_TOuter_TInner_TKey_TResult_6 = new Func<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, IEnumerable<object>, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.GroupJoin<object, object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TOuter, TInner, TKey, TResult);
 
         private static MethodInfo s_Intersect_TSource_2;
 
         public static MethodInfo Intersect_TSource_2(Type TSource) =>
              (s_Intersect_TSource_2 ??
-             (s_Intersect_TSource_2 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Intersect<object>).GetGenericMethodDefinition()))
+             (s_Intersect_TSource_2 = new Func<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Intersect<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Intersect_TSource_3;
 
         public static MethodInfo Intersect_TSource_3(Type TSource) =>
              (s_Intersect_TSource_3 ??
-             (s_Intersect_TSource_3 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Intersect<object>).GetGenericMethodDefinition()))
+             (s_Intersect_TSource_3 = new Func<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Intersect<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Join_TOuter_TInner_TKey_TResult_5;
 
         public static MethodInfo Join_TOuter_TInner_TKey_TResult_5(Type TOuter, Type TInner, Type TKey, Type TResult) =>
              (s_Join_TOuter_TInner_TKey_TResult_5 ??
-             (s_Join_TOuter_TInner_TKey_TResult_5 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.Join<object, object, object, object>).GetGenericMethodDefinition()))
+             (s_Join_TOuter_TInner_TKey_TResult_5 = new Func<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.Join<object, object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TOuter, TInner, TKey, TResult);
 
         private static MethodInfo s_Join_TOuter_TInner_TKey_TResult_6;
 
         public static MethodInfo Join_TOuter_TInner_TKey_TResult_6(Type TOuter, Type TInner, Type TKey, Type TResult) =>
              (s_Join_TOuter_TInner_TKey_TResult_6 ??
-             (s_Join_TOuter_TInner_TKey_TResult_6 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, object, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Join<object, object, object, object>).GetGenericMethodDefinition()))
+             (s_Join_TOuter_TInner_TKey_TResult_6 = new Func<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object>>, Expression<Func<object, object>>, Expression<Func<object, object, object>>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Join<object, object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TOuter, TInner, TKey, TResult);
 
         private static MethodInfo s_Last_TSource_1;
 
         public static MethodInfo Last_TSource_1(Type TSource) =>
              (s_Last_TSource_1 ??
-             (s_Last_TSource_1 = GetMethodInfoOf<IQueryable<object>, object>(Queryable.Last<object>).GetGenericMethodDefinition()))
+             (s_Last_TSource_1 = new Func<IQueryable<object>, object>(Queryable.Last<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Last_TSource_2;
 
         public static MethodInfo Last_TSource_2(Type TSource) =>
              (s_Last_TSource_2 ??
-             (s_Last_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.Last<object>).GetGenericMethodDefinition()))
+             (s_Last_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.Last<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_LastOrDefault_TSource_1;
 
         public static MethodInfo LastOrDefault_TSource_1(Type TSource) =>
              (s_LastOrDefault_TSource_1 ??
-             (s_LastOrDefault_TSource_1 = GetMethodInfoOf<IQueryable<object>, object>(Queryable.LastOrDefault<object>).GetGenericMethodDefinition()))
+             (s_LastOrDefault_TSource_1 = new Func<IQueryable<object>, object>(Queryable.LastOrDefault<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_LastOrDefault_TSource_2;
 
         public static MethodInfo LastOrDefault_TSource_2(Type TSource) =>
              (s_LastOrDefault_TSource_2 ??
-             (s_LastOrDefault_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.LastOrDefault<object>).GetGenericMethodDefinition()))
+             (s_LastOrDefault_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.LastOrDefault<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_LongCount_TSource_1;
 
         public static MethodInfo LongCount_TSource_1(Type TSource) =>
              (s_LongCount_TSource_1 ??
-             (s_LongCount_TSource_1 = GetMethodInfoOf<IQueryable<object>, long>(Queryable.LongCount<object>).GetGenericMethodDefinition()))
+             (s_LongCount_TSource_1 = new Func<IQueryable<object>, long>(Queryable.LongCount<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_LongCount_TSource_2;
 
         public static MethodInfo LongCount_TSource_2(Type TSource) =>
              (s_LongCount_TSource_2 ??
-             (s_LongCount_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, long>(Queryable.LongCount<object>).GetGenericMethodDefinition()))
+             (s_LongCount_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, long>(Queryable.LongCount<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Max_TSource_1;
 
         public static MethodInfo Max_TSource_1(Type TSource) =>
              (s_Max_TSource_1 ??
-             (s_Max_TSource_1 = GetMethodInfoOf<IQueryable<object>, object>(Queryable.Max<object>).GetGenericMethodDefinition()))
+             (s_Max_TSource_1 = new Func<IQueryable<object>, object>(Queryable.Max<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Max_TSource_TResult_2;
 
         public static MethodInfo Max_TSource_TResult_2(Type TSource, Type TResult) =>
              (s_Max_TSource_TResult_2 ??
-             (s_Max_TSource_TResult_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, object>(Queryable.Max<object, object>).GetGenericMethodDefinition()))
+             (s_Max_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, object>(Queryable.Max<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TResult);
 
         private static MethodInfo s_Min_TSource_1;
 
         public static MethodInfo Min_TSource_1(Type TSource) =>
              (s_Min_TSource_1 ??
-             (s_Min_TSource_1 = GetMethodInfoOf<IQueryable<object>, object>(Queryable.Min<object>).GetGenericMethodDefinition()))
+             (s_Min_TSource_1 = new Func<IQueryable<object>, object>(Queryable.Min<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Min_TSource_TResult_2;
 
         public static MethodInfo Min_TSource_TResult_2(Type TSource, Type TResult) =>
              (s_Min_TSource_TResult_2 ??
-             (s_Min_TSource_TResult_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, object>(Queryable.Min<object, object>).GetGenericMethodDefinition()))
+             (s_Min_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, object>(Queryable.Min<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TResult);
 
         private static MethodInfo s_OfType_TResult_1;
 
         public static MethodInfo OfType_TResult_1(Type TResult) =>
              (s_OfType_TResult_1 ??
-             (s_OfType_TResult_1 = GetMethodInfoOf<IQueryable, IQueryable<object>>(Queryable.OfType<object>).GetGenericMethodDefinition()))
+             (s_OfType_TResult_1 = new Func<IQueryable, IQueryable<object>>(Queryable.OfType<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TResult);
 
         private static MethodInfo s_OrderBy_TSource_TKey_2;
 
         public static MethodInfo OrderBy_TSource_TKey_2(Type TSource, Type TKey) =>
              (s_OrderBy_TSource_TKey_2 ??
-             (s_OrderBy_TSource_TKey_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.OrderBy<object, object>).GetGenericMethodDefinition()))
+             (s_OrderBy_TSource_TKey_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.OrderBy<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_OrderBy_TSource_TKey_3;
 
         public static MethodInfo OrderBy_TSource_TKey_3(Type TSource, Type TKey) =>
              (s_OrderBy_TSource_TKey_3 ??
-             (s_OrderBy_TSource_TKey_3 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.OrderBy<object, object>).GetGenericMethodDefinition()))
+             (s_OrderBy_TSource_TKey_3 = new Func<IQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.OrderBy<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_OrderByDescending_TSource_TKey_2;
 
         public static MethodInfo OrderByDescending_TSource_TKey_2(Type TSource, Type TKey) =>
              (s_OrderByDescending_TSource_TKey_2 ??
-             (s_OrderByDescending_TSource_TKey_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.OrderByDescending<object, object>).GetGenericMethodDefinition()))
+             (s_OrderByDescending_TSource_TKey_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.OrderByDescending<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_OrderByDescending_TSource_TKey_3;
 
         public static MethodInfo OrderByDescending_TSource_TKey_3(Type TSource, Type TKey) =>
              (s_OrderByDescending_TSource_TKey_3 ??
-             (s_OrderByDescending_TSource_TKey_3 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.OrderByDescending<object, object>).GetGenericMethodDefinition()))
+             (s_OrderByDescending_TSource_TKey_3 = new Func<IQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.OrderByDescending<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_Reverse_TSource_1;
 
         public static MethodInfo Reverse_TSource_1(Type TSource) =>
              (s_Reverse_TSource_1 ??
-             (s_Reverse_TSource_1 = GetMethodInfoOf<IQueryable<object>, IQueryable<object>>(Queryable.Reverse<object>).GetGenericMethodDefinition()))
+             (s_Reverse_TSource_1 = new Func<IQueryable<object>, IQueryable<object>>(Queryable.Reverse<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Select_TSource_TResult_2;
 
         public static MethodInfo Select_TSource_TResult_2(Type TSource, Type TResult) =>
              (s_Select_TSource_TResult_2 ??
-             (s_Select_TSource_TResult_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, object>>, IQueryable<object>>(Queryable.Select<object, object>).GetGenericMethodDefinition()))
+             (s_Select_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, object>>, IQueryable<object>>(Queryable.Select<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TResult);
 
         private static MethodInfo s_Select_Index_TSource_TResult_2;
 
         public static MethodInfo Select_Index_TSource_TResult_2(Type TSource, Type TResult) =>
              (s_Select_Index_TSource_TResult_2 ??
-             (s_Select_Index_TSource_TResult_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int, object>>, IQueryable<object>>(Queryable.Select<object, object>).GetGenericMethodDefinition()))
+             (s_Select_Index_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, int, object>>, IQueryable<object>>(Queryable.Select<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TResult);
 
         private static MethodInfo s_SelectMany_TSource_TResult_2;
 
         public static MethodInfo SelectMany_TSource_TResult_2(Type TSource, Type TResult) =>
              (s_SelectMany_TSource_TResult_2 ??
-             (s_SelectMany_TSource_TResult_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, IEnumerable<object>>>, IQueryable<object>>(Queryable.SelectMany<object, object>).GetGenericMethodDefinition()))
+             (s_SelectMany_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, IEnumerable<object>>>, IQueryable<object>>(Queryable.SelectMany<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TResult);
 
         private static MethodInfo s_SelectMany_Index_TSource_TResult_2;
 
         public static MethodInfo SelectMany_Index_TSource_TResult_2(Type TSource, Type TResult) =>
              (s_SelectMany_Index_TSource_TResult_2 ??
-             (s_SelectMany_Index_TSource_TResult_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int, IEnumerable<object>>>, IQueryable<object>>(Queryable.SelectMany<object, object>).GetGenericMethodDefinition()))
+             (s_SelectMany_Index_TSource_TResult_2 = new Func<IQueryable<object>, Expression<Func<object, int, IEnumerable<object>>>, IQueryable<object>>(Queryable.SelectMany<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TResult);
 
         private static MethodInfo s_SelectMany_Index_TSource_TCollection_TResult_3;
 
         public static MethodInfo SelectMany_Index_TSource_TCollection_TResult_3(Type TSource, Type TCollection, Type TResult) =>
              (s_SelectMany_Index_TSource_TCollection_TResult_3 ??
-             (s_SelectMany_Index_TSource_TCollection_TResult_3 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int, IEnumerable<object>>>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.SelectMany<object, object, object>).GetGenericMethodDefinition()))
+             (s_SelectMany_Index_TSource_TCollection_TResult_3 = new Func<IQueryable<object>, Expression<Func<object, int, IEnumerable<object>>>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.SelectMany<object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TCollection, TResult);
 
         private static MethodInfo s_SelectMany_TSource_TCollection_TResult_3;
 
         public static MethodInfo SelectMany_TSource_TCollection_TResult_3(Type TSource, Type TCollection, Type TResult) =>
              (s_SelectMany_TSource_TCollection_TResult_3 ??
-             (s_SelectMany_TSource_TCollection_TResult_3 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, IEnumerable<object>>>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.SelectMany<object, object, object>).GetGenericMethodDefinition()))
+             (s_SelectMany_TSource_TCollection_TResult_3 = new Func<IQueryable<object>, Expression<Func<object, IEnumerable<object>>>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.SelectMany<object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TCollection, TResult);
 
         private static MethodInfo s_SequenceEqual_TSource_2;
 
         public static MethodInfo SequenceEqual_TSource_2(Type TSource) =>
              (s_SequenceEqual_TSource_2 ??
-             (s_SequenceEqual_TSource_2 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, bool>(Queryable.SequenceEqual<object>).GetGenericMethodDefinition()))
+             (s_SequenceEqual_TSource_2 = new Func<IQueryable<object>, IEnumerable<object>, bool>(Queryable.SequenceEqual<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_SequenceEqual_TSource_3;
 
         public static MethodInfo SequenceEqual_TSource_3(Type TSource) =>
              (s_SequenceEqual_TSource_3 ??
-             (s_SequenceEqual_TSource_3 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, bool>(Queryable.SequenceEqual<object>).GetGenericMethodDefinition()))
+             (s_SequenceEqual_TSource_3 = new Func<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, bool>(Queryable.SequenceEqual<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Single_TSource_1;
 
         public static MethodInfo Single_TSource_1(Type TSource) =>
              (s_Single_TSource_1 ??
-             (s_Single_TSource_1 = GetMethodInfoOf<IQueryable<object>, object>(Queryable.Single<object>).GetGenericMethodDefinition()))
+             (s_Single_TSource_1 = new Func<IQueryable<object>, object>(Queryable.Single<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Single_TSource_2;
 
         public static MethodInfo Single_TSource_2(Type TSource) =>
              (s_Single_TSource_2 ??
-             (s_Single_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.Single<object>).GetGenericMethodDefinition()))
+             (s_Single_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.Single<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_SingleOrDefault_TSource_1;
 
         public static MethodInfo SingleOrDefault_TSource_1(Type TSource) =>
              (s_SingleOrDefault_TSource_1 ??
-             (s_SingleOrDefault_TSource_1 = GetMethodInfoOf<IQueryable<object>, object>(Queryable.SingleOrDefault<object>).GetGenericMethodDefinition()))
+             (s_SingleOrDefault_TSource_1 = new Func<IQueryable<object>, object>(Queryable.SingleOrDefault<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_SingleOrDefault_TSource_2;
 
         public static MethodInfo SingleOrDefault_TSource_2(Type TSource) =>
              (s_SingleOrDefault_TSource_2 ??
-             (s_SingleOrDefault_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.SingleOrDefault<object>).GetGenericMethodDefinition()))
+             (s_SingleOrDefault_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(Queryable.SingleOrDefault<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Skip_TSource_2;
 
         public static MethodInfo Skip_TSource_2(Type TSource) =>
              (s_Skip_TSource_2 ??
-             (s_Skip_TSource_2 = GetMethodInfoOf<IQueryable<object>, int, IQueryable<object>>(Queryable.Skip<object>).GetGenericMethodDefinition()))
+             (s_Skip_TSource_2 = new Func<IQueryable<object>, int, IQueryable<object>>(Queryable.Skip<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_SkipWhile_TSource_2;
 
         public static MethodInfo SkipWhile_TSource_2(Type TSource) =>
              (s_SkipWhile_TSource_2 ??
-             (s_SkipWhile_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, IQueryable<object>>(Queryable.SkipWhile<object>).GetGenericMethodDefinition()))
+             (s_SkipWhile_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, IQueryable<object>>(Queryable.SkipWhile<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_SkipWhile_Index_TSource_2;
 
         public static MethodInfo SkipWhile_Index_TSource_2(Type TSource) =>
              (s_SkipWhile_Index_TSource_2 ??
-             (s_SkipWhile_Index_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int, bool>>, IQueryable<object>>(Queryable.SkipWhile<object>).GetGenericMethodDefinition()))
+             (s_SkipWhile_Index_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int, bool>>, IQueryable<object>>(Queryable.SkipWhile<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_Int32_1;
 
         public static MethodInfo Sum_Int32_1 =>
              s_Sum_Int32_1 ??
-            (s_Sum_Int32_1 = GetMethodInfoOf<IQueryable<int>, int>(Queryable.Sum));
+            (s_Sum_Int32_1 = new Func<IQueryable<int>, int>(Queryable.Sum).GetMethodInfo());
 
         private static MethodInfo s_Sum_NullableInt32_1;
 
         public static MethodInfo Sum_NullableInt32_1 =>
              s_Sum_NullableInt32_1 ??
-            (s_Sum_NullableInt32_1 = GetMethodInfoOf<IQueryable<int?>, int?>(Queryable.Sum));
+            (s_Sum_NullableInt32_1 = new Func<IQueryable<int?>, int?>(Queryable.Sum).GetMethodInfo());
 
         private static MethodInfo s_Sum_Int64_1;
 
         public static MethodInfo Sum_Int64_1 =>
              s_Sum_Int64_1 ??
-            (s_Sum_Int64_1 = GetMethodInfoOf<IQueryable<long>, long>(Queryable.Sum));
+            (s_Sum_Int64_1 = new Func<IQueryable<long>, long>(Queryable.Sum).GetMethodInfo());
 
         private static MethodInfo s_Sum_NullableInt64_1;
 
         public static MethodInfo Sum_NullableInt64_1 =>
              s_Sum_NullableInt64_1 ??
-            (s_Sum_NullableInt64_1 = GetMethodInfoOf<IQueryable<long?>, long?>(Queryable.Sum));
+            (s_Sum_NullableInt64_1 = new Func<IQueryable<long?>, long?>(Queryable.Sum).GetMethodInfo());
 
         private static MethodInfo s_Sum_Single_1;
 
         public static MethodInfo Sum_Single_1 =>
              s_Sum_Single_1 ??
-            (s_Sum_Single_1 = GetMethodInfoOf<IQueryable<float>, float>(Queryable.Sum));
+            (s_Sum_Single_1 = new Func<IQueryable<float>, float>(Queryable.Sum).GetMethodInfo());
 
         private static MethodInfo s_Sum_NullableSingle_1;
 
         public static MethodInfo Sum_NullableSingle_1 =>
              s_Sum_NullableSingle_1 ??
-            (s_Sum_NullableSingle_1 = GetMethodInfoOf<IQueryable<float?>, float?>(Queryable.Sum));
+            (s_Sum_NullableSingle_1 = new Func<IQueryable<float?>, float?>(Queryable.Sum).GetMethodInfo());
 
         private static MethodInfo s_Sum_Double_1;
 
         public static MethodInfo Sum_Double_1 =>
              s_Sum_Double_1 ??
-            (s_Sum_Double_1 = GetMethodInfoOf<IQueryable<double>, double>(Queryable.Sum));
+            (s_Sum_Double_1 = new Func<IQueryable<double>, double>(Queryable.Sum).GetMethodInfo());
 
         private static MethodInfo s_Sum_NullableDouble_1;
 
         public static MethodInfo Sum_NullableDouble_1 =>
              s_Sum_NullableDouble_1 ??
-            (s_Sum_NullableDouble_1 = GetMethodInfoOf<IQueryable<double?>, double?>(Queryable.Sum));
+            (s_Sum_NullableDouble_1 = new Func<IQueryable<double?>, double?>(Queryable.Sum).GetMethodInfo());
 
         private static MethodInfo s_Sum_Decimal_1;
 
         public static MethodInfo Sum_Decimal_1 =>
              s_Sum_Decimal_1 ??
-            (s_Sum_Decimal_1 = GetMethodInfoOf<IQueryable<decimal>, decimal>(Queryable.Sum));
+            (s_Sum_Decimal_1 = new Func<IQueryable<decimal>, decimal>(Queryable.Sum).GetMethodInfo());
 
         private static MethodInfo s_Sum_NullableDecimal_1;
 
         public static MethodInfo Sum_NullableDecimal_1 =>
              s_Sum_NullableDecimal_1 ??
-            (s_Sum_NullableDecimal_1 = GetMethodInfoOf<IQueryable<decimal?>, decimal?>(Queryable.Sum));
+            (s_Sum_NullableDecimal_1 = new Func<IQueryable<decimal?>, decimal?>(Queryable.Sum).GetMethodInfo());
 
         private static MethodInfo s_Sum_NullableDecimal_TSource_2;
 
         public static MethodInfo Sum_NullableDecimal_TSource_2(Type TSource) =>
              (s_Sum_NullableDecimal_TSource_2 ??
-             (s_Sum_NullableDecimal_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, decimal?>>, decimal?>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+             (s_Sum_NullableDecimal_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, decimal?>>, decimal?>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_Int32_TSource_2;
 
         public static MethodInfo Sum_Int32_TSource_2(Type TSource) =>
              (s_Sum_Int32_TSource_2 ??
-             (s_Sum_Int32_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int>>, int>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+             (s_Sum_Int32_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int>>, int>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_NullableInt32_TSource_2;
 
         public static MethodInfo Sum_NullableInt32_TSource_2(Type TSource) =>
              (s_Sum_NullableInt32_TSource_2 ??
-             (s_Sum_NullableInt32_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int?>>, int?>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+             (s_Sum_NullableInt32_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int?>>, int?>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_Int64_TSource_2;
 
         public static MethodInfo Sum_Int64_TSource_2(Type TSource) =>
              (s_Sum_Int64_TSource_2 ??
-             (s_Sum_Int64_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, long>>, long>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+             (s_Sum_Int64_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, long>>, long>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_NullableInt64_TSource_2;
 
         public static MethodInfo Sum_NullableInt64_TSource_2(Type TSource) =>
              (s_Sum_NullableInt64_TSource_2 ??
-             (s_Sum_NullableInt64_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, long?>>, long?>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+             (s_Sum_NullableInt64_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, long?>>, long?>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_Single_TSource_2;
 
         public static MethodInfo Sum_Single_TSource_2(Type TSource) =>
              (s_Sum_Single_TSource_2 ??
-             (s_Sum_Single_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, float>>, float>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+             (s_Sum_Single_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, float>>, float>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_NullableSingle_TSource_2;
 
         public static MethodInfo Sum_NullableSingle_TSource_2(Type TSource) =>
              (s_Sum_NullableSingle_TSource_2 ??
-             (s_Sum_NullableSingle_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, float?>>, float?>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+             (s_Sum_NullableSingle_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, float?>>, float?>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_Double_TSource_2;
 
         public static MethodInfo Sum_Double_TSource_2(Type TSource) =>
              (s_Sum_Double_TSource_2 ??
-             (s_Sum_Double_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, double>>, double>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+             (s_Sum_Double_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, double>>, double>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_NullableDouble_TSource_2;
 
         public static MethodInfo Sum_NullableDouble_TSource_2(Type TSource) =>
              (s_Sum_NullableDouble_TSource_2 ??
-             (s_Sum_NullableDouble_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, double?>>, double?>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+             (s_Sum_NullableDouble_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, double?>>, double?>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Sum_Decimal_TSource_2;
 
         public static MethodInfo Sum_Decimal_TSource_2(Type TSource) =>
              (s_Sum_Decimal_TSource_2 ??
-             (s_Sum_Decimal_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, decimal>>, decimal>(Queryable.Sum<object>).GetGenericMethodDefinition()))
+             (s_Sum_Decimal_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, decimal>>, decimal>(Queryable.Sum<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Take_TSource_2;
 
         public static MethodInfo Take_TSource_2(Type TSource) =>
              (s_Take_TSource_2 ??
-             (s_Take_TSource_2 = GetMethodInfoOf<IQueryable<object>, int, IQueryable<object>>(Queryable.Take<object>).GetGenericMethodDefinition()))
+             (s_Take_TSource_2 = new Func<IQueryable<object>, int, IQueryable<object>>(Queryable.Take<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_TakeWhile_TSource_2;
 
         public static MethodInfo TakeWhile_TSource_2(Type TSource) =>
              (s_TakeWhile_TSource_2 ??
-             (s_TakeWhile_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, IQueryable<object>>(Queryable.TakeWhile<object>).GetGenericMethodDefinition()))
+             (s_TakeWhile_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, IQueryable<object>>(Queryable.TakeWhile<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_TakeWhile_Index_TSource_2;
 
         public static MethodInfo TakeWhile_Index_TSource_2(Type TSource) =>
              (s_TakeWhile_Index_TSource_2 ??
-             (s_TakeWhile_Index_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int, bool>>, IQueryable<object>>(Queryable.TakeWhile<object>).GetGenericMethodDefinition()))
+             (s_TakeWhile_Index_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int, bool>>, IQueryable<object>>(Queryable.TakeWhile<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_ThenBy_TSource_TKey_2;
 
         public static MethodInfo ThenBy_TSource_TKey_2(Type TSource, Type TKey) =>
              (s_ThenBy_TSource_TKey_2 ??
-             (s_ThenBy_TSource_TKey_2 = GetMethodInfoOf<IOrderedQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.ThenBy<object, object>).GetGenericMethodDefinition()))
+             (s_ThenBy_TSource_TKey_2 = new Func<IOrderedQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.ThenBy<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_ThenBy_TSource_TKey_3;
 
         public static MethodInfo ThenBy_TSource_TKey_3(Type TSource, Type TKey) =>
              (s_ThenBy_TSource_TKey_3 ??
-             (s_ThenBy_TSource_TKey_3 = GetMethodInfoOf<IOrderedQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.ThenBy<object, object>).GetGenericMethodDefinition()))
+             (s_ThenBy_TSource_TKey_3 = new Func<IOrderedQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.ThenBy<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_ThenByDescending_TSource_TKey_2;
 
         public static MethodInfo ThenByDescending_TSource_TKey_2(Type TSource, Type TKey) =>
              (s_ThenByDescending_TSource_TKey_2 ??
-             (s_ThenByDescending_TSource_TKey_2 = GetMethodInfoOf<IOrderedQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.ThenByDescending<object, object>).GetGenericMethodDefinition()))
+             (s_ThenByDescending_TSource_TKey_2 = new Func<IOrderedQueryable<object>, Expression<Func<object, object>>, IOrderedQueryable<object>>(Queryable.ThenByDescending<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_ThenByDescending_TSource_TKey_3;
 
         public static MethodInfo ThenByDescending_TSource_TKey_3(Type TSource, Type TKey) =>
              (s_ThenByDescending_TSource_TKey_3 ??
-             (s_ThenByDescending_TSource_TKey_3 = GetMethodInfoOf<IOrderedQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.ThenByDescending<object, object>).GetGenericMethodDefinition()))
+             (s_ThenByDescending_TSource_TKey_3 = new Func<IOrderedQueryable<object>, Expression<Func<object, object>>, IComparer<object>, IOrderedQueryable<object>>(Queryable.ThenByDescending<object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource, TKey);
 
         private static MethodInfo s_Union_TSource_2;
 
         public static MethodInfo Union_TSource_2(Type TSource) =>
              (s_Union_TSource_2 ??
-             (s_Union_TSource_2 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Union<object>).GetGenericMethodDefinition()))
+             (s_Union_TSource_2 = new Func<IQueryable<object>, IEnumerable<object>, IQueryable<object>>(Queryable.Union<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Union_TSource_3;
 
         public static MethodInfo Union_TSource_3(Type TSource) =>
              (s_Union_TSource_3 ??
-             (s_Union_TSource_3 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Union<object>).GetGenericMethodDefinition()))
+             (s_Union_TSource_3 = new Func<IQueryable<object>, IEnumerable<object>, IEqualityComparer<object>, IQueryable<object>>(Queryable.Union<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Where_TSource_2;
 
         public static MethodInfo Where_TSource_2(Type TSource) =>
              (s_Where_TSource_2 ??
-             (s_Where_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, bool>>, IQueryable<object>>(Queryable.Where<object>).GetGenericMethodDefinition()))
+             (s_Where_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, bool>>, IQueryable<object>>(Queryable.Where<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Where_Index_TSource_2;
 
         public static MethodInfo Where_Index_TSource_2(Type TSource) =>
              (s_Where_Index_TSource_2 ??
-             (s_Where_Index_TSource_2 = GetMethodInfoOf<IQueryable<object>, Expression<Func<object, int, bool>>, IQueryable<object>>(Queryable.Where<object>).GetGenericMethodDefinition()))
+             (s_Where_Index_TSource_2 = new Func<IQueryable<object>, Expression<Func<object, int, bool>>, IQueryable<object>>(Queryable.Where<object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TSource);
 
         private static MethodInfo s_Zip_TFirst_TSecond_TResult_3;
 
         public static MethodInfo Zip_TFirst_TSecond_TResult_3(Type TFirst, Type TSecond, Type TResult) =>
              (s_Zip_TFirst_TSecond_TResult_3 ??
-             (s_Zip_TFirst_TSecond_TResult_3 = GetMethodInfoOf<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.Zip<object, object, object>).GetGenericMethodDefinition()))
+             (s_Zip_TFirst_TSecond_TResult_3 = new Func<IQueryable<object>, IEnumerable<object>, Expression<Func<object, object, object>>, IQueryable<object>>(Queryable.Zip<object, object, object>).GetMethodInfo().GetGenericMethodDefinition()))
               .MakeGenericMethod(TFirst, TSecond, TResult);
 
-        private static MethodInfo GetMethodInfoOf<T1, R>(Func<T1, R> f) => GetMethodInfoOf((Delegate)f);
-        private static MethodInfo GetMethodInfoOf<T1, T2, R>(Func<T1, T2, R> f) => GetMethodInfoOf((Delegate)f);
-        private static MethodInfo GetMethodInfoOf<T1, T2, T3, R>(Func<T1, T2, T3, R> f) => GetMethodInfoOf((Delegate)f);
-        private static MethodInfo GetMethodInfoOf<T1, T2, T3, T4, R>(Func<T1, T2, T3, T4, R> f) => GetMethodInfoOf((Delegate)f);
-        private static MethodInfo GetMethodInfoOf<T1, T2, T3, T4, T5, R>(Func<T1, T2, T3, T4, T5, R> f) => GetMethodInfoOf((Delegate)f);
-        private static MethodInfo GetMethodInfoOf<T1, T2, T3, T4, T5, T6, R>(Func<T1, T2, T3, T4, T5, T6, R> f) => GetMethodInfoOf((Delegate)f);
-        private static MethodInfo GetMethodInfoOf(Delegate f) => f.GetMethodInfo();
     }
 }

--- a/src/System.Linq.Queryable/src/System/Linq/Queryable.cs
+++ b/src/System.Linq.Queryable/src/System/Linq/Queryable.cs
@@ -39,9 +39,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Where(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, bool>>))),
+                    CachedReflectionInfo.Where_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(predicate) }
                     ));
         }
@@ -55,9 +53,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Where(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, int, bool>>))),
+                    CachedReflectionInfo.Where_Index_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(predicate) }
                     ));
         }
@@ -69,8 +65,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.OfType<TResult>(
-                        default(IQueryable))),
+                    CachedReflectionInfo.OfType_TResult_1(typeof(TResult)),
                     new Expression[] { source.Expression }
                     ));
         }
@@ -82,8 +77,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Cast<TResult>(
-                        default(IQueryable))),
+                    CachedReflectionInfo.Cast_TResult_1(typeof(TResult)),
                     new Expression[] { source.Expression }
                     ));
         }
@@ -97,9 +91,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Select(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, TResult>>))),
+                    CachedReflectionInfo.Select_TSource_TResult_2(typeof(TSource), typeof(TResult)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -113,9 +105,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Select(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, int, TResult>>))),
+                    CachedReflectionInfo.Select_Index_TSource_TResult_2(typeof(TSource), typeof(TResult)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -129,9 +119,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.SelectMany(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, IEnumerable<TResult>>>))),
+                    CachedReflectionInfo.SelectMany_TSource_TResult_2(typeof(TSource), typeof(TResult)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -145,9 +133,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.SelectMany(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, int, IEnumerable<TResult>>>))),
+                    CachedReflectionInfo.SelectMany_Index_TSource_TResult_2(typeof(TSource), typeof(TResult)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -163,10 +149,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.SelectMany(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, int, IEnumerable<TCollection>>>),
-                        default(Expression<Func<TSource, TCollection, TResult>>))),
+                    CachedReflectionInfo.SelectMany_Index_TSource_TCollection_TResult_3(typeof(TSource), typeof(TCollection), typeof(TResult)),
                     new Expression[] { source.Expression, Expression.Quote(collectionSelector), Expression.Quote(resultSelector) }
                     ));
         }
@@ -182,10 +165,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.SelectMany(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, IEnumerable<TCollection>>>),
-                        default(Expression<Func<TSource, TCollection, TResult>>))),
+                    CachedReflectionInfo.SelectMany_TSource_TCollection_TResult_3(typeof(TSource), typeof(TCollection), typeof(TResult)),
                     new Expression[] { source.Expression, Expression.Quote(collectionSelector), Expression.Quote(resultSelector) }
                     ));
         }
@@ -212,12 +192,7 @@ namespace System.Linq
             return outer.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Join(
-                        default(IQueryable<TOuter>),
-                        default(IEnumerable<TInner>),
-                        default(Expression<Func<TOuter, TKey>>),
-                        default(Expression<Func<TInner, TKey>>),
-                        default(Expression<Func<TOuter, TInner, TResult>>))),
+                    CachedReflectionInfo.Join_TOuter_TInner_TKey_TResult_5(typeof(TOuter), typeof(TInner), typeof(TKey), typeof(TResult)),
                     new Expression[] {
                         outer.Expression,
                         GetSourceExpression(inner),
@@ -243,13 +218,7 @@ namespace System.Linq
             return outer.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Join(
-                        default(IQueryable<TOuter>),
-                        default(IEnumerable<TInner>),
-                        default(Expression<Func<TOuter, TKey>>),
-                        default(Expression<Func<TInner, TKey>>),
-                        default(Expression<Func<TOuter, TInner, TResult>>),
-                        default(IEqualityComparer<TKey>))),
+                    CachedReflectionInfo.Join_TOuter_TInner_TKey_TResult_6(typeof(TOuter), typeof(TInner), typeof(TKey), typeof(TResult)),
                     new Expression[] {
                         outer.Expression,
                         GetSourceExpression(inner),
@@ -276,12 +245,7 @@ namespace System.Linq
             return outer.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.GroupJoin(
-                        default(IQueryable<TOuter>),
-                        default(IEnumerable<TInner>),
-                        default(Expression<Func<TOuter, TKey>>),
-                        default(Expression<Func<TInner, TKey>>),
-                        default(Expression<Func<TOuter, IEnumerable<TInner>, TResult>>))),
+                    CachedReflectionInfo.GroupJoin_TOuter_TInner_TKey_TResult_5(typeof(TOuter), typeof(TInner), typeof(TKey), typeof(TResult)),
                     new Expression[] {
                         outer.Expression,
                         GetSourceExpression(inner),
@@ -306,13 +270,7 @@ namespace System.Linq
             return outer.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.GroupJoin(
-                        default(IQueryable<TOuter>),
-                        default(IEnumerable<TInner>),
-                        default(Expression<Func<TOuter, TKey>>),
-                        default(Expression<Func<TInner, TKey>>),
-                        default(Expression<Func<TOuter, IEnumerable<TInner>, TResult>>),
-                        default(IEqualityComparer<TKey>))),
+                    CachedReflectionInfo.GroupJoin_TOuter_TInner_TKey_TResult_6(typeof(TOuter), typeof(TInner), typeof(TKey), typeof(TResult)),
                     new Expression[] {
                         outer.Expression,
                         GetSourceExpression(inner),
@@ -332,9 +290,7 @@ namespace System.Linq
             return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.OrderBy(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, TKey>>))),
+                    CachedReflectionInfo.OrderBy_TSource_TKey_2(typeof(TSource), typeof(TKey)),
                     new Expression[] { source.Expression, Expression.Quote(keySelector) }
                     ));
         }
@@ -348,10 +304,7 @@ namespace System.Linq
             return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.OrderBy(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, TKey>>),
-                        default(IComparer<TKey>))),
+                    CachedReflectionInfo.OrderBy_TSource_TKey_3(typeof(TSource), typeof(TKey)),
                     new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Constant(comparer, typeof(IComparer<TKey>)) }
                     ));
         }
@@ -365,9 +318,7 @@ namespace System.Linq
             return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.OrderByDescending(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, TKey>>))),
+                    CachedReflectionInfo.OrderByDescending_TSource_TKey_2(typeof(TSource), typeof(TKey)),
                     new Expression[] { source.Expression, Expression.Quote(keySelector) }
                     ));
         }
@@ -381,10 +332,7 @@ namespace System.Linq
             return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.OrderByDescending(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, TKey>>),
-                        default(IComparer<TKey>))),
+                    CachedReflectionInfo.OrderByDescending_TSource_TKey_3(typeof(TSource), typeof(TKey)),
                     new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Constant(comparer, typeof(IComparer<TKey>)) }
                     ));
         }
@@ -398,9 +346,7 @@ namespace System.Linq
             return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.ThenBy(
-                        default(IOrderedQueryable<TSource>),
-                        default(Expression<Func<TSource, TKey>>))),
+                    CachedReflectionInfo.ThenBy_TSource_TKey_2(typeof(TSource), typeof(TKey)),
                     new Expression[] { source.Expression, Expression.Quote(keySelector) }
                     ));
         }
@@ -414,10 +360,7 @@ namespace System.Linq
             return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.ThenBy(
-                        default(IOrderedQueryable<TSource>),
-                        default(Expression<Func<TSource, TKey>>),
-                        default(IComparer<TKey>))),
+                    CachedReflectionInfo.ThenBy_TSource_TKey_3(typeof(TSource), typeof(TKey)),
                     new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Constant(comparer, typeof(IComparer<TKey>)) }
                     ));
         }
@@ -431,9 +374,7 @@ namespace System.Linq
             return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.ThenByDescending(
-                        default(IOrderedQueryable<TSource>),
-                        default(Expression<Func<TSource, TKey>>))),
+                    CachedReflectionInfo.ThenByDescending_TSource_TKey_2(typeof(TSource), typeof(TKey)),
                     new Expression[] { source.Expression, Expression.Quote(keySelector) }
                     ));
         }
@@ -447,10 +388,7 @@ namespace System.Linq
             return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.ThenByDescending(
-                        default(IOrderedQueryable<TSource>),
-                        default(Expression<Func<TSource, TKey>>),
-                        default(IComparer<TKey>))),
+                    CachedReflectionInfo.ThenByDescending_TSource_TKey_3(typeof(TSource), typeof(TKey)),
                     new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Constant(comparer, typeof(IComparer<TKey>)) }
                     ));
         }
@@ -462,9 +400,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Take(
-                        default(IQueryable<TSource>),
-                        default(int))),
+                    CachedReflectionInfo.Take_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Constant(count) }
                     ));
         }
@@ -478,9 +414,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.TakeWhile(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, bool>>))),
+                    CachedReflectionInfo.TakeWhile_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(predicate) }
                     ));
         }
@@ -494,9 +428,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.TakeWhile(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, int, bool>>))),
+                    CachedReflectionInfo.TakeWhile_Index_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(predicate) }
                     ));
         }
@@ -508,9 +440,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Skip(
-                        default(IQueryable<TSource>),
-                        default(int))),
+                    CachedReflectionInfo.Skip_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Constant(count) }
                     ));
         }
@@ -524,9 +454,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.SkipWhile(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, bool>>))),
+                    CachedReflectionInfo.SkipWhile_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(predicate) }
                     ));
         }
@@ -540,9 +468,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.SkipWhile(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, int, bool>>))),
+                    CachedReflectionInfo.SkipWhile_Index_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(predicate) }
                     ));
         }
@@ -556,9 +482,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<IGrouping<TKey, TSource>>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.GroupBy(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, TKey>>))),
+                    CachedReflectionInfo.GroupBy_TSource_TKey_2(typeof(TSource), typeof(TKey)),
                     new Expression[] { source.Expression, Expression.Quote(keySelector) }
                     ));
         }
@@ -574,10 +498,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<IGrouping<TKey, TElement>>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.GroupBy(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, TKey>>),
-                        default(Expression<Func<TSource, TElement>>))),
+                    CachedReflectionInfo.GroupBy_TSource_TKey_TElement_3(typeof(TSource), typeof(TKey), typeof(TElement)),
                     new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Quote(elementSelector) }
                     ));
         }
@@ -591,10 +512,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<IGrouping<TKey, TSource>>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.GroupBy(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, TKey>>),
-                        default(IEqualityComparer<TKey>))),
+                    CachedReflectionInfo.GroupBy_TSource_TKey_3(typeof(TSource), typeof(TKey)),
                     new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Constant(comparer, typeof(IEqualityComparer<TKey>)) }
                     ));
         }
@@ -610,11 +528,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<IGrouping<TKey, TElement>>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.GroupBy(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, TKey>>),
-                        default(Expression<Func<TSource, TElement>>),
-                        default(IEqualityComparer<TKey>))),
+                    CachedReflectionInfo.GroupBy_TSource_TKey_TElement_4(typeof(TSource), typeof(TKey), typeof(TElement)),
                     new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Quote(elementSelector), Expression.Constant(comparer, typeof(IEqualityComparer<TKey>)) }
                     ));
         }
@@ -632,11 +546,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.GroupBy(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, TKey>>),
-                        default(Expression<Func<TSource, TElement>>),
-                        default(Expression<Func<TKey, IEnumerable<TElement>, TResult>>))),
+                    CachedReflectionInfo.GroupBy_TSource_TKey_TElement_TResult_4(typeof(TSource), typeof(TKey), typeof(TElement), typeof(TResult)),
                     new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Quote(elementSelector), Expression.Quote(resultSelector) }
                     ));
         }
@@ -652,10 +562,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.GroupBy(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, TKey>>),
-                        default(Expression<Func<TKey, IEnumerable<TSource>, TResult>>))),
+                    CachedReflectionInfo.GroupBy_TSource_TKey_TResult_3(typeof(TSource), typeof(TKey), typeof(TResult)),
                     new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Quote(resultSelector) }
                     ));
         }
@@ -671,11 +578,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.GroupBy(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, TKey>>),
-                        default(Expression<Func<TKey, IEnumerable<TSource>, TResult>>),
-                        default(IEqualityComparer<TKey>))),
+                    CachedReflectionInfo.GroupBy_TSource_TKey_TResult_4(typeof(TSource), typeof(TKey), typeof(TResult)),
                     new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Quote(resultSelector), Expression.Constant(comparer, typeof(IEqualityComparer<TKey>)) }
                     ));
         }
@@ -693,12 +596,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.GroupBy(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, TKey>>),
-                        default(Expression<Func<TSource, TElement>>),
-                        default(Expression<Func<TKey, IEnumerable<TElement>, TResult>>),
-                        default(IEqualityComparer<TKey>))),
+                    CachedReflectionInfo.GroupBy_TSource_TKey_TElement_TResult_5(typeof(TSource), typeof(TKey), typeof(TElement), typeof(TResult)),
                     new Expression[] { source.Expression, Expression.Quote(keySelector), Expression.Quote(elementSelector), Expression.Quote(resultSelector), Expression.Constant(comparer, typeof(IEqualityComparer<TKey>)) }
                     ));
         }
@@ -710,8 +608,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Distinct(
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.Distinct_TSource_1(typeof(TSource)),
                     new Expression[] { source.Expression }
                     ));
         }
@@ -723,9 +620,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Distinct(
-                        default(IQueryable<TSource>),
-                        default(IEqualityComparer<TSource>))),
+                    CachedReflectionInfo.Distinct_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Constant(comparer, typeof(IEqualityComparer<TSource>)) }
                     ));
         }
@@ -739,9 +634,7 @@ namespace System.Linq
             return source1.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Concat(
-                        default(IQueryable<TSource>),
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.Concat_TSource_2(typeof(TSource)),
                     new Expression[] { source1.Expression, GetSourceExpression(source2) }
                     ));
         }
@@ -757,10 +650,7 @@ namespace System.Linq
             return source1.Provider.CreateQuery<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Zip(
-                        default(IQueryable<TFirst>),
-                        default(IEnumerable<TSecond>),
-                        default(Expression<Func<TFirst, TSecond, TResult>>))),
+                    CachedReflectionInfo.Zip_TFirst_TSecond_TResult_3(typeof(TFirst), typeof(TSecond), typeof(TResult)),
                     new Expression[] { source1.Expression, GetSourceExpression(source2), Expression.Quote(resultSelector) }
                     ));
         }
@@ -774,9 +664,7 @@ namespace System.Linq
             return source1.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Union(
-                        default(IQueryable<TSource>),
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.Union_TSource_2(typeof(TSource)),
                     new Expression[] { source1.Expression, GetSourceExpression(source2) }
                     ));
         }
@@ -790,10 +678,7 @@ namespace System.Linq
             return source1.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Union(
-                        default(IQueryable<TSource>),
-                        default(IQueryable<TSource>),
-                        default(IEqualityComparer<TSource>))),
+                    CachedReflectionInfo.Union_TSource_3(typeof(TSource)),
                     new Expression[] {
                         source1.Expression,
                         GetSourceExpression(source2),
@@ -811,9 +696,7 @@ namespace System.Linq
             return source1.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Intersect(
-                        default(IQueryable<TSource>),
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.Intersect_TSource_2(typeof(TSource)),
                     new Expression[] { source1.Expression, GetSourceExpression(source2) }
                     ));
         }
@@ -827,10 +710,7 @@ namespace System.Linq
             return source1.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Intersect(
-                        default(IQueryable<TSource>),
-                        default(IEnumerable<TSource>),
-                        default(IEqualityComparer<TSource>))),
+                    CachedReflectionInfo.Intersect_TSource_3(typeof(TSource)),
                     new Expression[] {
                         source1.Expression,
                         GetSourceExpression(source2),
@@ -848,9 +728,7 @@ namespace System.Linq
             return source1.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Except(
-                        default(IQueryable<TSource>),
-                        default(IEnumerable<TSource>))),
+                    CachedReflectionInfo.Except_TSource_2(typeof(TSource)),
                     new Expression[] { source1.Expression, GetSourceExpression(source2) }
                     ));
         }
@@ -864,10 +742,7 @@ namespace System.Linq
             return source1.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Except(
-                        default(IQueryable<TSource>),
-                        default(IEnumerable<TSource>),
-                        default(IEqualityComparer<TSource>))),
+                    CachedReflectionInfo.Except_TSource_3(typeof(TSource)),
                     new Expression[] {
                         source1.Expression,
                         GetSourceExpression(source2),
@@ -883,8 +758,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.First(
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.First_TSource_1(typeof(TSource)),
                     new Expression[] { source.Expression }
                     ));
         }
@@ -898,9 +772,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.First(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, bool>>))),
+                    CachedReflectionInfo.First_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(predicate) }
                     ));
         }
@@ -912,8 +784,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.FirstOrDefault(
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.FirstOrDefault_TSource_1(typeof(TSource)),
                     new Expression[] { source.Expression }
                     ));
         }
@@ -927,9 +798,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.FirstOrDefault(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, bool>>))),
+                    CachedReflectionInfo.FirstOrDefault_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(predicate) }
                     ));
         }
@@ -941,8 +810,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Last(
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.Last_TSource_1(typeof(TSource)),
                     new Expression[] { source.Expression }
                     ));
         }
@@ -956,9 +824,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Last(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, bool>>))),
+                    CachedReflectionInfo.Last_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(predicate) }
                     ));
         }
@@ -970,8 +836,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.LastOrDefault(
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.LastOrDefault_TSource_1(typeof(TSource)),
                     new Expression[] { source.Expression }
                     ));
         }
@@ -985,9 +850,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.LastOrDefault(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, bool>>))),
+                    CachedReflectionInfo.LastOrDefault_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(predicate) }
                     ));
         }
@@ -999,8 +862,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Single(
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.Single_TSource_1(typeof(TSource)),
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1014,9 +876,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Single(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, bool>>))),
+                    CachedReflectionInfo.Single_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(predicate) }
                     ));
         }
@@ -1028,8 +888,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.SingleOrDefault(
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.SingleOrDefault_TSource_1(typeof(TSource)),
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1043,9 +902,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.SingleOrDefault(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, bool>>))),
+                    CachedReflectionInfo.SingleOrDefault_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(predicate) }
                     ));
         }
@@ -1059,9 +916,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.ElementAt(
-                        default(IQueryable<TSource>),
-                        default(int))),
+                    CachedReflectionInfo.ElementAt_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Constant(index) }
                     ));
         }
@@ -1073,9 +928,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.ElementAtOrDefault(
-                        default(IQueryable<TSource>),
-                        default(int))),
+                    CachedReflectionInfo.ElementAtOrDefault_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Constant(index) }
                     ));
         }
@@ -1087,8 +940,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.DefaultIfEmpty(
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.DefaultIfEmpty_TSource_1(typeof(TSource)),
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1100,9 +952,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.DefaultIfEmpty(
-                        default(IQueryable<TSource>),
-                        default(TSource))),
+                    CachedReflectionInfo.DefaultIfEmpty_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Constant(defaultValue, typeof(TSource)) }
                     ));
         }
@@ -1114,9 +964,7 @@ namespace System.Linq
             return source.Provider.Execute<bool>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Contains(
-                        default(IQueryable<TSource>),
-                        default(TSource))),
+                    CachedReflectionInfo.Contains_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Constant(item, typeof(TSource)) }
                     ));
         }
@@ -1128,10 +976,7 @@ namespace System.Linq
             return source.Provider.Execute<bool>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Contains(
-                        default(IQueryable<TSource>),
-                        default(TSource),
-                        default(IEqualityComparer<TSource>))),
+                    CachedReflectionInfo.Contains_TSource_3(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Constant(item, typeof(TSource)), Expression.Constant(comparer, typeof(IEqualityComparer<TSource>)) }
                     ));
         }
@@ -1143,8 +988,7 @@ namespace System.Linq
             return source.Provider.CreateQuery<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Reverse(
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.Reverse_TSource_1(typeof(TSource)),
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1158,9 +1002,7 @@ namespace System.Linq
             return source1.Provider.Execute<bool>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.SequenceEqual(
-                        default(IQueryable<TSource>),
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.SequenceEqual_TSource_2(typeof(TSource)),
                     new Expression[] { source1.Expression, GetSourceExpression(source2) }
                     ));
         }
@@ -1174,10 +1016,7 @@ namespace System.Linq
             return source1.Provider.Execute<bool>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.SequenceEqual(
-                        default(IQueryable<TSource>),
-                        default(IEnumerable<TSource>),
-                        default(IEqualityComparer<TSource>))),
+                    CachedReflectionInfo.SequenceEqual_TSource_3(typeof(TSource)),
                     new Expression[] {
                         source1.Expression,
                         GetSourceExpression(source2),
@@ -1193,8 +1032,7 @@ namespace System.Linq
             return source.Provider.Execute<bool>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Any(
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.Any_TSource_1(typeof(TSource)),
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1208,9 +1046,7 @@ namespace System.Linq
             return source.Provider.Execute<bool>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Any(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, bool>>))),
+                    CachedReflectionInfo.Any_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(predicate) }
                     ));
         }
@@ -1224,9 +1060,7 @@ namespace System.Linq
             return source.Provider.Execute<bool>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.All(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, bool>>))),
+                    CachedReflectionInfo.All_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(predicate) }
                     ));
         }
@@ -1238,8 +1072,7 @@ namespace System.Linq
             return source.Provider.Execute<int>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Count(
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.Count_TSource_1(typeof(TSource)),
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1253,9 +1086,7 @@ namespace System.Linq
             return source.Provider.Execute<int>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Count(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, bool>>))),
+                    CachedReflectionInfo.Count_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(predicate) }
                     ));
         }
@@ -1267,8 +1098,7 @@ namespace System.Linq
             return source.Provider.Execute<long>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.LongCount(
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.LongCount_TSource_1(typeof(TSource)),
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1282,9 +1112,7 @@ namespace System.Linq
             return source.Provider.Execute<long>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.LongCount(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, bool>>))),
+                    CachedReflectionInfo.LongCount_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(predicate) }
                     ));
         }
@@ -1296,8 +1124,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Min(
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.Min_TSource_1(typeof(TSource)),
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1311,9 +1138,7 @@ namespace System.Linq
             return source.Provider.Execute<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Min(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, TResult>>))),
+                    CachedReflectionInfo.Min_TSource_TResult_2(typeof(TSource), typeof(TResult)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1325,8 +1150,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Max(
-                        default(IQueryable<TSource>))),
+                    CachedReflectionInfo.Max_TSource_1(typeof(TSource)),
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1340,9 +1164,7 @@ namespace System.Linq
             return source.Provider.Execute<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Max(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, TResult>>))),
+                    CachedReflectionInfo.Max_TSource_TResult_2(typeof(TSource), typeof(TResult)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1354,8 +1176,7 @@ namespace System.Linq
             return source.Provider.Execute<int>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<int>))),
+                    CachedReflectionInfo.Sum_Int32_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1367,8 +1188,7 @@ namespace System.Linq
             return source.Provider.Execute<int?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<int?>))),
+                    CachedReflectionInfo.Sum_NullableInt32_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1380,8 +1200,7 @@ namespace System.Linq
             return source.Provider.Execute<long>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<long>))),
+                    CachedReflectionInfo.Sum_Int64_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1393,8 +1212,7 @@ namespace System.Linq
             return source.Provider.Execute<long?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<long?>))),
+                    CachedReflectionInfo.Sum_NullableInt64_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1406,8 +1224,7 @@ namespace System.Linq
             return source.Provider.Execute<float>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<float>))),
+                    CachedReflectionInfo.Sum_Single_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1419,8 +1236,7 @@ namespace System.Linq
             return source.Provider.Execute<float?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<float?>))),
+                    CachedReflectionInfo.Sum_NullableSingle_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1432,8 +1248,7 @@ namespace System.Linq
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<double>))),
+                    CachedReflectionInfo.Sum_Double_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1445,8 +1260,7 @@ namespace System.Linq
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<double?>))),
+                    CachedReflectionInfo.Sum_NullableDouble_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1458,8 +1272,7 @@ namespace System.Linq
             return source.Provider.Execute<decimal>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<decimal>))),
+                    CachedReflectionInfo.Sum_Decimal_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1471,8 +1284,7 @@ namespace System.Linq
             return source.Provider.Execute<decimal?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<decimal?>))),
+                    CachedReflectionInfo.Sum_NullableDecimal_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1486,9 +1298,7 @@ namespace System.Linq
             return source.Provider.Execute<int>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, int>>))),
+                    CachedReflectionInfo.Sum_Int32_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1502,9 +1312,7 @@ namespace System.Linq
             return source.Provider.Execute<int?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, int?>>))),
+                    CachedReflectionInfo.Sum_NullableInt32_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1518,9 +1326,7 @@ namespace System.Linq
             return source.Provider.Execute<long>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, long>>))),
+                    CachedReflectionInfo.Sum_Int64_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1534,9 +1340,7 @@ namespace System.Linq
             return source.Provider.Execute<long?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, long?>>))),
+                    CachedReflectionInfo.Sum_NullableInt64_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1550,9 +1354,7 @@ namespace System.Linq
             return source.Provider.Execute<float>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, float>>))),
+                    CachedReflectionInfo.Sum_Single_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1566,9 +1368,7 @@ namespace System.Linq
             return source.Provider.Execute<float?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, float?>>))),
+                    CachedReflectionInfo.Sum_NullableSingle_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1582,9 +1382,7 @@ namespace System.Linq
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, double>>))),
+                    CachedReflectionInfo.Sum_Double_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1598,9 +1396,7 @@ namespace System.Linq
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, double?>>))),
+                    CachedReflectionInfo.Sum_NullableDouble_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1614,9 +1410,7 @@ namespace System.Linq
             return source.Provider.Execute<decimal>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, decimal>>))),
+                    CachedReflectionInfo.Sum_Decimal_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1630,9 +1424,7 @@ namespace System.Linq
             return source.Provider.Execute<decimal?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Sum(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, decimal?>>))),
+                    CachedReflectionInfo.Sum_NullableDecimal_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1644,8 +1436,7 @@ namespace System.Linq
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<int>))),
+                    CachedReflectionInfo.Average_Int32_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1657,8 +1448,7 @@ namespace System.Linq
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<int?>))),
+                    CachedReflectionInfo.Average_NullableInt32_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1670,8 +1460,7 @@ namespace System.Linq
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<long>))),
+                    CachedReflectionInfo.Average_Int64_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1683,8 +1472,7 @@ namespace System.Linq
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<long?>))),
+                    CachedReflectionInfo.Average_NullableInt64_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1696,8 +1484,7 @@ namespace System.Linq
             return source.Provider.Execute<float>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<float>))),
+                    CachedReflectionInfo.Average_Single_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1709,8 +1496,7 @@ namespace System.Linq
             return source.Provider.Execute<float?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<float?>))),
+                    CachedReflectionInfo.Average_NullableSingle_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1722,8 +1508,7 @@ namespace System.Linq
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<double>))),
+                    CachedReflectionInfo.Average_Double_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1735,8 +1520,7 @@ namespace System.Linq
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<double?>))),
+                    CachedReflectionInfo.Average_NullableDouble_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1748,8 +1532,7 @@ namespace System.Linq
             return source.Provider.Execute<decimal>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<decimal>))),
+                    CachedReflectionInfo.Average_Decimal_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1761,8 +1544,7 @@ namespace System.Linq
             return source.Provider.Execute<decimal?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<decimal?>))),
+                    CachedReflectionInfo.Average_NullableDecimal_1,
                     new Expression[] { source.Expression }
                     ));
         }
@@ -1776,9 +1558,7 @@ namespace System.Linq
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, int>>))),
+                    CachedReflectionInfo.Average_Int32_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1792,9 +1572,7 @@ namespace System.Linq
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, int?>>))),
+                    CachedReflectionInfo.Average_NullableInt32_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1808,9 +1586,7 @@ namespace System.Linq
             return source.Provider.Execute<float>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, float>>))),
+                    CachedReflectionInfo.Average_Single_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1824,9 +1600,7 @@ namespace System.Linq
             return source.Provider.Execute<float?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, float?>>))),
+                    CachedReflectionInfo.Average_NullableSingle_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1840,9 +1614,7 @@ namespace System.Linq
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, long>>))),
+                    CachedReflectionInfo.Average_Int64_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1856,9 +1628,7 @@ namespace System.Linq
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, long?>>))),
+                    CachedReflectionInfo.Average_NullableInt64_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1872,9 +1642,7 @@ namespace System.Linq
             return source.Provider.Execute<double>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, double>>))),
+                    CachedReflectionInfo.Average_Double_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1888,9 +1656,7 @@ namespace System.Linq
             return source.Provider.Execute<double?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, double?>>))),
+                    CachedReflectionInfo.Average_NullableDouble_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1904,9 +1670,7 @@ namespace System.Linq
             return source.Provider.Execute<decimal>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, decimal>>))),
+                    CachedReflectionInfo.Average_Decimal_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1920,9 +1684,7 @@ namespace System.Linq
             return source.Provider.Execute<decimal?>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Average(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, decimal?>>))),
+                    CachedReflectionInfo.Average_NullableDecimal_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(selector) }
                     ));
         }
@@ -1936,9 +1698,7 @@ namespace System.Linq
             return source.Provider.Execute<TSource>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Aggregate(
-                        default(IQueryable<TSource>),
-                        default(Expression<Func<TSource, TSource, TSource>>))),
+                    CachedReflectionInfo.Aggregate_TSource_2(typeof(TSource)),
                     new Expression[] { source.Expression, Expression.Quote(func) }
                     ));
         }
@@ -1952,10 +1712,7 @@ namespace System.Linq
             return source.Provider.Execute<TAccumulate>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Aggregate(
-                        default(IQueryable<TSource>),
-                        default(TAccumulate),
-                        default(Expression<Func<TAccumulate, TSource, TAccumulate>>))),
+                    CachedReflectionInfo.Aggregate_TSource_TAccumulate_3(typeof(TSource), typeof(TAccumulate)),
                     new Expression[] { source.Expression, Expression.Constant(seed), Expression.Quote(func) }
                     ));
         }
@@ -1971,19 +1728,9 @@ namespace System.Linq
             return source.Provider.Execute<TResult>(
                 Expression.Call(
                     null,
-                    GetMethodInfoOf(() => Queryable.Aggregate(
-                        default(IQueryable<TSource>),
-                        default(TAccumulate),
-                        default(Expression<Func<TAccumulate, TSource, TAccumulate>>),
-                        default(Expression<Func<TAccumulate, TResult>>))),
+                    CachedReflectionInfo.Aggregate_TSource_TAccumulate_TResult_4(typeof(TSource), typeof(TAccumulate), typeof(TResult)),
                     new Expression[] { source.Expression, Expression.Constant(seed), Expression.Quote(func), Expression.Quote(selector) }
                     ));
-        }
-
-        private static MethodInfo GetMethodInfoOf<T>(Expression<Func<T>> expression)
-        {
-            var body = (MethodCallExpression)expression.Body;
-            return body.Method;
         }
     }
 }


### PR DESCRIPTION
Generated `CachedReflectionInfo` to cache `MethodInfo` objects representing `Queryable` methods for use by these methods to construct expression trees.

Prior to .NET Core, the construction of expression trees was using `MethodBase.GetCurrentMethod` to obtain the open generic method representing the containing method whose call's expression representation was being built.

At some point, `GetCurrentMethod` was substituted for an `infoof` based approach using an expression tree to obtain the `MethodInfo` (see removed code in this PR). This causes allocation of an expression tree (with a ton of runtime checks) for every call to a `Queryable` method only to get the `MethodInfo` instance to use in the resulting expression tree. All we really need is a `ldftn` instruction.

This PR replaces this approach by introducing a `CachedReflectionInfo` class containing static properties and methods to obtain (closed generic) `MethodInfo` instances for the `Queryable` methods. The (open generic) `MethodInfo` instances are cached in static fields. This is very similar to the technique we use in `System.Linq.Expressions` to cache reflection objects. The means to obtain the `MethodInfo` is using a method group conversion to a `Delegate` and a call to `GetMethodInfo` (instead of being expression based).

The `CachedReflectionInfo` type was generated using a T4 template. We could check that in if we want, but we don't have an precedent for doing that AFAIK.

CC @JonHanna, @stephentoub