### PR TITLE
Rewrite Uri.CheckForUnicode to improve throughput and reduce allocations

### DIFF
--- a/src/System.Private.Uri/src/System/UriExt.cs
+++ b/src/System.Private.Uri/src/System/UriExt.cs
@@ -194,23 +194,26 @@ namespace System
         //
         private bool CheckForUnicode(string data)
         {
-            bool hasUnicode = false;
-            char[] chars = new char[data.Length];
-            int count = 0;
-
-            chars = UriHelper.UnescapeString(data, 0, data.Length, chars, ref count, c_DummyChar, c_DummyChar,
-                c_DummyChar, UnescapeMode.Unescape | UnescapeMode.UnescapeAll, null, false);
-
-            for (int i = 0; i < count; ++i)
+            for (int i = 0; i < data.Length; i++)
             {
-                if (chars[i] > '\x7f')
+                char c = data[i];
+                if (c == '%')
                 {
-                    // Unicode 
-                    hasUnicode = true;
-                    break;
+                    if (i + 2 < data.Length)
+                    {
+                        if (UriHelper.EscapedAscii(data[i + 1], data[i + 2]) > 0x7F)
+                        {
+                            return true;
+                        }
+                        i += 2;
+                    }
+                }
+                else if (c > 0x7F)
+                {
+                    return true;
                 }
             }
-            return hasUnicode;
+            return false;
         }
 
         // Does this string have any %6A sequences that are 3986 Unreserved characters?  These should be un-escaped.


### PR DESCRIPTION
Constructing Uri from a string calls CheckForUnicode, and every call to this is allocating a new char[], unencoding the string into that array, and then iterating through the array looking for non-ASCII chars.  We can simplify all of that to avoid needing to store the results into the destination.  This avoids the allocation, the copy, and a second iteration through the results.  It also lets us bail early if we do fine unicode characters.  All tested scenarios get measurably faster, some significantly, with fewer allocations.

Here's a little repro app that uses a variety of Uris:
```C#
using System;
using System.Diagnostics;

class Program
{
    static void Main()
    {
        string[] urls = new[]
        {
             // short ASCII uri
            "http://bing.com",

            // short ASCII uri with escaped char at end
            "http://bing.com/%20",

            // short uri with unescaped unicode
            "http://bing.com/\u0395",

            // short uri with escaped unicode
            "http://bing.com/%CE%95",

            // long uri with escaped char at end
            "http://www.bing.com/images/search?q=dotnet-bot&view=detailv2&&id=32C6FE9F03213C3FC9C05C605AA02ED5DC14796D&selectedIndex=0&ccid=tsBIuVWG&simid=608052183613704343&thid=OIP.Mb6c048b9558657301210048fd4949b6bo0&ajaxhist=0%2b",

            // long uri with escaped unicode at end
            "http://www.bing.com/images/search?q=dotnet-bot&view=detailv2&&id=32C6FE9F03213C3FC9C05C605AA02ED5DC14796D&selectedIndex=0&ccid=tsBIuVWG&simid=608052183613704343&thid=OIP.Mb6c048b9558657301210048fd4949b6bo0&ajaxhist=0%CE%95",

            // long uri with escaped unicode early
            "http://www.bing.com/images/search?q=%CE%95dotnet-bot&view=detailv2&&id=32C6FE9F03213C3FC9C05C605AA02ED5DC14796D&selectedIndex=0&ccid=tsBIuVWG&simid=608052183613704343&thid=OIP.Mb6c048b9558657301210048fd4949b6bo0&ajaxhist=0",

            // long ASCII uri
            "http://www.bing.com/images/search?q=dotnet-bot&view=detailv2&&id=32C6FE9F03213C3FC9C05C605AA02ED5DC14796D&selectedIndex=0&ccid=tsBIuVWG&simid=608052183613704343&thid=OIP.Mb6c048b9558657301210048fd4949b6bo0&ajaxhist=0",
        };

        var sw = new Stopwatch();
        foreach (string url in urls)
        {
            int gen0 = GC.CollectionCount(0);
            sw.Restart();
            for (int i = 0; i < 5000000; i++) new Uri(url);
            sw.Stop();
            gen0 = GC.CollectionCount(0) - gen0;
            Console.WriteLine(sw.Elapsed.TotalSeconds + ", " + gen0);
        }
    }
}
```
Results (lower is better, and these tests were run including the commit from #13643):

|Before (time, GCs)|After (time, GCs)|
|---|---|
|2.3879161, 305|1.9582606, 171|
|2.5444187, 324|2.2631903, 172|
|6.0763754, 1526|5.7146562, 1373|
|9.8780414, 2594|7.1667422, 1907|
|10.3655053, 1278|4.3081596, 172|
|32.5682384, 6884|23.7972498, 5245|
|29.4111472, 9479|22.1958248, 6542|
|9.9326049, 1259|4.4754632, 171|

With https://github.com/dotnet/corefx/pull/13643, fixes #13622.
cc: @davidsh, @cipop, @geoffkizer, @justinvp 