### PR TITLE
Expando object improvements

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/ContractUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/ContractUtils.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 
 namespace System.Dynamic.Utils
 {
@@ -138,6 +139,12 @@ namespace System.Dynamic.Utils
                     throw new ArgumentNullException(GetParamName(arrayName, i));
                 }
             }
+        }
+
+        [Conditional("DEBUG")]
+        public static void AssertLockHeld(object lockObject)
+        {
+            Debug.Assert(Monitor.IsEntered(lockObject), "Expected lock is not held.");
         }
 
         private static string GetParamName(string paramName, int index)

--- a/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
@@ -239,6 +239,7 @@ namespace System.Dynamic
         /// </summary>
         internal bool IsDeletedMember(int index)
         {
+            ContractUtils.AssertLockHeld(LockObject);
             Debug.Assert(index >= 0 && index <= _data.Length);
 
             if (index == _data.Length)
@@ -263,15 +264,14 @@ namespace System.Dynamic
         private ExpandoData PromoteClassCore(ExpandoClass oldClass, ExpandoClass newClass)
         {
             Debug.Assert(oldClass != newClass);
+            ContractUtils.AssertLockHeld(LockObject);
 
-            lock (LockObject)
+            if (_data.Class == oldClass)
             {
-                if (_data.Class == oldClass)
-                {
-                    _data = _data.UpdateClass(newClass);
-                }
-                return _data;
+                _data = _data.UpdateClass(newClass);
             }
+
+            return _data;
         }
 
         /// <summary>
@@ -281,7 +281,10 @@ namespace System.Dynamic
         /// </summary>
         internal void PromoteClass(object oldClass, object newClass)
         {
-            PromoteClassCore((ExpandoClass)oldClass, (ExpandoClass)newClass);
+            lock (LockObject)
+            {
+                PromoteClassCore((ExpandoClass)oldClass, (ExpandoClass)newClass);
+            }
         }
 
         #endregion
@@ -311,6 +314,7 @@ namespace System.Dynamic
 
         private bool ExpandoContainsKey(string key)
         {
+            ContractUtils.AssertLockHeld(LockObject);
             return _data.Class.GetValueIndexCaseSensitive(key) >= 0;
         }
 
@@ -712,11 +716,11 @@ namespace System.Dynamic
         void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
         {
             ContractUtils.RequiresNotNull(array, nameof(array));
-            ContractUtils.RequiresArrayRange(array, arrayIndex, _count, nameof(arrayIndex), nameof(ICollection<KeyValuePair<string, object>>.Count));
 
-            // We want this to be atomic and not throw
+            // We want this to be atomic and not throw, though we must do the range checks inside this lock.
             lock (LockObject)
             {
+                ContractUtils.RequiresArrayRange(array, arrayIndex, _count, nameof(arrayIndex), nameof(ICollection<KeyValuePair<string, object>>.Count));
                 foreach (KeyValuePair<string, object> item in this)
                 {
                     array[arrayIndex++] = item;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -44,7 +44,7 @@ namespace System.Linq.Expressions
         /// </summary>
         internal static Exception SameKeyExistsInExpando(object p0)
         {
-            return new ArgumentException(Strings.SameKeyExistsInExpando(p0));
+            return new ArgumentException(Strings.SameKeyExistsInExpando(p0), "key");
         }
         /// <summary>
         /// System.Collections.Generic.KeyNotFoundException with message like "The specified key '{0}' does not exist in the ExpandoObject."

--- a/src/System.Linq.Expressions/tests/Dynamic/ExpandoObjectTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/ExpandoObjectTests.cs
@@ -48,7 +48,7 @@ namespace System.Dynamic.Tests
         {
             IDictionary<string, object> eo = new ExpandoObject();
             eo.Add("The test key to add.", "value");
-            var ae = Assert.Throws<ArgumentException>(() => eo.Add("The test key to add.", "value"));
+            var ae = Assert.Throws<ArgumentException>("key", () => eo.Add("The test key to add.", "value"));
             Assert.Contains("The test key to add.", ae.Message);
         }
 

--- a/src/System.Linq.Expressions/tests/Dynamic/ExpandoObjectTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/ExpandoObjectTests.cs
@@ -1,0 +1,188 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using Xunit;
+
+namespace System.Dynamic.Tests
+{
+    // Tests for ExpandoObject accessed directly, rather than through dynamic.
+    public class ExpandoObjectTests
+    {
+        [Fact]
+        public void InitialState()
+        {
+            IDictionary<string, object> eo = new ExpandoObject();
+            Assert.Equal(0, eo.Count);
+            Assert.False(eo.IsReadOnly);
+        }
+
+        [Fact]
+        public void Indexer()
+        {
+            // Deliberately using keys that the C# syntax won't use, to check they're covered too.
+            var boxedInts = Enumerable.Range(0, 10).Select(i => (object)i).ToArray();
+            IDictionary<string, object> eo = new ExpandoObject();
+            foreach (var boxed in boxedInts)
+                eo[boxed.ToString()] = boxed;
+
+            Assert.Equal(10, eo.Count);
+            foreach (var boxed in boxedInts)
+                Assert.Same(boxed, eo[boxed.ToString()]);
+
+            var knfe = Assert.Throws<KeyNotFoundException>(() => eo["A string that's a key"]);
+            Assert.Contains("A string that's a key", knfe.Message);
+
+            Assert.Throws<KeyNotFoundException>(() => eo[null]);
+            Assert.Throws<ArgumentNullException>("key", () => eo[null] = 0);
+            // Can overwrite
+            eo["1"] = 1;
+        }
+
+        [Fact]
+        public void AddDup()
+        {
+            IDictionary<string, object> eo = new ExpandoObject();
+            eo.Add("The test key to add.", "value");
+            var ae = Assert.Throws<ArgumentException>(() => eo.Add("The test key to add.", "value"));
+            Assert.Contains("The test key to add.", ae.Message);
+        }
+
+        [Fact]
+        public void DeleteAndReInsert()
+        {
+            IDictionary<string, object> eo = new ExpandoObject();
+            eo.Add("key", 1);
+            Assert.Equal(Enumerable.Repeat(new KeyValuePair<string, object>("key", 1), 1), eo);
+            eo.Remove("key");
+            Assert.Empty(eo);
+            eo.Add("key", 2);
+            Assert.Equal(Enumerable.Repeat(new KeyValuePair<string, object>("key", 2), 1), eo);
+        }
+
+        [Fact, ActiveIssue(13541)]
+        public void DictionaryMatchesProperties()
+        {
+            dynamic eo = new ExpandoObject();
+            IDictionary<string, object> dict = eo;
+            eo.X = 1;
+            eo.Y = 2;
+            Assert.Equal(2, dict.Count);
+            Assert.Equal(1, dict["X"]);
+            Assert.Equal(2, dict["Y"]);
+        }
+
+        [Fact]
+        public void PropertyNotify()
+        {
+            var eo = new ExpandoObject();
+            IDictionary<string, object> dict = eo;
+            INotifyPropertyChanged note = eo;
+            int changeCount = 0;
+            string lastKey = null;
+            note.PropertyChanged += (sender, args) =>
+            {
+                Assert.Same(eo, sender);
+                ++changeCount;
+                lastKey = args.PropertyName;
+            };
+            Assert.Equal(0, changeCount);
+            dict.Add("X", 1);
+            Assert.Equal(1, changeCount);
+            Assert.Equal(lastKey, "X");
+            dict["Y"] = 2;
+            Assert.Equal(2, changeCount);
+            Assert.Equal(lastKey, "Y");
+            object boxed = 0;
+            dict["Z"] = boxed;
+            Assert.Equal(3, changeCount);
+            Assert.Equal("Z", lastKey);
+            dict["Z"] = boxed; // exact same object.
+            Assert.Equal(3, changeCount);
+            dict["Z"] = 0; // same value but different instance.
+            Assert.Equal(4, changeCount);
+            dict.Remove("Not there");
+            Assert.Equal(4, changeCount);
+            dict.Remove("Z");
+            Assert.Equal(5, changeCount);
+            dict.Clear();
+            Assert.Equal(7, changeCount); // trigger for each key.
+        }
+
+        [Fact]
+        public void KeyCollection()
+        {
+            IDictionary<string, object> dict = new ExpandoObject();
+            dict["X"] = 1;
+            dict["Z"] = 3;
+            dict["Y"] = 2;
+            dict.Remove("Z");
+            var keys = dict.Keys;
+            Assert.Equal(2, keys.Count);
+            Assert.True(keys.IsReadOnly);
+            Assert.Equal(new[] {"X", "Y"}, keys.OrderBy(k => k)); // OrderBy because order is not guaranteed.
+            Assert.Throws<NotSupportedException>(() => keys.Add("Z"));
+            Assert.Throws<NotSupportedException>(() => keys.Clear());
+            Assert.Throws<NotSupportedException>(() => keys.Remove("X"));
+            Assert.True(keys.Contains("X"));
+            Assert.False(keys.Contains("x"));
+            string[] array = new string[3];
+            keys.CopyTo(array, 1);
+            Assert.Null(array[0]);
+            Array.Sort(array); // Because order is not guaranteed.
+            Assert.Equal(new[] {null, "X", "Y"}, array);
+            var keysEnumerated = new List<object>();
+            foreach (var key in (IEnumerable)keys) // going through non-generic to test delegation to generic
+            {
+                keysEnumerated.Add(key);
+            }
+            Assert.Equal(new[] {"X", "Y"}, keysEnumerated.OrderBy(k => k));
+            using (var en = keys.GetEnumerator())
+            {
+                en.MoveNext();
+                dict["Z"] = 3;
+                Assert.Throws<InvalidOperationException>(() => en.MoveNext());
+            }
+        }
+
+        [Fact]
+        public void ValueCollection()
+        {
+            IDictionary<string, object> dict = new ExpandoObject();
+            dict["X"] = 1;
+            dict["Z"] = 3;
+            dict["Y"] = 2;
+            dict.Remove("Z");
+            var values = dict.Values;
+            Assert.Equal(2, values.Count);
+            Assert.True(values.IsReadOnly);
+            Assert.Equal(new object[] {1, 2}, values.OrderBy(k => k)); // OrderBy because order is not guaranteed.
+            Assert.Throws<NotSupportedException>(() => values.Add(3));
+            Assert.Throws<NotSupportedException>(() => values.Clear());
+            Assert.Throws<NotSupportedException>(() => values.Remove(1));
+            Assert.True(values.Contains(1));
+            Assert.False(values.Contains(1.0));
+            object[] array = new object[3];
+            values.CopyTo(array, 1);
+            Assert.Null(array[0]);
+            Array.Sort(array); // Because order is not guaranteed.
+            Assert.Equal(new object[] {null, 1, 2}, array);
+            var valuesEnumerated = new List<object>();
+            foreach (var value in (IEnumerable)values) // going through non-generic to test delegation to generic
+            {
+                valuesEnumerated.Add(value);
+            }
+            Assert.Equal(new object[] {1, 2}, valuesEnumerated.OrderBy(k => k));
+            using (var en = values.GetEnumerator())
+            {
+                en.MoveNext();
+                dict["Z"] = 3;
+                Assert.Throws<InvalidOperationException>(() => en.MoveNext());
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Dynamic\ConvertBinderTests.cs" />
     <Compile Include="Dynamic\DynamicObjectDefaultBehaviorTests.cs" />
     <Compile Include="Dynamic\ExpandoObjectProxyTests.cs" />
+    <Compile Include="Dynamic\ExpandoObjectTests.cs" />
     <Compile Include="Dynamic\GetIndexBinderTests.cs" />
     <Compile Include="Dynamic\GetMemberBinderTests.cs" />
     <Compile Include="Dynamic\InvokeMemberBindingTests.cs" />


### PR DESCRIPTION
Includes some tests for `ExpandoObject`.

Lock changes:

1. Avoid re-entering lock on PromoteClassCore when called from `TrySetValue`, assert instead, and add lock to the other outer call.
2. Further assertions on lock being held where that is necessary.
3. Move range-check in `ICollection<KeyValuePair<string, object>>.CopyTo` to inside lock. Fixes #13633

Add parameter name to `ArgumentException` called on duplicate key in Expando.

CC @bartdesmet @stephentoub