### PR TITLE
Don't use string parsing in overflow test

### DIFF
--- a/src/System.ComponentModel.Annotations/tests/RangeAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/RangeAttributeTests.cs
@@ -167,13 +167,20 @@ namespace System.ComponentModel.DataAnnotations.Tests
         }
 
         [Theory]
-        [InlineData(typeof(int), "1", "2", "2147483648")]
-        [InlineData(typeof(int), "1", "2", "-2147483649")]
-        [InlineData(typeof(double), "1.0", "2.0", "2E+308")]
-        [InlineData(typeof(double), "1.0", "2.0", "-2E+308")]
-        public static void Validate_ConversionOverflows_ThrowsOverflowException(Type type, string minimum, string maximum, object value)
+        [InlineData(1, 2, "2147483648")]
+        [InlineData(1, 2, "-2147483649")]
+        public static void Validate_IntConversionOverflows_ThrowsOverflowException(int minimum, int maximum, object value)
         {
-            RangeAttribute attribute = new RangeAttribute(type, minimum, maximum);
+            RangeAttribute attribute = new RangeAttribute(minimum, maximum);
+            Assert.Throws<OverflowException>(() => attribute.Validate(value, new ValidationContext(new object())));
+        }
+
+        [Theory]
+        [InlineData(1.0, 2.0, "2E+308")]
+        [InlineData(1.0, 2.0, "-2E+308")]
+        public static void Validate_DoubleConversionOverflows_ThrowsOverflowException(double minimum, double maximum, object value)
+        {
+            RangeAttribute attribute = new RangeAttribute(minimum, maximum);
             Assert.Throws<OverflowException>(() => attribute.Validate(value, new ValidationContext(new object())));
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/13604.

Instead of one test method for both `int` and `double` that relies on culture-sensitive parsing, use separate methods for `int` and `double`.