### PR TITLE
Upgrading System.Linq.Queryable to netstandard1.7

### DIFF
--- a/src/System.Linq.Queryable/pkg/System.Linq.Queryable.pkgproj
+++ b/src/System.Linq.Queryable/pkg/System.Linq.Queryable.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Linq.Queryable.csproj">
-      <SupportedFramework>net45;netcore45;netcoreapp1.0;wp8;wpa81;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>net463;netcoreapp1.1;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Linq.Queryable.builds" />
     <InboxOnTargetFramework Include="monoandroid10" />

--- a/src/System.Linq.Queryable/ref/System.Linq.Queryable.csproj
+++ b/src/System.Linq.Queryable/ref/System.Linq.Queryable.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.0</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Linq.Queryable.cs" />

--- a/src/System.Linq.Queryable/ref/project.json
+++ b/src/System.Linq.Queryable/ref/project.json
@@ -1,10 +1,10 @@
 {
   "dependencies": {
-    "System.Runtime": "4.1.0",
-    "System.Linq.Expressions": "4.1.0",
-    "System.Linq": "4.1.0"
+    "System.Runtime": "4.4.0-beta-24711-02",
+    "System.Linq.Expressions": "4.4.0-beta-24711-02",
+    "System.Linq": "4.4.0-beta-24711-02"
   },
   "frameworks": {
-    "netstandard1.0": {}
+    "netstandard1.7": {}
   }
 }

--- a/src/System.Linq.Queryable/src/System.Linq.Queryable.csproj
+++ b/src/System.Linq.Queryable/src/System.Linq.Queryable.csproj
@@ -7,8 +7,7 @@
     <RootNamespace>System.Linq.Queryable</RootNamespace>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' == 'net46'">None</ResourcesSourceOutputDirectory>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
-    <PackageTargetFramework Condition="'$(TargetGroup)' == ''">netstandard1.3;netcore50</PackageTargetFramework>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Linq.Queryable/src/project.json
+++ b/src/System.Linq.Queryable/src/project.json
@@ -1,23 +1,19 @@
 {
-  "frameworks": {
-    "netstandard1.3": {
-      "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1",
-        "System.Collections": "4.0.11",
-        "System.Diagnostics.Debug": "4.0.11",
-        "System.Linq": "4.1.0",
-        "System.Linq.Expressions": "4.1.0",
-        "System.Reflection": "4.1.0",
-        "System.Reflection.Extensions": "4.0.1",
-        "System.Resources.ResourceManager": "4.0.1",
-        "System.Runtime": "4.1.0",
-        "System.Threading.Tasks": "4.0.11"
-      }
+    "dependencies": {
+      "Microsoft.NETCore.Platforms": "1.2.0-beta-24711-02",
+      "System.Collections": "4.4.0-beta-24711-02",
+      "System.Diagnostics.Debug": "4.4.0-beta-24711-02",
+      "System.IO": "4.4.0-beta-24711-02",
+      "System.Linq": "4.4.0-beta-24711-02",
+      "System.Linq.Expressions": "4.4.0-beta-24711-02",
+      "System.Reflection": "4.4.0-beta-24711-02",
+      "System.Reflection.Extensions": "4.4.0-beta-24711-02",
+      "System.Resources.ResourceManager": "4.4.0-beta-24711-02",
+      "System.Runtime": "4.4.0-beta-24711-02",
+      "System.Threading.Tasks": "4.4.0-beta-24711-02"
     },
-    "net46": {
-      "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
-      }
+    "frameworks": {
+      "netstandard1.7": {}
     }
   }
 }

--- a/src/System.Linq.Queryable/tests/System.Linq.Queryable.Tests.builds
+++ b/src/System.Linq.Queryable/tests/System.Linq.Queryable.Tests.builds
@@ -5,6 +5,11 @@
     <Project Include="System.Linq.Queryable.Tests.csproj" />
     <Project Include="System.Linq.Queryable.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
+      <TestTFMs>net463</TestTFMs> 
+    </Project>
+    <Project Include="System.Linq.Queryable.Tests.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netstandard1.3</TargetGroup>
       <TestTFMs>netcore50;net46</TestTFMs>
     </Project>
   </ItemGroup>

--- a/src/System.Linq.Queryable/tests/System.Linq.Queryable.Tests.csproj
+++ b/src/System.Linq.Queryable/tests/System.Linq.Queryable.Tests.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Linq.Queryable.Tests</AssemblyName>
     <RootNamespace>System.Linq.Queryable.Tests</RootNamespace>
-    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
As discussed in https://github.com/dotnet/corefx/pull/13561, upgrading this project to `netstandard1.7` based on the changes made for `Microsoft.CSharp`. I've verified that I can now see `GetCurrentMethod` locally in Visual Studio.

CC @jkotas, @ericstj