### PR TITLE
Reducing copying of variables collection passed to Block factories

### DIFF
--- a/src/Common/src/System/Runtime/CompilerServices/TrueReadOnlyCollection.cs
+++ b/src/Common/src/System/Runtime/CompilerServices/TrueReadOnlyCollection.cs
@@ -12,7 +12,7 @@ namespace System.Runtime.CompilerServices
         /// Creates instance of TrueReadOnlyCollection, wrapping passed in array.
         /// !!! DOES NOT COPY THE ARRAY !!!
         /// </summary>
-        public TrueReadOnlyCollection(T[] list)
+        public TrueReadOnlyCollection(params T[] list)
             : base(list)
         {
         }

--- a/src/System.Linq.Expressions/src/System/Dynamic/BindingRestrictions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/BindingRestrictions.cs
@@ -326,7 +326,7 @@ namespace System.Dynamic
 
                 ParameterExpression temp = Expression.Parameter(typeof(object), null);
                 return Expression.Block(
-                    new[] { temp },
+                    new TrueReadOnlyCollection<ParameterExpression>(new[] { temp }),
 #if ENABLEDYNAMICPROGRAMMING
                     Expression.Assign(
                         temp,

--- a/src/System.Linq.Expressions/src/System/Dynamic/BindingRestrictions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/BindingRestrictions.cs
@@ -326,7 +326,7 @@ namespace System.Dynamic
 
                 ParameterExpression temp = Expression.Parameter(typeof(object), null);
                 return Expression.Block(
-                    new TrueReadOnlyCollection<ParameterExpression>(new[] { temp }),
+                    new TrueReadOnlyCollection<ParameterExpression>(temp),
 #if ENABLEDYNAMICPROGRAMMING
                     Expression.Assign(
                         temp,

--- a/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
@@ -585,7 +585,7 @@ namespace System.Dynamic
 
                 var callDynamic = new DynamicMetaObject(
                     Expression.Block(
-                        new TrueReadOnlyCollection<ParameterExpression>(new[] { result, callArgs }),
+                        new TrueReadOnlyCollection<ParameterExpression>(result, callArgs),
                         methodName != nameof(DynamicObject.TryBinaryOperation) ? Expression.Assign(callArgs, Expression.NewArrayInit(typeof(object), callArgsValue)) : Expression.Assign(callArgs, callArgsValue[0]),
                         Expression.Condition(
                             Expression.Call(
@@ -643,7 +643,7 @@ namespace System.Dynamic
 
                 var callDynamic = new DynamicMetaObject(
                     Expression.Block(
-                        new TrueReadOnlyCollection<ParameterExpression>(new[] { result, callArgs }),
+                        new TrueReadOnlyCollection<ParameterExpression>(result, callArgs),
                         Expression.Assign(callArgs, Expression.NewArrayInit(typeof(object), callArgsValue)),
                         Expression.Condition(
                             Expression.Call(
@@ -704,7 +704,7 @@ namespace System.Dynamic
                 //
                 var callDynamic = new DynamicMetaObject(
                     Expression.Block(
-                        new TrueReadOnlyCollection<ParameterExpression>(new[] { callArgs }),
+                        new TrueReadOnlyCollection<ParameterExpression>(callArgs),
                         Expression.Assign(callArgs, Expression.NewArrayInit(typeof(object), callArgsValue)),
                         Expression.Condition(
                             Expression.Call(

--- a/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
@@ -585,7 +585,7 @@ namespace System.Dynamic
 
                 var callDynamic = new DynamicMetaObject(
                     Expression.Block(
-                        new[] { result, callArgs },
+                        new TrueReadOnlyCollection<ParameterExpression>(new[] { result, callArgs }),
                         methodName != nameof(DynamicObject.TryBinaryOperation) ? Expression.Assign(callArgs, Expression.NewArrayInit(typeof(object), callArgsValue)) : Expression.Assign(callArgs, callArgsValue[0]),
                         Expression.Condition(
                             Expression.Call(
@@ -643,7 +643,7 @@ namespace System.Dynamic
 
                 var callDynamic = new DynamicMetaObject(
                     Expression.Block(
-                        new[] { result, callArgs },
+                        new TrueReadOnlyCollection<ParameterExpression>(new[] { result, callArgs }),
                         Expression.Assign(callArgs, Expression.NewArrayInit(typeof(object), callArgsValue)),
                         Expression.Condition(
                             Expression.Call(
@@ -704,7 +704,7 @@ namespace System.Dynamic
                 //
                 var callDynamic = new DynamicMetaObject(
                     Expression.Block(
-                        new[] { callArgs },
+                        new TrueReadOnlyCollection<ParameterExpression>(new[] { callArgs }),
                         Expression.Assign(callArgs, Expression.NewArrayInit(typeof(object), callArgsValue)),
                         Expression.Condition(
                             Expression.Call(

--- a/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
@@ -788,7 +788,7 @@ namespace System.Dynamic
 
                 result = new DynamicMetaObject(
                     Expression.Block(
-                        new[] { value },
+                        new TrueReadOnlyCollection<ParameterExpression>(new[] { value }),
                         Expression.Condition(
                             tryGetValue,
                             result.Expression,

--- a/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
@@ -788,7 +788,7 @@ namespace System.Dynamic
 
                 result = new DynamicMetaObject(
                     Expression.Block(
-                        new TrueReadOnlyCollection<ParameterExpression>(new[] { value }),
+                        new TrueReadOnlyCollection<ParameterExpression>(value),
                         Expression.Condition(
                             tryGetValue,
                             result.Expression,

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic.Utils;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using static System.Linq.Expressions.CachedReflectionInfo;
 
 namespace System.Linq.Expressions
@@ -229,7 +230,7 @@ namespace System.Linq.Expressions
                 Expression e4 = temp2;
 
                 return Expression.Block(
-                    new ParameterExpression[] { temp1, temp2 },
+                    new TrueReadOnlyCollection<ParameterExpression>(new[] { temp1, temp2 }),
                     e1, e2, e3, e4
                 );
             }
@@ -420,7 +421,7 @@ namespace System.Linq.Expressions
             Debug.Assert(opTrueFalse != null);
 
             return Block(
-                new[] { left },
+                new TrueReadOnlyCollection<ParameterExpression>(new[] { left }),
                 Assign(left, Left),
                 Condition(
                     Property(left, "HasValue"),
@@ -428,7 +429,7 @@ namespace System.Linq.Expressions
                         Call(opTrueFalse, Call(left, "GetValueOrDefault", null)),
                         left,
                         Block(
-                            new[] { right },
+                            new TrueReadOnlyCollection<ParameterExpression>(new[] { right }),
                             Assign(right, Right),
                             Condition(
                                 Property(right, "HasValue"),

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -230,7 +230,7 @@ namespace System.Linq.Expressions
                 Expression e4 = temp2;
 
                 return Expression.Block(
-                    new TrueReadOnlyCollection<ParameterExpression>(new[] { temp1, temp2 }),
+                    new TrueReadOnlyCollection<ParameterExpression>(temp1, temp2),
                     e1, e2, e3, e4
                 );
             }
@@ -421,7 +421,7 @@ namespace System.Linq.Expressions
             Debug.Assert(opTrueFalse != null);
 
             return Block(
-                new TrueReadOnlyCollection<ParameterExpression>(new[] { left }),
+                new TrueReadOnlyCollection<ParameterExpression>(left),
                 Assign(left, Left),
                 Condition(
                     Property(left, "HasValue"),
@@ -429,7 +429,7 @@ namespace System.Linq.Expressions
                         Call(opTrueFalse, Call(left, "GetValueOrDefault", null)),
                         left,
                         Block(
-                            new TrueReadOnlyCollection<ParameterExpression>(new[] { right }),
+                            new TrueReadOnlyCollection<ParameterExpression>(right),
                             Assign(right, Right),
                             Condition(
                                 Property(right, "HasValue"),

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
@@ -733,7 +733,7 @@ namespace System.Linq.Expressions.Compiler
             ParameterExpression switchValue = Expression.Variable(typeof(string), "switchValue");
             ParameterExpression switchIndex = Expression.Variable(typeof(int), "switchIndex");
             BlockExpression reduced = Expression.Block(
-                new TrueReadOnlyCollection<ParameterExpression>(new[] { switchIndex, switchValue }),
+                new TrueReadOnlyCollection<ParameterExpression>(switchIndex, switchValue),
                 Expression.Assign(switchValue, node.SwitchValue),
                 Expression.IfThenElse(
                     Expression.Equal(switchValue, Expression.Constant(null, typeof(string))),

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
@@ -8,6 +8,7 @@ using System.Dynamic.Utils;
 using System.Globalization;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
 using static System.Linq.Expressions.CachedReflectionInfo;
 
 namespace System.Linq.Expressions.Compiler
@@ -732,7 +733,7 @@ namespace System.Linq.Expressions.Compiler
             ParameterExpression switchValue = Expression.Variable(typeof(string), "switchValue");
             ParameterExpression switchIndex = Expression.Variable(typeof(int), "switchIndex");
             BlockExpression reduced = Expression.Block(
-                new[] { switchIndex, switchValue },
+                new TrueReadOnlyCollection<ParameterExpression>(new[] { switchIndex, switchValue }),
                 Expression.Assign(switchValue, node.SwitchValue),
                 Expression.IfThenElse(
                     Expression.Equal(switchValue, Expression.Constant(null, typeof(string))),

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Dynamic.Utils;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using static System.Linq.Expressions.CachedReflectionInfo;
 
 namespace System.Linq.Expressions
@@ -94,7 +95,7 @@ namespace System.Linq.Expressions
             parameter = Expression.Parameter(typeof(object));
 
             return Expression.Block(
-                new[] { parameter },
+                new TrueReadOnlyCollection<ParameterExpression>(new[] { parameter }),
                 Expression.Assign(parameter, Expression),
                 ByValParameterTypeEqual(parameter)
             );
@@ -113,7 +114,11 @@ namespace System.Linq.Expressions
             if (TypeOperand.GetTypeInfo().IsInterface)
             {
                 ParameterExpression temp = Expression.Parameter(typeof(Type));
-                getType = Expression.Block(new[] { temp }, Expression.Assign(temp, getType), temp);
+                getType = Expression.Block(
+                    new TrueReadOnlyCollection<ParameterExpression>(new[] { temp }),
+                    Expression.Assign(temp, getType),
+                    temp
+                );
             }
 
             // We use reference equality when comparing to null for correctness

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
@@ -95,7 +95,7 @@ namespace System.Linq.Expressions
             parameter = Expression.Parameter(typeof(object));
 
             return Expression.Block(
-                new TrueReadOnlyCollection<ParameterExpression>(new[] { parameter }),
+                new TrueReadOnlyCollection<ParameterExpression>(parameter),
                 Expression.Assign(parameter, Expression),
                 ByValParameterTypeEqual(parameter)
             );
@@ -115,7 +115,7 @@ namespace System.Linq.Expressions
             {
                 ParameterExpression temp = Expression.Parameter(typeof(Type));
                 getType = Expression.Block(
-                    new TrueReadOnlyCollection<ParameterExpression>(new[] { temp }),
+                    new TrueReadOnlyCollection<ParameterExpression>(temp),
                     Expression.Assign(temp, getType),
                     temp
                 );

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -170,7 +170,7 @@ namespace System.Linq.Expressions
             // temp
             ParameterExpression temp = Parameter(Operand.Type, name: null);
             return Block(
-                new[] { temp },
+                new  TrueReadOnlyCollection<ParameterExpression>(new[] { temp }),
                 Assign(temp, Operand),
                 Assign(Operand, FunctionalOp(temp)),
                 temp
@@ -198,7 +198,7 @@ namespace System.Linq.Expressions
                     // temp1 = value
                     // temp1.member = op(temp1.member)
                     return Block(
-                        new[] { temp1 },
+                        new TrueReadOnlyCollection<ParameterExpression>(new[] { temp1 }),
                         initTemp1,
                         Assign(member, FunctionalOp(member))
                     );
@@ -212,7 +212,7 @@ namespace System.Linq.Expressions
                 // temp2
                 ParameterExpression temp2 = Parameter(member.Type, name: null);
                 return Block(
-                    new[] { temp1, temp2 },
+                    new TrueReadOnlyCollection<ParameterExpression>(new[] { temp1, temp2 }),
                     initTemp1,
                     Assign(temp2, member),
                     Assign(member, FunctionalOp(temp2)),

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -170,7 +170,7 @@ namespace System.Linq.Expressions
             // temp
             ParameterExpression temp = Parameter(Operand.Type, name: null);
             return Block(
-                new  TrueReadOnlyCollection<ParameterExpression>(new[] { temp }),
+                new  TrueReadOnlyCollection<ParameterExpression>(temp),
                 Assign(temp, Operand),
                 Assign(Operand, FunctionalOp(temp)),
                 temp
@@ -198,7 +198,7 @@ namespace System.Linq.Expressions
                     // temp1 = value
                     // temp1.member = op(temp1.member)
                     return Block(
-                        new TrueReadOnlyCollection<ParameterExpression>(new[] { temp1 }),
+                        new TrueReadOnlyCollection<ParameterExpression>(temp1),
                         initTemp1,
                         Assign(member, FunctionalOp(member))
                     );
@@ -212,7 +212,7 @@ namespace System.Linq.Expressions
                 // temp2
                 ParameterExpression temp2 = Parameter(member.Type, name: null);
                 return Block(
-                    new TrueReadOnlyCollection<ParameterExpression>(new[] { temp1, temp2 }),
+                    new TrueReadOnlyCollection<ParameterExpression>(temp1, temp2),
                     initTemp1,
                     Assign(temp2, member),
                     Assign(member, FunctionalOp(temp2)),


### PR DESCRIPTION
We're calling the `Block` factory method taking an `IEnumerable<ParameterExpression>` in various places with an array whose ownership can be transferred. The `Block` factory uses `ToReadOnly` though, causing a copy of the array to be made. This PR allocates `TrueReadOnlyCollection<T>` to pass the variables collections and thus avoid a copy being made by `ToReadOnly`.

CC @stephentoub