### PR TITLE
S.IO.Compression: Use lang keywords instead of BCL types

### DIFF
--- a/src/Common/tests/System/IO/Compression/CRC.cs
+++ b/src/Common/tests/System/IO/Compression/CRC.cs
@@ -52,13 +52,13 @@ public class CRC
         return c;
     }
 
-    internal static String CalculateCRC(byte[] buf)
+    internal static string CalculateCRC(byte[] buf)
     {
         return CalculateCRC(buf, buf.Length);
     }
 
     /* Return the CRC of the bytes buf[0..len-1]. */
-    internal static String CalculateCRC(byte[] buf, int len)
+    internal static string CalculateCRC(byte[] buf, int len)
     {
         return (update_crc(0xffffffffL, buf, len) ^ 0xffffffffL).ToString();
     }

--- a/src/Common/tests/System/IO/Compression/FileData.cs
+++ b/src/Common/tests/System/IO/Compression/FileData.cs
@@ -9,14 +9,14 @@ using System.Linq;
 
 public class FileData
 {
-    public String Name { get; set; }
-    public String FullName { get; set; }
+    public string Name { get; set; }
+    public string FullName { get; set; }
     public long Length { get; set; }
-    public String CRC { get; set; }
+    public string CRC { get; set; }
     public DateTime LastModifiedDate { get; set; }
     public bool IsFile { get; set; }
     public bool IsFolder { get; set; }
-    public String OrigFolder { get; set; }
+    public string OrigFolder { get; set; }
 
     public override string ToString()
     {
@@ -25,14 +25,14 @@ public class FileData
 
     public static List<FileData> Files { get; private set; }
 
-    public static FileData GetFile(String Path)
+    public static FileData GetFile(string Path)
     {
-        return Files.Where(f => String.Equals(System.IO.Path.Combine(f.OrigFolder, f.FullName), Path, StringComparison.OrdinalIgnoreCase)).First();
+        return Files.Where(f => string.Equals(System.IO.Path.Combine(f.OrigFolder, f.FullName), Path, StringComparison.OrdinalIgnoreCase)).First();
     }
 
-    public static List<FileData> InPath(String Path)
+    public static List<FileData> InPath(string Path)
     {
-        return Files.Where(f => String.Equals(f.OrigFolder, Path, StringComparison.OrdinalIgnoreCase)).ToList();
+        return Files.Where(f => string.Equals(f.OrigFolder, Path, StringComparison.OrdinalIgnoreCase)).ToList();
     }
 
     static FileData()

--- a/src/Common/tests/System/IO/Compression/LocalMemoryStream.cs
+++ b/src/Common/tests/System/IO/Compression/LocalMemoryStream.cs
@@ -18,7 +18,7 @@ public class LocalMemoryStream : MemoryStream
         return local;
     }
 
-    public static async Task<LocalMemoryStream> readAppFileAsync(String testFile)
+    public static async Task<LocalMemoryStream> readAppFileAsync(string testFile)
     {
         var baseStream = await StreamHelpers.CreateTempCopyStream(testFile);
         var ms = new LocalMemoryStream();

--- a/src/Common/tests/System/IO/Compression/StreamHelpers.cs
+++ b/src/Common/tests/System/IO/Compression/StreamHelpers.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 public static partial class StreamHelpers
 {
-    public static async Task<MemoryStream> CreateTempCopyStream(String path)
+    public static async Task<MemoryStream> CreateTempCopyStream(string path)
     {
         var bytes = File.ReadAllBytes(path);
 

--- a/src/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -14,12 +14,12 @@ namespace System.IO.Compression.Tests
     {
         #region filename helpers
 
-        public static String bad(String filename) { return Path.Combine("ZipTestData", "badzipfiles", filename); }
-        public static String compat(String filename) { return Path.Combine("ZipTestData", "compat", filename); }
-        public static String strange(String filename) { return Path.Combine("ZipTestData", "StrangeZipFiles", filename); }
-        public static String zfile(String filename) { return Path.Combine("ZipTestData", "refzipfiles", filename); }
-        public static String zfolder(String filename) { return Path.Combine("ZipTestData", "refzipfolders", filename); }
-        public static String zmodified(String filename) { return Path.Combine("ZipTestData", "modified", filename); }
+        public static string bad(string filename) { return Path.Combine("ZipTestData", "badzipfiles", filename); }
+        public static string compat(string filename) { return Path.Combine("ZipTestData", "compat", filename); }
+        public static string strange(string filename) { return Path.Combine("ZipTestData", "StrangeZipFiles", filename); }
+        public static string zfile(string filename) { return Path.Combine("ZipTestData", "refzipfiles", filename); }
+        public static string zfolder(string filename) { return Path.Combine("ZipTestData", "refzipfolders", filename); }
+        public static string zmodified(string filename) { return Path.Combine("ZipTestData", "modified", filename); }
 
         #endregion
 
@@ -32,12 +32,12 @@ namespace System.IO.Compression.Tests
             return newfile;
         }
 
-        public static Int64 LengthOfUnseekableStream(Stream s)
+        public static long LengthOfUnseekableStream(Stream s)
         {
-            Int64 totalBytes = 0;
-            const Int32 bufSize = 4096;
-            Byte[] buf = new Byte[bufSize];
-            Int64 bytesRead = 0;
+            long totalBytes = 0;
+            const int bufSize = 4096;
+            byte[] buf = new byte[bufSize];
+            long bytesRead = 0;
 
             do
             {
@@ -49,22 +49,22 @@ namespace System.IO.Compression.Tests
         }
 
         //reads exactly bytesToRead out of stream, unless it is out of bytes
-        public static void ReadBytes(Stream stream, Byte[] buffer, Int64 bytesToRead)
+        public static void ReadBytes(Stream stream, byte[] buffer, long bytesToRead)
         {
-            Int32 bytesLeftToRead;
-            if (bytesToRead > Int32.MaxValue)
+            int bytesLeftToRead;
+            if (bytesToRead > int.MaxValue)
             {
                 throw new NotImplementedException("64 bit addresses");
             }
             else
             {
-                bytesLeftToRead = (Int32)bytesToRead;
+                bytesLeftToRead = (int)bytesToRead;
             }
-            Int32 totalBytesRead = 0;
+            int totalBytesRead = 0;
 
             while (bytesLeftToRead > 0)
             {
-                Int32 bytesRead = stream.Read(buffer, totalBytesRead, bytesLeftToRead);
+                int bytesRead = stream.Read(buffer, totalBytesRead, bytesLeftToRead);
                 if (bytesRead == 0) throw new IOException("Unexpected end of stream");
 
                 totalBytesRead += bytesRead;
@@ -75,16 +75,16 @@ namespace System.IO.Compression.Tests
         public static bool ArraysEqual<T>(T[] a, T[] b) where T : IComparable<T>
         {
             if (a.Length != b.Length) return false;
-            for (Int32 i = 0; i < a.Length; i++)
+            for (int i = 0; i < a.Length; i++)
             {
                 if (a[i].CompareTo(b[i]) != 0) return false;
             }
             return true;
         }
 
-        public static bool ArraysEqual<T>(T[] a, T[] b, Int32 length) where T : IComparable<T>
+        public static bool ArraysEqual<T>(T[] a, T[] b, int length) where T : IComparable<T>
         {
-            for (Int32 i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 if (a[i].CompareTo(b[i]) != 0) return false;
             }
@@ -96,21 +96,21 @@ namespace System.IO.Compression.Tests
             StreamsEqual(ast, bst, -1);
         }
 
-        public static void StreamsEqual(Stream ast, Stream bst, Int32 blocksToRead)
+        public static void StreamsEqual(Stream ast, Stream bst, int blocksToRead)
         {
             if (ast.CanSeek)
                 ast.Seek(0, SeekOrigin.Begin);
             if (bst.CanSeek)
                 bst.Seek(0, SeekOrigin.Begin);
 
-            const Int32 bufSize = 4096;
-            Byte[] ad = new Byte[bufSize];
-            Byte[] bd = new Byte[bufSize];
+            const int bufSize = 4096;
+            byte[] ad = new byte[bufSize];
+            byte[] bd = new byte[bufSize];
 
-            Int32 ac = 0;
-            Int32 bc = 0;
+            int ac = 0;
+            int bc = 0;
 
-            Int32 blocksRead = 0;
+            int blocksRead = 0;
 
             //assume read doesn't do weird things
             do
@@ -122,7 +122,7 @@ namespace System.IO.Compression.Tests
                 bc = bst.Read(bd, 0, 4096);
 
                 Assert.Equal(ac, bc);
-                Assert.True(ArraysEqual<Byte>(ad, bd, ac), "Stream contents not equal: " + ast.ToString() + ", " + bst.ToString());
+                Assert.True(ArraysEqual<byte>(ad, bd, ac), "Stream contents not equal: " + ast.ToString() + ", " + bst.ToString());
 
                 blocksRead++;
             } while (ac == 4096);
@@ -132,18 +132,18 @@ namespace System.IO.Compression.Tests
 
         #region "Validation"
 
-        public static async Task IsZipSameAsDirAsync(String archiveFile, String directory, ZipArchiveMode mode)
+        public static async Task IsZipSameAsDirAsync(string archiveFile, string directory, ZipArchiveMode mode)
         {
             await IsZipSameAsDirAsync(archiveFile, directory, mode, false, false);
         }
 
-        public static async Task IsZipSameAsDirAsync(String archiveFile, String directory, ZipArchiveMode mode, bool requireExplicit, bool checkTimes)
+        public static async Task IsZipSameAsDirAsync(string archiveFile, string directory, ZipArchiveMode mode, bool requireExplicit, bool checkTimes)
         {
             var s = await StreamHelpers.CreateTempCopyStream(archiveFile);
             IsZipSameAsDir(s, directory, mode, requireExplicit, checkTimes);
         }
 
-        public static void IsZipSameAsDir(Stream archiveFile, String directory, ZipArchiveMode mode, bool requireExplicit, bool checkTimes)
+        public static void IsZipSameAsDir(Stream archiveFile, string directory, ZipArchiveMode mode, bool requireExplicit, bool checkTimes)
         {
             int count = 0;
 
@@ -152,7 +152,7 @@ namespace System.IO.Compression.Tests
                 List<FileData> files = FileData.InPath(directory);
                 Assert.All<FileData>(files, (file) => {
                     count++;
-                    String entryName = file.FullName;
+                    string entryName = file.FullName;
                     if (file.IsFolder)
                         entryName += Path.DirectorySeparatorChar;
                     ZipArchiveEntry entry = archive.GetEntry(entryName);
@@ -164,13 +164,13 @@ namespace System.IO.Compression.Tests
                     if (file.IsFile)
                     {
                         Assert.NotNull(entry);
-                        Int64 givenLength = entry.Length;
+                        long givenLength = entry.Length;
 
                         var buffer = new byte[entry.Length];
                         using (Stream entrystream = entry.Open())
                         {
                             entrystream.Read(buffer, 0, buffer.Length);
-                            String crc = CRC.CalculateCRC(buffer);
+                            string crc = CRC.CalculateCRC(buffer);
                             Assert.Equal(file.Length, givenLength);
                             Assert.Equal(file.CRC, crc);
                         }
@@ -242,7 +242,7 @@ namespace System.IO.Compression.Tests
                 name;
         }
 
-        public static void DirsEqual(String actual, String expected)
+        public static void DirsEqual(string actual, string expected)
         {
             var expectedList = FileData.InPath(expected);
             var actualList = Directory.GetFiles(actual, "*.*", SearchOption.AllDirectories);
@@ -261,17 +261,17 @@ namespace System.IO.Compression.Tests
             Assert.True(Enumerable.SequenceEqual(expectedEntries.Select(i => Path.GetFileName(i)), actualEntries.Select(i => Path.GetFileName(i))));
         }
 
-        private static void ItemEqual(String[] actualList, List<FileData> expectedList, Boolean isFile)
+        private static void ItemEqual(string[] actualList, List<FileData> expectedList, bool isFile)
         {
             for (int i = 0; i < actualList.Length; i++)
             {
                 var actualFile = actualList[i];
-                String aEntry = Path.GetFullPath(actualFile);
-                String aName = Path.GetFileName(aEntry);
+                string aEntry = Path.GetFullPath(actualFile);
+                string aName = Path.GetFileName(aEntry);
 
-                var bData = expectedList.Where(f => String.Equals(f.Name, aName, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
-                String bEntry = Path.GetFullPath(Path.Combine(bData.OrigFolder, bData.FullName));
-                String bName = Path.GetFileName(bEntry);
+                var bData = expectedList.Where(f => string.Equals(f.Name, aName, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                string bEntry = Path.GetFullPath(Path.Combine(bData.OrigFolder, bData.FullName));
+                string bName = Path.GetFileName(bEntry);
                 // expected 'emptydir' folder doesn't exist because MSBuild doesn't copy empty dir
                 if (!isFile && aName.Contains("emptydir") && bName.Contains("emptydir"))
                     continue;
@@ -289,7 +289,7 @@ namespace System.IO.Compression.Tests
             }
         }
 
-        public static async Task CreateFromDir(String directory, Stream archiveStream, ZipArchiveMode mode)
+        public static async Task CreateFromDir(string directory, Stream archiveStream, ZipArchiveMode mode)
         {
             var files = FileData.InPath(directory);
             using (ZipArchive archive = new ZipArchive(archiveStream, mode, true))
@@ -298,7 +298,7 @@ namespace System.IO.Compression.Tests
                 {
                     if (i.IsFolder)
                     {
-                        String entryName = i.FullName;
+                        string entryName = i.FullName;
 
                         ZipArchiveEntry e = archive.CreateEntry(entryName.Replace('\\', '/') + "/");
                         e.LastWriteTime = i.LastModifiedDate;
@@ -309,7 +309,7 @@ namespace System.IO.Compression.Tests
                 {
                     if (i.IsFile)
                     {
-                        String entryName = i.FullName;
+                        string entryName = i.FullName;
 
                         var installStream = await StreamHelpers.CreateTempCopyStream(Path.Combine(i.OrigFolder, i.FullName));
 
@@ -327,7 +327,7 @@ namespace System.IO.Compression.Tests
             }
         }
 
-        internal static void AddEntry(ZipArchive archive, String name, String contents, DateTimeOffset lastWrite)
+        internal static void AddEntry(ZipArchive archive, string name, string contents, DateTimeOffset lastWrite)
         {
             ZipArchiveEntry e = archive.CreateEntry(name);
             e.LastWriteTime = lastWrite;

--- a/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.cs
+++ b/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.cs
@@ -34,7 +34,7 @@ namespace System.IO.Compression
         /// 
         /// <param name="archiveFileName">A string specifying the path on the filesystem to open the archive on. The path is permitted
         /// to specify relative or absolute path information. Relative path information is interpreted as relative to the current working directory.</param>
-        public static ZipArchive OpenRead(String archiveFileName)
+        public static ZipArchive OpenRead(string archiveFileName)
         {
             return Open(archiveFileName, ZipArchiveMode.Read);
         }
@@ -76,7 +76,7 @@ namespace System.IO.Compression
         /// If the file exists and is empty or does not exist, a new Zip file will be created.
         /// Note that creating a Zip file with the <code>ZipArchiveMode.Create</code> mode is more efficient when creating a new Zip file.</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]  // See comment in the body.
-        public static ZipArchive Open(String archiveFileName, ZipArchiveMode mode)
+        public static ZipArchive Open(string archiveFileName, ZipArchiveMode mode)
         {
             return Open(archiveFileName, mode, entryNameEncoding: null);
         }
@@ -157,7 +157,7 @@ namespace System.IO.Compression
         ///     otherwise an <see cref="ArgumentException"/> is thrown.</para>
         /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]  // See comment in the body.
-        public static ZipArchive Open(String archiveFileName, ZipArchiveMode mode, Encoding entryNameEncoding)
+        public static ZipArchive Open(string archiveFileName, ZipArchiveMode mode, Encoding entryNameEncoding)
         {
             // Relies on FileStream's ctor for checking of archiveFileName
 
@@ -247,7 +247,7 @@ namespace System.IO.Compression
         ///                                         
         /// <param name="sourceDirectoryName">The path to the directory on the file system to be archived. </param>
         /// <param name="destinationArchiveFileName">The name of the archive to be created.</param>
-        public static void CreateFromDirectory(String sourceDirectoryName, String destinationArchiveFileName)
+        public static void CreateFromDirectory(string sourceDirectoryName, string destinationArchiveFileName)
         {
             DoCreateFromDirectory(sourceDirectoryName, destinationArchiveFileName,
                                   compressionLevel: null, includeBaseDirectory: false, entryNameEncoding: null);
@@ -297,8 +297,8 @@ namespace System.IO.Compression
         /// <param name="includeBaseDirectory"><code>true</code> to indicate that a directory named <code>sourceDirectoryName</code> should
         /// be included at the root of the archive. <code>false</code> to indicate that the files and directories in <code>sourceDirectoryName</code>
         /// should be included directly in the archive.</param>
-        public static void CreateFromDirectory(String sourceDirectoryName, String destinationArchiveFileName,
-                                               CompressionLevel compressionLevel, Boolean includeBaseDirectory)
+        public static void CreateFromDirectory(string sourceDirectoryName, string destinationArchiveFileName,
+                                               CompressionLevel compressionLevel, bool includeBaseDirectory)
         {
             DoCreateFromDirectory(sourceDirectoryName, destinationArchiveFileName, compressionLevel, includeBaseDirectory, entryNameEncoding: null);
         }
@@ -370,8 +370,8 @@ namespace System.IO.Compression
         ///     <para>Note that Unicode encodings other than UTF-8 may not be currently used for the <c>entryNameEncoding</c>,
         ///     otherwise an <see cref="ArgumentException"/> is thrown.</para>
         /// </param>
-        public static void CreateFromDirectory(String sourceDirectoryName, String destinationArchiveFileName,
-                                               CompressionLevel compressionLevel, Boolean includeBaseDirectory,
+        public static void CreateFromDirectory(string sourceDirectoryName, string destinationArchiveFileName,
+                                               CompressionLevel compressionLevel, bool includeBaseDirectory,
                                                Encoding entryNameEncoding)
         {
             DoCreateFromDirectory(sourceDirectoryName, destinationArchiveFileName, compressionLevel, includeBaseDirectory, entryNameEncoding);
@@ -408,7 +408,7 @@ namespace System.IO.Compression
         /// 
         /// <param name="sourceArchiveFileName">The path to the archive on the file system that is to be extracted.</param>
         /// <param name="destinationDirectoryName">The path to the directory on the file system. The directory specified must not exist, but the directory that it is contained in must exist.</param>
-        public static void ExtractToDirectory(String sourceArchiveFileName, String destinationDirectoryName)
+        public static void ExtractToDirectory(string sourceArchiveFileName, string destinationDirectoryName)
         {
             ExtractToDirectory(sourceArchiveFileName, destinationDirectoryName, entryNameEncoding: null);
         }
@@ -466,7 +466,7 @@ namespace System.IO.Compression
         ///     <para>Note that Unicode encodings other than UTF-8 may not be currently used for the <c>entryNameEncoding</c>,
         ///     otherwise an <see cref="ArgumentException"/> is thrown.</para>
         /// </param>
-        public static void ExtractToDirectory(String sourceArchiveFileName, String destinationDirectoryName, Encoding entryNameEncoding)
+        public static void ExtractToDirectory(string sourceArchiveFileName, string destinationDirectoryName, Encoding entryNameEncoding)
         {
             if (sourceArchiveFileName == null)
                 throw new ArgumentNullException(nameof(sourceArchiveFileName));
@@ -478,8 +478,8 @@ namespace System.IO.Compression
         }
 
 
-        private static void DoCreateFromDirectory(String sourceDirectoryName, String destinationArchiveFileName,
-                                                  CompressionLevel? compressionLevel, Boolean includeBaseDirectory,
+        private static void DoCreateFromDirectory(string sourceDirectoryName, string destinationArchiveFileName,
+                                                  CompressionLevel? compressionLevel, bool includeBaseDirectory,
                                                   Encoding entryNameEncoding)
         {
             // Rely on Path.GetFullPath for validation of sourceDirectoryName and destinationArchive
@@ -514,13 +514,13 @@ namespace System.IO.Compression
                     {
                         directoryIsEmpty = false;
 
-                        Int32 entryNameLength = file.FullName.Length - basePath.Length;
+                        int entryNameLength = file.FullName.Length - basePath.Length;
                         Debug.Assert(entryNameLength > 0);
 
                         if (file is FileInfo)
                         {
                             // Create entry for file:
-                            String entryName = EntryFromPath(file.FullName, basePath.Length, entryNameLength, ref entryNameBuffer);
+                            string entryName = EntryFromPath(file.FullName, basePath.Length, entryNameLength, ref entryNameBuffer);
                             ZipFileExtensions.DoCreateEntryFromFile(archive, file.FullName, entryName, compressionLevel);
                         }
                         else
@@ -531,7 +531,7 @@ namespace System.IO.Compression
                             {
                                 // FullName never returns a directory separator character on the end,
                                 // but Zip archives require it to specify an explicit directory:
-                                String entryName = EntryFromPath(file.FullName, basePath.Length, entryNameLength, ref entryNameBuffer, appendPathSeparator: true);
+                                string entryName = EntryFromPath(file.FullName, basePath.Length, entryNameLength, ref entryNameBuffer, appendPathSeparator: true);
                                 archive.CreateEntry(entryName);
                             }
                         }
@@ -566,7 +566,7 @@ namespace System.IO.Compression
             }
 
             if (length == 0)
-                return appendPathSeparator ? PathSeparator.ToString() : String.Empty;
+                return appendPathSeparator ? PathSeparator.ToString() : string.Empty;
 
             int resultLength = appendPathSeparator ? length + 1 : length;
             EnsureCapacity(ref buffer, resultLength);
@@ -602,9 +602,9 @@ namespace System.IO.Compression
             }
         }
 
-        private static Boolean IsDirEmpty(DirectoryInfo possiblyEmptyDir)
+        private static bool IsDirEmpty(DirectoryInfo possiblyEmptyDir)
         {
-            using (IEnumerator<String> enumerator = Directory.EnumerateFileSystemEntries(possiblyEmptyDir.FullName).GetEnumerator())
+            using (IEnumerator<string> enumerator = Directory.EnumerateFileSystemEntries(possiblyEmptyDir.FullName).GetEnumerator())
                 return !enumerator.MoveNext();
         }
     }  // class ZipFile

--- a/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.cs
+++ b/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.cs
@@ -45,7 +45,7 @@ namespace System.IO.Compression
         /// relative or absolute path information. Relative path information is interpreted as relative to the current working directory.</param>
         /// <param name="entryName">The name of the entry to be created.</param>
         /// <returns>A wrapper for the newly created entry.</returns>
-        public static ZipArchiveEntry CreateEntryFromFile(this ZipArchive destination, String sourceFileName, String entryName)
+        public static ZipArchiveEntry CreateEntryFromFile(this ZipArchive destination, string sourceFileName, string entryName)
         {
             Contract.Ensures(Contract.Result<ZipArchiveEntry>() != null);
             Contract.EndContractBlock();
@@ -82,7 +82,7 @@ namespace System.IO.Compression
         /// <param name="compressionLevel">The level of the compression (speed/memory vs. compressed size trade-off).</param>
         /// <returns>A wrapper for the newly created entry.</returns>   
         public static ZipArchiveEntry CreateEntryFromFile(this ZipArchive destination,
-                                                          String sourceFileName, String entryName, CompressionLevel compressionLevel)
+                                                          string sourceFileName, string entryName, CompressionLevel compressionLevel)
         {
             // Checking of compressionLevel is passed down to DeflateStream and the IDeflater implementation
             // as it is a pluggable component that completely encapsulates the meaning of compressionLevel.
@@ -121,7 +121,7 @@ namespace System.IO.Compression
         /// <param name="destinationDirectoryName">The path to the directory on the file system.
         /// The directory specified must not exist. The path is permitted to specify relative or absolute path information.
         /// Relative path information is interpreted as relative to the current working directory.</param>
-        public static void ExtractToDirectory(this ZipArchive source, String destinationDirectoryName)
+        public static void ExtractToDirectory(this ZipArchive source, string destinationDirectoryName)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -135,11 +135,11 @@ namespace System.IO.Compression
 
             // Note that this will give us a good DirectoryInfo even if destinationDirectoryName exists:
             DirectoryInfo di = Directory.CreateDirectory(destinationDirectoryName);
-            String destinationDirectoryFullPath = di.FullName;
+            string destinationDirectoryFullPath = di.FullName;
 
             foreach (ZipArchiveEntry entry in source.Entries)
             {
-                String fileDestinationPath = Path.GetFullPath(Path.Combine(destinationDirectoryFullPath, entry.FullName));
+                string fileDestinationPath = Path.GetFullPath(Path.Combine(destinationDirectoryFullPath, entry.FullName));
 
                 if (!fileDestinationPath.StartsWith(destinationDirectoryFullPath, PathInternal.StringComparison))
                     throw new IOException(SR.IO_ExtractingResultsInOutside);
@@ -165,7 +165,7 @@ namespace System.IO.Compression
 
 
         internal static ZipArchiveEntry DoCreateEntryFromFile(ZipArchive destination,
-                                                              String sourceFileName, String entryName, CompressionLevel? compressionLevel)
+                                                              string sourceFileName, string entryName, CompressionLevel? compressionLevel)
         {
             if (destination == null)
                 throw new ArgumentNullException(nameof(destination));
@@ -236,7 +236,7 @@ namespace System.IO.Compression
         /// <param name="destinationFileName">The name of the file that will hold the contents of the entry.
         /// The path is permitted to specify relative or absolute path information.
         /// Relative path information is interpreted as relative to the current working directory.</param>
-        public static void ExtractToFile(this ZipArchiveEntry source, String destinationFileName)
+        public static void ExtractToFile(this ZipArchiveEntry source, string destinationFileName)
         {
             ExtractToFile(source, destinationFileName, false);
         }
@@ -269,7 +269,7 @@ namespace System.IO.Compression
         /// The path is permitted to specify relative or absolute path information.
         /// Relative path information is interpreted as relative to the current working directory.</param>
         /// <param name="overwrite">True to indicate overwrite.</param>
-        public static void ExtractToFile(this ZipArchiveEntry source, String destinationFileName, Boolean overwrite)
+        public static void ExtractToFile(this ZipArchiveEntry source, string destinationFileName, bool overwrite)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileInvalidFileTests.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileInvalidFileTests.cs
@@ -100,7 +100,7 @@ namespace System.IO.Compression.Tests
         [Theory]
         [InlineData("LZMA.zip", true)]
         [InlineData("invalidDeflate.zip", false)]
-        public void UnsupportedCompressionRoutine(string zipName, Boolean throwsOnOpen)
+        public void UnsupportedCompressionRoutine(string zipName, bool throwsOnOpen)
         {
             string filename = bad(zipName);
             using (ZipArchive archive = ZipFile.OpenRead(filename))
@@ -122,7 +122,7 @@ namespace System.IO.Compression.Tests
             using (TempFile updatedCopy = CreateTempCopyFile(filename, GetTestFilePath()))
             {
                 string name;
-                Int64 length, compressedLength;
+                long length, compressedLength;
                 DateTimeOffset lastWriteTime;
                 using (ZipArchive archive = ZipFile.Open(updatedCopy.Path, ZipArchiveMode.Update))
                 {

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/DeflateManagedStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/DeflateManagedStream.cs
@@ -322,7 +322,7 @@ namespace System.IO.Compression
             TaskToApm.End<int>(asyncResult);
 #endif
 
-        public override Task<int> ReadAsync(Byte[] array, int offset, int count, CancellationToken cancellationToken)
+        public override Task<int> ReadAsync(byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
             EnsureDecompressionMode();
 
@@ -579,7 +579,7 @@ namespace System.IO.Compression
             }
         }
 
-        public override Task WriteAsync(Byte[] array, int offset, int count, CancellationToken cancellationToken)
+        public override Task WriteAsync(byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
             EnsureCompressionMode();
 
@@ -596,7 +596,7 @@ namespace System.IO.Compression
             return WriteAsyncCore(array, offset, count, cancellationToken);
         }
 
-        private async Task WriteAsyncCore(Byte[] array, int offset, int count, CancellationToken cancellationToken)
+        private async Task WriteAsyncCore(byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
             Interlocked.Increment(ref _asyncOperations);
             try

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -368,7 +368,7 @@ namespace System.IO.Compression
             TaskToApm.End<int>(asyncResult);
 #endif
 
-        public override Task<int> ReadAsync(Byte[] array, int offset, int count, CancellationToken cancellationToken)
+        public override Task<int> ReadAsync(byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
             EnsureDecompressionMode();
 
@@ -619,7 +619,7 @@ namespace System.IO.Compression
             TaskToApm.End(asyncResult);
 #endif
 
-        public override Task WriteAsync(Byte[] array, int offset, int count, CancellationToken cancellationToken)
+        public override Task WriteAsync(byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
             EnsureCompressionMode();
 
@@ -636,7 +636,7 @@ namespace System.IO.Compression
             return WriteAsyncCore(array, offset, count, cancellationToken);
         }
 
-        private async Task WriteAsyncCore(Byte[] array, int offset, int count, CancellationToken cancellationToken)
+        private async Task WriteAsyncCore(byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
             IncrementAsyncOperations();
             try

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/ZLibNative.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/ZLibNative.cs
@@ -21,7 +21,7 @@ namespace System.IO.Compression
 
         // This is the NULL pointer for using with ZLib pointers;
         // we prefer it to IntPtr.Zero to mimic the definition of Z_NULL in zlib.h:
-        internal static readonly IntPtr ZNullPtr = (IntPtr)((Int32)0);
+        internal static readonly IntPtr ZNullPtr = IntPtr.Zero;
 
         public enum FlushCode : int
         {
@@ -53,20 +53,20 @@ namespace System.IO.Compression
         /// ZLib definitions, which map to our public NoCompression, Fastest, and Optimal respectively.
         /// <p><em>Optimal Compression:</em></p>
         /// <p><code>ZLibNative.CompressionLevel compressionLevel = ZLibNative.CompressionLevel.DefaultCompression;</code> <br />
-        ///    <code>Int32 windowBits = 15;  // or -15 if no headers required</code> <br />
-        ///    <code>Int32 memLevel = 8;</code> <br />
+        ///    <code>int windowBits = 15;  // or -15 if no headers required</code> <br />
+        ///    <code>int memLevel = 8;</code> <br />
         ///    <code>ZLibNative.CompressionStrategy strategy = ZLibNative.CompressionStrategy.DefaultStrategy;</code> </p>
         /// 
         ///<p><em>Fastest compression:</em></p>
         ///<p><code>ZLibNative.CompressionLevel compressionLevel = ZLibNative.CompressionLevel.BestSpeed;</code> <br />
-        ///   <code>Int32 windowBits = 15;  // or -15 if no headers required</code> <br />
-        ///   <code>Int32 memLevel = 8; </code> <br />
+        ///   <code>int windowBits = 15;  // or -15 if no headers required</code> <br />
+        ///   <code>int memLevel = 8; </code> <br />
         ///   <code>ZLibNative.CompressionStrategy strategy = ZLibNative.CompressionStrategy.DefaultStrategy;</code> </p>
         ///
         /// <p><em>No compression (even faster, useful for data that cannot be compressed such some image formats):</em></p>
         /// <p><code>ZLibNative.CompressionLevel compressionLevel = ZLibNative.CompressionLevel.NoCompression;</code> <br />
-        ///    <code>Int32 windowBits = 15;  // or -15 if no headers required</code> <br />
-        ///    <code>Int32 memLevel = 7;</code> <br />
+        ///    <code>int windowBits = 15;  // or -15 if no headers required</code> <br />
+        ///    <code>int memLevel = 7;</code> <br />
         ///    <code>ZLibNative.CompressionStrategy strategy = ZLibNative.CompressionStrategy.DefaultStrategy;</code> </p>
         /// </summary>
         public enum CompressionLevel : int
@@ -241,7 +241,7 @@ namespace System.IO.Compression
                 [SecurityCritical] set { _zStream.nextIn = value; }
             }
 
-            public UInt32 AvailIn
+            public uint AvailIn
             {
                 [SecurityCritical] get { return _zStream.availIn; }
                 [SecurityCritical] set { _zStream.availIn = value; }
@@ -253,7 +253,7 @@ namespace System.IO.Compression
                 [SecurityCritical] set { _zStream.nextOut = value; }
             }
 
-            public UInt32 AvailOut
+            public uint AvailOut
             {
                 [SecurityCritical] get { return _zStream.availOut; }
                 [SecurityCritical] set { _zStream.availOut = value; }

--- a/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
@@ -175,13 +175,13 @@ namespace System.IO.Compression
             }
         }
 
-        public override Task<int> ReadAsync(Byte[] array, int offset, int count, CancellationToken cancellationToken)
+        public override Task<int> ReadAsync(byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
             CheckDeflateStream();
             return _deflateStream.ReadAsync(array, offset, count, cancellationToken);
         }
 
-        public override Task WriteAsync(Byte[] array, int offset, int count, CancellationToken cancellationToken)
+        public override Task WriteAsync(byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
             CheckDeflateStream();
             return _deflateStream.WriteAsync(array, offset, count, cancellationToken);

--- a/src/System.IO.Compression/src/System/IO/Compression/ZLibException.Serialization.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZLibException.Serialization.cs
@@ -28,7 +28,7 @@ namespace System.IO.Compression
         {
             base.GetObjectData(si, context);
             si.AddValue("zlibErrorContext", _zlibErrorContext);
-            si.AddValue("zlibErrorCode", (Int32)_zlibErrorCode);
+            si.AddValue("zlibErrorCode", (int)_zlibErrorCode);
             si.AddValue("zlibErrorMessage", _zlibErrorMessage);
         }
     }

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -23,19 +23,19 @@ namespace System.IO.Compression
         private ZipArchiveMode _mode;
         private List<ZipArchiveEntry> _entries;
         private ReadOnlyCollection<ZipArchiveEntry> _entriesCollection;
-        private Dictionary<String, ZipArchiveEntry> _entriesDictionary;
-        private Boolean _readEntries;
-        private Boolean _leaveOpen;
-        private Int64 _centralDirectoryStart; //only valid after ReadCentralDirectory
-        private Boolean _isDisposed;
-        private UInt32 _numberOfThisDisk; //only valid after ReadCentralDirectory
-        private Int64 _expectedNumberOfEntries;
+        private Dictionary<string, ZipArchiveEntry> _entriesDictionary;
+        private bool _readEntries;
+        private bool _leaveOpen;
+        private long _centralDirectoryStart; //only valid after ReadCentralDirectory
+        private bool _isDisposed;
+        private uint _numberOfThisDisk; //only valid after ReadCentralDirectory
+        private long _expectedNumberOfEntries;
         private Stream _backingStream;
-        private Byte[] _archiveComment;
+        private byte[] _archiveComment;
         private Encoding _entryNameEncoding;
 
 #if DEBUG_FORCE_ZIP64
-        public Boolean _forceZip64;
+        public bool _forceZip64;
 #endif
         #endregion Fields
 
@@ -74,7 +74,7 @@ namespace System.IO.Compression
         /// <param name="stream">The input or output stream.</param>
         /// <param name="mode">See the description of the ZipArchiveMode enum. Read requires the stream to support reading, Create requires the stream to support writing, and Update requires the stream to support reading, writing, and seeking.</param>
         /// <param name="leaveOpen">true to leave the stream open upon disposing the ZipArchive, otherwise false.</param>
-        public ZipArchive(Stream stream, ZipArchiveMode mode, Boolean leaveOpen) : this(stream, mode, leaveOpen, entryNameEncoding: null) { }
+        public ZipArchive(Stream stream, ZipArchiveMode mode, bool leaveOpen) : this(stream, mode, leaveOpen, entryNameEncoding: null) { }
 
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace System.IO.Compression
         ///     otherwise an <see cref="ArgumentException"/> is thrown.</para>
         /// </param>
         /// <exception cref="ArgumentException">If a Unicode encoding other than UTF-8 is specified for the <code>entryNameEncoding</code>.</exception>
-        public ZipArchive(Stream stream, ZipArchiveMode mode, Boolean leaveOpen, Encoding entryNameEncoding)
+        public ZipArchive(Stream stream, ZipArchiveMode mode, bool leaveOpen, Encoding entryNameEncoding)
         {
             if (stream == null)
                 throw new ArgumentNullException(nameof(stream));
@@ -194,7 +194,7 @@ namespace System.IO.Compression
         /// <exception cref="ObjectDisposedException">The ZipArchive has already been closed.</exception>
         /// <param name="entryName">A path relative to the root of the archive, indicating the name of the entry to be created.</param>
         /// <returns>A wrapper for the newly created file entry in the archive.</returns>
-        public ZipArchiveEntry CreateEntry(String entryName)
+        public ZipArchiveEntry CreateEntry(string entryName)
         {
             Contract.Ensures(Contract.Result<ZipArchiveEntry>() != null);
             Contract.EndContractBlock();
@@ -213,7 +213,7 @@ namespace System.IO.Compression
         /// <param name="entryName">A path relative to the root of the archive, indicating the name of the entry to be created.</param>
         /// <param name="compressionLevel">The level of the compression (speed/memory vs. compressed size trade-off).</param>
         /// <returns>A wrapper for the newly created file entry in the archive.</returns>
-        public ZipArchiveEntry CreateEntry(String entryName, CompressionLevel compressionLevel)
+        public ZipArchiveEntry CreateEntry(string entryName, CompressionLevel compressionLevel)
         {
             Contract.Ensures(Contract.Result<ZipArchiveEntry>() != null);
             Contract.EndContractBlock();
@@ -226,7 +226,7 @@ namespace System.IO.Compression
         /// Releases the unmanaged resources used by ZipArchive and optionally finishes writing the archive and releases the managed resources.
         /// </summary>
         /// <param name="disposing">true to finish writing the archive and release unmanaged and managed resources, false to release only unmanaged resources.</param>
-        protected virtual void Dispose(Boolean disposing)
+        protected virtual void Dispose(bool disposing)
         {
             if (disposing && !_isDisposed)
             {
@@ -272,7 +272,7 @@ namespace System.IO.Compression
         /// <exception cref="InvalidDataException">The Zip archive is corrupt and the entries cannot be retrieved.</exception>
         /// <param name="entryName">A path relative to the root of the archive, identifying the desired entry.</param>
         /// <returns>A wrapper for the file entry in the archive. If no entry in the archive exists with the specified name, null will be returned.</returns>
-        public ZipArchiveEntry GetEntry(String entryName)
+        public ZipArchiveEntry GetEntry(string entryName)
         {
             if (entryName == null)
                 throw new ArgumentNullException(nameof(entryName));
@@ -296,7 +296,7 @@ namespace System.IO.Compression
 
         internal Stream ArchiveStream { get { return _archiveStream; } }
 
-        internal UInt32 NumberOfThisDisk { get { return _numberOfThisDisk; } }
+        internal uint NumberOfThisDisk { get { return _numberOfThisDisk; } }
 
         internal Encoding EntryNameEncoding
         {
@@ -337,14 +337,14 @@ namespace System.IO.Compression
             }
         }
 
-        private ZipArchiveEntry DoCreateEntry(String entryName, CompressionLevel? compressionLevel)
+        private ZipArchiveEntry DoCreateEntry(string entryName, CompressionLevel? compressionLevel)
         {
             Contract.Ensures(Contract.Result<ZipArchiveEntry>() != null);
 
             if (entryName == null)
                 throw new ArgumentNullException(nameof(entryName));
 
-            if (String.IsNullOrEmpty(entryName))
+            if (string.IsNullOrEmpty(entryName))
                 throw new ArgumentException(SR.CannotBeEmpty, nameof(entryName));
 
             if (_mode == ZipArchiveMode.Read)
@@ -385,7 +385,7 @@ namespace System.IO.Compression
         {
             _entries.Add(entry);
 
-            String entryName = entry.FullName;
+            string entryName = entry.FullName;
             if (!_entriesDictionary.ContainsKey(entryName))
             {
                 _entriesDictionary.Add(entryName, entry);
@@ -394,7 +394,7 @@ namespace System.IO.Compression
 
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "This code is used in a contract check.")]
-        internal Boolean IsStillArchiveStreamOwner(ZipArchiveEntry entry)
+        internal bool IsStillArchiveStreamOwner(ZipArchiveEntry entry)
         {
             return _archiveStreamOwner == entry;
         }
@@ -455,7 +455,7 @@ namespace System.IO.Compression
         }
 
 
-        private void Init(Stream stream, ZipArchiveMode mode, Boolean leaveOpen)
+        private void Init(Stream stream, ZipArchiveMode mode, bool leaveOpen)
         {
             Stream extraTempStream = null;
 
@@ -502,7 +502,7 @@ namespace System.IO.Compression
                     _archiveReader = new BinaryReader(_archiveStream);
                 _entries = new List<ZipArchiveEntry>();
                 _entriesCollection = new ReadOnlyCollection<ZipArchiveEntry>(_entries);
-                _entriesDictionary = new Dictionary<String, ZipArchiveEntry>();
+                _entriesDictionary = new Dictionary<string, ZipArchiveEntry>();
                 _readEntries = false;
                 _leaveOpen = leaveOpen;
                 _centralDirectoryStart = 0; //invalid until ReadCentralDirectory
@@ -555,11 +555,11 @@ namespace System.IO.Compression
 
                 _archiveStream.Seek(_centralDirectoryStart, SeekOrigin.Begin);
 
-                Int64 numberOfEntries = 0;
+                long numberOfEntries = 0;
 
                 //read the central directory
                 ZipCentralDirectoryFileHeader currentHeader;
-                Boolean saveExtraFieldsAndComments = Mode == ZipArchiveMode.Update;
+                bool saveExtraFieldsAndComments = Mode == ZipArchiveMode.Update;
                 while (ZipCentralDirectoryFileHeader.TryReadBlock(_archiveReader,
                                                         saveExtraFieldsAndComments, out currentHeader))
                 {
@@ -590,11 +590,11 @@ namespace System.IO.Compression
                 if (!ZipHelper.SeekBackwardsToSignature(_archiveStream, ZipEndOfCentralDirectoryBlock.SignatureConstant))
                     throw new InvalidDataException(SR.EOCDNotFound);
 
-                Int64 eocdStart = _archiveStream.Position;
+                long eocdStart = _archiveStream.Position;
 
                 //read the EOCD
                 ZipEndOfCentralDirectoryBlock eocd;
-                Boolean eocdProper = ZipEndOfCentralDirectoryBlock.TryReadBlock(_archiveReader, out eocd);
+                bool eocdProper = ZipEndOfCentralDirectoryBlock.TryReadBlock(_archiveReader, out eocd);
                 Debug.Assert(eocdProper); //we just found this using the signature finder, so it should be okay
 
                 if (eocd.NumberOfThisDisk != eocd.NumberOfTheDiskWithTheStartOfTheCentralDirectory)
@@ -625,12 +625,12 @@ namespace System.IO.Compression
                     {
                         //use locator to get to Zip64EOCD
                         Zip64EndOfCentralDirectoryLocator locator;
-                        Boolean zip64eocdLocatorProper = Zip64EndOfCentralDirectoryLocator.TryReadBlock(_archiveReader, out locator);
+                        bool zip64eocdLocatorProper = Zip64EndOfCentralDirectoryLocator.TryReadBlock(_archiveReader, out locator);
                         Debug.Assert(zip64eocdLocatorProper); //we just found this using the signature finder, so it should be okay
 
-                        if (locator.OffsetOfZip64EOCD > (UInt64)Int64.MaxValue)
+                        if (locator.OffsetOfZip64EOCD > (ulong)long.MaxValue)
                             throw new InvalidDataException(SR.FieldTooBigOffsetToZip64EOCD);
-                        Int64 zip64EOCDOffset = (Int64)locator.OffsetOfZip64EOCD;
+                        long zip64EOCDOffset = (long)locator.OffsetOfZip64EOCD;
 
                         _archiveStream.Seek(zip64EOCDOffset, SeekOrigin.Begin);
 
@@ -641,15 +641,15 @@ namespace System.IO.Compression
 
                         _numberOfThisDisk = record.NumberOfThisDisk;
 
-                        if (record.NumberOfEntriesTotal > (UInt64)Int64.MaxValue)
+                        if (record.NumberOfEntriesTotal > (ulong)long.MaxValue)
                             throw new InvalidDataException(SR.FieldTooBigNumEntries);
-                        if (record.OffsetOfCentralDirectory > (UInt64)Int64.MaxValue)
+                        if (record.OffsetOfCentralDirectory > (ulong)long.MaxValue)
                             throw new InvalidDataException(SR.FieldTooBigOffsetToCD);
                         if (record.NumberOfEntriesTotal != record.NumberOfEntriesOnThisDisk)
                             throw new InvalidDataException(SR.SplitSpanned);
 
-                        _expectedNumberOfEntries = (Int64)record.NumberOfEntriesTotal;
-                        _centralDirectoryStart = (Int64)record.OffsetOfCentralDirectory;
+                        _expectedNumberOfEntries = (long)record.NumberOfEntriesTotal;
+                        _centralDirectoryStart = (long)record.OffsetOfCentralDirectory;
                     }
                 }
 
@@ -695,14 +695,14 @@ namespace System.IO.Compression
                 entry.WriteAndFinishLocalEntry();
             }
 
-            Int64 startOfCentralDirectory = _archiveStream.Position;
+            long startOfCentralDirectory = _archiveStream.Position;
 
             foreach (ZipArchiveEntry entry in _entries)
             {
                 entry.WriteCentralDirectoryFileHeader();
             }
 
-            Int64 sizeOfCentralDirectory = _archiveStream.Position - startOfCentralDirectory;
+            long sizeOfCentralDirectory = _archiveStream.Position - startOfCentralDirectory;
 
             WriteArchiveEpilogue(startOfCentralDirectory, sizeOfCentralDirectory);
         }
@@ -710,13 +710,13 @@ namespace System.IO.Compression
 
         //writes eocd, and if needed, zip 64 eocd, zip64 eocd locator
         //should only throw an exception in extremely exceptional cases because it is called from dispose
-        private void WriteArchiveEpilogue(Int64 startOfCentralDirectory, Int64 sizeOfCentralDirectory)
+        private void WriteArchiveEpilogue(long startOfCentralDirectory, long sizeOfCentralDirectory)
         {
             //determine if we need Zip 64
-            Boolean needZip64 = false;
+            bool needZip64 = false;
 
-            if (startOfCentralDirectory >= UInt32.MaxValue
-                    || sizeOfCentralDirectory >= UInt32.MaxValue
+            if (startOfCentralDirectory >= uint.MaxValue
+                    || sizeOfCentralDirectory >= uint.MaxValue
                     || _entries.Count >= ZipHelper.Mask16Bit
 #if DEBUG_FORCE_ZIP64
                 || _forceZip64
@@ -727,7 +727,7 @@ namespace System.IO.Compression
             //if we need zip 64, write zip 64 eocd and locator
             if (needZip64)
             {
-                Int64 zip64EOCDRecordStart = _archiveStream.Position;
+                long zip64EOCDRecordStart = _archiveStream.Position;
 
                 Zip64EndOfCentralDirectoryRecord.WriteBlock(_archiveStream, _entries.Count, startOfCentralDirectory, sizeOfCentralDirectory);
                 Zip64EndOfCentralDirectoryLocator.WriteBlock(_archiveStream, zip64EOCDRecordStart);

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -15,37 +15,37 @@ namespace System.IO.Compression
     {
         #region Fields
 
-        private const UInt16 DefaultVersionToExtract = 10;
+        private const ushort DefaultVersionToExtract = 10;
 
         //The maximum index of our buffers, from the maximum index of a byte array
         private const int MaxSingleBufferSize = 0x7FFFFFC7;
 
         private ZipArchive _archive;
-        private readonly Boolean _originallyInArchive;
-        private readonly Int32 _diskNumberStart;
+        private readonly bool _originallyInArchive;
+        private readonly int _diskNumberStart;
         private readonly ZipVersionMadeByPlatform _versionMadeByPlatform;
         private ZipVersionNeededValues _versionMadeBySpecification;
         private ZipVersionNeededValues _versionToExtract;
         private BitFlagValues _generalPurposeBitFlag;
         private CompressionMethodValues _storedCompressionMethod;
         private DateTimeOffset _lastModified;
-        private Int64 _compressedSize;
-        private Int64 _uncompressedSize;
-        private Int64 _offsetOfLocalHeader;
-        private Int64? _storedOffsetOfCompressedData;
-        private UInt32 _crc32;
+        private long _compressedSize;
+        private long _uncompressedSize;
+        private long _offsetOfLocalHeader;
+        private long? _storedOffsetOfCompressedData;
+        private uint _crc32;
         //An array of buffers, each a maximum of MaxSingleBufferSize in size
-        private Byte[][] _compressedBytes;
+        private byte[][] _compressedBytes;
         private MemoryStream _storedUncompressedData;
-        private Boolean _currentlyOpenForWrite;
-        private Boolean _everOpenedForWrite;
+        private bool _currentlyOpenForWrite;
+        private bool _everOpenedForWrite;
         private Stream _outstandingWriteStream;
-        private String _storedEntryName;
-        private Byte[] _storedEntryNameBytes;
+        private string _storedEntryName;
+        private byte[] _storedEntryNameBytes;
         //only apply to update mode
         private List<ZipGenericExtraField> _cdUnknownExtraFields;
         private List<ZipGenericExtraField> _lhUnknownExtraFields;
-        private Byte[] _fileComment;
+        private byte[] _fileComment;
         private CompressionLevel? _compressionLevel;
 
         #endregion Fields
@@ -98,7 +98,7 @@ namespace System.IO.Compression
         }
 
         //Initializes new entry
-        internal ZipArchiveEntry(ZipArchive archive, String entryName, CompressionLevel compressionLevel)
+        internal ZipArchiveEntry(ZipArchive archive, string entryName, CompressionLevel compressionLevel)
 
             : this(archive, entryName)
         {
@@ -106,7 +106,7 @@ namespace System.IO.Compression
         }
 
         //Initializes new entry
-        internal ZipArchiveEntry(ZipArchive archive, String entryName)
+        internal ZipArchiveEntry(ZipArchive archive, string entryName)
         {
             _archive = archive;
 
@@ -140,7 +140,7 @@ namespace System.IO.Compression
 
             _compressionLevel = null;
 
-            if (_storedEntryNameBytes.Length > UInt16.MaxValue)
+            if (_storedEntryNameBytes.Length > ushort.MaxValue)
                 throw new ArgumentException(SR.EntryNamesTooLong);
 
             //grab the stream if we're in create mode
@@ -159,11 +159,11 @@ namespace System.IO.Compression
         /// The compressed size of the entry. If the archive that the entry belongs to is in Create mode, attempts to get this property will always throw an exception. If the archive that the entry belongs to is in update mode, this property will only be valid if the entry has not been opened. 
         /// </summary>
         /// <exception cref="InvalidOperationException">This property is not available because the entry has been written to or modified.</exception>
-        public Int64 CompressedLength
+        public long CompressedLength
         {
             get
             {
-                Contract.Ensures(Contract.Result<Int64>() >= 0);
+                Contract.Ensures(Contract.Result<long>() >= 0);
 
                 if (_everOpenedForWrite)
                     throw new InvalidOperationException(SR.LengthAfterWrite);
@@ -174,11 +174,11 @@ namespace System.IO.Compression
         /// <summary>
         /// The relative path of the entry as stored in the Zip archive. Note that Zip archives allow any string to be the path of the entry, including invalid and absolute paths.
         /// </summary>
-        public String FullName
+        public string FullName
         {
             get
             {
-                Contract.Ensures(Contract.Result<String>() != null);
+                Contract.Ensures(Contract.Result<string>() != null);
                 return _storedEntryName;
             }
 
@@ -235,11 +235,11 @@ namespace System.IO.Compression
         /// The uncompressed size of the entry. This property is not valid in Create mode, and it is only valid in Update mode if the entry has not been opened.
         /// </summary>
         /// <exception cref="InvalidOperationException">This property is not available because the entry has been written to or modified.</exception>
-        public Int64 Length
+        public long Length
         {
             get
             {
-                Contract.Ensures(Contract.Result<Int64>() >= 0);
+                Contract.Ensures(Contract.Result<long>() >= 0);
 
                 if (_everOpenedForWrite)
                     throw new InvalidOperationException(SR.LengthAfterWrite);
@@ -250,7 +250,7 @@ namespace System.IO.Compression
         /// <summary>
         /// The filename of the entry. This is equivalent to the substring of Fullname that follows the final directory separator character.
         /// </summary>
-        public String Name
+        public string Name
         {
             get
             {
@@ -312,20 +312,20 @@ namespace System.IO.Compression
         /// Returns the FullName of the entry.
         /// </summary>
         /// <returns>FullName of the entry</returns>
-        public override String ToString()
+        public override string ToString()
         {
-            Contract.Ensures(Contract.Result<String>() != null);
+            Contract.Ensures(Contract.Result<string>() != null);
 
             return FullName;
         }
 
         /*
-        public void MoveTo(String destinationEntryName)
+        public void MoveTo(string destinationEntryName)
         {
             if (destinationEntryName == null)
                 throw new ArgumentNullException(nameof(destinationEntryName));
 
-            if (String.IsNullOrEmpty(destinationEntryName))
+            if (string.IsNullOrEmpty(destinationEntryName))
                 throw new ArgumentException("destinationEntryName cannot be empty", nameof(destinationEntryName));
 
             if (_archive == null)
@@ -337,9 +337,9 @@ namespace System.IO.Compression
             if (_archive.Mode != ZipArchiveMode.Update)
                 throw new NotSupportedException("MoveTo can only be used when the archive is in Update mode");
 
-            String oldFilename = _filename;
+            string oldFilename = _filename;
             _filename = destinationEntryName;
-            if (_filenameLength > UInt16.MaxValue)
+            if (_filenameLength > ushort.MaxValue)
             {
                 _filename = oldFilename;
                 throw new ArgumentException("Archive entry names must be smaller than 2^16 bytes");
@@ -354,9 +354,9 @@ namespace System.IO.Compression
         // will not work in a 32-bit process.
         private static readonly bool s_allowLargeZipArchiveEntriesInUpdateMode = IntPtr.Size > 4;
 
-        internal Boolean EverOpenedForWrite { get { return _everOpenedForWrite; } }
+        internal bool EverOpenedForWrite { get { return _everOpenedForWrite; } }
 
-        private Int64 OffsetOfCompressedData
+        private long OffsetOfCompressedData
         {
             get
             {
@@ -381,9 +381,9 @@ namespace System.IO.Compression
                 {
                     //this means we have never opened it before
 
-                    //if _uncompressedSize > Int32.MaxValue, it's still okay, because MemoryStream will just
+                    //if _uncompressedSize > int.MaxValue, it's still okay, because MemoryStream will just
                     //grow as data is copied into it
-                    _storedUncompressedData = new MemoryStream((Int32)_uncompressedSize);
+                    _storedUncompressedData = new MemoryStream((int)_uncompressedSize);
 
                     if (_originallyInArchive)
                     {
@@ -431,7 +431,7 @@ namespace System.IO.Compression
             }
         }
 
-        private String DecodeEntryName(Byte[] entryNameBytes)
+        private string DecodeEntryName(byte[] entryNameBytes)
         {
             Debug.Assert(entryNameBytes != null);
 
@@ -450,7 +450,7 @@ namespace System.IO.Compression
             return readEntryNameEncoding.GetString(entryNameBytes);
         }
 
-        private Byte[] EncodeEntryName(String entryName, out bool isUTF8)
+        private byte[] EncodeEntryName(string entryName, out bool isUTF8)
         {
             Debug.Assert(entryName != null);
 
@@ -490,14 +490,14 @@ namespace System.IO.Compression
             BinaryWriter writer = new BinaryWriter(_archive.ArchiveStream);
 
             //_entryname only gets set when we read in or call moveTo. MoveTo does a check, and
-            //reading in should not be able to produce a entryname longer than UInt16.MaxValue
-            Debug.Assert(_storedEntryNameBytes.Length <= UInt16.MaxValue);
+            //reading in should not be able to produce a entryname longer than ushort.MaxValue
+            Debug.Assert(_storedEntryNameBytes.Length <= ushort.MaxValue);
 
             //decide if we need the Zip64 extra field:
             Zip64ExtraField zip64ExtraField = new Zip64ExtraField();
-            UInt32 compressedSizeTruncated, uncompressedSizeTruncated, offsetOfLocalHeaderTruncated;
+            uint compressedSizeTruncated, uncompressedSizeTruncated, offsetOfLocalHeaderTruncated;
 
-            Boolean zip64Needed = false;
+            bool zip64Needed = false;
 
             if (SizesTooLarge()
 #if DEBUG_FORCE_ZIP64
@@ -515,12 +515,12 @@ namespace System.IO.Compression
             }
             else
             {
-                compressedSizeTruncated = (UInt32)_compressedSize;
-                uncompressedSizeTruncated = (UInt32)_uncompressedSize;
+                compressedSizeTruncated = (uint)_compressedSize;
+                uncompressedSizeTruncated = (uint)_uncompressedSize;
             }
 
 
-            if (_offsetOfLocalHeader > UInt32.MaxValue
+            if (_offsetOfLocalHeader > uint.MaxValue
 #if DEBUG_FORCE_ZIP64
  || _archive._forceZip64
 #endif
@@ -534,46 +534,46 @@ namespace System.IO.Compression
             }
             else
             {
-                offsetOfLocalHeaderTruncated = (UInt32)_offsetOfLocalHeader;
+                offsetOfLocalHeaderTruncated = (uint)_offsetOfLocalHeader;
             }
 
             if (zip64Needed)
                 VersionToExtractAtLeast(ZipVersionNeededValues.Zip64);
 
             //determine if we can fit zip64 extra field and original extra fields all in
-            Int32 bigExtraFieldLength = (zip64Needed ? zip64ExtraField.TotalSize : 0)
+            int bigExtraFieldLength = (zip64Needed ? zip64ExtraField.TotalSize : 0)
                                       + (_cdUnknownExtraFields != null ? ZipGenericExtraField.TotalSize(_cdUnknownExtraFields) : 0);
-            UInt16 extraFieldLength;
-            if (bigExtraFieldLength > UInt16.MaxValue)
+            ushort extraFieldLength;
+            if (bigExtraFieldLength > ushort.MaxValue)
             {
-                extraFieldLength = (UInt16)(zip64Needed ? zip64ExtraField.TotalSize : 0);
+                extraFieldLength = (ushort)(zip64Needed ? zip64ExtraField.TotalSize : 0);
                 _cdUnknownExtraFields = null;
             }
             else
             {
-                extraFieldLength = (UInt16)bigExtraFieldLength;
+                extraFieldLength = (ushort)bigExtraFieldLength;
             }
 
             writer.Write(ZipCentralDirectoryFileHeader.SignatureConstant);      // Central directory file header signature  (4 bytes)
             writer.Write((byte)_versionMadeBySpecification);                    // Version made by Specification (version)  (1 byte)
             writer.Write((byte)CurrentZipPlatform);                             // Version made by Compatibility (type)     (1 byte)
-            writer.Write((UInt16)_versionToExtract);                            // Minimum version needed to extract        (2 bytes)
-            writer.Write((UInt16)_generalPurposeBitFlag);                       // General Purpose bit flag                 (2 bytes)
-            writer.Write((UInt16)CompressionMethod);                            // The Compression method                   (2 bytes)
+            writer.Write((ushort)_versionToExtract);                            // Minimum version needed to extract        (2 bytes)
+            writer.Write((ushort)_generalPurposeBitFlag);                       // General Purpose bit flag                 (2 bytes)
+            writer.Write((ushort)CompressionMethod);                            // The Compression method                   (2 bytes)
             writer.Write(ZipHelper.DateTimeToDosTime(_lastModified.DateTime));  // File last modification time and date     (4 bytes)
             writer.Write(_crc32);                                               // CRC-32                                   (4 bytes)
             writer.Write(compressedSizeTruncated);                              // Compressed Size                          (4 bytes)
             writer.Write(uncompressedSizeTruncated);                            // Uncompressed Size                        (4 bytes)
-            writer.Write((UInt16)_storedEntryNameBytes.Length);                 // File Name Length                         (2 bytes)
+            writer.Write((ushort)_storedEntryNameBytes.Length);                 // File Name Length                         (2 bytes)
             writer.Write(extraFieldLength);                                     // Extra Field Length                       (2 bytes)
 
             // This should hold because of how we read it originally in ZipCentralDirectoryFileHeader:
-            Debug.Assert((_fileComment == null) || (_fileComment.Length <= UInt16.MaxValue));
+            Debug.Assert((_fileComment == null) || (_fileComment.Length <= ushort.MaxValue));
 
-            writer.Write(_fileComment != null ? (UInt16)_fileComment.Length : (UInt16)0);    //file comment length
-            writer.Write((UInt16)0);    //disk number start
-            writer.Write((UInt16)0);    //internal file attributes
-            writer.Write((UInt32)0);    //external file attributes
+            writer.Write(_fileComment != null ? (ushort)_fileComment.Length : (ushort)0);    //file comment length
+            writer.Write((ushort)0);    //disk number start
+            writer.Write((ushort)0);    //internal file attributes
+            writer.Write((uint)0);    //external file attributes
             writer.Write(offsetOfLocalHeaderTruncated); //offset of local header
 
             writer.Write(_storedEntryNameBytes);
@@ -590,9 +590,9 @@ namespace System.IO.Compression
 
         //returns false if fails, will get called on every entry before closing in update mode
         //can throw InvalidDataException
-        internal Boolean LoadLocalHeaderExtraFieldAndCompressedBytesIfNeeded()
+        internal bool LoadLocalHeaderExtraFieldAndCompressedBytesIfNeeded()
         {
-            String message;
+            string message;
             //we should have made this exact call in _archive.Init through ThrowIfOpenable
             Debug.Assert(IsOpenable(false, true, out message));
 
@@ -608,12 +608,12 @@ namespace System.IO.Compression
             {
                 //we know that it is openable at this point
 
-                _compressedBytes = new Byte[(_compressedSize / MaxSingleBufferSize) + 1][];
+                _compressedBytes = new byte[(_compressedSize / MaxSingleBufferSize) + 1][];
                 for (int i = 0; i < _compressedBytes.Length - 1; i++)
                 {
-                    _compressedBytes[i] = new Byte[MaxSingleBufferSize];
+                    _compressedBytes[i] = new byte[MaxSingleBufferSize];
                 }
-                _compressedBytes[_compressedBytes.Length - 1] = new Byte[_compressedSize % MaxSingleBufferSize];
+                _compressedBytes[_compressedBytes.Length - 1] = new byte[_compressedSize % MaxSingleBufferSize];
 
                 _archive.ArchiveStream.Seek(OffsetOfCompressedData, SeekOrigin.Begin);
 
@@ -621,20 +621,20 @@ namespace System.IO.Compression
                 {
                     ZipHelper.ReadBytes(_archive.ArchiveStream, _compressedBytes[i], MaxSingleBufferSize);
                 }
-                ZipHelper.ReadBytes(_archive.ArchiveStream, _compressedBytes[_compressedBytes.Length - 1], (Int32)(_compressedSize % MaxSingleBufferSize));
+                ZipHelper.ReadBytes(_archive.ArchiveStream, _compressedBytes[_compressedBytes.Length - 1], (int)(_compressedSize % MaxSingleBufferSize));
             }
 
             return true;
         }
 
-        internal void ThrowIfNotOpenable(Boolean needToUncompress, Boolean needToLoadIntoMemory)
+        internal void ThrowIfNotOpenable(bool needToUncompress, bool needToLoadIntoMemory)
         {
-            String message;
+            string message;
             if (!IsOpenable(needToUncompress, needToLoadIntoMemory, out message))
                 throw new InvalidDataException(message);
         }
 
-        private CheckSumAndSizeWriteStream GetDataCompressor(Stream backingStream, Boolean leaveBackingStreamOpen, EventHandler onClose)
+        private CheckSumAndSizeWriteStream GetDataCompressor(Stream backingStream, bool leaveBackingStreamOpen, EventHandler onClose)
         {
             //stream stack: backingStream -> DeflateStream -> CheckSumWriteStream
 
@@ -645,16 +645,16 @@ namespace System.IO.Compression
             Stream compressorStream = _compressionLevel.HasValue
                                             ? new DeflateStream(backingStream, _compressionLevel.Value, leaveBackingStreamOpen)
                                             : new DeflateStream(backingStream, CompressionMode.Compress, leaveBackingStreamOpen);
-            Boolean isIntermediateStream = true;
+            bool isIntermediateStream = true;
 
-            Boolean leaveCompressorStreamOpenOnClose = leaveBackingStreamOpen && !isIntermediateStream;
+            bool leaveCompressorStreamOpenOnClose = leaveBackingStreamOpen && !isIntermediateStream;
             var checkSumStream = new CheckSumAndSizeWriteStream(
                 compressorStream,
                 backingStream,
                 leaveCompressorStreamOpenOnClose,
                 this,
                 onClose,
-                (Int64 initialPosition, Int64 currentPosition, UInt32 checkSum, Stream backing, ZipArchiveEntry thisRef, EventHandler closeHandler) =>
+                (long initialPosition, long currentPosition, uint checkSum, Stream backing, ZipArchiveEntry thisRef, EventHandler closeHandler) =>
                 {
                     thisRef._crc32 = checkSum;
                     thisRef._uncompressedSize = currentPosition;
@@ -691,7 +691,7 @@ namespace System.IO.Compression
             return uncompressedStream;
         }
 
-        private Stream OpenInReadMode(Boolean checkOpenable)
+        private Stream OpenInReadMode(bool checkOpenable)
         {
             if (checkOpenable)
                 ThrowIfNotOpenable(true, false);
@@ -743,7 +743,7 @@ namespace System.IO.Compression
             });
         }
 
-        private Boolean IsOpenable(Boolean needToUncompress, Boolean needToLoadIntoMemory, out String message)
+        private bool IsOpenable(bool needToUncompress, bool needToLoadIntoMemory, out string message)
         {
             message = null;
 
@@ -796,7 +796,7 @@ namespace System.IO.Compression
                 //compatibility.
                 if (needToLoadIntoMemory)
                 {
-                    if (_compressedSize > Int32.MaxValue)
+                    if (_compressedSize > int.MaxValue)
                     {
                         if (!s_allowLargeZipArchiveEntriesInUpdateMode)
                         {
@@ -810,24 +810,24 @@ namespace System.IO.Compression
             return true;
         }
 
-        private Boolean SizesTooLarge()
+        private bool SizesTooLarge()
         {
-            return _compressedSize > UInt32.MaxValue || _uncompressedSize > UInt32.MaxValue;
+            return _compressedSize > uint.MaxValue || _uncompressedSize > uint.MaxValue;
         }
 
         //return value is true if we allocated an extra field for 64 bit headers, un/compressed size
-        private Boolean WriteLocalFileHeader(Boolean isEmptyFile)
+        private bool WriteLocalFileHeader(bool isEmptyFile)
         {
             BinaryWriter writer = new BinaryWriter(_archive.ArchiveStream);
 
             //_entryname only gets set when we read in or call moveTo. MoveTo does a check, and
-            //reading in should not be able to produce a entryname longer than UInt16.MaxValue
-            Debug.Assert(_storedEntryNameBytes.Length <= UInt16.MaxValue);
+            //reading in should not be able to produce a entryname longer than ushort.MaxValue
+            Debug.Assert(_storedEntryNameBytes.Length <= ushort.MaxValue);
 
             //decide if we need the Zip64 extra field:
             Zip64ExtraField zip64ExtraField = new Zip64ExtraField();
-            Boolean zip64Used = false;
-            UInt32 compressedSizeTruncated, uncompressedSizeTruncated;
+            bool zip64Used = false;
+            uint compressedSizeTruncated, uncompressedSizeTruncated;
 
             //if we already know that we have an empty file don't worry about anything, just do a straight shot of the header
             if (isEmptyFile)
@@ -873,8 +873,8 @@ namespace System.IO.Compression
                     else
                     {
                         zip64Used = false;
-                        compressedSizeTruncated = (UInt32)_compressedSize;
-                        uncompressedSizeTruncated = (UInt32)_uncompressedSize;
+                        compressedSizeTruncated = (uint)_compressedSize;
+                        uncompressedSizeTruncated = (uint)_uncompressedSize;
                     }
                 }
             }
@@ -883,30 +883,30 @@ namespace System.IO.Compression
             _offsetOfLocalHeader = writer.BaseStream.Position;
 
             //calculate extra field. if zip64 stuff + original extraField aren't going to fit, dump the original extraField, because this is more important
-            Int32 bigExtraFieldLength = (zip64Used ? zip64ExtraField.TotalSize : 0)
+            int bigExtraFieldLength = (zip64Used ? zip64ExtraField.TotalSize : 0)
                                       + (_lhUnknownExtraFields != null ? ZipGenericExtraField.TotalSize(_lhUnknownExtraFields) : 0);
-            UInt16 extraFieldLength;
-            if (bigExtraFieldLength > UInt16.MaxValue)
+            ushort extraFieldLength;
+            if (bigExtraFieldLength > ushort.MaxValue)
             {
-                extraFieldLength = (UInt16)(zip64Used ? zip64ExtraField.TotalSize : 0);
+                extraFieldLength = (ushort)(zip64Used ? zip64ExtraField.TotalSize : 0);
                 _lhUnknownExtraFields = null;
             }
             else
             {
-                extraFieldLength = (UInt16)bigExtraFieldLength;
+                extraFieldLength = (ushort)bigExtraFieldLength;
             }
 
             //write header
             writer.Write(ZipLocalFileHeader.SignatureConstant);
-            writer.Write((UInt16)_versionToExtract);
-            writer.Write((UInt16)_generalPurposeBitFlag);
-            writer.Write((UInt16)CompressionMethod);
-            writer.Write(ZipHelper.DateTimeToDosTime(_lastModified.DateTime)); //UInt32
-            writer.Write(_crc32);               //UInt32
-            writer.Write(compressedSizeTruncated);  //UInt32
-            writer.Write(uncompressedSizeTruncated); //UInt32
-            writer.Write((UInt16)_storedEntryNameBytes.Length);
-            writer.Write(extraFieldLength);    //UInt16
+            writer.Write((ushort)_versionToExtract);
+            writer.Write((ushort)_generalPurposeBitFlag);
+            writer.Write((ushort)CompressionMethod);
+            writer.Write(ZipHelper.DateTimeToDosTime(_lastModified.DateTime)); //uint
+            writer.Write(_crc32);               //uint
+            writer.Write(compressedSizeTruncated);  //uint
+            writer.Write(uncompressedSizeTruncated); //uint
+            writer.Write((ushort)_storedEntryNameBytes.Length);
+            writer.Write(extraFieldLength);    //ushort
 
             writer.Write(_storedEntryNameBytes);
 
@@ -945,7 +945,7 @@ namespace System.IO.Compression
                     if (_uncompressedSize == 0)
                         CompressionMethod = CompressionMethodValues.Stored;
                     WriteLocalFileHeader(false);
-                    foreach (Byte[] compressedBytes in _compressedBytes)
+                    foreach (byte[] compressedBytes in _compressedBytes)
                     {
                         _archive.ArchiveStream.Write(compressedBytes, 0, compressedBytes.Length);
                     }
@@ -965,20 +965,20 @@ namespace System.IO.Compression
          * writes them, then seeks back to where you started
          * Assumes that the stream is currently at the end of the data
         */
-        private void WriteCrcAndSizesInLocalHeader(Boolean zip64HeaderUsed)
+        private void WriteCrcAndSizesInLocalHeader(bool zip64HeaderUsed)
         {
-            Int64 finalPosition = _archive.ArchiveStream.Position;
+            long finalPosition = _archive.ArchiveStream.Position;
             BinaryWriter writer = new BinaryWriter(_archive.ArchiveStream);
 
-            Boolean zip64Needed = SizesTooLarge()
+            bool zip64Needed = SizesTooLarge()
 #if DEBUG_FORCE_ZIP64
  || _archive._forceZip64
 #endif
 ;
-            Boolean pretendStreaming = zip64Needed && !zip64HeaderUsed;
+            bool pretendStreaming = zip64Needed && !zip64HeaderUsed;
 
-            UInt32 compressedSizeTruncated = zip64Needed ? ZipHelper.Mask32Bit : (UInt32)_compressedSize;
-            UInt32 uncompressedSizeTruncated = zip64Needed ? ZipHelper.Mask32Bit : (UInt32)_uncompressedSize;
+            uint compressedSizeTruncated = zip64Needed ? ZipHelper.Mask32Bit : (uint)_compressedSize;
+            uint uncompressedSizeTruncated = zip64Needed ? ZipHelper.Mask32Bit : (uint)_uncompressedSize;
 
             /* first step is, if we need zip64, but didn't allocate it, pretend we did a stream write, because
              * we can't go back and give ourselves the space that the extra field needs.
@@ -989,7 +989,7 @@ namespace System.IO.Compression
 
                 _archive.ArchiveStream.Seek(_offsetOfLocalHeader + ZipLocalFileHeader.OffsetToBitFlagFromHeaderStart,
                                             SeekOrigin.Begin);
-                writer.Write((UInt16)_generalPurposeBitFlag);
+                writer.Write((ushort)_generalPurposeBitFlag);
             }
 
             /* next step is fill out the 32-bit size values in the normal header. we can't assume that
@@ -1004,9 +1004,9 @@ namespace System.IO.Compression
             }
             else //but if we are pretending to stream, we want to fill in with zeroes
             {
-                writer.Write((UInt32)0);
-                writer.Write((UInt32)0);
-                writer.Write((UInt32)0);
+                writer.Write((uint)0);
+                writer.Write((uint)0);
+                writer.Write((uint)0);
             }
 
             /* next step: if we wrote the 64 bit header initially, a different implementation might
@@ -1056,8 +1056,8 @@ namespace System.IO.Compression
             }
             else
             {
-                writer.Write((UInt32)_compressedSize);
-                writer.Write((UInt32)_uncompressedSize);
+                writer.Write((uint)_compressedSize);
+                writer.Write((uint)_uncompressedSize);
             }
         }
 
@@ -1132,13 +1132,13 @@ namespace System.IO.Compression
         {
             #region fields
 
-            private Int64 _position;
+            private long _position;
             private CheckSumAndSizeWriteStream _crcSizeStream;
-            private Boolean _everWritten;
-            private Boolean _isDisposed;
+            private bool _everWritten;
+            private bool _isDisposed;
             private ZipArchiveEntry _entry;
-            private Boolean _usedZip64inLH;
-            private Boolean _canWrite;
+            private bool _usedZip64inLH;
+            private bool _canWrite;
 
             #endregion
 
@@ -1161,7 +1161,7 @@ namespace System.IO.Compression
 
             #region properties
 
-            public override Int64 Length
+            public override long Length
             {
                 get
                 {
@@ -1169,11 +1169,11 @@ namespace System.IO.Compression
                     throw new NotSupportedException(SR.SeekingNotSupported);
                 }
             }
-            public override Int64 Position
+            public override long Position
             {
                 get
                 {
-                    Contract.Ensures(Contract.Result<Int64>() >= 0);
+                    Contract.Ensures(Contract.Result<long>() >= 0);
 
                     ThrowIfDisposed();
                     return _position;
@@ -1185,9 +1185,9 @@ namespace System.IO.Compression
                 }
             }
 
-            public override Boolean CanRead { get { return false; } }
-            public override Boolean CanSeek { get { return false; } }
-            public override Boolean CanWrite { get { return _canWrite; } }
+            public override bool CanRead { get { return false; } }
+            public override bool CanSeek { get { return false; } }
+            public override bool CanWrite { get { return _canWrite; } }
 
             #endregion
 
@@ -1199,19 +1199,19 @@ namespace System.IO.Compression
                     throw new ObjectDisposedException(this.GetType().ToString(), SR.HiddenStreamName);
             }
 
-            public override Int32 Read(Byte[] buffer, Int32 offset, Int32 count)
+            public override int Read(byte[] buffer, int offset, int count)
             {
                 ThrowIfDisposed();
                 throw new NotSupportedException(SR.ReadingNotSupported);
             }
 
-            public override Int64 Seek(Int64 offset, SeekOrigin origin)
+            public override long Seek(long offset, SeekOrigin origin)
             {
                 ThrowIfDisposed();
                 throw new NotSupportedException(SR.SeekingNotSupported);
             }
 
-            public override void SetLength(Int64 value)
+            public override void SetLength(long value)
             {
                 ThrowIfDisposed();
                 throw new NotSupportedException(SR.SetLengthRequiresSeekingAndWriting);
@@ -1219,7 +1219,7 @@ namespace System.IO.Compression
 
             //careful: assumes that write is the only way to write to the stream, if writebyte/beginwrite are implemented
             //they must set _everWritten, etc.
-            public override void Write(Byte[] buffer, Int32 offset, Int32 count)
+            public override void Write(byte[] buffer, int offset, int count)
             {
                 //we can't pass the argument checking down a level
                 if (buffer == null)
@@ -1258,7 +1258,7 @@ namespace System.IO.Compression
                 _crcSizeStream.Flush();
             }
 
-            protected override void Dispose(Boolean disposing)
+            protected override void Dispose(bool disposing)
             {
                 if (disposing && !_isDisposed)
                 {

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -12,16 +12,16 @@ namespace System.IO.Compression
 
     internal struct ZipGenericExtraField
     {
-        private const Int32 SizeOfHeader = 4;
+        private const int SizeOfHeader = 4;
 
-        private UInt16 _tag;
-        private UInt16 _size;
-        private Byte[] _data;
+        private ushort _tag;
+        private ushort _size;
+        private byte[] _data;
 
-        public UInt16 Tag { get { return _tag; } }
+        public ushort Tag { get { return _tag; } }
         //returns size of data, not of the entire block
-        public UInt16 Size { get { return _size; } }
-        public Byte[] Data { get { return _data; } }
+        public ushort Size { get { return _size; } }
+        public byte[] Data { get { return _data; } }
 
         public void WriteBlock(Stream stream)
         {
@@ -33,7 +33,7 @@ namespace System.IO.Compression
 
         //shouldn't ever read the byte at position endExtraField
         //assumes we are positioned at the beginning of an extra field subfield
-        public static Boolean TryReadBlock(BinaryReader reader, Int64 endExtraField, out ZipGenericExtraField field)
+        public static bool TryReadBlock(BinaryReader reader, long endExtraField, out ZipGenericExtraField field)
         {
             field = new ZipGenericExtraField();
 
@@ -69,9 +69,9 @@ namespace System.IO.Compression
             return extraFields;
         }
 
-        public static Int32 TotalSize(List<ZipGenericExtraField> fields)
+        public static int TotalSize(List<ZipGenericExtraField> fields)
         {
-            Int32 size = 0;
+            int size = 0;
             foreach (ZipGenericExtraField field in fields)
                 size += field.Size + SizeOfHeader; //size is only size of data
             return size;
@@ -91,36 +91,36 @@ namespace System.IO.Compression
          * one of uncompressed/compressed size
          * */
 
-        public const Int32 OffsetToFirstField = 4;
-        private const UInt16 TagConstant = 1;
+        public const int OffsetToFirstField = 4;
+        private const ushort TagConstant = 1;
 
-        private UInt16 _size;
-        private Int64? _uncompressedSize;
-        private Int64? _compressedSize;
-        private Int64? _localHeaderOffset;
-        private Int32? _startDiskNumber;
+        private ushort _size;
+        private long? _uncompressedSize;
+        private long? _compressedSize;
+        private long? _localHeaderOffset;
+        private int? _startDiskNumber;
 
-        public UInt16 TotalSize
+        public ushort TotalSize
         {
-            get { return (UInt16)(_size + 4); }
+            get { return (ushort)(_size + 4); }
         }
 
-        public Int64? UncompressedSize
+        public long? UncompressedSize
         {
             get { return _uncompressedSize; }
             set { _uncompressedSize = value; UpdateSize(); }
         }
-        public Int64? CompressedSize
+        public long? CompressedSize
         {
             get { return _compressedSize; }
             set { _compressedSize = value; UpdateSize(); }
         }
-        public Int64? LocalHeaderOffset
+        public long? LocalHeaderOffset
         {
             get { return _localHeaderOffset; }
             set { _localHeaderOffset = value; UpdateSize(); }
         }
-        public Int32? StartDiskNumber
+        public int? StartDiskNumber
         {
             get { return _startDiskNumber; }
         }
@@ -150,8 +150,8 @@ namespace System.IO.Compression
          * If there are more than one Zip64 extra fields, we take the first one that has the expected size
          */
         public static Zip64ExtraField GetJustZip64Block(Stream extraFieldStream,
-            Boolean readUncompressedSize, Boolean readCompressedSize,
-            Boolean readLocalHeaderOffset, Boolean readStartDiskNumber)
+            bool readUncompressedSize, bool readCompressedSize,
+            bool readLocalHeaderOffset, bool readStartDiskNumber)
         {
             Zip64ExtraField zip64Field;
             using (BinaryReader reader = new BinaryReader(extraFieldStream))
@@ -177,9 +177,9 @@ namespace System.IO.Compression
             return zip64Field;
         }
 
-        private static Boolean TryGetZip64BlockFromGenericExtraField(ZipGenericExtraField extraField,
-            Boolean readUncompressedSize, Boolean readCompressedSize,
-            Boolean readLocalHeaderOffset, Boolean readStartDiskNumber,
+        private static bool TryGetZip64BlockFromGenericExtraField(ZipGenericExtraField extraField,
+            bool readUncompressedSize, bool readCompressedSize,
+            bool readLocalHeaderOffset, bool readStartDiskNumber,
             out Zip64ExtraField zip64Block)
         {
             zip64Block = new Zip64ExtraField();
@@ -203,7 +203,7 @@ namespace System.IO.Compression
 
                     zip64Block._size = extraField.Size;
 
-                    UInt16 expectedSize = 0;
+                    ushort expectedSize = 0;
 
                     if (readUncompressedSize) expectedSize += 8;
                     if (readCompressedSize) expectedSize += 8;
@@ -236,8 +236,8 @@ namespace System.IO.Compression
         }
 
         public static Zip64ExtraField GetAndRemoveZip64Block(List<ZipGenericExtraField> extraFields,
-            Boolean readUncompressedSize, Boolean readCompressedSize,
-            Boolean readLocalHeaderOffset, Boolean readStartDiskNumber)
+            bool readUncompressedSize, bool readCompressedSize,
+            bool readLocalHeaderOffset, bool readStartDiskNumber)
         {
             Zip64ExtraField zip64Field = new Zip64ExtraField();
 
@@ -247,7 +247,7 @@ namespace System.IO.Compression
             zip64Field._startDiskNumber = null;
 
             List<ZipGenericExtraField> markedForDelete = new List<ZipGenericExtraField>();
-            Boolean zip64FieldFound = false;
+            bool zip64FieldFound = false;
 
             foreach (ZipGenericExtraField ef in extraFields)
             {
@@ -296,14 +296,14 @@ namespace System.IO.Compression
 
     internal struct Zip64EndOfCentralDirectoryLocator
     {
-        public const UInt32 SignatureConstant = 0x07064B50;
-        public const Int32 SizeOfBlockWithoutSignature = 16;
+        public const uint SignatureConstant = 0x07064B50;
+        public const int SizeOfBlockWithoutSignature = 16;
 
-        public UInt32 NumberOfDiskWithZip64EOCD;
-        public UInt64 OffsetOfZip64EOCD;
-        public UInt32 TotalNumberOfDisks;
+        public uint NumberOfDiskWithZip64EOCD;
+        public ulong OffsetOfZip64EOCD;
+        public uint TotalNumberOfDisks;
 
-        public static Boolean TryReadBlock(BinaryReader reader, out Zip64EndOfCentralDirectoryLocator zip64EOCDLocator)
+        public static bool TryReadBlock(BinaryReader reader, out Zip64EndOfCentralDirectoryLocator zip64EOCDLocator)
         {
             zip64EOCDLocator = new Zip64EndOfCentralDirectoryLocator();
 
@@ -316,32 +316,32 @@ namespace System.IO.Compression
             return true;
         }
 
-        public static void WriteBlock(Stream stream, Int64 zip64EOCDRecordStart)
+        public static void WriteBlock(Stream stream, long zip64EOCDRecordStart)
         {
             BinaryWriter writer = new BinaryWriter(stream);
             writer.Write(SignatureConstant);
-            writer.Write((UInt32)0);    //number of disk with start of zip64 eocd
+            writer.Write((uint)0);    //number of disk with start of zip64 eocd
             writer.Write(zip64EOCDRecordStart);
-            writer.Write((UInt32)1);    //total number of disks
+            writer.Write((uint)1);    //total number of disks
         }
     }
 
     internal struct Zip64EndOfCentralDirectoryRecord
     {
-        private const UInt32 SignatureConstant = 0x06064B50;
-        private const UInt64 NormalSize = 0x2C; //the size of the data excluding the size/signature fields if no extra data included
+        private const uint SignatureConstant = 0x06064B50;
+        private const ulong NormalSize = 0x2C; //the size of the data excluding the size/signature fields if no extra data included
 
-        public UInt64 SizeOfThisRecord;
-        public UInt16 VersionMadeBy;
-        public UInt16 VersionNeededToExtract;
-        public UInt32 NumberOfThisDisk;
-        public UInt32 NumberOfDiskWithStartOfCD;
-        public UInt64 NumberOfEntriesOnThisDisk;
-        public UInt64 NumberOfEntriesTotal;
-        public UInt64 SizeOfCentralDirectory;
-        public UInt64 OffsetOfCentralDirectory;
+        public ulong SizeOfThisRecord;
+        public ushort VersionMadeBy;
+        public ushort VersionNeededToExtract;
+        public uint NumberOfThisDisk;
+        public uint NumberOfDiskWithStartOfCD;
+        public ulong NumberOfEntriesOnThisDisk;
+        public ulong NumberOfEntriesTotal;
+        public ulong SizeOfCentralDirectory;
+        public ulong OffsetOfCentralDirectory;
 
-        public static Boolean TryReadBlock(BinaryReader reader, out Zip64EndOfCentralDirectoryRecord zip64EOCDRecord)
+        public static bool TryReadBlock(BinaryReader reader, out Zip64EndOfCentralDirectoryRecord zip64EOCDRecord)
         {
             zip64EOCDRecord = new Zip64EndOfCentralDirectoryRecord();
 
@@ -361,17 +361,17 @@ namespace System.IO.Compression
             return true;
         }
 
-        public static void WriteBlock(Stream stream, Int64 numberOfEntries, Int64 startOfCentralDirectory, Int64 sizeOfCentralDirectory)
+        public static void WriteBlock(Stream stream, long numberOfEntries, long startOfCentralDirectory, long sizeOfCentralDirectory)
         {
             BinaryWriter writer = new BinaryWriter(stream);
 
             //write Zip 64 EOCD record
             writer.Write(SignatureConstant);
             writer.Write(NormalSize);
-            writer.Write((UInt16)ZipVersionNeededValues.Zip64);   //version needed is 45 for zip 64 support
-            writer.Write((UInt16)ZipVersionNeededValues.Zip64);   //version made by: high byte is 0 for MS DOS, low byte is version needed
-            writer.Write((UInt32)0);    //number of this disk is 0
-            writer.Write((UInt32)0);    //number of disk with start of central directory is 0
+            writer.Write((ushort)ZipVersionNeededValues.Zip64);   //version needed is 45 for zip 64 support
+            writer.Write((ushort)ZipVersionNeededValues.Zip64);   //version made by: high byte is 0 for MS DOS, low byte is version needed
+            writer.Write((uint)0);    //number of this disk is 0
+            writer.Write((uint)0);    //number of disk with start of central directory is 0
             writer.Write(numberOfEntries); //number of entries on this disk
             writer.Write(numberOfEntries); //number of entries total
             writer.Write(sizeOfCentralDirectory);
@@ -381,11 +381,11 @@ namespace System.IO.Compression
 
     internal struct ZipLocalFileHeader
     {
-        public const UInt32 DataDescriptorSignature = 0x08074B50;
-        public const UInt32 SignatureConstant = 0x04034B50;
-        public const Int32 OffsetToCrcFromHeaderStart = 14;
-        public const Int32 OffsetToBitFlagFromHeaderStart = 6;
-        public const Int32 SizeOfLocalHeader = 30;
+        public const uint DataDescriptorSignature = 0x08074B50;
+        public const uint SignatureConstant = 0x04034B50;
+        public const int OffsetToCrcFromHeaderStart = 14;
+        public const int OffsetToBitFlagFromHeaderStart = 6;
+        public const int SizeOfLocalHeader = 30;
 
         static public List<ZipGenericExtraField> GetExtraFields(BinaryReader reader)
         {
@@ -393,12 +393,12 @@ namespace System.IO.Compression
 
             List<ZipGenericExtraField> result;
 
-            const Int32 OffsetToFilenameLength = 26; //from the point before the signature
+            const int OffsetToFilenameLength = 26; //from the point before the signature
 
             reader.BaseStream.Seek(OffsetToFilenameLength, SeekOrigin.Current);
 
-            UInt16 filenameLength = reader.ReadUInt16();
-            UInt16 extraFieldLength = reader.ReadUInt16();
+            ushort filenameLength = reader.ReadUInt16();
+            ushort extraFieldLength = reader.ReadUInt16();
 
             reader.BaseStream.Seek(filenameLength, SeekOrigin.Current);
 
@@ -413,9 +413,9 @@ namespace System.IO.Compression
         }
 
         //will not throw end of stream exception
-        static public Boolean TrySkipBlock(BinaryReader reader)
+        static public bool TrySkipBlock(BinaryReader reader)
         {
-            const Int32 OffsetToFilenameLength = 22; //from the point after the signature
+            const int OffsetToFilenameLength = 22; //from the point after the signature
 
             if (reader.ReadUInt32() != SignatureConstant)
                 return false;
@@ -426,8 +426,8 @@ namespace System.IO.Compression
 
             reader.BaseStream.Seek(OffsetToFilenameLength, SeekOrigin.Current);
 
-            UInt16 filenameLength = reader.ReadUInt16();
-            UInt16 extraFieldLength = reader.ReadUInt16();
+            ushort filenameLength = reader.ReadUInt16();
+            ushort extraFieldLength = reader.ReadUInt16();
 
             if (reader.BaseStream.Length < reader.BaseStream.Position + filenameLength + extraFieldLength)
                 return false;
@@ -440,31 +440,31 @@ namespace System.IO.Compression
 
     internal struct ZipCentralDirectoryFileHeader
     {
-        public const UInt32 SignatureConstant = 0x02014B50;
+        public const uint SignatureConstant = 0x02014B50;
         public byte VersionMadeByCompatibility;
         public byte VersionMadeBySpecification;
-        public UInt16 VersionNeededToExtract;
-        public UInt16 GeneralPurposeBitFlag;
-        public UInt16 CompressionMethod;
-        public UInt32 LastModified; //convert this on the fly
-        public UInt32 Crc32;
-        public Int64 CompressedSize;
-        public Int64 UncompressedSize;
-        public UInt16 FilenameLength;
-        public UInt16 ExtraFieldLength;
-        public UInt16 FileCommentLength;
-        public Int32 DiskNumberStart;
-        public UInt16 InternalFileAttributes;
-        public UInt32 ExternalFileAttributes;
-        public Int64 RelativeOffsetOfLocalHeader;
+        public ushort VersionNeededToExtract;
+        public ushort GeneralPurposeBitFlag;
+        public ushort CompressionMethod;
+        public uint LastModified; //convert this on the fly
+        public uint Crc32;
+        public long CompressedSize;
+        public long UncompressedSize;
+        public ushort FilenameLength;
+        public ushort ExtraFieldLength;
+        public ushort FileCommentLength;
+        public int DiskNumberStart;
+        public ushort InternalFileAttributes;
+        public uint ExternalFileAttributes;
+        public long RelativeOffsetOfLocalHeader;
 
-        public Byte[] Filename;
-        public Byte[] FileComment;
+        public byte[] Filename;
+        public byte[] FileComment;
         public List<ZipGenericExtraField> ExtraFields;
 
         //if saveExtraFieldsAndComments is false, FileComment and ExtraFields will be null
         //in either case, the zip64 extra field info will be incorporated into other fields
-        static public Boolean TryReadBlock(BinaryReader reader, Boolean saveExtraFieldsAndComments, out ZipCentralDirectoryFileHeader header)
+        static public bool TryReadBlock(BinaryReader reader, bool saveExtraFieldsAndComments, out ZipCentralDirectoryFileHeader header)
         {
             header = new ZipCentralDirectoryFileHeader();
 
@@ -477,22 +477,22 @@ namespace System.IO.Compression
             header.CompressionMethod = reader.ReadUInt16();
             header.LastModified = reader.ReadUInt32();
             header.Crc32 = reader.ReadUInt32();
-            UInt32 compressedSizeSmall = reader.ReadUInt32();
-            UInt32 uncompressedSizeSmall = reader.ReadUInt32();
+            uint compressedSizeSmall = reader.ReadUInt32();
+            uint uncompressedSizeSmall = reader.ReadUInt32();
             header.FilenameLength = reader.ReadUInt16();
             header.ExtraFieldLength = reader.ReadUInt16();
             header.FileCommentLength = reader.ReadUInt16();
-            UInt16 diskNumberStartSmall = reader.ReadUInt16();
+            ushort diskNumberStartSmall = reader.ReadUInt16();
             header.InternalFileAttributes = reader.ReadUInt16();
             header.ExternalFileAttributes = reader.ReadUInt32();
-            UInt32 relativeOffsetOfLocalHeaderSmall = reader.ReadUInt32();
+            uint relativeOffsetOfLocalHeaderSmall = reader.ReadUInt32();
 
             header.Filename = reader.ReadBytes(header.FilenameLength);
 
-            Boolean uncompressedSizeInZip64 = uncompressedSizeSmall == ZipHelper.Mask32Bit;
-            Boolean compressedSizeInZip64 = compressedSizeSmall == ZipHelper.Mask32Bit;
-            Boolean relativeOffsetInZip64 = relativeOffsetOfLocalHeaderSmall == ZipHelper.Mask32Bit;
-            Boolean diskNumberStartInZip64 = diskNumberStartSmall == ZipHelper.Mask16Bit;
+            bool uncompressedSizeInZip64 = uncompressedSizeSmall == ZipHelper.Mask32Bit;
+            bool compressedSizeInZip64 = compressedSizeSmall == ZipHelper.Mask32Bit;
+            bool relativeOffsetInZip64 = relativeOffsetOfLocalHeaderSmall == ZipHelper.Mask32Bit;
+            bool diskNumberStartInZip64 = diskNumberStartSmall == ZipHelper.Mask16Bit;
 
             Zip64ExtraField zip64;
 
@@ -546,45 +546,45 @@ namespace System.IO.Compression
 
     internal struct ZipEndOfCentralDirectoryBlock
     {
-        public const UInt32 SignatureConstant = 0x06054B50;
-        public const Int32 SizeOfBlockWithoutSignature = 18;
-        public UInt32 Signature;
-        public UInt16 NumberOfThisDisk;
-        public UInt16 NumberOfTheDiskWithTheStartOfTheCentralDirectory;
-        public UInt16 NumberOfEntriesInTheCentralDirectoryOnThisDisk;
-        public UInt16 NumberOfEntriesInTheCentralDirectory;
-        public UInt32 SizeOfCentralDirectory;
-        public UInt32 OffsetOfStartOfCentralDirectoryWithRespectToTheStartingDiskNumber;
-        public Byte[] ArchiveComment;
+        public const uint SignatureConstant = 0x06054B50;
+        public const int SizeOfBlockWithoutSignature = 18;
+        public uint Signature;
+        public ushort NumberOfThisDisk;
+        public ushort NumberOfTheDiskWithTheStartOfTheCentralDirectory;
+        public ushort NumberOfEntriesInTheCentralDirectoryOnThisDisk;
+        public ushort NumberOfEntriesInTheCentralDirectory;
+        public uint SizeOfCentralDirectory;
+        public uint OffsetOfStartOfCentralDirectoryWithRespectToTheStartingDiskNumber;
+        public byte[] ArchiveComment;
 
-        public static void WriteBlock(Stream stream, Int64 numberOfEntries, Int64 startOfCentralDirectory, Int64 sizeOfCentralDirectory, Byte[] archiveComment)
+        public static void WriteBlock(Stream stream, long numberOfEntries, long startOfCentralDirectory, long sizeOfCentralDirectory, byte[] archiveComment)
         {
             BinaryWriter writer = new BinaryWriter(stream);
 
-            UInt16 numberOfEntriesTruncated = numberOfEntries > UInt16.MaxValue ?
-                                                        ZipHelper.Mask16Bit : (UInt16)numberOfEntries;
-            UInt32 startOfCentralDirectoryTruncated = startOfCentralDirectory > UInt32.MaxValue ?
-                                                        ZipHelper.Mask32Bit : (UInt32)startOfCentralDirectory;
-            UInt32 sizeOfCentralDirectoryTruncated = sizeOfCentralDirectory > UInt32.MaxValue ?
-                                                        ZipHelper.Mask32Bit : (UInt32)sizeOfCentralDirectory;
+            ushort numberOfEntriesTruncated = numberOfEntries > ushort.MaxValue ?
+                                                        ZipHelper.Mask16Bit : (ushort)numberOfEntries;
+            uint startOfCentralDirectoryTruncated = startOfCentralDirectory > uint.MaxValue ?
+                                                        ZipHelper.Mask32Bit : (uint)startOfCentralDirectory;
+            uint sizeOfCentralDirectoryTruncated = sizeOfCentralDirectory > uint.MaxValue ?
+                                                        ZipHelper.Mask32Bit : (uint)sizeOfCentralDirectory;
 
             writer.Write(SignatureConstant);
-            writer.Write((UInt16)0);            //number of this disk
-            writer.Write((UInt16)0);            //number of disk with start of CD
+            writer.Write((ushort)0);            //number of this disk
+            writer.Write((ushort)0);            //number of disk with start of CD
             writer.Write(numberOfEntriesTruncated); //number of entries on this disk's cd
             writer.Write(numberOfEntriesTruncated); //number of entries in entire CD
             writer.Write(sizeOfCentralDirectoryTruncated);
             writer.Write(startOfCentralDirectoryTruncated);
 
             //Should be valid because of how we read archiveComment in TryReadBlock:
-            Debug.Assert((archiveComment == null) || (archiveComment.Length < UInt16.MaxValue));
+            Debug.Assert((archiveComment == null) || (archiveComment.Length < ushort.MaxValue));
 
-            writer.Write(archiveComment != null ? (UInt16)archiveComment.Length : (UInt16)0);    //zip file comment length
+            writer.Write(archiveComment != null ? (ushort)archiveComment.Length : (ushort)0);    //zip file comment length
             if (archiveComment != null)
                 writer.Write(archiveComment);
         }
 
-        public static Boolean TryReadBlock(BinaryReader reader, out ZipEndOfCentralDirectoryBlock eocdBlock)
+        public static bool TryReadBlock(BinaryReader reader, out ZipEndOfCentralDirectoryBlock eocdBlock)
         {
             eocdBlock = new ZipEndOfCentralDirectoryBlock();
             if (reader.ReadUInt32() != SignatureConstant)
@@ -598,7 +598,7 @@ namespace System.IO.Compression
             eocdBlock.SizeOfCentralDirectory = reader.ReadUInt32();
             eocdBlock.OffsetOfStartOfCentralDirectoryWithRespectToTheStartingDiskNumber = reader.ReadUInt32();
 
-            UInt16 commentLength = reader.ReadUInt16();
+            ushort commentLength = reader.ReadUInt16();
             eocdBlock.ArchiveComment = reader.ReadBytes(commentLength);
 
             return true;

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
@@ -12,24 +12,24 @@ namespace System.IO.Compression
         #region fields
 
         private readonly Stream _baseStream;
-        private readonly Boolean _closeBaseStream;
+        private readonly bool _closeBaseStream;
 
         // Delegate that will be invoked on stream disposing
         private readonly Action<ZipArchiveEntry> _onClosed;
 
         // Instance that will be passed to _onClose delegate
         private readonly ZipArchiveEntry _zipArchiveEntry;
-        private Boolean _isDisposed;
+        private bool _isDisposed;
 
         #endregion
 
         #region constructors
 
-        internal WrappedStream(Stream baseStream, Boolean closeBaseStream)
+        internal WrappedStream(Stream baseStream, bool closeBaseStream)
             : this(baseStream, closeBaseStream, null, null)
         { }
 
-        private WrappedStream(Stream baseStream, Boolean closeBaseStream, ZipArchiveEntry entry, Action<ZipArchiveEntry> onClosed)
+        private WrappedStream(Stream baseStream, bool closeBaseStream, ZipArchiveEntry entry, Action<ZipArchiveEntry> onClosed)
         {
             _baseStream = baseStream;
             _closeBaseStream = closeBaseStream;
@@ -168,8 +168,8 @@ namespace System.IO.Compression
         private long _positionInSuperStream;
         private readonly long _endInSuperStream;
         private readonly Stream _superStream;
-        private Boolean _canRead;
-        private Boolean _isDisposed;
+        private bool _canRead;
+        private bool _isDisposed;
 
         #endregion
 
@@ -193,7 +193,7 @@ namespace System.IO.Compression
         {
             get
             {
-                Contract.Ensures(Contract.Result<Int64>() >= 0);
+                Contract.Ensures(Contract.Result<long>() >= 0);
 
                 ThrowIfDisposed();
 
@@ -205,7 +205,7 @@ namespace System.IO.Compression
         {
             get
             {
-                Contract.Ensures(Contract.Result<Int64>() >= 0);
+                Contract.Ensures(Contract.Result<long>() >= 0);
 
                 ThrowIfDisposed();
 
@@ -306,22 +306,22 @@ namespace System.IO.Compression
 
         private readonly Stream _baseStream;
         private readonly Stream _baseBaseStream;
-        private Int64 _position;
-        private UInt32 _checksum;
+        private long _position;
+        private uint _checksum;
 
-        private readonly Boolean _leaveOpenOnClose;
-        private Boolean _canWrite;
-        private Boolean _isDisposed;
+        private readonly bool _leaveOpenOnClose;
+        private bool _canWrite;
+        private bool _isDisposed;
 
-        private Boolean _everWritten;
+        private bool _everWritten;
 
         //this is the position in BaseBaseStream
-        private Int64 _initialPosition;
+        private long _initialPosition;
         private readonly ZipArchiveEntry _zipArchiveEntry;
         private readonly EventHandler _onClose;
         // Called when the stream is closed.
         // parameters are initialPosition, currentPosition, checkSum, baseBaseStream, zipArchiveEntry and onClose handler
-        private readonly Action<Int64, Int64, UInt32, Stream, ZipArchiveEntry, EventHandler> _saveCrcAndSizes;
+        private readonly Action<long, long, uint, Stream, ZipArchiveEntry, EventHandler> _saveCrcAndSizes;
 
         #endregion
 
@@ -335,9 +335,9 @@ namespace System.IO.Compression
          *  zipArchiveEntry passed here so as to avoid closure allocation,
          *  onClose handler passed here so as to avoid closure allocation
         */
-        public CheckSumAndSizeWriteStream(Stream baseStream, Stream baseBaseStream, Boolean leaveOpenOnClose,
+        public CheckSumAndSizeWriteStream(Stream baseStream, Stream baseBaseStream, bool leaveOpenOnClose,
             ZipArchiveEntry entry, EventHandler onClose,
-            Action<Int64, Int64, UInt32, Stream, ZipArchiveEntry, EventHandler> saveCrcAndSizes)
+            Action<long, long, uint, Stream, ZipArchiveEntry, EventHandler> saveCrcAndSizes)
         {
             _baseStream = baseStream;
             _baseBaseStream = baseBaseStream;
@@ -356,7 +356,7 @@ namespace System.IO.Compression
 
         #region properties
 
-        public override Int64 Length
+        public override long Length
         {
             get
             {
@@ -365,11 +365,11 @@ namespace System.IO.Compression
             }
         }
 
-        public override Int64 Position
+        public override long Position
         {
             get
             {
-                Contract.Ensures(Contract.Result<Int64>() >= 0);
+                Contract.Ensures(Contract.Result<long>() >= 0);
                 ThrowIfDisposed();
                 return _position;
             }
@@ -380,11 +380,11 @@ namespace System.IO.Compression
             }
         }
 
-        public override Boolean CanRead { get { return false; } }
+        public override bool CanRead { get { return false; } }
 
-        public override Boolean CanSeek { get { return false; } }
+        public override bool CanSeek { get { return false; } }
 
-        public override Boolean CanWrite { get { return _canWrite; } }
+        public override bool CanWrite { get { return _canWrite; } }
 
         #endregion
 
@@ -396,25 +396,25 @@ namespace System.IO.Compression
                 throw new ObjectDisposedException(this.GetType().ToString(), SR.HiddenStreamName);
         }
 
-        public override Int32 Read(Byte[] buffer, Int32 offset, Int32 count)
+        public override int Read(byte[] buffer, int offset, int count)
         {
             ThrowIfDisposed();
             throw new NotSupportedException(SR.ReadingNotSupported);
         }
 
-        public override Int64 Seek(Int64 offset, SeekOrigin origin)
+        public override long Seek(long offset, SeekOrigin origin)
         {
             ThrowIfDisposed();
             throw new NotSupportedException(SR.SeekingNotSupported);
         }
 
-        public override void SetLength(Int64 value)
+        public override void SetLength(long value)
         {
             ThrowIfDisposed();
             throw new NotSupportedException(SR.SetLengthRequiresSeekingAndWriting);
         }
 
-        public override void Write(Byte[] buffer, Int32 offset, Int32 count)
+        public override void Write(byte[] buffer, int offset, int count)
         {
             //we can't pass the argument checking down a level
             if (buffer == null)
@@ -455,7 +455,7 @@ namespace System.IO.Compression
             _baseStream.Flush();
         }
 
-        protected override void Dispose(Boolean disposing)
+        protected override void Dispose(bool disposing)
         {
             if (disposing && !_isDisposed)
             {

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
@@ -8,21 +8,21 @@ namespace System.IO.Compression
 {
     internal static class ZipHelper
     {
-        internal const UInt32 Mask32Bit = 0xFFFFFFFF;
-        internal const UInt16 Mask16Bit = 0xFFFF;
+        internal const uint Mask32Bit = 0xFFFFFFFF;
+        internal const ushort Mask16Bit = 0xFFFF;
 
-        private const Int32 BackwardsSeekingBufferSize = 32;
+        private const int BackwardsSeekingBufferSize = 32;
 
-        internal const Int32 ValidZipDate_YearMin = 1980;
-        internal const Int32 ValidZipDate_YearMax = 2107;
+        internal const int ValidZipDate_YearMin = 1980;
+        internal const int ValidZipDate_YearMax = 2107;
 
         private static readonly DateTime s_invalidDateIndicator = new DateTime(ValidZipDate_YearMin, 1, 1, 0, 0, 0);
 
-        internal static Boolean RequiresUnicode(String test)
+        internal static bool RequiresUnicode(string test)
         {
             Debug.Assert(test != null);
 
-            foreach (Char c in test)
+            foreach (char c in test)
             {
                 // The Zip Format uses code page 437 when the Unicode bit is not set. This format
                 // is the same as ASCII for characters 32-126 but differs otherwise. If we can fit 
@@ -35,15 +35,15 @@ namespace System.IO.Compression
         }
 
         //reads exactly bytesToRead out of stream, unless it is out of bytes
-        internal static void ReadBytes(Stream stream, Byte[] buffer, Int32 bytesToRead)
+        internal static void ReadBytes(Stream stream, byte[] buffer, int bytesToRead)
         {
-            Int32 bytesLeftToRead = bytesToRead;
+            int bytesLeftToRead = bytesToRead;
 
-            Int32 totalBytesRead = 0;
+            int totalBytesRead = 0;
 
             while (bytesLeftToRead > 0)
             {
-                Int32 bytesRead = stream.Read(buffer, totalBytesRead, bytesLeftToRead);
+                int bytesRead = stream.Read(buffer, totalBytesRead, bytesLeftToRead);
                 if (bytesRead == 0) throw new IOException(SR.UnexpectedEndOfStream);
 
                 totalBytesRead += bytesRead;
@@ -60,17 +60,17 @@ namespace System.IO.Compression
         //Second: 5 bits
         */
 
-        //will silently return InvalidDateIndicator if the UInt32 is not a valid Dos DateTime
-        internal static DateTime DosTimeToDateTime(UInt32 dateTime)
+        //will silently return InvalidDateIndicator if the uint is not a valid Dos DateTime
+        internal static DateTime DosTimeToDateTime(uint dateTime)
         {
             // do the bit shift as unsigned because the fields are unsigned, but
-            // we can safely convert to Int32, because they won't be too big
-            Int32 year = (Int32)(ValidZipDate_YearMin + (dateTime >> 25));
-            Int32 month = (Int32)((dateTime >> 21) & 0xF);
-            Int32 day = (Int32)((dateTime >> 16) & 0x1F);
-            Int32 hour = (Int32)((dateTime >> 11) & 0x1F);
-            Int32 minute = (Int32)((dateTime >> 5) & 0x3F);
-            Int32 second = (Int32)((dateTime & 0x001F) * 2);       // only 5 bits for second, so we only have a granularity of 2 sec. 
+            // we can safely convert to int, because they won't be too big
+            int year = (int)(ValidZipDate_YearMin + (dateTime >> 25));
+            int month = (int)((dateTime >> 21) & 0xF);
+            int day = (int)((dateTime >> 16) & 0x1F);
+            int hour = (int)((dateTime >> 11) & 0x1F);
+            int minute = (int)((dateTime >> 5) & 0x3F);
+            int second = (int)((dateTime & 0x001F) * 2);       // only 5 bits for second, so we only have a granularity of 2 sec. 
 
             try
             {
@@ -88,7 +88,7 @@ namespace System.IO.Compression
 
 
         //assume date time has passed IsConvertibleToDosTime
-        internal static UInt32 DateTimeToDosTime(DateTime dateTime)
+        internal static uint DateTimeToDosTime(DateTime dateTime)
         {
             // DateTime must be Convertible to DosTime:
             Debug.Assert(ValidZipDate_YearMin <= dateTime.Year && dateTime.Year <= ValidZipDate_YearMax);
@@ -106,14 +106,14 @@ namespace System.IO.Compression
         //assumes all bytes of signatureToFind are non zero, looks backwards from current position in stream,
         //if the signature is found then returns true and positions stream at first byte of signature
         //if the signature is not found, returns false
-        internal static Boolean SeekBackwardsToSignature(Stream stream, UInt32 signatureToFind)
+        internal static bool SeekBackwardsToSignature(Stream stream, uint signatureToFind)
         {
-            Int32 bufferPointer = 0;
-            UInt32 currentSignature = 0;
+            int bufferPointer = 0;
+            uint currentSignature = 0;
             byte[] buffer = new byte[BackwardsSeekingBufferSize];
 
-            Boolean outOfBytes = false;
-            Boolean signatureFound = false;
+            bool outOfBytes = false;
+            bool signatureFound = false;
 
             while (!signatureFound && !outOfBytes)
             {
@@ -123,7 +123,7 @@ namespace System.IO.Compression
 
                 while (bufferPointer >= 0 && !signatureFound)
                 {
-                    currentSignature = (currentSignature << 8) | ((UInt32)buffer[bufferPointer]);
+                    currentSignature = (currentSignature << 8) | ((uint)buffer[bufferPointer]);
                     if (currentSignature == signatureToFind)
                     {
                         signatureFound = true;
@@ -163,7 +163,7 @@ namespace System.IO.Compression
         }
 
         //Returns true if we are out of bytes
-        private static Boolean SeekBackwardsAndRead(Stream stream, Byte[] buffer, out Int32 bufferPointer)
+        private static bool SeekBackwardsAndRead(Stream stream, byte[] buffer, out int bufferPointer)
         {
             if (stream.Position >= buffer.Length)
             {
@@ -175,7 +175,7 @@ namespace System.IO.Compression
             }
             else
             {
-                Int32 bytesToRead = (Int32)stream.Position;
+                int bytesToRead = (int)stream.Position;
                 stream.Seek(0, SeekOrigin.Begin);
                 ZipHelper.ReadBytes(stream, buffer, bytesToRead);
                 stream.Seek(0, SeekOrigin.Begin);

--- a/src/System.IO.Compression/tests/DeflateStreamTests.cs
+++ b/src/System.IO.Compression/tests/DeflateStreamTests.cs
@@ -12,7 +12,7 @@ namespace System.IO.Compression.Tests
 {
     public class DeflateStreamTests
     {
-        static string gzTestFile(String fileName) { return Path.Combine("GZTestData", fileName); }
+        static string gzTestFile(string fileName) { return Path.Combine("GZTestData", fileName); }
 
         [Fact]
         public void BaseStream1()
@@ -42,7 +42,7 @@ namespace System.IO.Compression.Tests
 
             var zip = new DeflateStream(newMs, CompressionMode.Decompress);
             int size = 1024;
-            Byte[] bytes = new Byte[size];
+            byte[] bytes = new byte[size];
             zip.BaseStream.Read(bytes, 0, size); // This will throw if the underlying stream is not writable as expected
 
             zip.BaseStream.Position = 0;
@@ -104,7 +104,7 @@ namespace System.IO.Compression.Tests
             zip.Dispose();
 
             int size = 1024;
-            Byte[] bytes = new Byte[size];
+            byte[] bytes = new byte[size];
             baseStream.Read(bytes, 0, size); // This will throw if the underlying stream is not writable as expected
 
             baseStream.Position = 0;
@@ -114,13 +114,13 @@ namespace System.IO.Compression.Tests
         [Fact]
         public async Task DecompressFailsWithRealGzStream()
         {
-            String[] files = { gzTestFile("GZTestDocument.doc.gz"), gzTestFile("GZTestDocument.txt.gz") };
-            foreach (String fileName in files)
+            string[] files = { gzTestFile("GZTestDocument.doc.gz"), gzTestFile("GZTestDocument.txt.gz") };
+            foreach (string fileName in files)
             {
                 var baseStream = await LocalMemoryStream.readAppFileAsync(fileName);
                 var zip = new DeflateStream(baseStream, CompressionMode.Decompress);
                 int _bufferSize = 2048;
-                var bytes = new Byte[_bufferSize];
+                var bytes = new byte[_bufferSize];
                 Assert.Throws<InvalidDataException>(() => { zip.Read(bytes, 0, _bufferSize); });
                 zip.Dispose();
             }
@@ -204,7 +204,7 @@ namespace System.IO.Compression.Tests
         {
             //Create the DeflateStream
             int _bufferSize = 1024;
-            var bytes = new Byte[_bufferSize];
+            var bytes = new byte[_bufferSize];
             var baseStream = new MemoryStream(bytes, true);
             DeflateStream ds;
 
@@ -218,9 +218,9 @@ namespace System.IO.Compression.Tests
             }
 
             //Write some data and Close the stream
-            String strData = "Test Data";
+            string strData = "Test Data";
             var encoding = Encoding.UTF8;
-            Byte[] data = encoding.GetBytes(strData);
+            byte[] data = encoding.GetBytes(strData);
             ds.Write(data, 0, data.Length);
             ds.Flush();
             ds.Dispose();
@@ -232,7 +232,7 @@ namespace System.IO.Compression.Tests
             }
 
             //Read the data
-            Byte[] data2 = new Byte[_bufferSize];
+            byte[] data2 = new byte[_bufferSize];
             baseStream = new MemoryStream(bytes, false);
             ds = new DeflateStream(baseStream, CompressionMode.Decompress);
             int size = ds.Read(data2, 0, _bufferSize - 5);
@@ -804,7 +804,7 @@ namespace System.IO.Compression.Tests
         public bool ReadHit = false;  // For validation of the async methods we want to ensure they correctly delegate the async
         public bool WriteHit = false; // methods of the underlying stream. This bool acts as a toggle to check that they're being used.
 
-        public static async Task<ManualSyncMemoryStream> GetStreamFromFileAsync(String testFile, bool sync = false, bool strip = false)
+        public static async Task<ManualSyncMemoryStream> GetStreamFromFileAsync(string testFile, bool sync = false, bool strip = false)
         {
             var baseStream = await StreamHelpers.CreateTempCopyStream(testFile);
             if (strip)
@@ -824,7 +824,7 @@ namespace System.IO.Compression.Tests
             isSync = sync;
         }
 
-        public override async Task<int> ReadAsync(Byte[] array, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
             ReadHit = true;
             if (isSync)
@@ -839,7 +839,7 @@ namespace System.IO.Compression.Tests
             return await base.ReadAsync(array, offset, count, cancellationToken);
         }
 
-        public override async Task WriteAsync(Byte[] array, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
             WriteHit = true;
             if (isSync)
@@ -859,7 +859,7 @@ namespace System.IO.Compression.Tests
     {
         public abstract Task<int> ReadAsync(DeflateStream unzip, byte[] buffer, int offset, int count);
         public abstract Task WriteAsync(DeflateStream unzip, byte[] buffer, int offset, int count);
-        protected static string gzTestFile(String fileName) { return Path.Combine("GZTestData", fileName); }
+        protected static string gzTestFile(string fileName) { return Path.Combine("GZTestData", fileName); }
 
         [Fact]
         public async Task OverlappingFlushAsync_DuringFlushAsync()
@@ -1034,7 +1034,7 @@ namespace System.IO.Compression.Tests
             var deflateStream = new MemoryStream();
 
             int _bufferSize = 1024;
-            var bytes = new Byte[_bufferSize];
+            var bytes = new byte[_bufferSize];
             bool finished = false;
             int retCount;
             while (!finished)

--- a/src/System.IO.Compression/tests/GZipStreamTests.cs
+++ b/src/System.IO.Compression/tests/GZipStreamTests.cs
@@ -10,7 +10,7 @@ namespace System.IO.Compression.Tests
 {
     public class GZipStreamTests
     {
-        static String gzTestFile(String fileName) { return Path.Combine("GZTestData", fileName); }
+        static string gzTestFile(string fileName) { return Path.Combine("GZTestData", fileName); }
 
         [Fact]
         public void BaseStream1()
@@ -39,7 +39,7 @@ namespace System.IO.Compression.Tests
 
             var zip = new GZipStream(ms, CompressionMode.Decompress);
             int size = 1024;
-            Byte[] bytes = new Byte[size];
+            byte[] bytes = new byte[size];
             zip.BaseStream.Read(bytes, 0, size); // This will throw if the underlying stream is not writable as expected
         }
 
@@ -96,7 +96,7 @@ namespace System.IO.Compression.Tests
             zip.Dispose();
 
             int size = 1024;
-            Byte[] bytes = new Byte[size];
+            byte[] bytes = new byte[size];
             baseStream.Read(bytes, 0, size); // This will throw if the underlying stream is not writable as expected
         }
 
@@ -267,7 +267,7 @@ namespace System.IO.Compression.Tests
         {
             //Create the GZipStream
             int _bufferSize = 1024;
-            var bytes = new Byte[_bufferSize];
+            var bytes = new byte[_bufferSize];
             var baseStream = new MemoryStream(bytes, true);
             GZipStream ds;
 
@@ -281,9 +281,9 @@ namespace System.IO.Compression.Tests
             }
 
             //Write some data and Close the stream
-            String strData = "Test Data";
+            string strData = "Test Data";
             var encoding = Encoding.UTF8;
-            Byte[] data = encoding.GetBytes(strData);
+            byte[] data = encoding.GetBytes(strData);
             ds.Write(data, 0, data.Length);
             ds.Flush();
             ds.Dispose();
@@ -295,7 +295,7 @@ namespace System.IO.Compression.Tests
             }
 
             //Read the data
-            Byte[] data2 = new Byte[_bufferSize];
+            byte[] data2 = new byte[_bufferSize];
             baseStream = new MemoryStream(bytes, false);
             ds = new GZipStream(baseStream, CompressionMode.Decompress);
             int size = ds.Read(data2, 0, _bufferSize - 5);

--- a/src/System.IO.Compression/tests/Utilities/StripHeaderAndFooter.cs
+++ b/src/System.IO.Compression/tests/Utilities/StripHeaderAndFooter.cs
@@ -18,7 +18,7 @@ class StripHeaderAndFooter
         var outputStream = new MemoryStream();
 
         bool fText, fCRC, fextra, fname, fComment;
-        Byte flag;
+        byte flag;
         int len;
         int value;
 
@@ -30,7 +30,7 @@ class StripHeaderAndFooter
         SkipBytes(inputStream, 3);
 
         //flag
-        flag = (Byte)inputStream.ReadByte();
+        flag = (byte)inputStream.ReadByte();
         fText = ((flag & 1) != 0);
         fCRC = ((flag & 2) != 0);
         fextra = ((flag & 4) != 0);
@@ -66,11 +66,11 @@ class StripHeaderAndFooter
         //body
         //We will now write the body to the output file
 
-        List<Byte> bitlist = new List<Byte>();
+        List<byte> bitlist = new List<byte>();
 
         while ((value = inputStream.ReadByte()) != -1)
         {
-            bitlist.Add((Byte)value);
+            bitlist.Add((byte)value);
             //				outputStream.WriteByte((Byte)value);
         }
 
@@ -87,7 +87,7 @@ class StripHeaderAndFooter
         //			inputStream = new MemoryStream(inputFileName, FileMode.Open, FileAccess.Read, FileShare.Read);
 
         //			outputStream.Flush();
-        Byte[] bits = new Byte[bitlist.Count - 8];
+        byte[] bits = new byte[bitlist.Count - 8];
         bitlist.CopyTo(0, bits, 0, bitlist.Count - 8);
         outputStream.Write(bits, 0, bits.Length);
 

--- a/src/System.IO.Compression/tests/Utilities/WrappedStream.cs
+++ b/src/System.IO.Compression/tests/Utilities/WrappedStream.cs
@@ -7,7 +7,7 @@ using System.IO;
 
 internal class WrappedStream : Stream
 {
-    internal WrappedStream(Stream baseStream, Boolean canRead, Boolean canWrite, Boolean canSeek, EventHandler onClosed)
+    internal WrappedStream(Stream baseStream, bool canRead, bool canWrite, bool canSeek, EventHandler onClosed)
     {
         _baseStream = baseStream;
         _onClosed = onClosed;
@@ -121,5 +121,5 @@ internal class WrappedStream : Stream
 
     private Stream _baseStream;
     private EventHandler _onClosed;
-    private Boolean _canRead, _canWrite, _canSeek;
+    private bool _canRead, _canWrite, _canSeek;
 }

--- a/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -10,7 +10,7 @@ namespace System.IO.Compression.Tests
 {
     public class zip_InvalidParametersAndStrangeFiles : ZipFileTestBase
     {
-        private static void ConstructorThrows<TException>(Func<ZipArchive> constructor, String Message) where TException : Exception
+        private static void ConstructorThrows<TException>(Func<ZipArchive> constructor, string Message) where TException : Exception
         {
             try
             {
@@ -96,12 +96,12 @@ namespace System.IO.Compression.Tests
         [Theory]
         [InlineData("LZMA.zip")]
         [InlineData("invalidDeflate.zip")]
-        public static async Task ZipArchiveEntry_InvalidUpdate(String zipname)
+        public static async Task ZipArchiveEntry_InvalidUpdate(string zipname)
         {
             string filename = bad(zipname);
             Stream updatedCopy = await StreamHelpers.CreateTempCopyStream(filename);
-            String name;
-            Int64 length, compressedLength;
+            string name;
+            long length, compressedLength;
             DateTimeOffset lastWriteTime;
             using (ZipArchive archive = new ZipArchive(updatedCopy, ZipArchiveMode.Update, true))
             {
@@ -128,7 +128,7 @@ namespace System.IO.Compression.Tests
         [Theory]
         [InlineData("CDoffsetOutOfBounds.zip")]
         [InlineData("EOCDmissing.zip")]
-        public static async Task ZipArchive_InvalidStream(String zipname)
+        public static async Task ZipArchive_InvalidStream(string zipname)
         {
             string filename = bad(zipname);
             using (var stream = await StreamHelpers.CreateTempCopyStream(filename))
@@ -138,7 +138,7 @@ namespace System.IO.Compression.Tests
         [Theory]
         [InlineData("CDoffsetInBoundsWrong.zip")]
         [InlineData("numberOfEntriesDifferent.zip")]
-        public static async Task ZipArchive_InvalidEntryTable(String zipname)
+        public static async Task ZipArchive_InvalidEntryTable(string zipname)
         {
             string filename = bad(zipname);
             using (ZipArchive archive = new ZipArchive(await StreamHelpers.CreateTempCopyStream(filename), ZipArchiveMode.Read))
@@ -151,7 +151,7 @@ namespace System.IO.Compression.Tests
         [InlineData("localFileOffsetOutOfBounds.zip", true)]
         [InlineData("LZMA.zip", true)]
         [InlineData("invalidDeflate.zip", false)]
-        public static async Task ZipArchive_InvalidEntry(String zipname, Boolean throwsOnOpen)
+        public static async Task ZipArchive_InvalidEntry(string zipname, bool throwsOnOpen)
         {
             string filename = bad(zipname);
             using (ZipArchive archive = new ZipArchive(await StreamHelpers.CreateTempCopyStream(filename), ZipArchiveMode.Read))

--- a/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
@@ -70,10 +70,10 @@ namespace System.IO.Compression.Tests
                 ZipArchiveEntry e2 = archive.GetEntry("notempty/second.txt");
 
                 //read all of e1 and e2's contents
-                Byte[] e1readnormal = new Byte[e1.Length];
-                Byte[] e2readnormal = new Byte[e2.Length];
-                Byte[] e1interleaved = new Byte[e1.Length];
-                Byte[] e2interleaved = new Byte[e2.Length];
+                byte[] e1readnormal = new byte[e1.Length];
+                byte[] e2readnormal = new byte[e2.Length];
+                byte[] e1interleaved = new byte[e1.Length];
+                byte[] e2interleaved = new byte[e2.Length];
 
                 using (Stream e1s = e1.Open())
                 {
@@ -85,66 +85,66 @@ namespace System.IO.Compression.Tests
                 }
 
                 //now read interleaved, assume we are working with < 4gb files
-                const Int32 bytesAtATime = 15;
+                const int bytesAtATime = 15;
 
                 using (Stream e1s = e1.Open(), e2s = e2.Open())
                 {
-                    Int32 e1pos = 0;
-                    Int32 e2pos = 0;
+                    int e1pos = 0;
+                    int e2pos = 0;
 
                     while (e1pos < e1.Length || e2pos < e2.Length)
                     {
                         if (e1pos < e1.Length)
                         {
-                            Int32 e1bytesRead = e1s.Read(e1interleaved, e1pos,
-                                bytesAtATime + e1pos > e1.Length ? (Int32)e1.Length - e1pos : bytesAtATime);
+                            int e1bytesRead = e1s.Read(e1interleaved, e1pos,
+                                bytesAtATime + e1pos > e1.Length ? (int)e1.Length - e1pos : bytesAtATime);
                             e1pos += e1bytesRead;
                         }
 
                         if (e2pos < e2.Length)
                         {
-                            Int32 e2bytesRead = e2s.Read(e2interleaved, e2pos,
-                                bytesAtATime + e2pos > e2.Length ? (Int32)e2.Length - e2pos : bytesAtATime);
+                            int e2bytesRead = e2s.Read(e2interleaved, e2pos,
+                                bytesAtATime + e2pos > e2.Length ? (int)e2.Length - e2pos : bytesAtATime);
                             e2pos += e2bytesRead;
                         }
                     }
                 }
 
                 //now compare to original read
-                ArraysEqual<Byte>(e1readnormal, e1interleaved, e1readnormal.Length);
-                ArraysEqual<Byte>(e2readnormal, e2interleaved, e2readnormal.Length);
+                ArraysEqual<byte>(e1readnormal, e1interleaved, e1readnormal.Length);
+                ArraysEqual<byte>(e2readnormal, e2interleaved, e2readnormal.Length);
 
                 //now read one entry interleaved
-                Byte[] e1selfInterleaved1 = new Byte[e1.Length];
-                Byte[] e1selfInterleaved2 = new Byte[e2.Length];
+                byte[] e1selfInterleaved1 = new byte[e1.Length];
+                byte[] e1selfInterleaved2 = new byte[e2.Length];
 
 
                 using (Stream s1 = e1.Open(), s2 = e1.Open())
                 {
-                    Int32 s1pos = 0;
-                    Int32 s2pos = 0;
+                    int s1pos = 0;
+                    int s2pos = 0;
 
                     while (s1pos < e1.Length || s2pos < e1.Length)
                     {
                         if (s1pos < e1.Length)
                         {
-                            Int32 s1bytesRead = s1.Read(e1interleaved, s1pos,
-                                bytesAtATime + s1pos > e1.Length ? (Int32)e1.Length - s1pos : bytesAtATime);
+                            int s1bytesRead = s1.Read(e1interleaved, s1pos,
+                                bytesAtATime + s1pos > e1.Length ? (int)e1.Length - s1pos : bytesAtATime);
                             s1pos += s1bytesRead;
                         }
 
                         if (s2pos < e1.Length)
                         {
-                            Int32 s2bytesRead = s2.Read(e2interleaved, s2pos,
-                                bytesAtATime + s2pos > e1.Length ? (Int32)e1.Length - s2pos : bytesAtATime);
+                            int s2bytesRead = s2.Read(e2interleaved, s2pos,
+                                bytesAtATime + s2pos > e1.Length ? (int)e1.Length - s2pos : bytesAtATime);
                             s2pos += s2bytesRead;
                         }
                     }
                 }
 
                 //now compare to original read
-                ArraysEqual<Byte>(e1readnormal, e1selfInterleaved1, e1readnormal.Length);
-                ArraysEqual<Byte>(e1readnormal, e1selfInterleaved2, e1readnormal.Length);
+                ArraysEqual<byte>(e1readnormal, e1selfInterleaved1, e1readnormal.Length);
+                ArraysEqual<byte>(e1readnormal, e1selfInterleaved2, e1readnormal.Length);
             }
         }
         [Fact]

--- a/src/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -30,7 +30,7 @@ namespace System.IO.Compression.Tests
             using (ZipArchive archive = new ZipArchive(await StreamHelpers.CreateTempCopyStream(zfile("small.zip")), ZipArchiveMode.Update))
             {
                 ZipArchiveEntry entry = archive.Entries[0];
-                String contents1, contents2;
+                string contents1, contents2;
                 using (StreamReader s = new StreamReader(entry.Open()))
                 {
                     contents1 = s.ReadToEnd();
@@ -58,8 +58,8 @@ namespace System.IO.Compression.Tests
         [InlineData(ZipArchiveMode.Update)]
         public static void EmptyEntryTest(ZipArchiveMode mode)
         {
-            String data1 = "test data written to file.";
-            String data2 = "more test data written to file.";
+            string data1 = "test data written to file.";
+            string data2 = "more test data written to file.";
             DateTimeOffset lastWrite = new DateTimeOffset(1992, 4, 5, 12, 00, 30, new TimeSpan(-5, 0, 0));
 
             var baseline = new LocalMemoryStream();
@@ -166,7 +166,7 @@ namespace System.IO.Compression.Tests
 
             using (ZipArchive archive = new ZipArchive(testArchive, ZipArchiveMode.Update, true))
             {
-                String fileName = zmodified(Path.Combine("overwrite", "first.txt"));
+                string fileName = zmodified(Path.Combine("overwrite", "first.txt"));
                 ZipArchiveEntry e = archive.GetEntry("first.txt");
 
                 var file = FileData.GetFile(fileName);
@@ -231,7 +231,7 @@ namespace System.IO.Compression.Tests
             IsZipSameAsDir(testArchive, zmodified("addFile"), ZipArchiveMode.Read, requireExplicit: true, checkTimes: true);
         }
 
-        private static async Task updateArchive(ZipArchive archive, String installFile, String entryName)
+        private static async Task updateArchive(ZipArchive archive, string installFile, string entryName)
         {
             ZipArchiveEntry e = archive.CreateEntry(entryName);
 


### PR DESCRIPTION
Use language keywords instead of BCL types per the coding style for the repo.

cc: @ianhays