### PR TITLE
Caching common constant expressions in System.Linq.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/BindingRestrictions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/BindingRestrictions.cs
@@ -7,11 +7,12 @@ using System.Diagnostics;
 using System.Dynamic.Utils;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
+using AstUtils = System.Linq.Expressions.Utils;
 
 namespace System.Dynamic
 {
     /// <summary>
-    /// Represents a set of binding restrictions on the <see cref="DynamicMetaObject"/>under which the dynamic binding is valid.
+    /// Represents a set of binding restrictions on the <see cref="DynamicMetaObject"/> under which the dynamic binding is valid.
     /// </summary>
     [DebuggerTypeProxy(typeof(BindingRestrictionsProxy)), DebuggerDisplay("{DebugView}")]
     public abstract class BindingRestrictions
@@ -20,7 +21,7 @@ namespace System.Dynamic
         /// Represents an empty set of binding restrictions. This field is read only.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly BindingRestrictions Empty = new CustomRestriction(Expression.Constant(true));
+        public static readonly BindingRestrictions Empty = new CustomRestriction(AstUtils.Constant(true));
 
         private const int TypeRestrictionHash = 0x10000000;
         private const int InstanceRestrictionHash = 0x20000000;
@@ -191,7 +192,7 @@ namespace System.Dynamic
 
             if (this == Empty)
             {
-                return Expression.Constant(true);
+                return AstUtils.Constant(true);
             }
 
             var testBuilder = new TestBuilder();
@@ -320,7 +321,7 @@ namespace System.Dynamic
                 {
                     return Expression.Equal(
                         Expression.Convert(_expression, typeof(object)),
-                        Expression.Constant(null)
+                        AstUtils.Null
                     );
                 }
 
@@ -343,7 +344,7 @@ namespace System.Dynamic
 #endif
                     Expression.AndAlso(
                         //check that WeekReference was not collected.
-                        Expression.NotEqual(temp, Expression.Constant(null)),
+                        Expression.NotEqual(temp, AstUtils.Null),
                         Expression.Equal(
                             Expression.Convert(_expression, typeof(object)),
                             temp

--- a/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
@@ -7,6 +7,7 @@ using System.Dynamic.Utils;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using AstUtils = System.Linq.Expressions.Utils;
 
 namespace System.Dynamic
 {
@@ -419,7 +420,7 @@ namespace System.Dynamic
                                 Expression.Convert(
                                     Expression.ArrayIndex(
                                         callArgs,
-                                        Expression.Constant(i)
+                                        AstUtils.Constant(i)
                                     ),
                                     args[i].Type
                                 )
@@ -431,7 +432,7 @@ namespace System.Dynamic
                 if (block != null)
                     return Expression.Block(block);
                 else
-                    return Expression.Empty();
+                    return AstUtils.Empty;
             }
 
             /// <summary>
@@ -545,7 +546,7 @@ namespace System.Dynamic
                     else
                     {
                         condition = Expression.OrElse(
-                                        Expression.Equal(resultMO.Expression, Expression.Constant(null)),
+                                        Expression.Equal(resultMO.Expression, AstUtils.Null),
                                         Expression.TypeIs(resultMO.Expression, binder.ReturnType));
                     }
 
@@ -559,7 +560,7 @@ namespace System.Dynamic
                                     Expression.Constant(convertFailed),
                                     Expression.NewArrayInit(typeof(object),
                                         Expression.Condition(
-                                            Expression.Equal(resultMO.Expression, Expression.Constant(null)),
+                                            Expression.Equal(resultMO.Expression, AstUtils.Null),
                                             Expression.Constant("null"),
                                             Expression.Call(
                                                 resultMO.Expression,
@@ -599,7 +600,7 @@ namespace System.Dynamic
                                 )
                             ),
                             Expression.Block(
-                                methodName != nameof(DynamicObject.TryBinaryOperation) ? ReferenceArgAssign(callArgs, args) : Expression.Empty(),
+                                methodName != nameof(DynamicObject.TryBinaryOperation) ? ReferenceArgAssign(callArgs, args) : AstUtils.Empty,
                                 resultMO.Expression
                             ),
                             fallbackResult.Expression,
@@ -719,7 +720,7 @@ namespace System.Dynamic
                             ),
                             Expression.Block(
                                 ReferenceArgAssign(callArgs, args),
-                                Expression.Empty()
+                                AstUtils.Empty
                             ),
                             fallbackResult.Expression,
                             typeof(void)

--- a/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Dynamic.Utils;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
+using AstUtils = System.Linq.Expressions.Utils;
 
 namespace System.Dynamic
 {
@@ -774,9 +775,9 @@ namespace System.Dynamic
                     typeof(RuntimeOps).GetMethod("ExpandoTryGetValue"),
                     GetLimitedSelf(),
                     Expression.Constant(klass, typeof(object)),
-                    Expression.Constant(index),
+                    AstUtils.Constant(index),
                     Expression.Constant(name),
-                    Expression.Constant(ignoreCase),
+                    AstUtils.Constant(ignoreCase),
                     value
                 );
 
@@ -845,10 +846,10 @@ namespace System.Dynamic
                             typeof(RuntimeOps).GetMethod("ExpandoTrySetValue"),
                             GetLimitedSelf(),
                             Expression.Constant(klass, typeof(object)),
-                            Expression.Constant(index),
+                            AstUtils.Constant(index),
                             Expression.Convert(value.Expression, typeof(object)),
                             Expression.Constant(binder.Name),
-                            Expression.Constant(binder.IgnoreCase)
+                            AstUtils.Constant(binder.IgnoreCase)
                         ),
                         BindingRestrictions.Empty
                     )
@@ -865,9 +866,9 @@ namespace System.Dynamic
                     typeof(RuntimeOps).GetMethod("ExpandoTryDeleteValue"),
                     GetLimitedSelf(),
                     Expression.Constant(Value.Class, typeof(object)),
-                    Expression.Constant(index),
+                    AstUtils.Constant(index),
                     Expression.Constant(binder.Name),
-                    Expression.Constant(binder.IgnoreCase)
+                    AstUtils.Constant(binder.IgnoreCase)
                 );
                 DynamicMetaObject fallback = binder.FallbackDeleteMember(this);
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
@@ -677,14 +677,14 @@ namespace System.Linq.Expressions.Compiler
                 {
                     if (t.Value != null)
                     {
-                        initializers.Add(Expression.ElementInit(add, t, Expression.Constant(i)));
+                        initializers.Add(Expression.ElementInit(add, t, Utils.Constant(i)));
                     }
                     else
                     {
                         nullCase = i;
                     }
                 }
-                cases.UncheckedAdd(Expression.SwitchCase(node.Cases[i].Body, Expression.Constant(i)));
+                cases.UncheckedAdd(Expression.SwitchCase(node.Cases[i].Body, Utils.Constant(i)));
             }
 
             // Create the field to hold the lazily initialized dictionary
@@ -700,7 +700,7 @@ namespace System.Linq.Expressions.Compiler
                     Expression.ListInit(
                         Expression.New(
                             DictionaryOfStringInt32_Ctor_Int32,
-                            Expression.Constant(initializers.Count)
+                            Utils.Constant(initializers.Count)
                         ),
                         initializers
                     )
@@ -736,11 +736,11 @@ namespace System.Linq.Expressions.Compiler
                 Expression.Assign(switchValue, node.SwitchValue),
                 Expression.IfThenElse(
                     Expression.Equal(switchValue, Expression.Constant(null, typeof(string))),
-                    Expression.Assign(switchIndex, Expression.Constant(nullCase)),
+                    Expression.Assign(switchIndex, Utils.Constant(nullCase)),
                     Expression.IfThenElse(
                         Expression.Call(dictInit, "TryGetValue", null, switchValue, switchIndex),
-                        Utils.Empty(),
-                        Expression.Assign(switchIndex, Expression.Constant(-1))
+                        Utils.Empty,
+                        Expression.Assign(switchIndex, Utils.Constant(-1))
                     )
                 ),
                 Expression.Switch(node.Type, switchIndex, node.DefaultBody, null, cases.ToReadOnly())

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Bindings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Bindings.cs
@@ -118,7 +118,7 @@ namespace System.Linq.Expressions.Compiler
                 }
                 else
                 {
-                    block[_bindings.Count + 1] = Utils.Empty();
+                    block[_bindings.Count + 1] = Utils.Empty;
                 }
                 return MakeBlock(block);
             }
@@ -200,7 +200,7 @@ namespace System.Linq.Expressions.Compiler
                 }
                 else
                 {
-                    block[_inits.Count + 1] = Utils.Empty();
+                    block[_inits.Count + 1] = Utils.Empty;
                 }
                 return MakeBlock(block);
             }
@@ -240,7 +240,7 @@ namespace System.Linq.Expressions.Compiler
                 return MakeBlock(
                     new AssignBinaryExpression(memberTemp, _rhs),
                     new AssignBinaryExpression(member, memberTemp),
-                    Utils.Empty()
+                    Utils.Empty
                 );
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ConditionalExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ConditionalExpression.cs
@@ -68,7 +68,7 @@ namespace System.Linq.Expressions
         internal virtual Expression GetFalse()
         {
             // Using a singleton here to ensure a stable object identity for IfFalse, which Update relies on.
-            return AstUtils.Empty();
+            return AstUtils.Empty;
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -1425,7 +1425,7 @@ namespace System.Linq.Expressions.Interpreter
             var node = (ConditionalExpression)expr;
             Compile(node.Test);
 
-            if (node.IfTrue == AstUtils.Empty())
+            if (node.IfTrue == AstUtils.Empty)
             {
                 BranchLabel endOfFalse = _instructions.MakeLabel();
                 _instructions.EmitBranchTrue(endOfFalse);
@@ -1438,7 +1438,7 @@ namespace System.Linq.Expressions.Interpreter
                 _instructions.EmitBranchFalse(endOfTrue);
                 Compile(node.IfTrue, asVoid);
 
-                if (node.IfFalse != AstUtils.Empty())
+                if (node.IfFalse != AstUtils.Empty)
                 {
                     BranchLabel endOfFalse = _instructions.MakeLabel();
                     _instructions.EmitBranch(endOfFalse, false, !asVoid);
@@ -1563,7 +1563,7 @@ namespace System.Linq.Expressions.Interpreter
                         Expression.Condition(
                             Expression.Equal(temp.Parameter, val, false, node.Comparison),
                             Expression.Goto(doneLabel, @case.Body),
-                            AstUtils.Empty()
+                            AstUtils.Empty
                         ),
                         asVoid: true);
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalVariables.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalVariables.cs
@@ -43,7 +43,7 @@ namespace System.Linq.Expressions.Interpreter
 
         internal Expression LoadFromArray(Expression frameData, Expression closure, Type parameterType)
         {
-            Expression result = Expression.ArrayAccess(InClosure ? closure : frameData, Expression.Constant(Index));
+            Expression result = Expression.ArrayAccess(InClosure ? closure : frameData, Utils.Constant(Index));
             return (IsBoxed && !InClosure) ? Expression.Convert(result, typeof(StrongBox<object>)) : result;
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
@@ -78,7 +78,7 @@ namespace System.Linq.Expressions
             {
                 block[i + 1] = ReduceMemberBinding(objVar, bindings[i]);
             }
-            block[count + 1] = keepOnStack ? (Expression)objVar : Expression.Empty();
+            block[count + 1] = keepOnStack ? (Expression)objVar : Utils.Empty;
             return Expression.Block(new TrueReadOnlyCollection<Expression>(block));
         }
 
@@ -93,7 +93,7 @@ namespace System.Linq.Expressions
                 ElementInit element = initializers[i];
                 block[i + 1] = Expression.Call(listVar, element.AddMethod, element.Arguments);
             }
-            block[count + 1] = keepOnStack ? (Expression)listVar : Expression.Empty();
+            block[count + 1] = keepOnStack ? (Expression)listVar : Utils.Empty;
             return Expression.Block(new TrueReadOnlyCollection<Expression>(block));
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
@@ -60,7 +60,7 @@ namespace System.Linq.Expressions
                     // either matches or is its type argument (T to its T?).
                     if (cType.GetNonNullableType() != TypeOperand.GetNonNullableType())
                     {
-                        return Expression.Block(Expression, Expression.Constant(value: false));
+                        return Expression.Block(Expression, Utils.Constant(value: false));
                     }
                     else
                     {
@@ -71,7 +71,7 @@ namespace System.Linq.Expressions
                 {
                     // For other value types (including Void), we can
                     // determine the result now
-                    return Expression.Block(Expression, Expression.Constant(cType == TypeOperand.GetNonNullableType()));
+                    return Expression.Block(Expression, Utils.Constant(cType == TypeOperand.GetNonNullableType()));
                 }
             }
 
@@ -120,7 +120,7 @@ namespace System.Linq.Expressions
             // (don't invoke a user defined operator), and reference equality
             // on types for performance (so the JIT can optimize the IL).
             return Expression.AndAlso(
-                Expression.ReferenceNotEqual(value, Expression.Constant(value: null)),
+                Expression.ReferenceNotEqual(value, Utils.Null),
                 Expression.ReferenceEqual(
                     getType,
                     Expression.Constant(TypeOperand.GetNonNullableType(), typeof(Type))
@@ -134,11 +134,11 @@ namespace System.Linq.Expressions
             //TypeEqual(null, T) always returns false.
             if (ce.Value == null)
             {
-                return Expression.Constant(value: false);
+                return Utils.Constant(value: false);
             }
             else
             {
-                return Expression.Constant(TypeOperand.GetNonNullableType() == ce.Value.GetType());
+                return Utils.Constant(TypeOperand.GetNonNullableType() == ce.Value.GetType());
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Utils.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Utils.cs
@@ -6,11 +6,31 @@ namespace System.Linq.Expressions
 {
     internal static class Utils
     {
-        private static readonly DefaultExpression s_voidInstance = Expression.Empty();
+        private static readonly ConstantExpression s_true = Expression.Constant(true);
+        private static readonly ConstantExpression s_false = Expression.Constant(false);
 
-        public static DefaultExpression Empty()
+        private static readonly ConstantExpression s_m1 = Expression.Constant(-1);
+        private static readonly ConstantExpression s_0 = Expression.Constant(0);
+        private static readonly ConstantExpression s_1 = Expression.Constant(1);
+        private static readonly ConstantExpression s_2 = Expression.Constant(2);
+        private static readonly ConstantExpression s_3 = Expression.Constant(3);
+
+        public static readonly DefaultExpression Empty = Expression.Empty();
+        public static readonly ConstantExpression Null = Expression.Constant(null);
+
+        public static ConstantExpression Constant(bool value) => value ? s_true : s_false;
+
+        public static ConstantExpression Constant(int value)
         {
-            return s_voidInstance;
+            switch (value)
+            {
+                case -1: return s_m1;
+                case 0: return s_0;
+                case 1: return s_1;
+                case 2: return s_2;
+                case 3: return s_3;
+                default: return Expression.Constant(value);
+            }
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
@@ -477,7 +477,7 @@ namespace System.Runtime.CompilerServices
                     ),
                     Expression.Block(
                         Expression.Assign(count, Expression.ArrayLength(applicable)),
-                        Expression.Assign(index, Expression.Constant(0)),
+                        Expression.Assign(index, Utils.Constant(0)),
                         Expression.Loop(
                             Expression.Block(
                                 breakIfDone,
@@ -567,7 +567,7 @@ namespace System.Runtime.CompilerServices
                 Expression.Assign(rule, Expression.ArrayAccess(applicable, index))
             );
 
-            body.Add(Expression.Assign(index, Expression.Constant(0)));
+            body.Add(Expression.Assign(index, Utils.Constant(0)));
             body.Add(Expression.Assign(count, Expression.ArrayLength(applicable)));
             body.Add(
                 Expression.Loop(


### PR DESCRIPTION
The merged DLR code didn't have access to the singleton for `Expression.Empty()`, so using that now where applicable. Also found a bunch of places where we create `Constant` nodes of type `Boolean` or `Int32` with commonly used values, so adding caching for common values. I'll add some review comments inline to clarify.