### PR TITLE
Reduce allocations in HttpClient

### DIFF
--- a/src/Common/src/System/Net/Http/NoWriteNoSeekStreamContent.cs
+++ b/src/Common/src/System/Net/Http/NoWriteNoSeekStreamContent.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Http
+{
+    /// <summary>Provides an HttpContent for a Stream that is inherently read-only without support for writing or seeking.</summary>
+    /// <remarks>Same as StreamContent, but specialized for no-write, no-seek, and without being constrained by its public API.</remarks>
+    internal sealed class NoWriteNoSeekStreamContent : HttpContent
+    {
+        private readonly Stream _content;
+        private readonly CancellationToken _cancellationToken;
+        private bool _contentConsumed;
+
+        internal NoWriteNoSeekStreamContent(Stream content, CancellationToken cancellationToken)
+        {
+            Debug.Assert(content != null);
+            Debug.Assert(content.CanRead);
+            Debug.Assert(!content.CanWrite);
+            Debug.Assert(!content.CanSeek);
+
+            _content = content;
+            _cancellationToken = cancellationToken;
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+            Debug.Assert(stream != null);
+
+            if (_contentConsumed)
+            {
+                throw new InvalidOperationException(SR.net_http_content_stream_already_read);
+            }
+            _contentConsumed = true;
+
+            // If the stream can't be re-read, make sure that it gets disposed once it is consumed.
+            const int BufferSize = 8192;
+            return StreamToStreamCopy.CopyAsync(_content, stream, BufferSize, disposeSource: true, cancellationToken: _cancellationToken);
+        }
+
+        protected internal override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _content.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        protected override Task<Stream> CreateContentReadStreamAsync() => Task.FromResult<Stream>(_content);
+    }
+}

--- a/src/Common/src/System/Net/HttpKnownHeaderNames.TryGetHeaderName.cs
+++ b/src/Common/src/System/Net/HttpKnownHeaderNames.TryGetHeaderName.cs
@@ -89,6 +89,7 @@ namespace System.Net
                     {
                         case 'A': potentialHeader = Age; goto TryMatch; // [A]ge
                         case 'P': potentialHeader = P3P; goto TryMatch; // [P]3P
+                        case 'T': potentialHeader = TSV; goto TryMatch; // [T]SV
                         case 'V': potentialHeader = Via; goto TryMatch; // [V]ia
                     }
                     break;
@@ -100,6 +101,7 @@ namespace System.Net
                         case 'E': potentialHeader = ETag; goto TryMatch; // [E]Tag
                         case 'F': potentialHeader = From; goto TryMatch; // [F]rom
                         case 'H': potentialHeader = Host; goto TryMatch; // [H]ost
+                        case 'L': potentialHeader = Link; goto TryMatch; // [L]ink
                         case 'V': potentialHeader = Vary; goto TryMatch; // [V]ary
                     }
                     break;
@@ -127,6 +129,7 @@ namespace System.Net
                 case 7:
                     switch (charAt(key, startIndex))
                     {
+                        case 'A': potentialHeader = AltSvc; goto TryMatch;  // [A]lt-Svc
                         case 'C': potentialHeader = Cookie2; goto TryMatch; // [C]ookie2
                         case 'E': potentialHeader = Expires; goto TryMatch; // [E]xpires
                         case 'R': potentialHeader = Referer; goto TryMatch; // [R]eferer
@@ -165,11 +168,13 @@ namespace System.Net
                     break;
 
                 case 12:
-                    switch (charAt(key, startIndex))
+                    switch (charAt(key, startIndex + 2))
                     {
-                        case 'C': potentialHeader = ContentType; goto TryMatch; // [C]ontent-Type
-                        case 'M': potentialHeader = MaxForwards; goto TryMatch; // [M]ax-Forwards
-                        case 'X': potentialHeader = XPoweredBy; goto TryMatch;  // [X]-Powered-By
+                        case 'c': potentialHeader = AcceptPatch; goto TryMatch; // Ac[c]ept-Patch
+                        case 'n': potentialHeader = ContentType; goto TryMatch; // Co[n]tent-Type
+                        case 'x': potentialHeader = MaxForwards; goto TryMatch; // Ma[x]-Forwards
+                        case 'P': potentialHeader = XPoweredBy; goto TryMatch;  // X-[P]owered-By
+                        case 'R': potentialHeader = XRequestID; goto TryMatch;  // X-[R]equest-ID
                     }
                     break;
 
@@ -196,7 +201,10 @@ namespace System.Net
                 case 15:
                     switch (charAt(key, startIndex + 7))
                     {
+                        case '-': potentialHeader = XFrameOptions; goto TryMatch;  // X-Frame[-]Options
+                        case 'm': potentialHeader = XUACompatible; goto TryMatch;  // X-UA-Co[m]patible
                         case 'E': potentialHeader = AcceptEncoding; goto TryMatch; // Accept-[E]ncoding
+                        case 'K': potentialHeader = PublicKeyPins; goto TryMatch;  // Public-[K]ey-Pins
                         case 'L': potentialHeader = AcceptLanguage; goto TryMatch; // Accept-[L]anguage
                     }
                     break;
@@ -223,7 +231,12 @@ namespace System.Net
                     break;
 
                 case 18:
-                    potentialHeader = ProxyAuthenticate; goto TryMatch; // Proxy-Authenticate
+                    switch (charAt(key, startIndex))
+                    {
+                        case 'P': potentialHeader = ProxyAuthenticate; goto TryMatch; // [P]roxy-Authenticate
+                        case 'X': potentialHeader = XContentDuration; goto TryMatch;  // [X]-Content-Duration
+                    }
+                    break;
 
                 case 19:
                     switch (charAt(key, startIndex))
@@ -241,10 +254,44 @@ namespace System.Net
                     potentialHeader = SecWebSocketVersion; goto TryMatch; // Sec-WebSocket-Version
 
                 case 22:
-                    potentialHeader = SecWebSocketProtocol; goto TryMatch; // Sec-WebSocket-Protocol
+                    switch (charAt(key, startIndex))
+                    {
+                        case 'A': potentialHeader = AccessControlMaxAge; goto TryMatch;  // [A]ccess-Control-Max-Age
+                        case 'S': potentialHeader = SecWebSocketProtocol; goto TryMatch; // [S]ec-WebSocket-Protocol
+                        case 'X': potentialHeader = XContentTypeOptions; goto TryMatch;  // [X]-Content-Type-Options
+                    }
+                    break;
+
+                case 23:
+                    potentialHeader = ContentSecurityPolicy; goto TryMatch; // Content-Security-Policy
 
                 case 24:
                     potentialHeader = SecWebSocketExtensions; goto TryMatch; // Sec-WebSocket-Extensions
+
+                case 25:
+                    switch (charAt(key, startIndex))
+                    {
+                        case 'S': potentialHeader = StrictTransportSecurity; goto TryMatch; // [S]trict-Transport-Security
+                        case 'U': potentialHeader = UpgradeInsecureRequests; goto TryMatch; // [U]pgrade-Insecure-Requests
+                    }
+                    break;
+
+                case 27:
+                    potentialHeader = AccessControlAllowOrigin; goto TryMatch; // Access-Control-Allow-Origin
+
+                case 28:
+                    switch (charAt(key, startIndex + 21))
+                    {
+                        case 'H': potentialHeader = AccessControlAllowHeaders; goto TryMatch; // Access-Control-Allow-[H]eaders
+                        case 'M': potentialHeader = AccessControlAllowMethods; goto TryMatch; // Access-Control-Allow-[M]ethods
+                    }
+                    break;
+
+                case 29:
+                    potentialHeader = AccessControlExposeHeaders; goto TryMatch; // Access-Control-Expose-Headers
+
+                case 32:
+                    potentialHeader = AccessControlAllowCredentials; goto TryMatch; // Access-Control-Allow-Credentials
             }
 
             name = null;

--- a/src/Common/src/System/Net/HttpKnownHeaderNames.cs
+++ b/src/Common/src/System/Net/HttpKnownHeaderNames.cs
@@ -12,9 +12,17 @@ namespace System.Net
         public const string AcceptCharset = "Accept-Charset";
         public const string AcceptEncoding = "Accept-Encoding";
         public const string AcceptLanguage = "Accept-Language";
+        public const string AcceptPatch = "Accept-Patch";
         public const string AcceptRanges = "Accept-Ranges";
+        public const string AccessControlAllowCredentials = "Access-Control-Allow-Credentials";
+        public const string AccessControlAllowHeaders = "Access-Control-Allow-Headers";
+        public const string AccessControlAllowMethods = "Access-Control-Allow-Methods";
+        public const string AccessControlAllowOrigin = "Access-Control-Allow-Origin";
+        public const string AccessControlExposeHeaders = "Access-Control-Expose-Headers";
+        public const string AccessControlMaxAge = "Access-Control-Max-Age";
         public const string Age = "Age";
         public const string Allow = "Allow";
+        public const string AltSvc = "Alt-Svc";
         public const string Authorization = "Authorization";
         public const string CacheControl = "Cache-Control";
         public const string Connection = "Connection";
@@ -25,6 +33,7 @@ namespace System.Net
         public const string ContentLocation = "Content-Location";
         public const string ContentMD5 = "Content-MD5";
         public const string ContentRange = "Content-Range";
+        public const string ContentSecurityPolicy = "Content-Security-Policy";
         public const string ContentType = "Content-Type";
         public const string Cookie = "Cookie";
         public const string Cookie2 = "Cookie2";
@@ -41,6 +50,7 @@ namespace System.Net
         public const string IfUnmodifiedSince = "If-Unmodified-Since";
         public const string KeepAlive = "Keep-Alive";
         public const string LastModified = "Last-Modified";
+        public const string Link = "Link";
         public const string Location = "Location";
         public const string MaxForwards = "Max-Forwards";
         public const string Origin = "Origin";
@@ -49,6 +59,7 @@ namespace System.Net
         public const string ProxyAuthenticate = "Proxy-Authenticate";
         public const string ProxyAuthorization = "Proxy-Authorization";
         public const string ProxyConnection = "Proxy-Connection";
+        public const string PublicKeyPins = "Public-Key-Pins";
         public const string Range = "Range";
         public const string Referer = "Referer"; // NB: The spelling-mistake "Referer" for "Referrer" must be matched.
         public const string RetryAfter = "Retry-After";
@@ -60,16 +71,24 @@ namespace System.Net
         public const string Server = "Server";
         public const string SetCookie = "Set-Cookie";
         public const string SetCookie2 = "Set-Cookie2";
+        public const string StrictTransportSecurity = "Strict-Transport-Security";
         public const string TE = "TE";
+        public const string TSV = "TSV";
         public const string Trailer = "Trailer";
         public const string TransferEncoding = "Transfer-Encoding";
         public const string Upgrade = "Upgrade";
+        public const string UpgradeInsecureRequests = "Upgrade-Insecure-Requests";
         public const string UserAgent = "User-Agent";
         public const string Vary = "Vary";
         public const string Via = "Via";
         public const string WWWAuthenticate = "WWW-Authenticate";
         public const string Warning = "Warning";
         public const string XAspNetVersion = "X-AspNet-Version";
+        public const string XContentDuration = "X-Content-Duration";
+        public const string XContentTypeOptions = "X-Content-Type-Options";
+        public const string XFrameOptions = "X-Frame-Options";
         public const string XPoweredBy = "X-Powered-By";
+        public const string XRequestID = "X-Request-ID";
+        public const string XUACompatible = "X-UA-Compatible";
     }
 }

--- a/src/Common/src/System/Threading/Tasks/RendezvousAwaitable.cs
+++ b/src/Common/src/System/Threading/Tasks/RendezvousAwaitable.cs
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+
+namespace System.Threading.Tasks
+{
+    /// <summary>Provides a reusable object that can be awaited by a consumer and manually completed by a producer.</summary>
+    /// <typeparam name="TResult">The type of data being passed from producer to consumer.</typeparam>
+    internal sealed class RendezvousAwaitable<TResult> : ICriticalNotifyCompletion
+    {
+        /// <summary>Sentinel object indicating that the operation has completed prior to OnCompleted being called.</summary>
+        private static readonly Action s_completionSentinel = () => Debug.Fail("Completion sentinel should never be invoked");
+
+        /// <summary>
+        /// The continuation to invoke when the operation completes, or <see cref="s_completionSentinel"/> if the operation
+        /// has completed before OnCompleted is called.
+        /// </summary>
+        private Action _continuation;
+        /// <summary>The exception representing the failed async operation, if it failed.</summary>
+        private ExceptionDispatchInfo _error;
+        /// <summary>The result of the async operation, if it succeeded.</summary>
+        private TResult _result;
+#if DEBUG
+        private bool _resultSet;
+#endif
+
+        /// <summary>true if the producer should invoke the continuation asynchronously; otherwise, false.</summary>
+        public bool RunContinuationsAsynchronously { get; set; } = true;
+
+        /// <summary>Gets this instance as an awaiter.</summary>
+        public RendezvousAwaitable<TResult> GetAwaiter() => this;
+
+        /// <summary>Whether the operation has already completed.</summary>
+        public bool IsCompleted
+        {
+            get
+            {
+                Action c = Volatile.Read(ref _continuation);
+                Debug.Assert(c == null || c == s_completionSentinel);
+                return c != null;
+            }
+        }
+
+        public TResult GetResult()
+        {
+            AssertResultConsistency(expectedCompleted: true);
+
+            // Clear out the continuation to prepare for another use
+            Debug.Assert(_continuation != null);
+            _continuation = null;
+
+            // Propagate any error if there is one, clearing it out first to prepare for reuse.
+            // We don't need to clear a result, as result and error are mutually exclusive.
+            ExceptionDispatchInfo error = _error;
+            if (error != null)
+            {
+                _error = null;
+                error.Throw();
+            }
+
+            // The operation completed successfully.  Clear and return the result.
+            TResult result = _result;
+            _result = default(TResult);
+#if DEBUG
+            _resultSet = false;
+#endif
+            return result;
+        }
+
+        /// <summary>Set the result of the operation.</summary>
+        public void SetResult(TResult result)
+        {
+            AssertResultConsistency(expectedCompleted: false);
+            _result = result;
+#if DEBUG
+            _resultSet = true;
+#endif
+            NotifyAwaiter();
+        }
+
+        /// <summary>Set that the operation was canceled.</summary>
+        public void SetCanceled(CancellationToken token = default(CancellationToken))
+        {
+            SetException(token.IsCancellationRequested ? new OperationCanceledException(token) : new OperationCanceledException());
+        }
+
+        /// <summary>Set the failure for the operation.</summary>
+        public void SetException(Exception exception)
+        {
+            Debug.Assert(exception != null);
+            AssertResultConsistency(expectedCompleted: false);
+
+            _error = ExceptionDispatchInfo.Capture(exception);
+            NotifyAwaiter();
+        }
+
+        /// <summary>Alerts any awaiter that the operation has completed.</summary>
+        private void NotifyAwaiter()
+        {
+            Action c = _continuation ?? Interlocked.CompareExchange(ref _continuation, s_completionSentinel, null);
+            if (c != null)
+            {
+                Debug.Assert(c != s_completionSentinel);
+
+                if (RunContinuationsAsynchronously)
+                {
+                    Task.Run(c);
+                }
+                else
+                {
+                    c();
+                }
+            }
+        }
+
+        /// <summary>Register the continuation to invoke when the operation completes.</summary>
+        public void OnCompleted(Action continuation)
+        {
+            Debug.Assert(continuation != null);
+
+            Action c = _continuation ?? Interlocked.CompareExchange(ref _continuation, continuation, null);
+            if (c != null)
+            {
+                Debug.Assert(c == s_completionSentinel);
+                Task.Run(continuation);
+            }
+        }
+
+        /// <summary>Register the continuation to invoke when the operation completes.</summary>
+        public void UnsafeOnCompleted(Action continuation) => OnCompleted(continuation);
+
+        [Conditional("DEBUG")]
+        private void AssertResultConsistency(bool expectedCompleted)
+        {
+#if DEBUG
+            if (expectedCompleted)
+            {
+                Debug.Assert(_resultSet ^ (_error != null));
+            }
+            else
+            {
+                Debug.Assert(!_resultSet && _error == null);
+            }
+#endif
+        }
+    }
+}

--- a/src/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
+++ b/src/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
@@ -165,4 +165,19 @@
   <data name="net_http_buffer_insufficient_length" xml:space="preserve">
     <value>The buffer was not long enough.</value>
   </data>
+  <data name="ArgumentOutOfRange_NeedPosNum" xml:space="preserve">
+    <value>Positive number required.</value>
+  </data>
+  <data name="NotSupported_UnreadableStream" xml:space="preserve">
+    <value>Stream does not support reading.</value>
+  </data>
+  <data name="NotSupported_UnwritableStream" xml:space="preserve">
+    <value>Stream does not support writing.</value>
+  </data>
+  <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
+    <value>Can not access a closed Stream.</value>
+  </data>
+  <data name="net_http_content_stream_already_read" xml:space="preserve">
+    <value>The stream was already consumed. It cannot be read again.</value>
+  </data>
 </root>

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
@@ -17,11 +17,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <Import Project="System.Net.Http.WinHttpHandler.msbuild" Condition="'$(TargetsWindows)' == 'true'" />
-  <ItemGroup>
-    <Compile Include="$(CommonPath)\System\Net\HttpVersionInternal.cs">
-      <Link>Common\System\Net\HttpVersionInternal.cs</Link>
-    </Compile>
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
     <!-- Need to compile it here since the NET46 target here is building against System.Runtime whereas the
          the list of other files in System.Net.Http.WinHttpHandler.msbuild is also used by System.Net.Http
@@ -34,6 +29,12 @@
          up item called CompileItem and then just include it here. -->
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <Compile Include="@(CompileItem)" />
+    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.CopyValidation.cs">
+      <Link>Common\System\IO\StreamHelpers.CopyValidation.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\HttpVersionInternal.cs">
+      <Link>Common\System\Net\HttpVersionInternal.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
@@ -24,6 +24,7 @@
     <CompileItem Include="$(CommonPath)\System\Net\Http\HttpHandlerDiagnosticListenerExtensions.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Http\HttpHandlerLoggingStrings.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Http\WinHttpException.cs" />
+    <CompileItem Include="$(CommonPath)\System\Threading\Tasks\RendezvousAwaitable.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpAuthHelper.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpCertificateHelper.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpChannelBinding.cs" />

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
@@ -23,6 +23,7 @@
     <CompileItem Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Http\HttpHandlerDiagnosticListenerExtensions.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Http\HttpHandlerLoggingStrings.cs" />
+    <CompileItem Include="$(CommonPath)\System\Net\Http\NoWriteNoSeekStreamContent.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Http\WinHttpException.cs" />
     <CompileItem Include="$(CommonPath)\System\Threading\Tasks\RendezvousAwaitable.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpAuthHelper.cs" />

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -611,7 +611,7 @@ namespace System.Net.Http
             var requestHeadersBuffer = new StringBuilder();
 
             // Manually add cookies.
-            if (cookies != null)
+            if (cookies != null && cookies.Count > 0)
             {
                 string cookieHeader = WinHttpCookieContainerAdapter.GetCookieHeader(requestMessage.RequestUri, cookies);
                 if (!string.IsNullOrEmpty(cookieHeader))

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
@@ -32,7 +32,7 @@ namespace System.Net.Http
         // A GCHandle for this operation object.
         // This is owned by the callback and will be deallocated when the sessionHandle has been closed.
         private GCHandle _operationHandle;
-
+        private WinHttpTransportContext _transportContext;
         private volatile bool _disposed = false; // To detect redundant calls.
 
         public WinHttpRequestState()
@@ -40,7 +40,6 @@ namespace System.Net.Http
 #if DEBUG
             Interlocked.Increment(ref s_dbg_allocated);
 #endif
-            TransportContext = new WinHttpTransportContext();
         }
 
         public void Pin()
@@ -139,7 +138,11 @@ namespace System.Net.Http
             SslPolicyErrors,
             bool> ServerCertificateValidationCallback { get; set; }
 
-        public WinHttpTransportContext TransportContext { get; private set; }
+        public WinHttpTransportContext TransportContext
+        {
+            get { return _transportContext ?? (_transportContext = new WinHttpTransportContext()); }
+            set { _transportContext = value; }
+        }
 
         public WindowsProxyUsePolicy WindowsProxyUsePolicy { get; set; }
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
@@ -32,86 +33,92 @@ namespace System.Net.Http
             // This buffer is the length needed for WINHTTP_QUERY_RAW_HEADERS_CRLF, which includes the status line
             // and all headers separated by CRLF, so it should be large enough for any individual status line or header queries.
             int bufferLength = GetResponseHeaderCharBufferLength(requestHandle, Interop.WinHttp.WINHTTP_QUERY_RAW_HEADERS_CRLF);
-            char[] buffer = new char[bufferLength];
-
-            // Get HTTP version, status code, reason phrase from the response headers.
-
-            if (IsResponseHttp2(requestHandle))
+            char[] buffer = ArrayPool<char>.Shared.Rent(bufferLength);
+            try
             {
-                response.Version = WinHttpHandler.HttpVersion20;
-            }
-            else
-            {
-                int versionLength = GetResponseHeader(requestHandle, Interop.WinHttp.WINHTTP_QUERY_VERSION, buffer);
-                response.Version =
-                    CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase("HTTP/1.1", buffer, 0, versionLength) ? HttpVersionInternal.Version11 :
-                    CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase("HTTP/1.0", buffer, 0, versionLength) ? HttpVersionInternal.Version10 :
-                    WinHttpHandler.HttpVersionUnknown;
-            }
+                // Get HTTP version, status code, reason phrase from the response headers.
 
-            response.StatusCode = (HttpStatusCode)GetResponseHeaderNumberInfo(
-                requestHandle,
-                Interop.WinHttp.WINHTTP_QUERY_STATUS_CODE);
-
-            int reasonPhraseLength = GetResponseHeader(requestHandle, Interop.WinHttp.WINHTTP_QUERY_STATUS_TEXT, buffer);
-            response.ReasonPhrase = reasonPhraseLength > 0 ?
-                GetReasonPhrase(response.StatusCode, buffer, reasonPhraseLength) :
-                string.Empty;
-
-            // Create response stream and wrap it in a StreamContent object.
-            var responseStream = new WinHttpResponseStream(requestHandle, state);
-            state.RequestHandle = null; // ownership successfully transfered to WinHttpResponseStram.
-            Stream decompressedStream = responseStream;
-
-            if (doManualDecompressionCheck)
-            {
-                int contentEncodingStartIndex = 0;
-                int contentEncodingLength = GetResponseHeader(
-                    requestHandle,
-                    Interop.WinHttp.WINHTTP_QUERY_CONTENT_ENCODING,
-                    buffer);
-
-                CharArrayHelpers.Trim(buffer, ref contentEncodingStartIndex, ref contentEncodingLength);
-
-                if (contentEncodingLength > 0)
+                if (IsResponseHttp2(requestHandle))
                 {
-                    if (CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase(
-                        EncodingNameGzip, buffer, contentEncodingStartIndex, contentEncodingLength))
+                    response.Version = WinHttpHandler.HttpVersion20;
+                }
+                else
+                {
+                    int versionLength = GetResponseHeader(requestHandle, Interop.WinHttp.WINHTTP_QUERY_VERSION, buffer);
+                    response.Version =
+                        CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase("HTTP/1.1", buffer, 0, versionLength) ? HttpVersionInternal.Version11 :
+                        CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase("HTTP/1.0", buffer, 0, versionLength) ? HttpVersionInternal.Version10 :
+                        WinHttpHandler.HttpVersionUnknown;
+                }
+
+                response.StatusCode = (HttpStatusCode)GetResponseHeaderNumberInfo(
+                    requestHandle,
+                    Interop.WinHttp.WINHTTP_QUERY_STATUS_CODE);
+
+                int reasonPhraseLength = GetResponseHeader(requestHandle, Interop.WinHttp.WINHTTP_QUERY_STATUS_TEXT, buffer);
+                response.ReasonPhrase = reasonPhraseLength > 0 ?
+                    GetReasonPhrase(response.StatusCode, buffer, reasonPhraseLength) :
+                    string.Empty;
+
+                // Create response stream and wrap it in a StreamContent object.
+                var responseStream = new WinHttpResponseStream(requestHandle, state);
+                state.RequestHandle = null; // ownership successfully transfered to WinHttpResponseStram.
+                Stream decompressedStream = responseStream;
+
+                if (doManualDecompressionCheck)
+                {
+                    int contentEncodingStartIndex = 0;
+                    int contentEncodingLength = GetResponseHeader(
+                        requestHandle,
+                        Interop.WinHttp.WINHTTP_QUERY_CONTENT_ENCODING,
+                        buffer);
+
+                    CharArrayHelpers.Trim(buffer, ref contentEncodingStartIndex, ref contentEncodingLength);
+
+                    if (contentEncodingLength > 0)
                     {
-                        decompressedStream = new GZipStream(responseStream, CompressionMode.Decompress);
-                        stripEncodingHeaders = true;
-                    }
-                    else if (CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase(
-                        EncodingNameDeflate, buffer, contentEncodingStartIndex, contentEncodingLength))
-                    {
-                        decompressedStream = new DeflateStream(responseStream, CompressionMode.Decompress);
-                        stripEncodingHeaders = true;
+                        if (CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase(
+                            EncodingNameGzip, buffer, contentEncodingStartIndex, contentEncodingLength))
+                        {
+                            decompressedStream = new GZipStream(responseStream, CompressionMode.Decompress);
+                            stripEncodingHeaders = true;
+                        }
+                        else if (CharArrayHelpers.EqualsOrdinalAsciiIgnoreCase(
+                            EncodingNameDeflate, buffer, contentEncodingStartIndex, contentEncodingLength))
+                        {
+                            decompressedStream = new DeflateStream(responseStream, CompressionMode.Decompress);
+                            stripEncodingHeaders = true;
+                        }
                     }
                 }
-            }
 
 #if HTTP_DLL
             var content = new StreamContent(decompressedStream, state.CancellationToken);
 #else
-            // TODO: Issue https://github.com/dotnet/corefx/issues/9071
-            // We'd like to be able to pass state.CancellationToken into the StreamContent so that its
-            // SerializeToStreamAsync method can use it, but that ctor isn't public, nor is there a
-            // SerializeToStreamAsync override that takes a CancellationToken.
-            var content = new StreamContent(decompressedStream);
+                // TODO: Issue https://github.com/dotnet/corefx/issues/9071
+                // We'd like to be able to pass state.CancellationToken into the StreamContent so that its
+                // SerializeToStreamAsync method can use it, but that ctor isn't public, nor is there a
+                // SerializeToStreamAsync override that takes a CancellationToken.
+                var content = new StreamContent(decompressedStream);
 #endif
 
-            response.Content = content;
-            response.RequestMessage = request;
+                response.Content = content;
+                response.RequestMessage = request;
 
-            // Parse raw response headers and place them into response message.
-            ParseResponseHeaders(requestHandle, response, buffer, stripEncodingHeaders);
+                // Parse raw response headers and place them into response message.
+                ParseResponseHeaders(requestHandle, response, buffer, stripEncodingHeaders);
 
-            if (response.RequestMessage.Method != HttpMethod.Head)
-            {
-                state.ExpectedBytesToRead = response.Content.Headers.ContentLength;
+                if (response.RequestMessage.Method != HttpMethod.Head)
+                {
+                    state.ExpectedBytesToRead = response.Content.Headers.ContentLength;
+                }
+
+                return response;
             }
-
-            return response;
+            finally
+            {
+                ArrayPool<char>.Shared.Return(buffer);
+            }
         }
 
         /// <summary>

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -92,17 +92,7 @@ namespace System.Net.Http
                     }
                 }
 
-#if HTTP_DLL
-            var content = new StreamContent(decompressedStream, state.CancellationToken);
-#else
-                // TODO: Issue https://github.com/dotnet/corefx/issues/9071
-                // We'd like to be able to pass state.CancellationToken into the StreamContent so that its
-                // SerializeToStreamAsync method can use it, but that ctor isn't public, nor is there a
-                // SerializeToStreamAsync override that takes a CancellationToken.
-                var content = new StreamContent(decompressedStream);
-#endif
-
-                response.Content = content;
+                response.Content = new NoWriteNoSeekStreamContent(decompressedStream, state.CancellationToken);
                 response.RequestMessage = request;
 
                 // Parse raw response headers and place them into response message.

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -158,8 +158,8 @@ namespace System.Net.Http
                 ArrayPool<byte>.Shared.Return(buffer);
             }
 
-            // TODO: ReadAsync wasn't/isn't unpinning the buffer.  Is that a bug?
-            // Should it be unpinned there and here?
+            // Leaving buffer pinned as it is in ReadAsync.  It'll get unpinned when another read
+            // request is made with a different buffer or when the state is cleared.
         }
 
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken token)

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -84,6 +85,83 @@ namespace System.Net.Http
                 Task.CompletedTask;
         }
 
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            // Validate arguments as would base CopyToAsync
+            StreamHelpers.ValidateCopyToArgs(this, destination, bufferSize);
+
+            // Check that there are no other pending read operations
+            if (_state.AsyncReadInProgress)
+            {
+                throw new InvalidOperationException(SR.net_http_no_concurrent_io_allowed);
+            }
+
+            // Early check for cancellation
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled(cancellationToken);
+            }
+
+            // Check out a buffer and start the copy
+            return CopyToAsyncCore(destination, ArrayPool<byte>.Shared.Rent(bufferSize), cancellationToken);
+        }
+
+        private async Task CopyToAsyncCore(Stream destination, byte[] buffer, CancellationToken cancellationToken)
+        {
+            _state.PinReceiveBuffer(buffer);
+            CancellationTokenRegistration ctr = cancellationToken.Register(s => ((WinHttpResponseStream)s).CancelPendingResponseStreamReadOperation(), this);
+            _state.AsyncReadInProgress = true;
+            try
+            {
+                // Loop until there's no more data to be read
+                while (true)
+                {
+                    // Query for data available
+                    lock (_state.Lock)
+                    {
+                        if (!Interop.WinHttp.WinHttpQueryDataAvailable(_requestHandle, IntPtr.Zero))
+                        {
+                            throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError());
+                        }
+                    }
+                    int bytesAvailable = await _state.LifecycleAwaitable;
+                    if (bytesAvailable == 0)
+                    {
+                        break;
+                    }
+                    Debug.Assert(bytesAvailable > 0);
+
+                    // Read the available data
+                    cancellationToken.ThrowIfCancellationRequested();
+                    lock (_state.Lock)
+                    {
+                        if (!Interop.WinHttp.WinHttpReadData(_requestHandle, Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0), (uint)Math.Min(bytesAvailable, buffer.Length), IntPtr.Zero))
+                        {
+                            throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError());
+                        }
+                    }
+                    int bytesRead = await _state.LifecycleAwaitable;
+                    if (bytesRead == 0)
+                    {
+                        break;
+                    }
+                    Debug.Assert(bytesRead > 0);
+
+                    // Write that data out to the output stream
+                    await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                _state.AsyncReadInProgress = false;
+                ctr.Dispose();
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+
+            // TODO: ReadAsync wasn't/isn't unpinning the buffer.  Is that a bug?
+            // Should it be unpinned there and here?
+        }
+
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken token)
         {
             if (buffer == null)
@@ -113,85 +191,52 @@ namespace System.Net.Http
 
             CheckDisposed();
 
-            if (_state.TcsReadFromResponseStream != null && !_state.TcsReadFromResponseStream.Task.IsCompleted)
+            if (_state.AsyncReadInProgress)
             {
                 throw new InvalidOperationException(SR.net_http_no_concurrent_io_allowed);
             }
 
+            return ReadAsyncCore(buffer, offset, count, token);
+        }
+
+        private async Task<int> ReadAsyncCore(byte[] buffer, int offset, int count, CancellationToken token)
+        {
             _state.PinReceiveBuffer(buffer);
-
-            _state.TcsReadFromResponseStream =
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-            _state.TcsQueryDataAvailable =
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-            _state.TcsQueryDataAvailable.Task.ContinueWith((previousTask) => 
+            var ctr = token.Register(s => ((WinHttpResponseStream)s).CancelPendingResponseStreamReadOperation(), this);
+            _state.AsyncReadInProgress = true;
+            try
+            {
+                lock (_state.Lock)
                 {
-                    if (previousTask.IsFaulted)
+                    Debug.Assert(!_requestHandle.IsInvalid);
+                    if (!Interop.WinHttp.WinHttpQueryDataAvailable(_requestHandle, IntPtr.Zero))
                     {
-                        _state.DisposeCtrReadFromResponseStream();
-                        _state.TcsReadFromResponseStream.TrySetException(previousTask.Exception.InnerException);
+                        throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError());
                     }
-                    else if (previousTask.IsCanceled || token.IsCancellationRequested)
-                    {
-                        _state.DisposeCtrReadFromResponseStream();
-                        _state.TcsReadFromResponseStream.TrySetCanceled(token);
-                    }
-                    else
-                    {
-                        int bytesToRead;
-                        int bytesAvailable = previousTask.Result;
-                        if (bytesAvailable > count)
-                        {
-                            bytesToRead = count;
-                        }
-                        else
-                        {
-                            bytesToRead = bytesAvailable;
-                        }
-                        
-                        lock (_state.Lock)
-                        {
-                            Debug.Assert(!_requestHandle.IsInvalid);
-                            if (!Interop.WinHttp.WinHttpReadData(
-                                _requestHandle,
-                                Marshal.UnsafeAddrOfPinnedArrayElement(buffer, offset),
-                                (uint)bytesToRead,
-                                IntPtr.Zero))
-                            {
-                                _state.DisposeCtrReadFromResponseStream();
-                                _state.TcsReadFromResponseStream.TrySetException(
-                                    new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError().InitializeStackTrace()));
-                            }
-                        }
-                    }
-                }, 
-                CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
-
-            // Register callback on cancellation token to cancel any pending WinHTTP operation.
-            if (token.CanBeCanceled)
-            {
-                WinHttpTraceHelper.Trace("WinHttpResponseStream.ReadAsync: registering for cancellation token request");
-                _state.CtrReadFromResponseStream =
-                    token.Register(s => ((WinHttpResponseStream)s).CancelPendingResponseStreamReadOperation(), this);
-            }
-            else
-            {
-                WinHttpTraceHelper.Trace("WinHttpResponseStream.ReadAsync: received no cancellation token");
-            }
-
-            lock (_state.Lock)
-            {
-                Debug.Assert(!_requestHandle.IsInvalid);
-                if (!Interop.WinHttp.WinHttpQueryDataAvailable(_requestHandle, IntPtr.Zero))
-                {
-                    _state.DisposeCtrReadFromResponseStream();
-                    _state.TcsReadFromResponseStream.TrySetException(
-                        new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError().InitializeStackTrace()));
                 }
-            }
 
-            return _state.TcsReadFromResponseStream.Task;
+                int bytesAvailable = await _state.LifecycleAwaitable;
+
+                lock (_state.Lock)
+                {
+                    Debug.Assert(!_requestHandle.IsInvalid);
+                    if (!Interop.WinHttp.WinHttpReadData(
+                        _requestHandle,
+                        Marshal.UnsafeAddrOfPinnedArrayElement(buffer, offset),
+                        (uint)Math.Min(bytesAvailable, count),
+                        IntPtr.Zero))
+                    {
+                        throw new IOException(SR.net_http_io_read, WinHttpException.CreateExceptionUsingLastError());
+                    }
+                }
+
+                return await _state.LifecycleAwaitable;
+            }
+            finally
+            {
+                _state.AsyncReadInProgress = false;
+                ctr.Dispose();
+            }
         }
 
         public override int Read(byte[] buffer, int offset, int count)
@@ -256,10 +301,7 @@ namespace System.Net.Http
             WinHttpTraceHelper.Trace("WinHttpResponseStream.CancelPendingResponseStreamReadOperation");
             lock (_state.Lock)
             {
-                WinHttpTraceHelper.Trace(
-                    string.Format("WinHttpResponseStream.CancelPendingResponseStreamReadOperation: {0} {1}",
-                    (int)_state.TcsQueryDataAvailable.Task.Status, (int)_state.TcsReadFromResponseStream.Task.Status));
-                if (!_state.TcsQueryDataAvailable.Task.IsCompleted)
+                if (_state.AsyncReadInProgress)
                 {
                     Debug.Assert(_requestHandle != null);
                     Debug.Assert(!_requestHandle.IsInvalid);

--- a/src/System.Net.Http.WinHttpHandler/src/project.json
+++ b/src/System.Net.Http.WinHttpHandler/src/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1",
     "Microsoft.Win32.Primitives": "4.0.1",
+    "System.Buffers": "4.0.0",
     "System.Collections": "4.0.11",
     "System.Diagnostics.DiagnosticSource": "4.0.0",
     "System.Diagnostics.Debug": "4.0.11",

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -50,6 +50,9 @@
     <Compile Include="$(CommonPath)\System\Diagnostics\ExceptionExtensions.cs">
       <Link>Common\System\Diagnostics\ExceptionExtensions.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.CopyValidation.cs">
+      <Link>Common\System\IO\StreamHelpers.CopyValidation.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>
@@ -77,8 +80,14 @@
     <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerLoggingStrings.cs">
       <Link>Common\System\Net\Http\HttpHandlerLoggingStrings.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Http\NoWriteNoSeekStreamContent.cs">
+      <Link>Common\System\Net\Http\NoWriteNoSeekStreamContent.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\Http\WinHttpException.cs">
       <Link>Common\System\Net\Http\WinHttpException.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Threading\Tasks\RendezvousAwaitable.cs">
+      <Link>Common\System\Threading\Tasks\RendezvousAwaitable.cs</Link>
     </Compile>
     <Compile Include="..\..\src\System\Net\Http\WinHttpAuthHelper.cs">
       <Link>ProductionCode\WinHttpAuthHelper.cs</Link>

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.2.0-beta-24714-01",
     "Microsoft.Win32.Primitives": "4.4.0-beta-24714-01",
+    "System.Buffers": "4.4.0-beta-24714-01",
     "System.Diagnostics.DiagnosticSource": "4.4.0-beta-24714-01",
     "System.Globalization": "4.4.0-beta-24714-01",
     "System.IO": "4.4.0-beta-24714-01",

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -360,4 +360,16 @@
   <data name="net_http_response_headers_exceeded_length" xml:space="preserve">
     <value>The HTTP response headers length exceeded the set limit of {0} bytes.</value>
   </data>
+  <data name="ArgumentOutOfRange_NeedPosNum" xml:space="preserve">
+    <value>Positive number required.</value>
+  </data>
+  <data name="NotSupported_UnreadableStream" xml:space="preserve">
+    <value>Stream does not support reading.</value>
+  </data>
+  <data name="NotSupported_UnwritableStream" xml:space="preserve">
+    <value>Stream does not support writing.</value>
+  </data>
+  <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
+    <value>Can not access a closed Stream.</value>
+  </data>
 </root>

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -95,6 +95,9 @@
     <Compile Include="System\Net\Http\Headers\UriHeaderParser.cs" />
     <Compile Include="System\Net\Http\Headers\ViaHeaderValue.cs" />
     <Compile Include="System\Net\Http\Headers\WarningHeaderValue.cs" />
+    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.CopyValidation.cs">
+      <Link>Common\System\IO\StreamHelpers.CopyValidation.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\HttpVersionInternal.cs">
       <Link>Common\System\Net\HttpVersionInternal.cs</Link>
     </Compile>
@@ -357,10 +360,6 @@
     <TargetingPackReference Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup>
-    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
-    <ProjectReference Include="..\..\System.Runtime.Extensions\pkg\System.Runtime.Extensions.pkgproj" />
-    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
-    <ProjectReference Include="..\..\System.IO\pkg\System.IO.pkgproj" />
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -101,9 +101,6 @@
     <Compile Include="$(CommonPath)\System\Net\HttpVersionInternal.cs">
       <Link>Common\System\Net\HttpVersionInternal.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\NoWriteNoSeekStreamContent.cs">
-      <Link>Common\System\Net\Http\NoWriteNoSeekStreamContent.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\Net\Mail\MailAddress.cs">
       <Link>Common\System\Net\Mail\MailAddress.cs</Link>
     </Compile>

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -101,6 +101,9 @@
     <Compile Include="$(CommonPath)\System\Net\HttpVersionInternal.cs">
       <Link>Common\System\Net\HttpVersionInternal.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Http\NoWriteNoSeekStreamContent.cs">
+      <Link>Common\System\Net\Http\NoWriteNoSeekStreamContent.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\Mail\MailAddress.cs">
       <Link>Common\System\Net\Mail\MailAddress.cs</Link>
     </Compile>

--- a/src/System.Net.Http/src/System/Net/Http/Headers/GenericHeaderParser.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/GenericHeaderParser.cs
@@ -13,49 +13,30 @@ namespace System.Net.Http.Headers
 
         #region Parser instances
 
-        internal static readonly HttpHeaderParser HostParser = new GenericHeaderParser(false, ParseHost,
-            StringComparer.OrdinalIgnoreCase);
-        internal static readonly HttpHeaderParser TokenListParser = new GenericHeaderParser(true, ParseTokenList,
-            StringComparer.OrdinalIgnoreCase);
-        internal static readonly HttpHeaderParser SingleValueNameValueWithParametersParser = new GenericHeaderParser(false,
-            NameValueWithParametersHeaderValue.GetNameValueWithParametersLength);
-        internal static readonly HttpHeaderParser MultipleValueNameValueWithParametersParser = new GenericHeaderParser(true,
-            NameValueWithParametersHeaderValue.GetNameValueWithParametersLength);
-        internal static readonly HttpHeaderParser SingleValueNameValueParser = new GenericHeaderParser(false, ParseNameValue);
-        internal static readonly HttpHeaderParser MultipleValueNameValueParser = new GenericHeaderParser(true, ParseNameValue);
-        internal static readonly HttpHeaderParser MailAddressParser = new GenericHeaderParser(false, ParseMailAddress);
-        internal static readonly HttpHeaderParser SingleValueProductParser = new GenericHeaderParser(false, ParseProduct);
-        internal static readonly HttpHeaderParser MultipleValueProductParser = new GenericHeaderParser(true, ParseProduct);
-        internal static readonly HttpHeaderParser RangeConditionParser = new GenericHeaderParser(false,
-            RangeConditionHeaderValue.GetRangeConditionLength);
-        internal static readonly HttpHeaderParser SingleValueAuthenticationParser = new GenericHeaderParser(false,
-            AuthenticationHeaderValue.GetAuthenticationLength);
-        internal static readonly HttpHeaderParser MultipleValueAuthenticationParser = new GenericHeaderParser(true,
-            AuthenticationHeaderValue.GetAuthenticationLength);
-        internal static readonly HttpHeaderParser RangeParser = new GenericHeaderParser(false,
-            RangeHeaderValue.GetRangeLength);
-        internal static readonly HttpHeaderParser RetryConditionParser = new GenericHeaderParser(false,
-            RetryConditionHeaderValue.GetRetryConditionLength);
-        internal static readonly HttpHeaderParser ContentRangeParser = new GenericHeaderParser(false,
-            ContentRangeHeaderValue.GetContentRangeLength);
-        internal static readonly HttpHeaderParser ContentDispositionParser = new GenericHeaderParser(false,
-            ContentDispositionHeaderValue.GetDispositionTypeLength);
-        internal static readonly HttpHeaderParser SingleValueStringWithQualityParser = new GenericHeaderParser(false,
-            StringWithQualityHeaderValue.GetStringWithQualityLength);
-        internal static readonly HttpHeaderParser MultipleValueStringWithQualityParser = new GenericHeaderParser(true,
-            StringWithQualityHeaderValue.GetStringWithQualityLength);
-        internal static readonly HttpHeaderParser SingleValueEntityTagParser = new GenericHeaderParser(false,
-            ParseSingleEntityTag);
-        internal static readonly HttpHeaderParser MultipleValueEntityTagParser = new GenericHeaderParser(true,
-            ParseMultipleEntityTags);
-        internal static readonly HttpHeaderParser SingleValueViaParser = new GenericHeaderParser(false,
-            ViaHeaderValue.GetViaLength);
-        internal static readonly HttpHeaderParser MultipleValueViaParser = new GenericHeaderParser(true,
-            ViaHeaderValue.GetViaLength);
-        internal static readonly HttpHeaderParser SingleValueWarningParser = new GenericHeaderParser(false,
-            WarningHeaderValue.GetWarningLength);
-        internal static readonly HttpHeaderParser MultipleValueWarningParser = new GenericHeaderParser(true,
-            WarningHeaderValue.GetWarningLength);
+        internal static readonly GenericHeaderParser HostParser = new GenericHeaderParser(false, ParseHost, StringComparer.OrdinalIgnoreCase);
+        internal static readonly GenericHeaderParser TokenListParser = new GenericHeaderParser(true, ParseTokenList, StringComparer.OrdinalIgnoreCase);
+        internal static readonly GenericHeaderParser SingleValueNameValueWithParametersParser = new GenericHeaderParser(false, NameValueWithParametersHeaderValue.GetNameValueWithParametersLength);
+        internal static readonly GenericHeaderParser MultipleValueNameValueWithParametersParser = new GenericHeaderParser(true, NameValueWithParametersHeaderValue.GetNameValueWithParametersLength);
+        internal static readonly GenericHeaderParser SingleValueNameValueParser = new GenericHeaderParser(false, ParseNameValue);
+        internal static readonly GenericHeaderParser MultipleValueNameValueParser = new GenericHeaderParser(true, ParseNameValue);
+        internal static readonly GenericHeaderParser MailAddressParser = new GenericHeaderParser(false, ParseMailAddress);
+        internal static readonly GenericHeaderParser SingleValueProductParser = new GenericHeaderParser(false, ParseProduct);
+        internal static readonly GenericHeaderParser MultipleValueProductParser = new GenericHeaderParser(true, ParseProduct);
+        internal static readonly GenericHeaderParser RangeConditionParser = new GenericHeaderParser(false, RangeConditionHeaderValue.GetRangeConditionLength);
+        internal static readonly GenericHeaderParser SingleValueAuthenticationParser = new GenericHeaderParser(false, AuthenticationHeaderValue.GetAuthenticationLength);
+        internal static readonly GenericHeaderParser MultipleValueAuthenticationParser = new GenericHeaderParser(true, AuthenticationHeaderValue.GetAuthenticationLength);
+        internal static readonly GenericHeaderParser RangeParser = new GenericHeaderParser(false, RangeHeaderValue.GetRangeLength);
+        internal static readonly GenericHeaderParser RetryConditionParser = new GenericHeaderParser(false, RetryConditionHeaderValue.GetRetryConditionLength);
+        internal static readonly GenericHeaderParser ContentRangeParser = new GenericHeaderParser(false, ContentRangeHeaderValue.GetContentRangeLength);
+        internal static readonly GenericHeaderParser ContentDispositionParser = new GenericHeaderParser(false, ContentDispositionHeaderValue.GetDispositionTypeLength);
+        internal static readonly GenericHeaderParser SingleValueStringWithQualityParser = new GenericHeaderParser(false, StringWithQualityHeaderValue.GetStringWithQualityLength);
+        internal static readonly GenericHeaderParser MultipleValueStringWithQualityParser = new GenericHeaderParser(true, StringWithQualityHeaderValue.GetStringWithQualityLength);
+        internal static readonly GenericHeaderParser SingleValueEntityTagParser = new GenericHeaderParser(false, ParseSingleEntityTag);
+        internal static readonly GenericHeaderParser MultipleValueEntityTagParser = new GenericHeaderParser(true, ParseMultipleEntityTags);
+        internal static readonly GenericHeaderParser SingleValueViaParser = new GenericHeaderParser(false, ViaHeaderValue.GetViaLength);
+        internal static readonly GenericHeaderParser MultipleValueViaParser = new GenericHeaderParser(true, ViaHeaderValue.GetViaLength);
+        internal static readonly GenericHeaderParser SingleValueWarningParser = new GenericHeaderParser(false, WarningHeaderValue.GetWarningLength);
+        internal static readonly GenericHeaderParser MultipleValueWarningParser = new GenericHeaderParser(true, WarningHeaderValue.GetWarningLength);
 
         #endregion
 

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpContentHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpContentHeaders.cs
@@ -15,7 +15,7 @@ namespace System.Net.Http.Headers
         private static readonly Dictionary<string, HttpHeaderParser> s_parserStore = CreateParserStore();
         private static readonly HashSet<string> s_invalidHeaders = CreateInvalidHeaders();
 
-        private Func<long?> _calculateLengthFunc;
+        private readonly HttpContent _parent;
         private bool _contentLengthSet;
 
         private HttpHeaderValueCollection<string> _allow;
@@ -82,7 +82,7 @@ namespace System.Net.Http.Headers
                     // If we don't have a value for Content-Length in the store, try to let the content calculate
                     // it's length. If the content object is able to calculate the length, we'll store it in the
                     // store.
-                    long? calculatedLength = _calculateLengthFunc();
+                    long? calculatedLength = _parent.GetComputedOrBufferLength();
 
                     if (calculatedLength != null)
                     {
@@ -146,9 +146,9 @@ namespace System.Net.Http.Headers
             set { SetOrRemoveParsedValue(HttpKnownHeaderNames.LastModified, value); }
         }
 
-        internal HttpContentHeaders(Func<long?> calculateLengthFunc)
+        internal HttpContentHeaders(HttpContent parent)
         {
-            _calculateLengthFunc = calculateLengthFunc;
+            _parent = parent;
 
             SetConfiguration(s_parserStore, s_invalidHeaders);
         }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
@@ -37,7 +37,18 @@ namespace System.Net.Http.Headers
         {
             get
             {
-                if (ConnectionCore.IsSpecialValueSet)
+                // If we've already initialized the connection header value collection
+                // and it contains the special value, or if we haven't and the headers contain
+                // the parsed special value, return true.  We don't just access ConnectionCore,
+                // as doing so will unnecessarily initialize the collection even if it's not needed.
+                if (_connection != null)
+                {
+                    if (_connection.IsSpecialValueSet)
+                    {
+                        return true;
+                    }
+                }
+                else if (_parent.ContainsParsedValue(HttpKnownHeaderNames.Connection, HeaderUtilities.ConnectionClose))
                 {
                     return true;
                 }
@@ -102,7 +113,18 @@ namespace System.Net.Http.Headers
         {
             get
             {
-                if (TransferEncodingCore.IsSpecialValueSet)
+                // If we've already initialized the transfer encoding header value collection
+                // and it contains the special value, or if we haven't and the headers contain
+                // the parsed special value, return true.  We don't just access TransferEncodingCore,
+                // as doing so will unnecessarily initialize the collection even if it's not needed.
+                if (_transferEncoding != null)
+                {
+                    if (_transferEncoding.IsSpecialValueSet)
+                    {
+                        return true;
+                    }
+                }
+                else if (_parent.ContainsParsedValue(HttpKnownHeaderNames.TransferEncoding, HeaderUtilities.TransferEncodingChunked))
                 {
                     return true;
                 }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -225,6 +225,11 @@ namespace System.Net.Http.Headers
 
         public override string ToString()
         {
+            if (_headerStore == null || _headerStore.Count == 0)
+            {
+                return string.Empty;
+            }
+
             // Return all headers as string similar to: 
             // HeaderName1: Value1, Value2
             // HeaderName2: Value1

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -308,11 +308,13 @@ namespace System.Net.Http.Headers
 
         public IEnumerator<KeyValuePair<string, IEnumerable<string>>> GetEnumerator()
         {
-            if (_headerStore == null)
-            {
-                yield break;
-            }
+            return _headerStore != null && _headerStore.Count > 0 ?
+                GetEnumeratorCore() :
+                ((IEnumerable<KeyValuePair<string, IEnumerable<string>>>)Array.Empty<KeyValuePair<string, IEnumerable<string>>>()).GetEnumerator();
+        }
 
+        private IEnumerator<KeyValuePair<string, IEnumerable<string>>> GetEnumeratorCore()
+        {
             List<string> invalidHeaders = null;
 
             foreach (var header in _headerStore)

--- a/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -660,6 +660,24 @@ namespace System.Net.Http
                 return base.WriteAsync(buffer, offset, count, cancellationToken);
             }
 
+            public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+            {
+                ArraySegment<byte> buffer;
+                if (TryGetBuffer(out buffer))
+                {
+                    StreamHelpers.ValidateCopyToArgs(this, destination, bufferSize);
+
+                    long pos = Position;
+                    long length = Length;
+                    Position = length;
+
+                    long bytesToWrite = length - pos;
+                    return destination.WriteAsync(buffer.Array, (int)(buffer.Offset + pos), (int)bytesToWrite, cancellationToken);
+                }
+
+                return base.CopyToAsync(destination, bufferSize, cancellationToken);
+            }
+
             private void CheckSize(int countToAdd)
             {
                 if (_maxSize - Length < countToAdd)

--- a/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -124,7 +124,7 @@ namespace System.Net.Http
             {
                 if (_headers == null)
                 {
-                    _headers = new HttpContentHeaders(GetComputedOrBufferLength);
+                    _headers = new HttpContentHeaders(this);
                 }
                 return _headers;
             }
@@ -391,7 +391,7 @@ namespace System.Net.Http
         // that case (send chunked, buffer first, etc.).
         protected internal abstract bool TryComputeLength(out long length);
 
-        private long? GetComputedOrBufferLength()
+        internal long? GetComputedOrBufferLength()
         {
             CheckDisposed();
 

--- a/src/System.Net.Http/src/System/Net/Http/StreamToStreamCopy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamToStreamCopy.cs
@@ -28,90 +28,12 @@ namespace System.Net.Http
             Debug.Assert(destination != null);
             Debug.Assert(bufferSize > 0);
 
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return Task.FromCanceled(cancellationToken);
-            }
-
             try
             {
-                // If the source is a MemoryStream from which we can extract the internal buffer,
-                // then we can perform the copy in a single write operation.
-                ArraySegment<byte> sourceBuffer;
-                MemoryStream sourceMemoryStream = source as MemoryStream;
-                if (sourceMemoryStream != null && sourceMemoryStream.TryGetBuffer(out sourceBuffer))
-                {
-                    // It's possible source derives from MemoryStream but has a bad override of Position.
-                    // If we get back a value that doesn't make sense, don't take the optimized path.
-                    long pos = source.CanSeek ? source.Position : -1;
-                    if (pos >= 0 && pos < sourceBuffer.Count)
-                    {
-                        // We need to copy from the current position, so if necessary update the buffer
-                        // based on the position of the stream.
-                        if (pos != 0)
-                        {
-                            sourceBuffer = new ArraySegment<byte>(
-                                sourceBuffer.Array, 
-                                (int)checked(sourceBuffer.Offset + pos),
-                                (int)checked(sourceBuffer.Count - pos));
-                        }
-
-                        // Update position to simulate reading all the data
-                        source.Position += sourceBuffer.Count; 
-
-                        // Now write the buffer to the destination stream. This will complete synchronously if the 
-                        // destination's WriteAsync completes synchronously, such as if destination is also a MemoryStream.  
-                        // Thus we don't need to special case it.
-                        return WriteToAnyStreamAsync(sourceBuffer, source, destination, disposeSource, cancellationToken);
-                    }
-                }
-
-                // The source is not a MemoryStream whose buffer we can use directly, but the destination might be our special 
-                // LimitMemoryStream, in which case if it's been pre-sized with a capacity, we can optimize the copy 
-                // by giving its buffer to the source directly, avoiding the need for an intermediate buffer.
-                HttpContent.LimitMemoryStream destinationLimitStream = destination as HttpContent.LimitMemoryStream;
-                if (destinationLimitStream != null)
-                {
-                    // We primarily care about the case where the stream has been presized based on a Content-Length.
-                    // If capacity is 0, we have no buffer to copy to, so we skip.  If capacity is <= the max size allowed,
-                    // then we can fill the capacity that's there, and if it's not enough (which should be very rare), 
-                    // we'll just fall back to continuing with a read/write loop for any additional data.  If the capacity 
-                    // is greater than the max size, we don't want to copy to it, as if we use all of the capacity, we'll 
-                    // end up exceeding the max, so we skip the optimization for that case.  That case could happen if
-                    // there's no Content-Length, and the stream is written to by something before it's given to us, in which 
-                    // case the growth-algorithm inside the MemoryStream could cause its capacity to grow beyond the MaxSize; 
-                    // that case should also be extremely rare, and we don't care about it from an optimization perspective.
-                    int capacity = destinationLimitStream.Capacity;
-                    if (capacity > 0 && capacity <= destinationLimitStream.MaxSize)
-                    {
-                        return CopyAsyncToPreSizedLimitMemoryStream(source, destinationLimitStream, bufferSize, disposeSource, cancellationToken);
-                    }
-                }
-
-                // If the source is a MemoryStream, at this point we know we can't get its buffer.  But, since
-                // we're about to allocate a new byte[] of length bufferSize, if the MemoryStream's Length is
-                // no larger than that and we're at the beginning of the stream, we can just ask it for its array 
-                // and still do a single write to the target.
-                if (sourceMemoryStream != null && 
-                    sourceMemoryStream.CanSeek &&
-                    sourceMemoryStream.Position == 0 &&
-                    sourceMemoryStream.Length <= bufferSize)
-                {
-                    var buffer = new ArraySegment<byte>(sourceMemoryStream.ToArray());
-                    sourceMemoryStream.Position = buffer.Count; // Update position to simulate reading all the data
-                    return WriteToAnyStreamAsync(buffer, sourceMemoryStream, destination, disposeSource, cancellationToken);
-                }
-
-                // No special-stream cases worked, so we need to fall back to doing a normal copy, involving
-                // allocating a byte[] of length bufferSize. However, if we don't need to dispose of the source, 
-                // then there's no work to be performed after the copy operation finishes, and we can simply delegate 
-                // to the source's CopyToAsync implementation to provide the best implementation the source can muster. 
-                // If we do need to dispose of the source, then using CopyToAsync would result in needing an extra
-                // async method wrapper and its potential allocations, so we fall back to our own read/write loop that 
-                // does the copy and the disposal in a single async method.
+                Task copyTask = source.CopyToAsync(destination, bufferSize, cancellationToken);
                 return disposeSource ?
-                    CopyAsyncAnyStreamToAnyStreamCore(source, destination, bufferSize, disposeSource, cancellationToken) :
-                    source.CopyToAsync(destination, bufferSize, cancellationToken);
+                    DisposeSourceWhenCompleteAsync(copyTask, source) :
+                    copyTask;
             }
             catch (Exception e)
             {
@@ -121,152 +43,31 @@ namespace System.Net.Http
             }
         }
 
-        /// <summary>Writes the array segment to the destination stream.</summary>
-        /// <param name="buffer">The array segment to write.</param>
-        /// <param name="source">The source stream with which <paramref name="buffer"/> is associated.</param>
-        /// <param name="destination">The destination stream to which to write.</param>
-        /// <param name="disposeSource">Whether to dispose of the source stream after the copy has finished successfully.</param>
-        private static async Task WriteToAnyStreamAsync(ArraySegment<byte> buffer, Stream source, Stream destination, bool disposeSource, CancellationToken cancellationToken)
+        private static Task DisposeSourceWhenCompleteAsync(Task task, Stream source)
         {
-            await destination.WriteAsync(buffer.Array, buffer.Offset, buffer.Count, cancellationToken).ConfigureAwait(false);
-            DisposeSource(disposeSource, source);
-        }
-
-        /// <summary>Copies a source stream to a LimitMemoryStream by writing directly to the LimitMemoryStream's buffer.</summary>
-        /// <param name="source">The source stream from which to copy.</param>
-        /// <param name="destination">The destination LimitMemoryStream to write to.</param>
-        /// <param name="bufferSize">The size of the buffer to allocate if one needs to be allocated.</param>
-        /// <param name="disposeSource">Whether to dispose of the source stream after the copy has finished successfully.</param>
-        private static async Task CopyAsyncToPreSizedLimitMemoryStream(Stream source, HttpContent.LimitMemoryStream destination, int bufferSize, bool disposeSource, CancellationToken cancellationToken)
-        {
-            // When a LimitMemoryStream is constructed to represent a response with a particular ContentLength, its
-            // Capacity is set to that amount in order to pre-size it.  We can take advantage of that in this copy
-            // by handing the destination's pre-sized underlying byte[] to the source stream for it to read into
-            // rather than creating a temporary buffer, copying from the source into that, and then copying again
-            // from the buffer into the LimitMemoryStream.
-            long capacity = destination.Capacity;
-            Debug.Assert(capacity > 0, "Caller should have checked that there's capacity");
-
-            // Get the initial length of the stream.  When the length of a LimitMemoryStream is increased, the newly available
-            // space is zero-filled, either due to allocating a new array or due to an explicit clear.  As a result, we can't
-            // write into the array directly and then increase the length to the right size afterward, as doing so will overwrite
-            // all of the data newly written.  Instead, we need to increase the length to the capacity, write in our data, and
-            // then subsequently trim back the length to the end of the written data.
-            long startingLength = destination.Length;
-            if (startingLength < capacity)
+            switch (task.Status)
             {
-                destination.SetLength(capacity);
-            }
+                case TaskStatus.RanToCompletion:
+                    DisposeSource(source);
+                    return Task.CompletedTask;
 
-            int bytesRead;
-            try
-            {
-                // Get the LimitMemoryStream's buffer.
-                ArraySegment<byte> entireBuffer;
-                bool gotBuffer = destination.TryGetBuffer(out entireBuffer);
-                Debug.Assert(gotBuffer, "Should only be in CopyAsyncToMemoryStream if we were able to get the buffer");
-                Debug.Assert(entireBuffer.Offset == 0, "LimitMemoryStream's are only constructed with a 0-offset");
-                Debug.Assert(entireBuffer.Count == entireBuffer.Array.Length, $"LimitMemoryStream's buffer count {entireBuffer.Count} should be the same as its length {entireBuffer.Array.Length}");
+                case TaskStatus.Faulted:
+                case TaskStatus.Canceled:
+                    return task;
 
-                // While there's space remaining in the destination buffer, do another read to try to fill it.
-                // Each time we read successfully, we update the position of the destination stream to be
-                // at the end of the data read.
-                int spaceRemaining = (int)(entireBuffer.Array.Length - destination.Position);
-                while (spaceRemaining > 0)
-                {
-                    // Read into the buffer
-                    bytesRead = await source.ReadAsync(entireBuffer.Array, (int)destination.Position, spaceRemaining, cancellationToken).ConfigureAwait(false);
-                    if (bytesRead == 0)
+                default:
+                    return task.ContinueWith((completed, innerSource) =>
                     {
-                        DisposeSource(disposeSource, source);
-                        return;
-                    }
-                    destination.Position += bytesRead;
-                    spaceRemaining -= bytesRead;
-                }
+                        completed.GetAwaiter().GetResult(); // propagate any exceptions
+                        DisposeSource((Stream)innerSource);
+                    },
+                    source, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.DenyChildAttach, TaskScheduler.Default);
             }
-            finally
-            {
-                // Now that we're done reading directly into the buffer, if we previously increased the length
-                // of the stream, set it be at the end of the data read.
-                if (startingLength < capacity)
-                {
-                    destination.SetLength(destination.Position);
-                }
-            }
-
-            // A typical case will be that we read exactly the amount requested.  This means that the next
-            // read will likely return 0 bytes, but we need to try to do the read to know that, which means
-            // we need a buffer to read into.  Use a cached single-byte array to do a read for 1-byte.
-            // Ideally this read returns 0, and we're done.
-            byte[] singleByteArray = RentCachedSingleByteArray();
-            bytesRead = await source.ReadAsync(singleByteArray, 0, 1, cancellationToken).ConfigureAwait(false);
-            if (bytesRead == 0)
-            {
-                ReturnCachedSingleByteArray(singleByteArray);
-                DisposeSource(disposeSource, source);
-                return;
-            }
-
-            // The read actually returned data, which means there was more data available then
-            // the capacity of the LimitMemoryStream.  This is likely an error condition, but
-            // regardless we need to finish the copy.  First, we write out the byte we read...
-            await destination.WriteAsync(singleByteArray, 0, 1, cancellationToken).ConfigureAwait(false);
-            ReturnCachedSingleByteArray(singleByteArray);
-
-            // ...then we fall back to doing the normal read/write loop.
-            await CopyAsyncAnyStreamToAnyStreamCore(source, destination, bufferSize, disposeSource, cancellationToken).ConfigureAwait(false);
-        }
-
-        /// <summary>Copies a source stream to a destination stream via a standard read/write loop.</summary>
-        /// <param name="source">The source stream from which to copy.</param>
-        /// <param name="destination">The destination stream to which to copy.</param>
-        /// <param name="bufferSize">The size of the buffer to allocate if one needs to be allocated.</param>
-        /// <param name="disposeSource">Whether to dispose of the source stream after the copy has finished successfully.</param>
-        private static async Task CopyAsyncAnyStreamToAnyStreamCore(Stream source, Stream destination, int bufferSize, bool disposeSource, CancellationToken cancellationToken)
-        {
-            var buffer = new byte[bufferSize];
-
-            int bytesRead;
-            while ((bytesRead = await source.ReadAsync(buffer, 0, bufferSize, cancellationToken).ConfigureAwait(false)) > 0)
-            {
-                await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
-            }
-
-            DisposeSource(disposeSource, source);
-        }
-
-        /// <summary>A cached byte[1] array.</summary>
-        [ThreadStatic]
-        private static byte[] t_singleByteArray;
-
-        /// <summary>Gets a byte[1] array, either taking a cached one or allocating one a new.</summary>
-        private static byte[] RentCachedSingleByteArray()
-        {
-            byte[] singleByteArray = t_singleByteArray;
-            if (singleByteArray != null)
-            {
-                // This will be used across async points, so we need to ensure no one else can use
-                // the array while it's in use.
-                t_singleByteArray = null;
-                return singleByteArray;
-            }
-            else
-            {
-                return new byte[1];
-            }
-        }
-
-        private static void ReturnCachedSingleByteArray(byte[] singleByteArray)
-        {
-            t_singleByteArray = singleByteArray; // ok if we overwrite one already there
         }
 
         /// <summary>Disposes the source stream if <paramref name="disposeSource"/> is true.</summary>
-        private static void DisposeSource(bool disposeSource, Stream source)
+        private static void DisposeSource(Stream source)
         {
-            if (!disposeSource) return;
-
             try
             {
                 source.Dispose();

--- a/src/System.Net.Http/src/project.json
+++ b/src/System.Net.Http/src/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "System.Buffers": "4.4.0-beta-24714-01",
     "System.Diagnostics.DiagnosticSource": "4.4.0-beta-24714-01"
   },
   "frameworks": {

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -111,10 +111,6 @@
     <Compile Include="DefaultCredentialsTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
-    <ProjectReference Include="..\..\..\System.Runtime.Extensions\pkg\System.Runtime.Extensions.pkgproj" />
-    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
-    <ProjectReference Include="..\..\..\System.IO\pkg\System.IO.pkgproj" />
     <ProjectReference Include="..\..\pkg\System.Net.Http.pkgproj">
       <Project>{1D422B1D-D7C4-41B9-862D-EB3D98DF37DE}</Project>
       <Name>System.Net.Http</Name>

--- a/src/System.Net.Http/tests/UnitTests/Headers/HttpContentHeadersTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/HttpContentHeadersTest.cs
@@ -4,10 +4,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Text;
-
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Net.Http.Tests
@@ -24,16 +25,16 @@ namespace System.Net.Http.Tests
         [Fact]
         public void ContentLength_AddInvalidValueUsingUnusualCasing_ParserRetrievedUsingCaseInsensitiveComparison()
         {
-            _headers = new HttpContentHeaders(() => { return 15; });
+            _headers = new HttpContentHeaders(new ComputeLengthHttpContent(() => 15));
 
             // Use uppercase header name to make sure the parser gets retrieved using case-insensitive comparison.
             Assert.Throws<FormatException>(() => { _headers.Add("CoNtEnT-LeNgTh", "this is invalid"); });
         }
 
         [Fact]
-        public void ContentLength_ReadValue_DelegateInvoked()
+        public void ContentLength_ReadValue_TryComputeLengthInvoked()
         {
-            _headers = new HttpContentHeaders(() => { return 15; });
+            _headers = new HttpContentHeaders(new ComputeLengthHttpContent(() => 15));
 
             // The delegate is invoked to return the length.
             Assert.Equal(15, _headers.ContentLength);
@@ -50,9 +51,9 @@ namespace System.Net.Http.Tests
         }
 
         [Fact]
-        public void ContentLength_SetCustomValue_DelegateNotInvoked()
+        public void ContentLength_SetCustomValue_TryComputeLengthNotInvoked()
         {
-            _headers = new HttpContentHeaders(() => { throw new ShouldNotBeInvokedException(); });
+            _headers = new HttpContentHeaders(new ComputeLengthHttpContent(() => { throw new ShouldNotBeInvokedException(); }));
 
             _headers.ContentLength = 27;
             Assert.Equal((long)27, _headers.ContentLength);
@@ -71,7 +72,7 @@ namespace System.Net.Http.Tests
         [Fact]
         public void ContentLength_UseAddMethod_AddedValueCanBeRetrievedUsingProperty()
         {
-            _headers = new HttpContentHeaders(() => { throw new ShouldNotBeInvokedException(); });
+            _headers = new HttpContentHeaders(new ComputeLengthHttpContent(() => { throw new ShouldNotBeInvokedException(); }));
             _headers.TryAddWithoutValidation(HttpKnownHeaderNames.ContentLength, " 68 \r\n ");
 
             Assert.Equal(68, _headers.ContentLength);
@@ -499,6 +500,25 @@ namespace System.Net.Http.Tests
             Assert.Throws<InvalidOperationException>(() => { _headers.Add("Upgrade", "v"); });
             Assert.Throws<InvalidOperationException>(() => { _headers.Add("Via", "v"); });
             Assert.Throws<InvalidOperationException>(() => { _headers.Add("Warning", "v"); });
+        }
+
+        private sealed class ComputeLengthHttpContent : HttpContent
+        {
+            private readonly Func<long?> _tryComputeLength;
+
+            internal ComputeLengthHttpContent(Func<long?> tryComputeLength)
+            {
+                _tryComputeLength = tryComputeLength;
+            }
+
+            protected internal override bool TryComputeLength(out long length)
+            {
+                long? result = _tryComputeLength();
+                length = result.GetValueOrDefault();
+                return result.HasValue;
+            }
+
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext context) { throw new NotImplementedException(); }
         }
     }
 }

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -32,6 +32,9 @@
     <Compile Include="$(CommonPath)\System\StringExtensions.cs">
       <Link>ProductionCode\Common\System\StringExtensions.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.CopyValidation.cs">
+      <Link>ProductionCode\Common\System\IO\StreamHelpers.CopyValidation.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
       <Link>ProductionCode\Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>


### PR DESCRIPTION
Weekend project...

This PR significantly reduces the number and size of allocations in HttpClient.  Some of the changes are in HttpClient itself, and thus apply to any handler/platform, while some are specific to the Windows implementation.

Analysis of the following program was used to drive the changes.  It simply downloads the contents of httpbin.org, dumping it to a null stream, 1000 times:
```C#
using System;
using System.IO;
using System.Linq;
using System.Net.Http;
using System.Threading;
using System.Threading.Tasks;

class Program
{
    static void Main()
    {
        var client = new HttpClient() { Timeout = Timeout.InfiniteTimeSpan };
        var uri = new Uri("http://httpbin.org");
        Task.WaitAll(Enumerable.Range(0, 1000).Select(async _ =>
        {
            using (Stream responseStream = await client.GetStreamAsync(uri))
            {
                await responseStream.CopyToAsync(Stream.Null);
            }
        }).ToArray());
    }
}
```

Before these changes, these allocations show up (divide each line by 1000 to get the appx per iteration count):
![image](https://cloud.githubusercontent.com/assets/2642209/20248813/c3e13a5c-a9b9-11e6-987d-7ce6759811a5.png)
That's ~127 allocations and ~8518 bytes per iteration.

After these changes, these allocations show up:
![image](https://cloud.githubusercontent.com/assets/2642209/20248823/db254532-a9b9-11e6-9fc6-ad150bfb4cd0.png)
That's ~60 allocations and ~4449 bytes per iteration.

For this particular scenario then, this represents an ~50% reduction in both number and size of allocations.  Other scenarios will benefit from many of these changes, but will also have their own additional allocations that can likely be reduced.

I've kept the changes isolated in their own commits.  The commit descriptions provide more details, but the main changes:
- Added more headers to the HttpKnownHeaderNames table.  Even for a basic site like httpbin.org, there were headers coming back that are commonly used but weren't in our table.  The table now contains all of the response entries that kestrel has in its similar optimization as well as some additional headers listed as common response headers on wikipedia.
- Significantly reduce the number of tasks and task completion sources used in WinHttpHandler.  Every stage of its lifecycle was represented with its own TCS/Task.  Instead, I added a common "RendezvousAwaitable", a reusable awaitable object that can be produced to via SetResult/SetException/SetCanceled just like TaskCompletionSource and can be awaited to consume the results, but which can be allocated once and reused any number of times (this is something I we may want to consider exposing publicly from the BCL at some point; it's quite handy and helpful).  I then use that throughout WinHttpHandler, cutting back on the number of tasks used and on the size of the state object used to hold them.  As part of this, I added a CopyToAsync implementation to WinHttpResponseStream; we can subsequently do something similar for the CurlResponseStream (that one should be easier, too, as libcurl is already a push-based model, which maps nicely to CopyToAsync).
- Optimized common cases (often via lazy-initialization) where allocations were being done for empty cases, e.g. allocating an enumerator when there weren't any headers to enumerate, allocating cookie-related state when there weren't any cookies, allocating a TransportContext object even when it wouldn't be needed, etc.
- Avoiding allocating a CancellationTokenSource per request when the user didn't provide a CancellationToken and when no timeout is set.  This helps avoid not only the CTS allocation itself, but also the state within the CTS that's allocated on first use.
- Removing unnecessary allocations, like a lock object used per state object, when the state object itself can be used for locking.
- Using a buffer from ArrayPool to avoid allocating a new char[] to store all of the response headers
- Avoiding the need for allocating a ReadOnlyStream to wrap the WinHttpResponseStream, which is already read-only.
- Reducing the sizes of async state machines by being a bit more thoughtful about what locals will end up getting promoted to fields in the state machine.
- Avoiding async state machine objects altogether for simple cases where a ContinueWith is sufficient and less expensive.
Etc.

Contributes to #13589 
cc: @davidsh, @cipop, @geoffkizer, @benaadams