### PR TITLE
Disabling some Numerics and Math tests when running in x86

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp1.1.cs
+++ b/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp1.1.cs
@@ -26,6 +26,8 @@ namespace System.Tests
        // use CrossPlatformMachineEpsilon * 10.
         public const float CrossPlatformMachineEpsilon = 4.76837158e-07f;
 
+        private static unsafe bool Is64Bit => sizeof(void*) == 8;
+
         /// <summary>
         /// Verifies that two <see cref="float"/> values are equal, within the <paramref name="allowedVariance"/>.
         /// </summary>
@@ -90,7 +92,7 @@ namespace System.Tests
             AssertEqual(-MathF.PI / 2.0f, MathF.Atan(float.NegativeInfinity), CrossPlatformMachineEpsilon * 10);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(Is64Bit))]
         public static void Atan2()
         {
             AssertEqual(-MathF.PI, MathF.Atan2(-0.0f, -0.0f), CrossPlatformMachineEpsilon * 10);
@@ -238,7 +240,7 @@ namespace System.Tests
             Assert.Equal(float.NaN, MathF.Min(float.NaN, float.NaN));
         }
 
-        [Fact]
+        [ConditionalFact(nameof(Is64Bit))]
         public static void Pow()
         {
             Assert.Equal(1.0f, MathF.Pow(0.0f, 0.0f));

--- a/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp1.1.cs
+++ b/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp1.1.cs
@@ -26,7 +26,7 @@ namespace System.Tests
        // use CrossPlatformMachineEpsilon * 10.
         public const float CrossPlatformMachineEpsilon = 4.76837158e-07f;
 
-        private static unsafe bool Is64Bit => sizeof(void*) == 8;
+        private static bool Is64Bit => IntPtr.Size == 8;
 
         /// <summary>
         /// Verifies that two <see cref="float"/> values are equal, within the <paramref name="allowedVariance"/>.

--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -13,6 +13,7 @@ namespace System.Numerics.Tests
     public partial class ComplexTests
     {
         private static Random s_random = new Random(-55);
+        private static unsafe bool Is64Bit => sizeof(void*) == 8;
         
         public static readonly double[] s_validDoubleValues = new double[]
         {
@@ -486,7 +487,7 @@ namespace System.Numerics.Tests
             }
         }
 
-        [Theory, MemberData("Cos_Advanced_TestData")]
+        [ConditionalTheory(nameof(Is64Bit)), MemberData("Cos_Advanced_TestData")]
         public static void Cos_Advanced(double real, double imaginary, double expectedReal, double expectedImaginary)
         {
             var complex = new Complex(real, imaginary);
@@ -538,7 +539,7 @@ namespace System.Numerics.Tests
             }
         }
 
-        [Theory, MemberData("Cosh_Advanced_TestData")]
+        [ConditionalTheory(nameof(Is64Bit)), MemberData("Cosh_Advanced_TestData")]
         public static void Cosh_Advanced(double real, double imaginary, double expectedReal, double expectedImaginary)
         {
             var complex = new Complex(real, imaginary);
@@ -729,7 +730,7 @@ namespace System.Numerics.Tests
             yield return new object[] { double.MinValue, double.MinValue };
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(Is64Bit))]
         [MemberData(nameof(Exp_TestData))]
         [MemberData(nameof(Primitives_2_TestData))]
         [MemberData(nameof(SmallRandom_2_TestData))]
@@ -1068,7 +1069,7 @@ namespace System.Numerics.Tests
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
         }
         
-        [Theory]
+        [ConditionalTheory(nameof(Is64Bit))]
         [MemberData(nameof(Boundaries_2_TestData))]
         [MemberData(nameof(Primitives_2_TestData))]
         [MemberData(nameof(SmallRandom_2_TestData))]
@@ -1134,7 +1135,7 @@ namespace System.Numerics.Tests
             }
         }
 
-        [Theory, MemberData("Sin_Advanced_TestData")]
+        [ConditionalTheory(nameof(Is64Bit)), MemberData("Sin_Advanced_TestData")]
         public static void Sin_Advanced(double real, double imaginary, double expectedReal, double expectedImaginary)
         {
             var complex = new Complex(real, imaginary);
@@ -1186,7 +1187,7 @@ namespace System.Numerics.Tests
             }
         }
 
-        [Theory, MemberData("Sinh_Advanced_TestData")]
+        [ConditionalTheory(nameof(Is64Bit)), MemberData("Sinh_Advanced_TestData")]
         public static void Sinh_Advanced(double real, double imaginary, double expectedReal, double expectedImaginary)
         {
             var complex = new Complex(real, imaginary);

--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -13,7 +13,7 @@ namespace System.Numerics.Tests
     public partial class ComplexTests
     {
         private static Random s_random = new Random(-55);
-        private static unsafe bool Is64Bit => sizeof(void*) == 8;
+        private static bool Is64Bit => IntPtr.Size == 8;
         
         public static readonly double[] s_validDoubleValues = new double[]
         {

--- a/src/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
+++ b/src/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
@@ -9,6 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Numerics.Tests</RootNamespace>
     <AssemblyName>System.Runtime.Numerics.Tests</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{28AE24F8-BEF4-4358-B612-ADD9D587C8E1}</ProjectGuid>
     <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>

--- a/src/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
+++ b/src/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
@@ -9,7 +9,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Numerics.Tests</RootNamespace>
     <AssemblyName>System.Runtime.Numerics.Tests</AssemblyName>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{28AE24F8-BEF4-4358-B612-ADD9D587C8E1}</ProjectGuid>
     <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>


### PR DESCRIPTION
cc: @stephentoub @danmosemsft @weshaggard 

Progress towards #13448 

I ran a local test run using x86 as the build architecture and some Numerics and Math tests fail(which is expected). With this PR I'm disabling them for x86 runs so that we can have a green x86 run which I'll soon add to the pipebuilds and probably a CI as well.