### PR TITLE
Use Apple SecurityTransforms for RSA, DSA, and ECDSA on macOS.

### DIFF
--- a/src/Common/src/Internal/Cryptography/AsymmetricAlgorithmHelpers.cs
+++ b/src/Common/src/Internal/Cryptography/AsymmetricAlgorithmHelpers.cs
@@ -12,7 +12,7 @@ namespace Internal.Cryptography
     //
     // Common infrastructure for AsymmetricAlgorithm-derived classes that layer on OpenSSL.
     //
-    internal static class OpenSslAsymmetricAlgorithmCore
+    internal static class AsymmetricAlgorithmHelpers
     {
         public static byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
         {

--- a/src/Common/src/Interop/OSX/Interop.CoreFoundation.CFData.cs
+++ b/src/Common/src/Interop/OSX/Interop.CoreFoundation.CFData.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using Microsoft.Win32.SafeHandles;
+
+// Declared as signed long, which has sizeof(void*) on OSX.
+using CFIndex=System.IntPtr;
+
+internal static partial class Interop
+{
+    internal static partial class CoreFoundation
+    {
+        [DllImport(Libraries.CoreFoundationLibrary)]
+        private static extern unsafe byte* CFDataGetBytePtr(SafeCFDataHandle cfData);
+
+        [DllImport(Libraries.CoreFoundationLibrary)]
+        private static extern CFIndex CFDataGetLength(SafeCFDataHandle cfData);
+
+        internal static byte[] CFGetData(SafeCFDataHandle cfData)
+        {
+            bool addedRef = false;
+
+            try
+            {
+                cfData.DangerousAddRef(ref addedRef);
+                byte[] bytes = new byte[CFDataGetLength(cfData).ToInt64()];
+
+                unsafe
+                {
+                    byte* dataBytes = CFDataGetBytePtr(cfData);
+                    Marshal.Copy((IntPtr)dataBytes, bytes, 0, bytes.Length);
+                }
+
+                return bytes;
+
+            }
+            finally
+            {
+                if (addedRef)
+                {
+                    cfData.DangerousRelease();
+                }
+            }
+        }
+    }
+}
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal sealed class SafeCFDataHandle : SafeHandle
+    {
+        internal SafeCFDataHandle()
+            : base(IntPtr.Zero, ownsHandle: true)
+        {
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            Interop.CoreFoundation.CFRelease(handle);
+            SetHandle(IntPtr.Zero);
+            return true;
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+    }
+}

--- a/src/Common/src/Interop/OSX/Interop.CoreFoundation.CFError.cs
+++ b/src/Common/src/Interop/OSX/Interop.CoreFoundation.CFError.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+using Microsoft.Win32.SafeHandles;
+
+// Declared as signed long, which has sizeof(void*) on OSX.
+using CFIndex=System.IntPtr;
+
+internal static partial class Interop
+{
+    internal static partial class CoreFoundation
+    {
+        [DllImport(Libraries.CoreFoundationLibrary)]
+        private static extern CFIndex CFErrorGetCode(SafeCFErrorHandle cfError);
+
+        [DllImport(Libraries.CoreFoundationLibrary)]
+        private static extern SafeCFStringHandle CFErrorCopyDescription(SafeCFErrorHandle cfError);
+
+        internal static int GetErrorCode(SafeCFErrorHandle cfError)
+        {
+            unchecked
+            {
+                return (int)(CFErrorGetCode(cfError).ToInt64());
+            }
+        }
+
+        internal static string GetErrorDescription(SafeCFErrorHandle cfError)
+        {
+            Debug.Assert(cfError != null);
+
+            if (cfError.IsInvalid)
+            {
+                return null;
+            }
+
+            Debug.Assert(!cfError.IsClosed);
+
+            using (SafeCFStringHandle cfString = CFErrorCopyDescription(cfError))
+            {
+                return CFStringToString(cfString);
+            }
+        }
+    }
+}
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal sealed class SafeCFErrorHandle : SafeHandle
+    {
+        internal SafeCFErrorHandle()
+            : base(IntPtr.Zero, ownsHandle: true)
+        {
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            Interop.CoreFoundation.CFRelease(handle);
+            SetHandle(IntPtr.Zero);
+            return true;
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+    }
+}

--- a/src/Common/src/Interop/OSX/Interop.CoreFoundation.CFString.cs
+++ b/src/Common/src/Interop/OSX/Interop.CoreFoundation.CFString.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class CoreFoundation
+    {
+        /// <summary>
+        /// Returns the interior pointer of the cfString if it has the specified encoding.
+        /// If it has the wrong encoding, or if the interior pointer isn't being shared for some reason, returns NULL
+        /// </summary>
+        [DllImport(Libraries.CoreFoundationLibrary)]
+        private static extern IntPtr CFStringGetCStringPtr(
+            SafeCFStringHandle cfString,
+            CFStringBuiltInEncodings encoding);
+
+        [DllImport(Libraries.CoreFoundationLibrary)]
+        private static extern SafeCFDataHandle CFStringCreateExternalRepresentation(
+            IntPtr alloc,
+            SafeCFStringHandle theString,
+            CFStringBuiltInEncodings encoding,
+            byte lossByte);
+
+        internal static string CFStringToString(SafeCFStringHandle cfString)
+        {
+            Debug.Assert(cfString != null);
+            Debug.Assert(!cfString.IsInvalid);
+            Debug.Assert(!cfString.IsClosed);
+
+            IntPtr interiorPointer = CFStringGetCStringPtr(
+                cfString,
+                CFStringBuiltInEncodings.kCFStringEncodingUTF8);
+
+            if (interiorPointer != IntPtr.Zero)
+            {
+                return Marshal.PtrToStringUTF8(interiorPointer);
+            }
+
+            SafeCFDataHandle cfData = CFStringCreateExternalRepresentation(
+                IntPtr.Zero,
+                cfString,
+                CFStringBuiltInEncodings.kCFStringEncodingUTF8,
+                0);
+
+            using (cfData)
+            {
+                bool addedRef = false;
+
+                try
+                {
+                    cfData.DangerousAddRef(ref addedRef);
+
+                    unsafe
+                    {
+                        // Note that CFDataGetLength(cfData).ToInt32() will throw on
+                        // too large of an input. Since a >2GB string is pretty unlikely,
+                        // that's considered a good thing here.
+                        return Encoding.UTF8.GetString(
+                            CFDataGetBytePtr(cfData),
+                            CFDataGetLength(cfData).ToInt32());
+                    }
+                }
+                finally
+                {
+                    if (addedRef)
+                    {
+                        cfData.DangerousRelease();
+                    }
+                }
+            }
+        }
+    }
+}
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal sealed class SafeCFStringHandle : SafeHandle
+    {
+        internal SafeCFStringHandle()
+            : base(IntPtr.Zero, ownsHandle: true)
+        {
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            Interop.CoreFoundation.CFRelease(handle);
+            SetHandle(IntPtr.Zero);
+            return true;
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+    }
+}

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ecc.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ecc.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.Apple;
+
+internal static partial class Interop
+{
+    internal static partial class AppleCrypto
+    {
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_EccGenerateKey")]
+        internal static extern int EccGenerateKey(
+            int keySizeInBits,
+            out SafeSecKeyRefHandle pPublicKey,
+            out SafeSecKeyRefHandle pPrivateKey,
+            out int pOSStatus);
+
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_EccGetKeySizeInBits")]
+        internal static extern long EccGetKeySizeInBits(SafeSecKeyRefHandle publicKey);
+    }
+}

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Err.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Err.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Security.Cryptography;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
@@ -11,6 +13,7 @@ internal static partial class Interop
     {
         internal const string CCCryptorStatus = "CCCryptorStatus";
         internal const string CCRNGStatus = "CCRNGStatus";
+        internal const string OSStatus = "OSStatus";
 
         internal static Exception CreateExceptionForCCError(int errorCode, string errorType)
         {
@@ -20,6 +23,27 @@ internal static partial class Interop
                     SR.Cryptography_Unmapped_System_Typed_Error,
                     errorCode,
                     errorType));
+        }
+
+        internal static Exception CreateExceptionForCFError(SafeCFErrorHandle cfError)
+        {
+            Debug.Assert(cfError != null);
+
+            if (cfError.IsInvalid)
+            {
+                return new CryptographicException();
+            }
+
+            return new AppleCFErrorCryptographicException(cfError);
+        }
+
+        private sealed class AppleCFErrorCryptographicException : CryptographicException
+        {
+            internal AppleCFErrorCryptographicException(SafeCFErrorHandle cfError)
+                : base(Interop.CoreFoundation.GetErrorDescription(cfError))
+            {
+                HResult = Interop.CoreFoundation.GetErrorCode(cfError);
+            }
         }
 
         private sealed class AppleCommonCryptoCryptographicException : CryptographicException

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Apple;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class AppleCrypto
+    {
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaGenerateKey")]
+        internal static extern int RsaGenerateKey(
+            int keySizeInBits,
+            out SafeSecKeyRefHandle pPublicKey,
+            out SafeSecKeyRefHandle pPrivateKey,
+            out int pOSStatus);
+
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaEncryptOaep")]
+        private static extern int RsaEncryptOaep(
+            SafeSecKeyRefHandle publicKey,
+            byte[] pbData,
+            int cbData,
+            PAL_HashAlgorithm mgfAlgorithm,
+            out SafeCFDataHandle pEncryptedOut,
+            out SafeCFErrorHandle pErrorOut);
+
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaEncryptPkcs")]
+        private static extern int RsaEncryptPkcs(
+            SafeSecKeyRefHandle publicKey,
+            byte[] pbData,
+            int cbData,
+            out SafeCFDataHandle pEncryptedOut,
+            out SafeCFErrorHandle pErrorOut);
+
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaDecryptOaep")]
+        private static extern int RsaDecryptOaep(
+            SafeSecKeyRefHandle publicKey,
+            byte[] pbData,
+            int cbData,
+            PAL_HashAlgorithm mgfAlgorithm,
+            out SafeCFDataHandle pEncryptedOut,
+            out SafeCFErrorHandle pErrorOut);
+
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaDecryptPkcs")]
+        private static extern int RsaDecryptPkcs(
+            SafeSecKeyRefHandle publicKey,
+            byte[] pbData,
+            int cbData,
+            out SafeCFDataHandle pEncryptedOut,
+            out SafeCFErrorHandle pErrorOut);
+
+        internal static byte[] RsaEncrypt(
+            SafeSecKeyRefHandle publicKey,
+            byte[] data,
+            RSAEncryptionPadding padding)
+        {
+            return ExecuteTransform(
+                (out SafeCFDataHandle encrypted, out SafeCFErrorHandle error) =>
+                {
+                    if (padding == RSAEncryptionPadding.Pkcs1)
+                    {
+                        return RsaEncryptPkcs(publicKey, data, data.Length, out encrypted, out error);
+                    }
+
+                    Debug.Assert(padding.Mode == RSAEncryptionPaddingMode.Oaep);
+
+                    return RsaEncryptOaep(
+                        publicKey,
+                        data,
+                        data.Length,
+                        PalAlgorithmFromAlgorithmName(padding.OaepHashAlgorithm),
+                        out encrypted,
+                        out error);
+                });
+
+        }
+
+        internal static byte[] RsaDecrypt(
+            SafeSecKeyRefHandle privateKey,
+            byte[] data,
+            RSAEncryptionPadding padding)
+        {
+            return ExecuteTransform(
+                (out SafeCFDataHandle decrypted, out SafeCFErrorHandle error) =>
+                {
+                    if (padding == RSAEncryptionPadding.Pkcs1)
+                    {
+                        return RsaDecryptPkcs(privateKey, data, data.Length, out decrypted, out error);
+                    }
+
+                    Debug.Assert(padding.Mode == RSAEncryptionPaddingMode.Oaep);
+
+                    return RsaDecryptOaep(
+                        privateKey,
+                        data,
+                        data.Length,
+                        PalAlgorithmFromAlgorithmName(padding.OaepHashAlgorithm),
+                        out decrypted,
+                        out error);
+                });
+        }
+
+        private static Interop.AppleCrypto.PAL_HashAlgorithm PalAlgorithmFromAlgorithmName(
+                HashAlgorithmName hashAlgorithmName)
+        {
+            if (hashAlgorithmName == HashAlgorithmName.MD5)
+            {
+                return Interop.AppleCrypto.PAL_HashAlgorithm.Md5;
+            }
+            else if (hashAlgorithmName == HashAlgorithmName.SHA1)
+            {
+                return Interop.AppleCrypto.PAL_HashAlgorithm.Sha1;
+            }
+            else if (hashAlgorithmName == HashAlgorithmName.SHA256)
+            {
+                return Interop.AppleCrypto.PAL_HashAlgorithm.Sha256;
+            }
+            else if (hashAlgorithmName == HashAlgorithmName.SHA384)
+            {
+                return Interop.AppleCrypto.PAL_HashAlgorithm.Sha384;
+            }
+            else if (hashAlgorithmName == HashAlgorithmName.SHA512)
+            {
+                return Interop.AppleCrypto.PAL_HashAlgorithm.Sha512;
+            }
+
+            throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmName.Name);
+        }
+    }
+}

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKeyRef.Export.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKeyRef.Export.cs
@@ -1,0 +1,215 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Apple;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class AppleCrypto
+    {
+        private const string OidPbes2 = "1.2.840.113549.1.5.13";
+        private const string OidPbkdf2 = "1.2.840.113549.1.5.12";
+        private const string OidSha1 = "1.3.14.3.2.26";
+        private const string OidTripleDesCbc = "1.2.840.113549.3.7";
+
+        private static readonly SafeCreateHandle s_nullExportString = new SafeCreateHandle();
+
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static extern int AppleCryptoNative_SecKeyExport(
+            SafeSecKeyRefHandle key,
+            int exportPrivate,
+            SafeCreateHandle cfExportPassphrase,
+            out SafeCFDataHandle cfDataOut,
+            out int pOSStatus);
+
+        internal static DerSequenceReader SecKeyExport(
+            SafeSecKeyRefHandle key,
+            bool exportPrivate)
+        {
+            // Apple requires all private keys to be exported encrypted, but since we're trying to export
+            // as parsed structures we will need to decrypt it for the user.
+            const string ExportPassword = "DotnetExportPassphrase";
+
+            SafeCreateHandle exportPassword = exportPrivate
+                ? CoreFoundation.CFStringCreateWithCString(ExportPassword)
+                : s_nullExportString;
+
+            int ret;
+            SafeCFDataHandle cfData;
+            int osStatus;
+
+            try
+            {
+                ret = AppleCryptoNative_SecKeyExport(
+                    key,
+                    exportPrivate ? 1 : 0,
+                    exportPassword,
+                    out cfData,
+                    out osStatus);
+            }
+            finally
+            {
+                if (exportPassword != s_nullExportString)
+                {
+                    exportPassword.Dispose();
+                }
+            }
+
+            byte[] exportedData;
+
+            using (cfData)
+            {
+                if (ret == 0)
+                {
+                    throw CreateExceptionForCCError(osStatus, OSStatus);
+                }
+
+                if (ret != 1)
+                {
+                    Debug.Fail($"AppleCryptoNative_SecKeyExport returned {ret}");
+                    throw new CryptographicException();
+                }
+
+                exportedData = CoreFoundation.CFGetData(cfData);
+            }
+
+            DerSequenceReader reader = new DerSequenceReader(exportedData);
+
+            if (!exportPrivate)
+            {
+                return reader;
+            }
+
+            byte tag = reader.PeekTag();
+
+            // PKCS#8 defines two structures, PrivateKeyInfo, which starts with an integer,
+            // and EncryptedPrivateKey, which starts with an encryption algorithm (DER sequence).
+            if (tag == (byte)DerSequenceReader.DerTag.Integer)
+            {
+                return reader;
+            }
+
+            const byte ConstructedSequence =
+                DerSequenceReader.ConstructedFlag | (byte)DerSequenceReader.DerTag.Sequence;
+
+            if (tag == ConstructedSequence)
+            {
+                return ReadEncryptedPkcs8Blob(ExportPassword, reader);
+            }
+
+            Debug.Fail($"Data was neither PrivateKey or EncryptedPrivateKey: {tag:X2}");
+            throw new CryptographicException();
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "3DES identified from payload by OID")]
+        private static DerSequenceReader ReadEncryptedPkcs8Blob(string passphrase, DerSequenceReader reader)
+        {
+            // EncryptedPrivateKeyInfo::= SEQUENCE {
+            //    encryptionAlgorithm EncryptionAlgorithmIdentifier,
+            //    encryptedData        EncryptedData }
+            //
+            // EncryptionAlgorithmIdentifier ::= AlgorithmIdentifier
+            //
+            // EncryptedData ::= OCTET STRING
+            DerSequenceReader algorithmIdentifier = reader.ReadSequence();
+            string algorithmOid = algorithmIdentifier.ReadOidAsString();
+
+            // PBES2 (Password-Based Encryption Scheme 2)
+            if (algorithmOid != OidPbes2)
+            {
+                Debug.Fail($"Expected PBES2 ({OidPbes2}), got {algorithmOid}");
+                throw new CryptographicException();
+            }
+
+            // PBES2-params ::= SEQUENCE {
+            //    keyDerivationFunc AlgorithmIdentifier { { PBES2 - KDFs} },
+            //    encryptionScheme AlgorithmIdentifier { { PBES2 - Encs} }
+            // }
+
+            DerSequenceReader pbes2Params = algorithmIdentifier.ReadSequence();
+            algorithmIdentifier = pbes2Params.ReadSequence();
+
+            string kdfOid = algorithmIdentifier.ReadOidAsString();
+
+            // PBKDF2 (Password-Based Key Derivation Function 2)
+            if (kdfOid != OidPbkdf2)
+            {
+                Debug.Fail($"Expected PBKDF2 ({OidPbkdf2}), got {kdfOid}");
+                throw new CryptographicException();
+            }
+
+            // PBKDF2-params ::= SEQUENCE {
+            //   salt CHOICE {
+            //     specified OCTET STRING,
+            //     otherSource AlgorithmIdentifier { { PBKDF2 - SaltSources} }
+            //   },
+            //   iterationCount INTEGER (1..MAX),
+            //   keyLength INTEGER(1..MAX) OPTIONAL,
+            //   prf AlgorithmIdentifier { { PBKDF2 - PRFs} }  DEFAULT algid - hmacWithSHA1
+            // }
+            DerSequenceReader pbkdf2Params = algorithmIdentifier.ReadSequence();
+
+            byte[] salt = pbkdf2Params.ReadOctetString();
+            int iterCount = pbkdf2Params.ReadInteger();
+            int keySize = -1;
+
+            if (pbkdf2Params.HasData && pbkdf2Params.PeekTag() == (byte)DerSequenceReader.DerTag.Integer)
+            {
+                keySize = pbkdf2Params.ReadInteger();
+            }
+
+            if (pbkdf2Params.HasData)
+            {
+                string prfOid = pbkdf2Params.ReadOidAsString();
+
+                // SHA-1 is the only hash algorithm our PBKDF2 supports.
+                if (prfOid != OidSha1)
+                {
+                    Debug.Fail($"Expected SHA1 ({OidSha1}), got {prfOid}");
+                    throw new CryptographicException();
+                }
+            }
+
+            DerSequenceReader encryptionScheme = pbes2Params.ReadSequence();
+            string cipherOid = encryptionScheme.ReadOidAsString();
+
+            // DES-EDE3-CBC (TripleDES in CBC mode)
+            if (cipherOid != OidTripleDesCbc)
+            {
+                Debug.Fail($"Expected DES-EDE3-CBC ({OidTripleDesCbc}), got {cipherOid}");
+                throw new CryptographicException();
+            }
+
+            byte[] decrypted;
+
+            using (TripleDES des3 = TripleDES.Create())
+            {
+                if (keySize == -1)
+                {
+                    foreach (KeySizes keySizes in des3.LegalKeySizes)
+                    {
+                        keySize = Math.Max(keySize, keySizes.MaxSize);
+                    }
+                }
+
+                byte[] iv = encryptionScheme.ReadOctetString();
+
+                using (Rfc2898DeriveBytes pbkdf2 = new Rfc2898DeriveBytes(passphrase, salt, iterCount))
+                using (ICryptoTransform decryptor = des3.CreateDecryptor(pbkdf2.GetBytes(keySize / 8), iv))
+                {
+                    byte[] encrypted = reader.ReadOctetString();
+                    decrypted = decryptor.TransformFinalBlock(encrypted, 0, encrypted.Length);
+                }
+            }
+
+            DerSequenceReader pkcs8Reader = new DerSequenceReader(decrypted);
+            return pkcs8Reader;
+        }
+    }
+}

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKeyRef.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKeyRef.cs
@@ -1,0 +1,268 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Apple;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class AppleCrypto
+    {
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static extern int AppleCryptoNative_SecKeyImportEphemeral(
+            byte[] pbKeyBlob,
+            int cbKeyBlob,
+            int isPrivateKey,
+            out SafeSecKeyRefHandle ppKeyOut,
+            out int pOSStatus);
+
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static extern int AppleCryptoNative_GenerateSignature(
+            SafeSecKeyRefHandle privateKey,
+            byte[] pbDataHash,
+            int cbDataHash,
+            out SafeCFDataHandle pSignatureOut,
+            out SafeCFErrorHandle pErrorOut);
+
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static extern int AppleCryptoNative_GenerateSignatureWithHashAlgorithm(
+            SafeSecKeyRefHandle privateKey,
+            byte[] pbDataHash,
+            int cbDataHash,
+            PAL_HashAlgorithm hashAlgorithm,
+            out SafeCFDataHandle pSignatureOut,
+            out SafeCFErrorHandle pErrorOut);
+
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static extern int AppleCryptoNative_VerifySignature(
+            SafeSecKeyRefHandle publicKey,
+            byte[] pbDataHash,
+            int cbDataHash,
+            byte[] pbSignature,
+            int cbSignature,
+            out SafeCFErrorHandle pErrorOut);
+
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static extern int AppleCryptoNative_VerifySignatureWithHashAlgorithm(
+            SafeSecKeyRefHandle publicKey,
+            byte[] pbDataHash,
+            int cbDataHash,
+            byte[] pbSignature,
+            int cbSignature,
+            PAL_HashAlgorithm hashAlgorithm,
+            out SafeCFErrorHandle pErrorOut);
+
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static extern ulong AppleCryptoNative_SecKeyGetSimpleKeySizeInBytes(SafeSecKeyRefHandle publicKey);
+
+        private delegate int SecKeyTransform(out SafeCFDataHandle data, out SafeCFErrorHandle error);
+
+        private static byte[] ExecuteTransform(SecKeyTransform transform)
+        {
+            const int Success = 1;
+            const int kErrorSeeError = -2;
+
+            SafeCFDataHandle data;
+            SafeCFErrorHandle error;
+
+            int ret = transform(out data, out error);
+
+            using (error)
+            using (data)
+            {
+                if (ret == Success)
+                {
+                    return CoreFoundation.CFGetData(data);
+                }
+
+                if (ret == kErrorSeeError)
+                {
+                    throw CreateExceptionForCFError(error);
+                }
+
+                Debug.Fail($"transform returned {ret}");
+                throw new CryptographicException();
+            }
+        }
+
+        internal static int GetSimpleKeySizeInBits(SafeSecKeyRefHandle publicKey)
+        {
+            ulong keySizeInBytes = AppleCryptoNative_SecKeyGetSimpleKeySizeInBytes(publicKey);
+
+            checked
+            {
+                return (int)(keySizeInBytes * 8);
+            }
+        }
+
+        internal static SafeSecKeyRefHandle ImportEphemeralKey(byte[] keyBlob, bool hasPrivateKey)
+        {
+            Debug.Assert(keyBlob != null);
+
+            SafeSecKeyRefHandle keyHandle;
+            int osStatus;
+
+            int ret = AppleCryptoNative_SecKeyImportEphemeral(
+                keyBlob,
+                keyBlob.Length,
+                hasPrivateKey ? 1 : 0,
+                out keyHandle,
+                out osStatus);
+
+            if (ret == 1 && !keyHandle.IsInvalid)
+            {
+                return keyHandle;
+            }
+
+            if (ret == 0)
+            {
+                throw CreateExceptionForCCError(osStatus, OSStatus);
+            }
+
+            Debug.Fail($"SecKeyImportEphemeral returned {ret}");
+            throw new CryptographicException();
+        }
+
+        internal static byte[] GenerateSignature(SafeSecKeyRefHandle privateKey, byte[] dataHash)
+        {
+            Debug.Assert(privateKey != null, "privateKey != null");
+            Debug.Assert(dataHash != null, "dataHash != null");
+
+            return ExecuteTransform(
+                (out SafeCFDataHandle signature, out SafeCFErrorHandle error) =>
+                    AppleCryptoNative_GenerateSignature(
+                        privateKey,
+                        dataHash,
+                        dataHash.Length,
+                        out signature,
+                        out error));
+        }
+
+        internal static byte[] GenerateSignature(
+            SafeSecKeyRefHandle privateKey,
+            byte[] dataHash,
+            PAL_HashAlgorithm hashAlgorithm)
+        {
+            Debug.Assert(privateKey != null, "privateKey != null");
+            Debug.Assert(dataHash != null, "dataHash != null");
+            Debug.Assert(hashAlgorithm != PAL_HashAlgorithm.Unknown, "hashAlgorithm != PAL_HashAlgorithm.Unknown");
+
+            return ExecuteTransform(
+                (out SafeCFDataHandle signature, out SafeCFErrorHandle error) =>
+                    AppleCryptoNative_GenerateSignatureWithHashAlgorithm(
+                        privateKey,
+                        dataHash,
+                        dataHash.Length,
+                        hashAlgorithm,
+                        out signature,
+                        out error));
+        }
+
+        internal static bool VerifySignature(
+            SafeSecKeyRefHandle publicKey,
+            byte[] dataHash,
+            byte[] signature)
+        {
+            Debug.Assert(publicKey != null, "publicKey != null");
+            Debug.Assert(dataHash != null, "dataHash != null");
+            Debug.Assert(signature != null, "signature != null");
+
+            SafeCFErrorHandle error;
+
+            int ret = AppleCryptoNative_VerifySignature(
+                publicKey,
+                dataHash,
+                dataHash.Length,
+                signature,
+                signature.Length,
+                out error);
+
+            const int True = 1;
+            const int False = 0;
+            const int kErrorSeeError = -2;
+
+            using (error)
+            {
+                switch (ret)
+                {
+                    case True:
+                        return true;
+                    case False:
+                        return false;
+                    case kErrorSeeError:
+                        throw CreateExceptionForCFError(error);
+                    default:
+                        Debug.Fail($"VerifySignature returned {ret}");
+                        throw new CryptographicException();
+                }
+            }
+        }
+
+        internal static bool VerifySignature(
+            SafeSecKeyRefHandle publicKey,
+            byte[] dataHash,
+            byte[] signature,
+            PAL_HashAlgorithm hashAlgorithm)
+        {
+            Debug.Assert(publicKey != null, "publicKey != null");
+            Debug.Assert(dataHash != null, "dataHash != null");
+            Debug.Assert(signature != null, "signature != null");
+            Debug.Assert(hashAlgorithm != PAL_HashAlgorithm.Unknown);
+
+            SafeCFErrorHandle error;
+
+            int ret = AppleCryptoNative_VerifySignatureWithHashAlgorithm(
+                publicKey,
+                dataHash,
+                dataHash.Length,
+                signature,
+                signature.Length,
+                hashAlgorithm,
+                out error);
+
+            const int True = 1;
+            const int False = 0;
+            const int kErrorSeeError = -2;
+
+            using (error)
+            {
+                switch (ret)
+                {
+                    case True:
+                        return true;
+                    case False:
+                        return false;
+                    case kErrorSeeError:
+                        throw CreateExceptionForCFError(error);
+                    default:
+                        Debug.Fail($"VerifySignature returned {ret}");
+                        throw new CryptographicException();
+                }
+            }
+        }
+    }
+}
+
+namespace System.Security.Cryptography.Apple
+{
+    internal sealed class SafeSecKeyRefHandle : SafeHandle
+    {
+        internal SafeSecKeyRefHandle()
+            : base(IntPtr.Zero, ownsHandle: true)
+        {
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            Interop.CoreFoundation.CFRelease(handle);
+            SetHandle(IntPtr.Zero);
+            return true;
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
@@ -173,12 +173,12 @@ namespace System.Security.Cryptography
                 Debug.Assert(count >= 0 && count <= data.Length);
                 Debug.Assert(!string.IsNullOrEmpty(hashAlgorithm.Name));
 
-                return OpenSslAsymmetricAlgorithmCore.HashData(data, offset, count, hashAlgorithm);
+                return AsymmetricAlgorithmHelpers.HashData(data, offset, count, hashAlgorithm);
             }
 
             protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
             {
-                return OpenSslAsymmetricAlgorithmCore.HashData(data, hashAlgorithm);
+                return AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
             }
 
             public override byte[] CreateSignature(byte[] rgbHash)
@@ -204,7 +204,7 @@ namespace System.Security.Cryptography
                     signature.Length);
 
                 int signatureFieldSize = Interop.Crypto.DsaSignatureFieldSize(key) * BitsPerByte;
-                byte[] converted = OpenSslAsymmetricAlgorithmCore.ConvertDerToIeee1363(signature, 0, signatureSize, signatureFieldSize);
+                byte[] converted = AsymmetricAlgorithmHelpers.ConvertDerToIeee1363(signature, 0, signatureSize, signatureFieldSize);
                 return converted;
             }
 
@@ -224,7 +224,7 @@ namespace System.Security.Cryptography
                     return false;
                 }
 
-                byte[] openSslFormat = OpenSslAsymmetricAlgorithmCore.ConvertIeee1363ToDer(rgbSignature);
+                byte[] openSslFormat = AsymmetricAlgorithmHelpers.ConvertIeee1363ToDer(rgbSignature);
 
                 return Interop.Crypto.DsaVerify(key, rgbHash, rgbHash.Length, openSslFormat, openSslFormat.Length);
             }

--- a/src/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
@@ -1,0 +1,399 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.IO;
+using System.Security.Cryptography.Apple;
+using Internal.Cryptography;
+
+namespace System.Security.Cryptography
+{
+    public partial class DSA : AsymmetricAlgorithm
+    {
+        public static DSA Create()
+        {
+            return new DSAImplementation.DSASecurityTransforms();
+        }
+
+        internal static partial class DSAImplementation
+        {
+            public sealed partial class DSASecurityTransforms : DSA
+            {
+                private SecKeyPair _keys;
+
+                public DSASecurityTransforms()
+                    : this(1024)
+                {
+                }
+
+                public DSASecurityTransforms(int keySize)
+                {
+                    KeySize = keySize;
+                }
+
+                public override KeySizes[] LegalKeySizes
+                {
+                    get
+                    {
+                        return new[] { new KeySizes(minSize: 512, maxSize: 1024, skipSize: 64) };
+                    }
+                }
+
+                public override int KeySize
+                {
+                    get
+                    {
+                        return base.KeySize;
+                    }
+                    set
+                    {
+                        if (KeySize == value)
+                            return;
+
+                        // Set the KeySize before freeing the key so that an invalid value doesn't throw away the key
+                        base.KeySize = value;
+
+                        _keys?.Dispose();
+                        _keys = null;
+                    }
+                }
+
+                public override DSAParameters ExportParameters(bool includePrivateParameters)
+                {
+                    SecKeyPair keys = GetKeys();
+
+                    if (keys.PublicKey == null ||
+                        (includePrivateParameters && keys.PrivateKey == null))
+                    { 
+                        throw new CryptographicException(SR.Cryptography_OpenInvalidHandle);
+                    }
+
+                    DSAParameters parameters = new DSAParameters();
+
+                    DerSequenceReader publicKeyReader =
+                        Interop.AppleCrypto.SecKeyExport(keys.PublicKey, exportPrivate: false);
+
+                    publicKeyReader.ReadSubjectPublicKeyInfo(ref parameters);
+
+                    if (includePrivateParameters)
+                    {
+                        DerSequenceReader privateKeyReader =
+                            Interop.AppleCrypto.SecKeyExport(keys.PrivateKey, exportPrivate: true);
+
+                        privateKeyReader.ReadPkcs8Blob(ref parameters);
+                    }
+
+                    KeyBlobHelpers.TrimPaddingByte(ref parameters.P);
+                    KeyBlobHelpers.TrimPaddingByte(ref parameters.Q);
+
+                    KeyBlobHelpers.PadOrTrim(ref parameters.G, parameters.P.Length);
+                    KeyBlobHelpers.PadOrTrim(ref parameters.Y, parameters.P.Length);
+
+                    if (includePrivateParameters)
+                    {
+                        KeyBlobHelpers.PadOrTrim(ref parameters.X, parameters.Q.Length);
+                    }
+
+                    return parameters;
+                }
+
+                public override void ImportParameters(DSAParameters parameters)
+                {
+                    if (parameters.P == null || parameters.Q == null || parameters.G == null || parameters.Y == null)
+                        throw new ArgumentException(SR.Cryptography_InvalidDsaParameters_MissingFields);
+
+                    // J is not required and is not even used on CNG blobs.
+                    // It should, however, be less than P (J == (P-1) / Q).
+                    // This validation check is just to maintain parity with DSACng and DSACryptoServiceProvider,
+                    // which also perform this check.
+                    if (parameters.J != null && parameters.J.Length >= parameters.P.Length)
+                        throw new ArgumentException(SR.Cryptography_InvalidDsaParameters_MismatchedPJ);
+
+                    int keySize = parameters.P.Length;
+                    bool hasPrivateKey = parameters.X != null;
+
+                    if (parameters.G.Length != keySize || parameters.Y.Length != keySize)
+                        throw new ArgumentException(SR.Cryptography_InvalidDsaParameters_MismatchedPGY);
+
+                    if (hasPrivateKey && parameters.X.Length != parameters.Q.Length)
+                        throw new ArgumentException(SR.Cryptography_InvalidDsaParameters_MismatchedQX);
+
+                    if (!(8 * parameters.P.Length).IsLegalSize(LegalKeySizes))
+                        throw new CryptographicException(SR.Cryptography_InvalidKeySize);
+
+                    if (parameters.Q.Length != 20)
+                        throw new CryptographicException(SR.Cryptography_InvalidDsaParameters_QRestriction_ShortKey);
+
+                    if (hasPrivateKey)
+                    {
+                        SafeSecKeyRefHandle privateKey = ImportKey(parameters);
+
+                        DSAParameters publicOnly = parameters;
+                        publicOnly.X = null;
+
+                        SafeSecKeyRefHandle publicKey;
+                        try
+                        {
+                            publicKey = ImportKey(publicOnly);
+                        }
+                        catch
+                        {
+                            privateKey.Dispose();
+                            throw;
+                        }
+
+                        SetKey(SecKeyPair.PublicPrivatePair(publicKey, privateKey));
+                    }
+                    else
+                    {
+                        SafeSecKeyRefHandle publicKey = ImportKey(parameters);
+                        SetKey(SecKeyPair.PublicOnly(publicKey));
+                    }
+                }
+
+                private static SafeSecKeyRefHandle ImportKey(DSAParameters parameters)
+                {
+                    bool hasPrivateKey = parameters.X != null;
+                    byte[] blob = hasPrivateKey ? parameters.ToPrivateKeyBlob() : parameters.ToSubjectPublicKeyInfo();
+
+                    return Interop.AppleCrypto.ImportEphemeralKey(blob, hasPrivateKey);
+                }
+
+                public override byte[] CreateSignature(byte[] hash)
+                {
+                    if (hash == null)
+                        throw new ArgumentNullException(nameof(hash));
+
+                    SecKeyPair keys = GetKeys();
+
+                    if (keys.PrivateKey == null)
+                    {
+                        throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
+                    }
+
+                    byte[] derFormatSignature = Interop.AppleCrypto.GenerateSignature(keys.PrivateKey, hash);
+
+                    // Since the AppleCrypto implementation is limited to FIPS 186-2, signature field sizes
+                    // are always 160 bits / 20 bytes (the size of SHA-1, and the only legal length for Q).
+                    byte[] ieeeFormatSignature = AsymmetricAlgorithmHelpers.ConvertDerToIeee1363(
+                        derFormatSignature,
+                        0,
+                        derFormatSignature.Length,
+                        fieldSizeBits: 160);
+
+                    return ieeeFormatSignature;
+                }
+
+                public override bool VerifySignature(byte[] hash, byte[] signature)
+                {
+                    if (hash == null)
+                        throw new ArgumentNullException(nameof(hash));
+                    if (signature == null)
+                        throw new ArgumentNullException(nameof(signature));
+
+                    byte[] derFormatSignature = AsymmetricAlgorithmHelpers.ConvertIeee1363ToDer(signature);
+
+                    return Interop.AppleCrypto.VerifySignature(
+                        GetKeys().PublicKey,
+                        hash,
+                        derFormatSignature);
+                }
+
+                protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
+                {
+                    if (hashAlgorithm != HashAlgorithmName.SHA1)
+                    {
+                        // Matching DSACryptoServiceProvider's "I only understand SHA-1/FIPS 186-2" exception
+                        throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name);
+                    }
+
+                    return AsymmetricAlgorithmHelpers.HashData(data, offset, count, hashAlgorithm);
+                }
+
+                protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
+                {
+                    return AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
+                }
+
+                protected override void Dispose(bool disposing)
+                {
+                    if (disposing)
+                    {
+                        _keys?.Dispose();
+                        _keys = null;
+                    }
+
+                    base.Dispose(disposing);
+                }
+
+                private SecKeyPair GetKeys()
+                {
+                    SecKeyPair current = _keys;
+
+                    if (current != null)
+                    {
+                        return current;
+                    }
+
+                    // macOS 10.11 and macOS 10.12 declare DSA invalid for key generation.
+                    // Rather than write code which might or might not work, returning
+                    // (OSStatus)-4 (errSecUnimplemented), just make the exception occur here.
+                    //
+                    // When the native code can be verified, then it can be added.
+                    throw new PlatformNotSupportedException(SR.Cryptography_DSA_KeyGenNotSupported);
+                }
+
+                private void SetKey(SecKeyPair newKeyPair)
+                {
+                    SecKeyPair current = _keys;
+                    _keys = newKeyPair;
+                    current?.Dispose();
+
+                    if (newKeyPair != null)
+                    {
+                        int size = Interop.AppleCrypto.GetSimpleKeySizeInBits(newKeyPair.PublicKey);
+                        KeySizeValue = size;
+                    }
+                }
+            }
+        }
+    }
+
+    internal static class DsaKeyBlobHelpers
+    {
+        private static readonly Oid s_idDsa = new Oid("1.2.840.10040.4.1");
+
+        internal static void ReadSubjectPublicKeyInfo(this DerSequenceReader keyInfo, ref DSAParameters parameters)
+        {
+            // SubjectPublicKeyInfo::= SEQUENCE  {
+            //    algorithm AlgorithmIdentifier,
+            //    subjectPublicKey     BIT STRING  }
+            DerSequenceReader algorithm = keyInfo.ReadSequence();
+            string algorithmOid = algorithm.ReadOidAsString();
+
+            // EC Public Key
+            if (algorithmOid != s_idDsa.Value)
+            {
+                throw new CryptographicException();
+            }
+
+            // Dss-Parms ::= SEQUENCE {
+            //   p INTEGER,
+            //   q INTEGER,
+            //   g INTEGER
+            // }
+
+            DerSequenceReader algParameters = algorithm.ReadSequence();
+            parameters.P = algParameters.ReadIntegerBytes();
+            parameters.Q = algParameters.ReadIntegerBytes();
+            parameters.G = algParameters.ReadIntegerBytes();
+
+            byte[] publicKeyBlob = keyInfo.ReadBitString();
+            DerSequenceReader privateKeyReader = DerSequenceReader.CreateForPayload(publicKeyBlob);
+            parameters.Y = privateKeyReader.ReadIntegerBytes();
+
+            // We don't care about the rest of the blob here, but it's expected to not exist.
+        }
+
+        internal static byte[] ToSubjectPublicKeyInfo(this DSAParameters parameters)
+        {
+            // SubjectPublicKeyInfo::= SEQUENCE  {
+            //    algorithm AlgorithmIdentifier,
+            //    subjectPublicKey     BIT STRING  }
+
+            // Dss-Parms ::= SEQUENCE {
+            //   p INTEGER,
+            //   q INTEGER,
+            //   g INTEGER
+            // }
+
+            return DerEncoder.ConstructSequence(
+                DerEncoder.ConstructSegmentedSequence(
+                    DerEncoder.SegmentedEncodeOid(s_idDsa),
+                    DerEncoder.ConstructSegmentedSequence(
+                        DerEncoder.SegmentedEncodeUnsignedInteger(parameters.P),
+                        DerEncoder.SegmentedEncodeUnsignedInteger(parameters.Q),
+                        DerEncoder.SegmentedEncodeUnsignedInteger(parameters.G)
+                    )
+                ),
+                DerEncoder.SegmentedEncodeBitString(
+                    DerEncoder.SegmentedEncodeUnsignedInteger(parameters.Y))
+            );
+        }
+
+        internal static void ReadPkcs8Blob(this DerSequenceReader reader, ref DSAParameters parameters)
+        {
+            // Since the PKCS#8 blob for DSS/DSA does not include the public key (Y) this
+            // structure is only read after filling the public half.
+            Debug.Assert(parameters.P != null);
+            Debug.Assert(parameters.Q != null);
+            Debug.Assert(parameters.G != null);
+            Debug.Assert(parameters.Y != null);
+
+            // OneAsymmetricKey ::= SEQUENCE {
+            //   version                   Version,
+            //   privateKeyAlgorithm       PrivateKeyAlgorithmIdentifier,
+            //   privateKey                PrivateKey,
+            //   attributes            [0] Attributes OPTIONAL,
+            //   ...,
+            //   [[2: publicKey        [1] PublicKey OPTIONAL ]],
+            //   ...
+            // }
+            //
+            // PrivateKeyInfo ::= OneAsymmetricKey
+            //
+            // PrivateKey ::= OCTET STRING
+
+            int version = reader.ReadInteger();
+
+            // We understand both version 0 and 1 formats,
+            // which are now known as v1 and v2, respectively.
+            if (version > 1)
+            {
+                throw new CryptographicException();
+            }
+
+            {
+                // Ensure we're reading DSA, extract the parameters
+                DerSequenceReader algorithm = reader.ReadSequence();
+
+                string algorithmOid = algorithm.ReadOidAsString();
+
+                if (algorithmOid != s_idDsa.Value)
+                {
+                    throw new CryptographicException();
+                }
+
+                // The Dss-Params SEQUENCE is present here, but not needed since
+                // we got it from the public key already.
+            }
+
+            byte[] privateKeyBlob = reader.ReadOctetString();
+            DerSequenceReader privateKeyReader = DerSequenceReader.CreateForPayload(privateKeyBlob);
+            parameters.X = privateKeyReader.ReadIntegerBytes();
+        }
+
+        internal static byte[] ToPrivateKeyBlob(this DSAParameters parameters)
+        {
+            Debug.Assert(parameters.X != null);
+
+            // DSAPrivateKey ::= SEQUENCE(
+            //   version INTEGER,
+            //   p INTEGER,
+            //   q INTEGER,
+            //   g INTEGER,
+            //   y INTEGER,
+            //   x INTEGER,
+            // )
+
+            return DerEncoder.ConstructSequence(
+                DerEncoder.SegmentedEncodeUnsignedInteger(new byte[] { 0 }),
+                DerEncoder.SegmentedEncodeUnsignedInteger(parameters.P),
+                DerEncoder.SegmentedEncodeUnsignedInteger(parameters.Q),
+                DerEncoder.SegmentedEncodeUnsignedInteger(parameters.G),
+                DerEncoder.SegmentedEncodeUnsignedInteger(parameters.Y),
+                DerEncoder.SegmentedEncodeUnsignedInteger(parameters.X));
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/DerSequenceReader.cs
+++ b/src/Common/src/System/Security/Cryptography/DerSequenceReader.cs
@@ -15,6 +15,7 @@ namespace System.Security.Cryptography
     internal class DerSequenceReader
     {
         internal const byte ContextSpecificTagFlag = 0x80;
+        internal const byte ConstructedFlag = 0x20;
 
         private readonly byte[] _data;
         private readonly int _end;
@@ -92,6 +93,22 @@ namespace System.Security.Cryptography
             EatTag(DerTag.Integer);
 
             return ReadContentAsBytes();
+        }
+
+        internal byte[] ReadBitString()
+        {
+            EatTag(DerTag.BitString);
+
+            int contentLength = EatLength();
+            // skip the "unused bits" byte
+            contentLength--;
+            _position++;
+
+            byte[] octets = new byte[contentLength];
+            Buffer.BlockCopy(_data, _position, octets, 0, contentLength);
+
+            _position += contentLength;
+            return octets;
         }
 
         internal byte[] ReadOctetString()

--- a/src/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -84,7 +84,7 @@ namespace System.Security.Cryptography
                 if (!Interop.Crypto.EcDsaSign(hash, hash.Length, signature, ref signatureLength, key))
                     throw Interop.Crypto.CreateOpenSslCryptographicException();
 
-                byte[] converted = OpenSslAsymmetricAlgorithmCore.ConvertDerToIeee1363(signature, 0, signatureLength, KeySize);
+                byte[] converted = AsymmetricAlgorithmHelpers.ConvertDerToIeee1363(signature, 0, signatureLength, KeySize);
 
                 return converted;
             }
@@ -99,14 +99,14 @@ namespace System.Security.Cryptography
                 // The signature format for .NET is r.Concat(s). Each of r and s are of length BitsToBytes(KeySize), even
                 // when they would have leading zeroes.  If it's the correct size, then we need to encode it from
                 // r.Concat(s) to SEQUENCE(INTEGER(r), INTEGER(s)), because that's the format that OpenSSL expects.
-                int expectedBytes = 2 * OpenSslAsymmetricAlgorithmCore.BitsToBytes(KeySize);
+                int expectedBytes = 2 * AsymmetricAlgorithmHelpers.BitsToBytes(KeySize);
                 if (signature.Length != expectedBytes)
                 {
                     // The input isn't of the right length, so we can't sensibly re-encode it.
                     return false;
                 }
 
-                byte[] openSslFormat = OpenSslAsymmetricAlgorithmCore.ConvertIeee1363ToDer(signature);
+                byte[] openSslFormat = AsymmetricAlgorithmHelpers.ConvertIeee1363ToDer(signature);
 
                 SafeEcKeyHandle key = _key.Value;
                 int verifyResult = Interop.Crypto.EcDsaVerify(hash, hash.Length, openSslFormat, openSslFormat.Length, key);
@@ -115,12 +115,12 @@ namespace System.Security.Cryptography
 
             protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
             {
-                return OpenSslAsymmetricAlgorithmCore.HashData(data, offset, count, hashAlgorithm);
+                return AsymmetricAlgorithmHelpers.HashData(data, offset, count, hashAlgorithm);
             }
 
             protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
             {
-                return OpenSslAsymmetricAlgorithmCore.HashData(data, hashAlgorithm);
+                return AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
             }
 
             protected override void Dispose(bool disposing)

--- a/src/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
@@ -295,6 +295,7 @@ namespace System.Security.Cryptography
                         return current;
                     }
 
+#if APPLE_ASYMMETRIC_GENERATION
                     SafeSecKeyRefHandle publicKey;
                     SafeSecKeyRefHandle privateKey;
                     int osStatus;
@@ -309,6 +310,9 @@ namespace System.Security.Cryptography
                     current = SecKeyPair.PublicPrivatePair(publicKey, privateKey);
                     _keys = current;
                     return current;
+#else
+                    throw new CryptographicException("ECDSA Key Generation is temporarily disabled");
+#endif
                 }
             }
         }

--- a/src/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
@@ -1,0 +1,538 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.IO;
+using System.Security.Cryptography.Apple;
+using Internal.Cryptography;
+
+namespace System.Security.Cryptography
+{
+    public partial class ECDsa : AsymmetricAlgorithm
+    {
+        /// <summary>
+        /// Creates an instance of the platform specific implementation of the cref="ECDsa" algorithm.
+        /// </summary>
+        public static ECDsa Create()
+        {
+            return new ECDsaImplementation.ECDsaSecurityTransforms();
+        }
+
+        /// <summary>
+        /// Creates an instance of the platform specific implementation of the cref="ECDsa" algorithm.
+        /// </summary>
+        /// <param name="curve">
+        /// The <see cref="ECCurve"/> representing the elliptic curve.
+        /// </param>
+        public static ECDsa Create(ECCurve curve)
+        {
+            ECDsa ecdsa = Create();
+            ecdsa.GenerateKey(curve);
+            return ecdsa;
+        }
+
+        /// <summary>
+        /// Creates an instance of the platform specific implementation of the cref="ECDsa" algorithm.
+        /// </summary>
+        /// <param name="parameters">
+        /// The <see cref="ECParameters"/> representing the elliptic curve parameters.
+        /// </param>
+        public static ECDsa Create(ECParameters parameters)
+        {
+            ECDsa ecdsa = Create();
+            ecdsa.ImportParameters(parameters);
+            return ecdsa;
+        }
+
+        internal static partial class ECDsaImplementation
+        {
+            // TODO: Name this for real.
+            public sealed partial class ECDsaSecurityTransforms : ECDsa
+            {
+                private SecKeyPair _keys;
+
+                public ECDsaSecurityTransforms()
+                {
+                    KeySize = 521;
+                }
+
+                public override KeySizes[] LegalKeySizes
+                {
+                    get
+                    {
+                        // Return the three sizes that can be explicitly set (for backwards compatibility)
+                        return new[] {
+                            new KeySizes(minSize: 256, maxSize: 384, skipSize: 128),
+                            new KeySizes(minSize: 521, maxSize: 521, skipSize: 0),
+                        };
+                    }
+                }
+
+                public override int KeySize
+                {
+                    get
+                    {
+                        return base.KeySize;
+                    }
+                    set
+                    {
+                        if (KeySize == value)
+                            return;
+
+                        // Set the KeySize before freeing the key so that an invalid value doesn't throw away the key
+                        base.KeySize = value;
+
+                        _keys?.Dispose();
+                        _keys = null;
+                    }
+                }
+
+                public override byte[] SignHash(byte[] hash)
+                {
+                    if (hash == null)
+                        throw new ArgumentNullException(nameof(hash));
+
+                    SecKeyPair keys = GetKeys();
+
+                    if (keys.PrivateKey == null)
+                    {
+                        throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
+                    }
+
+                    byte[] derFormatSignature = Interop.AppleCrypto.GenerateSignature(keys.PrivateKey, hash);
+                    byte[] ieeeFormatSignature = AsymmetricAlgorithmHelpers.ConvertDerToIeee1363(
+                        derFormatSignature,
+                        0,
+                        derFormatSignature.Length,
+                        KeySize);
+
+                    return ieeeFormatSignature;
+                }
+
+                public override bool VerifyHash(byte[] hash, byte[] signature)
+                {
+                    if (hash == null)
+                        throw new ArgumentNullException(nameof(hash));
+                    if (signature == null)
+                        throw new ArgumentNullException(nameof(signature));
+
+                    byte[] derFormatSignature = AsymmetricAlgorithmHelpers.ConvertIeee1363ToDer(signature);
+
+                    return Interop.AppleCrypto.VerifySignature(
+                        GetKeys().PublicKey,
+                        hash,
+                        derFormatSignature);
+                }
+
+                protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
+                {
+                    return AsymmetricAlgorithmHelpers.HashData(data, offset, count, hashAlgorithm);
+                }
+
+                protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
+                {
+                    return AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
+                }
+
+                protected override void Dispose(bool disposing)
+                {
+                    if (disposing)
+                    {
+                        _keys?.Dispose();
+                        _keys = null;
+                    }
+
+                    base.Dispose(disposing);
+                }
+
+                public override ECParameters ExportExplicitParameters(bool includePrivateParameters)
+                {
+                    throw new PlatformNotSupportedException(SR.Cryptography_ECC_NamedCurvesOnly);
+                }
+
+                public override ECParameters ExportParameters(bool includePrivateParameters)
+                {
+                    SecKeyPair keys = GetKeys();
+
+                    SafeSecKeyRefHandle keyHandle = includePrivateParameters ? keys.PrivateKey : keys.PublicKey;
+
+                    if (keyHandle == null)
+                    {
+                        throw new CryptographicException(SR.Cryptography_OpenInvalidHandle);
+                    }
+
+                    DerSequenceReader keyReader = Interop.AppleCrypto.SecKeyExport(keyHandle, includePrivateParameters);
+                    ECParameters parameters = new ECParameters();
+
+                    if (includePrivateParameters)
+                    {
+                        keyReader.ReadPkcs8Blob(ref parameters);
+                    }
+                    else
+                    {
+                        keyReader.ReadSubjectPublicKeyInfo(ref parameters);
+                    }
+
+                    int size = AsymmetricAlgorithmHelpers.BitsToBytes(KeySize);
+
+                    KeyBlobHelpers.PadOrTrim(ref parameters.Q.X, size);
+                    KeyBlobHelpers.PadOrTrim(ref parameters.Q.Y, size);
+
+                    if (includePrivateParameters)
+                    {
+                        KeyBlobHelpers.PadOrTrim(ref parameters.D, size);
+                    }
+
+                    return parameters;
+                }
+
+                public override void ImportParameters(ECParameters parameters)
+                {
+                    parameters.Validate();
+
+                    bool isPrivateKey = parameters.D != null;
+
+                    if (isPrivateKey)
+                    {
+                        // Start with the private key, in case some of the private key fields don't
+                        // match the public key fields and the system determines an integrity failure.
+                        //
+                        // Public import should go off without a hitch.
+                        SafeSecKeyRefHandle privateKey = ImportKey(parameters);
+
+                        ECParameters publicOnly = parameters;
+                        publicOnly.D = null;
+
+                        SafeSecKeyRefHandle publicKey;
+                        try
+                        {
+                            publicKey = ImportKey(publicOnly);
+                        }
+                        catch
+                        {
+                            privateKey.Dispose();
+                            throw;
+                        }
+
+                        SetKey(SecKeyPair.PublicPrivatePair(publicKey, privateKey));
+                    }
+                    else
+                    {
+                        SafeSecKeyRefHandle publicKey = ImportKey(parameters);
+                        SetKey(SecKeyPair.PublicOnly(publicKey));
+                    }
+                }
+
+                public override void GenerateKey(ECCurve curve)
+                {
+                    curve.Validate();
+
+                    if (!curve.IsNamed)
+                    {
+                        throw new PlatformNotSupportedException(SR.Cryptography_ECC_NamedCurvesOnly);
+                    }
+
+                    int keySize;
+
+                    switch (curve.Oid.Value)
+                    {
+                        // secp256r1 / nistp256
+                        case "1.2.840.10045.3.1.7":
+                            keySize = 256;
+                            break;
+                        // secp384r1 / nistp384
+                        case "1.3.132.0.34":
+                            keySize = 384;
+                            break;
+                        // secp521r1 / nistp521
+                        case "1.3.132.0.35":
+                            keySize = 521;
+                            break;
+                        default:
+                            throw new PlatformNotSupportedException(
+                                SR.Format(SR.Cryptography_CurveNotSupported, curve.Oid.Value));
+                    }
+
+                    // Clear the current key, because GenerateKey on the same curve makes a new key,
+                    // unlike setting the KeySize property to the current value.
+                    SetKey(null);
+                    KeySizeValue = keySize;
+
+                    // Generate the keys immediately, because that's what the verb of this method is.
+                    GetKeys();
+                }
+
+                private static SafeSecKeyRefHandle ImportKey(ECParameters parameters)
+                {
+                    bool isPrivateKey = parameters.D != null;
+                    byte[] blob = isPrivateKey ? parameters.ToPrivateKeyBlob() : parameters.ToSubjectPublicKeyInfo();
+
+                    return Interop.AppleCrypto.ImportEphemeralKey(blob, isPrivateKey);
+                }
+
+                private void SetKey(SecKeyPair newKeyPair)
+                {
+                    SecKeyPair current = _keys;
+                    _keys = newKeyPair;
+                    current?.Dispose();
+
+                    if (newKeyPair != null)
+                    {
+                        long size = Interop.AppleCrypto.EccGetKeySizeInBits(newKeyPair.PublicKey);
+
+                        Debug.Assert(size == 256 || size == 384 || size == 512, $"Unknown keysize ({size})");
+                        KeySizeValue = (int)size;
+                    }
+                }
+
+                private SecKeyPair GetKeys()
+                {
+                    SecKeyPair current = _keys;
+
+                    if (current != null)
+                    {
+                        return current;
+                    }
+
+                    SafeSecKeyRefHandle publicKey;
+                    SafeSecKeyRefHandle privateKey;
+                    int osStatus;
+
+                    int gen = Interop.AppleCrypto.EccGenerateKey(KeySizeValue, out publicKey, out privateKey, out osStatus);
+
+                    if (gen != 1)
+                    {
+                        throw Interop.AppleCrypto.CreateExceptionForCCError(osStatus, Interop.AppleCrypto.OSStatus);
+                    }
+
+                    current = SecKeyPair.PublicPrivatePair(publicKey, privateKey);
+                    _keys = current;
+                    return current;
+                }
+            }
+        }
+    }
+
+    internal static class EcKeyBlobHelpers
+    {
+        private static readonly byte[] s_version1 = { 1 };
+        private static readonly byte[][] s_encodedVersion1 = DerEncoder.SegmentedEncodeUnsignedInteger(s_version1);
+
+        private static readonly Oid s_idEcPublicKey = new Oid("1.2.840.10045.2.1", null);
+        private static readonly byte[][] s_encodedIdEcPublicKey = DerEncoder.SegmentedEncodeOid(s_idEcPublicKey);
+
+        internal static void ReadPkcs8Blob(this DerSequenceReader reader, ref ECParameters parameters)
+        {
+            // OneAsymmetricKey ::= SEQUENCE {
+            //   version                   Version,
+            //   privateKeyAlgorithm       PrivateKeyAlgorithmIdentifier,
+            //   privateKey                PrivateKey,
+            //   attributes            [0] Attributes OPTIONAL,
+            //   ...,
+            //   [[2: publicKey        [1] PublicKey OPTIONAL ]],
+            //   ...
+            // }
+            //
+            // PrivateKeyInfo ::= OneAsymmetricKey
+            //
+            // PrivateKey ::= OCTET STRING
+
+            int version = reader.ReadInteger();
+
+            // We understand both version 0 and 1 formats,
+            // which are now known as v1 and v2, respectively.
+            if (version > 1)
+            {
+                throw new CryptographicException();
+            }
+
+            {
+                // Ensure we're reading EC Public Key (well, Private, but the OID says Public)
+                DerSequenceReader algorithm = reader.ReadSequence();
+
+                string algorithmOid = algorithm.ReadOidAsString();
+
+                if (algorithmOid != s_idEcPublicKey.Value)
+                {
+                    throw new CryptographicException();
+                }
+            }
+
+            byte[] privateKeyBlob = reader.ReadOctetString();
+
+            // ECPrivateKey{CURVES:IOSet} ::= SEQUENCE {
+            //   version INTEGER { ecPrivkeyVer1(1) } (ecPrivkeyVer1),
+            //   privateKey OCTET STRING,
+            //   parameters [0] Parameters{{IOSet}} OPTIONAL,
+            //   publicKey  [1] BIT STRING OPTIONAL
+            // }
+            DerSequenceReader keyReader = new DerSequenceReader(privateKeyBlob);
+            version = keyReader.ReadInteger();
+
+            // We understand the version 1 format
+            if (version > 1)
+            {
+                throw new CryptographicException();
+            }
+
+            parameters.D = keyReader.ReadOctetString();
+
+            // Check for context specific 0
+            const byte ConstructedContextSpecific =
+                DerSequenceReader.ContextSpecificTagFlag | DerSequenceReader.ConstructedFlag;
+
+            const byte ConstructedContextSpecific0 = (ConstructedContextSpecific | 0);
+            const byte ConstructedContextSpecific1 = (ConstructedContextSpecific | 1);
+
+            if (keyReader.PeekTag() != ConstructedContextSpecific0)
+            {
+                throw new CryptographicException();
+            }
+
+            // Parameters ::= CHOICE {
+            //   ecParameters ECParameters,
+            //   namedCurve CURVES.&id({ CurveNames}),
+            //   implicitlyCA  NULL
+            // }
+            DerSequenceReader parametersReader = keyReader.ReadSequence();
+
+            if (parametersReader.PeekTag() != (int)DerSequenceReader.DerTag.ObjectIdentifier)
+            {
+                throw new PlatformNotSupportedException(SR.Cryptography_ECC_NamedCurvesOnly);
+            }
+
+            parameters.Curve = ECCurve.CreateFromValue(parametersReader.ReadOidAsString());
+
+            // Check for context specific 1
+            if (keyReader.PeekTag() != ConstructedContextSpecific1)
+            {
+                throw new CryptographicException();
+            }
+
+            keyReader = keyReader.ReadSequence();
+            byte[] encodedPoint = keyReader.ReadBitString();
+            ReadEncodedPoint(encodedPoint, ref parameters);
+
+            // We don't care about the rest of the blob here, but it's expected to not exist.
+        }
+
+        internal static void ReadSubjectPublicKeyInfo(this DerSequenceReader keyInfo, ref ECParameters parameters)
+        {
+            // SubjectPublicKeyInfo::= SEQUENCE  {
+            //    algorithm AlgorithmIdentifier,
+            //    subjectPublicKey     BIT STRING  }
+            DerSequenceReader algorithm = keyInfo.ReadSequence();
+            string algorithmOid = algorithm.ReadOidAsString();
+
+            // EC Public Key
+            if (algorithmOid != s_idEcPublicKey.Value)
+            {
+                throw new CryptographicException();
+            }
+
+            if (algorithm.PeekTag() != (int)DerSequenceReader.DerTag.ObjectIdentifier)
+            {
+                throw new PlatformNotSupportedException(SR.Cryptography_ECC_NamedCurvesOnly);
+            }
+
+            parameters.Curve = ECCurve.CreateFromValue(algorithm.ReadOidAsString());
+
+            byte[] encodedPoint = keyInfo.ReadBitString();
+            ReadEncodedPoint(encodedPoint, ref parameters);
+
+            // We don't care about the rest of the blob here, but it's expected to not exist.
+        }
+
+        internal static byte[] ToSubjectPublicKeyInfo(this ECParameters parameters)
+        {
+            parameters.Validate();
+
+            if (!parameters.Curve.IsNamed)
+            {
+                throw new PlatformNotSupportedException(SR.Cryptography_ECC_NamedCurvesOnly);
+            }
+
+            byte[] pointBlob = GetPointBlob(ref parameters);
+
+            return DerEncoder.ConstructSequence(
+                DerEncoder.ConstructSegmentedSequence(
+                    s_encodedIdEcPublicKey,
+                    DerEncoder.SegmentedEncodeOid(parameters.Curve.Oid)),
+                DerEncoder.SegmentedEncodeBitString(pointBlob));
+        }
+
+        private static byte[] GetPointBlob(ref ECParameters parameters)
+        {
+            byte[] pointBlob = new byte[parameters.Q.X.Length + parameters.Q.Y.Length + 1];
+
+            // Uncompressed point
+            pointBlob[0] = 0x04;
+            Buffer.BlockCopy(parameters.Q.X, 0, pointBlob, 1, parameters.Q.X.Length);
+            Buffer.BlockCopy(parameters.Q.Y, 0, pointBlob, 1 + parameters.Q.X.Length, parameters.Q.Y.Length);
+            return pointBlob;
+        }
+
+        internal static byte[] ToPrivateKeyBlob(this ECParameters parameters)
+        {
+            parameters.Validate();
+
+            if (!parameters.Curve.IsNamed)
+            {
+                throw new PlatformNotSupportedException(SR.Cryptography_ECC_NamedCurvesOnly);
+            }
+
+            byte[] pointBlob = GetPointBlob(ref parameters);
+
+            // ECPrivateKey{CURVES:IOSet} ::= SEQUENCE {
+            //   version INTEGER { ecPrivkeyVer1(1) } (ecPrivkeyVer1),
+            //   privateKey OCTET STRING,
+            //   parameters [0] Parameters{{IOSet}} OPTIONAL,
+            //   publicKey  [1] BIT STRING OPTIONAL
+            // }
+            return DerEncoder.ConstructSequence(
+                s_encodedVersion1,
+                DerEncoder.SegmentedEncodeOctetString(parameters.D),
+                DerEncoder.ConstructSegmentedContextSpecificValue(
+                    0,
+                    DerEncoder.SegmentedEncodeOid(parameters.Curve.Oid)),
+                DerEncoder.ConstructSegmentedContextSpecificValue(
+                    1,
+                    DerEncoder.SegmentedEncodeBitString(pointBlob)));
+        }
+
+        private static void ReadEncodedPoint(byte[] encodedPoint, ref ECParameters parameters)
+        {
+            if (encodedPoint == null || encodedPoint.Length < 1)
+            {
+                throw new CryptographicException();
+            }
+
+            byte encoding = encodedPoint[0];
+
+            switch (encoding)
+            {
+                // Uncompressed encoding (04 xbytes ybytes)
+                case 0x04:
+                // Hybrid encoding, ~yp == 0 (06 xbytes ybytes)
+                case 0x06:
+                // Hybrid encoding, ~yp == 1 (07 xbytes ybytes)
+                case 0x07:
+                    break;
+                default:
+                    Debug.Fail($"Don't know how to read point encoding {encoding}");
+                    throw new CryptographicException();
+            }
+
+            // For formats 04, 06, and 07 the X and Y points are equal length, and they should
+            // already be left-padded with zeros in cases where they're short.
+            int pointEncodingSize = (encodedPoint.Length - 1) / 2;
+            byte[] encodedX = new byte[pointEncodingSize];
+            byte[] encodedY = new byte[pointEncodingSize];
+            Buffer.BlockCopy(encodedPoint, 1, encodedX, 0, pointEncodingSize);
+            Buffer.BlockCopy(encodedPoint, 1 + pointEncodingSize, encodedY, 0, pointEncodingSize);
+            parameters.Q.X = encodedX;
+            parameters.Q.Y = encodedY;
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/KeyBlobHelpers.cs
+++ b/src/Common/src/System/Security/Cryptography/KeyBlobHelpers.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography
+{
+    internal static class KeyBlobHelpers
+    {
+        internal static byte[] TrimPaddingByte(byte[] data)
+        {
+            byte[] dataLocal = data;
+            TrimPaddingByte(ref dataLocal);
+            return dataLocal;
+        }
+
+        internal static void TrimPaddingByte(ref byte[] data)
+        {
+            if (data[0] != 0)
+                return;
+
+            byte[] newData = new byte[data.Length - 1];
+            Buffer.BlockCopy(data, 1, newData, 0, newData.Length);
+            data = newData;
+        }
+
+        internal static byte[] PadOrTrim(byte[] data, int length)
+        {
+            byte[] dataLocal = data;
+            PadOrTrim(ref dataLocal, length);
+            return dataLocal;
+        }
+
+        internal static void PadOrTrim(ref byte[] data, int length)
+        {
+            if (data.Length == length)
+                return;
+
+            // Need to skip the sign-padding byte.
+            if (data.Length == length + 1 && data[0] == 0)
+            {
+                TrimPaddingByte(ref data);
+                return;
+            }
+
+            int offset = length - data.Length;
+
+            byte[] newData = new byte[length];
+            Buffer.BlockCopy(data, 0, newData, offset, data.Length);
+            data = newData;
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -352,12 +352,12 @@ namespace System.Security.Cryptography
 
         protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
         {
-            return OpenSslAsymmetricAlgorithmCore.HashData(data, offset, count, hashAlgorithm);
+            return AsymmetricAlgorithmHelpers.HashData(data, offset, count, hashAlgorithm);
         }
 
         protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
         {
-            return OpenSslAsymmetricAlgorithmCore.HashData(data, hashAlgorithm);
+            return AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
         }
 
         public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)

--- a/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
@@ -238,6 +238,7 @@ namespace System.Security.Cryptography
                     return current;
                 }
 
+#if APPLE_ASYMMETRIC_GENERATION
                 SafeSecKeyRefHandle publicKey;
                 SafeSecKeyRefHandle privateKey;
                 int osStatus;
@@ -253,6 +254,9 @@ namespace System.Security.Cryptography
                 current = SecKeyPair.PublicPrivatePair(publicKey, privateKey);
                 _keys = current;
                 return current;
+#else
+                throw new CryptographicException("RSA Key Generation is temporarily disabled");
+#endif
             }
 
             private void SetKey(SecKeyPair newKeyPair)

--- a/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
@@ -1,0 +1,463 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.IO;
+using System.Security.Cryptography.Apple;
+using Internal.Cryptography;
+
+namespace System.Security.Cryptography
+{
+    public partial class RSA : AsymmetricAlgorithm
+    {
+        public static RSA Create()
+        {
+            return new RSAImplementation.RSASecurityTransforms();
+        }
+    }
+
+    internal static partial class RSAImplementation
+    {
+        public sealed partial class RSASecurityTransforms : RSA
+        {
+            private SecKeyPair _keys;
+
+            public RSASecurityTransforms()
+                : this(2048)
+            {
+            }
+
+            public RSASecurityTransforms(int keySize)
+            {
+                KeySize = keySize;
+            }
+
+            public override KeySizes[] LegalKeySizes
+            {
+                get
+                {
+                    return new KeySizes[]
+                    {
+                        // All values are in bits.
+                        // 1024 was achieved via experimentation.
+                        // 1024 and 1024+64 both generated successfully, 1024-64 produced errSecParam.
+                        new KeySizes(minSize: 1024, maxSize: 16384, skipSize: 64),
+                    };
+                }
+            }
+
+            public override int KeySize
+            {
+                get
+                {
+                    return base.KeySize;
+                }
+                set
+                {
+                    if (KeySize == value)
+                        return;
+
+                    // Set the KeySize before freeing the key so that an invalid value doesn't throw away the key
+                    base.KeySize = value;
+
+                    _keys?.Dispose();
+                    _keys = null;
+                }
+            }
+
+            public override RSAParameters ExportParameters(bool includePrivateParameters)
+            {
+                SecKeyPair keys = GetKeys();
+
+                SafeSecKeyRefHandle keyHandle = includePrivateParameters ? keys.PrivateKey : keys.PublicKey;
+
+                if (keyHandle == null)
+                {
+                    throw new CryptographicException(SR.Cryptography_OpenInvalidHandle);
+                }
+
+                DerSequenceReader keyReader = Interop.AppleCrypto.SecKeyExport(keyHandle, includePrivateParameters);
+                RSAParameters parameters = new RSAParameters();
+
+                if (includePrivateParameters)
+                {
+                    keyReader.ReadPkcs8Blob(ref parameters);
+                }
+                else
+                {
+                    keyReader.ReadSubjectPublicKeyInfo(ref parameters);
+                }
+
+                return parameters;
+            }
+
+            public override void ImportParameters(RSAParameters parameters)
+            {
+                bool isPrivateKey = parameters.D != null;
+
+                if (isPrivateKey)
+                {
+                    // Start with the private key, in case some of the private key fields
+                    // don't match the public key fields.
+                    //
+                    // Public import should go off without a hitch.
+                    SafeSecKeyRefHandle privateKey = ImportKey(parameters);
+
+                    RSAParameters publicOnly = new RSAParameters
+                    {
+                        Modulus = parameters.Modulus,
+                        Exponent = parameters.Exponent,
+                    };
+
+                    SafeSecKeyRefHandle publicKey;
+                    try
+                    {
+                        publicKey = ImportKey(publicOnly);
+                    }
+                    catch
+                    {
+                        privateKey.Dispose();
+                        throw;
+                    }
+
+                    SetKey(SecKeyPair.PublicPrivatePair(publicKey, privateKey));
+                }
+                else
+                {
+                    SafeSecKeyRefHandle publicKey = ImportKey(parameters);
+                    SetKey(SecKeyPair.PublicOnly(publicKey));
+                }
+            }
+
+            public override byte[] Encrypt(byte[] data, RSAEncryptionPadding padding)
+            {
+                return Interop.AppleCrypto.RsaEncrypt(GetKeys().PublicKey, data, padding);
+            }
+
+            public override byte[] Decrypt(byte[] data, RSAEncryptionPadding padding)
+            {
+                SecKeyPair keys = GetKeys();
+
+                if (keys.PrivateKey == null)
+                {
+                    throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
+                }
+
+                return Interop.AppleCrypto.RsaDecrypt(keys.PrivateKey, data, padding);
+            }
+
+            public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
+            {
+                if (padding != RSASignaturePadding.Pkcs1)
+                    throw new CryptographicException(SR.Cryptography_InvalidPaddingMode);
+
+                SecKeyPair keys = GetKeys();
+
+                if (keys.PrivateKey == null)
+                {
+                    throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
+                }
+
+                return Interop.AppleCrypto.GenerateSignature(
+                    keys.PrivateKey,
+                    hash,
+                    PalAlgorithmFromAlgorithmName(hashAlgorithm));
+            }
+
+            public override bool VerifyHash(
+                byte[] hash,
+                byte[] signature,
+                HashAlgorithmName hashAlgorithm,
+                RSASignaturePadding padding)
+            {
+                if (padding != RSASignaturePadding.Pkcs1)
+                    throw new CryptographicException(SR.Cryptography_InvalidPaddingMode);
+
+                return Interop.AppleCrypto.VerifySignature(
+                    GetKeys().PublicKey,
+                    hash,
+                    signature,
+                    PalAlgorithmFromAlgorithmName(hashAlgorithm));
+            }
+
+            protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
+            {
+                return AsymmetricAlgorithmHelpers.HashData(data, offset, count, hashAlgorithm);
+            }
+
+            protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
+            {
+                return AsymmetricAlgorithmHelpers.HashData(data, hashAlgorithm);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _keys?.Dispose();
+                    _keys = null;
+                }
+
+                base.Dispose(disposing);
+            }
+
+            private static Interop.AppleCrypto.PAL_HashAlgorithm PalAlgorithmFromAlgorithmName(
+                HashAlgorithmName hashAlgorithmName)
+            {
+                if (hashAlgorithmName == HashAlgorithmName.MD5)
+                {
+                    return Interop.AppleCrypto.PAL_HashAlgorithm.Md5;
+                }
+                else if (hashAlgorithmName == HashAlgorithmName.SHA1)
+                {
+                    return Interop.AppleCrypto.PAL_HashAlgorithm.Sha1;
+                }
+                else if (hashAlgorithmName == HashAlgorithmName.SHA256)
+                {
+                    return Interop.AppleCrypto.PAL_HashAlgorithm.Sha256;
+                }
+                else if (hashAlgorithmName == HashAlgorithmName.SHA384)
+                {
+                    return Interop.AppleCrypto.PAL_HashAlgorithm.Sha384;
+                }
+                else if (hashAlgorithmName == HashAlgorithmName.SHA512)
+                {
+                    return Interop.AppleCrypto.PAL_HashAlgorithm.Sha512;
+                }
+
+                throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmName.Name);
+            }
+
+            private SecKeyPair GetKeys()
+            {
+                SecKeyPair current = _keys;
+
+                if (current != null)
+                {
+                    return current;
+                }
+
+                SafeSecKeyRefHandle publicKey;
+                SafeSecKeyRefHandle privateKey;
+                int osStatus;
+
+                int gen = Interop.AppleCrypto.RsaGenerateKey(KeySizeValue, out publicKey, out privateKey, out osStatus);
+
+                if (gen != 1)
+                {
+                    Debug.Assert(gen == 0, $"Expected gen=0, got gen={gen}");
+                    throw Interop.AppleCrypto.CreateExceptionForCCError(osStatus, Interop.AppleCrypto.OSStatus);
+                }
+
+                current = SecKeyPair.PublicPrivatePair(publicKey, privateKey);
+                _keys = current;
+                return current;
+            }
+
+            private void SetKey(SecKeyPair newKeyPair)
+            {
+                SecKeyPair current = _keys;
+                _keys = newKeyPair;
+                current?.Dispose();
+
+                if (newKeyPair != null)
+                {
+                    KeySizeValue = Interop.AppleCrypto.GetSimpleKeySizeInBits(newKeyPair.PublicKey);
+                }
+            }
+
+            private static SafeSecKeyRefHandle ImportKey(RSAParameters parameters)
+            {
+                bool isPrivateKey = parameters.D != null;
+                byte[] pkcs1Blob = isPrivateKey ? parameters.ToPkcs1Blob() : parameters.ToSubjectPublicKeyInfo();
+
+                return Interop.AppleCrypto.ImportEphemeralKey(pkcs1Blob, isPrivateKey);
+            }
+        }
+    }
+
+    internal static class RsaKeyBlobHelpers
+    {
+        private const string RsaOid = "1.2.840.113549.1.1.1";
+
+        // The PKCS#1 version blob for an RSA key based on 2 primes.
+        private static readonly byte[] s_versionNumberBytes = { 0 };
+
+        // The AlgorithmIdentifier structure for RSA contains an explicit NULL, for legacy/compat reasons.
+        private static readonly byte[][] s_encodedRsaAlgorithmIdentifier =
+            DerEncoder.ConstructSegmentedSequence(
+                DerEncoder.SegmentedEncodeOid(new Oid(RsaOid)),
+                // DER:NULL (0x05 0x00)
+                new byte[][]
+                {
+                    new byte[] { (byte)DerSequenceReader.DerTag.Null },
+                    new byte[] { 0 }, 
+                    Array.Empty<byte>(),
+                });
+
+        internal static byte[] ToPkcs1Blob(this RSAParameters parameters)
+        {
+            if (parameters.Exponent == null || parameters.Modulus == null)
+                throw new CryptographicException(SR.Cryptography_InvalidRsaParameters);
+
+            if (parameters.D == null)
+            {
+                if (parameters.P != null ||
+                    parameters.DP != null ||
+                    parameters.Q != null ||
+                    parameters.DQ != null ||
+                    parameters.InverseQ != null)
+                {
+                    throw new CryptographicException(SR.Cryptography_InvalidRsaParameters);
+                }
+
+                return DerEncoder.ConstructSequence(
+                    DerEncoder.SegmentedEncodeUnsignedInteger(parameters.Modulus),
+                    DerEncoder.SegmentedEncodeUnsignedInteger(parameters.Exponent));
+            }
+
+            if (parameters.P == null ||
+                parameters.DP == null ||
+                parameters.Q == null ||
+                parameters.DQ == null ||
+                parameters.InverseQ == null)
+            {
+                throw new CryptographicException(SR.Cryptography_InvalidRsaParameters);
+            }
+
+            return DerEncoder.ConstructSequence(
+                DerEncoder.SegmentedEncodeUnsignedInteger(s_versionNumberBytes),
+                DerEncoder.SegmentedEncodeUnsignedInteger(parameters.Modulus),
+                DerEncoder.SegmentedEncodeUnsignedInteger(parameters.Exponent),
+                DerEncoder.SegmentedEncodeUnsignedInteger(parameters.D),
+                DerEncoder.SegmentedEncodeUnsignedInteger(parameters.P),
+                DerEncoder.SegmentedEncodeUnsignedInteger(parameters.Q),
+                DerEncoder.SegmentedEncodeUnsignedInteger(parameters.DP),
+                DerEncoder.SegmentedEncodeUnsignedInteger(parameters.DQ),
+                DerEncoder.SegmentedEncodeUnsignedInteger(parameters.InverseQ));
+        }
+
+        internal static void ReadPkcs8Blob(this DerSequenceReader reader, ref RSAParameters parameters)
+        {
+            // OneAsymmetricKey ::= SEQUENCE {
+            //   version                   Version,
+            //   privateKeyAlgorithm       PrivateKeyAlgorithmIdentifier,
+            //   privateKey                PrivateKey,
+            //   attributes            [0] Attributes OPTIONAL,
+            //   ...,
+            //   [[2: publicKey        [1] PublicKey OPTIONAL ]],
+            //   ...
+            // }
+            //
+            // PrivateKeyInfo ::= OneAsymmetricKey
+            //
+            // PrivateKey ::= OCTET STRING
+
+            int version = reader.ReadInteger();
+
+            // We understand both version 0 and 1 formats,
+            // which are now known as v1 and v2, respectively.
+            if (version > 1)
+            {
+                throw new CryptographicException();
+            }
+
+            {
+                // Ensure we're reading RSA
+                DerSequenceReader algorithm = reader.ReadSequence();
+
+                string algorithmOid = algorithm.ReadOidAsString();
+
+                if (algorithmOid != RsaOid)
+                {
+                    throw new CryptographicException();
+                }
+            }
+
+            byte[] privateKeyBytes = reader.ReadOctetString();
+            // Because this was an RSA private key, the key format is PKCS#1.
+            ReadPkcs1PrivateBlob(privateKeyBytes, ref parameters);
+
+            // We don't care about the rest of the blob here, but it's expected to not exist.
+        }
+
+        internal static byte[] ToSubjectPublicKeyInfo(this RSAParameters parameters)
+        {
+            Debug.Assert(parameters.D == null);
+
+            // SubjectPublicKeyInfo::= SEQUENCE  {
+            //    algorithm AlgorithmIdentifier,
+            //    subjectPublicKey     BIT STRING  }
+            return DerEncoder.ConstructSequence(
+                s_encodedRsaAlgorithmIdentifier,
+                DerEncoder.SegmentedEncodeBitString(
+                    parameters.ToPkcs1Blob()));
+        }
+
+        internal static void ReadSubjectPublicKeyInfo(this DerSequenceReader keyInfo, ref RSAParameters parameters)
+        {
+            // SubjectPublicKeyInfo::= SEQUENCE  {
+            //    algorithm AlgorithmIdentifier,
+            //    subjectPublicKey     BIT STRING  }
+            DerSequenceReader algorithm = keyInfo.ReadSequence();
+            string algorithmOid = algorithm.ReadOidAsString();
+
+            if (algorithmOid != RsaOid)
+            {
+                throw new CryptographicException();
+            }
+
+            byte[] subjectPublicKeyBytes = keyInfo.ReadBitString();
+
+            DerSequenceReader subjectPublicKey = new DerSequenceReader(subjectPublicKeyBytes);
+
+            parameters.Modulus = KeyBlobHelpers.TrimPaddingByte(subjectPublicKey.ReadIntegerBytes());
+            parameters.Exponent = KeyBlobHelpers.TrimPaddingByte(subjectPublicKey.ReadIntegerBytes());
+
+            if (subjectPublicKey.HasData)
+                throw new CryptographicException();
+        }
+
+        private static void ReadPkcs1PrivateBlob(byte[] privateKeyBytes, ref RSAParameters parameters)
+        {
+            // RSAPrivateKey::= SEQUENCE {
+            //    version Version,
+            //    modulus           INTEGER,  --n
+            //    publicExponent INTEGER,  --e
+            //    privateExponent INTEGER,  --d
+            //    prime1 INTEGER,  --p
+            //    prime2 INTEGER,  --q
+            //    exponent1 INTEGER,  --d mod(p - 1)
+            //    exponent2 INTEGER,  --d mod(q - 1)
+            //    coefficient INTEGER,  --(inverse of q) mod p
+            //    otherPrimeInfos OtherPrimeInfos OPTIONAL
+            // }
+            DerSequenceReader privateKey = new DerSequenceReader(privateKeyBytes);
+            int version = privateKey.ReadInteger();
+
+            if (version != 0)
+            {
+                throw new CryptographicException();
+            }
+
+            parameters.Modulus = KeyBlobHelpers.TrimPaddingByte(privateKey.ReadIntegerBytes());
+            parameters.Exponent = KeyBlobHelpers.TrimPaddingByte(privateKey.ReadIntegerBytes());
+
+            int modulusLen = parameters.Modulus.Length;
+            int halfModulus = modulusLen / 2;
+
+            parameters.D = KeyBlobHelpers.PadOrTrim(privateKey.ReadIntegerBytes(), modulusLen);
+            parameters.P = KeyBlobHelpers.PadOrTrim(privateKey.ReadIntegerBytes(), halfModulus);
+            parameters.Q = KeyBlobHelpers.PadOrTrim(privateKey.ReadIntegerBytes(), halfModulus);
+            parameters.DP = KeyBlobHelpers.PadOrTrim(privateKey.ReadIntegerBytes(), halfModulus);
+            parameters.DQ = KeyBlobHelpers.PadOrTrim(privateKey.ReadIntegerBytes(), halfModulus);
+            parameters.InverseQ = KeyBlobHelpers.PadOrTrim(privateKey.ReadIntegerBytes(), halfModulus);
+
+            if (privateKey.HasData)
+            {
+                throw new CryptographicException();
+            }
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/SecKeyPair.cs
+++ b/src/Common/src/System/Security/Cryptography/SecKeyPair.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography.Apple;
+
+namespace System.Security.Cryptography
+{
+    internal sealed class SecKeyPair : IDisposable
+    {
+        internal SafeSecKeyRefHandle PublicKey { get; private set; }
+        internal SafeSecKeyRefHandle PrivateKey { get; private set; }
+
+        private SecKeyPair(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle privateKey)
+        {
+            PublicKey = publicKey;
+            PrivateKey = privateKey;
+        }
+
+        public void Dispose()
+        {
+            PrivateKey?.Dispose();
+            PrivateKey = null;
+            PublicKey?.Dispose();
+            PublicKey = null;
+        }
+
+        internal static SecKeyPair PublicPrivatePair(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle privateKey)
+        {
+            if (publicKey == null || publicKey.IsInvalid)
+                throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(publicKey));
+            if (privateKey == null || privateKey.IsInvalid)
+                throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(privateKey));
+
+            return new SecKeyPair(publicKey, privateKey);
+        }
+
+        internal static SecKeyPair PublicOnly(SafeSecKeyRefHandle publicKey)
+        {
+            if (publicKey == null || publicKey.IsInvalid)
+                throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(publicKey));
+
+            return new SecKeyPair(publicKey, null);
+        }
+    }
+}

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAFactory.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAFactory.cs
@@ -9,6 +9,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         DSA Create();
         DSA Create(int keySize);
         bool SupportsFips186_3 { get; }
+        bool SupportsKeyGeneration { get; }
     }
 
     public static partial class DSAFactory
@@ -27,12 +28,8 @@ namespace System.Security.Cryptography.Dsa.Tests
         /// If false, 186-2 is assumed which implies key size of 1024 or less and only SHA-1
         /// If true, 186-3 includes support for keysizes >1024 and SHA-2 algorithms
         /// </summary>
-        public static bool SupportsFips186_3
-        {
-            get
-            {
-                return s_provider.SupportsFips186_3;
-            }
-        }
+        public static bool SupportsFips186_3 => s_provider.SupportsFips186_3;
+
+        public static bool SupportsKeyGeneration => s_provider.SupportsKeyGeneration;
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAImportExport.cs
@@ -9,8 +9,9 @@ namespace System.Security.Cryptography.Dsa.Tests
     public partial class DSAImportExport
     {
         public static bool SupportsFips186_3 => DSAFactory.SupportsFips186_3;
+        public static bool SupportsKeyGeneration => DSAFactory.SupportsKeyGeneration;
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public static void ExportAutoKey()
         {
             DSAParameters privateParams;

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyGeneration.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyGeneration.cs
@@ -8,6 +8,8 @@ namespace System.Security.Cryptography.Dsa.Tests
 {
     public partial class DSAKeyGeneration
     {
+        public static bool SupportsKeyGeneration => DSAFactory.SupportsKeyGeneration;
+
         [Fact]
         public static void VerifyDefaultKeySize_Fips186_2()
         {
@@ -20,19 +22,19 @@ namespace System.Security.Cryptography.Dsa.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public static void GenerateMinKey()
         {
             GenerateKey(dsa => GetMin(dsa.LegalKeySizes));
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public static void GenerateSecondMinKey()
         {
             GenerateKey(dsa => GetSecondMin(dsa.LegalKeySizes));
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public static void GenerateKey_1024()
         {
             GenerateKey(1024);

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
@@ -9,7 +9,7 @@ namespace System.Security.Cryptography.Dsa.Tests
 {
     public partial class DSASignVerify
     {
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public static void InvalidKeySize_DoesNotInvalidateKey()
         {
             using (DSA dsa = DSAFactory.Create())
@@ -23,7 +23,7 @@ namespace System.Security.Cryptography.Dsa.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public static void SignAndVerifyDataNew1024()
         {
             using (DSA dsa = DSAFactory.Create(1024))
@@ -181,12 +181,7 @@ namespace System.Security.Cryptography.Dsa.Tests
             }
         }
 
-        static internal bool SupportsFips186_3
-        {
-            get
-            {
-                return DSAFactory.SupportsFips186_3;
-            }
-        }
+        public static bool SupportsFips186_3 => DSAFactory.SupportsFips186_3;
+        public static bool SupportsKeyGeneration => DSAFactory.SupportsKeyGeneration;
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignatureFormatter.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignatureFormatter.cs
@@ -14,8 +14,11 @@ namespace System.Security.Cryptography.Dsa.Tests
         {
             using (DSA dsa = DSAFactory.Create())
             {
+                dsa.ImportParameters(DSATestData.GetDSA1024Params());
+
                 var formatter = new DSASignatureFormatter(dsa);
                 var deformatter = new DSASignatureDeformatter(dsa);
+
                 using (SHA1 alg = SHA1.Create())
                 {
                     VerifySignature(formatter, deformatter, alg, "SHA1");

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaFactory.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaFactory.cs
@@ -11,6 +11,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         ECDsa Create(ECCurve curve);
         bool IsCurveValid(Oid oid);
         bool ExplicitCurvesSupported { get; }
+        bool SupportsKeyGeneration { get; }
     }
 
     public static partial class ECDsaFactory
@@ -35,12 +36,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
             return s_provider.IsCurveValid(oid);
         }
 
-        public static bool ExplicitCurvesSupported
-        {
-            get
-            {
-                return s_provider.ExplicitCurvesSupported;
-            }
-        }
+        public static bool ExplicitCurvesSupported => s_provider.ExplicitCurvesSupported;
+        public static bool SupportsKeyGeneration => s_provider.SupportsKeyGeneration;
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using Test.Cryptography;
 
 namespace System.Security.Cryptography.EcDsa.Tests
 {

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
@@ -9,7 +9,8 @@ namespace System.Security.Cryptography.EcDsa.Tests
 {
     public class ECDsaImportExportTests : ECDsaTestsBase
     {
-        [Theory, MemberData(nameof(TestCurvesFull))]
+        [ConditionalTheory(nameof(SupportsKeyGeneration))]
+        [MemberData(nameof(TestCurvesFull))]
         public static void TestNamedCurves(CurveDef curveDef)
         {
             using (ECDsa ec1 = ECDsaFactory.Create(curveDef.Curve))
@@ -114,7 +115,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
             Assert.Throws<ArgumentException>(() => ECCurve.CreateFromOid(new Oid("", "")));
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public static void TestKeySizeCreateKey()
         {
             using (ECDsa ec = ECDsaFactory.Create(ECCurve.NamedCurves.nistP256))

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
 {
     public partial class ECDsaTests : ECDsaTestsBase
     {
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public void KeySizeProp()
         {
             using (ECDsa e = ECDsaFactory.Create())
@@ -134,7 +134,8 @@ namespace System.Security.Cryptography.EcDsa.Tests
             }
         }
 
-        [Theory, MemberData(nameof(TestCurves))]
+        [ConditionalTheory(nameof(SupportsKeyGeneration))]
+        [MemberData(nameof(TestCurves))]
         public void TestRegenKeyNamed(CurveDef curveDef)
         {
             ECParameters param, param2;
@@ -178,7 +179,8 @@ namespace System.Security.Cryptography.EcDsa.Tests
             }
         }
 
-        [Theory, MemberData(nameof(TestCurves))]
+        [ConditionalTheory(nameof(SupportsKeyGeneration))]
+        [MemberData(nameof(TestCurves))]
         public void TestChangeFromNamedCurveToKeySize(CurveDef curveDef)
         {
             using (ECDsa ec = ECDsaFactory.Create(curveDef.Curve))
@@ -211,7 +213,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public void TestNegative256WithRandomKey()
         {
             using (ECDsa ecdsa = ECDsaFactory.Create(ECCurve.NamedCurves.nistP256))
@@ -476,7 +478,8 @@ namespace System.Security.Cryptography.EcDsa.Tests
         
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-        [Theory, MemberData(nameof(RealImplementations))]
+        [ConditionalTheory(nameof(SupportsKeyGeneration))]
+        [MemberData(nameof(RealImplementations))]
         public void SignData_MaxOffset_ZeroLength_NoThrow(ECDsa ecdsa)
         {
             // Explicitly larger than Array.Empty
@@ -486,7 +489,8 @@ namespace System.Security.Cryptography.EcDsa.Tests
             Assert.True(ecdsa.VerifyData(Array.Empty<byte>(), signature, HashAlgorithmName.SHA256));
         }
 
-        [Theory, MemberData(nameof(RealImplementations))]
+        [ConditionalTheory(nameof(SupportsKeyGeneration))]
+        [MemberData(nameof(RealImplementations))]
         public void VerifyData_MaxOffset_ZeroLength_NoThrow(ECDsa ecdsa)
         {
             // Explicitly larger than Array.Empty
@@ -496,7 +500,8 @@ namespace System.Security.Cryptography.EcDsa.Tests
             Assert.True(ecdsa.VerifyData(data, data.Length, 0, signature, HashAlgorithmName.SHA256));
         }
 
-        [Theory, MemberData(nameof(RealImplementations))]
+        [ConditionalTheory(nameof(SupportsKeyGeneration))]
+        [MemberData(nameof(RealImplementations))]
         public void Roundtrip_WithOffset(ECDsa ecdsa)
         {
             byte[] data = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
@@ -512,7 +517,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
 
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-        [Theory]
+        [ConditionalTheory(nameof(SupportsKeyGeneration))]
         [InlineData(256)]
         [InlineData(384)]
         [InlineData(521)]
@@ -543,7 +548,8 @@ namespace System.Security.Cryptography.EcDsa.Tests
             }
         }
 
-        [Theory, MemberData(nameof(InteroperableSignatureConfigurations))]
+        [ConditionalTheory(nameof(SupportsKeyGeneration))]
+        [MemberData(nameof(InteroperableSignatureConfigurations))]
         public void SignVerify_InteroperableSameKeys_RoundTripsUnlessTampered(ECDsa ecdsa, HashAlgorithmName hashAlgorithm)
         {
             byte[] data = Encoding.UTF8.GetBytes("something to repeat and sign");

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTestsBase.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTestsBase.cs
@@ -247,6 +247,8 @@ namespace System.Security.Cryptography.EcDsa.Tests
                 return ECDsaFactory.ExplicitCurvesSupported;
             }
         }
+
+        internal static bool SupportsKeyGeneration => ECDsaFactory.SupportsKeyGeneration ;
     }
 
     internal static class EcDsaTestExtensions

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
@@ -8,6 +8,8 @@ namespace System.Security.Cryptography.Rsa.Tests
 {
     public class EncryptDecrypt
     {
+        public static bool SupportsKeyGeneration => RSAFactory.SupportsKeyGeneration;
+
         [Fact]
         public static void DecryptSavedAnswer()
         {
@@ -137,7 +139,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             Assert.Equal(TestData.HelloBytes, output);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public static void RsaCryptRoundtrip()
         {
             byte[] crypt;
@@ -153,7 +155,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             Assert.Equal(TestData.HelloBytes, output);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public static void RsaDecryptAfterExport()
         {
             byte[] output;

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -151,6 +151,24 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        public static void ImportPrivateExportPublic()
+        {
+            RSAParameters imported = TestData.RSA1024Params;
+
+            using (RSA rsa = RSAFactory.Create())
+            {
+                rsa.ImportParameters(imported);
+
+                RSAParameters exportedPublic = rsa.ExportParameters(false);
+
+                Assert.Equal(imported.Modulus, exportedPublic.Modulus);
+                Assert.Equal(imported.Exponent, exportedPublic.Exponent);
+                Assert.Null(exportedPublic.D);
+                ValidateParameters(ref exportedPublic);
+            }
+        }
+
+        [Fact]
         public static void MultiExport()
         {
             RSAParameters imported = TestData.RSA1024Params;

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -10,7 +10,9 @@ namespace System.Security.Cryptography.Rsa.Tests
 {
     public partial class ImportExport
     {
-        [Fact]
+        public static bool SupportsKeyGeneration => RSAFactory.SupportsKeyGeneration;
+
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public static void ExportAutoKey()
         {
             RSAParameters privateParams;
@@ -120,7 +122,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             AssertKeyEquals(ref unusualExponentParameters, ref exported);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public static void ImportReset()
         {
             using (RSA rsa = RSAFactory.Create())

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/KeyGeneration.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/KeyGeneration.cs
@@ -8,13 +8,15 @@ namespace System.Security.Cryptography.Rsa.Tests
 {
     public class KeyGeneration
     {
-        [Fact]
+        public static bool SupportsKeyGeneration => RSAFactory.SupportsKeyGeneration;
+
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public static void GenerateMinKey()
         {
             GenerateKey(rsa => GetMin(rsa.LegalKeySizes));
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public static void GenerateSecondMinKey()
         {
             GenerateKey(rsa => GetSecondMin(rsa.LegalKeySizes));
@@ -26,13 +28,13 @@ namespace System.Security.Cryptography.Rsa.Tests
             GenerateKey(rsa => GetMax(rsa.LegalKeySizes));
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public static void GenerateKey_2048()
         {
             GenerateKey(2048);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public static void GenerateKey_4096()
         {
             GenerateKey(4096);

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
@@ -10,6 +10,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         RSA Create(int keySize);
         bool Supports384PrivateKey { get; }
         bool SupportsSha2Oaep { get; }
+        bool SupportsKeyGeneration { get; }
     }
 
     public static partial class RSAFactory
@@ -24,14 +25,10 @@ namespace System.Security.Cryptography.Rsa.Tests
             return s_provider.Create(keySize);
         }
 
-        public static bool Supports384PrivateKey
-        {
-            get { return s_provider.Supports384PrivateKey; }
-        }
+        public static bool Supports384PrivateKey => s_provider.Supports384PrivateKey;
 
-        public static bool SupportsSha2Oaep
-        {
-            get { return s_provider.SupportsSha2Oaep; }
-        }
+        public static bool SupportsSha2Oaep => s_provider.SupportsSha2Oaep;
+
+        public static bool SupportsKeyGeneration => s_provider.SupportsKeyGeneration;
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyExchangeFormatter.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyExchangeFormatter.cs
@@ -15,6 +15,8 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             using (RSA rsa = RSAFactory.Create())
             {
+                rsa.ImportParameters(TestData.RSA2048Params);
+
                 var formatter = new RSAOAEPKeyExchangeFormatter(rsa);
                 var deformatter = new RSAOAEPKeyExchangeDeformatter(rsa);
                 VerifyDecryptKeyExchange(formatter, deformatter);
@@ -26,6 +28,8 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             using (RSA rsa = RSAFactory.Create())
             {
+                rsa.ImportParameters(TestData.RSA2048Params);
+
                 var formatter = new RSAPKCS1KeyExchangeFormatter(rsa);
                 var deformatter = new RSAPKCS1KeyExchangeDeformatter(rsa);
                 VerifyDecryptKeyExchange(formatter, deformatter);

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSASignatureFormatter.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSASignatureFormatter.cs
@@ -15,6 +15,8 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             using (RSA rsa = RSAFactory.Create())
             {
+                rsa.ImportParameters(TestData.RSA2048Params);
+
                 var formatter = new RSAPKCS1SignatureFormatter(rsa);
                 var deformatter = new RSAPKCS1SignatureDeformatter(rsa);
 
@@ -31,6 +33,8 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             using (RSA rsa = RSAFactory.Create())
             {
+                rsa.ImportParameters(TestData.RSA2048Params);
+
                 var formatter = new RSAPKCS1SignatureFormatter(rsa);
                 var deformatter = new RSAPKCS1SignatureDeformatter(rsa);
 

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
@@ -10,7 +10,9 @@ namespace System.Security.Cryptography.Rsa.Tests
 {
     public class SignVerify
     {
-        [Fact]
+        public static bool SupportsKeyGeneration => RSAFactory.SupportsKeyGeneration;
+
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
         public static void InvalidKeySize_DoesNotInvalidateKey()
         {
             using (RSA rsa = RSAFactory.Create())

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
@@ -5,10 +5,17 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_definitions(-DPIC=1)
 
+find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+find_library(SECURITY_LIBRARY Security)
+
 set(NATIVECRYPTO_SOURCES
     pal_digest.cpp
+    pal_ecc.cpp
     pal_hmac.cpp
     pal_random.cpp
+    pal_rsa.cpp
+    pal_seckey.cpp
+    pal_signverify.cpp
     pal_symmetric.cpp
 )
 
@@ -22,6 +29,8 @@ add_library(System.Security.Cryptography.Native.Apple
 set_target_properties(System.Security.Cryptography.Native.Apple PROPERTIES PREFIX "")
 
 target_link_libraries(System.Security.Cryptography.Native.Apple
+    ${COREFOUNDATION_LIBRARY}
+    ${SECURITY_LIBRARY}
 )
 
 install_library_and_symbols (System.Security.Cryptography.Native.Apple)

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.cpp
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "pal_ecc.h"
+
+extern "C" int
+AppleCryptoNative_EccGenerateKey(int32_t keySizeBits, SecKeyRef* pPublicKey, SecKeyRef* pPrivateKey, int32_t* pOSStatus)
+{
+    if (pPublicKey != nullptr)
+        *pPublicKey = nullptr;
+    if (pPrivateKey != nullptr)
+        *pPrivateKey = nullptr;
+
+    if (pPublicKey == nullptr || pPrivateKey == nullptr || pOSStatus == nullptr)
+        return kErrorBadInput;
+
+    CFMutableDictionaryRef attributes = CFDictionaryCreateMutable(nullptr, 2, &kCFTypeDictionaryKeyCallBacks, nullptr);
+
+    CFNumberRef cfKeySizeValue = CFNumberCreate(nullptr, kCFNumberIntType, &keySizeBits);
+
+    CFDictionaryAddValue(attributes, kSecAttrKeyType, kSecAttrKeyTypeEC);
+    CFDictionaryAddValue(attributes, kSecAttrKeySizeInBits, cfKeySizeValue);
+
+    OSStatus status = SecKeyGeneratePair(attributes, pPublicKey, pPrivateKey);
+
+    CFRelease(attributes);
+    CFRelease(cfKeySizeValue);
+
+    *pOSStatus = status;
+    return status == noErr;
+}
+
+extern "C" uint64_t AppleCryptoNative_EccGetKeySizeInBits(SecKeyRef publicKey)
+{
+    if (publicKey == nullptr)
+    {
+        return 0;
+    }
+
+    size_t blockSize = SecKeyGetBlockSize(publicKey);
+
+    // This seems to be the expected size of an ECDSA signature for this key.
+    // But since Apple uses the DER SEQUENCE(r, s) format the signature size isn't
+    // fixed. It might be trying to encode the biggest the DER value could be:
+    //
+    // 256: r is 32 bytes, but maybe one padding byte, so 33.
+    //      s is 32 bytes, but maybe one padding byte, so 33.
+    //      each of those values gets one tag and one length byte
+    //      35 * 2 is 70 payload bytes for the sequence, so one length byte
+    //      and one tag byte, makes 72.
+    //
+    // 384: r,s are 48 bytes, plus padding, length, and tag: 51
+    //      2 * 51 = 102, requires one length byte and one tag byte, 104.
+    //
+    // 521: neither r nor s can have the high bit set, no padding. 66 content bytes
+    //      plus tag and length is 68.
+    //      2 * 68 is 136, since it's greater than 127 it takes 2 length bytes
+    //      so 136 + 2 + 1 = 139. Looks like they accounted for padding bytes anyways.
+    //
+    // This completely needs to be revisited if Apple adds support for "generic" ECC.
+    //
+    // Word of caution: While seeking meaning in these numbers I ran across a snippet of code
+    // which suggests that on iOS (vs macOS) they use a different set of reasoning and produce
+    // different numbers (they used (8 + 2*thisValue) on iOS for "signature length").
+    switch (blockSize)
+    {
+        case 72:
+            return 256;
+        case 104:
+            return 384;
+        case 141:
+            return 521;
+    }
+
+    return 0;
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.h
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "pal_seckey.h"
+
+#include <Security/Security.h>
+
+/*
+Generate an ECC keypair of the specified size.
+
+Returns 1 on success, 0 on failure. On failure, *pOSStatus should carry the OS failure code.
+*/
+extern "C" int AppleCryptoNative_EccGenerateKey(int32_t keySizeBits,
+                                                SecKeyRef* pPublicKey,
+                                                SecKeyRef* pPrivateKey,
+                                                int32_t* pOSStatus);
+
+/*
+Get the keysize, in bits, of an ECC key.
+
+Returns the keysize, in bits, of the ECC key, or 0 on error.
+*/
+extern "C" uint64_t AppleCryptoNative_EccGetKeySizeInBits(SecKeyRef publicKey);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.cpp
@@ -1,0 +1,258 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "pal_rsa.h"
+
+static int32_t ExecuteCFDataTransform(
+    SecTransformRef xform, uint8_t* pbData, int32_t cbData, CFDataRef* pDataOut, CFErrorRef* pErrorOut);
+
+extern "C" int
+AppleCryptoNative_RsaGenerateKey(int32_t keySizeBits, SecKeyRef* pPublicKey, SecKeyRef* pPrivateKey, int32_t* pOSStatus)
+{
+    if (pPublicKey != nullptr)
+        *pPublicKey = nullptr;
+    if (pPrivateKey != nullptr)
+        *pPrivateKey = nullptr;
+
+    if (pPublicKey == nullptr || pPrivateKey == nullptr || pOSStatus == nullptr)
+        return kErrorBadInput;
+    if (keySizeBits < 384 || keySizeBits > 16384)
+        return -2;
+
+    CFMutableDictionaryRef attributes = CFDictionaryCreateMutable(nullptr, 2, &kCFTypeDictionaryKeyCallBacks, nullptr);
+
+    CFNumberRef cfKeySizeValue = CFNumberCreate(nullptr, kCFNumberIntType, &keySizeBits);
+    OSStatus status;
+
+    if (attributes != nullptr && cfKeySizeValue != nullptr)
+    {
+        CFDictionaryAddValue(attributes, kSecAttrKeyType, kSecAttrKeyTypeRSA);
+        CFDictionaryAddValue(attributes, kSecAttrKeySizeInBits, cfKeySizeValue);
+
+        status = SecKeyGeneratePair(attributes, pPublicKey, pPrivateKey);
+    }
+    else
+    {
+        status = errSecAllocate;
+    }
+
+    if (attributes != nullptr)
+        CFRelease(attributes);
+    if (cfKeySizeValue != nullptr)
+        CFRelease(cfKeySizeValue);
+
+    *pOSStatus = status;
+    return status == noErr;
+}
+
+static int32_t ExecuteOaepTransform(SecTransformRef xform,
+                                    uint8_t* pbData,
+                                    int32_t cbData,
+                                    PAL_HashAlgorithm algorithm,
+                                    CFDataRef* pDataOut,
+                                    CFErrorRef* pErrorOut)
+{
+    if (!SecTransformSetAttribute(xform, kSecPaddingKey, kSecPaddingOAEPKey, pErrorOut))
+    {
+        return kErrorSeeError;
+    }
+
+    // Documentation mentions kSecOAEPMGF1DigestAlgorithmAttributeName, but on the Apple platform
+    // "SHA2" is an algorithm and the size is encoded separately. Since there doesn't seem to be
+    // a second attribute to encode SHA2-256 vs SHA2-384, be limited to SHA-1.
+    if (algorithm != PAL_SHA1)
+    {
+        return kErrorUnknownAlgorithm;
+    }
+
+    return ExecuteCFDataTransform(xform, pbData, cbData, pDataOut, pErrorOut);
+}
+
+extern "C" int32_t AppleCryptoNative_RsaDecryptOaep(SecKeyRef privateKey,
+                                                    uint8_t* pbData,
+                                                    int32_t cbData,
+                                                    PAL_HashAlgorithm mfgAlgorithm,
+                                                    CFDataRef* pDecryptedOut,
+                                                    CFErrorRef* pErrorOut)
+{
+    if (pDecryptedOut != nullptr)
+        *pDecryptedOut = nullptr;
+    if (pErrorOut != nullptr)
+        *pErrorOut = nullptr;
+
+    if (privateKey == nullptr || pbData == nullptr || cbData < 0 || pDecryptedOut == nullptr || pErrorOut == nullptr)
+    {
+        return kErrorBadInput;
+    }
+
+    int ret = kErrorSeeError;
+    SecTransformRef decryptor = SecDecryptTransformCreate(privateKey, pErrorOut);
+
+    if (decryptor != nullptr)
+    {
+        if (*pErrorOut == nullptr)
+        {
+            ret = ExecuteOaepTransform(decryptor, pbData, cbData, mfgAlgorithm, pDecryptedOut, pErrorOut);
+        }
+
+        CFRelease(decryptor);
+    }
+
+    return ret;
+}
+
+extern "C" int32_t AppleCryptoNative_RsaDecryptPkcs(
+    SecKeyRef privateKey, uint8_t* pbData, int32_t cbData, CFDataRef* pDecryptedOut, CFErrorRef* pErrorOut)
+{
+    if (pDecryptedOut != nullptr)
+        *pDecryptedOut = nullptr;
+    if (pErrorOut != nullptr)
+        *pErrorOut = nullptr;
+
+    if (privateKey == nullptr || pbData == nullptr || cbData < 0 || pDecryptedOut == nullptr || pErrorOut == nullptr)
+    {
+        return kErrorBadInput;
+    }
+
+    int ret = kErrorSeeError;
+    SecTransformRef decryptor = SecDecryptTransformCreate(privateKey, pErrorOut);
+
+    if (decryptor != nullptr)
+    {
+        if (*pErrorOut == nullptr)
+        {
+            ret = ExecuteCFDataTransform(decryptor, pbData, cbData, pDecryptedOut, pErrorOut);
+        }
+
+        CFRelease(decryptor);
+    }
+
+    return ret;
+}
+
+extern "C" int32_t AppleCryptoNative_RsaEncryptOaep(SecKeyRef publicKey,
+                                                    uint8_t* pbData,
+                                                    int32_t cbData,
+                                                    PAL_HashAlgorithm mgfAlgorithm,
+                                                    CFDataRef* pEncryptedOut,
+                                                    CFErrorRef* pErrorOut)
+{
+    if (pEncryptedOut != nullptr)
+        *pEncryptedOut = nullptr;
+    if (pErrorOut != nullptr)
+        *pErrorOut = nullptr;
+
+    if (publicKey == nullptr || pbData == nullptr || cbData < 0 || pEncryptedOut == nullptr || pErrorOut == nullptr)
+    {
+        return kErrorBadInput;
+    }
+
+    int ret = kErrorSeeError;
+    SecTransformRef encryptor = SecEncryptTransformCreate(publicKey, pErrorOut);
+
+    if (encryptor != nullptr)
+    {
+        if (*pErrorOut == nullptr)
+        {
+            ret = ExecuteOaepTransform(encryptor, pbData, cbData, mgfAlgorithm, pEncryptedOut, pErrorOut);
+        }
+
+        CFRelease(encryptor);
+    }
+
+    return ret;
+}
+
+extern "C" int32_t AppleCryptoNative_RsaEncryptPkcs(
+    SecKeyRef publicKey, uint8_t* pbData, int32_t cbData, CFDataRef* pEncryptedOut, CFErrorRef* pErrorOut)
+{
+    if (pEncryptedOut != nullptr)
+        *pEncryptedOut = nullptr;
+    if (pErrorOut != nullptr)
+        *pErrorOut = nullptr;
+
+    if (publicKey == nullptr || pbData == nullptr || cbData < 0 || pEncryptedOut == nullptr || pErrorOut == nullptr)
+    {
+        return kErrorBadInput;
+    }
+
+    int ret = kErrorSeeError;
+    SecTransformRef encryptor = SecEncryptTransformCreate(publicKey, pErrorOut);
+
+    if (encryptor != nullptr)
+    {
+        if (*pErrorOut == nullptr)
+        {
+            ret = ExecuteCFDataTransform(encryptor, pbData, cbData, pEncryptedOut, pErrorOut);
+        }
+
+        CFRelease(encryptor);
+    }
+
+    return ret;
+}
+
+static int32_t ExecuteCFDataTransform(
+    SecTransformRef xform, uint8_t* pbData, int32_t cbData, CFDataRef* pDataOut, CFErrorRef* pErrorOut)
+{
+    if (xform == nullptr || pbData == nullptr || cbData < 0 || pDataOut == nullptr || pErrorOut == nullptr)
+    {
+        return kErrorBadInput;
+    }
+
+    *pDataOut = nullptr;
+    *pErrorOut = nullptr;
+
+    CFTypeRef xformOutput = nullptr;
+    CFDataRef cfData = nullptr;
+    int ret = INT_MIN;
+
+    cfData = CFDataCreateWithBytesNoCopy(nullptr, pbData, cbData, kCFAllocatorNull);
+
+    if (cfData == nullptr)
+    {
+        // This probably means that there wasn't enough memory available, but no
+        // particular failure cases are described.
+        return kErrorUnknownState;
+    }
+
+    if (!SecTransformSetAttribute(xform, kSecTransformInputAttributeName, cfData, pErrorOut))
+    {
+        ret = kErrorSeeError;
+        goto cleanup;
+    }
+
+    xformOutput = SecTransformExecute(xform, pErrorOut);
+
+    if (xformOutput == nullptr || *pErrorOut != nullptr)
+    {
+        ret = kErrorSeeError;
+        goto cleanup;
+    }
+
+    if (CFGetTypeID(xformOutput) == CFDataGetTypeID())
+    {
+        CFDataRef cfDataOut = reinterpret_cast<CFDataRef>(const_cast<void*>(xformOutput));
+        CFRetain(cfDataOut);
+        *pDataOut = cfDataOut;
+        ret = 1;
+    }
+    else
+    {
+        ret = kErrorUnknownState;
+    }
+
+cleanup:
+    if (xformOutput != nullptr)
+    {
+        CFRelease(xformOutput);
+    }
+
+    if (cfData != nullptr)
+    {
+        CFRelease(cfData);
+    }
+
+    return ret;
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.h
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "pal_digest.h"
+#include "pal_seckey.h"
+
+#include <Security/Security.h>
+
+/*
+Generate a new RSA keypair with the specified key size, in bits.
+
+Returns 1 on success, 0 on failure.  On failure, *pOSStatus should contain the OS reported error.
+*/
+extern "C" int AppleCryptoNative_RsaGenerateKey(int32_t keySizeBits,
+                                                SecKeyRef* pPublicKey,
+                                                SecKeyRef* pPrivateKey,
+                                                int32_t* pOSStatus);
+
+/*
+Decrypt the contents of pbData using the provided privateKey under OAEP padding.
+
+Follows pal_seckey return conventions.
+*/
+extern "C" int32_t AppleCryptoNative_RsaDecryptOaep(SecKeyRef privateKey,
+                                                    uint8_t* pbData,
+                                                    int32_t cbData,
+                                                    PAL_HashAlgorithm mfgAlgorithm,
+                                                    CFDataRef* pDecryptedOut,
+                                                    CFErrorRef* pErrorOut);
+
+/*
+Decrypt the contents of pbData using the provided privateKey under PKCS#1 padding.
+
+Follows pal_seckey return conventions.
+*/
+extern "C" int32_t AppleCryptoNative_RsaDecryptPkcs(
+    SecKeyRef privateKey, uint8_t* pbData, int32_t cbData, CFDataRef* pDecryptedOut, CFErrorRef* pErrorOut);
+
+/*
+Encrypt pbData for the provided publicKey using OAEP padding.
+
+Follows pal_seckey return conventions.
+*/
+extern "C" int32_t AppleCryptoNative_RsaEncryptOaep(SecKeyRef publicKey,
+                                                    uint8_t* pbData,
+                                                    int32_t cbData,
+                                                    PAL_HashAlgorithm mgfAlgorithm,
+                                                    CFDataRef* pEncryptedOut,
+                                                    CFErrorRef* pErrorOut);
+
+/*
+Encrypt pbData for the provided publicKey using PKCS#1 padding.
+
+Follows pal_seckey return conventions.
+*/
+extern "C" int32_t AppleCryptoNative_RsaEncryptPkcs(
+    SecKeyRef publicKey, uint8_t* pbData, int32_t cbData, CFDataRef* pEncryptedOut, CFErrorRef* pErrorOut);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_secimportexport.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_secimportexport.cpp
@@ -1,5 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-#include "pal_secimportexport.h"

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_secimportexport.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_secimportexport.h
@@ -1,9 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-#pragma once
-
-#include "pal_types.h"
-
-#include <Security/Security.h>

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_seckey.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_seckey.cpp
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "pal_seckey.h"
+
+extern "C" int32_t AppleCryptoNative_SecKeyExport(
+    SecKeyRef pKey, int32_t exportPrivate, CFStringRef cfExportPassphrase, CFDataRef* ppDataOut, int32_t* pOSStatus)
+{
+    if (ppDataOut != nullptr)
+        *ppDataOut = nullptr;
+    if (pOSStatus != nullptr)
+        *pOSStatus = noErr;
+
+    if (pKey == nullptr || ppDataOut == nullptr || pOSStatus == nullptr)
+    {
+        return kErrorBadInput;
+    }
+
+    SecExternalFormat dataFormat = kSecFormatOpenSSL;
+    SecItemImportExportKeyParameters keyParams = {};
+    keyParams.version = SEC_KEY_IMPORT_EXPORT_PARAMS_VERSION;
+
+    if (exportPrivate)
+    {
+        if (cfExportPassphrase == nullptr)
+        {
+            return kErrorBadInput;
+        }
+
+        keyParams.passphrase = cfExportPassphrase;
+        dataFormat = kSecFormatWrappedPKCS8;
+    }
+
+    *pOSStatus = SecItemExport(pKey, dataFormat, 0, &keyParams, ppDataOut);
+
+    return (*pOSStatus == noErr);
+}
+
+extern "C" int32_t AppleCryptoNative_SecKeyImportEphemeral(
+    uint8_t* pbKeyBlob, int32_t cbKeyBlob, int32_t isPrivateKey, SecKeyRef* ppKeyOut, int32_t* pOSStatus)
+{
+    if (ppKeyOut != nullptr)
+        *ppKeyOut = nullptr;
+    if (pOSStatus != nullptr)
+        *pOSStatus = noErr;
+
+    if (pbKeyBlob == nullptr || cbKeyBlob < 0 || isPrivateKey < 0 || isPrivateKey > 1 || ppKeyOut == nullptr ||
+        pOSStatus == nullptr)
+    {
+        return kErrorBadInput;
+    }
+
+    int32_t ret = 0;
+    CFDataRef cfData = CFDataCreateWithBytesNoCopy(nullptr, pbKeyBlob, cbKeyBlob, kCFAllocatorNull);
+
+    SecExternalFormat dataFormat = kSecFormatOpenSSL;
+    SecExternalFormat actualFormat = dataFormat;
+
+    SecExternalItemType itemType = isPrivateKey ? kSecItemTypePrivateKey : kSecItemTypePublicKey;
+    SecExternalItemType actualType = itemType;
+
+    CFIndex itemCount;
+    CFArrayRef outItems = nullptr;
+    CFTypeRef outItem = nullptr;
+
+    *pOSStatus = SecItemImport(cfData, nullptr, &actualFormat, &actualType, 0, nullptr, nullptr, &outItems);
+
+    if (*pOSStatus != noErr)
+    {
+        ret = 0;
+        goto cleanup;
+    }
+
+    if (actualFormat != dataFormat || actualType != itemType)
+    {
+        ret = -2;
+        goto cleanup;
+    }
+
+    if (outItems == nullptr)
+    {
+        ret = -3;
+        goto cleanup;
+    }
+
+    itemCount = CFArrayGetCount(outItems);
+
+    if (itemCount == 0)
+    {
+        ret = -4;
+        goto cleanup;
+    }
+
+    if (itemCount > 1)
+    {
+        ret = -5;
+        goto cleanup;
+    }
+
+    outItem = CFArrayGetValueAtIndex(outItems, 0);
+
+    if (outItem == nullptr)
+    {
+        ret = -6;
+        goto cleanup;
+    }
+
+    if (CFGetTypeID(outItem) != SecKeyGetTypeID())
+    {
+        ret = -7;
+        goto cleanup;
+    }
+
+    CFRetain(outItem);
+    *ppKeyOut = reinterpret_cast<SecKeyRef>(const_cast<void*>(outItem));
+    ret = 1;
+
+cleanup:
+    if (outItems != nullptr)
+    {
+        CFRelease(outItems);
+    }
+
+    CFRelease(cfData);
+    return ret;
+}
+
+extern "C" uint64_t AppleCryptoNative_SecKeyGetSimpleKeySizeInBytes(SecKeyRef publicKey)
+{
+    if (publicKey == nullptr)
+    {
+        return 0;
+    }
+
+    return SecKeyGetBlockSize(publicKey);
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_seckey.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_seckey.h
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "pal_types.h"
+
+#include <Security/Security.h>
+
+// Unless another interpretation is "obvious", pal_seckey functions return 1 on success.
+// functions which represent a boolean return 0 on "successful false"
+// otherwise functions will return one of the following return values:
+static const int kErrorBadInput = -1;
+static const int kErrorSeeError = -2;
+static const int kErrorUnknownAlgorithm = -3;
+static const int kErrorUnknownState = -4;
+
+/*
+Export a key object.
+
+Public keys are exported using the "OpenSSL" format option, which means, essentially,
+"whatever format the openssl CLI would use for this algorithm by default".
+
+Private keys are exported using the "Wrapped PKCS#8" format. These formats are available via
+`openssl pkcs8 -topk8 ...`. While the PKCS#8 container is the same for all key types, the
+payload is algorithm-dependent (though identified by the PKCS#8 wrapper).
+
+An export passphrase is required for private keys, and ignored for public keys.
+
+Follows pal_seckey return conventions.
+*/
+extern "C" int32_t AppleCryptoNative_SecKeyExport(
+    SecKeyRef pKey, int32_t exportPrivate, CFStringRef cfExportPassphrase, CFDataRef* ppDataOut, int32_t* pOSStatus);
+
+/*
+Import a key from a key blob.
+
+Imports are always done using the "OpenSSL" format option, which means the format used for an
+unencrypted private key via the openssl CLI verb of the algorithm being imported.
+
+For public keys the "OpenSSL" format is NOT the format used by the openssl CLI for that algorithm,
+but is in fact the X.509 SubjectPublicKeyInfo structure.
+
+Returns 1 on success, 0 on failure (*pOSStatus should be set) and negative numbers for various
+state machine errors.
+*/
+extern "C" int32_t AppleCryptoNative_SecKeyImportEphemeral(
+    uint8_t* pbKeyBlob, int32_t cbKeyBlob, int32_t isPrivateKey, SecKeyRef* ppKeyOut, int32_t* pOSStatus);
+
+/*
+For RSA and DSA this function returns the number of bytes in "the key", which corresponds to
+the length of n/Modulus for RSA and for P in DSA.
+
+For ECC the value should not be used.
+
+0 is returned for invalid inputs.
+*/
+extern "C" uint64_t AppleCryptoNative_SecKeyGetSimpleKeySizeInBytes(SecKeyRef publicKey);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_signverify.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_signverify.cpp
@@ -1,0 +1,287 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "pal_signverify.h"
+
+static int ExecuteSignTransform(SecTransformRef signer, CFDataRef* pSignatureOut, CFErrorRef* pErrorOut);
+static int ExecuteVerifyTransform(SecTransformRef verifier, CFErrorRef* pErrorOut);
+
+static int ConfigureSignVerifyTransform(
+    SecTransformRef xform, CFDataRef cfDataHash, PAL_HashAlgorithm, bool useDigestAlgorithm, CFErrorRef* pErrorOut);
+
+static int GenerateSignature(SecKeyRef privateKey,
+                             uint8_t* pbDataHash,
+                             int32_t cbDataHash,
+                             PAL_HashAlgorithm hashAlgorithm,
+                             bool useHashAlgorithm,
+                             CFDataRef* pSignatureOut,
+                             CFErrorRef* pErrorOut)
+{
+    if (pSignatureOut != nullptr)
+        *pSignatureOut = nullptr;
+    if (pErrorOut != nullptr)
+        *pErrorOut = nullptr;
+
+    if (privateKey == nullptr || pbDataHash == nullptr || cbDataHash < 0 || pSignatureOut == nullptr ||
+        pErrorOut == nullptr)
+    {
+        return kErrorBadInput;
+    }
+
+    CFDataRef dataHash = CFDataCreateWithBytesNoCopy(nullptr, pbDataHash, cbDataHash, kCFAllocatorNull);
+
+    if (dataHash == nullptr)
+    {
+        return kErrorUnknownState;
+    }
+
+    int ret = kErrorSeeError;
+    SecTransformRef signer = SecSignTransformCreate(privateKey, pErrorOut);
+
+    if (signer != nullptr)
+    {
+        if (*pErrorOut == nullptr)
+        {
+            if (ConfigureSignVerifyTransform(signer, dataHash, hashAlgorithm, useHashAlgorithm, pErrorOut))
+            {
+                ret = ExecuteSignTransform(signer, pSignatureOut, pErrorOut);
+            }
+        }
+
+        CFRelease(signer);
+    }
+
+    CFRelease(dataHash);
+    return ret;
+}
+
+extern "C" int AppleCryptoNative_GenerateSignature(
+    SecKeyRef privateKey, uint8_t* pbDataHash, int32_t cbDataHash, CFDataRef* pSignatureOut, CFErrorRef* pErrorOut)
+{
+    return GenerateSignature(privateKey, pbDataHash, cbDataHash, PAL_Unknown, false, pSignatureOut, pErrorOut);
+}
+
+extern "C" int AppleCryptoNative_GenerateSignatureWithHashAlgorithm(SecKeyRef privateKey,
+                                                                    uint8_t* pbDataHash,
+                                                                    int32_t cbDataHash,
+                                                                    PAL_HashAlgorithm hashAlgorithm,
+                                                                    CFDataRef* pSignatureOut,
+                                                                    CFErrorRef* pErrorOut)
+{
+    return GenerateSignature(privateKey, pbDataHash, cbDataHash, hashAlgorithm, true, pSignatureOut, pErrorOut);
+}
+
+static int VerifySignature(SecKeyRef publicKey,
+                           uint8_t* pbDataHash,
+                           int32_t cbDataHash,
+                           uint8_t* pbSignature,
+                           int32_t cbSignature,
+                           PAL_HashAlgorithm hashAlgorithm,
+                           bool useHashAlgorithm,
+                           CFErrorRef* pErrorOut)
+{
+    if (pErrorOut != nullptr)
+        *pErrorOut = nullptr;
+
+    if (publicKey == nullptr || pbDataHash == nullptr || cbDataHash < 0 || pbSignature == nullptr || cbSignature < 0 ||
+        pErrorOut == nullptr)
+        return kErrorBadInput;
+
+    CFDataRef dataHash = CFDataCreateWithBytesNoCopy(nullptr, pbDataHash, cbDataHash, kCFAllocatorNull);
+
+    if (dataHash == nullptr)
+    {
+        return kErrorUnknownState;
+    }
+
+    CFDataRef signature = CFDataCreateWithBytesNoCopy(nullptr, pbSignature, cbSignature, kCFAllocatorNull);
+
+    if (signature == nullptr)
+    {
+        CFRelease(dataHash);
+        return kErrorUnknownState;
+    }
+
+    int ret = kErrorSeeError;
+    SecTransformRef verifier = SecVerifyTransformCreate(publicKey, signature, pErrorOut);
+
+    if (verifier != nullptr)
+    {
+        if (*pErrorOut == nullptr)
+        {
+            if (ConfigureSignVerifyTransform(verifier, dataHash, hashAlgorithm, useHashAlgorithm, pErrorOut))
+            {
+                ret = ExecuteVerifyTransform(verifier, pErrorOut);
+            }
+        }
+
+        CFRelease(verifier);
+    }
+
+    CFRelease(dataHash);
+    CFRelease(signature);
+
+    return ret;
+}
+
+extern "C" int AppleCryptoNative_VerifySignatureWithHashAlgorithm(SecKeyRef publicKey,
+                                                                  uint8_t* pbDataHash,
+                                                                  int32_t cbDataHash,
+                                                                  uint8_t* pbSignature,
+                                                                  int32_t cbSignature,
+                                                                  PAL_HashAlgorithm hashAlgorithm,
+                                                                  CFErrorRef* pErrorOut)
+{
+    return VerifySignature(publicKey, pbDataHash, cbDataHash, pbSignature, cbSignature, hashAlgorithm, true, pErrorOut);
+}
+
+extern "C" int AppleCryptoNative_VerifySignature(SecKeyRef publicKey,
+                                                 uint8_t* pbDataHash,
+                                                 int32_t cbDataHash,
+                                                 uint8_t* pbSignature,
+                                                 int32_t cbSignature,
+                                                 CFErrorRef* pErrorOut)
+{
+    return VerifySignature(publicKey, pbDataHash, cbDataHash, pbSignature, cbSignature, PAL_Unknown, false, pErrorOut);
+}
+
+static int ExecuteSignTransform(SecTransformRef signer, CFDataRef* pSignatureOut, CFErrorRef* pErrorOut)
+{
+    assert(signer != nullptr);
+    assert(pSignatureOut != nullptr);
+    assert(pErrorOut != nullptr);
+
+    int ret = INT_MIN;
+    CFTypeRef signerResponse = SecTransformExecute(signer, pErrorOut);
+    CFDataRef signature = nullptr;
+
+    if (signerResponse == nullptr || *pErrorOut != nullptr)
+    {
+        ret = kErrorSeeError;
+        goto cleanup;
+    }
+
+    if (CFGetTypeID(signerResponse) != CFDataGetTypeID())
+    {
+        ret = kErrorUnknownState;
+        goto cleanup;
+    }
+
+    signature = reinterpret_cast<CFDataRef>(const_cast<void*>(signerResponse));
+
+    if (CFDataGetLength(signature) > 0)
+    {
+        // We're going to call CFRelease in cleanup, so this keeps it alive
+        // to be interpreted by the managed code.
+        CFRetain(signature);
+        *pSignatureOut = signature;
+        ret = 1;
+    }
+    else
+    {
+        ret = kErrorUnknownState;
+        *pSignatureOut = nullptr;
+    }
+
+cleanup:
+    if (signerResponse != nullptr)
+    {
+        CFRelease(signerResponse);
+    }
+
+    return ret;
+}
+
+static int ExecuteVerifyTransform(SecTransformRef verifier, CFErrorRef* pErrorOut)
+{
+    assert(verifier != nullptr);
+    assert(pErrorOut != nullptr);
+
+    int ret = kErrorSeeError;
+    CFTypeRef verifierResponse = SecTransformExecute(verifier, pErrorOut);
+
+    if (verifierResponse != nullptr)
+    {
+        if (*pErrorOut == nullptr)
+        {
+            ret = (verifierResponse == kCFBooleanTrue);
+        }
+
+        CFRelease(verifierResponse);
+    }
+
+    return ret;
+}
+
+static int ConfigureSignVerifyTransform(SecTransformRef xform,
+                                        CFDataRef cfDataHash,
+                                        PAL_HashAlgorithm hashAlgorithm,
+                                        bool includeHashAlgorithm,
+                                        CFErrorRef* pErrorOut)
+{
+    if (!SecTransformSetAttribute(xform, kSecInputIsAttributeName, kSecInputIsDigest, pErrorOut))
+    {
+        return 0;
+    }
+
+    if (!SecTransformSetAttribute(xform, kSecTransformInputAttributeName, cfDataHash, pErrorOut))
+    {
+        return 0;
+    }
+
+    if (includeHashAlgorithm)
+    {
+        CFStringRef cfHashName = nullptr;
+        int hashSize = 0;
+
+        switch (hashAlgorithm)
+        {
+            case PAL_MD5:
+                cfHashName = kSecDigestMD5;
+                break;
+            case PAL_SHA1:
+                cfHashName = kSecDigestSHA1;
+                break;
+            case PAL_SHA256:
+                cfHashName = kSecDigestSHA2;
+                hashSize = 256;
+                break;
+            case PAL_SHA384:
+                cfHashName = kSecDigestSHA2;
+                hashSize = 384;
+                break;
+            case PAL_SHA512:
+                cfHashName = kSecDigestSHA2;
+                hashSize = 512;
+                break;
+            default:
+                return kErrorUnknownAlgorithm;
+        }
+
+        if (!SecTransformSetAttribute(xform, kSecDigestTypeAttribute, cfHashName, pErrorOut))
+        {
+            return 0;
+        }
+
+        if (hashSize != 0)
+        {
+            CFNumberRef cfHashSize = CFNumberCreate(nullptr, kCFNumberIntType, &hashSize);
+
+            if (cfHashSize == nullptr)
+            {
+                return 0;
+            }
+
+            if (!SecTransformSetAttribute(xform, kSecDigestLengthAttribute, cfHashSize, pErrorOut))
+            {
+                CFRelease(cfHashSize);
+                return 0;
+            }
+
+            CFRelease(cfHashSize);
+        }
+    }
+
+    return 1;
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_signverify.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_signverify.h
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "pal_digest.h"
+#include "pal_seckey.h"
+
+#include <Security/Security.h>
+
+/*
+Generate a signature for algorithms which require only the data hash blob, like DSA and ECDSA.
+
+Follows pal_seckey return conventions.
+*/
+extern "C" int AppleCryptoNative_GenerateSignature(
+    SecKeyRef privateKey, uint8_t* pbDataHash, int32_t cbDataHash, CFDataRef* pSignatureOut, CFErrorRef* pErrorOut);
+
+/*
+Generate a signature for algorithms which require the pair of (dataHash, algorithmId), like RSA.
+
+Follows pal_seckey return conventions.
+*/
+extern "C" int AppleCryptoNative_GenerateSignatureWithHashAlgorithm(SecKeyRef privateKey,
+                                                                    uint8_t* pbDataHash,
+                                                                    int32_t cbDataHash,
+                                                                    PAL_HashAlgorithm hashAlgorithm,
+                                                                    CFDataRef* pSignatureOut,
+                                                                    CFErrorRef* pErrorOut);
+
+/*
+Verify a signature for algorithms which only require the data hash blob, like DSA and ECDSA.
+
+Returns 1 when the signature is correct, 0 when it is incorrect, and otherwise
+follows pal_seckey return conventions.
+*/
+extern "C" int AppleCryptoNative_VerifySignatureWithHashAlgorithm(SecKeyRef publicKey,
+                                                                  uint8_t* pbDataHash,
+                                                                  int32_t cbDataHash,
+                                                                  uint8_t* pbSignature,
+                                                                  int32_t cbSignature,
+                                                                  PAL_HashAlgorithm hashAlgorithm,
+                                                                  CFErrorRef* pErrorOut);
+
+/*
+Verify a signature for algorithms which require the pair of (dataHash, algorithmId), like RSA.
+
+Returns 1 when the signature is correct, 0 when it is incorrect, and otherwise
+follows pal_seckey return conventions.
+*/
+extern "C" int AppleCryptoNative_VerifySignature(SecKeyRef publicKey,
+                                                 uint8_t* pbDataHash,
+                                                 int32_t cbDataHash,
+                                                 uint8_t* pbSignature,
+                                                 int32_t cbSignature,
+                                                 CFErrorRef* pErrorOut);

--- a/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -141,6 +141,12 @@
   <data name="Cryptography_CSP_NoPrivateKey" xml:space="preserve">
     <value>Object contains only the public half of a key pair. A private key must also be provided.</value>
   </data>
+  <data name="Cryptography_DSA_KeyGenNotSupported" xml:space="preserve">
+    <value>DSA keys can be imported, but new key generation is not supported on this platform.</value>
+  </data>
+  <data name="Cryptography_ECC_NamedCurvesOnly" xml:space="preserve">
+    <value>Only named curves are supported on this platform.</value>
+  </data>
   <data name="Cryptography_HashAlgorithmNameNullOrEmpty" xml:space="preserve">
     <value>The hash algorithm name cannot be null or empty.</value>
   </data>

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -335,8 +335,8 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="System\Security\Cryptography\ECDsaOpenSsl.cs" />
-    <Compile Include="$(CommonPath)\Internal\Cryptography\OpenSslAsymmetricAlgorithmCore.cs">
-      <Link>Common\Internal\Cryptography\OpenSslAsymmetricAlgorithmCore.cs</Link>
+    <Compile Include="$(CommonPath)\Internal\Cryptography\AsymmetricAlgorithmHelpers.cs">
+      <Link>Common\Internal\Cryptography\AsymmetricAlgorithmHelpers.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -277,67 +277,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' AND '$(TargetsOSX)' != 'true' ">
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.cs">
-      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.Cipher.cs">
-      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.Cipher.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Hmac.cs">
-      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Hmac.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpCipherCtxHandle.Unix.cs">
-      <Link>Common\Microsoft\Win32\SafeHandles\SafeEvpCipherCtxHandle.Unix.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpMdCtxHandle.Unix.cs">
-      <Link>Common\Microsoft\Win32\SafeHandles\SafeEvpMdCtxHandle.Unix.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHmacCtxHandle.Unix.cs">
-      <Link>Common\Microsoft\Win32\SafeHandles\SafeHmacCtxHandle.Unix.cs</Link>
-    </Compile>
-    <Compile Include="Internal\Cryptography\AesImplementation.Unix.cs" />
-    <Compile Include="Internal\Cryptography\DesImplementation.Unix.cs" />
-    <Compile Include="Internal\Cryptography\HashProviderDispenser.Unix.cs" />
-    <Compile Include="Internal\Cryptography\OpenSslCipher.cs" />
-    <Compile Include="Internal\Cryptography\RandomNumberGeneratorImplementation.Unix.cs" />
-    <Compile Include="Internal\Cryptography\RC2Implementation.Unix.cs" />
-    <Compile Include="Internal\Cryptography\TripleDesImplementation.Unix.cs" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
-      <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Digest.cs">
-      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Digest.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs">
-      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Hmac.cs">
-      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Hmac.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.PAL_HashAlgorithm.cs">
-      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.PAL_HashAlgorithm.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Random.cs">
-      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Random.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Symmetric.cs">
-      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Symmetric.cs</Link>
-    </Compile>
-    <Compile Include="Internal\Cryptography\AesImplementation.OSX.cs" />
-    <Compile Include="Internal\Cryptography\AppleCCCryptor.cs" />
-    <Compile Include="Internal\Cryptography\DesImplementation.OSX.cs" />
-    <Compile Include="Internal\Cryptography\HashProviderDispenser.OSX.cs" />
-    <Compile Include="Internal\Cryptography\RandomNumberGeneratorImplementation.OSX.cs" />
-    <Compile Include="Internal\Cryptography\RC2Implementation.OSX.cs" />
-    <Compile Include="Internal\Cryptography\TripleDesImplementation.OSX.cs" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
-    <Compile Include="System\Security\Cryptography\ECDsaOpenSsl.cs" />
-    <Compile Include="$(CommonPath)\Internal\Cryptography\AsymmetricAlgorithmHelpers.cs">
-      <Link>Common\Internal\Cryptography\AsymmetricAlgorithmHelpers.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
@@ -365,6 +304,15 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.Cipher.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.Cipher.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Hmac.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Hmac.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>
     </Compile>
@@ -383,20 +331,23 @@
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeDsaHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeDsaHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
-      <Link>Common\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEcKeyHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeEcKeyHandle.Unix.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpCipherCtxHandle.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeEvpCipherCtxHandle.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpMdCtxHandle.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeEvpMdCtxHandle.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHmacCtxHandle.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeHmacCtxHandle.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeRsaHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeRsaHandle.Unix.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\DerEncoder.cs">
-      <Link>Common\System\Security\Cryptography\DerEncoder.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\DerSequenceReader.cs">
-      <Link>Common\System\Security\Cryptography\DerSequenceReader.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Security\Cryptography\DSAOpenSsl.cs">
       <Link>Common\System\Security\Cryptography\DSAOpenSsl.cs</Link>
@@ -409,6 +360,97 @@
     </Compile>
     <Compile Include="$(CommonPath)\System\Security\Cryptography\RSAOpenSsl.cs">
       <Link>Common\System\Security\Cryptography\RSAOpenSsl.cs</Link>
+    </Compile>
+    <Compile Include="Internal\Cryptography\AesImplementation.Unix.cs" />
+    <Compile Include="Internal\Cryptography\DesImplementation.Unix.cs" />
+    <Compile Include="Internal\Cryptography\HashProviderDispenser.Unix.cs" />
+    <Compile Include="Internal\Cryptography\OpenSslCipher.cs" />
+    <Compile Include="Internal\Cryptography\RandomNumberGeneratorImplementation.Unix.cs" />
+    <Compile Include="Internal\Cryptography\RC2Implementation.Unix.cs" />
+    <Compile Include="Internal\Cryptography\TripleDesImplementation.Unix.cs" />
+    <Compile Include="System\Security\Cryptography\ECDsaOpenSsl.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.cs">
+      <Link>Common\Interop\OSX\Interop.CoreFoundation.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFData.cs">
+      <Link>Common\Interop\OSX\Interop.CoreFoundation.CFData.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFError.cs">
+      <Link>Common\Interop\OSX\Interop.CoreFoundation.CFError.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFString.cs">
+      <Link>Common\Interop\OSX\Interop.CoreFoundation.CFString.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
+      <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Digest.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Digest.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Ecc.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Ecc.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Hmac.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Hmac.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.PAL_HashAlgorithm.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.PAL_HashAlgorithm.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Random.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Random.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.RSA.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.RSA.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.Export.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.Export.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Symmetric.cs">
+      <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Symmetric.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Security\Cryptography\DSASecurityTransforms.cs">
+      <Link>Common\System\Security\Cryptography\DSASecurityTransforms.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDsaSecurityTransforms.cs">
+      <Link>Common\System\Security\Cryptography\ECDsaSecurityTransforms.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Security\Cryptography\KeyBlobHelpers.cs">
+      <Link>Common\System\Security\Cryptography\KeyBlobHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Security\Cryptography\RSASecurityTransforms.cs">
+      <Link>Common\System\Security\Cryptography\RSASecurityTransforms.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Security\Cryptography\SecKeyPair.cs">
+      <Link>Common\System\Security\Cryptography\SecKeyPair.cs</Link>
+    </Compile>
+    <Compile Include="Internal\Cryptography\AesImplementation.OSX.cs" />
+    <Compile Include="Internal\Cryptography\AppleCCCryptor.cs" />
+    <Compile Include="Internal\Cryptography\DesImplementation.OSX.cs" />
+    <Compile Include="Internal\Cryptography\HashProviderDispenser.OSX.cs" />
+    <Compile Include="Internal\Cryptography\RandomNumberGeneratorImplementation.OSX.cs" />
+    <Compile Include="Internal\Cryptography\RC2Implementation.OSX.cs" />
+    <Compile Include="Internal\Cryptography\TripleDesImplementation.OSX.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsUnix)' == 'true'">
+    <Compile Include="$(CommonPath)\Internal\Cryptography\AsymmetricAlgorithmHelpers.cs">
+      <Link>Common\Internal\Cryptography\AsymmetricAlgorithmHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Security\Cryptography\DerEncoder.cs">
+      <Link>Common\System\Security\Cryptography\DerEncoder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Security\Cryptography\DerSequenceReader.cs">
+      <Link>Common\System\Security\Cryptography\DerSequenceReader.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != '' And '$(IsPartialFacadeAssembly)' != 'true'">

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultDSAProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultDSAProvider.cs
@@ -22,9 +22,11 @@ namespace System.Security.Cryptography.Dsa.Tests
         {
             get
             {
-                return (!PlatformDetection.IsWindows7);
+                return !(PlatformDetection.IsWindows7 || PlatformDetection.IsOSX);
             }
         }
+
+        public bool SupportsKeyGeneration => !PlatformDetection.IsOSX;
     }
 
     public partial class DSAFactory

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.cs
@@ -32,6 +32,10 @@ namespace System.Security.Cryptography.EcDsa.Tests
                 // Friendly name required for windows
                 return NativeOidFriendlyNameExists(oid.FriendlyName);
             }
+            if (PlatformDetection.IsOSX)
+            {
+                return false;
+            }
             if (!string.IsNullOrEmpty(oid.Value))
             {
                 // Value is passed before FriendlyName
@@ -48,6 +52,12 @@ namespace System.Security.Cryptography.EcDsa.Tests
                 {
                     return PlatformDetection.WindowsVersion >= 10;
                 }
+
+                if (PlatformDetection.IsOSX)
+                {
+                    return false;
+                }
+
                 return true;
             }
         }

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.cs
@@ -95,6 +95,8 @@ namespace System.Security.Cryptography.EcDsa.Tests
             }
             return false;
         }
+
+        public bool SupportsKeyGeneration => !RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
     }
 
     public partial class ECDsaFactory

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
@@ -48,6 +48,8 @@ namespace System.Security.Cryptography.Rsa.Tests
             // Currently only RSACng does, which is the default provider on Windows.
             get { return RuntimeInformation.IsOSPlatform(OSPlatform.Windows); }
         }
+
+        public bool SupportsKeyGeneration => !RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
     }
 
     public partial class RSAFactory

--- a/src/System.Security.Cryptography.Cng/tests/DSACngProvider.cs
+++ b/src/System.Security.Cryptography.Cng/tests/DSACngProvider.cs
@@ -16,13 +16,8 @@ namespace System.Security.Cryptography.Dsa.Tests
             return new DSACng(keySize);
         }
 
-        public bool SupportsFips186_3
-        {
-            get
-            {
-                return (!PlatformDetection.IsWindows7);
-            }
-        }
+        public bool SupportsFips186_3 => (!PlatformDetection.IsWindows7);
+        public bool SupportsKeyGeneration => true;
     }
 
     public partial class DSAFactory

--- a/src/System.Security.Cryptography.Cng/tests/ECDsaCngProvider.cs
+++ b/src/System.Security.Cryptography.Cng/tests/ECDsaCngProvider.cs
@@ -52,6 +52,8 @@ namespace System.Security.Cryptography.EcDsa.Tests
                 return false;
             }
         }
+
+        public bool SupportsKeyGeneration => true;
     }
 
     public partial class ECDsaFactory

--- a/src/System.Security.Cryptography.Cng/tests/RSACngProvider.cs
+++ b/src/System.Security.Cryptography.Cng/tests/RSACngProvider.cs
@@ -38,6 +38,8 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             get { return true; }
         }
+
+        public bool SupportsKeyGeneration => true;
     }
 
     public partial class RSAFactory

--- a/src/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderProvider.cs
+++ b/src/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderProvider.cs
@@ -16,13 +16,8 @@ namespace System.Security.Cryptography.Dsa.Tests
             return new DSACryptoServiceProvider(keySize);
         }
 
-        public bool SupportsFips186_3
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public bool SupportsFips186_3 => false;
+        public bool SupportsKeyGeneration => true;
     }
 
     public partial class DSAFactory

--- a/src/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderProvider.cs
+++ b/src/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderProvider.cs
@@ -25,6 +25,8 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             get { return false; }
         }
+
+        public bool SupportsKeyGeneration => true;
     }
 
     public partial class RSAFactory

--- a/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -25,8 +25,8 @@
     <Compile Include="System\Security\Cryptography\ECDsaOpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\RSAOpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\SafeEvpPKeyHandle.Unix.cs" />
-    <Compile Include="$(CommonPath)\Internal\Cryptography\OpenSslAsymmetricAlgorithmCore.cs">
-      <Link>Common\Internal\Cryptography\OpenSslAsymmetricAlgorithmCore.cs</Link>
+    <Compile Include="$(CommonPath)\Internal\Cryptography\AsymmetricAlgorithmHelpers.cs">
+      <Link>Common\Internal\Cryptography\AsymmetricAlgorithmHelpers.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>

--- a/src/System.Security.Cryptography.OpenSsl/tests/DsaOpenSslProvider.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/DsaOpenSslProvider.cs
@@ -16,13 +16,8 @@ namespace System.Security.Cryptography.Dsa.Tests
             return new DSAOpenSsl(keySize);
         }
 
-        public bool SupportsFips186_3
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public bool SupportsFips186_3 => true;
+        public bool SupportsKeyGeneration => true;
     }
 
     public partial class DSAFactory

--- a/src/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslProvider.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslProvider.cs
@@ -54,6 +54,8 @@ namespace System.Security.Cryptography.EcDsa.Tests
                 return true;
             }
         }
+
+        public bool SupportsKeyGeneration => true;
     }
 
     public partial class ECDsaFactory

--- a/src/System.Security.Cryptography.OpenSsl/tests/RSAOpenSslProvider.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/RSAOpenSslProvider.cs
@@ -25,6 +25,8 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             get { return false; }
         }
+
+        public bool SupportsKeyGeneration => true;
     }
 
     public partial class RSAFactory


### PR DESCRIPTION
With this change the System.Security.Cryptography.Algorithms library has no
direct dependency on OpenSSL (it has an indirect one from OID lookup via
the S.S.C.Encoding library).

Observable changes:
* The test library runs in ~1.7 seconds before this change, ~30 seconds (up to 48) after.
  * The tests complete in ~1.2 seconds when all key generation is disabled.
  * ~21 seconds with ECDSA enabled (26 tests), RSA disabled
  * ~10 seconds with RSA enabled (13 tests), ECDSA disabled
* Ephemeral key generation populates the keychain, this is not desired, so has been disabled pending a workaround.
* DSA key generation is not possible via Apple's libraries.
* DSA is limited to FIPS 186-2 behaviors, a loss of functionality.
* ECDSA only supports the 3 main NIST curves (256, 384, 521).
* ECDSA explicit import/export is no longer possible.

cc: @steveharter @stephentoub 