### PR TITLE
Fixing the dependencies of SqlClient Stress Tests

### DIFF
--- a/src/System.Data.SqlClient/System.Data.SqlClient.sln
+++ b/src/System.Data.SqlClient/System.Data.SqlClient.sln
@@ -10,7 +10,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Data.SqlClient.Tests
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Data.SqlClient.ManualTesting.Tests", "tests\ManualTests\System.Data.SqlClient.ManualTesting.Tests.csproj", "{45DB5F86-7AE3-45C6-870D-F9357B66BDB5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "stresstest", "tests\stress\StressTest\stresstest.csproj", "{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Data.SqlClient.Stress.Tests", "tests\StressTests\System.Data.SqlClient.Stress.Tests\System.Data.SqlClient.Stress.Tests.csproj", "{B94B8E6D-3E41-4046-B758-4A2E281F74EE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -54,18 +54,18 @@ Global
 		{45DB5F86-7AE3-45C6-870D-F9357B66BDB5}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
 		{45DB5F86-7AE3-45C6-870D-F9357B66BDB5}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{45DB5F86-7AE3-45C6-870D-F9357B66BDB5}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
-		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
-		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
-		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
-		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
-		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Unix_Debug|Any CPU.ActiveCfg = Unix_Debug|Any CPU
-		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Unix_Debug|Any CPU.Build.0 = Unix_Debug|Any CPU
-		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Unix_Release|Any CPU.ActiveCfg = Unix_Release|Any CPU
-		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Unix_Release|Any CPU.Build.0 = Unix_Release|Any CPU
-		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
-		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
-		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
-		{529B187A-DE4F-4F4D-9FBB-D3D416FDB683}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+        {B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Unix_Debug|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Unix_Debug|Any CPU.Build.0 = Windows_Release|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Unix_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Unix_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -73,5 +73,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{F3E72F35-0351-4D67-9388-725BCAD807BA} = {ECE6CCAC-682B-4054-B737-E6DB4A4FA79A}
 		{45DB5F86-7AE3-45C6-870D-F9357B66BDB5} = {ECE6CCAC-682B-4054-B737-E6DB4A4FA79A}
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE} = {ECE6CCAC-682B-4054-B737-E6DB4A4FA79A}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Data.SqlClient/tests/StressTests/IMonitorLoader/project.json
+++ b/src/System.Data.SqlClient/tests/StressTests/IMonitorLoader/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Collections": "4.4.0-beta-24711-02",
+  },
+  "frameworks": {
+    "netstandard1.3": {}
+  }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.SqlClient.Stress.Tests/System.Data.SqlClient.Stress.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.SqlClient.Stress.Tests/System.Data.SqlClient.Stress.Tests.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <!--Import the targets-->
   <ItemGroup>
-    <ProjectReference Include="..\..\pkg\System.Data.SqlClient.pkgproj" />
+    <ProjectReference Include="..\..\..\pkg\System.Data.SqlClient.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressFramework/System.Data.StressFramework.csproj
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressFramework/System.Data.StressFramework.csproj
@@ -26,6 +26,7 @@
     <Compile Include="TrackedRandom.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="project.json" />
     <None Include="StressTest.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressFramework/project.json
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressFramework/project.json
@@ -1,0 +1,41 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.2.0-beta-24711-02",
+    "System.Console": "4.4.0-beta-24711-02",
+    "System.Collections": "4.4.0-beta-24711-02",
+    "System.Collections.Concurrent": "4.4.0-beta-24711-02",
+    "System.Data.Common": "4.4.0-beta-24711-02",
+    "System.Data.SqlClient": "4.4.0-beta-24711-02",
+    "System.Diagnostics.Debug": "4.4.0-beta-24711-02",
+    "System.Diagnostics.DiagnosticSource": "4.4.0-beta-24711-02",
+    "System.Diagnostics.FileVersionInfo": "4.4.0-beta-24711-02",
+    "System.Diagnostics.Process": "4.4.0-beta-24711-02",
+    "System.Diagnostics.TextWriterTraceListener": "4.4.0-beta-24711-02",
+    "System.Diagnostics.TraceSource": "4.4.0-beta-24711-02",
+    "System.IO.FileSystem": "4.4.0-beta-24711-02",
+    "System.Linq": "4.4.0-beta-24711-02",
+    "System.Linq.Expressions": "4.4.0-beta-24711-02",
+    "System.Net.NameResolution": "4.4.0-beta-24711-02",
+    "System.Reflection": "4.4.0-beta-24711-02",
+    "System.Reflection.Emit": "4.4.0-beta-24711-02",
+    "System.Reflection.Extensions": "4.4.0-beta-24711-02",
+    "System.Reflection.TypeExtensions": "4.4.0-beta-24711-02",
+    "System.Runtime.Extensions": "4.4.0-beta-24711-02",
+    "System.Runtime.InteropServices": "4.4.0-beta-24711-02",
+    "System.Security.Principal": "4.4.0-beta-24711-02",
+    "System.Security.Principal.Windows": "4.4.0-beta-24711-02",
+    "System.Text.RegularExpressions": "4.4.0-beta-24711-02",
+    "System.Threading": "4.4.0-beta-24711-02",
+    "System.Threading.Timer": "4.4.0-beta-24711-02",
+    "System.Threading.Thread": "4.4.0-beta-24711-02",
+    "System.Threading.ThreadPool": "4.4.0-beta-24711-02",
+    "System.Runtime.Serialization.Primitives": "4.1.1",
+    "System.Xml.ReaderWriter": "4.4.0-beta-24711-02",
+    "System.Xml.XPath": "4.4.0-beta-24711-02",
+    "System.Xml.XmlDocument": "4.4.0-beta-24711-02",
+    "runtime.native.System.Data.SqlClient.sni": "4.4.0-beta-24711-02"
+  },
+  "frameworks": {
+    "netstandard1.3": {}
+  }
+}

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/project.json
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/project.json
@@ -1,0 +1,44 @@
+{
+  "dependencies": {
+    "System.Runtime": "4.4.0-beta-24711-02",
+    "Microsoft.NETCore.Platforms": "1.2.0-beta-24711-02",
+    "System.AppContext": "4.4.0-beta-24711-02",
+    "System.Console": "4.4.0-beta-24711-02",
+    "System.Collections": "4.4.0-beta-24711-02",
+    "System.Collections.Concurrent": "4.4.0-beta-24711-02",
+    "System.Data.Common": "4.4.0-beta-24711-02",
+    "System.Data.SqlClient": "4.4.0-beta-24711-02",
+    "System.Diagnostics.Debug": "4.4.0-beta-24711-02",
+    "System.Diagnostics.DiagnosticSource": "4.4.0-beta-24711-02",
+    "System.Diagnostics.FileVersionInfo": "4.4.0-beta-24711-02",
+    "System.Diagnostics.Process": "4.4.0-beta-24711-02",
+    "System.Diagnostics.TextWriterTraceListener": "4.4.0-beta-24711-02",
+    "System.Diagnostics.TraceSource": "4.4.0-beta-24711-02",
+    "System.IO.FileSystem": "4.4.0-beta-24711-02",
+    "System.Net.NameResolution": "4.4.0-beta-24711-02",
+    "System.Security.Principal": "4.4.0-beta-24711-02",
+    "System.Security.Principal.Windows": "4.4.0-beta-24711-02",
+    "System.Threading.Thread": "4.0.0",
+    "System.Threading": "4.4.0-beta-24711-02",
+    "System.Threading.Timer": "4.4.0-beta-24711-02",
+    "System.Reflection.Extensions": "4.4.0-beta-24711-02",
+    "System.Reflection": "4.4.0-beta-24711-02",
+    "System.Reflection.Emit": "4.4.0-beta-24711-02",
+    "System.Reflection.TypeExtensions": "4.4.0-beta-24711-02",
+    "System.Runtime.InteropServices": "4.4.0-beta-24711-02",
+    "System.Threading.ThreadPool": "4.4.0-beta-24711-02",
+    "System.Runtime.Extensions": "4.4.0-beta-24711-02",
+    "System.Text.RegularExpressions": "4.4.0-beta-24711-02",
+    "System.Xml.ReaderWriter": "4.4.0-beta-24711-02",
+    "System.Xml.XmlDocument": "4.4.0-beta-24711-02",
+    "runtime.native.System.Data.SqlClient.sni": "4.4.0-beta-24711-02"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dnxcore50"
+      ]
+    },
+    "netstandard1.3": {}
+  }
+}

--- a/src/System.Data.SqlClient/tests/System.Data.SqlClient.Tests.builds
+++ b/src/System.Data.SqlClient/tests/System.Data.SqlClient.Tests.builds
@@ -12,6 +12,7 @@
       <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>net46</TestTFMs>
     </Project>
+    <Project Include="StressTests\System.Data.SqlClient.Stress.Tests\System.Data.SqlClient.Stress.Tests.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>


### PR DESCRIPTION
1. Reverting the project.json files needed to build the stress test dependencies of SqlClient
2. Added the stresstest project to the tests build file.
3. Added the stress test to the solution.

Fixes #13602