### PR TITLE
Special-case known schemes in Uri.CheckSchemeSyntax

### DIFF
--- a/src/System.Private.Uri/tests/FunctionalTests/UriGetComponentsTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriGetComponentsTest.cs
@@ -53,9 +53,9 @@ namespace System.PrivateUri.Tests
             // IP Address containing 0, 00 and 000
             testUri = new Uri("abcd://123.0.10.100/dir");
             Assert.Equal("123.0.10.100", testUri.Authority);
-            testUri = new Uri("efgh://123.00.10.100/dir");
+            testUri = new Uri("efghi://123.00.10.100/dir");
             Assert.Equal("123.00.10.100", testUri.Authority);
-            testUri = new Uri("ijkl://123.000.10.100/dir");
+            testUri = new Uri("ijklmn://123.000.10.100/dir");
             Assert.Equal("123.000.10.100", testUri.Authority);
 
             // Known limitation: port will always be canonicalized since it is exposed as an int.


### PR DESCRIPTION
The 32-bit special-casing is already handled by CheckKnownSchemes.  On 64-bit, without this we end up allocating a string for the scheme and doing a dictionary lookup; instead, we can special-case the common schemes to avoid that allocation and lookup.

(With a small tweak to the existing tests, this new code has 100% line and branch coverage.)

Contributes to https://github.com/dotnet/corefx/issues/13622
cc: @cipop, @davidsh, @geoffkizer 