### PR TITLE
Skip Loopback while enumerating Host Entry

### DIFF
--- a/src/System.Net.WebProxy/tests/WebProxyTest.cs
+++ b/src/System.Net.WebProxy/tests/WebProxyTest.cs
@@ -145,7 +145,7 @@ namespace System.Net.Tests
             yield return new object[] { new Uri($"http://{Guid.NewGuid().ToString("N")}"), true };
             foreach (IPAddress address in Dns.GetHostEntryAsync(Dns.GetHostName()).GetAwaiter().GetResult().AddressList)
             {
-                if (address.AddressFamily == AddressFamily.InterNetwork)
+                if (address.AddressFamily == AddressFamily.InterNetwork && !IPAddress.IsLoopback(address))
                 {
                     Uri uri;
                     try { uri = new Uri($"http://{address}"); }


### PR DESCRIPTION
Ubunut-like system may have loopback ip in /etc/hosts, which leads to test failure discussed at #13464. 

This commit exclude loopback entry for ``System.Net.Tests.WebProxyTest.BypassOnLocal_MatchesExpected`` in order to fix #13464.