### PR TITLE
Using some named parameters in DLR code

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
@@ -282,13 +282,13 @@ namespace System.Dynamic
         {
             ContractUtils.RequiresNotNull(key, nameof(key));
             // Pass null to the class, which forces lookup.
-            TrySetValue(null, -1, value, key, false, true);
+            TrySetValue(null, -1, value, key, ignoreCase: false, add: true);
         }
 
         private bool TryGetValueForKey(string key, out object value)
         {
             // Pass null to the class, which forces lookup.
-            return TryGetValue(null, -1, key, false, out value);
+            return TryGetValue(null, -1, key, ignoreCase: false, value: out value);
         }
 
         private bool ExpandoContainsKey(string key)
@@ -612,7 +612,7 @@ namespace System.Dynamic
             {
                 ContractUtils.RequiresNotNull(key, nameof(key));
                 // Pass null to the class, which forces lookup.
-                TrySetValue(null, -1, value, key, false, false);
+                TrySetValue(null, -1, value, key, ignoreCase: false, add: false);
             }
         }
 
@@ -634,7 +634,7 @@ namespace System.Dynamic
         {
             ContractUtils.RequiresNotNull(key, nameof(key));
             // Pass null to the class, which forces lookup.
-            return TryDeleteValue(null, -1, key, false, Uninitialized);
+            return TryDeleteValue(null, -1, key, ignoreCase: false, deleteValue: Uninitialized);
         }
 
         bool IDictionary<string, object>.TryGetValue(string key, out object value)
@@ -708,7 +708,7 @@ namespace System.Dynamic
 
         bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> item)
         {
-            return TryDeleteValue(null, -1, item.Key, false, item.Value);
+            return TryDeleteValue(null, -1, item.Key, ignoreCase: false, deleteValue: item.Value);
         }
 
         #endregion

--- a/src/System.Linq.Expressions/src/System/Dynamic/UpdateDelegates.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/UpdateDelegates.Generated.cs
@@ -9,7 +9,7 @@ namespace System.Dynamic
     internal static partial class UpdateDelegates
     {
 #if FEATURE_COMPILE
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static TRet UpdateAndExecute0<TRet>(CallSite site)
         {
             //
@@ -142,7 +142,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static TRet NoMatch0<TRet>(CallSite site)
         {
@@ -150,7 +150,7 @@ namespace System.Dynamic
             return default(TRet);
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static TRet UpdateAndExecute1<T0, TRet>(CallSite site, T0 arg0)
         {
             //
@@ -283,7 +283,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static TRet NoMatch1<T0, TRet>(CallSite site, T0 arg0)
         {
@@ -293,7 +293,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static TRet UpdateAndExecute2<T0, T1, TRet>(CallSite site, T0 arg0, T1 arg1)
         {
             //
@@ -426,7 +426,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static TRet NoMatch2<T0, T1, TRet>(CallSite site, T0 arg0, T1 arg1)
         {
@@ -436,7 +436,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static TRet UpdateAndExecute3<T0, T1, T2, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2)
         {
             //
@@ -569,7 +569,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static TRet NoMatch3<T0, T1, T2, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2)
         {
@@ -579,7 +579,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static TRet UpdateAndExecute4<T0, T1, T2, T3, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
         {
             //
@@ -712,7 +712,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static TRet NoMatch4<T0, T1, T2, T3, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
         {
@@ -722,7 +722,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static TRet UpdateAndExecute5<T0, T1, T2, T3, T4, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             //
@@ -855,7 +855,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static TRet NoMatch5<T0, T1, T2, T3, T4, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
@@ -865,7 +865,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static TRet UpdateAndExecute6<T0, T1, T2, T3, T4, T5, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             //
@@ -998,7 +998,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static TRet NoMatch6<T0, T1, T2, T3, T4, T5, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
@@ -1008,7 +1008,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static TRet UpdateAndExecute7<T0, T1, T2, T3, T4, T5, T6, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             //
@@ -1141,7 +1141,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static TRet NoMatch7<T0, T1, T2, T3, T4, T5, T6, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
@@ -1151,7 +1151,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static TRet UpdateAndExecute8<T0, T1, T2, T3, T4, T5, T6, T7, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             //
@@ -1284,7 +1284,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static TRet NoMatch8<T0, T1, T2, T3, T4, T5, T6, T7, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
@@ -1294,7 +1294,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static TRet UpdateAndExecute9<T0, T1, T2, T3, T4, T5, T6, T7, T8, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             //
@@ -1427,7 +1427,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static TRet NoMatch9<T0, T1, T2, T3, T4, T5, T6, T7, T8, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
@@ -1437,7 +1437,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static TRet UpdateAndExecute10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             //
@@ -1570,7 +1570,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static TRet NoMatch10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
@@ -1580,7 +1580,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static void UpdateAndExecuteVoid1<T0>(CallSite site, T0 arg0)
         {
             //
@@ -1712,7 +1712,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static void NoMatchVoid1<T0>(CallSite site, T0 arg0)
         {
@@ -1722,7 +1722,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static void UpdateAndExecuteVoid2<T0, T1>(CallSite site, T0 arg0, T1 arg1)
         {
             //
@@ -1854,7 +1854,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static void NoMatchVoid2<T0, T1>(CallSite site, T0 arg0, T1 arg1)
         {
@@ -1864,7 +1864,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static void UpdateAndExecuteVoid3<T0, T1, T2>(CallSite site, T0 arg0, T1 arg1, T2 arg2)
         {
             //
@@ -1996,7 +1996,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static void NoMatchVoid3<T0, T1, T2>(CallSite site, T0 arg0, T1 arg1, T2 arg2)
         {
@@ -2006,7 +2006,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static void UpdateAndExecuteVoid4<T0, T1, T2, T3>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
         {
             //
@@ -2138,7 +2138,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static void NoMatchVoid4<T0, T1, T2, T3>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
         {
@@ -2148,7 +2148,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static void UpdateAndExecuteVoid5<T0, T1, T2, T3, T4>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             //
@@ -2280,7 +2280,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static void NoMatchVoid5<T0, T1, T2, T3, T4>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
@@ -2290,7 +2290,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static void UpdateAndExecuteVoid6<T0, T1, T2, T3, T4, T5>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             //
@@ -2422,7 +2422,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static void NoMatchVoid6<T0, T1, T2, T3, T4, T5>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
@@ -2432,7 +2432,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static void UpdateAndExecuteVoid7<T0, T1, T2, T3, T4, T5, T6>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             //
@@ -2564,7 +2564,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static void NoMatchVoid7<T0, T1, T2, T3, T4, T5, T6>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
@@ -2574,7 +2574,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static void UpdateAndExecuteVoid8<T0, T1, T2, T3, T4, T5, T6, T7>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             //
@@ -2706,7 +2706,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static void NoMatchVoid8<T0, T1, T2, T3, T4, T5, T6, T7>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
@@ -2716,7 +2716,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static void UpdateAndExecuteVoid9<T0, T1, T2, T3, T4, T5, T6, T7, T8>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             //
@@ -2848,7 +2848,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static void NoMatchVoid9<T0, T1, T2, T3, T4, T5, T6, T7, T8>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
@@ -2858,7 +2858,7 @@ namespace System.Dynamic
 
 
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static void UpdateAndExecuteVoid10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             //
@@ -2990,7 +2990,7 @@ namespace System.Dynamic
             }
         }
 
-        [Obsolete("pregenerated CallSite<T>.Update delegate", true)]
+        [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters")]
         internal static void NoMatchVoid10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteOps.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteOps.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.CompilerServices
         /// </summary>
         /// <typeparam name="T">The type of the delegate of the <see cref="CallSite"/>.</typeparam>
         /// <returns>The new call site.</returns>
-        [Obsolete("do not use this method", true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static CallSite<T> CreateMatchmaker<T>(CallSite<T> site) where T : class
         {
             var mm = site.CreateMatchMaker();
@@ -37,7 +37,7 @@ namespace System.Runtime.CompilerServices
         /// </summary>
         /// <param name="site">An instance of the dynamic call site.</param>
         /// <returns>true if rule does not need updating, false otherwise.</returns>
-        [Obsolete("do not use this method", true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static bool SetNotMatched(CallSite site)
         {
             var res = site._match;
@@ -50,7 +50,7 @@ namespace System.Runtime.CompilerServices
         /// </summary>
         /// <param name="site">An instance of the dynamic call site.</param>
         /// <returns>true if rule matched, false otherwise.</returns>
-        [Obsolete("do not use this method", true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static bool GetMatch(CallSite site)
         {
             return site._match;
@@ -60,7 +60,7 @@ namespace System.Runtime.CompilerServices
         /// Clears the match flag on the matchmaker call site.
         /// </summary>
         /// <param name="site">An instance of the dynamic call site.</param>
-        [Obsolete("do not use this method", true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static void ClearMatch(CallSite site)
         {
             site._match = true;
@@ -72,7 +72,7 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="T">The type of the delegate of the <see cref="CallSite"/>.</typeparam>
         /// <param name="site">An instance of the dynamic call site.</param>
         /// <param name="rule">An instance of the call site rule.</param>
-        [Obsolete("do not use this method", true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static void AddRule<T>(CallSite<T> site, T rule) where T : class
         {
             site.AddRule(rule);
@@ -84,7 +84,7 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="T">The type of the delegate of the <see cref="CallSite"/>.</typeparam>
         /// <param name="this">An instance of the dynamic call site.</param>
         /// <param name="matched">The matched rule index.</param>
-        [Obsolete("do not use this method", true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static void UpdateRules<T>(CallSite<T> @this, int matched) where T : class
         {
             if (matched > 1)
@@ -99,7 +99,7 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="T">The type of the delegate of the <see cref="CallSite"/>.</typeparam>
         /// <param name="site">An instance of the dynamic call site.</param>
         /// <returns>An array of dynamic binding rules.</returns>
-        [Obsolete("do not use this method", true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static T[] GetRules<T>(CallSite<T> site) where T : class
         {
             return site.Rules;
@@ -112,7 +112,7 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="T">The type of the delegate of the <see cref="CallSite"/>.</typeparam>
         /// <param name="site">An instance of the dynamic call site.</param>
         /// <returns>The cache.</returns>
-        [Obsolete("do not use this method", true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static RuleCache<T> GetRuleCache<T>(CallSite<T> site) where T : class
         {
             return site.Binder.GetRuleCache<T>();
@@ -126,7 +126,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="cache">The call site rule cache.</param>
         /// <param name="rule">An instance of the call site rule.</param>
         /// <param name="i">An index of the call site rule.</param>
-        [Obsolete("do not use this method", true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static void MoveRule<T>(RuleCache<T> cache, T rule, int i) where T : class
         {
             if (i > 1)
@@ -141,7 +141,7 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="T">The type of the delegate of the <see cref="CallSite"/>.</typeparam>
         /// <param name="cache">The cache.</param>
         /// <returns>The collection of applicable rules.</returns>
-        [Obsolete("do not use this method", true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static T[] GetCachedRules<T>(RuleCache<T> cache) where T : class
         {
             return cache.GetRules();
@@ -155,7 +155,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="site">An instance of the dynamic call site.</param>
         /// <param name="args">Arguments to the call site.</param>
         /// <returns>The new call site target.</returns>
-        [Obsolete("do not use this method", true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static T Bind<T>(CallSiteBinder binder, CallSite<T> site, object[] args) where T : class
         {
             return binder.BindCore(site, args);


### PR DESCRIPTION
This code was merged recently and the bulk rewrite to use named parameters was not applied to it. Doing that now.

CC @stephentoub