### PR TITLE
Adding back RuntimeOps for ExpandoObject

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Dynamic;
 using System.Dynamic.Utils;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
@@ -771,7 +772,7 @@ namespace System.Dynamic
                 ParameterExpression value = Expression.Parameter(typeof(object), "value");
 
                 Expression tryGetValue = Expression.Call(
-                    typeof(RuntimeOps).GetMethod("ExpandoTryGetValue"),
+                    typeof(RuntimeOps).GetMethod(nameof(RuntimeOps.ExpandoTryGetValue)),
                     GetLimitedSelf(),
                     Expression.Constant(klass, typeof(object)),
                     Expression.Constant(index),
@@ -842,7 +843,7 @@ namespace System.Dynamic
                     originalClass,
                     new DynamicMetaObject(
                         Expression.Call(
-                            typeof(RuntimeOps).GetMethod("ExpandoTrySetValue"),
+                            typeof(RuntimeOps).GetMethod(nameof(RuntimeOps.ExpandoTrySetValue)),
                             GetLimitedSelf(),
                             Expression.Constant(klass, typeof(object)),
                             Expression.Constant(index),
@@ -862,7 +863,7 @@ namespace System.Dynamic
                 int index = Value.Class.GetValueIndex(binder.Name, binder.IgnoreCase, Value);
 
                 Expression tryDelete = Expression.Call(
-                    typeof(RuntimeOps).GetMethod("ExpandoTryDeleteValue"),
+                    typeof(RuntimeOps).GetMethod(nameof(RuntimeOps.ExpandoTryDeleteValue)),
                     GetLimitedSelf(),
                     Expression.Constant(Value.Class, typeof(object)),
                     Expression.Constant(index),
@@ -911,7 +912,7 @@ namespace System.Dynamic
                     ifTestSucceeds = Expression.Block(
                         Expression.Call(
                             null,
-                            typeof(RuntimeOps).GetMethod("ExpandoPromoteClass"),
+                            typeof(RuntimeOps).GetMethod(nameof(RuntimeOps.ExpandoPromoteClass)),
                             GetLimitedSelf(),
                             Expression.Constant(originalClass, typeof(object)),
                             Expression.Constant(klass, typeof(object))
@@ -924,7 +925,7 @@ namespace System.Dynamic
                     Expression.Condition(
                         Expression.Call(
                             null,
-                            typeof(RuntimeOps).GetMethod("ExpandoCheckVersion"),
+                            typeof(RuntimeOps).GetMethod(nameof(RuntimeOps.ExpandoCheckVersion)),
                             GetLimitedSelf(),
                             Expression.Constant(originalClass ?? klass, typeof(object))
                         ),
@@ -1113,3 +1114,86 @@ namespace System.Dynamic
     }
 }
 
+namespace System.Runtime.CompilerServices
+{
+    //
+    // Note: these helpers are kept as simple wrappers so they have a better 
+    // chance of being inlined.
+    //
+    public static partial class RuntimeOps
+    {
+        /// <summary>
+        /// Gets the value of an item in an expando object.
+        /// </summary>
+        /// <param name="expando">The expando object.</param>
+        /// <param name="indexClass">The class of the expando object.</param>
+        /// <param name="index">The index of the member.</param>
+        /// <param name="name">The name of the member.</param>
+        /// <param name="ignoreCase">true if the name should be matched ignoring case; false otherwise.</param>
+        /// <param name="value">The out parameter containing the value of the member.</param>
+        /// <returns>True if the member exists in the expando object, otherwise false.</returns>
+        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool ExpandoTryGetValue(ExpandoObject expando, object indexClass, int index, string name, bool ignoreCase, out object value)
+        {
+            return expando.TryGetValue(indexClass, index, name, ignoreCase, out value);
+        }
+
+        /// <summary>
+        /// Sets the value of an item in an expando object.
+        /// </summary>
+        /// <param name="expando">The expando object.</param>
+        /// <param name="indexClass">The class of the expando object.</param>
+        /// <param name="index">The index of the member.</param>
+        /// <param name="value">The value of the member.</param>
+        /// <param name="name">The name of the member.</param>
+        /// <param name="ignoreCase">true if the name should be matched ignoring case; false otherwise.</param>
+        /// <returns>
+        /// Returns the index for the set member.
+        /// </returns>
+        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        public static object ExpandoTrySetValue(ExpandoObject expando, object indexClass, int index, object value, string name, bool ignoreCase)
+        {
+            expando.TrySetValue(indexClass, index, value, name, ignoreCase, false);
+            return value;
+        }
+
+        /// <summary>
+        /// Deletes the value of an item in an expando object.
+        /// </summary>
+        /// <param name="expando">The expando object.</param>
+        /// <param name="indexClass">The class of the expando object.</param>
+        /// <param name="index">The index of the member.</param>
+        /// <param name="name">The name of the member.</param>
+        /// <param name="ignoreCase">true if the name should be matched ignoring case; false otherwise.</param>
+        /// <returns>true if the item was successfully removed; otherwise, false.</returns>
+        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool ExpandoTryDeleteValue(ExpandoObject expando, object indexClass, int index, string name, bool ignoreCase)
+        {
+            return expando.TryDeleteValue(indexClass, index, name, ignoreCase, ExpandoObject.Uninitialized);
+        }
+
+        /// <summary>
+        /// Checks the version of the expando object.
+        /// </summary>
+        /// <param name="expando">The expando object.</param>
+        /// <param name="version">The version to check.</param>
+        /// <returns>true if the version is equal; otherwise, false.</returns>
+        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool ExpandoCheckVersion(ExpandoObject expando, object version)
+        {
+            return expando.Class == version;
+        }
+
+        /// <summary>
+        /// Promotes an expando object from one class to a new class.
+        /// </summary>
+        /// <param name="expando">The expando object.</param>
+        /// <param name="oldClass">The old class of the expando object.</param>
+        /// <param name="newClass">The new class of the expando object.</param>
+        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        public static void ExpandoPromoteClass(ExpandoObject expando, object oldClass, object newClass)
+        {
+            expando.PromoteClass(oldClass, newClass);
+        }
+    }
+}


### PR DESCRIPTION
This addresses issue #13541. Missing methods were detected during `nameof` conversion of strings passed to `GetMethod`.

My guess is the code was dropped because it was in a `partial` class in a different assembly. However, it left a bunch of `GetMethod` calls returning `null`. There's definitely a test gap in `ExpandoObject` because we didn't catch this. I'll open a separate issue for that.

Note that these methods were already in `ref` files under `src/System.Core/ref/Compat/System.Core.cs`. Also note that the method is marked as `Obsolete` with `error` set to `true`. This is the same for all runtime helper methods to avoid users from calling them directly (so their apparent obsolete status shouldn't have been a reason to drop them).

CC @stephentoub, @joperezr