### PR TITLE
Consolidate cached boxed values between Expressions and Interpreter

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
@@ -159,13 +159,13 @@ namespace System.Linq.Expressions.Interpreter
                     }
                     else
                     {
-                        frame.Push((bool)right ? null : ScriptingRuntimeHelpers.Boolean_False);
+                        frame.Push((bool)right ? null : Utils.BoxedFalse);
                     }
                     return +1;
                 }
                 else if (right == null)
                 {
-                    frame.Push((bool)left ? null : ScriptingRuntimeHelpers.Boolean_False);
+                    frame.Push((bool)left ? null : Utils.BoxedFalse);
                     return +1;
                 }
                 frame.Push(((bool)left) & ((bool)right));

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
@@ -27,15 +27,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
+                    frame.Push(right == null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_False);
+                    frame.Push(false);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((bool)left) == ((bool)right)));
+                    frame.Push((bool)left == (bool)right);
                 }
                 return +1;
             }
@@ -49,15 +49,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
+                    frame.Push(right == null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_False);
+                    frame.Push(false);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((sbyte)left) == ((sbyte)right)));
+                    frame.Push((sbyte)left == (sbyte)right);
                 }
                 return +1;
             }
@@ -71,15 +71,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
+                    frame.Push(right == null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_False);
+                    frame.Push(false);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((short)left) == ((short)right)));
+                    frame.Push((short)left == (short)right);
                 }
                 return +1;
             }
@@ -93,15 +93,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
+                    frame.Push(right == null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_False);
+                    frame.Push(false);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((char)left) == ((char)right)));
+                    frame.Push((char)left == (char)right);
                 }
                 return +1;
             }
@@ -115,15 +115,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
+                    frame.Push(right == null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_False);
+                    frame.Push(false);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((int)left) == ((int)right)));
+                    frame.Push((int)left == (int)right);
                 }
                 return +1;
             }
@@ -137,15 +137,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
+                    frame.Push(right == null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_False);
+                    frame.Push(false);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((long)left) == ((long)right)));
+                    frame.Push((long)left == (long)right);
                 }
                 return +1;
             }
@@ -159,15 +159,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
+                    frame.Push(right == null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_False);
+                    frame.Push(false);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((byte)left) == ((byte)right)));
+                    frame.Push((byte)left == (byte)right);
                 }
                 return +1;
             }
@@ -181,15 +181,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
+                    frame.Push(right == null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_False);
+                    frame.Push(false);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((ushort)left) == ((ushort)right)));
+                    frame.Push((ushort)left == (ushort)right);
                 }
                 return +1;
             }
@@ -203,15 +203,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
+                    frame.Push(right == null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_False);
+                    frame.Push(false);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((uint)left) == ((uint)right)));
+                    frame.Push((uint)left == (uint)right);
                 }
                 return +1;
             }
@@ -225,15 +225,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
+                    frame.Push(right == null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_False);
+                    frame.Push(false);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((ulong)left) == ((ulong)right)));
+                    frame.Push((ulong)left == (ulong)right);
                 }
                 return +1;
             }
@@ -247,15 +247,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
+                    frame.Push(right == null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_False);
+                    frame.Push(false);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((float)left) == ((float)right)));
+                    frame.Push((float)left == (float)right);
                 }
                 return +1;
             }
@@ -269,15 +269,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right == null));
+                    frame.Push(right == null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_False);
+                    frame.Push(false);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((double)left) == ((double)right)));
+                    frame.Push((double)left == (double)right);
                 }
                 return +1;
             }
@@ -287,7 +287,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                frame.Push(ScriptingRuntimeHelpers.BooleanToObject(frame.Pop() == frame.Pop()));
+                frame.Push(frame.Pop() == frame.Pop());
                 return +1;
             }
         }
@@ -304,7 +304,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((bool)left) == ((bool)right)));
+                    frame.Push((bool)left == (bool)right);
                 }
                 return +1;
             }
@@ -322,7 +322,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((sbyte)left) == ((sbyte)right)));
+                    frame.Push((sbyte)left == (sbyte)right);
                 }
                 return +1;
             }
@@ -340,7 +340,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((short)left) == ((short)right)));
+                    frame.Push((short)left == (short)right);
                 }
                 return +1;
             }
@@ -358,7 +358,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((char)left) == ((char)right)));
+                    frame.Push((char)left == (char)right);
                 }
                 return +1;
             }
@@ -376,7 +376,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((int)left) == ((int)right)));
+                    frame.Push((int)left == (int)right);
                 }
                 return +1;
             }
@@ -394,7 +394,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((long)left) == ((long)right)));
+                    frame.Push((long)left == (long)right);
                 }
                 return +1;
             }
@@ -412,7 +412,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((byte)left) == ((byte)right)));
+                    frame.Push((byte)left == (byte)right);
                 }
                 return +1;
             }
@@ -430,7 +430,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((ushort)left) == ((ushort)right)));
+                    frame.Push((ushort)left == (ushort)right);
                 }
                 return +1;
             }
@@ -448,7 +448,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((uint)left) == ((uint)right)));
+                    frame.Push((uint)left == (uint)right);
                 }
                 return +1;
             }
@@ -466,7 +466,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((ulong)left) == ((ulong)right)));
+                    frame.Push((ulong)left == (ulong)right);
                 }
                 return +1;
             }
@@ -484,7 +484,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((float)left) == ((float)right)));
+                    frame.Push((float)left == (float)right);
                 }
                 return +1;
             }
@@ -502,7 +502,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((double)left) == ((double)right)));
+                    frame.Push((double)left == (double)right);
                 }
                 return +1;
             }
@@ -521,7 +521,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(left == right));
+                    frame.Push(left == right);
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
@@ -303,17 +303,17 @@ namespace System.Linq.Expressions.Interpreter
             {
                 switch (type.GetNonNullableType().GetTypeCode())
                 {
-                    case TypeCode.SByte: return s_SByte ?? (s_SByte = new GreaterThanSByte(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Byte: return s_byte ?? (s_byte = new GreaterThanByte(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Char: return s_char ?? (s_char = new GreaterThanChar(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Int16: return s_int16 ?? (s_int16 = new GreaterThanInt16(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Int32: return s_int32 ?? (s_int32 = new GreaterThanInt32(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Int64: return s_int64 ?? (s_int64 = new GreaterThanInt64(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new GreaterThanUInt16(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new GreaterThanUInt32(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new GreaterThanUInt64(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Single: return s_single ?? (s_single = new GreaterThanSingle(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Double: return s_double ?? (s_double = new GreaterThanDouble(ScriptingRuntimeHelpers.Boolean_False));
+                    case TypeCode.SByte: return s_SByte ?? (s_SByte = new GreaterThanSByte(Utils.BoxedFalse));
+                    case TypeCode.Byte: return s_byte ?? (s_byte = new GreaterThanByte(Utils.BoxedFalse));
+                    case TypeCode.Char: return s_char ?? (s_char = new GreaterThanChar(Utils.BoxedFalse));
+                    case TypeCode.Int16: return s_int16 ?? (s_int16 = new GreaterThanInt16(Utils.BoxedFalse));
+                    case TypeCode.Int32: return s_int32 ?? (s_int32 = new GreaterThanInt32(Utils.BoxedFalse));
+                    case TypeCode.Int64: return s_int64 ?? (s_int64 = new GreaterThanInt64(Utils.BoxedFalse));
+                    case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new GreaterThanUInt16(Utils.BoxedFalse));
+                    case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new GreaterThanUInt32(Utils.BoxedFalse));
+                    case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new GreaterThanUInt64(Utils.BoxedFalse));
+                    case TypeCode.Single: return s_single ?? (s_single = new GreaterThanSingle(Utils.BoxedFalse));
+                    case TypeCode.Double: return s_double ?? (s_double = new GreaterThanDouble(Utils.BoxedFalse));
 
                     default:
                         throw Error.ExpressionNotSupportedForType("GreaterThan", type);
@@ -619,17 +619,17 @@ namespace System.Linq.Expressions.Interpreter
             {
                 switch (type.GetNonNullableType().GetTypeCode())
                 {
-                    case TypeCode.SByte: return s_SByte ?? (s_SByte = new GreaterThanOrEqualSByte(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Byte: return s_byte ?? (s_byte = new GreaterThanOrEqualByte(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Char: return s_char ?? (s_char = new GreaterThanOrEqualChar(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Int16: return s_int16 ?? (s_int16 = new GreaterThanOrEqualInt16(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Int32: return s_int32 ?? (s_int32 = new GreaterThanOrEqualInt32(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Int64: return s_int64 ?? (s_int64 = new GreaterThanOrEqualInt64(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new GreaterThanOrEqualUInt16(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new GreaterThanOrEqualUInt32(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new GreaterThanOrEqualUInt64(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Single: return s_single ?? (s_single = new GreaterThanOrEqualSingle(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Double: return s_double ?? (s_double = new GreaterThanOrEqualDouble(ScriptingRuntimeHelpers.Boolean_False));
+                    case TypeCode.SByte: return s_SByte ?? (s_SByte = new GreaterThanOrEqualSByte(Utils.BoxedFalse));
+                    case TypeCode.Byte: return s_byte ?? (s_byte = new GreaterThanOrEqualByte(Utils.BoxedFalse));
+                    case TypeCode.Char: return s_char ?? (s_char = new GreaterThanOrEqualChar(Utils.BoxedFalse));
+                    case TypeCode.Int16: return s_int16 ?? (s_int16 = new GreaterThanOrEqualInt16(Utils.BoxedFalse));
+                    case TypeCode.Int32: return s_int32 ?? (s_int32 = new GreaterThanOrEqualInt32(Utils.BoxedFalse));
+                    case TypeCode.Int64: return s_int64 ?? (s_int64 = new GreaterThanOrEqualInt64(Utils.BoxedFalse));
+                    case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new GreaterThanOrEqualUInt16(Utils.BoxedFalse));
+                    case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new GreaterThanOrEqualUInt32(Utils.BoxedFalse));
+                    case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new GreaterThanOrEqualUInt64(Utils.BoxedFalse));
+                    case TypeCode.Single: return s_single ?? (s_single = new GreaterThanOrEqualSingle(Utils.BoxedFalse));
+                    case TypeCode.Double: return s_double ?? (s_double = new GreaterThanOrEqualDouble(Utils.BoxedFalse));
 
                     default:
                         throw Error.ExpressionNotSupportedForType("GreaterThanOrEqual", type);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -326,13 +326,13 @@ namespace System.Linq.Expressions.Interpreter
 
         public void EmitLoad(bool value)
         {
-            if ((bool)value)
+            if (value)
             {
-                Emit(s_true ?? (s_true = new LoadObjectInstruction(value)));
+                Emit(s_true ?? (s_true = new LoadObjectInstruction(Utils.BoxedTrue)));
             }
             else
             {
-                Emit(s_false ?? (s_false = new LoadObjectInstruction(value)));
+                Emit(s_false ?? (s_false = new LoadObjectInstruction(Utils.BoxedFalse)));
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
@@ -73,7 +73,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public void Push(bool value)
         {
-            Data[StackIndex++] = value ? ScriptingRuntimeHelpers.Boolean_True : ScriptingRuntimeHelpers.Boolean_False;
+            Data[StackIndex++] = value ? Utils.BoxedTrue : Utils.BoxedFalse;
         }
 
         public void Push(int value)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
@@ -303,17 +303,17 @@ namespace System.Linq.Expressions.Interpreter
             {
                 switch (type.GetNonNullableType().GetTypeCode())
                 {
-                    case TypeCode.SByte: return s_SByte ?? (s_SByte = new LessThanSByte(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Byte: return s_byte ?? (s_byte = new LessThanByte(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Char: return s_char ?? (s_char = new LessThanChar(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Int16: return s_int16 ?? (s_int16 = new LessThanInt16(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Int32: return s_int32 ?? (s_int32 = new LessThanInt32(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Int64: return s_int64 ?? (s_int64 = new LessThanInt64(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new LessThanUInt16(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new LessThanUInt32(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new LessThanUInt64(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Single: return s_single ?? (s_single = new LessThanSingle(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Double: return s_double ?? (s_double = new LessThanDouble(ScriptingRuntimeHelpers.Boolean_False));
+                    case TypeCode.SByte: return s_SByte ?? (s_SByte = new LessThanSByte(Utils.BoxedFalse));
+                    case TypeCode.Byte: return s_byte ?? (s_byte = new LessThanByte(Utils.BoxedFalse));
+                    case TypeCode.Char: return s_char ?? (s_char = new LessThanChar(Utils.BoxedFalse));
+                    case TypeCode.Int16: return s_int16 ?? (s_int16 = new LessThanInt16(Utils.BoxedFalse));
+                    case TypeCode.Int32: return s_int32 ?? (s_int32 = new LessThanInt32(Utils.BoxedFalse));
+                    case TypeCode.Int64: return s_int64 ?? (s_int64 = new LessThanInt64(Utils.BoxedFalse));
+                    case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new LessThanUInt16(Utils.BoxedFalse));
+                    case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new LessThanUInt32(Utils.BoxedFalse));
+                    case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new LessThanUInt64(Utils.BoxedFalse));
+                    case TypeCode.Single: return s_single ?? (s_single = new LessThanSingle(Utils.BoxedFalse));
+                    case TypeCode.Double: return s_double ?? (s_double = new LessThanDouble(Utils.BoxedFalse));
 
                     default:
                         throw Error.ExpressionNotSupportedForType("LessThan", type);
@@ -617,17 +617,17 @@ namespace System.Linq.Expressions.Interpreter
             {
                 switch (type.GetNonNullableType().GetTypeCode())
                 {
-                    case TypeCode.SByte: return s_SByte ?? (s_SByte = new LessThanOrEqualSByte(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Byte: return s_byte ?? (s_byte = new LessThanOrEqualByte(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Char: return s_char ?? (s_char = new LessThanOrEqualChar(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Int16: return s_int16 ?? (s_int16 = new LessThanOrEqualInt16(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Int32: return s_int32 ?? (s_int32 = new LessThanOrEqualInt32(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Int64: return s_int64 ?? (s_int64 = new LessThanOrEqualInt64(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new LessThanOrEqualUInt16(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new LessThanOrEqualUInt32(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new LessThanOrEqualUInt64(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Single: return s_single ?? (s_single = new LessThanOrEqualSingle(ScriptingRuntimeHelpers.Boolean_False));
-                    case TypeCode.Double: return s_double ?? (s_double = new LessThanOrEqualDouble(ScriptingRuntimeHelpers.Boolean_False));
+                    case TypeCode.SByte: return s_SByte ?? (s_SByte = new LessThanOrEqualSByte(Utils.BoxedFalse));
+                    case TypeCode.Byte: return s_byte ?? (s_byte = new LessThanOrEqualByte(Utils.BoxedFalse));
+                    case TypeCode.Char: return s_char ?? (s_char = new LessThanOrEqualChar(Utils.BoxedFalse));
+                    case TypeCode.Int16: return s_int16 ?? (s_int16 = new LessThanOrEqualInt16(Utils.BoxedFalse));
+                    case TypeCode.Int32: return s_int32 ?? (s_int32 = new LessThanOrEqualInt32(Utils.BoxedFalse));
+                    case TypeCode.Int64: return s_int64 ?? (s_int64 = new LessThanOrEqualInt64(Utils.BoxedFalse));
+                    case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new LessThanOrEqualUInt16(Utils.BoxedFalse));
+                    case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new LessThanOrEqualUInt32(Utils.BoxedFalse));
+                    case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new LessThanOrEqualUInt64(Utils.BoxedFalse));
+                    case TypeCode.Single: return s_single ?? (s_single = new LessThanOrEqualSingle(Utils.BoxedFalse));
+                    case TypeCode.Double: return s_double ?? (s_double = new LessThanOrEqualDouble(Utils.BoxedFalse));
 
                     default:
                         throw Error.ExpressionNotSupportedForType("LessThanOrEqual", type);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -821,12 +821,12 @@ namespace System.Linq.Expressions.Interpreter
                             if (node.NodeType == ExpressionType.Equal)
                             {
                                 // right null, left not, false
-                                _instructions.EmitLoad(ScriptingRuntimeHelpers.Boolean_False, typeof(bool));
+                                _instructions.EmitLoad(AstUtils.BoxedFalse, typeof(bool));
                             }
                             else
                             {
                                 // right null, left not, true
-                                _instructions.EmitLoad(ScriptingRuntimeHelpers.Boolean_True, typeof(bool));
+                                _instructions.EmitLoad(AstUtils.BoxedTrue, typeof(bool));
                             }
                             _instructions.EmitBranch(end, hasResult: false, hasValue: true);
 
@@ -871,7 +871,7 @@ namespace System.Linq.Expressions.Interpreter
                                     {
                                         goto default;
                                     }
-                                    _instructions.EmitLoad(ScriptingRuntimeHelpers.Boolean_False, typeof(object));
+                                    _instructions.EmitLoad(AstUtils.BoxedFalse, typeof(object));
                                     break;
                                 default:
                                     _instructions.EmitLoad(null, typeof(object));
@@ -1376,13 +1376,13 @@ namespace System.Linq.Expressions.Interpreter
             _instructions.EmitBranchTrue(returnNull);
 
             // return true
-            _instructions.EmitLoad(andAlso ? ScriptingRuntimeHelpers.Boolean_True : ScriptingRuntimeHelpers.Boolean_False, typeof(object));
+            _instructions.EmitLoad(andAlso ? AstUtils.BoxedTrue : AstUtils.BoxedFalse, typeof(object));
             _instructions.EmitStoreLocal(result.Index);
             _instructions.EmitBranch(returnValue);
 
             // return false
             _instructions.MarkLabel(returnFalse);
-            _instructions.EmitLoad(andAlso ? ScriptingRuntimeHelpers.Boolean_False : ScriptingRuntimeHelpers.Boolean_True, typeof(object));
+            _instructions.EmitLoad(andAlso ? AstUtils.BoxedFalse : AstUtils.BoxedTrue, typeof(object));
             _instructions.EmitStoreLocal(result.Index);
             _instructions.EmitBranch(returnValue);
 
@@ -2871,10 +2871,7 @@ namespace System.Linq.Expressions.Interpreter
                     _instructions.EmitPop();
                 }
 
-                _instructions.EmitLoad(
-                    ScriptingRuntimeHelpers.BooleanToObject(result == AnalyzeTypeIsResult.KnownTrue),
-                    typeof(bool)
-                );
+                _instructions.EmitLoad(result == AnalyzeTypeIsResult.KnownTrue);
                 return;
             }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
@@ -27,15 +27,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
+                    frame.Push(right != null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_True);
+                    frame.Push(true);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((bool)left) != ((bool)right)));
+                    frame.Push((bool)left != (bool)right);
                 }
                 return +1;
             }
@@ -49,15 +49,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
+                    frame.Push(right != null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_True);
+                    frame.Push(true);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((sbyte)left) != ((sbyte)right)));
+                    frame.Push((sbyte)left != (sbyte)right);
                 }
                 return +1;
             }
@@ -71,15 +71,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
+                    frame.Push(right != null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_True);
+                    frame.Push(true);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((short)left) != ((short)right)));
+                    frame.Push((short)left != (short)right);
                 }
                 return +1;
             }
@@ -93,15 +93,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
+                    frame.Push(right != null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_True);
+                    frame.Push(true);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((char)left) != ((char)right)));
+                    frame.Push((char)left != (char)right);
                 }
                 return +1;
             }
@@ -115,15 +115,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
+                    frame.Push(right != null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_True);
+                    frame.Push(true);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((int)left) != ((int)right)));
+                    frame.Push((int)left != (int)right);
                 }
                 return +1;
             }
@@ -137,15 +137,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
+                    frame.Push(right != null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_True);
+                    frame.Push(true);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((long)left) != ((long)right)));
+                    frame.Push((long)left != (long)right);
                 }
                 return +1;
             }
@@ -159,15 +159,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
+                    frame.Push(right != null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_True);
+                    frame.Push(true);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((byte)left) != ((byte)right)));
+                    frame.Push((byte)left != (byte)right);
                 }
                 return +1;
             }
@@ -181,15 +181,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
+                    frame.Push(right != null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_True);
+                    frame.Push(true);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((ushort)left) != ((ushort)right)));
+                    frame.Push((ushort)left != (ushort)right);
                 }
                 return +1;
             }
@@ -203,15 +203,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
+                    frame.Push(right != null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_True);
+                    frame.Push(true);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((uint)left) != ((uint)right)));
+                    frame.Push((uint)left != (uint)right);
                 }
                 return +1;
             }
@@ -225,15 +225,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
+                    frame.Push(right != null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_True);
+                    frame.Push(true);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((ulong)left) != ((ulong)right)));
+                    frame.Push((ulong)left != (ulong)right);
                 }
                 return +1;
             }
@@ -247,15 +247,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
+                    frame.Push(right != null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_True);
+                    frame.Push(true);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((float)left) != ((float)right)));
+                    frame.Push((float)left != (float)right);
                 }
                 return +1;
             }
@@ -269,15 +269,15 @@ namespace System.Linq.Expressions.Interpreter
                 object left = frame.Pop();
                 if (left == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(right != null));
+                    frame.Push(right != null);
                 }
                 else if (right == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_True);
+                    frame.Push(true);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((double)left) != ((double)right)));
+                    frame.Push((double)left != (double)right);
                 }
                 return +1;
             }
@@ -287,7 +287,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                frame.Push(ScriptingRuntimeHelpers.BooleanToObject(frame.Pop() != frame.Pop()));
+                frame.Push(frame.Pop() != frame.Pop());
                 return +1;
             }
         }
@@ -305,7 +305,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((bool)left) != ((bool)right)));
+                    frame.Push((bool)left != (bool)right);
                 }
                 return +1;
             }
@@ -323,7 +323,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((sbyte)left) != ((sbyte)right)));
+                    frame.Push((sbyte)left != (sbyte)right);
                 }
                 return +1;
             }
@@ -341,7 +341,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((short)left) != ((short)right)));
+                    frame.Push((short)left != (short)right);
                 }
                 return +1;
             }
@@ -359,7 +359,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((char)left) != ((char)right)));
+                    frame.Push((char)left != (char)right);
                 }
                 return +1;
             }
@@ -377,7 +377,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((int)left) != ((int)right)));
+                    frame.Push((int)left != (int)right);
                 }
                 return +1;
             }
@@ -395,7 +395,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((long)left) != ((long)right)));
+                    frame.Push((long)left != (long)right);
                 }
                 return +1;
             }
@@ -413,7 +413,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((byte)left) != ((byte)right)));
+                    frame.Push((byte)left != (byte)right);
                 }
                 return +1;
             }
@@ -431,7 +431,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((ushort)left) != ((ushort)right)));
+                    frame.Push((ushort)left != (ushort)right);
                 }
                 return +1;
             }
@@ -449,7 +449,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((uint)left) != ((uint)right)));
+                    frame.Push((uint)left != (uint)right);
                 }
                 return +1;
             }
@@ -467,7 +467,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((ulong)left) != ((ulong)right)));
+                    frame.Push((ulong)left != (ulong)right);
                 }
                 return +1;
             }
@@ -485,7 +485,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((float)left) != ((float)right)));
+                    frame.Push((float)left != (float)right);
                 }
                 return +1;
             }
@@ -503,7 +503,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(((double)left) != ((double)right)));
+                    frame.Push((double)left != (double)right);
                 }
                 return +1;
             }
@@ -513,7 +513,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int Run(InterpretedFrame frame)
             {
-                frame.Push(ScriptingRuntimeHelpers.BooleanToObject(frame.Pop() != frame.Pop()));
+                frame.Push(frame.Pop() != frame.Pop());
                 return +1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotInstruction.cs
@@ -27,7 +27,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((bool)value ? ScriptingRuntimeHelpers.Boolean_False : ScriptingRuntimeHelpers.Boolean_True);
+                    frame.Push(!(bool)value);
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
@@ -159,16 +159,18 @@ namespace System.Linq.Expressions.Interpreter
                     }
                     else
                     {
-                        frame.Push((bool)right ? ScriptingRuntimeHelpers.Boolean_True : null);
+                        frame.Push((bool)right ? Utils.BoxedTrue : null);
                     }
                     return +1;
                 }
-                else if (right == null)
+
+                if (right == null)
                 {
-                    frame.Push((bool)left ? ScriptingRuntimeHelpers.Boolean_True : null);
+                    frame.Push((bool)left ? Utils.BoxedTrue : null);
                     return +1;
                 }
-                frame.Push(((bool)left) | ((bool)right));
+
+                frame.Push((bool)left | (bool)right);
                 return +1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -61,7 +61,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int Run(InterpretedFrame frame)
         {
-            frame.Push(ScriptingRuntimeHelpers.BooleanToObject(_type.IsInstanceOfType(frame.Pop())));
+            frame.Push(_type.IsInstanceOfType(frame.Pop()));
             return +1;
         }
 
@@ -112,7 +112,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             object type = frame.Pop();
             object obj = frame.Pop();
-            frame.Push(ScriptingRuntimeHelpers.BooleanToObject(obj != null && (object)obj.GetType() == type));
+            frame.Push((object)obj?.GetType() == type);
             return +1;
         }
     }
@@ -131,7 +131,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             object type = frame.Pop();
             object obj = frame.Pop();
-            frame.Push(ScriptingRuntimeHelpers.BooleanToObject(obj != null && (object)obj.GetType() == type));
+            frame.Push((object)obj?.GetType() == type);
             return +1;
         }
     }
@@ -151,7 +151,7 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object obj = frame.Pop();
-                frame.Push(ScriptingRuntimeHelpers.BooleanToObject(obj != null));
+                frame.Push(obj != null);
                 return +1;
             }
         }
@@ -219,15 +219,15 @@ namespace System.Linq.Expressions.Interpreter
                 object obj = frame.Pop();
                 if (obj == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(other == null));
+                    frame.Push(other == null);
                 }
                 else if (other == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Boolean_False);
+                    frame.Push(Utils.BoxedFalse);
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.BooleanToObject(obj.Equals(other)));
+                    frame.Push(obj.Equals(other));
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -9,8 +9,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
-using AstUtils = System.Linq.Expressions.Utils;
-
 namespace System.Linq.Expressions.Interpreter
 {
 #if FEATURE_MAKE_RUN_METHODS
@@ -92,30 +90,19 @@ namespace System.Linq.Expressions.Interpreter
             switch (i)
             {
                 case -1:
-                    return Int32_M1;
+                    return Utils.BoxedIntM1;
                 case 0:
-                    return Int32_0;
+                    return Utils.BoxedInt0;
                 case 1:
-                    return Int32_1;
+                    return Utils.BoxedInt1;
                 case 2:
-                    return Int32_2;
+                    return Utils.BoxedInt2;
+                case 3:
+                    return Utils.BoxedInt3;
             }
 
             return i;
         }
-
-        private static readonly object Int32_M1 = -1;
-        private static readonly object Int32_0 = 0;
-        private static readonly object Int32_1 = 1;
-        private static readonly object Int32_2 = 2;
-
-        public static object BooleanToObject(bool b)
-        {
-            return b ? Boolean_True : Boolean_False;
-        }
-
-        internal static readonly object Boolean_True = true;
-        internal static readonly object Boolean_False = false;
 
         internal static object GetPrimitiveDefaultValue(Type type)
         {
@@ -124,7 +111,7 @@ namespace System.Linq.Expressions.Interpreter
             switch (type.GetTypeCode())
             {
                 case TypeCode.Boolean:
-                    result = Boolean_False;
+                    result = Utils.BoxedFalse;
                     break;
                 case TypeCode.SByte:
                     result = default(sbyte);
@@ -139,7 +126,7 @@ namespace System.Linq.Expressions.Interpreter
                     result = default(short);
                     break;
                 case TypeCode.Int32:
-                    result = Int32_0;
+                    result = Utils.BoxedInt0;
                     break;
                 case TypeCode.Int64:
                     result = default(long);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Utils.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Utils.cs
@@ -6,14 +6,22 @@ namespace System.Linq.Expressions
 {
     internal static class Utils
     {
-        private static readonly ConstantExpression s_true = Expression.Constant(true);
-        private static readonly ConstantExpression s_false = Expression.Constant(false);
+        public static readonly object BoxedFalse = false;
+        public static readonly object BoxedTrue = true;
+        public static readonly object BoxedIntM1 = -1;
+        public static readonly object BoxedInt0 = 0;
+        public static readonly object BoxedInt1 = 1;
+        public static readonly object BoxedInt2 = 2;
+        public static readonly object BoxedInt3 = 3;
 
-        private static readonly ConstantExpression s_m1 = Expression.Constant(-1);
-        private static readonly ConstantExpression s_0 = Expression.Constant(0);
-        private static readonly ConstantExpression s_1 = Expression.Constant(1);
-        private static readonly ConstantExpression s_2 = Expression.Constant(2);
-        private static readonly ConstantExpression s_3 = Expression.Constant(3);
+        private static readonly ConstantExpression s_true = Expression.Constant(BoxedTrue);
+        private static readonly ConstantExpression s_false = Expression.Constant(BoxedFalse);
+
+        private static readonly ConstantExpression s_m1 = Expression.Constant(BoxedIntM1);
+        private static readonly ConstantExpression s_0 = Expression.Constant(BoxedInt0);
+        private static readonly ConstantExpression s_1 = Expression.Constant(BoxedInt1);
+        private static readonly ConstantExpression s_2 = Expression.Constant(BoxedInt2);
+        private static readonly ConstantExpression s_3 = Expression.Constant(BoxedInt3);
 
         public static readonly DefaultExpression Empty = Expression.Empty();
         public static readonly ConstantExpression Null = Expression.Constant(null);


### PR DESCRIPTION
A utility class in Expressions has some cached instances of `ConstantExpression`
for common values.

A utility class in Interpreter has some cached boxed instances of the same values.

Consolidate these.

In updating `ScriptingRuntimeHelpers.BooleanToObject` accordingly I noticed that it is always used in a way that prevents an overload that does the exact same logic being used in `InterpretedFrame.Push` or `InstructionList.EmitLoad` (indeed the latter skips a few steps if given a boolean directly), so I just removed that method.