### PR TITLE
Test coalesce expressions with conversions in interpreter.

### DIFF
--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
@@ -356,28 +356,28 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory]
-        [InlineData(null, "YY")]
-        [InlineData("abc", "abcdef")]
-        public static void Conversion_String(string parameter, string expected)
+        [InlinePerCompilationType(null, "YY")]
+        [InlinePerCompilationType("abc", "abcdef")]
+        public static void Conversion_String(string parameter, string expected, bool useInterpreter)
         {
             Expression<Func<string, string>> conversion = x => x + "def";
             ParameterExpression parameterExpression = Expression.Parameter(typeof(string));
             BinaryExpression coalescion = Expression.Coalesce(parameterExpression, Expression.Constant("YY"), conversion);
 
-            Func<string, string> result = Expression.Lambda<Func<string, string>>(coalescion, parameterExpression).Compile();
+            Func<string, string> result = Expression.Lambda<Func<string, string>>(coalescion, parameterExpression).Compile(useInterpreter);
             Assert.Equal(expected, result(parameter));
         }
 
         [Theory]
-        [InlineData(null, 5)]
-        [InlineData(5, 10)]
-        public static void Conversion_NullableInt(int? parameter, int? expected)
+        [InlinePerCompilationType(null, 5)]
+        [InlinePerCompilationType(5, 10)]
+        public static void Conversion_NullableInt(int? parameter, int? expected, bool useInterpreter)
         {
             Expression<Func<int?, int?>> conversion = x => x * 2;
             ParameterExpression parameterExpression = Expression.Parameter(typeof(int?));
             BinaryExpression coalescion = Expression.Coalesce(parameterExpression, Expression.Constant(5, typeof(int?)), conversion);
 
-            Func<int?, int?> result = Expression.Lambda<Func<int?, int?>>(coalescion, parameterExpression).Compile();
+            Func<int?, int?> result = Expression.Lambda<Func<int?, int?>>(coalescion, parameterExpression).Compile(useInterpreter);
             Assert.Equal(expected, result(parameter));
         }
 

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Ternary\TernaryArrayTests.cs" />
     <Compile Include="Ternary\TernaryNullableTests.cs" />
     <Compile Include="Ternary\TernaryTests.cs" />
+    <Compile Include="TestExtensions\InlinePerCompilationTypeAttribute.cs" />
     <Compile Include="TestExtensions\PerCompilationTypeAttribute.cs" />
     <Compile Include="TestExtensions\TestOrderer.cs" />
     <Compile Include="TestExtensions\TestOrderAttribute.cs" />

--- a/src/System.Linq.Expressions/tests/TestExtensions/InlinePerCompilationTypeAttribute.cs
+++ b/src/System.Linq.Expressions/tests/TestExtensions/InlinePerCompilationTypeAttribute.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+using Xunit.Sdk;
+
+namespace System.Linq.Expressions.Tests
+{
+    internal class InlinePerCompilationTypeAttribute : DataAttribute
+    {
+        private static readonly object[] s_boxedBooleans = {false, true};
+
+        private readonly object[] _data;
+
+        public InlinePerCompilationTypeAttribute(params object[] data)
+        {
+            _data = data;
+        }
+
+        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+        {
+            // Re-using the arrays would be a nice optimization, and safe since this is internal and we could
+            // just not do the sort of uses that would break that, but xUnit pre-loads GetData() results and
+            // we'd therefore end up with multiple copies of the last result.
+            foreach (object compilationType in s_boxedBooleans)
+            {
+                object[] withType = new object[_data.Length + 1];
+                _data.CopyTo(withType, 0);
+                withType[withType.Length - 1] = compilationType;
+                yield return withType;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Extends tests by @hughbe that covered compiler to cover interpreter too.