### PR TITLE
Trim trailing whitespace in System.Linq.Expressions

### DIFF
--- a/src/Common/src/System/Collections/Generic/ArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/ArrayBuilder.cs
@@ -134,7 +134,7 @@ namespace System.Collections.Generic
             }
 
             nextCapacity = Math.Max(nextCapacity, minimum);
-            
+
             T[] next = new T[nextCapacity];
             if (_count > 0)
             {

--- a/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
+++ b/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
@@ -24,12 +24,12 @@ namespace System.Collections.Generic
                 {
                     return Array.Empty<T>();
                 }
-                
+
                 var result = new T[count];
                 collection.CopyTo(result, arrayIndex: 0);
                 return result;
             }
-            
+
             var builder = new LargeArrayBuilder<T>(initialize: true);
             builder.AddRange(source);
             return builder.ToArray();
@@ -50,11 +50,11 @@ namespace System.Collections.Generic
                 int count = ic.Count;
                 if (count != 0)
                 {
-                    // Allocate an array of the desired size, then copy the elements into it. Note that this has the same 
-                    // issue regarding concurrency as other existing collections like List<T>. If the collection size 
-                    // concurrently changes between the array allocation and the CopyTo, we could end up either getting an 
-                    // exception from overrunning the array (if the size went up) or we could end up not filling as many 
-                    // items as 'count' suggests (if the size went down).  This is only an issue for concurrent collections 
+                    // Allocate an array of the desired size, then copy the elements into it. Note that this has the same
+                    // issue regarding concurrency as other existing collections like List<T>. If the collection size
+                    // concurrently changes between the array allocation and the CopyTo, we could end up either getting an
+                    // exception from overrunning the array (if the size went up) or we could end up not filling as many
+                    // items as 'count' suggests (if the size went down).  This is only an issue for concurrent collections
                     // that implement ICollection<T>, which as of .NET 4.6 is just ConcurrentDictionary<TKey, TValue>.
                     T[] arr = new T[count];
                     ic.CopyTo(arr, 0);
@@ -84,15 +84,15 @@ namespace System.Collections.Generic
                                 const int MaxArrayLength = 0x7FEFFFFF;
 
                                 // This is the same growth logic as in List<T>:
-                                // If the array is currently empty, we make it a default size.  Otherwise, we attempt to 
+                                // If the array is currently empty, we make it a default size.  Otherwise, we attempt to
                                 // double the size of the array.  Doubling will overflow once the size of the array reaches
-                                // 2^30, since doubling to 2^31 is 1 larger than Int32.MaxValue.  In that case, we instead 
-                                // constrain the length to be MaxArrayLength (this overflow check works because of the 
-                                // cast to uint).  Because a slightly larger constant is used when T is one byte in size, we 
-                                // could then end up in a situation where arr.Length is MaxArrayLength or slightly larger, such 
-                                // that we constrain newLength to be MaxArrayLength but the needed number of elements is actually 
-                                // larger than that.  For that case, we then ensure that the newLength is large enough to hold 
-                                // the desired capacity.  This does mean that in the very rare case where we've grown to such a 
+                                // 2^30, since doubling to 2^31 is 1 larger than Int32.MaxValue.  In that case, we instead
+                                // constrain the length to be MaxArrayLength (this overflow check works because of the
+                                // cast to uint).  Because a slightly larger constant is used when T is one byte in size, we
+                                // could then end up in a situation where arr.Length is MaxArrayLength or slightly larger, such
+                                // that we constrain newLength to be MaxArrayLength but the needed number of elements is actually
+                                // larger than that.  For that case, we then ensure that the newLength is large enough to hold
+                                // the desired capacity.  This does mean that in the very rare case where we've grown to such a
                                 // large size, each new element added after MaxArrayLength will end up doing a resize.
                                 int newLength = count << 1;
                                 if ((uint)newLength > MaxArrayLength)

--- a/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
@@ -111,12 +111,12 @@ namespace System.Collections.Generic
             Debug.Assert(arrayIndex >= 0);
             Debug.Assert(count >= 0 && count <= Count);
             Debug.Assert(array.Length - arrayIndex >= count);
-            
+
             for (int i = -1; count > 0; i++)
             {
                 // Find the buffer we're copying from.
                 T[] buffer = i < 0 ? _first : i < _buffers.Count ? _buffers[i] : _current;
-                
+
                 // Copy until we satisfy count, or we reach the end of the buffer.
                 int toCopy = Math.Min(count, buffer.Length);
                 Array.Copy(buffer, 0, array, arrayIndex, toCopy);
@@ -153,7 +153,7 @@ namespace System.Collections.Generic
             CopyTo(array, 0, _count);
             return array;
         }
-        
+
         private void AllocateBuffer()
         {
             // - On the first few adds, simply resize _first.

--- a/src/Common/src/System/Dynamic/Utils/CacheDict.cs
+++ b/src/Common/src/System/Dynamic/Utils/CacheDict.cs
@@ -13,7 +13,7 @@ namespace System.Dynamic.Utils
     /// </summary>
     internal sealed class CacheDict<TKey, TValue>
     {
-        // cache size is always ^2. 
+        // cache size is always ^2.
         // items are placed at [hash ^ mask]
         // new item will displace previous one at the same location.
         private readonly int mask;

--- a/src/Common/src/System/Dynamic/Utils/CollectionExtensions.cs
+++ b/src/Common/src/System/Dynamic/Utils/CollectionExtensions.cs
@@ -13,7 +13,7 @@ namespace System.Dynamic.Utils
     {
         /// <summary>
         /// Wraps the provided enumerable into a ReadOnlyCollection{T}
-        /// 
+        ///
         /// Copies all of the data into a new array, so the data can't be
         /// changed after creation. The exception is if the enumerable is
         /// already a ReadOnlyCollection{T}, in which case we just return it.

--- a/src/Common/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/Common/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -25,7 +25,7 @@ namespace System.Dynamic.Utils
 #if !FEATURE_DYNAMIC_DELEGATE
 
         // We will generate the following code:
-        //  
+        //
         // object ret;
         // object[] args = new object[parameterCount];
         // args[0] = param0;
@@ -133,7 +133,7 @@ namespace System.Dynamic.Utils
 
             ilgen.Emit(OpCodes.Ret);
 
-            // TODO: we need to cache these. 
+            // TODO: we need to cache these.
             return thunkMethod.CreateDelegate(delegateType, handler);
         }
 

--- a/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
@@ -38,16 +38,16 @@ namespace System.Dynamic.Utils
 
         /// <summary>
         /// Helper used for ensuring we only return 1 instance of a ReadOnlyCollection of T.
-        /// 
-        /// This is similar to the ReturnReadOnly of T. This version supports nodes which hold 
+        ///
+        /// This is similar to the ReturnReadOnly of T. This version supports nodes which hold
         /// onto multiple Expressions where one is typed to object.  That object field holds either
         /// an expression or a ReadOnlyCollection of Expressions.  When it holds a ReadOnlyCollection
         /// the IList which backs it is a ListArgumentProvider which uses the Expression which
-        /// implements IArgumentProvider to get 2nd and additional values.  The ListArgumentProvider 
-        /// continues to hold onto the 1st expression.  
-        /// 
-        /// This enables users to get the ReadOnlyCollection w/o it consuming more memory than if 
-        /// it was just an array.  Meanwhile The DLR internally avoids accessing  which would force 
+        /// implements IArgumentProvider to get 2nd and additional values.  The ListArgumentProvider
+        /// continues to hold onto the 1st expression.
+        ///
+        /// This enables users to get the ReadOnlyCollection w/o it consuming more memory than if
+        /// it was just an array.  Meanwhile The DLR internally avoids accessing  which would force
         /// the readonly collection to be created resulting in a typical memory savings.
         /// </summary>
         public static ReadOnlyCollection<Expression> ReturnReadOnly(IArgumentProvider provider, ref object collection)
@@ -69,9 +69,9 @@ namespace System.Dynamic.Utils
 
 
         /// <summary>
-        /// Helper which is used for specialized subtypes which use ReturnReadOnly(ref object, ...). 
+        /// Helper which is used for specialized subtypes which use ReturnReadOnly(ref object, ...).
         /// This is the reverse version of ReturnReadOnly which takes an IArgumentProvider.
-        /// 
+        ///
         /// This is used to return the 1st argument.  The 1st argument is typed as object and either
         /// contains a ReadOnlyCollection or the Expression.  We check for the Expression and if it's
         /// present we return that, otherwise we return the 1st element of the ReadOnlyCollection.

--- a/src/Common/src/System/Dynamic/Utils/TypeExtensions.cs
+++ b/src/Common/src/System/Dynamic/Utils/TypeExtensions.cs
@@ -45,6 +45,6 @@ namespace System.Dynamic.Utils
 
             return (pi.Attributes & (ParameterAttributes.Out)) == ParameterAttributes.Out;
         }
-#endif 
+#endif
     }
 }

--- a/src/Common/src/System/Linq/Expressions/Compiler/DelegateHelpers.Generated.cs
+++ b/src/Common/src/System/Linq/Expressions/Compiler/DelegateHelpers.Generated.cs
@@ -84,7 +84,7 @@ namespace System.Linq.Expressions.Compiler
                 default: return null;
             }
         }
-#endif 
+#endif
 
         /// <summary>
         /// Creates a new delegate, or uses a func/action
@@ -124,7 +124,7 @@ namespace System.Linq.Expressions.Compiler
                 return MakeNewCustomDelegate(types);
 #else
                 return TryMakeVBStyledCallSite(types) ?? MakeNewCustomDelegate(types);
-#endif 
+#endif
             }
 
             Type result;

--- a/src/Common/src/System/SR.cs
+++ b/src/Common/src/System/SR.cs
@@ -24,7 +24,7 @@ namespace System
             }
         }
 
-        // This method is used to decide if we need to append the exception message parameters to the message when calling SR.Format. 
+        // This method is used to decide if we need to append the exception message parameters to the message when calling SR.Format.
         // by default it returns false.
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static bool UsingResourceKeys()

--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/src/System.Linq.Expressions/src/System/Dynamic/CallInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/CallInfo.cs
@@ -15,9 +15,9 @@ namespace System.Dynamic
     /// ArgumentCount - all inclusive number of arguments.
     /// ArgumentNames - names for those arguments that are named.
     ///
-    /// Argument names match to the argument values in left to right order 
+    /// Argument names match to the argument values in left to right order
     /// and last name corresponds to the last argument.
-    /// 
+    ///
     /// Example:
     ///   Foo(arg1, arg2, arg3, name1 = arg4, name2 = arg5, name3 = arg6)
     ///

--- a/src/System.Linq.Expressions/src/System/Dynamic/DynamicMetaObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/DynamicMetaObject.cs
@@ -127,7 +127,7 @@ namespace System.Dynamic
         }
 
         /// <summary>
-        /// Performs the binding of the dynamic set member operation. 
+        /// Performs the binding of the dynamic set member operation.
         /// </summary>
         /// <param name="binder">An instance of the <see cref="SetMemberBinder"/> that represents the details of the dynamic operation.</param>
         /// <param name="value">The <see cref="DynamicMetaObject"/> representing the value for the set member operation.</param>
@@ -278,13 +278,13 @@ namespace System.Dynamic
         }
 
         /// <summary>
-        /// Creates a meta-object for the specified object. 
+        /// Creates a meta-object for the specified object.
         /// </summary>
         /// <param name="value">The object to get a meta-object for.</param>
         /// <param name="expression">The expression representing this <see cref="DynamicMetaObject"/> during the dynamic binding process.</param>
         /// <returns>
         /// If the given object implements <see cref="IDynamicMetaObjectProvider"/> and is not a remote object from outside the current AppDomain,
-        /// returns the object's specific meta-object returned by <see cref="IDynamicMetaObjectProvider.GetMetaObject"/>. Otherwise a plain new meta-object 
+        /// returns the object's specific meta-object returned by <see cref="IDynamicMetaObjectProvider.GetMetaObject"/>. Otherwise a plain new meta-object
         /// with no restrictions is created and returned.
         /// </returns>
         public static DynamicMetaObject Create(object value, Expression expression)

--- a/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
@@ -14,7 +14,7 @@ namespace System.Dynamic
     /// Provides a simple class that can be inherited from to create an object with dynamic behavior
     /// at runtime.  Subclasses can override the various binder methods (GetMember, SetMember, Call, etc.)
     /// to provide custom behavior that will be invoked at runtime.
-    /// 
+    ///
     /// If a method is not overridden then the DynamicObject does not directly support that behavior and
     /// the call site will determine how the binding should be performed.
     /// </summary>
@@ -493,7 +493,7 @@ namespace System.Dynamic
             /// <summary>
             /// Helper method for generating a MetaObject which calls a
             /// specific method on DynamicObject that returns a result.
-            /// 
+            ///
             /// args is either an array of arguments to be passed
             /// to the method as an object[] or NoArgs to signify that
             /// the target method takes no parameters.
@@ -615,7 +615,7 @@ namespace System.Dynamic
             /// Helper method for generating a MetaObject which calls a
             /// specific method on Dynamic, but uses one of the arguments for
             /// the result.
-            /// 
+            ///
             /// args is either an array of arguments to be passed
             /// to the method as an object[] or NoArgs to signify that
             /// the target method takes no parameters.
@@ -682,7 +682,7 @@ namespace System.Dynamic
             /// Helper method for generating a MetaObject which calls a
             /// specific method on Dynamic, but uses one of the arguments for
             /// the result.
-            /// 
+            ///
             /// args is either an array of arguments to be passed
             /// to the method as an object[] or NoArgs to signify that
             /// the target method takes no parameters.

--- a/src/System.Linq.Expressions/src/System/Dynamic/ExpandoClass.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/ExpandoClass.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace System.Dynamic
 {
     /// <summary>
-    /// Represents a dynamically assigned class.  Expando objects which share the same 
+    /// Represents a dynamically assigned class.  Expando objects which share the same
     /// members will share the same class.  Classes are dynamically assigned as the
     /// expando object gains members.
     /// </summary>
@@ -33,7 +33,7 @@ namespace System.Dynamic
 
         /// <summary>
         /// Constructs a new ExpandoClass that can hold onto the specified keys.  The
-        /// keys must be sorted ordinally.  The hash code must be precalculated for 
+        /// keys must be sorted ordinally.  The hash code must be precalculated for
         /// the keys.
         /// </summary>
         internal ExpandoClass(string[] keys, int hashCode)
@@ -49,7 +49,7 @@ namespace System.Dynamic
         /// </summary>
         internal ExpandoClass FindNewClass(string newKey)
         {
-            // just XOR the newKey hash code 
+            // just XOR the newKey hash code
             int hashCode = _hashCode ^ newKey.GetHashCode();
 
             lock (this)

--- a/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
@@ -105,9 +105,9 @@ namespace System.Dynamic
 
                 if (data.Class != indexClass || ignoreCase)
                 {
-                    // The class has changed or we are doing a case-insensitive search, 
-                    // we need to get the correct index and set the value there.  If we 
-                    // don't have the value then we need to promote the class - that 
+                    // The class has changed or we are doing a case-insensitive search,
+                    // we need to get the correct index and set the value there.  If we
+                    // don't have the value then we need to promote the class - that
                     // should only happen when we have multiple concurrent writers.
                     index = data.Class.GetValueIndex(name, ignoreCase, this);
                     if (index == ExpandoObject.AmbiguousMatchFound)
@@ -116,7 +116,7 @@ namespace System.Dynamic
                     }
                     if (index == ExpandoObject.NoMatch)
                     {
-                        // Before creating a new class with the new member, need to check 
+                        // Before creating a new class with the new member, need to check
                         // if there is the exact same member but is deleted. We should reuse
                         // the class if there is such a member.
                         int exactMatch = ignoreCase ?
@@ -233,7 +233,7 @@ namespace System.Dynamic
         }
 
         /// <summary>
-        /// Exposes the ExpandoClass which we've associated with this 
+        /// Exposes the ExpandoClass which we've associated with this
         /// Expando object.  Used for type checks in rules.
         /// </summary>
         internal ExpandoClass Class => _data.Class;
@@ -737,7 +737,7 @@ namespace System.Dynamic
                 {
                     // The underlying expando object has changed:
                     // 1) the version of the expando data changed
-                    // 2) the data object is changed 
+                    // 2) the data object is changed
                     throw System.Linq.Expressions.Error.CollectionModifiedWhileEnumerating();
                 }
                 // Capture the value into a temp so we don't inadvertently
@@ -903,7 +903,7 @@ namespace System.Dynamic
                 if (originalClass != null)
                 {
                     // we are accessing a member which has not yet been defined on this class.
-                    // We force a class promotion after the type check.  If the class changes the 
+                    // We force a class promotion after the type check.  If the class changes the
                     // promotion will fail and the set/delete will do a full lookup using the new
                     // class to discover the name.
                     Debug.Assert(originalClass != klass);
@@ -1014,8 +1014,8 @@ namespace System.Dynamic
 
             /// <summary>
             /// data stored in the expando object, key names are stored in the class.
-            /// 
-            /// Expando._data must be locked when mutating the value.  Otherwise a copy of it 
+            ///
+            /// Expando._data must be locked when mutating the value.  Otherwise a copy of it
             /// could be made and lose values.
             /// </summary>
             private readonly object[] _dataArray;

--- a/src/System.Linq.Expressions/src/System/Dynamic/GetIndexBinder.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/GetIndexBinder.cs
@@ -25,7 +25,7 @@ namespace System.Dynamic
         /// The result type of the operation.
         /// </summary>
         public override sealed Type ReturnType => typeof(object);
-        
+
         /// <summary>
         /// Gets the signature of the arguments at the call site.
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Dynamic/UpdateDelegates.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/UpdateDelegates.Generated.cs
@@ -49,10 +49,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return result;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -190,10 +190,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return result;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -333,10 +333,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return result;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -476,10 +476,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return result;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -619,10 +619,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return result;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -762,10 +762,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return result;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -905,10 +905,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return result;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -1048,10 +1048,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return result;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -1191,10 +1191,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return result;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -1334,10 +1334,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return result;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -1477,10 +1477,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return result;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -1619,10 +1619,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -1761,10 +1761,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -1903,10 +1903,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -2045,10 +2045,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -2187,10 +2187,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -2329,10 +2329,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -2471,10 +2471,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -2613,10 +2613,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -2755,10 +2755,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }
@@ -2897,10 +2897,10 @@ namespace System.Dynamic
                         {
                             CallSiteOps.UpdateRules(@this, i);
                             return;
-                        }        
+                        }
 
                         // Rule didn't match, try the next one
-                        CallSiteOps.ClearMatch(site);            
+                        CallSiteOps.ClearMatch(site);
                     }
                 }
             }

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
@@ -30,8 +30,8 @@ namespace System.Dynamic.Utils
         /// <summary>
         /// Returns true if the method's parameter types are reference assignable from
         /// the argument types, otherwise false.
-        /// 
-        /// An example that can make the method return false is that 
+        ///
+        /// An example that can make the method return false is that
         /// typeof(double).GetMethod("op_Equality", ..., new[] { typeof(double), typeof(int) })
         /// returns a method with two double parameters, which doesn't match the provided
         /// argument types.

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -312,14 +312,14 @@ namespace System.Dynamic.Utils
         {
             Debug.Assert(source != null && dest != null);
 
-            // There *might* be a legal conversion from a generic delegate type S to generic delegate type  T, 
+            // There *might* be a legal conversion from a generic delegate type S to generic delegate type  T,
             // provided all of the follow are true:
             //   o Both types are constructed generic types of the same generic delegate type, D<X1,... Xk>.
             //     That is, S = D<S1...>, T = D<T1...>.
             //   o If type parameter Xi is declared to be invariant then Si must be identical to Ti.
             //   o If type parameter Xi is declared to be covariant ("out") then Si must be convertible
             //     to Ti via an identify conversion,  implicit reference conversion, or explicit reference conversion.
-            //   o If type parameter Xi is declared to be contravariant ("in") then either Si must be identical to Ti, 
+            //   o If type parameter Xi is declared to be contravariant ("in") then either Si must be identical to Ti,
             //     or Si and Ti must both be reference types.
 
             if (!IsDelegate(source) || !IsDelegate(dest) || !source.GetTypeInfo().IsGenericType || !dest.GetTypeInfo().IsGenericType)
@@ -414,7 +414,7 @@ namespace System.Dynamic.Utils
                 return false;
             }
 
-            // If we have an interface and a reference type then we can do 
+            // If we have an interface and a reference type then we can do
             // reference equality.
 
             // If we have two reference types and one is assignable to the
@@ -427,7 +427,7 @@ namespace System.Dynamic.Utils
 
         public static bool HasBuiltInEqualityOperator(Type left, Type right)
         {
-            // If we have an interface and a reference type then we can do 
+            // If we have an interface and a reference type then we can do
             // reference equality.
             if (left.GetTypeInfo().IsInterface && !right.GetTypeInfo().IsValueType)
             {
@@ -446,13 +446,13 @@ namespace System.Dynamic.Utils
                     return true;
                 }
             }
-            // Otherwise, if the types are not the same then we definitely 
+            // Otherwise, if the types are not the same then we definitely
             // do not have a built-in equality operator.
             if (!AreEquivalent(left, right))
             {
                 return false;
             }
-            // We have two identical value types, modulo nullability.  (If they were both the 
+            // We have two identical value types, modulo nullability.  (If they were both the
             // same reference type then we would have returned true earlier.)
             Debug.Assert(left.GetTypeInfo().IsValueType);
             // Equality between struct types is only defined for numerics, bools, enums,
@@ -695,7 +695,7 @@ namespace System.Dynamic.Utils
         /// Searches for an operator method on the type. The method must have
         /// the specified signature, no generic arguments, and have the
         /// SpecialName bit set. Also searches inherited operator methods.
-        /// 
+        ///
         /// NOTE: This was designed to satisfy the needs of op_True and
         /// op_False, because we have to do runtime lookup for those. It may
         /// not work right for unary operators in general.
@@ -748,7 +748,7 @@ namespace System.Dynamic.Utils
                     return false;
             }
         }
-#endif 
+#endif
 
         public static bool IsVector(this Type type)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -387,7 +387,7 @@ namespace System.Linq.Expressions
         // L.HasValue
         //     ? T.op_False(L.GetValueOrDefault())
         //         ? L
-        //         : R.HasValue 
+        //         : R.HasValue
         //             ? (T?)(T.op_BitwiseAnd(L.GetValueOrDefault(), R.GetValueOrDefault()))
         //             : null
         //     : null
@@ -398,14 +398,14 @@ namespace System.Linq.Expressions
         // L.HasValue
         //     ? T.op_True(L.GetValueOrDefault())
         //         ? L
-        //         : R.HasValue 
+        //         : R.HasValue
         //             ? (T?)(T.op_BitwiseOr(L.GetValueOrDefault(), R.GetValueOrDefault()))
         //             : null
         //     : null
         //
         //
         // This is the same behavior as VB. If you think about it, it makes
-        // sense: it's combining the normal pattern for short-circuiting 
+        // sense: it's combining the normal pattern for short-circuiting
         // operators, with the normal pattern for lifted operations: if either
         // of the operands is null, the result is also null.
         //
@@ -554,7 +554,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Assign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Assign"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression Assign(Expression left, Expression right)
@@ -600,7 +600,7 @@ namespace System.Linq.Expressions
             }
             return null;
         }
-        
+
         private static BinaryExpression GetMethodBasedBinaryOperator(ExpressionType binaryType, Expression left, Expression right, MethodInfo method, bool liftToNull)
         {
             System.Diagnostics.Debug.Assert(method != null);
@@ -651,7 +651,7 @@ namespace System.Linq.Expressions
             }
             return b;
         }
-        
+
         private static BinaryExpression GetUserDefinedBinaryOperatorOrThrow(ExpressionType binaryType, string name, Expression left, Expression right, bool liftToNull)
         {
             BinaryExpression b = GetUserDefinedBinaryOperator(binaryType, name, left, right, liftToNull);
@@ -720,7 +720,7 @@ namespace System.Linq.Expressions
                 pType = pType.GetElementType();
             return TypeUtils.AreReferenceAssignable(pType, argType);
         }
-        
+
         private static void ValidateParamswithOperandsOrThrow(Type paramType, Type operandType, ExpressionType exprType, string name)
         {
             if (TypeUtils.IsNullableType(paramType) && !TypeUtils.IsNullableType(operandType))
@@ -728,7 +728,7 @@ namespace System.Linq.Expressions
                 throw Error.OperandTypesDoNotMatchParameters(exprType, name);
             }
         }
-        
+
         private static void ValidateOperator(MethodInfo method)
         {
             Debug.Assert(method != null);
@@ -738,13 +738,13 @@ namespace System.Linq.Expressions
             if (method.ReturnType == typeof(void))
                 throw Error.UserDefinedOperatorMustNotBeVoid(method, nameof(method));
         }
-        
+
         private static void ValidateMethodInfo(MethodInfo method, string paramName)
         {
             if (method.ContainsGenericParameters)
                 throw method.IsGenericMethodDefinition ? Error.MethodIsGeneric(method, paramName) : Error.MethodContainsGenericParameters(method, paramName);
         }
-        
+
         private static bool IsNullComparison(Expression left, Expression right)
         {
             // If we have x==null, x!=null, null==x or null!=x where x is
@@ -761,7 +761,7 @@ namespace System.Linq.Expressions
             }
             return false;
         }
-        
+
         // Note: this has different meaning than ConstantCheck.IsNull
         // That function attempts to determine if the result of a tree will be
         // null at runtime. This function is used at tree construction time and
@@ -772,7 +772,7 @@ namespace System.Linq.Expressions
             var c = e as ConstantExpression;
             return c != null && c.Value == null;
         }
-        
+
         private static void ValidateUserDefinedConditionalLogicOperator(ExpressionType nodeType, Type left, Type right, MethodInfo method)
         {
             ValidateOperator(method);
@@ -959,13 +959,13 @@ namespace System.Linq.Expressions
         }
 
         #region Equality Operators
-        
+
         /// <summary>
         /// Creates a <see cref="BinaryExpression"/> that represents an equality comparison.
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Equal"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Equal"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Equal(Expression left, Expression right)
         {
@@ -979,7 +979,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="liftToNull">true to set IsLiftedToNull to true; false to set IsLiftedToNull to false.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Equal"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Equal"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.IsLiftedToNull"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression Equal(Expression left, Expression right, bool liftToNull, MethodInfo method)
@@ -998,7 +998,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Equal"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Equal"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression ReferenceEqual(Expression left, Expression right)
@@ -1017,7 +1017,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.NotEqual"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.NotEqual"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression NotEqual(Expression left, Expression right)
         {
@@ -1031,7 +1031,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="liftToNull">true to set IsLiftedToNull to true; false to set IsLiftedToNull to false.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.NotEqual"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.NotEqual"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.IsLiftedToNull"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression NotEqual(Expression left, Expression right, bool liftToNull, MethodInfo method)
@@ -1050,7 +1050,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.NotEqual"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.NotEqual"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression ReferenceNotEqual(Expression left, Expression right)
@@ -1110,7 +1110,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.GreaterThan"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.GreaterThan"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression GreaterThan(Expression left, Expression right)
         {
@@ -1124,7 +1124,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="liftToNull">true to set IsLiftedToNull to true; false to set IsLiftedToNull to false.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.GreaterThan"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.GreaterThan"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.IsLiftedToNull"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression GreaterThan(Expression left, Expression right, bool liftToNull, MethodInfo method)
@@ -1143,7 +1143,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LessThan"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LessThan"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
 
         public static BinaryExpression LessThan(Expression left, Expression right)
@@ -1158,7 +1158,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="liftToNull">true to set IsLiftedToNull to true; false to set IsLiftedToNull to false.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LessThan"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LessThan"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.IsLiftedToNull"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression LessThan(Expression left, Expression right, bool liftToNull, MethodInfo method)
@@ -1177,7 +1177,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.GreaterThanOrEqual"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.GreaterThanOrEqual"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression GreaterThanOrEqual(Expression left, Expression right)
         {
@@ -1191,7 +1191,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="liftToNull">true to set IsLiftedToNull to true; false to set IsLiftedToNull to false.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.GreaterThanOrEqual"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.GreaterThanOrEqual"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.IsLiftedToNull"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression GreaterThanOrEqual(Expression left, Expression right, bool liftToNull, MethodInfo method)
@@ -1204,13 +1204,13 @@ namespace System.Linq.Expressions
             }
             return GetMethodBasedBinaryOperator(ExpressionType.GreaterThanOrEqual, left, right, method, liftToNull);
         }
-        
+
         /// <summary>
         /// Creates a <see cref="BinaryExpression"/> that represents a "less than or equal" numeric comparison.
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LessThanOrEqual"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LessThanOrEqual"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression LessThanOrEqual(Expression left, Expression right)
         {
@@ -1224,7 +1224,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="liftToNull">true to set IsLiftedToNull to true; false to set IsLiftedToNull to false.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LessThanOrEqual"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LessThanOrEqual"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.IsLiftedToNull"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression LessThanOrEqual(Expression left, Expression right, bool liftToNull, MethodInfo method)
@@ -1263,7 +1263,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AndAlso"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AndAlso"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression AndAlso(Expression left, Expression right)
         {
@@ -1276,7 +1276,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AndAlso"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AndAlso"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression AndAlso(Expression left, Expression right, MethodInfo method)
@@ -1310,13 +1310,13 @@ namespace System.Linq.Expressions
             returnType = (TypeUtils.IsNullableType(left.Type) && TypeUtils.AreEquivalent(method.ReturnType, TypeUtils.GetNonNullableType(left.Type))) ? left.Type : method.ReturnType;
             return new MethodBinaryExpression(ExpressionType.AndAlso, left, right, returnType, method);
         }
-        
+
         /// <summary>
         /// Creates a <see cref="BinaryExpression"/> that represents a conditional OR operation that evaluates the second operand only if it has to.
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.OrElse"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.OrElse"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression OrElse(Expression left, Expression right)
         {
@@ -1329,7 +1329,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.OrElse"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.OrElse"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression OrElse(Expression left, Expression right, MethodInfo method)
@@ -1373,7 +1373,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression" /> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Coalesce"/> 
+        /// <returns>A <see cref="BinaryExpression" /> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Coalesce"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Coalesce(Expression left, Expression right)
         {
@@ -1386,7 +1386,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="conversion">A LambdaExpression to set the Conversion property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression" /> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Coalesce"/> 
+        /// <returns>A <see cref="BinaryExpression" /> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Coalesce"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/> and <see cref="BinaryExpression.Conversion"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression Coalesce(Expression left, Expression right, LambdaExpression conversion)
@@ -1466,13 +1466,13 @@ namespace System.Linq.Expressions
         #endregion
 
         #region Arithmetic Expressions
-        
+
         /// <summary>
         /// Creates a <see cref="BinaryExpression"/> that represents an arithmetic addition operation that does not have overflow checking.
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Add"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Add"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Add(Expression left, Expression right)
         {
@@ -1485,7 +1485,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Add"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Add"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression Add(Expression left, Expression right, MethodInfo method)
@@ -1508,7 +1508,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AddAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AddAssign"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression AddAssign(Expression left, Expression right)
         {
@@ -1521,7 +1521,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AddAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AddAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression AddAssign(Expression left, Expression right, MethodInfo method)
@@ -1536,7 +1536,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="conversion">A <see cref="LambdaExpression"/> to set the <see cref="BinaryExpression.Conversion"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AddAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AddAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.Method"/>,
         /// and <see cref="BinaryExpression.Conversion"/> properties set to the specified values.
         /// </returns>
@@ -1585,14 +1585,14 @@ namespace System.Linq.Expressions
                 }
             }
         }
-        
+
         /// <summary>
         /// Creates a <see cref="BinaryExpression"/> that represents an addition assignment operation that has overflow checking.
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to 
-        /// <see cref="ExpressionType.AddAssignChecked"/> and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to
+        /// <see cref="ExpressionType.AddAssignChecked"/> and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/>
         /// properties set to the specified values.
         /// </returns>
         public static BinaryExpression AddAssignChecked(Expression left, Expression right)
@@ -1606,7 +1606,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AddAssignChecked"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AddAssignChecked"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression AddAssignChecked(Expression left, Expression right, MethodInfo method)
@@ -1621,7 +1621,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="conversion">A <see cref="LambdaExpression"/> to set the <see cref="BinaryExpression.Conversion"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AddAssignChecked"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AddAssignChecked"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.Method"/>,
         /// and <see cref="BinaryExpression.Conversion"/> properties set to the specified values.
         /// </returns>
@@ -1652,7 +1652,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AddChecked"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AddChecked"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression AddChecked(Expression left, Expression right)
         {
@@ -1665,7 +1665,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AddChecked"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AddChecked"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression AddChecked(Expression left, Expression right, MethodInfo method)
@@ -1688,7 +1688,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Subtract"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Subtract"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Subtract(Expression left, Expression right)
         {
@@ -1701,7 +1701,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Subtract"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Subtract"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression Subtract(Expression left, Expression right, MethodInfo method)
@@ -1724,7 +1724,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.SubtractAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.SubtractAssign"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression SubtractAssign(Expression left, Expression right)
         {
@@ -1737,7 +1737,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.SubtractAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.SubtractAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression SubtractAssign(Expression left, Expression right, MethodInfo method)
@@ -1752,7 +1752,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="conversion">A <see cref="LambdaExpression"/> to set the <see cref="BinaryExpression.Conversion"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.SubtractAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.SubtractAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.Method"/>,
         /// and <see cref="BinaryExpression.Conversion"/> properties set to the specified values.
         /// </returns>
@@ -1776,13 +1776,13 @@ namespace System.Linq.Expressions
             }
             return GetMethodBasedAssignOperator(ExpressionType.SubtractAssign, left, right, method, conversion, liftToNull: true);
         }
-        
+
         /// <summary>
         /// Creates a <see cref="BinaryExpression"/> that represents a subtraction assignment operation that has overflow checking.
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.SubtractAssignChecked"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.SubtractAssignChecked"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression SubtractAssignChecked(Expression left, Expression right)
         {
@@ -1795,7 +1795,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.SubtractAssignChecked"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.SubtractAssignChecked"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression SubtractAssignChecked(Expression left, Expression right, MethodInfo method)
@@ -1810,7 +1810,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="conversion">A <see cref="LambdaExpression"/> to set the <see cref="BinaryExpression.Conversion"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.SubtractAssignChecked"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.SubtractAssignChecked"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.Method"/>,
         /// and <see cref="BinaryExpression.Conversion"/> properties set to the specified values.
         /// </returns>
@@ -1834,13 +1834,13 @@ namespace System.Linq.Expressions
             }
             return GetMethodBasedAssignOperator(ExpressionType.SubtractAssignChecked, left, right, method, conversion, liftToNull: true);
         }
-        
+
         /// <summary>
         /// Creates a <see cref="BinaryExpression"/> that represents an arithmetic subtraction operation that has overflow checking.
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.SubtractChecked"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.SubtractChecked"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression SubtractChecked(Expression left, Expression right)
         {
@@ -1853,7 +1853,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.SubtractChecked"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.SubtractChecked"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression SubtractChecked(Expression left, Expression right, MethodInfo method)
@@ -1876,7 +1876,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Divide"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Divide"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Divide(Expression left, Expression right)
         {
@@ -1889,7 +1889,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Divide"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Divide"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression Divide(Expression left, Expression right, MethodInfo method)
@@ -1906,13 +1906,13 @@ namespace System.Linq.Expressions
             }
             return GetMethodBasedBinaryOperator(ExpressionType.Divide, left, right, method, liftToNull: true);
         }
-        
+
         /// <summary>
         /// Creates a <see cref="BinaryExpression"/> that represents a division assignment operation that does not have overflow checking.
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.DivideAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.DivideAssign"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression DivideAssign(Expression left, Expression right)
         {
@@ -1925,7 +1925,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.DivideAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.DivideAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression DivideAssign(Expression left, Expression right, MethodInfo method)
@@ -1940,7 +1940,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="conversion">A <see cref="LambdaExpression"/> to set the <see cref="BinaryExpression.Conversion"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.DivideAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.DivideAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.Method"/>,
         /// and <see cref="BinaryExpression.Conversion"/> properties set to the specified values.
         /// </returns>
@@ -1970,7 +1970,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Modulo"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Modulo"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Modulo(Expression left, Expression right)
         {
@@ -1983,7 +1983,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Modulo"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Modulo"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression Modulo(Expression left, Expression right, MethodInfo method)
@@ -2000,13 +2000,13 @@ namespace System.Linq.Expressions
             }
             return GetMethodBasedBinaryOperator(ExpressionType.Modulo, left, right, method, liftToNull: true);
         }
-        
+
         /// <summary>
         /// Creates a <see cref="BinaryExpression"/> that represents a remainder assignment operation.
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ModuloAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ModuloAssign"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression ModuloAssign(Expression left, Expression right)
         {
@@ -2019,7 +2019,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ModuloAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ModuloAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression ModuloAssign(Expression left, Expression right, MethodInfo method)
@@ -2034,7 +2034,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="conversion">A <see cref="LambdaExpression"/> to set the <see cref="BinaryExpression.Conversion"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ModuloAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ModuloAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.Method"/>,
         /// and <see cref="BinaryExpression.Conversion"/> properties set to the specified values.
         /// </returns>
@@ -2058,13 +2058,13 @@ namespace System.Linq.Expressions
             }
             return GetMethodBasedAssignOperator(ExpressionType.ModuloAssign, left, right, method, conversion, liftToNull: true);
         }
-        
+
         /// <summary>
         /// Creates a <see cref="BinaryExpression"/> that represents an arithmetic multiplication operation that does not have overflow checking.
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Multiply"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Multiply"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Multiply(Expression left, Expression right)
         {
@@ -2077,7 +2077,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Multiply"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Multiply"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression Multiply(Expression left, Expression right, MethodInfo method)
@@ -2094,13 +2094,13 @@ namespace System.Linq.Expressions
             }
             return GetMethodBasedBinaryOperator(ExpressionType.Multiply, left, right, method, liftToNull: true);
         }
-        
+
         /// <summary>
         /// Creates a <see cref="BinaryExpression"/> that represents a multiplication assignment operation that does not have overflow checking.
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.MultiplyAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.MultiplyAssign"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression MultiplyAssign(Expression left, Expression right)
         {
@@ -2113,7 +2113,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.MultiplyAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.MultiplyAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression MultiplyAssign(Expression left, Expression right, MethodInfo method)
@@ -2128,7 +2128,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="conversion">A <see cref="LambdaExpression"/> to set the <see cref="BinaryExpression.Conversion"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.MultiplyAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.MultiplyAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.Method"/>,
         /// and <see cref="BinaryExpression.Conversion"/> properties set to the specified values.
         /// </returns>
@@ -2152,13 +2152,13 @@ namespace System.Linq.Expressions
             }
             return GetMethodBasedAssignOperator(ExpressionType.MultiplyAssign, left, right, method, conversion, liftToNull: true);
         }
-        
+
         /// <summary>
         /// Creates a <see cref="BinaryExpression"/> that represents a multiplication assignment operation that has overflow checking.
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.MultiplyAssignChecked"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.MultiplyAssignChecked"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression MultiplyAssignChecked(Expression left, Expression right)
         {
@@ -2171,7 +2171,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.MultiplyAssignChecked"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.MultiplyAssignChecked"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression MultiplyAssignChecked(Expression left, Expression right, MethodInfo method)
@@ -2186,7 +2186,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="conversion">A <see cref="LambdaExpression"/> to set the <see cref="BinaryExpression.Conversion"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.MultiplyAssignChecked"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.MultiplyAssignChecked"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.Method"/>,
         /// and <see cref="BinaryExpression.Conversion"/> properties set to the specified values.
         /// </returns>
@@ -2210,13 +2210,13 @@ namespace System.Linq.Expressions
             }
             return GetMethodBasedAssignOperator(ExpressionType.MultiplyAssignChecked, left, right, method, conversion, liftToNull: true);
         }
-        
+
         /// <summary>
         /// Creates a <see cref="BinaryExpression"/> that represents an arithmetic multiplication operation that has overflow checking.
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.MultiplyChecked"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.MultiplyChecked"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression MultiplyChecked(Expression left, Expression right)
         {
@@ -2229,7 +2229,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.MultiplyChecked"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.MultiplyChecked"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression MultiplyChecked(Expression left, Expression right, MethodInfo method)
@@ -2268,7 +2268,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LeftShift"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LeftShift"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression LeftShift(Expression left, Expression right)
         {
@@ -2281,7 +2281,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LeftShift"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LeftShift"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression LeftShift(Expression left, Expression right, MethodInfo method)
@@ -2305,7 +2305,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LeftShiftAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LeftShiftAssign"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression LeftShiftAssign(Expression left, Expression right)
         {
@@ -2318,7 +2318,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LeftShiftAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LeftShiftAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression LeftShiftAssign(Expression left, Expression right, MethodInfo method)
@@ -2333,7 +2333,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="conversion">A <see cref="LambdaExpression"/> to set the <see cref="BinaryExpression.Conversion"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LeftShiftAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.LeftShiftAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.Method"/>,
         /// and <see cref="BinaryExpression.Conversion"/> properties set to the specified values.
         /// </returns>
@@ -2358,13 +2358,13 @@ namespace System.Linq.Expressions
             }
             return GetMethodBasedAssignOperator(ExpressionType.LeftShiftAssign, left, right, method, conversion, liftToNull: true);
         }
-        
+
         /// <summary>
         /// Creates a <see cref="BinaryExpression"/> that represents an bitwise right-shift operation.
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.RightShift"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.RightShift"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression RightShift(Expression left, Expression right)
         {
@@ -2377,7 +2377,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.RightShift"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.RightShift"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression RightShift(Expression left, Expression right, MethodInfo method)
@@ -2401,7 +2401,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.RightShiftAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.RightShiftAssign"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression RightShiftAssign(Expression left, Expression right)
         {
@@ -2414,7 +2414,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.RightShiftAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.RightShiftAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression RightShiftAssign(Expression left, Expression right, MethodInfo method)
@@ -2429,7 +2429,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="conversion">A <see cref="LambdaExpression"/> to set the <see cref="BinaryExpression.Conversion"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.RightShiftAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.RightShiftAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.Method"/>,
         /// and <see cref="BinaryExpression.Conversion"/> properties set to the specified values.
         /// </returns>
@@ -2454,13 +2454,13 @@ namespace System.Linq.Expressions
             }
             return GetMethodBasedAssignOperator(ExpressionType.RightShiftAssign, left, right, method, conversion, liftToNull: true);
         }
-        
+
         /// <summary>
         /// Creates a <see cref="BinaryExpression"/> that represents an bitwise AND operation.
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.And"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.And"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression And(Expression left, Expression right)
         {
@@ -2473,7 +2473,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.And"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.And"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression And(Expression left, Expression right, MethodInfo method)
@@ -2496,7 +2496,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AndAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AndAssign"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression AndAssign(Expression left, Expression right)
         {
@@ -2509,7 +2509,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AndAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AndAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression AndAssign(Expression left, Expression right, MethodInfo method)
@@ -2524,7 +2524,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="conversion">A <see cref="LambdaExpression"/> to set the <see cref="BinaryExpression.Conversion"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AndAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.AndAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.Method"/>,
         /// and <see cref="BinaryExpression.Conversion"/> properties set to the specified values.
         /// </returns>
@@ -2548,13 +2548,13 @@ namespace System.Linq.Expressions
             }
             return GetMethodBasedAssignOperator(ExpressionType.AndAssign, left, right, method, conversion, liftToNull: true);
         }
-        
+
         /// <summary>
         /// Creates a <see cref="BinaryExpression"/> that represents an bitwise OR operation.
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Or"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Or"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Or(Expression left, Expression right)
         {
@@ -2567,7 +2567,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Or"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Or"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression Or(Expression left, Expression right, MethodInfo method)
@@ -2590,7 +2590,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.OrAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.OrAssign"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression OrAssign(Expression left, Expression right)
         {
@@ -2603,7 +2603,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.OrAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.OrAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression OrAssign(Expression left, Expression right, MethodInfo method)
@@ -2618,7 +2618,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="conversion">A <see cref="LambdaExpression"/> to set the <see cref="BinaryExpression.Conversion"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.OrAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.OrAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.Method"/>,
         /// and <see cref="BinaryExpression.Conversion"/> properties set to the specified values.
         /// </returns>
@@ -2648,7 +2648,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ExclusiveOr"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ExclusiveOr"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression ExclusiveOr(Expression left, Expression right)
         {
@@ -2661,7 +2661,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ExclusiveOr"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ExclusiveOr"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression ExclusiveOr(Expression left, Expression right, MethodInfo method)
@@ -2684,7 +2684,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ExclusiveOrAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ExclusiveOrAssign"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression ExclusiveOrAssign(Expression left, Expression right)
         {
@@ -2697,7 +2697,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ExclusiveOrAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ExclusiveOrAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression ExclusiveOrAssign(Expression left, Expression right, MethodInfo method)
@@ -2712,7 +2712,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="conversion">A <see cref="LambdaExpression"/> to set the <see cref="BinaryExpression.Conversion"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ExclusiveOrAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ExclusiveOrAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.Method"/>,
         /// and <see cref="BinaryExpression.Conversion"/> properties set to the specified values.
         /// </returns>
@@ -2742,7 +2742,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Power"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Power"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression Power(Expression left, Expression right)
         {
@@ -2755,7 +2755,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Power"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Power"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression Power(Expression left, Expression right, MethodInfo method)
@@ -2778,7 +2778,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.PowerAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.PowerAssign"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression PowerAssign(Expression left, Expression right)
         {
@@ -2791,7 +2791,7 @@ namespace System.Linq.Expressions
         /// <param name="left">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.PowerAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.PowerAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, and <see cref="BinaryExpression.Method"/> properties set to the specified values.
         /// </returns>
         public static BinaryExpression PowerAssign(Expression left, Expression right, MethodInfo method)
@@ -2806,7 +2806,7 @@ namespace System.Linq.Expressions
         /// <param name="right">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
         /// <param name="method">A <see cref="MethodInfo"/> to set the <see cref="BinaryExpression.Method"/> property equal to.</param>
         /// <param name="conversion">A <see cref="LambdaExpression"/> to set the <see cref="BinaryExpression.Conversion"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.PowerAssign"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.PowerAssign"/>
         /// and the <see cref="BinaryExpression.Left"/>, <see cref="BinaryExpression.Right"/>, <see cref="BinaryExpression.Method"/>,
         /// and <see cref="BinaryExpression.Conversion"/> properties set to the specified values.
         /// </returns>
@@ -2829,13 +2829,13 @@ namespace System.Linq.Expressions
         #endregion
 
         #region ArrayIndex Expression
-        
+
         /// <summary>
         /// Creates a <see cref="BinaryExpression"/> that represents applying an array index operator to an array of rank one.
         /// </summary>
         /// <param name="array">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Left"/> property equal to.</param>
         /// <param name="index">An <see cref="Expression"/> to set the <see cref="BinaryExpression.Right"/> property equal to.</param>
-        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ArrayIndex"/> 
+        /// <returns>A <see cref="BinaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ArrayIndex"/>
         /// and the <see cref="BinaryExpression.Left"/> and <see cref="BinaryExpression.Right"/> properties set to the specified values.</returns>
         public static BinaryExpression ArrayIndex(Expression array, Expression index)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -109,14 +109,14 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Makes a copy of this node replacing the parameters/args with the provided values.  The 
+        /// Makes a copy of this node replacing the parameters/args with the provided values.  The
         /// shape of the parameters/args needs to match the shape of the current block - in other
         /// words there should be the same # of parameters and args.
-        /// 
+        ///
         /// parameters can be null in which case the existing parameters are used.
-        /// 
+        ///
         /// This helper is provided to allow re-writing of nodes to not depend on the specific optimized
-        /// subclass of BlockExpression which is being used. 
+        /// subclass of BlockExpression which is being used.
         /// </summary>
         [ExcludeFromCodeCoverage] // Unreachable
         internal virtual BlockExpression Rewrite(ReadOnlyCollection<ParameterExpression> variables, Expression[] args)
@@ -126,15 +126,15 @@ namespace System.Linq.Expressions
 
         /// <summary>
         /// Helper used for ensuring we only return 1 instance of a ReadOnlyCollection of T.
-        /// 
+        ///
         /// This is similar to the ReturnReadOnly which only takes a single argument. This version
         /// supports nodes which hold onto 5 Expressions and puts all of the arguments into the
         /// ReadOnlyCollection.
-        /// 
+        ///
         /// Ultimately this means if we create the readonly collection we will be slightly more wasteful as we'll
         /// have a readonly collection + some fields in the type.  The DLR internally avoids accessing anything
         /// which would force the readonly collection to be created.
-        /// 
+        ///
         /// This is used by BlockExpression5 and MethodCallExpression5.
         /// </summary>
         internal static ReadOnlyCollection<Expression> ReturnReadOnlyExpressions(BlockExpression provider, ref object collection)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/CatchBlock.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/CatchBlock.cs
@@ -8,7 +8,7 @@ using System.Dynamic.Utils;
 namespace System.Linq.Expressions
 {
     /// <summary>
-    /// Represents a catch statement in a try block. 
+    /// Represents a catch statement in a try block.
     /// This must have the same return type (i.e., the type of <see cref="Body"/>) as the try block it is associated with.
     /// </summary>
     [DebuggerTypeProxy(typeof(Expression.CatchBlockProxy))]
@@ -43,7 +43,7 @@ namespace System.Linq.Expressions
         public Expression Filter { get; }
 
         /// <summary>
-        /// Returns a <see cref="String"/> that represents the current <see cref="Object"/>. 
+        /// Returns a <see cref="String"/> that represents the current <see cref="Object"/>.
         /// </summary>
         /// <returns>A <see cref="String"/> that represents the current <see cref="Object"/>.</returns>
         public override string ToString()
@@ -73,8 +73,8 @@ namespace System.Linq.Expressions
     public partial class Expression
     {
         /// <summary>
-        /// Creates a <see cref="CatchBlock"/> representing a catch statement. 
-        /// The <see cref="Type"/> of object to be caught can be specified but no reference to the object 
+        /// Creates a <see cref="CatchBlock"/> representing a catch statement.
+        /// The <see cref="Type"/> of object to be caught can be specified but no reference to the object
         /// will be available for use in the <see cref="CatchBlock"/>.
         /// </summary>
         /// <param name="type">The <see cref="Type"/> of <see cref="Exception"/> this <see cref="CatchBlock"/> will handle.</param>
@@ -98,7 +98,7 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates a <see cref="CatchBlock"/> representing a catch statement with 
+        /// Creates a <see cref="CatchBlock"/> representing a catch statement with
         /// an <see cref="Exception"/> filter but no reference to the caught <see cref="Exception"/> object.
         /// </summary>
         /// <param name="type">The <see cref="Type"/> of <see cref="Exception"/> this <see cref="CatchBlock"/> will handle.</param>
@@ -111,7 +111,7 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates a <see cref="CatchBlock"/> representing a catch statement with 
+        /// Creates a <see cref="CatchBlock"/> representing a catch statement with
         /// an <see cref="Exception"/> filter and a reference to the caught <see cref="Exception"/> object.
         /// </summary>
         /// <param name="variable">A <see cref="ParameterExpression"/> representing a reference to the <see cref="Exception"/> object caught by this handler.</param>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
@@ -26,7 +26,7 @@ namespace System.Linq.Expressions
                                       (s_Decimal_Ctor_Int64 = typeof(decimal).GetConstructor(new[] { typeof(long) }));
 
         private static ConstructorInfo s_Decimal_Ctor_Int32_Int32_Int32_Bool_Byte;
-        public  static ConstructorInfo   Decimal_Ctor_Int32_Int32_Int32_Bool_Byte => 
+        public  static ConstructorInfo   Decimal_Ctor_Int32_Int32_Int32_Bool_Byte =>
                                        s_Decimal_Ctor_Int32_Int32_Int32_Bool_Byte ??
                                       (s_Decimal_Ctor_Int32_Int32_Int32_Bool_Byte = typeof(decimal).GetConstructor(new[] { typeof(int), typeof(int), typeof(int), typeof(bool), typeof(byte) }));
 
@@ -102,52 +102,52 @@ namespace System.Linq.Expressions
 
         private static MethodInfo s_Object_GetType;
         public  static MethodInfo   Object_GetType =>
-                                  s_Object_GetType ?? 
+                                  s_Object_GetType ??
                                  (s_Object_GetType = typeof(object).GetMethod(nameof(object.GetType)));
 
         private static MethodInfo s_Decimal_op_Implicit_Byte;
         public  static MethodInfo   Decimal_op_Implicit_Byte =>
-                                  s_Decimal_op_Implicit_Byte ?? 
+                                  s_Decimal_op_Implicit_Byte ??
                                  (s_Decimal_op_Implicit_Byte = typeof(decimal).GetMethod("op_Implicit", new[] { typeof(byte) }));
 
         private static MethodInfo s_Decimal_op_Implicit_SByte;
         public  static MethodInfo   Decimal_op_Implicit_SByte =>
-                                  s_Decimal_op_Implicit_SByte ?? 
+                                  s_Decimal_op_Implicit_SByte ??
                                  (s_Decimal_op_Implicit_SByte = typeof(decimal).GetMethod("op_Implicit", new[] { typeof(sbyte) }));
 
         private static MethodInfo s_Decimal_op_Implicit_Int16;
         public  static MethodInfo   Decimal_op_Implicit_Int16 =>
-                                  s_Decimal_op_Implicit_Int16 ?? 
+                                  s_Decimal_op_Implicit_Int16 ??
                                  (s_Decimal_op_Implicit_Int16 = typeof(decimal).GetMethod("op_Implicit", new[] { typeof(short) }));
 
         private static MethodInfo s_Decimal_op_Implicit_UInt16;
         public  static MethodInfo   Decimal_op_Implicit_UInt16 =>
-                                  s_Decimal_op_Implicit_UInt16 ?? 
+                                  s_Decimal_op_Implicit_UInt16 ??
                                  (s_Decimal_op_Implicit_UInt16 = typeof(decimal).GetMethod("op_Implicit", new[] { typeof(ushort) }));
 
         private static MethodInfo s_Decimal_op_Implicit_Int32;
         public  static MethodInfo   Decimal_op_Implicit_Int32 =>
-                                  s_Decimal_op_Implicit_Int32 ?? 
+                                  s_Decimal_op_Implicit_Int32 ??
                                  (s_Decimal_op_Implicit_Int32 = typeof(decimal).GetMethod("op_Implicit", new[] { typeof(int) }));
 
         private static MethodInfo s_Decimal_op_Implicit_UInt32;
         public  static MethodInfo   Decimal_op_Implicit_UInt32 =>
-                                  s_Decimal_op_Implicit_UInt32 ?? 
+                                  s_Decimal_op_Implicit_UInt32 ??
                                  (s_Decimal_op_Implicit_UInt32 = typeof(decimal).GetMethod("op_Implicit", new[] { typeof(uint) }));
 
         private static MethodInfo s_Decimal_op_Implicit_Int64;
         public  static MethodInfo   Decimal_op_Implicit_Int64 =>
-                                  s_Decimal_op_Implicit_Int64 ?? 
+                                  s_Decimal_op_Implicit_Int64 ??
                                  (s_Decimal_op_Implicit_Int64 = typeof(decimal).GetMethod("op_Implicit", new[] { typeof(long) }));
 
         private static MethodInfo s_Decimal_op_Implicit_UInt64;
         public  static MethodInfo   Decimal_op_Implicit_UInt64 =>
-                                  s_Decimal_op_Implicit_UInt64 ?? 
+                                  s_Decimal_op_Implicit_UInt64 ??
                                  (s_Decimal_op_Implicit_UInt64 = typeof(decimal).GetMethod("op_Implicit", new[] { typeof(ulong) }));
 
         private static MethodInfo s_Decimal_op_Implicit_Char;
         public  static MethodInfo   Decimal_op_Implicit_Char =>
-                                  s_Decimal_op_Implicit_Char ?? 
+                                  s_Decimal_op_Implicit_Char ??
                                  (s_Decimal_op_Implicit_Char = typeof(decimal).GetMethod("op_Implicit", new[] { typeof(char) }));
 
         private static MethodInfo s_Math_Pow_Double_Double;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/ConstantCheck.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/ConstantCheck.cs
@@ -34,7 +34,7 @@ namespace System.Linq.Expressions
         /// If the result of a TypeBinaryExpression is known statically, this
         /// returns the result, otherwise it returns null, meaning we'll need
         /// to perform the IsInst instruction at runtime.
-        /// 
+        ///
         /// The result of this function must be equivalent to IsInst, or
         /// null.
         /// </summary>
@@ -47,7 +47,7 @@ namespace System.Linq.Expressions
         /// If the result of an isinst opcode is known statically, this
         /// returns the result, otherwise it returns null, meaning we'll need
         /// to perform the IsInst instruction at runtime.
-        /// 
+        ///
         /// The result of this function must be equivalent to IsInst, or
         /// null.
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.Storage.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.Storage.cs
@@ -44,7 +44,7 @@ namespace System.Linq.Expressions.Compiler
                 : base(compiler, variable)
             {
                 // ByRef variables are supported. This is used internally by
-                // the compiler when emitting an inlined lambda invoke, to 
+                // the compiler when emitting an inlined lambda invoke, to
                 // handle ByRef parameters. BlockExpression prevents this
                 // from being exposed to user created trees.
                 _local = compiler.GetNamedLocal(variable.IsByRef ? variable.Type.MakeByRefType() : variable.Type, variable);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.cs
@@ -25,7 +25,7 @@ namespace System.Linq.Expressions.Compiler
     ///   1. Parent relationship (for resolving variables)
     ///   2. Information about hoisted variables
     ///   3. Information for resolving closures
-    /// 
+    ///
     /// Instances are produced by VariableBinder, which does a tree walk
     /// looking for scope nodes: LambdaExpression, BlockExpression, and CatchBlock.
     /// </summary>
@@ -70,7 +70,7 @@ namespace System.Linq.Expressions.Compiler
 
         /// <summary>
         /// Scopes whose variables were merged into this one
-        /// 
+        ///
         /// Created lazily as we create hundreds of compiler scopes w/o merging scopes when compiling rules.
         /// </summary>
         internal HashSet<BlockExpression> MergedScopes;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.Generated.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Expressions.Compiler
     internal static partial class DelegateHelpers
     {
         /// <summary>
-        /// Finds a delegate type using the types in the array. 
+        /// Finds a delegate type using the types in the array.
         /// We use the cache to avoid copying the array, and to cache the
         /// created delegate type
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.netstandard1.7.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.netstandard1.7.cs
@@ -11,9 +11,9 @@ namespace System.Linq.Expressions.Compiler
     internal static partial class DelegateHelpers
     {
         /// <summary>
-        /// Finds a delegate type for a CallSite using the types in the ReadOnlyCollection of Expression. 
-        /// 
-        /// We take the readonly collection of Expression explicitly to avoid allocating memory (an array 
+        /// Finds a delegate type for a CallSite using the types in the ReadOnlyCollection of Expression.
+        ///
+        /// We take the readonly collection of Expression explicitly to avoid allocating memory (an array
         /// of types) on lookup of delegate types.
         /// </summary>
         internal static Type MakeCallSiteDelegate(ReadOnlyCollection<Expression> types, Type returnType)
@@ -45,8 +45,8 @@ namespace System.Linq.Expressions.Compiler
         }
 
         /// <summary>
-        /// Finds a delegate type for a CallSite using the MetaObject array. 
-        /// 
+        /// Finds a delegate type for a CallSite using the MetaObject array.
+        ///
         /// We take the array of MetaObject explicitly to avoid allocating memory (an array of types) on
         /// lookup of delegate types.
         /// </summary>
@@ -55,10 +55,10 @@ namespace System.Linq.Expressions.Compiler
             lock (_DelegateCache)
             {
                 TypeInfo curTypeInfo = _DelegateCache;
- 
+
                 // CallSite
                 curTypeInfo = NextTypeInfo(typeof(CallSite), curTypeInfo);
- 
+
                 // arguments
                 for (int i = 0; i < args.Length; i++)
                 {
@@ -70,10 +70,10 @@ namespace System.Linq.Expressions.Compiler
                     }
                     curTypeInfo = NextTypeInfo(paramType, curTypeInfo);
                 }
- 
+
                 // return type
                 curTypeInfo = NextTypeInfo(returnType, curTypeInfo);
- 
+
                 // see if we have the delegate already
                 if (curTypeInfo.DelegateType == null)
                 {
@@ -92,10 +92,10 @@ namespace System.Linq.Expressions.Compiler
                         }
                         paramTypes[i + 1] = paramType;
                     }
- 
+
                     curTypeInfo.DelegateType = MakeNewDelegate(paramTypes);
                 }
- 
+
                 return curTypeInfo.DelegateType;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/HoistedLocals.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/HoistedLocals.cs
@@ -15,7 +15,7 @@ namespace System.Linq.Expressions.Compiler
     //    (string s)=>()=>s.
     //
     // We wish to generate the outer as:
-    // 
+    //
     //      Func<string> OuterMethod(Closure closure, string s)
     //      {
     //          object[] locals = new object[1];
@@ -23,9 +23,9 @@ namespace System.Linq.Expressions.Compiler
     //          ((StrongBox<string>)locals[0]).Value = s;
     //          return ((DynamicMethod)closure.Constants[0]).CreateDelegate(typeof(Func<string>), new Closure(null, locals));
     //      }
-    //      
+    //
     // ... and the inner as:
-    // 
+    //
     //      string InnerMethod(Closure closure)
     //      {
     //          object[] locals = closure.Locals;
@@ -38,10 +38,10 @@ namespace System.Linq.Expressions.Compiler
     /// <summary>
     /// Stores information about locals and arguments that are hoisted into
     /// the closure array because they're referenced in an inner lambda.
-    /// 
+    ///
     /// This class is sometimes emitted as a runtime constant for internal
     /// use to hoist variables/parameters in quoted expressions
-    /// 
+    ///
     /// Invariant: this class stores no mutable state
     /// </summary>
     internal sealed class HoistedLocals

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -1035,7 +1035,7 @@ namespace System.Linq.Expressions.Compiler
         {
             Debug.Assert(TypeUtils.IsNullableType(typeFrom));
             // We've got a conversion from nullable to Object, ValueType, Enum, etc.  Just box it so that
-            // we get the nullable semantics.  
+            // we get the nullable semantics.
             il.Emit(OpCodes.Box, typeFrom);
         }
 
@@ -1115,7 +1115,7 @@ namespace System.Linq.Expressions.Compiler
         }
 
         /// <summary>
-        /// Emits an array construction code.  
+        /// Emits an array construction code.
         /// The code assumes that bounds for all dimensions
         /// are already emitted.
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LabelInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LabelInfo.cs
@@ -69,7 +69,7 @@ namespace System.Linq.Expressions.Compiler
 
         /// <summary>
         /// Indicates if it is legal to emit a "branch" instruction based on
-        /// currently available information. Call the Reference method before 
+        /// currently available information. Call the Reference method before
         /// using this property.
         /// </summary>
         internal bool CanBranch => _opCode != OpCodes.Leave;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
@@ -146,7 +146,7 @@ namespace System.Linq.Expressions.Compiler
                 // the address of field bar to do the call.  The address of a local which
                 // has the same value as bar is sufficient.
 
-                // The C# compiler will not compile a lambda expression tree 
+                // The C# compiler will not compile a lambda expression tree
                 // which writes to the address of an init-only field. But one could
                 // probably use the expression tree API to build such an expression.
                 // (When compiled, such an expression would fail silently.)  It might

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -360,7 +360,7 @@ namespace System.Linq.Expressions.Compiler
             _ilg.Emit(OpCodes.And);
         }
 
-        // Binary/unary operations on 8 and 16 bit operand types will leave a 
+        // Binary/unary operations on 8 and 16 bit operand types will leave a
         // 32-bit value on the stack, because that's how IL works. For these
         // cases, we need to cast it back to the resultType, possibly using a
         // checked conversion if the original operator was convert

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.ControlFlow.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.ControlFlow.cs
@@ -104,7 +104,7 @@ namespace System.Linq.Expressions.Compiler
             CompilationFlags tailCall = flags & CompilationFlags.EmitAsTailCallMask;
             if (tailCall != CompilationFlags.EmitAsNoTail)
             {
-                // Since tail call flags are not passed into EmitTryExpression, CanReturn 
+                // Since tail call flags are not passed into EmitTryExpression, CanReturn
                 // means the goto will be emitted as Ret. Therefore we can emit the goto's
                 // default value with tail call. This can be improved by detecting if the
                 // target label is equivalent to the return label.
@@ -147,7 +147,7 @@ namespace System.Linq.Expressions.Compiler
             // Anything that is "statement-like" -- e.g. has no associated
             // stack state can be jumped into, with the exception of try-blocks
             // We indicate this by a "Block"
-            // 
+            //
             // Otherwise, we push an "Expression" to indicate that it can't be
             // jumped into
             switch (node.NodeType)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -372,7 +372,7 @@ namespace System.Linq.Expressions.Compiler
                 Debug.Assert(obj != null);
                 EmitInstance(obj, out objectType);
             }
-            // if the obj has a value type, its address is passed to the method call so we cannot destroy the 
+            // if the obj has a value type, its address is passed to the method call so we cannot destroy the
             // stack by emitting a tail call
             if (obj != null && obj.Type.GetTypeInfo().IsValueType)
             {
@@ -403,7 +403,7 @@ namespace System.Linq.Expressions.Compiler
                 // This automatically boxes value types if necessary.
                 _ilg.Emit(OpCodes.Constrained, objectType);
             }
-            // The method call can be a tail call if 
+            // The method call can be a tail call if
             // 1) the method call is the last instruction before Ret
             // 2) the method does not have any ByRef parameters, refer to ECMA-335 Partition III Section 2.4.
             //    "Verification requires that no managed pointers are passed to the method being called, since
@@ -474,7 +474,7 @@ namespace System.Linq.Expressions.Compiler
             //
             // We never need to generate a non-virtual call to a virtual method on a reference type because
             // expression trees do not support "base.Foo()" style calling.
-            // 
+            //
             // We could do an optimization here for the case where we know that the object is a non-null
             // reference type and the method is a non-virtual instance method.  For example, if we had
             // (new Foo()).Bar() for instance method Bar we don't need the null check so we could do a

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Lambda.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Lambda.cs
@@ -88,7 +88,7 @@ namespace System.Linq.Expressions.Compiler
 
         /// <summary>
         /// Emits code which creates new instance of the delegateType delegate.
-        /// 
+        ///
         /// Since the delegate is getting closed over the "Closure" argument, this
         /// cannot be used with virtual/instance methods (inner must be static method)
         /// </summary>
@@ -125,7 +125,7 @@ namespace System.Linq.Expressions.Compiler
         /// May end up creating a wrapper to match the requested delegate type.
         /// </summary>
         /// <param name="lambda">Lambda for which to generate a delegate</param>
-        /// 
+        ///
         private void EmitDelegateConstruction(LambdaExpression lambda)
         {
             // 1. Create the new compiler
@@ -206,7 +206,7 @@ namespace System.Linq.Expressions.Compiler
         /// <param name="parent">The parent scope.</param>
         /// <param name="inlined">true if the lambda is inlined; false otherwise.</param>
         /// <param name="flags">
-        /// The enum to specify if the lambda is compiled with the tail call optimization. 
+        /// The enum to specify if the lambda is compiled with the tail call optimization.
         /// </param>
         private void EmitLambdaBody(CompilerScope parent, bool inlined, CompilationFlags flags)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
@@ -504,13 +504,13 @@ namespace System.Linq.Expressions.Compiler
         /// and generate similar IL to the C# compiler. This is important for
         /// the JIT to optimize patterns like:
         ///     x != null AndAlso x.GetType() == typeof(SomeType)
-        ///     
+        ///
         /// One optimization we don't do: we always emits at least one
         /// conditional branch to the label, and always possibly falls through,
         /// even if we know if the branch will always succeed or always fail.
         /// We do this to avoid generating unreachable code, which is fine for
         /// the CLR JIT, but doesn't verify with peverify.
-        /// 
+        ///
         /// This kind of optimization could be implemented safely, by doing
         /// constant folding over conditionals and logical expressions at the
         /// tree level.
@@ -632,7 +632,7 @@ namespace System.Linq.Expressions.Compiler
             }
         }
 
-        // For optimized Equal/NotEqual, we can eliminate reference 
+        // For optimized Equal/NotEqual, we can eliminate reference
         // conversions. IL allows comparing managed pointers regardless of
         // type. See ECMA-335 "Binary Comparison or Branch Operations", in
         // Partition III, Section 1.5 Table 4.
@@ -691,7 +691,7 @@ namespace System.Linq.Expressions.Compiler
         // or optimized OrElse with branch == false
         private void EmitBranchAnd(bool branch, BinaryExpression node, Label label)
         {
-            // if (left) then 
+            // if (left) then
             //   if (right) branch label
             // endif
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
@@ -569,7 +569,7 @@ namespace System.Linq.Expressions.Compiler
                 return;
             }
 
-            // 
+            //
             // If we're switching off of Int64/UInt64, we need more guards here
             // because we'll have to narrow the switch value to an Int32, and
             // we can't do that unless the value is in the right range.
@@ -913,7 +913,7 @@ namespace System.Linq.Expressions.Compiler
             }
 
             // emit filter block. Filter blocks are untyped so we need to do
-            // the type check ourselves.  
+            // the type check ourselves.
             Label endFilter = _ilg.DefineLabel();
             Label rightType = _ilg.DefineLabel();
 
@@ -934,7 +934,7 @@ namespace System.Linq.Expressions.Compiler
             EmitExpression(cb.Filter);
             PopLabelBlock(LabelScopeKind.Filter);
 
-            // begin the catch, clear the exception, we've 
+            // begin the catch, clear the exception, we've
             // already saved it
             _ilg.MarkLabel(endFilter);
             _ilg.BeginCatchBlock(exceptionType: null);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.cs
@@ -67,12 +67,12 @@ namespace System.Linq.Expressions.Compiler
             _lambda = lambda;
             _method = method;
 
-            // In a Win8 immersive process user code is not allowed to access non-W8P framework APIs through 
+            // In a Win8 immersive process user code is not allowed to access non-W8P framework APIs through
             // reflection or RefEmit. Framework code, however, is given an exemption.
             // This is to make sure that user code cannot access non-W8P framework APIs via ExpressionTree.
 
             // TODO: This API is not available, is there an alternative way to achieve the same.
-            // method.ProfileAPICheck = true; 
+            // method.ProfileAPICheck = true;
 
             _ilg = method.GetILGenerator();
 
@@ -189,7 +189,7 @@ namespace System.Linq.Expressions.Compiler
         /// <summary>
         /// Mutates the MethodBuilder parameter, filling in IL, parameters,
         /// and return type.
-        /// 
+        ///
         /// (probably shouldn't be modifying parameters/return type...)
         /// </summary>
         internal static void Compile(LambdaExpression lambda, MethodBuilder method)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Generated.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Expressions.Compiler
         /// <summary>
         /// Rewrite the expression
         /// </summary>
-        /// 
+        ///
         /// <param name="node">Expression to rewrite</param>
         /// <param name="stack">State of the stack before the expression is emitted.</param>
         /// <returns>Rewritten expression.</returns>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Temps.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Temps.cs
@@ -87,7 +87,7 @@ namespace System.Linq.Expressions.Compiler
                 return _usedTemps != null ? _usedTemps.Count : 0;
             }
 
-            // Free temporaries created since the last marking. 
+            // Free temporaries created since the last marking.
             // This is a performance optimization to lower the overall number of temporaries needed.
             internal void Free(int mark)
             {
@@ -119,8 +119,8 @@ namespace System.Linq.Expressions.Compiler
         /// stack starts in the initial state, and after the first subexpression
         /// is added it is changed to non-empty. This behavior can be overridden
         /// by setting the stack manually between adds.
-        /// 
-        /// When all children have been added, the caller should rewrite the 
+        ///
+        /// When all children have been added, the caller should rewrite the
         /// node if Rewrite is true. Then, it should call Finish with either
         /// the original expression or the rewritten expression. Finish will call
         /// Expression.Comma if necessary and return a new Result.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
@@ -188,7 +188,7 @@ namespace System.Linq.Expressions.Compiler
                     new IndexExpression(
                         cr[0],                              // Object
                         index.Indexer,
-                        cr[1, -2]                           // arguments                        
+                        cr[1, -2]                           // arguments
                     ),
                     cr[-1]                                  // value
                 );
@@ -206,7 +206,7 @@ namespace System.Linq.Expressions.Compiler
             Result left = RewriteExpression(node.Left, stack);
             // ... and so does the right one
             Result right = RewriteExpression(node.Right, stack);
-            //conversion is a lambda. stack state will be ignored. 
+            //conversion is a lambda. stack state will be ignored.
             Result conversion = RewriteExpression(node.Conversion, stack);
 
             RewriteAction action = left.Action | right.Action | conversion.Action;
@@ -468,7 +468,7 @@ namespace System.Linq.Expressions.Compiler
             }
             else
             {
-                // In a case of NewArrayBounds we make no modifications to the stack 
+                // In a case of NewArrayBounds we make no modifications to the stack
                 // before emitting bounds expressions.
             }
 
@@ -503,7 +503,7 @@ namespace System.Linq.Expressions.Compiler
                     RequireNoRefArgs(Expression.GetInvokeMethod(node.Expression));
                 }
 
-                // Lambda body also executes on current stack 
+                // Lambda body also executes on current stack
                 var spiller = new StackSpiller(stack);
                 lambda = lambda.Accept(spiller);
 
@@ -1028,7 +1028,7 @@ namespace System.Linq.Expressions.Compiler
         /// <summary>
         /// If we are spilling, requires that there are no byref arguments to
         /// the method call.
-        /// 
+        ///
         /// Used for:
         ///   NewExpression,
         ///   MethodCallExpression,
@@ -1053,7 +1053,7 @@ namespace System.Linq.Expressions.Compiler
         /// <summary>
         /// Requires that the instance is not a value type (primitive types are
         /// okay because they're immutable).
-        /// 
+        ///
         /// Used for:
         ///  MethodCallExpression,
         ///  MemberExpression (for properties),

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ConditionalExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ConditionalExpression.cs
@@ -130,8 +130,8 @@ namespace System.Linq.Expressions
         /// <param name="test">An <see cref="Expression"/> to set the <see cref="ConditionalExpression.Test"/> property equal to.</param>
         /// <param name="ifTrue">An <see cref="Expression"/> to set the <see cref="ConditionalExpression.IfTrue"/> property equal to.</param>
         /// <param name="ifFalse">An <see cref="Expression"/> to set the <see cref="ConditionalExpression.IfFalse"/> property equal to.</param>
-        /// <returns>A <see cref="ConditionalExpression"/> that has the <see cref="NodeType"/> property equal to 
-        /// <see cref="ExpressionType.Conditional"/> and the <see cref="ConditionalExpression.Test"/>, <see cref="ConditionalExpression.IfTrue"/>, 
+        /// <returns>A <see cref="ConditionalExpression"/> that has the <see cref="NodeType"/> property equal to
+        /// <see cref="ExpressionType.Conditional"/> and the <see cref="ConditionalExpression.Test"/>, <see cref="ConditionalExpression.IfTrue"/>,
         /// and <see cref="ConditionalExpression.IfFalse"/> properties set to the specified values.</returns>
         public static ConditionalExpression Condition(Expression test, Expression ifTrue, Expression ifFalse)
         {
@@ -150,7 +150,7 @@ namespace System.Linq.Expressions
 
             return ConditionalExpression.Make(test, ifTrue, ifFalse, ifTrue.Type);
         }
-        
+
         /// <summary>
         /// Creates a <see cref="ConditionalExpression"/>.
         /// </summary>
@@ -158,8 +158,8 @@ namespace System.Linq.Expressions
         /// <param name="ifTrue">An <see cref="Expression"/> to set the <see cref="ConditionalExpression.IfTrue"/> property equal to.</param>
         /// <param name="ifFalse">An <see cref="Expression"/> to set the <see cref="ConditionalExpression.IfFalse"/> property equal to.</param>
         /// <param name="type">A <see cref="Type"/> to set the <see cref="Type"/> property equal to.</param>
-        /// <returns>A <see cref="ConditionalExpression"/> that has the <see cref="NodeType"/> property equal to 
-        /// <see cref="ExpressionType.Conditional"/> and the <see cref="ConditionalExpression.Test"/>, <see cref="ConditionalExpression.IfTrue"/>, 
+        /// <returns>A <see cref="ConditionalExpression"/> that has the <see cref="NodeType"/> property equal to
+        /// <see cref="ExpressionType.Conditional"/> and the <see cref="ConditionalExpression.Test"/>, <see cref="ConditionalExpression.IfTrue"/>,
         /// and <see cref="ConditionalExpression.IfFalse"/> properties set to the specified values.</returns>
         /// <remarks>This method allows explicitly unifying the result type of the conditional expression in cases where the types of <paramref name="ifTrue"/>
         /// and <paramref name="ifFalse"/> expressions are not equal. Types of both <paramref name="ifTrue"/> and <paramref name="ifFalse"/> must be implicitly
@@ -193,8 +193,8 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="test">An <see cref="Expression"/> to set the <see cref="ConditionalExpression.Test"/> property equal to.</param>
         /// <param name="ifTrue">An <see cref="Expression"/> to set the <see cref="ConditionalExpression.IfTrue"/> property equal to.</param>
-        /// <returns>A <see cref="ConditionalExpression"/> that has the <see cref="NodeType"/> property equal to 
-        /// <see cref="ExpressionType.Conditional"/> and the <see cref="ConditionalExpression.Test"/>, <see cref="ConditionalExpression.IfTrue"/>, 
+        /// <returns>A <see cref="ConditionalExpression"/> that has the <see cref="NodeType"/> property equal to
+        /// <see cref="ExpressionType.Conditional"/> and the <see cref="ConditionalExpression.Test"/>, <see cref="ConditionalExpression.IfTrue"/>,
         /// properties set to the specified values. The <see cref="ConditionalExpression.IfFalse"/> property is set to default expression and
         /// the type of the resulting <see cref="ConditionalExpression"/> returned by this method is <see cref="Void"/>.</returns>
         public static ConditionalExpression IfThen(Expression test, Expression ifTrue)
@@ -208,8 +208,8 @@ namespace System.Linq.Expressions
         /// <param name="test">An <see cref="Expression"/> to set the <see cref="ConditionalExpression.Test"/> property equal to.</param>
         /// <param name="ifTrue">An <see cref="Expression"/> to set the <see cref="ConditionalExpression.IfTrue"/> property equal to.</param>
         /// <param name="ifFalse">An <see cref="Expression"/> to set the <see cref="ConditionalExpression.IfFalse"/> property equal to.</param>
-        /// <returns>A <see cref="ConditionalExpression"/> that has the <see cref="NodeType"/> property equal to 
-        /// <see cref="ExpressionType.Conditional"/> and the <see cref="ConditionalExpression.Test"/>, <see cref="ConditionalExpression.IfTrue"/>, 
+        /// <returns>A <see cref="ConditionalExpression"/> that has the <see cref="NodeType"/> property equal to
+        /// <see cref="ExpressionType.Conditional"/> and the <see cref="ConditionalExpression.Test"/>, <see cref="ConditionalExpression.IfTrue"/>,
         /// and <see cref="ConditionalExpression.IfFalse"/> properties set to the specified values. The type of the resulting <see cref="ConditionalExpression"/>
         /// returned by this method is <see cref="Void"/>.</returns>
         public static ConditionalExpression IfThenElse(Expression test, Expression ifTrue, Expression ifFalse)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ConstantExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ConstantExpression.cs
@@ -75,7 +75,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="value">An <see cref="Object"/> to set the <see cref="ConstantExpression.Value"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="ConstantExpression"/> that has the <see cref="NodeType"/> property equal to 
+        /// A <see cref="ConstantExpression"/> that has the <see cref="NodeType"/> property equal to
         /// <see cref="ExpressionType.Constant"/> and the <see cref="ConstantExpression.Value"/> property set to the specified value.
         /// </returns>
         public static ConstantExpression Constant(object value)
@@ -84,14 +84,14 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates a <see cref="ConstantExpression"/> that has the <see cref="ConstantExpression.Value"/> 
+        /// Creates a <see cref="ConstantExpression"/> that has the <see cref="ConstantExpression.Value"/>
         /// and <see cref="ConstantExpression.Type"/> properties set to the specified values. .
         /// </summary>
         /// <param name="value">An <see cref="Object"/> to set the <see cref="ConstantExpression.Value"/> property equal to.</param>
         /// <param name="type">A <see cref="Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="ConstantExpression"/> that has the <see cref="NodeType"/> property equal to 
-        /// <see cref="ExpressionType.Constant"/> and the <see cref="ConstantExpression.Value"/> and 
+        /// A <see cref="ConstantExpression"/> that has the <see cref="NodeType"/> property equal to
+        /// <see cref="ExpressionType.Constant"/> and the <see cref="ConstantExpression.Value"/> and
         /// <see cref="Type"/> properties set to the specified values.
         /// </returns>
         public static ConstantExpression Constant(object value, Type type)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugInfoExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugInfoExpression.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Expressions
 {
     /// <summary>
     /// Emits or clears a sequence point for debug information.
-    /// 
+    ///
     /// This allows the debugger to highlight the correct source code when
     /// debugging.
     /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugViewWriter.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugViewWriter.cs
@@ -616,7 +616,7 @@ namespace System.Linq.Expressions
                 // 3) Parent op is -, / or %, and the child is the left operand.
                 // In this case, if left and right operand are the same, we don't
                 // remove parenthesis, e.g. (x + y) - (x + y)
-                // 
+                //
                 switch (parent.NodeType)
                 {
                     case ExpressionType.AndAlso:

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DefaultExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DefaultExpression.cs
@@ -46,12 +46,12 @@ namespace System.Linq.Expressions
         /// Creates an empty expression that has <see cref="Void"/> type.
         /// </summary>
         /// <returns>
-        /// A <see cref="DefaultExpression"/> that has the <see cref="NodeType"/> property equal to 
+        /// A <see cref="DefaultExpression"/> that has the <see cref="NodeType"/> property equal to
         /// <see cref="ExpressionType.Default"/> and the <see cref="Type"/> property set to <see cref="Void"/>.
         /// </returns>
         public static DefaultExpression Empty()
         {
-            return new DefaultExpression(typeof(void)); // Create new object each time for different identity 
+            return new DefaultExpression(typeof(void)); // Create new object each time for different identity
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="type">A <see cref="Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="DefaultExpression"/> that has the <see cref="NodeType"/> property equal to 
+        /// A <see cref="DefaultExpression"/> that has the <see cref="NodeType"/> property equal to
         /// <see cref="ExpressionType.Default"/> and the <see cref="Type"/> property set to the specified type.
         /// </returns>
         public static DefaultExpression Default(Type type)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
@@ -173,11 +173,11 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Makes a copy of this node replacing the args with the provided values.  The 
+        /// Makes a copy of this node replacing the args with the provided values.  The
         /// number of the args needs to match the number of the current block.
-        /// 
+        ///
         /// This helper is provided to allow re-writing of nodes to not depend on the specific optimized
-        /// subclass of DynamicExpression which is being used. 
+        /// subclass of DynamicExpression which is being used.
         /// </summary>
         internal virtual DynamicExpression Rewrite(Expression[] args)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ElementInit.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ElementInit.cs
@@ -67,7 +67,7 @@ namespace System.Linq.Expressions
             return Expression.ElementInit(AddMethod, arguments);
         }
     }
-    
+
     public partial class Expression
     {
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -250,7 +250,7 @@ namespace System.Linq.Expressions
         internal static Exception OnlyStaticPropertiesHaveNullInstance(string paramName)
         {
             return new ArgumentException(Strings.OnlyStaticPropertiesHaveNullInstance, paramName);
-        }   
+        }
         /// <summary>
         /// ArgumentException with message like "Static method requires null instance, non-static method requires non-null instance."
         /// </summary>
@@ -1284,7 +1284,7 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// The exception that is thrown when an invoked method is not supported, or when there is an attempt to read, seek, or write to a stream that does not support the invoked functionality. 
+        /// The exception that is thrown when an invoked method is not supported, or when there is an attempt to read, seek, or write to a stream that does not support the invoked functionality.
         /// </summary>
         internal static Exception NotSupported()
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
@@ -110,7 +110,7 @@ comparand: null
         }
 
         /// <summary>
-        /// Indicates that the node can be reduced to a simpler node. If this 
+        /// Indicates that the node can be reduced to a simpler node. If this
         /// returns true, Reduce() can be called to produce the reduced form.
         /// </summary>
         public virtual bool CanReduce => false;
@@ -134,7 +134,7 @@ comparand: null
         /// <param name="visitor">An instance of <see cref="ExpressionVisitor"/>.</param>
         /// <returns>The expression being visited, or an expression which should replace it in the tree.</returns>
         /// <remarks>
-        /// Override this method to provide logic to walk the node's children. 
+        /// Override this method to provide logic to walk the node's children.
         /// A typical implementation will call visitor.Visit on each of its
         /// children, and if any of them change, should return a new copy of
         /// itself with the modified children.
@@ -231,12 +231,12 @@ comparand: null
 
         /// <summary>
         /// Helper used for ensuring we only return 1 instance of a ReadOnlyCollection of T.
-        /// 
+        ///
         /// This is called from various methods where we internally hold onto an IList of T
-        /// or a readonly collection of T.  We check to see if we've already returned a 
-        /// readonly collection of T and if so simply return the other one.  Otherwise we do 
+        /// or a readonly collection of T.  We check to see if we've already returned a
+        /// readonly collection of T and if so simply return the other one.  Otherwise we do
         /// a thread-safe replacement of the list w/ a readonly collection which wraps it.
-        /// 
+        ///
         /// Ultimately this saves us from having to allocate a ReadOnlyCollection for our
         /// data types because the compiler is capable of going directly to the IList of T.
         /// </summary>
@@ -247,16 +247,16 @@ comparand: null
 
         /// <summary>
         /// Helper used for ensuring we only return 1 instance of a ReadOnlyCollection of T.
-        /// 
-        /// This is similar to the ReturnReadOnly of T. This version supports nodes which hold 
+        ///
+        /// This is similar to the ReturnReadOnly of T. This version supports nodes which hold
         /// onto multiple Expressions where one is typed to object.  That object field holds either
         /// an expression or a ReadOnlyCollection of Expressions.  When it holds a ReadOnlyCollection
         /// the IList which backs it is a ListArgumentProvider which uses the Expression which
-        /// implements IArgumentProvider to get 2nd and additional values.  The ListArgumentProvider 
-        /// continues to hold onto the 1st expression.  
-        /// 
-        /// This enables users to get the ReadOnlyCollection w/o it consuming more memory than if 
-        /// it was just an array.  Meanwhile The DLR internally avoids accessing  which would force 
+        /// implements IArgumentProvider to get 2nd and additional values.  The ListArgumentProvider
+        /// continues to hold onto the 1st expression.
+        ///
+        /// This enables users to get the ReadOnlyCollection w/o it consuming more memory than if
+        /// it was just an array.  Meanwhile The DLR internally avoids accessing  which would force
         /// the readonly collection to be created resulting in a typical memory savings.
         /// </summary>
         internal static ReadOnlyCollection<Expression> ReturnReadOnly(IArgumentProvider provider, ref object collection)
@@ -265,9 +265,9 @@ comparand: null
         }
 
         /// <summary>
-        /// Helper which is used for specialized subtypes which use ReturnReadOnly(ref object, ...). 
+        /// Helper which is used for specialized subtypes which use ReturnReadOnly(ref object, ...).
         /// This is the reverse version of ReturnReadOnly which takes an IArgumentProvider.
-        /// 
+        ///
         /// This is used to return the 1st argument.  The 1st argument is typed as object and either
         /// contains a ReadOnlyCollection or the Expression.  We check for the Expression and if it's
         /// present we return that, otherwise we return the 1st element of the ReadOnlyCollection.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/GotoExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/GotoExpression.cs
@@ -105,7 +105,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Break"/>, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Break"/>,
         /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, and a null value to be passed to the target label upon jumping.
         /// </returns>
         public static GotoExpression Break(LabelTarget target)
@@ -119,8 +119,8 @@ namespace System.Linq.Expressions
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Break"/>, 
-        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Break"/>,
+        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>,
         /// and <paramref name="value"/> to be passed to the target label upon jumping.
         /// </returns>
         public static GotoExpression Break(LabelTarget target, Expression value)
@@ -134,8 +134,8 @@ namespace System.Linq.Expressions
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <param name="type">A <see cref="System.Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Break"/>, 
-        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Break"/>,
+        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>,
         /// and the <see cref="Type"/> property set to <paramref name="type"/>.
         /// </returns>
         public static GotoExpression Break(LabelTarget target, Type type)
@@ -144,15 +144,15 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates a <see cref="GotoExpression"/> representing a break statement with the specified type. 
+        /// Creates a <see cref="GotoExpression"/> representing a break statement with the specified type.
         /// The value passed to the label upon jumping can be specified.
         /// </summary>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <param name="type">A <see cref="System.Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Break"/>, 
-        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Break"/>,
+        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>,
         /// the <see cref="Type"/> property set to <paramref name="type"/>,
         /// and <paramref name="value"/> to be passed to the target label upon jumping.
         /// </returns>
@@ -166,8 +166,8 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Continue"/>, 
-        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Continue"/>,
+        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>,
         /// and a null value to be passed to the target label upon jumping.
         /// </returns>
         public static GotoExpression Continue(LabelTarget target)
@@ -181,8 +181,8 @@ namespace System.Linq.Expressions
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <param name="type">A <see cref="System.Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Continue"/>, 
-        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Continue"/>,
+        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>,
         /// the <see cref="Type"/> property set to <paramref name="type"/>,
         /// and a null value to be passed to the target label upon jumping.
         /// </returns>
@@ -196,8 +196,8 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Return"/>, 
-        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Return"/>,
+        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>,
         /// and a null value to be passed to the target label upon jumping.
         /// </returns>
         public static GotoExpression Return(LabelTarget target)
@@ -211,8 +211,8 @@ namespace System.Linq.Expressions
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <param name="type">A <see cref="System.Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Return"/>, 
-        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Return"/>,
+        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>,
         /// the <see cref="Type"/> property set to <paramref name="type"/>,
         /// and a null value to be passed to the target label upon jumping.
         /// </returns>
@@ -227,8 +227,8 @@ namespace System.Linq.Expressions
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Return"/>, 
-        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Return"/>,
+        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>,
         /// and <paramref name="value"/> to be passed to the target label upon jumping.
         /// </returns>
         public static GotoExpression Return(LabelTarget target, Expression value)
@@ -237,15 +237,15 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates a <see cref="GotoExpression"/> representing a return statement with the specified type. 
+        /// Creates a <see cref="GotoExpression"/> representing a return statement with the specified type.
         /// The value passed to the label upon jumping can be specified.
         /// </summary>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <param name="type">A <see cref="System.Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Return"/>, 
-        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Return"/>,
+        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>,
         /// the <see cref="Type"/> property set to <paramref name="type"/>,
         /// and <paramref name="value"/> to be passed to the target label upon jumping.
         /// </returns>
@@ -259,8 +259,8 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Goto"/>, 
-        /// the <see cref="GotoExpression.Target"/> property set to the specified value, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Goto"/>,
+        /// the <see cref="GotoExpression.Target"/> property set to the specified value,
         /// and a null value to be passed to the target label upon jumping.
         /// </returns>
         public static GotoExpression Goto(LabelTarget target)
@@ -274,8 +274,8 @@ namespace System.Linq.Expressions
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <param name="type">A <see cref="System.Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Goto"/>, 
-        /// the <see cref="GotoExpression.Target"/> property set to the specified value, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Goto"/>,
+        /// the <see cref="GotoExpression.Target"/> property set to the specified value,
         /// the <see cref="Type"/> property set to <paramref name="type"/>,
         /// and a null value to be passed to the target label upon jumping.
         /// </returns>
@@ -290,8 +290,8 @@ namespace System.Linq.Expressions
         /// <param name="target">The <see cref="LabelTarget"/> that the <see cref="GotoExpression"/> will jump to.</param>
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Goto"/>, 
-        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Goto"/>,
+        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>,
         /// and <paramref name="value"/> to be passed to the target label upon jumping.
         /// </returns>
         public static GotoExpression Goto(LabelTarget target, Expression value)
@@ -307,8 +307,8 @@ namespace System.Linq.Expressions
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <param name="type">A <see cref="System.Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Goto"/>, 
-        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <see cref="GotoExpressionKind.Goto"/>,
+        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>,
         /// the <see cref="Type"/> property set to <paramref name="type"/>,
         /// and <paramref name="value"/> to be passed to the target label upon jumping.
         /// </returns>
@@ -326,8 +326,8 @@ namespace System.Linq.Expressions
         /// <param name="value">The value that will be passed to the associated label upon jumping.</param>
         /// <param name="type">A <see cref="System.Type"/> to set the <see cref="Type"/> property equal to.</param>
         /// <returns>
-        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <paramref name="kind"/>, 
-        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>, 
+        /// A <see cref="GotoExpression"/> with <see cref="GotoExpression.Kind"/> equal to <paramref name="kind"/>,
+        /// the <see cref="GotoExpression.Target"/> property set to <paramref name="target"/>,
         /// the <see cref="Type"/> property set to <paramref name="type"/>,
         /// and <paramref name="value"/> to be passed to the target label upon jumping.
         /// </returns>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IArgumentProvider.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IArgumentProvider.cs
@@ -18,16 +18,16 @@ namespace System.Linq.Expressions
     /// both a <see cref="Collections.ObjectModel.ReadOnlyCollection{T}"/> and an array for storing their
     /// elements, thus saving 32 bytes per node.  This technique is used by various nodes including
     /// <see cref="BlockExpression"/>, <see cref="InvocationExpression"/>, <see cref="MethodCallExpression"/>.
-    /// 
+    ///
     /// Meanwhile the nodes can expose properties of <see cref="Collections.ObjectModel.ReadOnlyCollection{T}"/>s.
     /// They do this by re-using one field for storing both the array or an element that would normally be stored
     /// in the array.
-    /// 
+    ///
     /// For the array case the collection is typed to <see cref="Collections.Generic.IList{T}"/> instead
     /// of <see cref="Collections.ObjectModel.ReadOnlyCollection{T}"/>. When the node is initially constructed
     /// it is an array.  When utilities in this library access the arguments it uses this interface. If a user
     /// accesses the property the array is promoted to a <see cref="Collections.ObjectModel.ReadOnlyCollection{T}"/>.
-    /// 
+    ///
     /// For the object case we store the first argument in a field typed to <see cref="object"/> and when
     /// the node is initially constructed this holds directly onto the <see cref="Expression"/> of the
     /// first argument.  When utilities in this library access the arguments it again uses this interface
@@ -35,8 +35,8 @@ namespace System.Linq.Expressions
     /// which handles the <see cref="Expression"/> or <see cref="Collections.ObjectModel.ReadOnlyCollection{T}"/> case.
     /// When the user accesses the property the object field is updated to hold directly onto the
     /// <see cref="Collections.ObjectModel.ReadOnlyCollection{T}"/>.
-    /// 
-    /// It is important that <see cref="Expression"/> properties consistently return the same 
+    ///
+    /// It is important that <see cref="Expression"/> properties consistently return the same
     /// <see cref="Collections.ObjectModel.ReadOnlyCollection{T}"/> otherwise the rewriter used by expression
     /// visitors will be broken and it would be a breaking change from LINQ v1.  The problem is that currently
     /// users can rely on object identity to tell if the node has changed.  Storing the read-only collection in

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IDynamicExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IDynamicExpression.cs
@@ -15,11 +15,11 @@ namespace System.Linq.Expressions
         Type DelegateType { get; }
 
         /// <summary>
-        /// Rewrite this node replacing the args with the provided values.  The 
+        /// Rewrite this node replacing the args with the provided values.  The
         /// number of the args needs to match the number of the current block.
-        /// 
-        /// This helper is provided to allow re-writing of nodes to not depend on the specific 
-        /// class of DynamicExpression which is being used. 
+        ///
+        /// This helper is provided to allow re-writing of nodes to not depend on the specific
+        /// class of DynamicExpression which is being used.
         /// </summary>
         Expression Rewrite(Expression[] args);
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/BranchLabel.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/BranchLabel.cs
@@ -36,7 +36,7 @@ namespace System.Linq.Expressions.Interpreter
         private int _stackDepth = UnknownDepth;
         private int _continuationStackDepth = UnknownDepth;
 
-        // Offsets of forward branching instructions targeting this label 
+        // Offsets of forward branching instructions targeting this label
         // that need to be updated after we emit the label.
         private List<int> _forwardBranchFixups;
 
@@ -45,7 +45,7 @@ namespace System.Linq.Expressions.Interpreter
         internal int LabelIndex { get; set; } = UnknownIndex;
         internal bool HasRuntimeLabel => LabelIndex != UnknownIndex;
         internal int TargetIndex => _targetIndex;
-        
+
         internal RuntimeLabel ToRuntimeLabel()
         {
             Debug.Assert(_targetIndex != UnknownIndex && _stackDepth != UnknownDepth && _continuationStackDepth != UnknownDepth);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
@@ -24,13 +24,13 @@ namespace System.Linq.Expressions.Interpreter
         /// Fast creation works if we have a known primitive types for the entire
         /// method signature.  If we have any non-primitive types then FastCreate
         /// falls back to SlowCreate which works for all types.
-        /// 
+        ///
         /// Fast creation is fast because it avoids using reflection (MakeGenericType
         /// and Activator.CreateInstance) to create the types.  It does this through
         /// calling a series of generic methods picking up each strong type of the
-        /// signature along the way.  When it runs out of types it news up the 
+        /// signature along the way.  When it runs out of types it news up the
         /// appropriate CallInstruction with the strong-types that have been built up.
-        /// 
+        ///
         /// One relaxation is that for return types which are non-primitive types
         /// we can fall back to object due to relaxed delegates.
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -85,7 +85,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
             }
 
-            // create it 
+            // create it
             try
             {
 #if FEATURE_FAST_CREATE
@@ -110,9 +110,9 @@ namespace System.Linq.Expressions.Interpreter
             }
             catch (NotSupportedException)
             {
-                // if Delegate.CreateDelegate can't handle the method fall back to 
-                // the slow reflection version.  For example this can happen w/ 
-                // a generic method defined on an interface and implemented on a class or 
+                // if Delegate.CreateDelegate can't handle the method fall back to
+                // the slow reflection version.  For example this can happen w/
+                // a generic method defined on an interface and implemented on a class or
                 // a virtual generic method.
                 res = new MethodInfoCallInstruction(info, argumentCount);
             }
@@ -260,12 +260,12 @@ namespace System.Linq.Expressions.Interpreter
         public override int ConsumedStack => ArgumentCount;
 
         public override string ToString() => "Call()";
-        
+
         #endregion
 
         /// <summary>
         /// If the target of invocation happens to be a delegate
-        /// over enclosed instance lightLambda, return that instance. 
+        /// over enclosed instance lightLambda, return that instance.
         /// We can interpret LightLambdas directly.
         /// </summary>
         /// <param name="instance"></param>
@@ -476,7 +476,7 @@ namespace System.Linq.Expressions.Interpreter
                     {
                         if (arg.ArgumentIndex == -1)
                         {
-                            // instance param, just copy back the exact instance invoked with, which 
+                            // instance param, just copy back the exact instance invoked with, which
                             // gets passed by reference from reflection for value types.
                             arg.Update(frame, instance);
                         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -220,27 +220,27 @@ namespace System.Linq.Expressions.Interpreter
     }
 
     /// <summary>
-    /// This instruction implements a goto expression that can jump out of any expression. 
-    /// It pops values (arguments) from the evaluation stack that the expression tree nodes in between 
-    /// the goto expression and the target label node pushed and not consumed yet. 
-    /// A goto expression can jump into a node that evaluates arguments only if it carries 
-    /// a value and jumps right after the first argument (the carried value will be used as the first argument). 
-    /// Goto can jump into an arbitrary child of a BlockExpression since the block doesn't accumulate values 
+    /// This instruction implements a goto expression that can jump out of any expression.
+    /// It pops values (arguments) from the evaluation stack that the expression tree nodes in between
+    /// the goto expression and the target label node pushed and not consumed yet.
+    /// A goto expression can jump into a node that evaluates arguments only if it carries
+    /// a value and jumps right after the first argument (the carried value will be used as the first argument).
+    /// Goto can jump into an arbitrary child of a BlockExpression since the block doesn't accumulate values
     /// on evaluation stack as its child expressions are being evaluated.
-    /// 
+    ///
     /// Goto needs to execute any finally blocks on the way to the target label.
     /// <example>
-    /// { 
+    /// {
     ///     f(1, 2, try { g(3, 4, try { goto L } finally { ... }, 6) } finally { ... }, 7, 8)
-    ///     L: ... 
+    ///     L: ...
     /// }
     /// </example>
-    /// The goto expression here jumps to label L while having 4 items on evaluation stack (1, 2, 3 and 4). 
-    /// The jump needs to execute both finally blocks, the first one on stack level 4 the 
-    /// second one on stack level 2. So, it needs to jump the first finally block, pop 2 items from the stack, 
+    /// The goto expression here jumps to label L while having 4 items on evaluation stack (1, 2, 3 and 4).
+    /// The jump needs to execute both finally blocks, the first one on stack level 4 the
+    /// second one on stack level 2. So, it needs to jump the first finally block, pop 2 items from the stack,
     /// run second finally block and pop another 2 items from the stack and set instruction pointer to label L.
-    /// 
-    /// Goto also needs to rethrow ThreadAbortException iff it jumps out of a catch handler and 
+    ///
+    /// Goto also needs to rethrow ThreadAbortException iff it jumps out of a catch handler and
     /// the current thread is in "abort requested" state.
     /// </summary>
     internal sealed class GotoInstruction : IndexedBranchInstruction
@@ -249,15 +249,15 @@ namespace System.Linq.Expressions.Interpreter
         private static readonly GotoInstruction[] s_cache = new GotoInstruction[Variants * CacheSize];
 
         public override string InstructionName => "Goto";
-        
+
         private readonly bool _hasResult;
 
         private readonly bool _hasValue;
         private readonly bool _labelTargetGetsValue;
 
-        // The values should technically be Consumed = 1, Produced = 1 for gotos that target a label whose continuation depth 
+        // The values should technically be Consumed = 1, Produced = 1 for gotos that target a label whose continuation depth
         // is different from the current continuation depth. This is because we will consume one continuation from the _continuations
-        // and at meantime produce a new _pendingContinuation. However, in case of forward gotos, we don't not know that is the 
+        // and at meantime produce a new _pendingContinuation. However, in case of forward gotos, we don't not know that is the
         // case until the label is emitted. By then the consumed and produced stack information is useless.
         // The important thing here is that the stack balance is 0.
         public override int ConsumedContinuations => 0;
@@ -334,7 +334,7 @@ namespace System.Linq.Expressions.Interpreter
 
             if (_hasFinally)
             {
-                // Push finally. 
+                // Push finally.
                 frame.PushContinuation(_labelIndex);
             }
             int prevInstrIndex = frame.InstructionIndex;
@@ -515,7 +515,7 @@ namespace System.Linq.Expressions.Interpreter
             return frame.InstructionIndex - prevInstrIndex;
         }
     }
-    
+
     /// <summary>
     /// The first instruction of finally block.
     /// </summary>
@@ -686,10 +686,10 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string InstructionName => "EnterExceptionHandler";
 
-        // If an exception is throws in try-body the expression result of try-body is not evaluated and loaded to the stack. 
+        // If an exception is throws in try-body the expression result of try-body is not evaluated and loaded to the stack.
         // So the stack doesn't contain the try-body's value when we start executing the handler.
-        // However, while emitting instructions try block falls thru the catch block with a value on stack. 
-        // We need to declare it consumed so that the stack state upon entry to the handler corresponds to the real 
+        // However, while emitting instructions try block falls thru the catch block with a value on stack.
+        // We need to declare it consumed so that the stack state upon entry to the handler corresponds to the real
         // stack depth after throw jumped to this catch block.
         public override int ConsumedStack => _hasValue ? 1 : 0;
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
@@ -16,7 +16,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ConsumedStack => 2;
         public override int ProducedStack => 1;
         public override string InstructionName => "Equal";
-        
+
         private EqualInstruction() { }
 
         private sealed class EqualBoolean : EqualInstruction

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
@@ -333,7 +333,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ConsumedStack => 2;
         public override int ProducedStack => 1;
         public override string InstructionName => "GreaterThanOrEqual";
-        
+
         private GreaterThanOrEqualInstruction(object nullValue)
         {
             _nullValue = nullValue;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Interpreter.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Interpreter.cs
@@ -13,7 +13,7 @@ namespace System.Linq.Expressions.Interpreter
     /// off much faster compilation time for a slower execution performance.
     /// For code that is only run a small number of times this can be a
     /// sweet spot.
-    /// 
+    ///
     /// The core loop in the interpreter is the <see cref="Run(InterpretedFrame)"/>  method.
     /// </summary>
     internal sealed class Interpreter

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LabelInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LabelInfo.cs
@@ -22,7 +22,7 @@ namespace System.Linq.Expressions.Interpreter
         // The blocks where this label is defined. If it has more than one item,
         // the blocks can't be jumped to except from a child block
         // If there's only 1 block (the common case) it's stored here, if there's multiple blocks it's stored
-        // as a HashSet<LabelScopeInfo> 
+        // as a HashSet<LabelScopeInfo>
         private object _definitions;
 
         // Blocks that jump to this block

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
@@ -331,7 +331,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ConsumedStack => 2;
         public override int ProducedStack => 1;
         public override string InstructionName => "LessThanOrEqual";
-        
+
         private LessThanOrEqualInstruction(object nullValue)
         {
             _nullValue = nullValue;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -757,7 +757,7 @@ namespace System.Linq.Expressions.Interpreter
                 {
                     // lifting: we need to do the null checks for nullable types and reference types.  If the value
                     // is null we return null, or false for a comparison unless it's not equal, in which case we return
-                    // true.  
+                    // true.
 
                     // INCOMPAT: The DLR binder short circuits on comparisons other than equal and not equal,
                     // but C# doesn't.
@@ -1155,7 +1155,7 @@ namespace System.Linq.Expressions.Interpreter
 
             if (typeTo == typeof(object) || typeTo.IsAssignableFrom(typeFrom))
             {
-                // Conversions to a super-class or implemented interfaces are no-op. 
+                // Conversions to a super-class or implemented interfaces are no-op.
                 return;
             }
 
@@ -1556,8 +1556,8 @@ namespace System.Linq.Expressions.Interpreter
             {
                 foreach (Expression val in @case.TestValues)
                 {
-                    //  temp == val ? 
-                    //          goto(Body) doneLabel: 
+                    //  temp == val ?
+                    //          goto(Body) doneLabel:
                     //          {};
                     CompileConditionalExpression(
                         Expression.Condition(
@@ -1778,7 +1778,7 @@ namespace System.Linq.Expressions.Interpreter
             // Anything that is "statement-like" -- e.g. has no associated
             // stack state can be jumped into, with the exception of try-blocks
             // We indicate this by a "Block"
-            // 
+            //
             // Otherwise, we push an "Expression" to indicate that it can't be
             // jumped into
             switch (node.NodeType)
@@ -1959,7 +1959,7 @@ namespace System.Linq.Expressions.Interpreter
                 _instructions.MarkLabel(gotoEnd);
                 _instructions.EmitGoto(end, hasValue, hasValue, hasValue);
 
-                // keep the result on the stack:     
+                // keep the result on the stack:
                 if (node.Handlers.Count > 0)
                 {
                     exHandlers = new List<ExceptionHandler>();
@@ -2063,7 +2063,7 @@ namespace System.Linq.Expressions.Interpreter
             BranchLabel end = _instructions.MakeLabel();
             EnterTryFaultInstruction enterTryInstr = _instructions.EmitEnterTryFault(end);
             Debug.Assert(enterTryInstr == _instructions.GetInstruction(tryStart));
-            
+
             // Emit the try block.
             PushLabelBlock(LabelScopeKind.Try);
             bool hasValue = expr.Type != typeof(void);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
@@ -258,7 +258,7 @@ namespace System.Linq.Expressions.Interpreter
                     }
                 }
 
-#if FEATURE_MAKE_RUN_METHODS    
+#if FEATURE_MAKE_RUN_METHODS
                 if (DelegateHelpers.MakeDelegate(paramTypes) == delegateType)
                 {
                     name = "Make" + name + paramInfos.Length;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
@@ -196,7 +196,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ConsumedStack => 2;
         public override int ProducedStack => 1;
         public override string InstructionName => "MulOvf";
-        
+
         private MulOvfInstruction() { }
 
         private sealed class MulOvfInt32 : MulOvfInstruction

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/StackOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/StackOperations.cs
@@ -62,7 +62,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int ConsumedStack => 1;
         public override string InstructionName =>"Pop";
-        
+
         public override int Run(InterpretedFrame frame)
         {
             frame.Pop();
@@ -81,7 +81,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ConsumedStack => 0;
         public override int ProducedStack => 1;
         public override string InstructionName => "Dup";
-        
+
         public override int Run(InterpretedFrame frame)
         {
             object value = frame.Peek();

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -58,7 +58,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ConsumedStack => 1;
         public override int ProducedStack => 1;
         public override string InstructionName => "TypeIs";
-        
+
         public override int Run(InterpretedFrame frame)
         {
             frame.Push(ScriptingRuntimeHelpers.BooleanToObject(_type.IsInstanceOfType(frame.Pop())));
@@ -80,7 +80,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ConsumedStack => 1;
         public override int ProducedStack => 1;
         public override string InstructionName => "TypeAs";
-        
+
         public override int Run(InterpretedFrame frame)
         {
             object value = frame.Pop();
@@ -286,7 +286,7 @@ namespace System.Linq.Expressions.Interpreter
                     }
                 case "ToString": return s_toString ?? (s_toString = new ToStringClass());
                 default:
-                    // System.Nullable doesn't have other instance methods 
+                    // System.Nullable doesn't have other instance methods
                     throw ContractUtils.Unreachable;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -157,8 +157,8 @@ namespace System.Linq.Expressions.Interpreter
                     return default(float);
                 case TypeCode.Double:
                     return default(double);
-                //case TypeCode.DBNull: 
-                //    return default(DBNull); 
+                //case TypeCode.DBNull:
+                //    return default(DBNull);
                 case TypeCode.DateTime:
                     return default(DateTime);
                 case TypeCode.Decimal:

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
@@ -406,11 +406,11 @@ namespace System.Linq.Expressions
     public partial class Expression
     {
         /// <summary>
-        /// Creates an <see cref="InvocationExpression"/> that 
+        /// Creates an <see cref="InvocationExpression"/> that
         /// applies a delegate or lambda expression with no arguments.
         /// </summary>
         /// <returns>
-        /// An <see cref="InvocationExpression"/> that 
+        /// An <see cref="InvocationExpression"/> that
         /// applies the specified delegate or lambda expression.
         /// </returns>
         /// <param name="expression">
@@ -439,11 +439,11 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates an <see cref="InvocationExpression"/> that 
+        /// Creates an <see cref="InvocationExpression"/> that
         /// applies a delegate or lambda expression to one argument expression.
         /// </summary>
         /// <returns>
-        /// An <see cref="InvocationExpression"/> that 
+        /// An <see cref="InvocationExpression"/> that
         /// applies the specified delegate or lambda expression to the provided arguments.
         /// </returns>
         /// <param name="expression">
@@ -477,11 +477,11 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates an <see cref="InvocationExpression"/> that 
+        /// Creates an <see cref="InvocationExpression"/> that
         /// applies a delegate or lambda expression to two argument expressions.
         /// </summary>
         /// <returns>
-        /// An <see cref="InvocationExpression"/> that 
+        /// An <see cref="InvocationExpression"/> that
         /// applies the specified delegate or lambda expression to the provided arguments.
         /// </returns>
         /// <param name="expression">
@@ -518,11 +518,11 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates an <see cref="InvocationExpression"/> that 
+        /// Creates an <see cref="InvocationExpression"/> that
         /// applies a delegate or lambda expression to three argument expressions.
         /// </summary>
         /// <returns>
-        /// An <see cref="InvocationExpression"/> that 
+        /// An <see cref="InvocationExpression"/> that
         /// applies the specified delegate or lambda expression to the provided arguments.
         /// </returns>
         /// <param name="expression">
@@ -564,11 +564,11 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates an <see cref="InvocationExpression"/> that 
+        /// Creates an <see cref="InvocationExpression"/> that
         /// applies a delegate or lambda expression to four argument expressions.
         /// </summary>
         /// <returns>
-        /// An <see cref="InvocationExpression"/> that 
+        /// An <see cref="InvocationExpression"/> that
         /// applies the specified delegate or lambda expression to the provided arguments.
         /// </returns>
         /// <param name="expression">
@@ -614,11 +614,11 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates an <see cref="InvocationExpression"/> that 
+        /// Creates an <see cref="InvocationExpression"/> that
         /// applies a delegate or lambda expression to five argument expressions.
         /// </summary>
         /// <returns>
-        /// An <see cref="InvocationExpression"/> that 
+        /// An <see cref="InvocationExpression"/> that
         /// applies the specified delegate or lambda expression to the provided arguments.
         /// </returns>
         /// <param name="expression">
@@ -668,11 +668,11 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates an <see cref="InvocationExpression"/> that 
+        /// Creates an <see cref="InvocationExpression"/> that
         /// applies a delegate or lambda expression to a list of argument expressions.
         /// </summary>
         /// <returns>
-        /// An <see cref="InvocationExpression"/> that 
+        /// An <see cref="InvocationExpression"/> that
         /// applies the specified delegate or lambda expression to the provided arguments.
         /// </returns>
         /// <param name="expression">
@@ -695,11 +695,11 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates an <see cref="InvocationExpression"/> that 
+        /// Creates an <see cref="InvocationExpression"/> that
         /// applies a delegate or lambda expression to a list of argument expressions.
         /// </summary>
         /// <returns>
-        /// An <see cref="InvocationExpression"/> that 
+        /// An <see cref="InvocationExpression"/> that
         /// applies the specified delegate or lambda expression to the provided arguments.
         /// </returns>
         /// <param name="expression">

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelTarget.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelTarget.cs
@@ -31,7 +31,7 @@ namespace System.Linq.Expressions
         public Type Type { get; }
 
         /// <summary>
-        /// Returns a <see cref="String"/> that represents the current <see cref="Object"/>. 
+        /// Returns a <see cref="String"/> that represents the current <see cref="Object"/>.
         /// </summary>
         /// <returns>A <see cref="String"/> that represents the current <see cref="Object"/>.</returns>
         public override string ToString()

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -78,7 +78,7 @@ namespace System.Linq.Expressions
 
         /// <summary>
         /// Gets the value that indicates if the lambda expression will be compiled with
-        /// tail call optimization. 
+        /// tail call optimization.
         /// </summary>
         public bool TailCall => _tailCall;
 
@@ -676,7 +676,7 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates a <see cref="System.Type"/> object that represents a generic System.Action delegate type that has specific type arguments. 
+        /// Creates a <see cref="System.Type"/> object that represents a generic System.Action delegate type that has specific type arguments.
         /// </summary>
         /// <param name="typeArgs">An array of <see cref="System.Type"/> objects that specify the type arguments for the System.Action delegate type.</param>
         /// <returns>The type of a System.Action delegate that has the specified type arguments.</returns>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
@@ -15,8 +15,8 @@ namespace System.Linq.Expressions
     /// Represents a constructor call that has a collection initializer.
     /// </summary>
     /// <remarks>
-    /// Use the <see cref="Expression.ListInit"/> factory methods to create a ListInitExpression. 
-    /// The value of the <see cref="NodeType" /> property of a ListInitExpression is ListInit. 
+    /// Use the <see cref="Expression.ListInit"/> factory methods to create a ListInitExpression.
+    /// The value of the <see cref="NodeType" /> property of a ListInitExpression is ListInit.
     /// </remarks>
     [DebuggerTypeProxy(typeof(ListInitExpressionProxy))]
     public sealed class ListInitExpression : Expression
@@ -40,17 +40,17 @@ namespace System.Linq.Expressions
         public sealed override Type Type => NewExpression.Type;
 
         /// <summary>
-        /// Gets a value that indicates whether the expression tree node can be reduced. 
+        /// Gets a value that indicates whether the expression tree node can be reduced.
         /// </summary>
         public override bool CanReduce => true;
 
         /// <summary>
-        /// Gets the expression that contains a call to the constructor of a collection type. 
+        /// Gets the expression that contains a call to the constructor of a collection type.
         /// </summary>
         public NewExpression NewExpression { get; }
 
         /// <summary>
-        /// Gets the element initializers that are used to initialize a collection. 
+        /// Gets the element initializers that are used to initialize a collection.
         /// </summary>
         public ReadOnlyCollection<ElementInit> Initializers { get; }
 
@@ -63,9 +63,9 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Reduces the binary expression node to a simpler expression. 
+        /// Reduces the binary expression node to a simpler expression.
         /// If CanReduce returns true, this should return a valid expression.
-        /// This method is allowed to return another node which itself 
+        /// This method is allowed to return another node which itself
         /// must be reduced.
         /// </summary>
         /// <returns>The reduced expression.</returns>
@@ -139,7 +139,7 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates a <see cref="ListInitExpression"/> that uses a specified method to add elements to a collection. 
+        /// Creates a <see cref="ListInitExpression"/> that uses a specified method to add elements to a collection.
         /// </summary>
         /// <param name="newExpression">A <see cref="NewExpression"/> to set the <see cref="ListInitExpression.NewExpression"/> property equal to.</param>
         /// <param name="addMethod">A <see cref="MethodInfo"/> that represents an instance method named "Add" (case insensitive), that adds an element to a collection.</param>
@@ -169,11 +169,11 @@ namespace System.Linq.Expressions
         /// <param name="newExpression">A <see cref="NewExpression"/> to set the <see cref="ListInitExpression.NewExpression"/> property equal to.</param>
         /// <param name="initializers">An array that contains <see cref="Expressions.ElementInit"/> objects to use to populate the <see cref="ListInitExpression.Initializers"/> collection.</param>
         /// <returns>
-        /// A <see cref="ListInitExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ListInit"/> 
+        /// A <see cref="ListInitExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ListInit"/>
         /// and the <see cref="ListInitExpression.NewExpression"/> and <see cref="ListInitExpression.Initializers"/> properties set to the specified values.
         /// </returns>
         /// <remarks>
-        /// The <see cref="Type"/> property of <paramref name="newExpression"/> must represent a type that implements <see cref="Collections.IEnumerable"/>. 
+        /// The <see cref="Type"/> property of <paramref name="newExpression"/> must represent a type that implements <see cref="Collections.IEnumerable"/>.
         /// The <see cref="Type"/> property of the resulting <see cref="ListInitExpression"/> is equal to <paramref name="newExpression"/>.Type.
         /// </remarks>
         public static ListInitExpression ListInit(NewExpression newExpression, params ElementInit[] initializers)
@@ -188,7 +188,7 @@ namespace System.Linq.Expressions
         /// <param name="initializers">An <see cref="IEnumerable{T}"/> that contains <see cref="Expressions.ElementInit"/> objects to use to populate the <see cref="ListInitExpression.Initializers"/> collection.</param>
         /// <returns>An <see cref="IEnumerable{T}"/> that contains <see cref="Expressions.ElementInit"/> objects to use to populate the <see cref="ListInitExpression.Initializers"/> collection.</returns>
         /// <remarks>
-        /// The <see cref="Type"/> property of <paramref name="newExpression"/> must represent a type that implements <see cref="Collections.IEnumerable"/>. 
+        /// The <see cref="Type"/> property of <paramref name="newExpression"/> must represent a type that implements <see cref="Collections.IEnumerable"/>.
         /// The <see cref="Type"/> property of the resulting <see cref="ListInitExpression"/> is equal to <paramref name="newExpression"/>.Type.
         /// </remarks>
         public static ListInitExpression ListInit(NewExpression newExpression, IEnumerable<ElementInit> initializers)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberBinding.cs
@@ -53,7 +53,7 @@ namespace System.Linq.Expressions
         public MemberInfo Member { get; }
 
         /// <summary>
-        /// Returns a <see cref="String"/> that represents the current <see cref="Object"/>. 
+        /// Returns a <see cref="String"/> that represents the current <see cref="Object"/>.
         /// </summary>
         /// <returns>A <see cref="String"/> that represents the current <see cref="Object"/>.</returns>
         public override string ToString()

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -335,7 +335,7 @@ namespace System.Linq.Expressions
             {
                 return true;
             }
-            // If the type is an interface then the handle for the method got by the compiler will not be the 
+            // If the type is an interface then the handle for the method got by the compiler will not be the
             // same as that returned by reflection.
             // Check for this condition and try and get the method from reflection.
             Type type = method.DeclaringType;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions
         public sealed override Type Type => NewExpression.Type;
 
         /// <summary>
-        /// Gets a value that indicates whether the expression tree node can be reduced. 
+        /// Gets a value that indicates whether the expression tree node can be reduced.
         /// </summary>
         public override bool CanReduce => true;
 
@@ -57,9 +57,9 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Reduces the <see cref="MemberInitExpression"/> to a simpler expression. 
+        /// Reduces the <see cref="MemberInitExpression"/> to a simpler expression.
         /// If CanReduce returns true, this should return a valid expression.
-        /// This method is allowed to return another node which itself 
+        /// This method is allowed to return another node which itself
         /// must be reduced.
         /// </summary>
         /// <returns>The reduced expression.</returns>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
@@ -11,7 +11,7 @@ using System.Reflection;
 namespace System.Linq.Expressions
 {
     /// <summary>
-    /// Represents initializing the elements of a collection member of a newly created object. 
+    /// Represents initializing the elements of a collection member of a newly created object.
     /// </summary>
     public sealed class MemberListBinding : MemberBinding
     {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
@@ -14,7 +14,7 @@ namespace System.Linq.Expressions
     /// </summary>
     /// <remarks>
     /// Use the <see cref="Expression.MemberBind"/> factory methods to create a <see cref="MemberMemberBinding"/>.
-    /// The value of the <see cref="MemberBinding.BindingType"/> property of a <see cref="MemberMemberBinding"/> object is <see cref="MemberBinding"/>. 
+    /// The value of the <see cref="MemberBinding.BindingType"/> property of a <see cref="MemberMemberBinding"/> object is <see cref="MemberBinding"/>.
     /// </remarks>
     public sealed class MemberMemberBinding : MemberBinding
     {
@@ -27,7 +27,7 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Gets the bindings that describe how to initialize the members of a member. 
+        /// Gets the bindings that describe how to initialize the members of a member.
         /// </summary>
         public ReadOnlyCollection<MemberBinding> Bindings { get; }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
@@ -42,7 +42,7 @@ namespace System.Linq.Expressions
         public MethodInfo Method { get; }
 
         /// <summary>
-        /// Gets the <see cref="Expression"/> that represents the instance 
+        /// Gets the <see cref="Expression"/> that represents the instance
         /// for instance method calls or null for static method calls.
         /// </summary>
         public Expression Object => GetInstance();
@@ -87,9 +87,9 @@ namespace System.Linq.Expressions
         /// Returns a new MethodCallExpression replacing the existing instance/args with the
         /// newly provided instance and args.    Arguments can be null to use the existing
         /// arguments.
-        /// 
+        ///
         /// This helper is provided to allow re-writing of nodes to not depend on the specific optimized
-        /// subclass of MethodCallExpression which is being used. 
+        /// subclass of MethodCallExpression which is being used.
         /// </summary>
         [ExcludeFromCodeCoverage] // Unreachable
         internal virtual MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
@@ -42,7 +42,7 @@ namespace System.Linq.Expressions
         public sealed override Type Type { get; }
 
         /// <summary>
-        /// Gets the bounds of the array if the value of the <see cref="ExpressionType"/> property is NewArrayBounds, or the values to initialize the elements of the new array if the value of the <see cref="Expression.NodeType"/> property is NewArrayInit. 
+        /// Gets the bounds of the array if the value of the <see cref="ExpressionType"/> property is NewArrayBounds, or the values to initialize the elements of the new array if the value of the <see cref="Expression.NodeType"/> property is NewArrayInit.
         /// </summary>
         public ReadOnlyCollection<Expression> Expressions { get; }
 
@@ -241,7 +241,7 @@ namespace System.Linq.Expressions
             Type arrayType;
             if (dimensions == 1)
             {
-                //To get a vector, need call Type.MakeArrayType(). 
+                //To get a vector, need call Type.MakeArrayType().
                 //Type.MakeArrayType(1) gives a non-vector array, which will cause type check error.
                 arrayType = type.MakeArrayType();
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
@@ -116,7 +116,7 @@ namespace System.Linq.Expressions
         {
             return New(constructor, (IEnumerable<Expression>)null);
         }
-        
+
         /// <summary>
         /// Creates a new <see cref="NewExpression"/> that represents calling the specified constructor that takes no arguments.
         /// </summary>
@@ -127,7 +127,7 @@ namespace System.Linq.Expressions
         {
             return New(constructor, (IEnumerable<Expression>)arguments);
         }
-        
+
         /// <summary>
         /// Creates a new <see cref="NewExpression"/> that represents calling the specified constructor that takes no arguments.
         /// </summary>
@@ -145,7 +145,7 @@ namespace System.Linq.Expressions
 
             return new NewExpression(constructor, argList, null);
         }
-        
+
         /// <summary>
         /// Creates a new <see cref="NewExpression"/> that represents calling the specified constructor with the specified arguments. The members that access the constructor initialized fields are specified.
         /// </summary>
@@ -176,7 +176,7 @@ namespace System.Linq.Expressions
         {
             return New(constructor, arguments, (IEnumerable<MemberInfo>)members);
         }
-        
+
         /// <summary>
         /// Creates a <see cref="NewExpression"/> that represents calling the parameterless constructor of the specified type.
         /// </summary>
@@ -201,7 +201,7 @@ namespace System.Linq.Expressions
             }
             return new NewValueTypeExpression(type, EmptyReadOnlyCollection<Expression>.Instance, null);
         }
-        
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         private static void ValidateNewArgs(ConstructorInfo constructor, ref ReadOnlyCollection<Expression> arguments, ref ReadOnlyCollection<MemberInfo> members)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
@@ -104,7 +104,7 @@ namespace System.Linq.Expressions
     }
 
     /// <summary>
-    /// Specialized subclass to avoid holding onto the byref flag in a 
+    /// Specialized subclass to avoid holding onto the byref flag in a
     /// parameter expression.  This version always holds onto the expression
     /// type explicitly and therefore derives from TypedParameterExpression.
     /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchCase.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchCase.cs
@@ -32,7 +32,7 @@ namespace System.Linq.Expressions
         public Expression Body { get; }
 
         /// <summary>
-        /// Returns a <see cref="String"/> that represents the current <see cref="Object"/>. 
+        /// Returns a <see cref="String"/> that represents the current <see cref="Object"/>.
         /// </summary>
         /// <returns>A <see cref="String"/> that represents the current <see cref="Object"/>.</returns>
         public override string ToString()

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchExpression.cs
@@ -199,7 +199,7 @@ namespace System.Linq.Expressions
                 {
                     throw Error.IncorrectNumberOfMethodCallArguments(comparison, nameof(comparison));
                 }
-                // Validate that the switch value's type matches the comparison method's 
+                // Validate that the switch value's type matches the comparison method's
                 // left hand side parameter type.
                 ParameterInfo leftParam = pms[0];
                 bool liftedCall = false;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/SymbolDocumentInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/SymbolDocumentInfo.cs
@@ -91,7 +91,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="fileName">A <see cref="String"/> to set the <see cref="SymbolDocumentInfo.FileName"/> equal to.</param>
         /// <param name="language">A <see cref="Guid"/> to set the <see cref="SymbolDocumentInfo.Language"/> equal to.</param>
-        /// <returns>A <see cref="SymbolDocumentInfo"/> that has the <see cref="SymbolDocumentInfo.FileName"/> 
+        /// <returns>A <see cref="SymbolDocumentInfo"/> that has the <see cref="SymbolDocumentInfo.FileName"/>
         /// and <see cref="SymbolDocumentInfo.Language"/> properties set to the specified value.</returns>
         public static SymbolDocumentInfo SymbolDocument(string fileName, Guid language)
         {
@@ -104,8 +104,8 @@ namespace System.Linq.Expressions
         /// <param name="fileName">A <see cref="String"/> to set the <see cref="SymbolDocumentInfo.FileName"/> equal to.</param>
         /// <param name="language">A <see cref="Guid"/> to set the <see cref="SymbolDocumentInfo.Language"/> equal to.</param>
         /// <param name="languageVendor">A <see cref="Guid"/> to set the <see cref="SymbolDocumentInfo.LanguageVendor"/> equal to.</param>
-        /// <returns>A <see cref="SymbolDocumentInfo"/> that has the <see cref="SymbolDocumentInfo.FileName"/> 
-        /// and <see cref="SymbolDocumentInfo.Language"/> 
+        /// <returns>A <see cref="SymbolDocumentInfo"/> that has the <see cref="SymbolDocumentInfo.FileName"/>
+        /// and <see cref="SymbolDocumentInfo.Language"/>
         /// and <see cref="SymbolDocumentInfo.LanguageVendor"/> properties set to the specified value.</returns>
         public static SymbolDocumentInfo SymbolDocument(string fileName, Guid language, Guid languageVendor)
         {
@@ -119,9 +119,9 @@ namespace System.Linq.Expressions
         /// <param name="language">A <see cref="Guid"/> to set the <see cref="SymbolDocumentInfo.Language"/> equal to.</param>
         /// <param name="languageVendor">A <see cref="Guid"/> to set the <see cref="SymbolDocumentInfo.LanguageVendor"/> equal to.</param>
         /// <param name="documentType">A <see cref="Guid"/> to set the <see cref="SymbolDocumentInfo.DocumentType"/> equal to.</param>
-        /// <returns>A <see cref="SymbolDocumentInfo"/> that has the <see cref="SymbolDocumentInfo.FileName"/> 
-        /// and <see cref="SymbolDocumentInfo.Language"/> 
-        /// and <see cref="SymbolDocumentInfo.LanguageVendor"/> 
+        /// <returns>A <see cref="SymbolDocumentInfo"/> that has the <see cref="SymbolDocumentInfo.FileName"/>
+        /// and <see cref="SymbolDocumentInfo.Language"/>
+        /// and <see cref="SymbolDocumentInfo.LanguageVendor"/>
         /// and <see cref="SymbolDocumentInfo.DocumentType"/> properties set to the specified value.</returns>
         public static SymbolDocumentInfo SymbolDocument(string fileName, Guid language, Guid languageVendor, Guid documentType)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TryExpression.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Expressions
 {
     /// <summary>
     /// Represents a try/catch/finally/fault block.
-    /// 
+    ///
     /// The body is protected by the try block.
     /// The handlers consist of a set of <see cref="CatchBlock"/>s that can either be catch or filters.
     /// The fault runs if an exception is thrown.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -91,8 +91,8 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Gets a value that indicates whether the expression tree node can be reduced. 
-        /// </summary>        
+        /// Gets a value that indicates whether the expression tree node can be reduced.
+        /// </summary>
         public override bool CanReduce
         {
             get
@@ -110,9 +110,9 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Reduces the expression node to a simpler expression. 
+        /// Reduces the expression node to a simpler expression.
         /// If CanReduce returns true, this should return a valid expression.
-        /// This method is allowed to return another node which itself 
+        /// This method is allowed to return another node which itself
         /// must be reduced.
         /// </summary>
         /// <returns>The reduced expression.</returns>
@@ -542,7 +542,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="UnaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.NegateChecked"/> and the <see cref="UnaryExpression.Operand"/> property set to the specified value.</returns>
         /// <param name="expression">An <see cref="Expression"/> to set the <see cref="UnaryExpression.Operand"/> property equal to.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="expression"/> is null.</exception>
-        /// <exception cref="InvalidOperationException">Thrown when the unary minus operator is not defined for <paramref name="expression"/>.Type.</exception> 
+        /// <exception cref="InvalidOperationException">Thrown when the unary minus operator is not defined for <paramref name="expression"/>.Type.</exception>
         public static UnaryExpression NegateChecked(Expression expression)
         {
             return NegateChecked(expression, method: null);
@@ -1032,7 +1032,7 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates a <see cref="UnaryExpression"/> that represents the assignment of the expression 
+        /// Creates a <see cref="UnaryExpression"/> that represents the assignment of the expression
         /// followed by a subsequent increment by 1 of the original expression.
         /// </summary>
         /// <param name="expression">An <see cref="Expression"/> to apply the operations on.</param>
@@ -1043,7 +1043,7 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates a <see cref="UnaryExpression"/> that represents the assignment of the expression 
+        /// Creates a <see cref="UnaryExpression"/> that represents the assignment of the expression
         /// followed by a subsequent increment by 1 of the original expression.
         /// </summary>
         /// <param name="expression">An <see cref="Expression"/> to apply the operations on.</param>
@@ -1055,7 +1055,7 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates a <see cref="UnaryExpression"/> that represents the assignment of the expression 
+        /// Creates a <see cref="UnaryExpression"/> that represents the assignment of the expression
         /// followed by a subsequent decrement by 1 of the original expression.
         /// </summary>
         /// <param name="expression">An <see cref="Expression"/> to apply the operations on.</param>
@@ -1066,7 +1066,7 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// Creates a <see cref="UnaryExpression"/> that represents the assignment of the expression 
+        /// Creates a <see cref="UnaryExpression"/> that represents the assignment of the expression
         /// followed by a subsequent decrement by 1 of the original expression.
         /// </summary>
         /// <param name="expression">An <see cref="Expression"/> to apply the operations on.</param>

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
@@ -12,7 +12,7 @@ using System.Reflection;
 
 #if FEATURE_COMPILE
 using System.Linq.Expressions.Compiler;
-#endif 
+#endif
 
 namespace System.Runtime.CompilerServices
 {
@@ -22,16 +22,16 @@ namespace System.Runtime.CompilerServices
     // based on previous types that have been seen at the call-site. This delegate will
     // call UpdateAndExecute if it is called with types that it hasn't seen before.
     // Updating the binding will typically create (or lookup) a new delegate
-    // that supports fast-paths for both the new type and for any types that 
+    // that supports fast-paths for both the new type and for any types that
     // have been seen previously.
-    // 
+    //
     // DynamicSites will generate the fast-paths specialized for sets of runtime argument
     // types. However, they will generate exactly the right amount of code for the types
     // that are seen in the program so that int addition will remain as fast as it would
     // be with custom implementation of the addition, and the user-defined types can be
     // as fast as ints because they will all have the same optimal dynamically generated
     // fast-paths.
-    // 
+    //
     // DynamicSites don't encode any particular caching policy, but use their
     // CallSiteBinding to encode a caching policy.
     //
@@ -128,7 +128,7 @@ namespace System.Runtime.CompilerServices
         {
             get
             {
-                // if this site is set up for match making, then use NoMatch as an Update 
+                // if this site is set up for match making, then use NoMatch as an Update
                 if (_match)
                 {
                     Debug.Assert(s_cachedNoMatch != null, "all normal sites should have Update cached once there is an instance.");

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuleCache.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuleCache.cs
@@ -32,7 +32,7 @@ namespace System.Runtime.CompilerServices
         // this is called on every successful rule.
         internal void MoveRule(T rule, int i)
         {
-            // limit search to MaxSearch elements. 
+            // limit search to MaxSearch elements.
             // Rule should not get too far unless it has been already moved up.
             // need a lock to make sure we are moving the right rule and not loosing any.
             lock (_cacheLock)

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
@@ -224,7 +224,7 @@ namespace System.Linq.Expressions.Tests
         {
             Assert.Throws<ArgumentNullException>("right", () => Expression.Assign(Expression.Variable(typeof(int)), null));
         }
-        
+
         [Theory]
         [InlineData(typeof(int), "Hello", typeof(string))]
         [InlineData(typeof(long), 1, typeof(int))]

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
@@ -185,7 +185,7 @@ namespace System.Linq.Expressions.Tests
         {
             CheckGenericWithStructRestrictionCoalesceHelper<Scs>(useInterpreter);
         }
-        
+
         private static void CheckGenericWithClassRestrictionCoalesceHelper<Tc>(bool useInterpreter) where Tc : class
         {
             Tc[] array1 = new Tc[] { null, default(Tc) };
@@ -307,7 +307,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(ExpressionType.Coalesce, actual.NodeType);
 
             // Compile and evaluate with interpretation flag and without
-            // in case there are bugs in the compiler/interpreter. 
+            // in case there are bugs in the compiler/interpreter.
             Assert.Equal(2, conversion.Compile(false).Invoke(1.1));
             Assert.Equal(2, conversion.Compile(true).Invoke(1.1));
         }
@@ -389,7 +389,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => Expression.Coalesce(Expression.Constant(5), Expression.Constant(5)));
             Assert.Throws<InvalidOperationException>(() => Expression.Coalesce(Expression.Constant(5), Expression.Constant(5), conversion));
         }
-        
+
         [Fact]
         public static void RightLeft_NonEquivilentTypes_ThrowsArgumentException()
         {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/CompareTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/CompareTests.cs
@@ -57,7 +57,7 @@ namespace System.Linq.Expressions.Tests
                 }
             }
         }
-        
+
         [Theory]
         [MemberData(nameof(TestData))]
         public static void GreaterThan(Array array, bool useInterpreter)
@@ -74,7 +74,7 @@ namespace System.Linq.Expressions.Tests
                 }
             }
         }
-        
+
         [Theory]
         [MemberData(nameof(TestData))]
         public static void LessThanOrEqual(Array array, bool useInterpreter)
@@ -126,7 +126,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Same(exp, exp.Reduce());
             Assert.Throws<ArgumentException>(null, () => exp.ReduceAndCheck());
         }
-        
+
         [Fact]
         public static void LessThanOrEqual_CannotReduce()
         {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
@@ -516,7 +516,7 @@ namespace System.Linq.Expressions.Tests
             // Does not return bool
             TypeBuilder typeBuilder1 = GetTypeBuilder();
             yield return new object[] { typeBuilder1, typeof(void), new Type[] { typeBuilder1.AsType() } };
-            
+
             // Parameter is not assignable from left
             yield return new object[] { GetTypeBuilder(), typeof(bool), new Type[] { typeof(int) } };
 
@@ -724,7 +724,7 @@ namespace System.Linq.Expressions.Tests
             MethodBuilder method = builder.DefineMethod("op_BitwiseOr", MethodAttributes.Public | MethodAttributes.Static, typeof(int), new Type[] { typeof(int), typeof(int) });
             method.GetILGenerator().Emit(OpCodes.Ret);
 
-            TypeInfo createdType = builder.CreateTypeInfo();            
+            TypeInfo createdType = builder.CreateTypeInfo();
             Assert.Throws<InvalidOperationException>(() => Expression.OrElse(Expression.Constant(5), Expression.Constant(5)));
         }
 
@@ -775,7 +775,7 @@ namespace System.Linq.Expressions.Tests
             var e2 = Expression.OrElse(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(bool), "b"));
             Assert.Equal("(a OrElse b)", e2.ToString());
         }
-        
+
         private static TypeBuilder GetTypeBuilder()
         {
             AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.Run);

--- a/src/System.Linq.Expressions/tests/CompilerTests.cs
+++ b/src/System.Linq.Expressions/tests/CompilerTests.cs
@@ -156,7 +156,7 @@ namespace System.Linq.Expressions.Tests
 
                     IL_0000: ldc.i4.s   42
                     IL_0002: call       int32 class [System.Private.CoreLib]System.Math::Abs(int32)
-                    IL_0007: ret        
+                    IL_0007: ret
                   }");
         }
 
@@ -196,27 +196,27 @@ namespace System.Linq.Expressions.Tests
                       .try
                       {
                         IL_0000: ldc.i4.s   42
-                        IL_0002: ldarg.1    
-                        IL_0003: div        
+                        IL_0002: ldarg.1
+                        IL_0003: div
                         IL_0004: call       int32 class [System.Private.CoreLib]System.Math::Abs(int32)
-                        IL_0009: stloc.0    
+                        IL_0009: stloc.0
                         IL_000a: leave      IL_0017
                       }
                       catch (class [System.Private.CoreLib]System.DivideByZeroException)
                       {
-                        IL_000f: pop        
-                        IL_0010: ldc.i4.m1  
-                        IL_0011: stloc.0    
+                        IL_000f: pop
+                        IL_0010: ldc.i4.m1
+                        IL_0011: stloc.0
                         IL_0012: leave      IL_0017
                       }
                       IL_0017: leave      IL_001d
                     }
                     finally
                     {
-                      IL_001c: endfinally 
+                      IL_001c: endfinally
                     }
-                    IL_001d: ldloc.0    
-                    IL_001e: ret        
+                    IL_001d: ldloc.0
+                    IL_001e: ret
                   }");
         }
 
@@ -229,27 +229,27 @@ namespace System.Linq.Expressions.Tests
                 @".method class [System.Private.CoreLib]System.Func`1<int32> ::lambda_method(class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure)
                   {
                     .maxstack 3
-                  
-                    IL_0000: ldarg.0    
+
+                    IL_0000: ldarg.0
                     IL_0001: ldfld      class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::Constants
-                    IL_0006: ldc.i4.0   
-                    IL_0007: ldelem.ref 
+                    IL_0006: ldc.i4.0
+                    IL_0007: ldelem.ref
                     IL_0008: castclass  class [System.Private.CoreLib]System.Reflection.MethodInfo
                     IL_000d: ldtoken    class [System.Private.CoreLib]System.Func`1<int32>
                     IL_0012: call       class [System.Private.CoreLib]System.Type class [System.Private.CoreLib]System.Type::GetTypeFromHandle(valuetype [System.Private.CoreLib]System.RuntimeTypeHandle)
-                    IL_0017: ldnull     
+                    IL_0017: ldnull
                     IL_0018: callvirt   instance class [System.Private.CoreLib]System.Delegate class [System.Private.CoreLib]System.Reflection.MethodInfo::CreateDelegate(class [System.Private.CoreLib]System.Type,object)
                     IL_001d: castclass  class [System.Private.CoreLib]System.Func`1<int32>
-                    IL_0022: ret        
+                    IL_0022: ret
                   }
-                  
+
                   // closure.Constants[0]
                   .method int32 ::lambda_method(class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure)
                   {
                     .maxstack 1
-                  
+
                     IL_0000: ldc.i4.s   42
-                    IL_0002: ret        
+                    IL_0002: ret
                   }",
                 appendInnerLambdas: true);
         }
@@ -266,30 +266,30 @@ namespace System.Linq.Expressions.Tests
                     .locals init (
                       [0] object[]
                     )
-                  
-                    IL_0000: ldc.i4.1   
+
+                    IL_0000: ldc.i4.1
                     IL_0001: newarr     object
-                    IL_0006: dup        
-                    IL_0007: ldc.i4.0   
-                    IL_0008: ldarg.1    
+                    IL_0006: dup
+                    IL_0007: ldc.i4.0
+                    IL_0008: ldarg.1
                     IL_0009: newobj     instance void class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>::.ctor(int32)
-                    IL_000e: stelem.ref 
-                    IL_000f: stloc.0    
-                    IL_0010: ldarg.0    
+                    IL_000e: stelem.ref
+                    IL_000f: stloc.0
+                    IL_0010: ldarg.0
                     IL_0011: ldfld      class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::Constants
-                    IL_0016: ldc.i4.0   
-                    IL_0017: ldelem.ref 
+                    IL_0016: ldc.i4.0
+                    IL_0017: ldelem.ref
                     IL_0018: castclass  class [System.Private.CoreLib]System.Reflection.MethodInfo
                     IL_001d: ldtoken    class [System.Private.CoreLib]System.Func`1<int32>
                     IL_0022: call       class [System.Private.CoreLib]System.Type class [System.Private.CoreLib]System.Type::GetTypeFromHandle(valuetype [System.Private.CoreLib]System.RuntimeTypeHandle)
-                    IL_0027: ldnull     
-                    IL_0028: ldloc.0    
+                    IL_0027: ldnull
+                    IL_0028: ldloc.0
                     IL_0029: newobj     instance void class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::.ctor(object[],object[])
                     IL_002e: callvirt   instance class [System.Private.CoreLib]System.Delegate class [System.Private.CoreLib]System.Reflection.MethodInfo::CreateDelegate(class [System.Private.CoreLib]System.Type,object)
                     IL_0033: castclass  class [System.Private.CoreLib]System.Func`1<int32>
-                    IL_0038: ret        
+                    IL_0038: ret
                   }
-                  
+
                   // closure.Constants[0]
                   .method int32 ::lambda_method(class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure)
                   {
@@ -297,16 +297,16 @@ namespace System.Linq.Expressions.Tests
                     .locals init (
                       [0] object[]
                     )
-                  
-                    IL_0000: ldarg.0    
+
+                    IL_0000: ldarg.0
                     IL_0001: ldfld      class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::Locals
-                    IL_0006: stloc.0    
-                    IL_0007: ldloc.0    
-                    IL_0008: ldc.i4.0   
-                    IL_0009: ldelem.ref 
+                    IL_0006: stloc.0
+                    IL_0007: ldloc.0
+                    IL_0008: ldc.i4.0
+                    IL_0009: ldelem.ref
                     IL_000a: castclass  class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>
                     IL_000f: ldfld      class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>::Value
-                    IL_0014: ret        
+                    IL_0014: ret
                   }",
                 appendInnerLambdas: true);
         }
@@ -323,30 +323,30 @@ namespace System.Linq.Expressions.Tests
                     .locals init (
                       [0] object[]
                     )
-                  
-                    IL_0000: ldc.i4.1   
+
+                    IL_0000: ldc.i4.1
                     IL_0001: newarr     object
-                    IL_0006: dup        
-                    IL_0007: ldc.i4.0   
-                    IL_0008: ldarg.1    
+                    IL_0006: dup
+                    IL_0007: ldc.i4.0
+                    IL_0008: ldarg.1
                     IL_0009: newobj     instance void class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>::.ctor(int32)
-                    IL_000e: stelem.ref 
-                    IL_000f: stloc.0    
-                    IL_0010: ldarg.0    
+                    IL_000e: stelem.ref
+                    IL_000f: stloc.0
+                    IL_0010: ldarg.0
                     IL_0011: ldfld      class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::Constants
-                    IL_0016: ldc.i4.0   
-                    IL_0017: ldelem.ref 
+                    IL_0016: ldc.i4.0
+                    IL_0017: ldelem.ref
                     IL_0018: castclass  class [System.Private.CoreLib]System.Reflection.MethodInfo
                     IL_001d: ldtoken    class [System.Private.CoreLib]System.Func`2<int32,int32>
                     IL_0022: call       class [System.Private.CoreLib]System.Type class [System.Private.CoreLib]System.Type::GetTypeFromHandle(valuetype [System.Private.CoreLib]System.RuntimeTypeHandle)
-                    IL_0027: ldnull     
-                    IL_0028: ldloc.0    
+                    IL_0027: ldnull
+                    IL_0028: ldloc.0
                     IL_0029: newobj     instance void class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::.ctor(object[],object[])
                     IL_002e: callvirt   instance class [System.Private.CoreLib]System.Delegate class [System.Private.CoreLib]System.Reflection.MethodInfo::CreateDelegate(class [System.Private.CoreLib]System.Type,object)
                     IL_0033: castclass  class [System.Private.CoreLib]System.Func`2<int32,int32>
-                    IL_0038: ret        
+                    IL_0038: ret
                   }
-                  
+
                   // closure.Constants[0]
                   .method int32 ::lambda_method(class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure,int32)
                   {
@@ -354,18 +354,18 @@ namespace System.Linq.Expressions.Tests
                     .locals init (
                       [0] object[]
                     )
-                  
-                    IL_0000: ldarg.0    
+
+                    IL_0000: ldarg.0
                     IL_0001: ldfld      class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::Locals
-                    IL_0006: stloc.0    
-                    IL_0007: ldloc.0    
-                    IL_0008: ldc.i4.0   
-                    IL_0009: ldelem.ref 
+                    IL_0006: stloc.0
+                    IL_0007: ldloc.0
+                    IL_0008: ldc.i4.0
+                    IL_0009: ldelem.ref
                     IL_000a: castclass  class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>
                     IL_000f: ldfld      class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>::Value
-                    IL_0014: ldarg.1    
-                    IL_0015: add        
-                    IL_0016: ret        
+                    IL_0014: ldarg.1
+                    IL_0015: add
+                    IL_0016: ret
                   }",
                 appendInnerLambdas: true);
         }

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -288,7 +288,7 @@ namespace System.Linq.Expressions.Tests
         public void GenericMethod<T>() { }
         public static void StaticMethod() { }
     }
-    
+
     public class InvalidTypesData : IEnumerable<object[]>
     {
         private static readonly object[] GenericTypeDefinition = new object[] { typeof(GenericClass<>) };

--- a/src/System.Linq.Expressions/tests/ILReader/ILReaderFactory.cs
+++ b/src/System.Linq.Expressions/tests/ILReader/ILReaderFactory.cs
@@ -21,7 +21,7 @@ namespace System.Linq.Expressions.Tests
                 if (type == s_rtDynamicMethodType)
                 {
                     //
-                    // if the target is RTDynamicMethod, get the value of 
+                    // if the target is RTDynamicMethod, get the value of
                     // RTDynamicMethod.m_owner instead
                     //
                     dm = (DynamicMethod)s_fiOwner.GetValue(obj);

--- a/src/System.Linq.Expressions/tests/ILReader/SigParser.cs
+++ b/src/System.Linq.Expressions/tests/ILReader/SigParser.cs
@@ -29,14 +29,14 @@ namespace System.Linq.Expressions.Tests
 
         MethodRefSig ::= [[HASTHIS] [EXPLICITTHIS]] VARARG ParamCount RetType Param* [SENTINEL Param+]
 
-        StandAloneMethodSig ::=  [[HASTHIS] [EXPLICITTHIS]] (DEFAULT|VARARG|C|STDCALL|THISCALL|FASTCALL) 
+        StandAloneMethodSig ::=  [[HASTHIS] [EXPLICITTHIS]] (DEFAULT|VARARG|C|STDCALL|THISCALL|FASTCALL)
                             ParamCount RetType Param* [SENTINEL Param+]
 
         FieldSig ::= FIELD CustomMod* Type
 
         PropertySig ::= PROPERTY [HASTHIS] ParamCount CustomMod* Type Param*
 
-        LocalVarSig ::= LOCAL_SIG Count (TYPEDBYREF | ([CustomMod] [Constraint])* [BYREF] Type)+ 
+        LocalVarSig ::= LOCAL_SIG Count (TYPEDBYREF | ([CustomMod] [Constraint])* [BYREF] Type)+
 
 
         -------------
@@ -52,7 +52,7 @@ namespace System.Linq.Expressions.Tests
         Type ::= ( BOOLEAN | CHAR | I1 | U1 | U2 | U2 | I4 | U4 | I8 | U8 | R4 | R8 | I | U |
                         | VALUETYPE TypeDefOrRefEncoded
                         | CLASS TypeDefOrRefEncoded
-                        | STRING 
+                        | STRING
                         | OBJECT
                         | PTR CustomMod* VOID
                         | PTR CustomMod* Type
@@ -197,7 +197,7 @@ namespace System.Linq.Expressions.Tests
         protected virtual void NotifySize(sig_count count) { }
 
         // BUG BUG lower bounds can be negative, how can this be encoded?
-        // number of dimensions with specified lower bounds followed by lower bound of each 
+        // number of dimensions with specified lower bounds followed by lower bound of each
         protected virtual void NotifyNumLoBounds(sig_count count) { }
         protected virtual void NotifyLoBound(sig_count count) { }
 
@@ -432,7 +432,7 @@ namespace System.Linq.Expressions.Tests
 
         bool ParseLocals(sig_elem_type elem_type)
         {
-            //   LocalVarSig ::= LOCAL_SIG Count (TYPEDBYREF | ([CustomMod] [Constraint])* [BYREF] Type)+ 
+            //   LocalVarSig ::= LOCAL_SIG Count (TYPEDBYREF | ([CustomMod] [Constraint])* [BYREF] Type)+
 
             NotifyBeginLocals(elem_type);
 
@@ -681,7 +681,7 @@ namespace System.Linq.Expressions.Tests
             Type ::= ( BOOLEAN | CHAR | I1 | U1 | U2 | U2 | I4 | U4 | I8 | U8 | R4 | R8 | I | U |
                             | VALUETYPE TypeDefOrRefEncoded
                             | CLASS TypeDefOrRefEncoded
-                            | STRING 
+                            | STRING
                             | OBJECT
                             | PTR CustomMod* VOID
                             | PTR CustomMod* Type

--- a/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionHelpers.cs
+++ b/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionHelpers.cs
@@ -18,9 +18,9 @@ namespace System.Linq.Expressions.Tests
         internal static void AssertInvokeCorrect<T>(T expected, IndexExpression expression)
         {
             var lambda = Expression.Lambda<Func<T>>(expression);
-            
+
             // Compile and evaluate with interpretation flag and without
-            // in case there are bugs in the compiler/interpreter. 
+            // in case there are bugs in the compiler/interpreter.
             Assert.Equal(expected, lambda.Compile(false)());
             Assert.Equal(expected, lambda.Compile(true)());
         }

--- a/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionVisitorTests.cs
+++ b/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionVisitorTests.cs
@@ -33,7 +33,7 @@ namespace System.Linq.Expressions.Tests
                 return _dict.TryGetValue(node, out result) ? result : base.Visit(node);
             }
         }
-        
+
         [Fact]
         public void RewriteObjectTest()
         {
@@ -70,7 +70,7 @@ namespace System.Linq.Expressions.Tests
             var visitor = new IndexVisitor(expr, expr.Object, newArguments);
             IndexExpression expected = Expression.MakeIndex(expr.Object, expr.Indexer, newArguments);
             var actual = (IndexExpression) visitor.Visit(expr);
-            
+
             IndexExpressionHelpers.AssertEqual(expected, actual);
 
             // Invoke to check expression.

--- a/src/System.Linq.Expressions/tests/InterpreterTests.cs
+++ b/src/System.Linq.Expressions/tests/InterpreterTests.cs
@@ -25,7 +25,7 @@ namespace System.Linq.Expressions.Tests
                     .locals 1
                     .maxstack 2
                     .maxcontinuation 0
-                  
+
                     IP_0000: InitParameter(0)
                     IP_0001: LoadLocal(0)
                     IP_0002: LoadObject(null)
@@ -73,7 +73,7 @@ namespace System.Linq.Expressions.Tests
                     .locals 2
                     .maxstack 3
                     .maxcontinuation 1
-                  
+
                     IP_0000: InitParameter(0)
                     .try
                     {

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaAddNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaAddNullableTests.cs
@@ -897,7 +897,7 @@ namespace System.Linq.Expressions.Tests
             Func<Func<ulong?, ulong?, ulong?>> f4 = e4.Compile(useInterpreter);
 
             Assert.Equal(expected, f4()(a, b));
-            
+
             // verify with currying
             Expression<Func<ulong?, Func<ulong?, ulong?>>> e5 =
                 Expression.Lambda<Func<ulong?, Func<ulong?, ulong?>>>(

--- a/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -256,7 +256,7 @@ namespace System.Linq.Expressions.Tests
 
             Assert.Throws<ArgumentException>(null, () => Expression.MakeMemberAccess(expression, typeof(FC).GetField(nameof(FC.II))));
         }
-        
+
         [Fact]
         public static void Field_NoSuchFieldName_ThrowsArgumentException()
         {
@@ -395,7 +395,7 @@ namespace System.Linq.Expressions.Tests
         {
             Assert.Throws<ArgumentException>("property", () => Expression.Property(Expression.Default(typeof(UnreadableIndexableClass)), typeof(UnreadableIndexableClass).GetProperty("Item")));
         }
-        
+
         [Fact]
         public static void Property_NullProperty_ThrowsArgumentNullException()
         {
@@ -453,7 +453,7 @@ namespace System.Linq.Expressions.Tests
 
             Assert.Throws<ArgumentException>("property", () => Expression.MakeMemberAccess(expression, typeof(PC).GetProperty(nameof(PC.II))));
         }
-        
+
         [Fact]
         public static void Property_NoSuchPropertyName_ThrowsArgumentException()
         {

--- a/src/System.Linq.Expressions/tests/New/NewTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewTests.cs
@@ -346,7 +346,7 @@ namespace System.Linq.Expressions.Tests
         {
             ConstructorInfo constructor = typeof(ClassWithCtors).GetConstructor(new Type[] { typeof(string) });
             Expression[] expressions = new Expression[] { Expression.Constant(5) };
-            
+
             Assert.Throws<ArgumentException>("arguments[0]", () => Expression.New(constructor, expressions));
             Assert.Throws<ArgumentException>("arguments[0]", () => Expression.New(constructor, (IEnumerable<Expression>)expressions));
 
@@ -394,7 +394,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentException>("members[0]", () => Expression.New(constructor, arguments, members));
             Assert.Throws<ArgumentException>("members[0]", () => Expression.New(constructor, arguments, (IEnumerable<MemberInfo>)members));
         }
-        
+
         [Fact]
         public static void Members_MemberWriteOnly_ThrowsArgumentException()
         {

--- a/src/System.Linq.Expressions/tests/New/TypeExtensions.cs
+++ b/src/System.Linq.Expressions/tests/New/TypeExtensions.cs
@@ -61,7 +61,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         // Returns the matching method if the parameter types are reference
-        // assignable from the provided type arguments, otherwise null. 
+        // assignable from the provided type arguments, otherwise null.
         internal static MethodInfo GetAnyStaticMethodValidated(
             this Type type,
             string name,
@@ -80,8 +80,8 @@ namespace System.Linq.Expressions.Tests
         /// <summary>
         /// Returns true if the method's parameter types are reference assignable from
         /// the argument types, otherwise false.
-        /// 
-        /// An example that can make the method return false is that 
+        ///
+        /// An example that can make the method return false is that
         /// typeof(double).GetMethod("op_Equality", ..., new[] { typeof(double), typeof(int) })
         /// returns a method with two double parameters, which doesn't match the provided
         /// argument types.

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -1442,7 +1442,7 @@ namespace System.Linq.Expressions.Tests
                 /*
                  * needs more thought about what should happen.. these have undefined runtime behavior.
                  * results depend on whether values are in registers or locals, debug or retail etc.
-                 * 
+                 *
                 float fmin = float.MinValue;
                 float fmax = float.MaxValue;
                 double dmin = double.MinValue;
@@ -2205,7 +2205,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Lambda<Func<int, T>>(
                     // new T { A = v, B= v + 1, SYP = { B = v + 2 } }
                     Expression.MemberInit(
-                        // new T 
+                        // new T
                         Expression.New(typeof(T).GetConstructor(new Type[0])),
 
                         // { A = v, B= v + 1, SYP = { B = v + 2 } };
@@ -2216,7 +2216,7 @@ namespace System.Linq.Expressions.Tests
                             // B = v + 1
                             Expression.Bind(typeof(T).GetField("B"), Expression.Add(parameterV, Expression.Constant(1, typeof(int)))),
 
-                            // SYP = { B = v + 2 } 
+                            // SYP = { B = v + 2 }
                             Expression.MemberBind(
                                 typeof(T).GetMethod("get_SYP"),
                                 new MemberBinding[] {
@@ -2726,7 +2726,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Null(TestBinary<decimal?, decimal?>(ExpressionType.Divide, 5, null, useInterpreter));
             Assert.Null(TestBinary<decimal?, decimal?>(ExpressionType.Divide, null, null, useInterpreter));
 
-            // Modulo 
+            // Modulo
             Assert.Equal(3, TestBinary<int, int>(ExpressionType.Modulo, 7, 4, useInterpreter));
             Assert.Equal(3, TestBinary<int?, int?>(ExpressionType.Modulo, 7, 4, useInterpreter));
             Assert.Null(TestBinary<int?, int?>(ExpressionType.Modulo, null, 4, useInterpreter));

--- a/src/System.Linq.Expressions/tests/StackSpillerTests.cs
+++ b/src/System.Linq.Expressions/tests/StackSpillerTests.cs
@@ -287,7 +287,7 @@ namespace System.Linq.Expressions.Tests
                             Expression.MemberInit(
                                 Expression.New(typeof(BarHolder)),
                                 Expression.MemberBind(
-                                    bar, 
+                                    bar,
                                     Expression.Bind(baz, a),
                                     Expression.Bind(foo, b),
                                     Expression.Bind(qux, c)
@@ -396,7 +396,7 @@ namespace System.Linq.Expressions.Tests
             var v = Expression.Constant(new ValueVector());
             var item = typeof(ValueVector).GetProperty("Item");
             var i = Expression.Constant(0);
-            
+
             NotSupported(Expression.Property(v, item, Spill(i)));
         }
 
@@ -462,7 +462,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Assign(Expression.ArrayAccess(xs, i), v),
                     xs
                 );
-            
+
             e.VerifyIL(@"
                 .method void ::lambda_method(class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure,int32[])
                 {
@@ -474,36 +474,36 @@ namespace System.Linq.Expressions.Tests
                   )
 
                   // Save instance (`xs`) into V_0
-                  IL_0000: ldarg.1    
-                  IL_0001: stloc.0    
+                  IL_0000: ldarg.1
+                  IL_0001: stloc.0
 
                   // Save rhs (`try { 1 } finally {}`) into V_1
                   .try
                   {
-                    IL_0002: ldc.i4.1   
-                    IL_0003: stloc.2    
+                    IL_0002: ldc.i4.1
+                    IL_0003: stloc.2
                     IL_0004: leave      IL_000a
                   }
                   finally
                   {
-                    IL_0009: endfinally 
+                    IL_0009: endfinally
                   }
-                  IL_000a: ldloc.2    
-                  IL_000b: stloc.1    
+                  IL_000a: ldloc.2
+                  IL_000b: stloc.1
 
                   // Load instance from V_0
-                  IL_000c: ldloc.0    
+                  IL_000c: ldloc.0
 
                   // <OPTIMIZATION> Evaluate index (`0`) </OPTIMIZATION>
-                  IL_000d: ldc.i4.0   
+                  IL_000d: ldc.i4.0
 
                   // Load rhs from V_1
-                  IL_000e: ldloc.1    
+                  IL_000e: ldloc.1
 
                   // Evaluate `instance[index] = rhs` index assignment
-                  IL_000f: stelem.i4  
+                  IL_000f: stelem.i4
 
-                  IL_0010: ret        
+                  IL_0010: ret
                 }"
             );
         }
@@ -532,36 +532,36 @@ namespace System.Linq.Expressions.Tests
                   )
 
                   // Save instance (`xs`) into V_0
-                  IL_0000: ldarg.1    
-                  IL_0001: stloc.0    
+                  IL_0000: ldarg.1
+                  IL_0001: stloc.0
 
                   // Save rhs (`try { 1 } finally {}`) into V_1
                   .try
                   {
-                    IL_0002: ldc.i4.1   
-                    IL_0003: stloc.2    
+                    IL_0002: ldc.i4.1
+                    IL_0003: stloc.2
                     IL_0004: leave      IL_000a
                   }
                   finally
                   {
-                    IL_0009: endfinally 
+                    IL_0009: endfinally
                   }
-                  IL_000a: ldloc.2    
-                  IL_000b: stloc.1  
+                  IL_000a: ldloc.2
+                  IL_000b: stloc.1
 
-                  // Load instance from V_0  
-                  IL_000c: ldloc.0    
+                  // Load instance from V_0
+                  IL_000c: ldloc.0
 
                   // <OPTIMIZATION> Evaluate index (`0`) </OPTIMIZATION>
-                  IL_000d: ldc.i4.0   
+                  IL_000d: ldc.i4.0
 
                   // Load rhs from V_1
-                  IL_000e: ldloc.1    
+                  IL_000e: ldloc.1
 
                   // Evaluate `instance[index] = rhs` index assignment
-                  IL_000f: stelem.i4  
+                  IL_000f: stelem.i4
 
-                  IL_0010: ret        
+                  IL_0010: ret
                 }"
             );
         }
@@ -590,26 +590,26 @@ namespace System.Linq.Expressions.Tests
                   .try
                   {
                     IL_0000: ldc.r8     0
-                    IL_0009: stloc.1    
+                    IL_0009: stloc.1
                     IL_000a: leave      IL_0010
                   }
                   finally
                   {
-                    IL_000f: endfinally 
+                    IL_000f: endfinally
                   }
-                  IL_0010: ldloc.1    
-                  IL_0011: stloc.0    
+                  IL_0010: ldloc.1
+                  IL_0011: stloc.0
 
                   // <OPTIMIZATION> Evaluate lhs (`Math.PI` gets inlined) </OPTIMIZATION>
                   IL_0012: ldc.r8     3.14159265358979
 
-                  // Load rhs from V_0  
-                  IL_001b: ldloc.0    
+                  // Load rhs from V_0
+                  IL_001b: ldloc.0
 
                   // Evaluate `lhs + rhs`
-                  IL_001c: add        
+                  IL_001c: add
 
-                  IL_001d: ret        
+                  IL_001d: ret
                 }"
             );
         }
@@ -646,14 +646,14 @@ namespace System.Linq.Expressions.Tests
                   {
                     IL_000b: endfinally
                   }
-                  IL_000c: ldloc.1    
-                  IL_000d: stloc.0    
+                  IL_000c: ldloc.1
+                  IL_000d: stloc.0
 
                   // <OPTIMIZATION> Evaluate arg0 (`bool::TrueString`) </OPTIMIZATION>
                   IL_000e: ldsfld     bool::TrueString
 
                   // Load arg1 from V_0
-                  IL_0013: ldloc.0    
+                  IL_0013: ldloc.0
 
                   // Evaluate `string.Concat(arg0, arg1)` call
                   IL_0014: call       string string::Concat(string,string)
@@ -688,36 +688,36 @@ namespace System.Linq.Expressions.Tests
                   )
 
                   // Save target (`f`) into V_0
-                  IL_0000: ldarg.1    
-                  IL_0001: stloc.0    
+                  IL_0000: ldarg.1
+                  IL_0001: stloc.0
 
                   // Save arg1 (`try { 2 } finally {}`) into V_1
                   .try
                   {
-                    IL_0002: ldc.i4.2   
-                    IL_0003: stloc.2    
+                    IL_0002: ldc.i4.2
+                    IL_0003: stloc.2
                     IL_0004: leave      IL_000a
                   }
                   finally
                   {
-                    IL_0009: endfinally 
+                    IL_0009: endfinally
                   }
-                  IL_000a: ldloc.2    
-                  IL_000b: stloc.1   
+                  IL_000a: ldloc.2
+                  IL_000b: stloc.1
 
                   // Load target from V_0
-                  IL_000c: ldloc.0    
+                  IL_000c: ldloc.0
 
                   // <OPTIMIZATION> Load arg0 (`RuntimeVariables`) by calling RuntimeOps.CreateRuntimeVariables </OPTIMIZATION>
                   IL_000d: call       class [System.Linq.Expressions]System.Runtime.CompilerServices.IRuntimeVariables class [System.Linq.Expressions]System.Runtime.CompilerServices.RuntimeOps::CreateRuntimeVariables()
 
                   // Load arg1 from V_1
-                  IL_0012: ldloc.1    
+                  IL_0012: ldloc.1
 
                   // Evaluate `target(arg0, arg1)` delegate invocation
                   IL_0013: callvirt   instance void class [System.Private.CoreLib]System.Action`2<class [System.Linq.Expressions]System.Runtime.CompilerServices.IRuntimeVariables,int32>::Invoke(class [System.Linq.Expressions]System.Runtime.CompilerServices.IRuntimeVariables,int32)
 
-                  IL_0018: ret        
+                  IL_0018: ret
                 }"
             );
         }
@@ -750,52 +750,52 @@ namespace System.Linq.Expressions.Tests
                   )
 
                   // Hoist `x` to a closure in V_0
-                  IL_0000: ldc.i4.1   
+                  IL_0000: ldc.i4.1
                   IL_0001: newarr     object
-                  IL_0006: dup        
-                  IL_0007: ldc.i4.0   
-                  IL_0008: ldarg.2    
+                  IL_0006: dup
+                  IL_0007: ldc.i4.0
+                  IL_0008: ldarg.2
                   IL_0009: newobj     instance void class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>::.ctor(int32)
-                  IL_000e: stelem.ref 
-                  IL_000f: stloc.0    
+                  IL_000e: stelem.ref
+                  IL_000f: stloc.0
 
                   // Save target (`f`) into V_1
-                  IL_0010: ldarg.1    
-                  IL_0011: stloc.1    
+                  IL_0010: ldarg.1
+                  IL_0011: stloc.1
 
                   // Save arg1 (`try { 2 } finally {}`) into V_2
                   .try
                   {
-                    IL_0012: ldc.i4.2   
-                    IL_0013: stloc.3    
+                    IL_0012: ldc.i4.2
+                    IL_0013: stloc.3
                     IL_0014: leave      IL_001a
                   }
                   finally
                   {
-                    IL_0019: endfinally 
+                    IL_0019: endfinally
                   }
-                  IL_001a: ldloc.3    
-                  IL_001b: stloc.2   
+                  IL_001a: ldloc.3
+                  IL_001b: stloc.2
 
-                  // Load target from V_1 
-                  IL_001c: ldloc.1    
+                  // Load target from V_1
+                  IL_001c: ldloc.1
 
                   // <OPTIMIZATION> Load arg0 (`RuntimeVariables`) by calling RuntimeOps.CreateRuntimeVariables </OPTIMIZATION>
-                  IL_001d: ldloc.0    
-                  IL_001e: ldarg.0    
+                  IL_001d: ldloc.0
+                  IL_001e: ldarg.0
                   IL_001f: ldfld      class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::Constants
-                  IL_0024: ldc.i4.0   
-                  IL_0025: ldelem.ref 
+                  IL_0024: ldc.i4.0
+                  IL_0025: ldelem.ref
                   IL_0026: castclass  int64[]
                   IL_002b: call       class [System.Linq.Expressions]System.Runtime.CompilerServices.IRuntimeVariables class [System.Linq.Expressions]System.Runtime.CompilerServices.RuntimeOps::CreateRuntimeVariables(object[],int64[])
 
                   // Load arg1 from V_2
-                  IL_0030: ldloc.2    
+                  IL_0030: ldloc.2
 
                   // Evaluate `target(arg0, arg1)` delegate invocation
                   IL_0031: callvirt   instance void class [System.Private.CoreLib]System.Action`2<class [System.Linq.Expressions]System.Runtime.CompilerServices.IRuntimeVariables,int32>::Invoke(class [System.Linq.Expressions]System.Runtime.CompilerServices.IRuntimeVariables,int32)
 
-                  IL_0036: ret        
+                  IL_0036: ret
                 }"
             );
         }
@@ -839,37 +839,37 @@ namespace System.Linq.Expressions.Tests
                   )
 
                   // Save invocation target (`f`) into V_0
-                  IL_0000: ldarg.1    
-                  IL_0001: stloc.0    
+                  IL_0000: ldarg.1
+                  IL_0001: stloc.0
 
                   // Save arg0 (`try { x } finally {}`) into V_1
                   .try
                   {
-                    IL_0002: ldarg.2    
-                    IL_0003: stloc.2    
+                    IL_0002: ldarg.2
+                    IL_0003: stloc.2
                     IL_0004: leave      IL_000a
                   }
                   finally
                   {
-                    IL_0009: endfinally 
+                    IL_0009: endfinally
                   }
-                  IL_000a: ldloc.2    
-                  IL_000b: stloc.1    
+                  IL_000a: ldloc.2
+                  IL_000b: stloc.1
 
                   // Load invocation target from V_0
-                  IL_000c: ldloc.0    
+                  IL_000c: ldloc.0
 
                   // Load arg0 from V_1
-                  IL_000d: ldloc.1    
+                  IL_000d: ldloc.1
 
                   // <OPTIMIZATION> Load arguments beyond spill site </OPTIMIZATION>
-                  IL_000e: ldarg.3    
+                  IL_000e: ldarg.3
                   IL_000f: ldarg.s    V_4
 
                   // Evaluate `f(try { x } finally {}, y, z)`
                   IL_0011: callvirt   instance int32 class [System.Private.CoreLib]System.Func`4<int32,int32,int32,int32>::Invoke(int32,int32,int32)
 
-                  IL_0016: ret        
+                  IL_0016: ret
                 }");
         }
 
@@ -919,43 +919,43 @@ namespace System.Linq.Expressions.Tests
                   )
 
                   // Save `x1` into V_0
-                  IL_0000: ldarg.1    
-                  IL_0001: stloc.0    
+                  IL_0000: ldarg.1
+                  IL_0001: stloc.0
 
                   // Save `try { x2 } finally {}` into V_1
                   .try
                   {
-                    IL_0002: ldarg.2    
+                    IL_0002: ldarg.2
                     IL_0003: stloc.s    V_4
                     IL_0005: leave      IL_000b
                   }
                   finally
                   {
-                    IL_000a: endfinally 
+                    IL_000a: endfinally
                   }
                   IL_000b: ldloc.s    V_4
-                  IL_000d: stloc.1    
+                  IL_000d: stloc.1
 
                   // Eval `x1 + x2` and store into V_2
-                  IL_000e: ldloc.0    
-                  IL_000f: ldloc.1    
-                  IL_0010: add        
-                  IL_0011: stloc.2    
+                  IL_000e: ldloc.0
+                  IL_000f: ldloc.1
+                  IL_0010: add
+                  IL_0011: stloc.2
 
                   // Eval `(x1 + x2) + x3` and save into V_3
                   // <OPTIMIZATION> `x3` does not get stored in a temporary </OPTIMIZATION>
-                  IL_0012: ldloc.2    
-                  IL_0013: ldarg.3    
-                  IL_0014: add        
-                  IL_0015: stloc.3    
+                  IL_0012: ldloc.2
+                  IL_0013: ldarg.3
+                  IL_0014: add
+                  IL_0015: stloc.3
 
                   // Eval `((x1 + x2) + x3) + x4`
                   // <OPTIMIZATION> `x4` does not get stored in a temporary </OPTIMIZATION>
-                  IL_0016: ldloc.3    
+                  IL_0016: ldloc.3
                   IL_0017: ldarg.s    V_4
-                  IL_0019: add        
+                  IL_0019: add
 
-                  IL_001a: ret        
+                  IL_001a: ret
                 }");
         }
 

--- a/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
@@ -282,7 +282,7 @@ namespace System.Linq.Expressions.Tests
             ParameterExpression @ref = Expression.Parameter(typeof(T).MakeByRefType());
             ParameterExpression val = Expression.Parameter(typeof(T));
 
-            ByRefWriteAction<T> f = 
+            ByRefWriteAction<T> f =
                 Expression.Lambda<ByRefWriteAction<T>>(
                     Expression.Assign(@ref, val),
                     @ref, val


### PR DESCRIPTION
Kept coming across trailing whitespace in various previous changes that were PR'ed, so decided to do a search-and-replace across the solution to trim these out in bulk.

CC @stephentoub