### PR TITLE
Use singleton SetArrayItemInstruction.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
@@ -95,9 +95,9 @@ namespace System.Linq.Expressions.Interpreter
 
     internal sealed class GetArrayItemInstruction : Instruction
     {
-        internal static readonly GetArrayItemInstruction Instruction = new GetArrayItemInstruction();
+        internal static readonly GetArrayItemInstruction Instance = new GetArrayItemInstruction();
 
-        internal GetArrayItemInstruction() { }
+        private GetArrayItemInstruction() { }
 
         public override int ConsumedStack => 2;
         public override int ProducedStack => 1;
@@ -114,9 +114,9 @@ namespace System.Linq.Expressions.Interpreter
 
     internal sealed class SetArrayItemInstruction : Instruction
     {
-        internal static readonly SetArrayItemInstruction Instruction = new SetArrayItemInstruction();
+        internal static readonly SetArrayItemInstruction Instance = new SetArrayItemInstruction();
 
-        internal SetArrayItemInstruction() { }
+        private SetArrayItemInstruction() { }
 
         public override int ConsumedStack => 3;
         public override int ProducedStack => 0;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -656,12 +656,12 @@ namespace System.Linq.Expressions.Interpreter
 
         public void EmitGetArrayItem()
         {
-            Emit(GetArrayItemInstruction.Instruction);
+            Emit(GetArrayItemInstruction.Instance);
         }
 
         public void EmitSetArrayItem()
         {
-            Emit(new SetArrayItemInstruction());
+            Emit(SetArrayItemInstruction.Instance);
         }
 
         public void EmitNewArray(Type elementType)


### PR DESCRIPTION
A singleton `SetArrayItemInstruction` is created but not used. Change to do so.
Change name here and for `GetArrayItemInstruction` to `Instance` to match name of other singleton Instructions.
Make constructors private.