### PR TITLE
Fix XmlSchema and XSLT failing tests on Unix

### DIFF
--- a/src/Common/tests/System/Xml/XmlCoreTest/FilePathUtil.cs
+++ b/src/Common/tests/System/Xml/XmlCoreTest/FilePathUtil.cs
@@ -35,12 +35,12 @@ namespace XmlCoreTest.Common
 
         public static string GetFileStandardPath()
         {
-            return GetFileDataPath() + "/" + "StandardTests";
+            return Path.Combine(GetFileDataPath(), "StandardTests");
         }
 
         public static string GetHttpStandardPath()
         {
-            return GetHttpDataPath() + "/" + "StandardTests";
+            return Path.Combine(GetHttpDataPath(), "StandardTests");
         }
 
         public static string GetTestDataPath()
@@ -50,12 +50,12 @@ namespace XmlCoreTest.Common
 
         public static string GetFileTestDataPath()
         {
-            return GetFileDataPath() + "/" + "TestData";
+            return Path.Combine(GetFileDataPath(), "TestData");
         }
 
         public static string GetHttpTestDataPath()
         {
-            return GetHttpDataPath() + "/" + "TestData";
+            return Path.Combine(GetHttpDataPath(), "TestData");
         }
 
         public static string GetVariableValue(string name)

--- a/src/System.Private.Xml/tests/System.Private.Xml.Tests.builds
+++ b/src/System.Private.Xml/tests/System.Private.Xml.Tests.builds
@@ -77,12 +77,8 @@
       <TargetGroup>netstandard1.3</TargetGroup>
       <TestTFMs>netcoreapp1.0;netcore50;net46</TestTFMs>
     </Project>
-    <Project Include="XmlSchema\XmlSchemaSet\System.Xml.XmlSchemaSet.Tests.csproj">
-      <OSGroup>Windows_NT</OSGroup>
-    </Project>
-    <Project Include="XmlSchema\XmlSchemaValidatorApi\System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests.csproj">
-      <OSGroup>Windows_NT</OSGroup>
-    </Project>
+    <Project Include="XmlSchema\XmlSchemaSet\System.Xml.XmlSchemaSet.Tests.csproj" />
+    <Project Include="XmlSchema\XmlSchemaValidatorApi\System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests.csproj" />
     <Project Include="XmlSerializer\System.Xml.XmlSerializer.Tests.csproj" />
     <Project Include="XmlWriter\System.Xml.RW.XmlWriter.Tests.csproj" />
     <Project Include="XmlWriter\System.Xml.RW.XmlWriter.Tests.csproj">
@@ -100,15 +96,10 @@
       <TestTFMs>netcoreapp1.0;net46</TestTFMs>
     </Project>
     <Project Include="Xslt\XslCompiledTransformApi\System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj">
-      <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>netcoreapp1.1</TestTFMs>
     </Project>
-    <Project Include="Xslt\XsltCompiler\XsltCompiler.Tests.csproj">
-      <OSGroup>Windows_NT</OSGroup>
-    </Project>
-    <Project Include="Xslt\XslTransformApi\System.Xml.Xsl.XslTransformApi.Tests.csproj">
-      <OSGroup>Windows_NT</OSGroup>
-    </Project>
+    <Project Include="Xslt\XsltCompiler\XsltCompiler.Tests.csproj" />
+    <Project Include="Xslt\XslTransformApi\System.Xml.Xsl.XslTransformApi.Tests.csproj" />
     <Project Include="XmlDocument\Performance\System.Xml.XmlDocument.Performance.Tests.csproj">
       <TargetGroup>netstandard1.3</TargetGroup>
       <TestTFMs>netcoreapp1.0</TestTFMs>

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet.cs
@@ -2,33 +2,35 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
+
 namespace System.Xml.Tests
 {
     public class TestData
     {
-        internal static string _Root = @"TestFiles\TestData\";
-        internal static string StandardPath = @"TestFiles\StandardTests\";
-        internal static string _FileXSD1 = _Root + "schema1.xsd";
-        internal static string _FileXSD1bis = _Root + "schema1bis.xsd";
-        internal static string _NmspXSD1 = _Root + "schema1.xsd";
+        internal static string _Root = Path.Combine("TestFiles", "TestData");
+        internal static string StandardPath = Path.Combine("TestFiles", "StandardTests");
+        internal static string _FileXSD1 = Path.Combine(_Root, "schema1.xsd");
+        internal static string _FileXSD1bis = Path.Combine(_Root, "schema1bis.xsd");
+        internal static string _NmspXSD1 = Path.Combine(_Root, "schema1.xsd");
 
-        internal static string _FileXSD2 = _Root + "schema2.xsd";
-        internal static string _NmspXSD2 = _Root + "schema2.xsd";
+        internal static string _FileXSD2 = Path.Combine(_Root, "schema2.xsd");
+        internal static string _NmspXSD2 = Path.Combine(_Root, "schema2.xsd");
 
-        internal static string _XsdAuthor = _Root + "xsdauthor.xsd";
-        internal static string _XsdAuthorNoNs = _Root + "xsdauthor_nons.xsd"; // No targetNS
-        internal static string _XsdAuthorDup = _Root + "xsdauthor_dup.xsd";  // Colliding xsd
-        internal static string _XsdPrice = _Root + "xsdprice.xsd";
-        internal static string _XsdBookExternal = _Root + "xsdbookexternal.xsd";
-        internal static string _NmspBook = _Root + "xsdbook";
+        internal static string _XsdAuthor = Path.Combine(_Root, "xsdauthor.xsd");
+        internal static string _XsdAuthorNoNs = Path.Combine(_Root, "xsdauthor_nons.xsd"); // No targetNS
+        internal static string _XsdAuthorDup = Path.Combine(_Root, "xsdauthor_dup.xsd");  // Colliding xsd
+        internal static string _XsdPrice = Path.Combine(_Root, "xsdprice.xsd");
+        internal static string _XsdBookExternal = Path.Combine(_Root, "xsdbookexternal.xsd");
+        internal static string _NmspBook = Path.Combine(_Root, "xsdbook");
 
-        internal static string _XsdError = _Root + "xsderror.xsd";
-        internal static string _XsdError2 = _Root + "xsderror2.xsd";
-        internal static string _NmspError = _Root + "xsderror";
-        internal static string _XdrError = _Root + "xdrerror.xdr";
+        internal static string _XsdError = Path.Combine(_Root, "xsderror.xsd");
+        internal static string _XsdError2 = Path.Combine(_Root, "xsderror2.xsd");
+        internal static string _NmspError = Path.Combine(_Root, "xsderror");
+        internal static string _XdrError = Path.Combine(_Root, "xdrerror.xdr");
 
-        internal static string _XsdNoNs = _Root + "nons.xsd";
+        internal static string _XsdNoNs = Path.Combine(_Root, "nons.xsd");
 
-        internal static string _SchemaXdr = _Root + "schema1.xdr";
+        internal static string _SchemaXdr = Path.Combine(_Root, "schema1.xdr");
     }
 }

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_Schema.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_Schema.cs
@@ -190,21 +190,21 @@ namespace System.Xml.Tests
         [Fact]
         public void v7()
         {
-            Assert.Equal(0, AddSchema(TestData._Root + "Bug430164_c_import.xsd", TestData._Root + "Bug430164.xsd", 2));
+            Assert.Equal(0, AddSchema(Path.Combine(TestData._Root, "Bug430164_c_import.xsd"), Path.Combine(TestData._Root, "Bug430164.xsd"), 2));
         }
 
         //[Variation(Desc = "v8 - 430164_include Add(XmlSchema)")]
         [Fact]
         public void v8()
         {
-            Assert.Equal(0, AddSchema(TestData._Root + "Bug430164_b_include.xsd", TestData._Root + "Bug430164.xsd", 1));
+            Assert.Equal(0, AddSchema(Path.Combine(TestData._Root, "Bug430164_b_include.xsd"), Path.Combine(TestData._Root, "Bug430164.xsd"), 1));
         }
 
         //[Variation(Desc = "v9 - 430164_redefine Add(XmlSchema)")]
         [Fact]
         public void v9()
         {
-            Assert.Equal(0, AddSchema(TestData._Root + "Bug430164_a_redefine.xsd", TestData._Root + "Bug430164.xsd", 1));
+            Assert.Equal(0, AddSchema(Path.Combine(TestData._Root, "Bug430164_a_redefine.xsd"), Path.Combine(TestData._Root, "Bug430164.xsd"), 1));
         }
 
         private int AddSchema(string path1, string path2, int expCount)
@@ -253,11 +253,11 @@ namespace System.Xml.Tests
         public void v10()
         {
             XmlCachedSchemaSetResolver resolver = new XmlCachedSchemaSetResolver();
-            XmlTextReader r = new XmlTextReader(TestData._Root + @"RedefineEmployee.xsd");
+            XmlTextReader r = new XmlTextReader(Path.Combine(TestData._Root, @"RedefineEmployee.xsd"));
             XmlSchema s = XmlSchema.Read(r, null);
             resolver.Add(new Uri(s.SourceUri), s);
 
-            XmlTextReader r2 = new XmlTextReader(TestData._Root + @"BaseEmployee2.xsd");
+            XmlTextReader r2 = new XmlTextReader(Path.Combine(TestData._Root, @"BaseEmployee2.xsd"));
             XmlSchema s2 = XmlSchema.Read(r2, null);
             resolver.Add(new Uri(s2.SourceUri), s2);
 
@@ -281,7 +281,7 @@ namespace System.Xml.Tests
             Assert.Equal(set.Contains(s), true);
             Assert.Equal(set.IsCompiled, true);
 
-            XmlTextReader r3 = new XmlTextReader(TestData._Root + @"BaseEmployee2.xsd");
+            XmlTextReader r3 = new XmlTextReader(Path.Combine(TestData._Root, @"BaseEmployee2.xsd"));
             XmlSchema s3 = XmlSchema.Read(r3, null);
             resolver.Add(new Uri(s3.SourceUri), s3);
 
@@ -323,11 +323,11 @@ namespace System.Xml.Tests
         {
             XmlCachedSchemaSetResolver resolver = new XmlCachedSchemaSetResolver();
 
-            XmlTextReader r = new XmlTextReader(TestData._Root + @"RedefineEmployee.xsd");
+            XmlTextReader r = new XmlTextReader(Path.Combine(TestData._Root, @"RedefineEmployee.xsd"));
             XmlSchema s = XmlSchema.Read(r, null);
             resolver.Add(new Uri(s.SourceUri), s);
 
-            XmlTextReader r2 = new XmlTextReader(TestData._Root + @"BaseEmployee2.xsd");
+            XmlTextReader r2 = new XmlTextReader(Path.Combine(TestData._Root, @"BaseEmployee2.xsd"));
             XmlSchema s2 = XmlSchema.Read(r2, null);
             resolver.Add(new Uri(s2.SourceUri), s2);
 
@@ -353,11 +353,11 @@ namespace System.Xml.Tests
             settings.ValidationType = ValidationType.Schema;
             settings.Schemas = set;
 
-            using (XmlReader reader = XmlReader.Create(TestData._Root + "EmployeesDefaultPrefix.xml", settings))
+            using (XmlReader reader = XmlReader.Create(Path.Combine(TestData._Root, "EmployeesDefaultPrefix.xml"), settings))
             {
                 while (reader.Read()) ;
             }
-            XmlTextReader r3 = new XmlTextReader(TestData._Root + @"BaseEmployee2.xsd");
+            XmlTextReader r3 = new XmlTextReader(Path.Combine(TestData._Root, @"BaseEmployee2.xsd"));
             XmlSchema s3 = XmlSchema.Read(r3, null);
             resolver.Add(new Uri(s3.SourceUri), s3);
 
@@ -391,7 +391,7 @@ namespace System.Xml.Tests
 
             settings.Schemas = set2;
 
-            using (XmlReader reader = XmlReader.Create(TestData._Root + "EmployeesDefaultPrefix.xml", settings))
+            using (XmlReader reader = XmlReader.Create(Path.Combine(TestData._Root, "EmployeesDefaultPrefix.xml"), settings))
             {
                 while (reader.Read()) ;
             }
@@ -402,10 +402,10 @@ namespace System.Xml.Tests
         [Fact]
         public void v12a()
         {
-            using (XmlReader r = XmlReader.Create(TestData._Root + @"bug264908_v1.xsd"))
+            using (XmlReader r = XmlReader.Create(Path.Combine(TestData._Root, @"bug264908_v1.xsd")))
             {
                 XmlSchema s = XmlSchema.Read(r, null);
-                using (XmlReader r2 = XmlReader.Create(TestData._Root + @"bug264908_v1a.xsd"))
+                using (XmlReader r2 = XmlReader.Create(Path.Combine(TestData._Root, @"bug264908_v1a.xsd")))
                 {
                     XmlSchema s2 = XmlSchema.Read(r2, null);
                     XmlSchemaSet set = new XmlSchemaSet();

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_URL.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_URL.cs
@@ -154,7 +154,7 @@ namespace System.Xml.Tests
 
             try
             {
-                sc.Add(null, TestData._Root + "schema1.xdr");
+                sc.Add(null, Path.Combine(TestData._Root, "schema1.xdr"));
             }
             catch (XmlSchemaException)
             {
@@ -242,8 +242,8 @@ namespace System.Xml.Tests
         //[Variation(Desc = "435368 - schema validation error")]
         public void v13()
         {
-            string xsdPath = TestData._Root + @"bug435368.xsd";
-            string xmlPath = TestData._Root + @"bug435368.xml";
+            string xsdPath = Path.Combine(TestData._Root, @"bug435368.xsd");
+            string xmlPath = Path.Combine(TestData._Root, @"bug435368.xml");
 
             XmlSchemaSet xs = new XmlSchemaSet();
             xs.Add(null, xsdPath);

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_AllowXmlAttributes.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_AllowXmlAttributes.cs
@@ -4,6 +4,7 @@
 
 using Xunit;
 using Xunit.Abstractions;
+using System.IO;
 using System.Xml;
 using System.Xml.Schema;
 
@@ -29,7 +30,7 @@ namespace System.Xml.Tests
 
         public void Initialize()
         {
-            this.testData = TestData._Root + @"AllowXmlAttributes\";
+            this.testData = Path.Combine(TestData._Root, "AllowXmlAttributes");
             bWarningCallback = bErrorCallback = false;
             errorCount = warningCount = 0;
         }
@@ -273,9 +274,9 @@ namespace System.Xml.Tests
             xss.XmlResolver = new XmlUrlResolver();
             xss.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
             if (xsdFile != null)
-                xss.Add(null, testData + xsdFile);
+                xss.Add(null, Path.Combine(testData, xsdFile));
 
-            XmlReader vr = CreateReader(testData + xmlFile, xss, allowXmlAttributes);
+            XmlReader vr = CreateReader(Path.Combine(testData, xmlFile), xss, allowXmlAttributes);
             while (vr.Read()) ;
 
             Assert.Equal(warningCount, expectedWarningCount);

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -76,7 +76,7 @@ namespace System.Xml.Tests
 
             try
             {
-                sc.Add(null, TestData._Root + "schema1.xdr");
+                sc.Add(null, Path.Combine(TestData._Root, "schema1.xdr"));
             }
             catch (XmlSchemaException)
             {

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Count.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Count.cs
@@ -4,6 +4,7 @@
 
 using Xunit;
 using Xunit.Abstractions;
+using System.IO;
 using System.Xml.Schema;
 
 namespace System.Xml.Tests
@@ -55,7 +56,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.Add("xsdauthor", TestData._XsdAuthor);
-            sc.Add(null, TestData._Root + "xsdbookexternal.xsd");
+            sc.Add(null, Path.Combine(TestData._Root, "xsdbookexternal.xsd"));
 
             CError.Compare(sc.Count, 2, "Count");
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_EnableUpaCheck.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_EnableUpaCheck.cs
@@ -5,6 +5,7 @@
 using Xunit;
 using Xunit.Abstractions;
 using System;
+using System.IO;
 using System.Xml;
 using System.Xml.Schema;
 
@@ -32,7 +33,7 @@ namespace System.Xml.Tests
 
         public void Initialize()
         {
-            this.testData = TestData._Root + @"EnableUpaCheck\";
+            this.testData = Path.Combine(TestData._Root, "EnableUpaCheck");
             bWarningCallback = bErrorCallback = false;
             errorCount = 0;
             errorLineNumbers = new Int32[10];
@@ -148,9 +149,9 @@ namespace System.Xml.Tests
             XmlSchemaSet xss = new XmlSchemaSet();
             xss.XmlResolver = new XmlUrlResolver();
             xss.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            xss.Add(null, testData + xsdFile);
+            xss.Add(null, Path.Combine(testData, xsdFile));
 
-            XmlReader vr = CreateReader(testData + xmlFile, xss, false);
+            XmlReader vr = CreateReader(Path.Combine(testData, xmlFile), xss, false);
             while (vr.Read()) ;
 
             CError.Compare(errorCount, expectedErrorCount, "Error Count mismatch");

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_GlobalElements.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_GlobalElements.cs
@@ -181,7 +181,7 @@ namespace System.Xml.Tests
 
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
-            XmlSchema schema1 = ss.Add(null, TestData._Root + uri1);
+            XmlSchema schema1 = ss.Add(null, Path.Combine(TestData._Root, uri1));
             ss.Compile();
             CError.Compare(ss.GlobalElements.Count, 3, "Types Count after add"); // +1 for root in ns-a
             CError.Compare(ss.GlobalElements.Contains(new XmlQualifiedName(e1, ns1)), true, "Contains1");
@@ -217,8 +217,8 @@ namespace System.Xml.Tests
 
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
-            ss.Add(null, TestData._Root + "xsdauthor.xsd");
-            XmlSchema schema1 = ss.Add(null, TestData._Root + uri1);
+            ss.Add(null, Path.Combine(TestData._Root, "xsdauthor.xsd"));
+            XmlSchema schema1 = ss.Add(null, Path.Combine(TestData._Root, uri1));
             ss.Compile();
             CError.Compare(ss.GlobalElements.Count, 4, "Types Count");  // +1 for root in ns-a and xsdauthor
             CError.Compare(ss.GlobalElements.Contains(new XmlQualifiedName(e1, ns1)), true, "Contains1");
@@ -241,7 +241,7 @@ namespace System.Xml.Tests
             string e1 = param1.ToString();
             string e2 = param2.ToString();
             XmlSchema s1 = GetSchema(ns1, e1, e2);
-            XmlSchema s2 = XmlSchema.Read(new StreamReader(new FileStream(TestData._Root + "invalid.xsd", FileMode.Open, FileAccess.Read)), null);
+            XmlSchema s2 = XmlSchema.Read(new StreamReader(new FileStream(Path.Combine(TestData._Root, "invalid.xsd"), FileMode.Open, FileAccess.Read)), null);
 
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.Add(s1);

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_GlobalTypes.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_GlobalTypes.cs
@@ -185,7 +185,7 @@ namespace System.Xml.Tests
 
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
-            XmlSchema schema1 = ss.Add(null, TestData._Root + uri1);
+            XmlSchema schema1 = ss.Add(null, Path.Combine(TestData._Root, uri1));
             ss.Compile();
             CError.Compare(ss.GlobalTypes.Count, 3, "Types Count"); //+1 for anyType
             CError.Compare(ss.GlobalTypes.Contains(new XmlQualifiedName(type1, ns1)), true, "Contains1");
@@ -221,8 +221,8 @@ namespace System.Xml.Tests
 
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
-            ss.Add(null, TestData._Root + "xsdauthor.xsd");
-            XmlSchema schema1 = ss.Add(null, TestData._Root + uri1);
+            ss.Add(null, Path.Combine(TestData._Root, "xsdauthor.xsd"));
+            XmlSchema schema1 = ss.Add(null, Path.Combine(TestData._Root, uri1));
             ss.Compile();
             CError.Compare(ss.GlobalTypes.Count, 3, "Types Count"); //+1 for anyType
             CError.Compare(ss.GlobalTypes.Contains(new XmlQualifiedName(type1, ns1)), true, "Contains1");

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Imports.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Imports.cs
@@ -4,6 +4,7 @@
 
 using Xunit;
 using Xunit.Abstractions;
+using System.IO;
 using System.Xml;
 using System.Xml.Schema;
 
@@ -33,7 +34,7 @@ namespace System.Xml.Tests
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
 
-            XmlSchema parent = sc.Add(null, TestData._Root + param0.ToString());
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
             CError.Compare(sc.Count, param2, "Count");
 
             CError.Compare(sc.IsCompiled, false, "IsCompiled");
@@ -60,7 +61,7 @@ namespace System.Xml.Tests
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
 
-            sc.Add((string)param3, TestData._Root + param1.ToString());
+            sc.Add((string)param3, Path.Combine(TestData._Root, param1.ToString()));
             CError.Compare(sc.Count, 1, "AddCount");
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -68,7 +69,7 @@ namespace System.Xml.Tests
             CError.Compare(sc.Count, 1, "CompileCount");
             CError.Compare(sc.IsCompiled, true, "CompileIsCompiled");
 
-            XmlSchema parent = sc.Add(null, TestData._Root + param0.ToString());
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
 
             CError.Compare(sc.Count, param2, "Add2Count");
             CError.Compare(sc.IsCompiled, false, "Add2IsCompiled");
@@ -90,7 +91,7 @@ namespace System.Xml.Tests
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
 
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v5_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v5_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 2, "AddCount");
 
@@ -98,7 +99,7 @@ namespace System.Xml.Tests
             CError.Compare(sc.IsCompiled, true, "CompileIsCompiled");
             CError.Compare(sc.Count, 2, "CompileCount");
 
-            XmlSchema orig = sc.Add(null, TestData._Root + "import_v4_b.xsd"); // should be already present in the set
+            XmlSchema orig = sc.Add(null, Path.Combine(TestData._Root, "import_v4_b.xsd")); // should be already present in the set
 
             CError.Compare(sc.IsCompiled, true, "Add2IsCompiled");
             CError.Compare(sc.Count, 2, "Add2Count");
@@ -119,7 +120,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v5_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v5_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 2, "AddCount");
 
@@ -127,7 +128,7 @@ namespace System.Xml.Tests
             CError.Compare(sc.IsCompiled, true, "CompileIsCompiled");
             CError.Compare(sc.Count, 2, "CompileCount");
 
-            sc.Add("ns-b", TestData._Root + "import_v4_b.xsd"); // should be already present in the set
+            sc.Add("ns-b", Path.Combine(TestData._Root, "import_v4_b.xsd")); // should be already present in the set
 
             CError.Compare(sc.Count, 3, "Count");
             CError.Compare(sc.IsCompiled, false, "IsCompiled");
@@ -148,7 +149,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v2_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v2_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 2, "AddCount");
 
@@ -156,7 +157,7 @@ namespace System.Xml.Tests
             CError.Compare(sc.IsCompiled, true, "CompileIsCompiled");
             CError.Compare(sc.Count, 2, "CompileCount");
 
-            sc.Add("ns-b", TestData._Root + "import_v2_b.xsd"); // should be already present in the set
+            sc.Add("ns-b", Path.Combine(TestData._Root, "import_v2_b.xsd")); // should be already present in the set
             CError.Compare(sc.Count, 2, "Count");
             CError.Compare(sc.IsCompiled, true, "IsCompiled");
 
@@ -177,7 +178,7 @@ namespace System.Xml.Tests
             bool found = false;
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v9_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v9_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 3, "AddCount");
 
@@ -185,8 +186,8 @@ namespace System.Xml.Tests
             CError.Compare(sc.Count, 3, "CompileCount");
             CError.Compare(sc.IsCompiled, true, "CompileIsCompiled");
 
-            XmlSchema sch_B = sc.Add(null, TestData._Root + "import_v9_b.xsd"); // should be already present in the set
-            sc.Add(null, TestData._Root + "import_v9_c.xsd");				   // should be already present in the set
+            XmlSchema sch_B = sc.Add(null, Path.Combine(TestData._Root, "import_v9_b.xsd")); // should be already present in the set
+            sc.Add(null, Path.Combine(TestData._Root, "import_v9_c.xsd"));				   // should be already present in the set
 
             CError.Compare(sc.Count, 3, "Count");
             CError.Compare(sc.IsCompiled, true, "IsCompiled");
@@ -213,7 +214,7 @@ namespace System.Xml.Tests
             bool found = false;
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v10_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v10_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 3, "AddCount");
 
@@ -221,8 +222,8 @@ namespace System.Xml.Tests
             CError.Compare(sc.Count, 3, "CompileCount");
             CError.Compare(sc.IsCompiled, true, "CompileIsCompiled");
 
-            XmlSchema sch_B = sc.Add(null, TestData._Root + "import_v10_b.xsd"); // should be already present in the set
-            sc.Add(null, TestData._Root + "import_v10_c.xsd");				   // should be already present in the set
+            XmlSchema sch_B = sc.Add(null, Path.Combine(TestData._Root, "import_v10_b.xsd")); // should be already present in the set
+            sc.Add(null, Path.Combine(TestData._Root, "import_v10_c.xsd"));				   // should be already present in the set
 
             CError.Compare(sc.Count, 3, "Count");
             CError.Compare(sc.IsCompiled, true, "IsCompiled");
@@ -242,7 +243,7 @@ namespace System.Xml.Tests
             if (!found) Assert.True(false);
 
             // try adding no ns schema with an ns
-            sc.Add("ns-b", TestData._Root + "import_v10_b.xsd");
+            sc.Add("ns-b", Path.Combine(TestData._Root, "import_v10_b.xsd"));
             CError.Compare(sc.Count, 4, "Count");
 
             return;
@@ -256,7 +257,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v11_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v11_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 3, "AddCount");
 
@@ -275,7 +276,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v12_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v12_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 3, "AddCount");
 
@@ -294,7 +295,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v13_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v13_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 4, "AddCount");
 
@@ -312,7 +313,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v14_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v14_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 3, "AddCount");
 
@@ -331,7 +332,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v15_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v15_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 2, "AddCount");
 
@@ -348,11 +349,11 @@ namespace System.Xml.Tests
         public void v16()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
-            sc.Add(null, TestData._Root + "import_v16_b.xsd");
+            sc.Add(null, Path.Combine(TestData._Root, "import_v16_b.xsd"));
             CError.Compare(sc.IsCompiled, false, "Add1IsCompiled");
             CError.Compare(sc.Count, 1, "Add1Count");
 
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v16_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v16_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "Add2IsCompiled");
             CError.Compare(sc.Count, 2, "Add2Count");
 
@@ -370,7 +371,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v17_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v17_a.xsd"));
 
             CError.Compare(sc.Count, 2, "Count");
             CError.Compare(sc.IsCompiled, false, "IsCompiled");
@@ -394,7 +395,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v18_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v18_a.xsd"));
 
             CError.Compare(sc.Count, 2, "Count");
             CError.Compare(sc.IsCompiled, false, "IsCompiled");
@@ -418,7 +419,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v19_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v19_a.xsd"));
             CError.Compare(sc.Count, 3, "Count");
 
             sc.Compile();
@@ -438,14 +439,14 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v20_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v20_a.xsd"));
             CError.Compare(sc.Count, 4, "Count");
 
             sc.Compile();
             // try to add each individually
-            XmlSchema b = sc.Add(null, TestData._Root + "import_v20_b.xsd");
-            XmlSchema c = sc.Add(null, TestData._Root + "import_v20_c.xsd");
-            XmlSchema d = sc.Add(null, TestData._Root + "import_v20_d.xsd");
+            XmlSchema b = sc.Add(null, Path.Combine(TestData._Root, "import_v20_b.xsd"));
+            XmlSchema c = sc.Add(null, Path.Combine(TestData._Root, "import_v20_c.xsd"));
+            XmlSchema d = sc.Add(null, Path.Combine(TestData._Root, "import_v20_d.xsd"));
 
             CError.Compare(sc.Count, 4, "Count");
             CError.Compare(sc.IsCompiled, true, "IsCompiled");
@@ -466,10 +467,10 @@ namespace System.Xml.Tests
         public void v21(object param0, object param1, object param2, object param3)
         {
             XmlSchemaSet ss = new XmlSchemaSet();
-            ss.Add(null, TestData._Root + param0.ToString());
-            ss.Add(null, TestData._Root + param1.ToString());
-            ss.Add(null, TestData._Root + param2.ToString());
-            ss.Add(null, TestData._Root + param3.ToString());
+            ss.Add(null, Path.Combine(TestData._Root, param0.ToString()));
+            ss.Add(null, Path.Combine(TestData._Root, param1.ToString()));
+            ss.Add(null, Path.Combine(TestData._Root, param2.ToString()));
+            ss.Add(null, Path.Combine(TestData._Root, param3.ToString()));
             CError.Compare(ss.Count, 4, "AddCount");
             CError.Compare(ss.IsCompiled, false, "AddIsCompiled");
 
@@ -488,10 +489,10 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet ss = new XmlSchemaSet();
 
-            ss.Add(null, TestData._Root + param0.ToString());
-            ss.Add(null, TestData._Root + param1.ToString());
-            ss.Add(null, TestData._Root + param2.ToString());
-            ss.Add(null, TestData._Root + param3.ToString());
+            ss.Add(null, Path.Combine(TestData._Root, param0.ToString()));
+            ss.Add(null, Path.Combine(TestData._Root, param1.ToString()));
+            ss.Add(null, Path.Combine(TestData._Root, param2.ToString()));
+            ss.Add(null, Path.Combine(TestData._Root, param3.ToString()));
             CError.Compare(ss.Count, 4, "AddCount");
             CError.Compare(ss.IsCompiled, false, "AddIsCompiled");
 
@@ -509,8 +510,8 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
-            ss.Add(null, TestData._Root + "105897.xsd");
-            ss.Add(null, TestData._Root + "105897_a.xsd");
+            ss.Add(null, Path.Combine(TestData._Root, "105897.xsd"));
+            ss.Add(null, Path.Combine(TestData._Root, "105897_a.xsd"));
             CError.Compare(ss.Count, 3, "AddCount");
             CError.Compare(ss.IsCompiled, false, "AddIsCompiled");
 
@@ -526,7 +527,7 @@ namespace System.Xml.Tests
             settings.Schemas = new XmlSchemaSet();
             settings.Schemas.Add(ss);
 
-            using (XmlReader vr = XmlReader.Create(TestData._Root + "105897.xml", settings))
+            using (XmlReader vr = XmlReader.Create(Path.Combine(TestData._Root, "105897.xml"), settings))
             {
                 while (vr.Read()) ;
             }
@@ -547,7 +548,7 @@ namespace System.Xml.Tests
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
 
-            XmlSchema parent = sc.Add(null, TestData._Root + param0.ToString());
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
             CError.Compare(sc.Count, param2, "Count");
             CError.Compare(sc.IsCompiled, false, "IsCompiled");
 
@@ -577,7 +578,7 @@ namespace System.Xml.Tests
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
 
-            XmlSchema sch = sc.Add((string)param3, TestData._Root + param1.ToString());
+            XmlSchema sch = sc.Add((string)param3, Path.Combine(TestData._Root, param1.ToString()));
             CError.Compare(sc.Count, 1, "AddCount");
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -589,7 +590,7 @@ namespace System.Xml.Tests
             CError.Compare(sc.Count, 1, "CompileCount");
             CError.Compare(sc.IsCompiled, true, "CompileIsCompiled");
 
-            XmlSchema parent = sc.Add(null, TestData._Root + param0.ToString());
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
             CError.Compare(sc.Count, param2, "Add2Count");
             CError.Compare(sc.IsCompiled, false, "Add2IsCompiled");
 
@@ -617,7 +618,7 @@ namespace System.Xml.Tests
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
 
-            XmlSchema sch = sc.Add((string)param3, TestData._Root + param1.ToString());
+            XmlSchema sch = sc.Add((string)param3, Path.Combine(TestData._Root, param1.ToString()));
             CError.Compare(sc.Count, 1, "AddCount");
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -631,7 +632,7 @@ namespace System.Xml.Tests
 
             try
             {
-                XmlSchema parent = sc.Add(null, TestData._Root + param0.ToString());
+                XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
                 Assert.True(false);
             }
             catch (XmlSchemaException) { }
@@ -658,7 +659,7 @@ namespace System.Xml.Tests
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
 
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v5_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v5_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 2, "AddCount");
 
@@ -670,7 +671,7 @@ namespace System.Xml.Tests
             CError.Compare(sc.IsCompiled, true, "CompileIsCompiled");
             CError.Compare(sc.Count, 2, "CompileCount");
 
-            XmlSchema orig = sc.Add(null, TestData._Root + "import_v4_b.xsd"); // should be already present in the set
+            XmlSchema orig = sc.Add(null, Path.Combine(TestData._Root, "import_v4_b.xsd")); // should be already present in the set
             CError.Compare(sc.IsCompiled, true, "Add2IsCompiled");
             CError.Compare(sc.Count, 2, "Add2Count");
             CError.Compare(orig.SourceUri.Contains("import_v4_b.xsd"), true, "Compare the schema object");
@@ -699,7 +700,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v5_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v5_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 2, "AddCount");
 
@@ -711,7 +712,7 @@ namespace System.Xml.Tests
             CError.Compare(sc.IsCompiled, true, "CompileIsCompiled");
             CError.Compare(sc.Count, 2, "CompileCount");
 
-            XmlSchema sch_B = sc.Add("ns-b", TestData._Root + "import_v4_b.xsd"); // should be already present in the set
+            XmlSchema sch_B = sc.Add("ns-b", Path.Combine(TestData._Root, "import_v4_b.xsd")); // should be already present in the set
             CError.Compare(sc.Count, 3, "Count");
             CError.Compare(sc.IsCompiled, false, "IsCompiled");
 
@@ -739,7 +740,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v2_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v2_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 2, "AddCount");
 
@@ -751,7 +752,7 @@ namespace System.Xml.Tests
             CError.Compare(sc.IsCompiled, true, "CompileIsCompiled");
             CError.Compare(sc.Count, 2, "CompileCount");
 
-            XmlSchema sch_B = sc.Add("ns-b", TestData._Root + "import_v2_b.xsd"); // should be already present in the set
+            XmlSchema sch_B = sc.Add("ns-b", Path.Combine(TestData._Root, "import_v2_b.xsd")); // should be already present in the set
             CError.Compare(sc.Count, 2, "Count");
             CError.Compare(sc.IsCompiled, true, "IsCompiled");
 
@@ -780,7 +781,7 @@ namespace System.Xml.Tests
             bool found = false;
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v9_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v9_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 3, "AddCount");
 
@@ -792,8 +793,8 @@ namespace System.Xml.Tests
             CError.Compare(sc.Count, 3, "CompileCount");
             CError.Compare(sc.IsCompiled, true, "CompileIsCompiled");
 
-            XmlSchema sch_B = sc.Add(null, TestData._Root + "import_v9_b.xsd"); // should be already present in the set
-            sc.Add(null, TestData._Root + "import_v9_c.xsd");				   // should be already present in the set
+            XmlSchema sch_B = sc.Add(null, Path.Combine(TestData._Root, "import_v9_b.xsd")); // should be already present in the set
+            sc.Add(null, Path.Combine(TestData._Root, "import_v9_c.xsd"));				   // should be already present in the set
             CError.Compare(sc.Count, 3, "Count");
             CError.Compare(sc.IsCompiled, true, "IsCompiled");
 
@@ -827,7 +828,7 @@ namespace System.Xml.Tests
             bool found = false;
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v10_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v10_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 3, "AddCount");
 
@@ -839,8 +840,8 @@ namespace System.Xml.Tests
             CError.Compare(sc.Count, 3, "CompileCount");
             CError.Compare(sc.IsCompiled, true, "CompileIsCompiled");
 
-            XmlSchema sch_B = sc.Add(null, TestData._Root + "import_v10_b.xsd"); // should be already present in the set
-            sc.Add(null, TestData._Root + "import_v10_c.xsd");				   // should be already present in the set
+            XmlSchema sch_B = sc.Add(null, Path.Combine(TestData._Root, "import_v10_b.xsd")); // should be already present in the set
+            sc.Add(null, Path.Combine(TestData._Root, "import_v10_c.xsd"));				   // should be already present in the set
             CError.Compare(sc.Count, 3, "Count");
             CError.Compare(sc.IsCompiled, true, "IsCompiled");
 
@@ -867,7 +868,7 @@ namespace System.Xml.Tests
             if (!found) Assert.True(false);
 
             // try adding no ns schema with an ns
-            sch_B = sc.Add("ns-b", TestData._Root + "import_v10_b.xsd");
+            sch_B = sc.Add("ns-b", Path.Combine(TestData._Root, "import_v10_b.xsd"));
             CError.Compare(sc.Count, 4, "Count");
 
             sc.Reprocess(sch_B);
@@ -889,7 +890,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v11_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v11_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 3, "AddCount");
 
@@ -913,7 +914,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v12_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v12_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 3, "AddCount");
 
@@ -937,7 +938,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v13_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v13_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 4, "AddCount");
 
@@ -959,7 +960,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v14_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v14_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 3, "AddCount");
 
@@ -982,7 +983,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v15_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v15_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 2, "AddCount");
 
@@ -1003,11 +1004,11 @@ namespace System.Xml.Tests
         public void v113()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
-            sc.Add(null, TestData._Root + "import_v16_b.xsd");
+            sc.Add(null, Path.Combine(TestData._Root, "import_v16_b.xsd"));
             CError.Compare(sc.IsCompiled, false, "Add1IsCompiled");
             CError.Compare(sc.Count, 1, "Add1Count");
 
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v16_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v16_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "Add2IsCompiled");
             CError.Compare(sc.Count, 2, "Add2Count");
 
@@ -1029,7 +1030,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v17_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v17_a.xsd"));
 
             CError.Compare(sc.Count, 2, "Count");
             CError.Compare(sc.IsCompiled, false, "IsCompiled");
@@ -1057,7 +1058,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v18_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v18_a.xsd"));
 
             CError.Compare(sc.Count, 2, "Count");
             CError.Compare(sc.IsCompiled, false, "IsCompiled");
@@ -1085,7 +1086,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v19_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v19_a.xsd"));
             CError.Compare(sc.Count, 3, "Count");
 
             sc.Reprocess(parent);
@@ -1109,7 +1110,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v20_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v20_a.xsd"));
             CError.Compare(sc.Count, 4, "Count");
 
             sc.Reprocess(parent);
@@ -1120,9 +1121,9 @@ namespace System.Xml.Tests
             CError.Compare(sc.IsCompiled, true, "IsCompiled");
             CError.Compare(sc.Count, 4, "CompileCount");
 
-            XmlSchema b = sc.Add(null, TestData._Root + "import_v20_b.xsd");
-            XmlSchema c = sc.Add(null, TestData._Root + "import_v20_c.xsd");
-            XmlSchema d = sc.Add(null, TestData._Root + "import_v20_d.xsd");
+            XmlSchema b = sc.Add(null, Path.Combine(TestData._Root, "import_v20_b.xsd"));
+            XmlSchema c = sc.Add(null, Path.Combine(TestData._Root, "import_v20_c.xsd"));
+            XmlSchema d = sc.Add(null, Path.Combine(TestData._Root, "import_v20_d.xsd"));
 
             CError.Compare(sc.Count, 4, "Count");
             CError.Compare(sc.IsCompiled, true, "IsCompiled");
@@ -1154,10 +1155,10 @@ namespace System.Xml.Tests
         public void v118(object param0, object param1, object param2, object param3)
         {
             XmlSchemaSet ss = new XmlSchemaSet();
-            XmlSchema Schema1 = ss.Add(null, TestData._Root + param0.ToString());
-            XmlSchema Schema2 = ss.Add(null, TestData._Root + param1.ToString());
-            XmlSchema Schema3 = ss.Add(null, TestData._Root + param2.ToString());
-            XmlSchema Schema4 = ss.Add(null, TestData._Root + param3.ToString());
+            XmlSchema Schema1 = ss.Add(null, Path.Combine(TestData._Root, param0.ToString()));
+            XmlSchema Schema2 = ss.Add(null, Path.Combine(TestData._Root, param1.ToString()));
+            XmlSchema Schema3 = ss.Add(null, Path.Combine(TestData._Root, param2.ToString()));
+            XmlSchema Schema4 = ss.Add(null, Path.Combine(TestData._Root, param3.ToString()));
             CError.Compare(ss.Count, 4, "AddCount");
             CError.Compare(ss.IsCompiled, false, "AddIsCompiled");
 
@@ -1186,10 +1187,10 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet ss = new XmlSchemaSet();
 
-            XmlSchema Schema1 = ss.Add(null, TestData._Root + param0.ToString());
-            XmlSchema Schema2 = ss.Add(null, TestData._Root + param1.ToString());
-            XmlSchema Schema3 = ss.Add(null, TestData._Root + param2.ToString());
-            XmlSchema Schema4 = ss.Add(null, TestData._Root + param3.ToString());
+            XmlSchema Schema1 = ss.Add(null, Path.Combine(TestData._Root, param0.ToString()));
+            XmlSchema Schema2 = ss.Add(null, Path.Combine(TestData._Root, param1.ToString()));
+            XmlSchema Schema3 = ss.Add(null, Path.Combine(TestData._Root, param2.ToString()));
+            XmlSchema Schema4 = ss.Add(null, Path.Combine(TestData._Root, param3.ToString()));
             CError.Compare(ss.Count, 4, "AddCount");
             CError.Compare(ss.IsCompiled, false, "AddIsCompiled");
 
@@ -1217,8 +1218,8 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
-            XmlSchema Schema1 = ss.Add(null, TestData._Root + "105897.xsd");
-            XmlSchema Schema2 = ss.Add(null, TestData._Root + "105897_a.xsd");
+            XmlSchema Schema1 = ss.Add(null, Path.Combine(TestData._Root, "105897.xsd"));
+            XmlSchema Schema2 = ss.Add(null, Path.Combine(TestData._Root, "105897_a.xsd"));
             CError.Compare(ss.Count, 3, "AddCount");
             CError.Compare(ss.IsCompiled, false, "AddIsCompiled");
 
@@ -1240,7 +1241,7 @@ namespace System.Xml.Tests
             settings.Schemas = new XmlSchemaSet();
             settings.Schemas.Add(ss);
 
-            using (XmlReader vr = XmlReader.Create(TestData._Root + "105897.xml", settings))
+            using (XmlReader vr = XmlReader.Create(Path.Combine(TestData._Root, "105897.xml"), settings))
             {
                 while (vr.Read()) ;
             }
@@ -1261,7 +1262,7 @@ namespace System.Xml.Tests
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
 
-            XmlSchema parent = sc.Add(null, TestData._Root + param0.ToString());
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
             CError.Compare(sc.Count, param2, "Count");
             CError.Compare(sc.IsCompiled, false, "IsCompiled");
 
@@ -1289,7 +1290,7 @@ namespace System.Xml.Tests
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
 
-            XmlSchema sch = sc.Add((string)param3, TestData._Root + param1.ToString());
+            XmlSchema sch = sc.Add((string)param3, Path.Combine(TestData._Root, param1.ToString()));
             CError.Compare(sc.Count, 1, "AddCount");
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -1301,7 +1302,7 @@ namespace System.Xml.Tests
             CError.Compare(sc.IsCompiled, false, "ReprocessIsCompiled");
             CError.Compare(sc.Count, 1, "ReprocessCount");
 
-            XmlSchema parent = sc.Add(null, TestData._Root + param0.ToString());
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
             CError.Compare(sc.Count, param2, "Add2Count");
             CError.Compare(sc.IsCompiled, false, "Add2IsCompiled");
 
@@ -1329,7 +1330,7 @@ namespace System.Xml.Tests
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
 
-            XmlSchema sch = sc.Add((string)param3, TestData._Root + param1.ToString());
+            XmlSchema sch = sc.Add((string)param3, Path.Combine(TestData._Root, param1.ToString()));
             CError.Compare(sc.Count, 1, "AddCount");
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -1342,7 +1343,7 @@ namespace System.Xml.Tests
             CError.Compare(sc.Count, 1, "ReprocessCount");
             try
             {
-                XmlSchema parent = sc.Add(null, TestData._Root + param0.ToString());
+                XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
                 Assert.True(false);
             }
             catch (XmlSchemaException) { }
@@ -1373,7 +1374,7 @@ namespace System.Xml.Tests
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
 
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v5_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v5_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 2, "AddCount");
 
@@ -1385,7 +1386,7 @@ namespace System.Xml.Tests
             CError.Compare(sc.IsCompiled, false, "ReprocessIsCompiled");
             CError.Compare(sc.Count, 2, "ReprocessCount");
 
-            XmlSchema orig = sc.Add(null, TestData._Root + "import_v4_b.xsd"); // should be already present in the set
+            XmlSchema orig = sc.Add(null, Path.Combine(TestData._Root, "import_v4_b.xsd")); // should be already present in the set
             CError.Compare(sc.IsCompiled, false, "Add2IsCompiled");
             CError.Compare(sc.Count, 2, "Add2Count");
             CError.Compare(orig.SourceUri.Contains("import_v4_b.xsd"), true, "Compare the schema object");
@@ -1414,7 +1415,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v5_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v5_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 2, "AddCount");
 
@@ -1426,7 +1427,7 @@ namespace System.Xml.Tests
             CError.Compare(sc.IsCompiled, false, "ReprocessIsCompiled");
             CError.Compare(sc.Count, 2, "ReprocessCount");
 
-            XmlSchema sch_B = sc.Add("ns-b", TestData._Root + "import_v4_b.xsd"); // should be already present in the set
+            XmlSchema sch_B = sc.Add("ns-b", Path.Combine(TestData._Root, "import_v4_b.xsd")); // should be already present in the set
             CError.Compare(sc.Count, 3, "Count");
             CError.Compare(sc.IsCompiled, false, "IsCompiled");
 
@@ -1454,7 +1455,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v2_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v2_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 2, "AddCount");
 
@@ -1466,7 +1467,7 @@ namespace System.Xml.Tests
             CError.Compare(sc.IsCompiled, false, "ReprocessIsCompiled");
             CError.Compare(sc.Count, 2, "ReprocessCount");
 
-            XmlSchema sch_B = sc.Add("ns-b", TestData._Root + "import_v2_b.xsd"); // should be already present in the set
+            XmlSchema sch_B = sc.Add("ns-b", Path.Combine(TestData._Root, "import_v2_b.xsd")); // should be already present in the set
             CError.Compare(sc.Count, 2, "Count");
             CError.Compare(sc.IsCompiled, false, "IsCompiled");
 
@@ -1495,7 +1496,7 @@ namespace System.Xml.Tests
             bool found = false;
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v9_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v9_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 3, "AddCount");
 
@@ -1507,8 +1508,8 @@ namespace System.Xml.Tests
             CError.Compare(sc.IsCompiled, false, "ReprocessIsCompiled");
             CError.Compare(sc.Count, 3, "ReprocessCount");
 
-            XmlSchema sch_B = sc.Add(null, TestData._Root + "import_v9_b.xsd"); // should be already present in the set
-            sc.Add(null, TestData._Root + "import_v9_c.xsd");				   // should be already present in the set
+            XmlSchema sch_B = sc.Add(null, Path.Combine(TestData._Root, "import_v9_b.xsd")); // should be already present in the set
+            sc.Add(null, Path.Combine(TestData._Root, "import_v9_c.xsd"));				   // should be already present in the set
             CError.Compare(sc.Count, 3, "Count");
             CError.Compare(sc.IsCompiled, false, "IsCompiled");
 
@@ -1542,7 +1543,7 @@ namespace System.Xml.Tests
             bool found = false;
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v10_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v10_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 3, "AddCount");
 
@@ -1554,8 +1555,8 @@ namespace System.Xml.Tests
             CError.Compare(sc.IsCompiled, false, "ReprocessIsCompiled");
             CError.Compare(sc.Count, 3, "ReprocessCount");
 
-            XmlSchema sch_B = sc.Add(null, TestData._Root + "import_v10_b.xsd"); // should be already present in the set
-            sc.Add(null, TestData._Root + "import_v10_c.xsd");				   // should be already present in the set
+            XmlSchema sch_B = sc.Add(null, Path.Combine(TestData._Root, "import_v10_b.xsd")); // should be already present in the set
+            sc.Add(null, Path.Combine(TestData._Root, "import_v10_c.xsd"));				   // should be already present in the set
             CError.Compare(sc.Count, 3, "Count");
             CError.Compare(sc.IsCompiled, false, "IsCompiled");
 
@@ -1582,7 +1583,7 @@ namespace System.Xml.Tests
             if (!found) Assert.True(false);
 
             // try adding no ns schema with an ns
-            sch_B = sc.Add("ns-b", TestData._Root + "import_v10_b.xsd");
+            sch_B = sc.Add("ns-b", Path.Combine(TestData._Root, "import_v10_b.xsd"));
             CError.Compare(sc.Count, 4, "Count");
 
             sc.Compile();
@@ -1603,7 +1604,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v11_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v11_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 3, "AddCount");
 
@@ -1626,7 +1627,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v12_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v12_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 3, "AddCount");
 
@@ -1649,7 +1650,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v13_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v13_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 4, "AddCount");
 
@@ -1671,7 +1672,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v14_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v14_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 3, "AddCount");
 
@@ -1694,7 +1695,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v15_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v15_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
             CError.Compare(sc.Count, 2, "AddCount");
 
@@ -1715,11 +1716,11 @@ namespace System.Xml.Tests
         public void v213()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
-            sc.Add(null, TestData._Root + "import_v16_b.xsd");
+            sc.Add(null, Path.Combine(TestData._Root, "import_v16_b.xsd"));
             CError.Compare(sc.IsCompiled, false, "Add1IsCompiled");
             CError.Compare(sc.Count, 1, "Add1Count");
 
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v16_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v16_a.xsd"));
             CError.Compare(sc.IsCompiled, false, "Add2IsCompiled");
             CError.Compare(sc.Count, 2, "Add2Count");
 
@@ -1741,7 +1742,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v17_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v17_a.xsd"));
 
             CError.Compare(sc.Count, 2, "Count");
             CError.Compare(sc.IsCompiled, false, "IsCompiled");
@@ -1768,7 +1769,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v18_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v18_a.xsd"));
 
             CError.Compare(sc.Count, 2, "Count");
             CError.Compare(sc.IsCompiled, false, "IsCompiled");
@@ -1795,7 +1796,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v19_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v19_a.xsd"));
             CError.Compare(sc.Count, 3, "Count");
 
             sc.Compile();
@@ -1818,7 +1819,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema parent = sc.Add(null, TestData._Root + "import_v20_a.xsd");
+            XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v20_a.xsd"));
             CError.Compare(sc.Count, 4, "Count");
 
             sc.Reprocess(parent);
@@ -1829,9 +1830,9 @@ namespace System.Xml.Tests
             CError.Compare(sc.IsCompiled, true, "IsCompiled");
             CError.Compare(sc.Count, 4, "CompileCount");
 
-            XmlSchema b = sc.Add(null, TestData._Root + "import_v20_b.xsd");
-            XmlSchema c = sc.Add(null, TestData._Root + "import_v20_c.xsd");
-            XmlSchema d = sc.Add(null, TestData._Root + "import_v20_d.xsd");
+            XmlSchema b = sc.Add(null, Path.Combine(TestData._Root, "import_v20_b.xsd"));
+            XmlSchema c = sc.Add(null, Path.Combine(TestData._Root, "import_v20_c.xsd"));
+            XmlSchema d = sc.Add(null, Path.Combine(TestData._Root, "import_v20_d.xsd"));
 
             CError.Compare(sc.Count, 4, "Count");
             CError.Compare(sc.IsCompiled, true, "IsCompiled");
@@ -1863,10 +1864,10 @@ namespace System.Xml.Tests
         public void v218(object param0, object param1, object param2, object param3)
         {
             XmlSchemaSet ss = new XmlSchemaSet();
-            XmlSchema Schema1 = ss.Add(null, TestData._Root + param0.ToString());
-            XmlSchema Schema2 = ss.Add(null, TestData._Root + param1.ToString());
-            XmlSchema Schema3 = ss.Add(null, TestData._Root + param2.ToString());
-            XmlSchema Schema4 = ss.Add(null, TestData._Root + param3.ToString());
+            XmlSchema Schema1 = ss.Add(null, Path.Combine(TestData._Root, param0.ToString()));
+            XmlSchema Schema2 = ss.Add(null, Path.Combine(TestData._Root, param1.ToString()));
+            XmlSchema Schema3 = ss.Add(null, Path.Combine(TestData._Root, param2.ToString()));
+            XmlSchema Schema4 = ss.Add(null, Path.Combine(TestData._Root, param3.ToString()));
             CError.Compare(ss.Count, 4, "AddCount");
             CError.Compare(ss.IsCompiled, false, "AddIsCompiled");
 
@@ -1895,10 +1896,10 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet ss = new XmlSchemaSet();
 
-            XmlSchema Schema1 = ss.Add(null, TestData._Root + param0.ToString());
-            XmlSchema Schema2 = ss.Add(null, TestData._Root + param1.ToString());
-            XmlSchema Schema3 = ss.Add(null, TestData._Root + param2.ToString());
-            XmlSchema Schema4 = ss.Add(null, TestData._Root + param3.ToString());
+            XmlSchema Schema1 = ss.Add(null, Path.Combine(TestData._Root, param0.ToString()));
+            XmlSchema Schema2 = ss.Add(null, Path.Combine(TestData._Root, param1.ToString()));
+            XmlSchema Schema3 = ss.Add(null, Path.Combine(TestData._Root, param2.ToString()));
+            XmlSchema Schema4 = ss.Add(null, Path.Combine(TestData._Root, param3.ToString()));
             CError.Compare(ss.Count, 4, "AddCount");
             CError.Compare(ss.IsCompiled, false, "AddIsCompiled");
 
@@ -1926,8 +1927,8 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
-            XmlSchema Schema1 = ss.Add(null, TestData._Root + "105897.xsd");
-            XmlSchema Schema2 = ss.Add(null, TestData._Root + "105897_a.xsd");
+            XmlSchema Schema1 = ss.Add(null, Path.Combine(TestData._Root, "105897.xsd"));
+            XmlSchema Schema2 = ss.Add(null, Path.Combine(TestData._Root, "105897_a.xsd"));
             CError.Compare(ss.Count, 3, "AddCount");
             CError.Compare(ss.IsCompiled, false, "AddIsCompiled");
 
@@ -1949,7 +1950,7 @@ namespace System.Xml.Tests
             settings.Schemas = new XmlSchemaSet();
             settings.Schemas.Add(ss);
 
-            using (XmlReader vr = XmlReader.Create(TestData._Root + "105897.xml", settings))
+            using (XmlReader vr = XmlReader.Create(Path.Combine(TestData._Root, "105897.xml"), settings))
             {
                 while (vr.Read()) ;
             }

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Includes.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Includes.cs
@@ -5,6 +5,7 @@
 using Xunit;
 using Xunit.Abstractions;
 using System;
+using System.IO;
 using System.Xml.Schema;
 
 namespace System.Xml.Tests
@@ -40,7 +41,7 @@ namespace System.Xml.Tests
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
 
-            XmlSchema schema = sc.Add(null, TestData._Root + param0.ToString()); // param as filename
+            XmlSchema schema = sc.Add(null, Path.Combine(TestData._Root, param0.ToString())); // param as filename
             CError.Compare(sc.Count, param1, "AddCount"); //compare the count
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -74,7 +75,7 @@ namespace System.Xml.Tests
 
             try
             {
-                schema = sc.Add(null, TestData._Root + "include_v2.xsd");
+                schema = sc.Add(null, Path.Combine(TestData._Root, "include_v2.xsd"));
             }
             catch (XmlSchemaException)
             {
@@ -96,7 +97,7 @@ namespace System.Xml.Tests
             sc.XmlResolver = new XmlUrlResolver();
             int elem_count = 0;
 
-            XmlSchema schema = sc.Add(null, TestData._Root + "include_v8_a.xsd");
+            XmlSchema schema = sc.Add(null, Path.Combine(TestData._Root, "include_v8_a.xsd"));
             CError.Compare(sc.Count, 1, "AddCount");
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -123,7 +124,7 @@ namespace System.Xml.Tests
             sc.XmlResolver = new XmlUrlResolver();
             int elem_count = 0;
 
-            XmlSchema schema = sc.Add(null, TestData._Root + "include_v9_a.xsd");
+            XmlSchema schema = sc.Add(null, Path.Combine(TestData._Root, "include_v9_a.xsd"));
             CError.Compare(sc.Count, 1, "AddCount");
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -151,7 +152,7 @@ namespace System.Xml.Tests
             sc.XmlResolver = new XmlUrlResolver();
             int elem_count = 0;
 
-            XmlSchema schema = sc.Add(null, TestData._Root + "include_v10_a.xsd");
+            XmlSchema schema = sc.Add(null, Path.Combine(TestData._Root, "include_v10_a.xsd"));
             CError.Compare(sc.Count, 1, "AddCount");
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -184,7 +185,7 @@ namespace System.Xml.Tests
             sc.XmlResolver = new XmlUrlResolver();
             int elem_count = 0;
 
-            XmlSchema schema = sc.Add(null, TestData._Root + "include_v11_a.xsd");
+            XmlSchema schema = sc.Add(null, Path.Combine(TestData._Root, "include_v11_a.xsd"));
             CError.Compare(sc.Count, 1, "AddCount");
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -227,7 +228,7 @@ namespace System.Xml.Tests
 
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
-            XmlSchema a = ss.Add(null, TestData._Root + "include_v12_a.xsd");
+            XmlSchema a = ss.Add(null, Path.Combine(TestData._Root, "include_v12_a.xsd"));
             CError.Compare(ss.Count, 1, "AddCount");
             CError.Compare(ss.IsCompiled, false, "AddIsCompiled");
 
@@ -268,7 +269,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
-            XmlSchema schema = sc.Add(null, TestData._Root + param0.ToString()); // param as filename
+            XmlSchema schema = sc.Add(null, Path.Combine(TestData._Root, param0.ToString())); // param as filename
             CError.Compare(sc.Count, param1, "AddCount"); //compare the count
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -315,7 +316,7 @@ namespace System.Xml.Tests
 
             try
             {
-                schema = sc.Add(null, TestData._Root + "include_v2.xsd");
+                schema = sc.Add(null, Path.Combine(TestData._Root, "include_v2.xsd"));
             }
             catch (XmlSchemaException)
             {
@@ -346,7 +347,7 @@ namespace System.Xml.Tests
             sc.XmlResolver = new XmlUrlResolver();
             int elem_count = 0;
 
-            XmlSchema schema = sc.Add(null, TestData._Root + "include_v8_a.xsd");
+            XmlSchema schema = sc.Add(null, Path.Combine(TestData._Root, "include_v8_a.xsd"));
             CError.Compare(sc.Count, 1, "AddCount");
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -377,7 +378,7 @@ namespace System.Xml.Tests
             sc.XmlResolver = new XmlUrlResolver();
             int elem_count = 0;
 
-            XmlSchema schema = sc.Add(null, TestData._Root + "include_v9_a.xsd");
+            XmlSchema schema = sc.Add(null, Path.Combine(TestData._Root, "include_v9_a.xsd"));
             CError.Compare(sc.Count, 1, "AddCount");
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -409,7 +410,7 @@ namespace System.Xml.Tests
             sc.XmlResolver = new XmlUrlResolver();
             int elem_count = 0;
 
-            XmlSchema schema = sc.Add(null, TestData._Root + "include_v10_a.xsd");
+            XmlSchema schema = sc.Add(null, Path.Combine(TestData._Root, "include_v10_a.xsd"));
             CError.Compare(sc.Count, 1, "AddCount");
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -446,7 +447,7 @@ namespace System.Xml.Tests
             sc.XmlResolver = new XmlUrlResolver();
             int elem_count = 0;
 
-            XmlSchema schema = sc.Add(null, TestData._Root + "include_v11_a.xsd");
+            XmlSchema schema = sc.Add(null, Path.Combine(TestData._Root, "include_v11_a.xsd"));
             CError.Compare(sc.Count, 1, "AddCount");
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -493,7 +494,7 @@ namespace System.Xml.Tests
 
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
-            XmlSchema a = ss.Add(null, TestData._Root + "include_v12_a.xsd");
+            XmlSchema a = ss.Add(null, Path.Combine(TestData._Root, "include_v12_a.xsd"));
             CError.Compare(ss.Count, 1, "AddCount");
             CError.Compare(ss.IsCompiled, false, "AddIsCompiled");
 
@@ -539,7 +540,7 @@ namespace System.Xml.Tests
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
 
-            XmlSchema schema = sc.Add(null, TestData._Root + param0.ToString()); // param as filename
+            XmlSchema schema = sc.Add(null, Path.Combine(TestData._Root, param0.ToString())); // param as filename
             CError.Compare(sc.Count, param1, "AddCount"); //compare the count
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -586,7 +587,7 @@ namespace System.Xml.Tests
 
             try
             {
-                schema = sc.Add(null, TestData._Root + "include_v2.xsd");
+                schema = sc.Add(null, Path.Combine(TestData._Root, "include_v2.xsd"));
             }
             catch (XmlSchemaException)
             {
@@ -617,7 +618,7 @@ namespace System.Xml.Tests
             sc.XmlResolver = new XmlUrlResolver();
             int elem_count = 0;
 
-            XmlSchema schema = sc.Add(null, TestData._Root + "include_v8_a.xsd");
+            XmlSchema schema = sc.Add(null, Path.Combine(TestData._Root, "include_v8_a.xsd"));
             CError.Compare(sc.Count, 1, "AddCount");
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -648,7 +649,7 @@ namespace System.Xml.Tests
             sc.XmlResolver = new XmlUrlResolver();
             int elem_count = 0;
 
-            XmlSchema schema = sc.Add(null, TestData._Root + "include_v9_a.xsd");
+            XmlSchema schema = sc.Add(null, Path.Combine(TestData._Root, "include_v9_a.xsd"));
             CError.Compare(sc.Count, 1, "AddCount");
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -680,7 +681,7 @@ namespace System.Xml.Tests
             sc.XmlResolver = new XmlUrlResolver();
             int elem_count = 0;
 
-            XmlSchema schema = sc.Add(null, TestData._Root + "include_v10_a.xsd");
+            XmlSchema schema = sc.Add(null, Path.Combine(TestData._Root, "include_v10_a.xsd"));
             CError.Compare(sc.Count, 1, "AddCount");
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -717,7 +718,7 @@ namespace System.Xml.Tests
             sc.XmlResolver = new XmlUrlResolver();
             int elem_count = 0;
 
-            XmlSchema schema = sc.Add(null, TestData._Root + "include_v11_a.xsd");
+            XmlSchema schema = sc.Add(null, Path.Combine(TestData._Root, "include_v11_a.xsd"));
             CError.Compare(sc.Count, 1, "AddCount");
             CError.Compare(sc.IsCompiled, false, "AddIsCompiled");
 
@@ -764,7 +765,7 @@ namespace System.Xml.Tests
 
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
-            XmlSchema a = ss.Add(null, TestData._Root + "include_v12_a.xsd");
+            XmlSchema a = ss.Add(null, Path.Combine(TestData._Root, "include_v12_a.xsd"));
             CError.Compare(ss.Count, 1, "AddCount");
             CError.Compare(ss.IsCompiled, false, "AddIsCompiled");
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Misc.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Misc.cs
@@ -70,7 +70,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet xss = new XmlSchemaSet();
             xss.XmlResolver = new XmlUrlResolver();
-            using (XmlTextReader xtr = new XmlTextReader(TestData._Root + "bug110823.xsd"))
+            using (XmlTextReader xtr = new XmlTextReader(Path.Combine(TestData._Root, "bug110823.xsd")))
             {
                 xss.Add(XmlSchema.Read(xtr, null));
             }
@@ -85,7 +85,7 @@ namespace System.Xml.Tests
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
             ss.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            ss.Add(null, TestData._Root + "bug115049.xsd");
+            ss.Add(null, Path.Combine(TestData._Root, "bug115049.xsd"));
             ss.Compile();
 
             //create reader
@@ -96,7 +96,7 @@ namespace System.Xml.Tests
                                        XmlSchemaValidationFlags.ProcessInlineSchema;
             settings.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
             settings.Schemas.Add(ss);
-            XmlReader vr = XmlReader.Create(TestData._Root + "bug115049.xml", settings);
+            XmlReader vr = XmlReader.Create(Path.Combine(TestData._Root, "bug115049.xml"), settings);
             while (vr.Read()) ;
             CError.Compare(errorCount, 1, "Error Count mismatch!");
             return;
@@ -156,7 +156,7 @@ namespace System.Xml.Tests
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
             ss.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            ss.Add(null, TestData._Root + xmlFile);
+            ss.Add(null, Path.Combine(TestData._Root, xmlFile));
             ss.Compile();
 
             //test the count
@@ -186,7 +186,7 @@ namespace System.Xml.Tests
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
             ss.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            ss.Add(xmlns, TestData._Root + "bug264908_v11.xsd");
+            ss.Add(xmlns, Path.Combine(TestData._Root, "bug264908_v11.xsd"));
             ss.Compile();
 
             //test the count
@@ -213,7 +213,7 @@ namespace System.Xml.Tests
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
             ss.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            ss.Add(xmlns, TestData._Root + "bug338038_v1.xsd");
+            ss.Add(xmlns, Path.Combine(TestData._Root, "bug338038_v1.xsd"));
             ss.Compile();
 
             //test the count
@@ -237,7 +237,7 @@ namespace System.Xml.Tests
             string xmlns = @"http://www.w3.org/XML/1998/namespace";
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
-            ss.Add(xmlns, TestData._Root + "bug338038_v2.xsd");
+            ss.Add(xmlns, Path.Combine(TestData._Root, "bug338038_v2.xsd"));
 
             try
             {
@@ -263,9 +263,9 @@ namespace System.Xml.Tests
 
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
-            ss.Add(null, TestData._Root + "bug338038_v3.xsd");
+            ss.Add(null, Path.Combine(TestData._Root, "bug338038_v3.xsd"));
             ss.Compile();
-            ss.Add(null, TestData._Root + "bug338038_v3a.xsd");
+            ss.Add(null, Path.Combine(TestData._Root, "bug338038_v3a.xsd"));
             ss.Compile();
 
             CError.Compare(ss.Count, 4, "Count of SchemaSet not matched!");
@@ -289,13 +289,13 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
-            ss.Add(null, TestData._Root + "bug338038_v3.xsd");
+            ss.Add(null, Path.Combine(TestData._Root, "bug338038_v3.xsd"));
             ss.Compile();
-            ss.Add(null, TestData._Root + "bug338038_v3a.xsd");
+            ss.Add(null, Path.Combine(TestData._Root, "bug338038_v3a.xsd"));
             ss.Compile();
             try
             {
-                ss.Add(null, TestData._Root + "bug338038_v3b.xsd");
+                ss.Add(null, Path.Combine(TestData._Root, "bug338038_v3b.xsd"));
                 ss.Compile();
             }
             catch (XmlSchemaException e)
@@ -315,11 +315,11 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
-            ss.Add(null, TestData._Root + "bug338038_v3.xsd");
+            ss.Add(null, Path.Combine(TestData._Root, "bug338038_v3.xsd"));
             ss.Compile();
-            ss.Add(null, TestData._Root + "bug338038_v4a.xsd");
+            ss.Add(null, Path.Combine(TestData._Root, "bug338038_v4a.xsd"));
             ss.Compile();
-            ss.Add(null, TestData._Root + "bug338038_v4b.xsd");
+            ss.Add(null, Path.Combine(TestData._Root, "bug338038_v4b.xsd"));
             ss.Compile();
 
             foreach (XmlSchemaAttribute a in ss.GlobalAttributes.Values)
@@ -345,11 +345,11 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
-            ss.Add(null, TestData._Root + "bug338038_v3.xsd");
+            ss.Add(null, Path.Combine(TestData._Root, "bug338038_v3.xsd"));
             ss.Compile();
-            ss.Add(null, TestData._Root + "bug338038_v4a.xsd");
+            ss.Add(null, Path.Combine(TestData._Root, "bug338038_v4a.xsd"));
             ss.Compile();
-            ss.Add(null, TestData._Root + "bug338038_v5b.xsd");
+            ss.Add(null, Path.Combine(TestData._Root, "bug338038_v5b.xsd"));
             ss.Compile();
 
             foreach (XmlSchemaAttribute a in ss.GlobalAttributes.Values)
@@ -373,7 +373,7 @@ namespace System.Xml.Tests
 
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
-            ss.Add(null, TestData._Root + "bug338038_v3.xsd");
+            ss.Add(null, Path.Combine(TestData._Root, "bug338038_v3.xsd"));
             ss.Compile();
 
             foreach (XmlSchema s in ss.Schemas(xmlns))
@@ -381,9 +381,9 @@ namespace System.Xml.Tests
                 schema = s;
             }
 
-            ss.Add(null, TestData._Root + "bug338038_v4a.xsd");
+            ss.Add(null, Path.Combine(TestData._Root, "bug338038_v4a.xsd"));
             ss.Compile();
-            ss.Add(null, TestData._Root + "bug338038_v5b.xsd");
+            ss.Add(null, Path.Combine(TestData._Root, "bug338038_v5b.xsd"));
             ss.Compile();
 
             ss.Remove(schema);
@@ -458,8 +458,8 @@ namespace System.Xml.Tests
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
             ss.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            ss.Add(null, TestData._Root + "schZ013c.xsd");
-            ss.Add(null, TestData._Root + "schZ013a.xsd");
+            ss.Add(null, Path.Combine(TestData._Root, "schZ013c.xsd"));
+            ss.Add(null, Path.Combine(TestData._Root, "schZ013a.xsd"));
             ss.Compile();
             CError.Compare(warningCount, 0, "Warning Count mismatch!");
             CError.Compare(errorCount, 0, "Error Count mismatch!");
@@ -479,7 +479,7 @@ namespace System.Xml.Tests
             XmlSchemaSet ss1 = new XmlSchemaSet();
             ss1.XmlResolver = new XmlUrlResolver();
             ss1.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            ss1.Add(null, TestData._Root + "Misc103_x.xsd");
+            ss1.Add(null, Path.Combine(TestData._Root, "Misc103_x.xsd"));
             ss1.Compile();
 
             CError.Compare(ss1.Count, 1, "Schema Set 1 Count mismatch!");
@@ -487,7 +487,7 @@ namespace System.Xml.Tests
             XmlSchemaSet ss2 = new XmlSchemaSet();
             ss2.XmlResolver = new XmlUrlResolver();
             ss2.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            XmlSchema s = ss2.Add(null, TestData._Root + "Misc103_a.xsd");
+            XmlSchema s = ss2.Add(null, Path.Combine(TestData._Root, "Misc103_a.xsd"));
             ss2.Compile();
 
             CError.Compare(ss1.Count, 1, "Schema Set 1 Count mismatch!");
@@ -514,7 +514,7 @@ namespace System.Xml.Tests
             XmlSchemaSet ss3 = new XmlSchemaSet();
             ss3.XmlResolver = new XmlUrlResolver();
             ss3.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            ss3.Add(null, TestData._Root + "Misc103_c.xsd");
+            ss3.Add(null, Path.Combine(TestData._Root, "Misc103_c.xsd"));
             ss3.Compile();
             ss1.Add(ss3);
 
@@ -532,7 +532,7 @@ namespace System.Xml.Tests
             XmlSchemaSet schemaSet = new XmlSchemaSet();
             schemaSet.XmlResolver = new XmlUrlResolver();
             schemaSet.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            schemaSet.Add(null, TestData._Root + "Misc105.xsd");
+            schemaSet.Add(null, Path.Combine(TestData._Root, "Misc105.xsd"));
             CError.Compare(warningCount, 1, "Warning Count mismatch!");
             CError.Compare(errorCount, 0, "Error Count mismatch!");
             return;
@@ -552,7 +552,7 @@ namespace System.Xml.Tests
 #pragma warning disable 0618
             settings.ProhibitDtd = false;
 #pragma warning restore 0618
-            XmlReader r = XmlReader.Create(TestData._Root + "XmlSchema.xsd", settings);
+            XmlReader r = XmlReader.Create(Path.Combine(TestData._Root, "XMLSchema.xsd"), settings);
             ss1.Add(null, r);
             ss1.Compile();
 
@@ -565,7 +565,7 @@ namespace System.Xml.Tests
                 ss.Add(s);
             }
 
-            ss.Add(null, TestData._Root + "xsdauthor.xsd");
+            ss.Add(null, Path.Combine(TestData._Root, "xsdauthor.xsd"));
             ss.Compile();
             CError.Compare(warningCount, 0, "Warning Count mismatch!");
             CError.Compare(errorCount, 0, "Error Count mismatch!");
@@ -582,7 +582,7 @@ namespace System.Xml.Tests
             XmlSchemaSet schemaSet = new XmlSchemaSet();
             schemaSet.XmlResolver = new XmlUrlResolver();
             schemaSet.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            schemaSet.Add(null, TestData._Root + "bug356711_root.xsd");
+            schemaSet.Add(null, Path.Combine(TestData._Root, "bug356711_root.xsd"));
 
             XmlReaderSettings settings = new XmlReaderSettings();
             settings.XmlResolver = new XmlUrlResolver();
@@ -696,8 +696,8 @@ namespace System.Xml.Tests
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
             ss.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            ss.Add("http://EmployeeTest.org", TestData._Root + "EmployeeTypes.xsd");
-            ss.Add(null, TestData._Root + "EmployeeTypes.xsd");
+            ss.Add("http://EmployeeTest.org", Path.Combine(TestData._Root, "EmployeeTypes.xsd"));
+            ss.Add(null, Path.Combine(TestData._Root, "EmployeeTypes.xsd"));
 
             CError.Compare(warningCount, 0, "Warning Count mismatch!");
             CError.Compare(errorCount, 0, "Error Count mismatch!");
@@ -714,8 +714,8 @@ namespace System.Xml.Tests
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
             ss.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            XmlSchema s1 = ss.Add("http://EmployeeTest.org", TestData._Root + "EmployeeTypes.xsd");
-            XmlSchema s2 = ss.Add("http://EmployeeTest.org", TestData._Root + "EmployeeTypes.xsd");
+            XmlSchema s1 = ss.Add("http://EmployeeTest.org", Path.Combine(TestData._Root, "EmployeeTypes.xsd"));
+            XmlSchema s2 = ss.Add("http://EmployeeTest.org", Path.Combine(TestData._Root, "EmployeeTypes.xsd"));
 
             CError.Compare(warningCount, 0, "Warning Count mismatch!");
             CError.Compare(errorCount, 0, "Error Count mismatch!");
@@ -733,7 +733,7 @@ namespace System.Xml.Tests
             XmlSchemaSet newSet = new XmlSchemaSet();
             newSet.XmlResolver = new XmlUrlResolver();
             newSet.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            XmlSchema chameleon = newSet.Add(null, TestData._Root + "EmployeeTypes.xsd");
+            XmlSchema chameleon = newSet.Add(null, Path.Combine(TestData._Root, "EmployeeTypes.xsd"));
             newSet.Compile();
 
             CError.Compare(newSet.GlobalTypes.Count, 10, "GlobalTypes count mismatch!");
@@ -742,7 +742,7 @@ namespace System.Xml.Tests
             sc.XmlResolver = new XmlUrlResolver();
             sc.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
             sc.Add(chameleon);
-            sc.Add(null, TestData._Root + "baseEmployee.xsd");
+            sc.Add(null, Path.Combine(TestData._Root, "baseEmployee.xsd"));
             sc.Compile();
 
             CError.Compare(warningCount, 0, "Warning Count mismatch!");
@@ -760,16 +760,16 @@ namespace System.Xml.Tests
 
             XmlSchemaSet set2 = new XmlSchemaSet();
             set2.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            XmlSchema includedSchema = set2.Add(null, TestData._Root + "bug382035a1.xsd");
+            XmlSchema includedSchema = set2.Add(null, Path.Combine(TestData._Root, "bug382035a1.xsd"));
             set2.Compile();
 
             XmlSchemaSet set = new XmlSchemaSet();
             set.XmlResolver = new XmlUrlResolver();
             set.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            XmlSchema mainSchema = set.Add(null, TestData._Root + "bug382035a.xsd");
+            XmlSchema mainSchema = set.Add(null, Path.Combine(TestData._Root, "bug382035a.xsd"));
             set.Compile();
 
-            XmlReader r = XmlReader.Create(TestData._Root + "bug382035a1.xsd");
+            XmlReader r = XmlReader.Create(Path.Combine(TestData._Root, "bug382035a1.xsd"));
             XmlSchema reParsedInclude = XmlSchema.Read(r, new ValidationEventHandler(ValidationCallback));
 
             ((XmlSchemaExternal)mainSchema.Includes[0]).Schema = reParsedInclude;
@@ -889,7 +889,7 @@ namespace System.Xml.Tests
         [Theory]
         public void v118()
         {
-            using (XmlReader r = new XmlTextReader(TestData._Root + "bug424904.xsd"))
+            using (XmlReader r = new XmlTextReader(Path.Combine(TestData._Root, "Bug424904.xsd")))
             {
                 XmlSchema s = XmlSchema.Read(r, null);
                 XmlSchemaSet set = new XmlSchemaSet();
@@ -911,7 +911,7 @@ namespace System.Xml.Tests
         [Theory]
         public void v120()
         {
-            using (XmlReader schemaReader = XmlReader.Create(TestData._Root + "bug397633.xsd"))
+            using (XmlReader schemaReader = XmlReader.Create(Path.Combine(TestData._Root, "Bug397633.xsd")))
             {
                 XmlSchemaSet sc = new XmlSchemaSet();
                 sc.XmlResolver = new XmlUrlResolver();
@@ -922,7 +922,7 @@ namespace System.Xml.Tests
                 readerSettings.ValidationType = ValidationType.Schema;
                 readerSettings.Schemas = sc;
 
-                using (XmlReader docValidatingReader = XmlReader.Create(TestData._Root + "bug397633.xml", readerSettings))
+                using (XmlReader docValidatingReader = XmlReader.Create(Path.Combine(TestData._Root, "Bug397633.xml"), readerSettings))
                 {
                     XmlDocument doc = new XmlDocument();
                     try
@@ -949,7 +949,7 @@ namespace System.Xml.Tests
         {
             XmlReaderSettings readerSettings = new XmlReaderSettings();
             readerSettings.ValidationType = ValidationType.Schema;
-            using (XmlReader reader = XmlReader.Create(TestData._Root + "bug397633.xml", readerSettings))
+            using (XmlReader reader = XmlReader.Create(Path.Combine(TestData._Root, "Bug397633.xml"), readerSettings))
             {
                 XmlDocument doc = new XmlDocument();
                 try
@@ -1049,7 +1049,7 @@ namespace System.Xml.Tests
             string xml = @"<?xml version='1.0' encoding='utf-8'?><e1 xmlns='ns-a'>  <c23 xmlns='ns-b'/></e1>";
             XmlSchemaSet set = new XmlSchemaSet();
             set.XmlResolver = new XmlUrlResolver();
-            string path = Path.Combine(TestData.StandardPath, @"XSD10\schema\schN11_a.xsd");
+            string path = Path.Combine(TestData.StandardPath, "xsd10", "SCHEMA", "schN11_a.xsd");
             set.Add(null, path);
             set.Compile();
 
@@ -1097,8 +1097,8 @@ namespace System.Xml.Tests
         public void Dev10_40509()
         {
             Initialize();
-            string xml = TestData._Root + "bug511217.xml";
-            string xsd = TestData._Root + "bug511217.xsd";
+            string xml = Path.Combine(TestData._Root, "bug511217.xml");
+            string xsd = Path.Combine(TestData._Root, "bug511217.xsd");
             XmlSchemaSet s = new XmlSchemaSet();
             s.XmlResolver = new XmlUrlResolver();
             XmlReader r = XmlReader.Create(xsd);

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_ProhibitDTD.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_ProhibitDTD.cs
@@ -138,7 +138,7 @@ namespace System.Xml.Tests
             xss.ValidationEventHandler += ValidationCallback;
             try
             {
-                xss.Add(null, TestData._Root + "bug356711_a.xsd");
+                xss.Add(null, Path.Combine(TestData._Root, "bug356711_a.xsd"));
             }
             catch (XmlException e)
             {
@@ -156,7 +156,7 @@ namespace System.Xml.Tests
             Initialize();
             XmlSchemaSet xss = new XmlSchemaSet();
             xss.ValidationEventHandler += ValidationCallback;
-            XmlReader r = CreateReader(TestData._Root + "bug356711_a.xsd");
+            XmlReader r = CreateReader(Path.Combine(TestData._Root, "bug356711_a.xsd"));
             try
             {
                 xss.Add(null, r);
@@ -180,7 +180,7 @@ namespace System.Xml.Tests
             xss.ValidationEventHandler += ValidationCallback;
             try
             {
-                xss.Add(null, TestData._Root + "bug356711.xsd");
+                xss.Add(null, Path.Combine(TestData._Root, "bug356711.xsd"));
             }
             catch (XmlException)
             {
@@ -199,7 +199,7 @@ namespace System.Xml.Tests
             XmlSchemaSet xss = new XmlSchemaSet();
             xss.XmlResolver = new XmlUrlResolver();
             xss.ValidationEventHandler += ValidationCallback;
-            XmlReader r = CreateReader(TestData._Root + "bug356711.xsd");
+            XmlReader r = CreateReader(Path.Combine(TestData._Root, "bug356711.xsd"));
             try
             {
                 xss.Add(null, r);
@@ -222,7 +222,7 @@ namespace System.Xml.Tests
             XmlSchemaSet xss = new XmlSchemaSet();
             xss.XmlResolver = new XmlUrlResolver();
             xss.ValidationEventHandler += ValidationCallback;
-            XmlSchema schema = XmlSchema.Read(new StreamReader(new FileStream(TestData._Root + param0.ToString(), FileMode.Open, FileAccess.Read)), ValidationCallback);
+            XmlSchema schema = XmlSchema.Read(new StreamReader(new FileStream(Path.Combine(TestData._Root, param0.ToString()), FileMode.Open, FileAccess.Read)), ValidationCallback);
 #pragma warning disable 0618
             schema.Compile(ValidationCallback, new XmlUrlResolver());
 #pragma warning restore 0618
@@ -249,7 +249,7 @@ namespace System.Xml.Tests
             XmlSchemaSet xss = new XmlSchemaSet();
             xss.XmlResolver = new XmlUrlResolver();
             xss.ValidationEventHandler += ValidationCallback;
-            var reader = new XmlTextReader(TestData._Root + param0.ToString());
+            var reader = new XmlTextReader(Path.Combine(TestData._Root, param0.ToString()));
             reader.XmlResolver = new XmlUrlResolver();
             XmlSchema schema = XmlSchema.Read(reader, ValidationCallback);
 #pragma warning disable 0618
@@ -273,7 +273,7 @@ namespace System.Xml.Tests
 
             try
             {
-                XmlSchema schema = XmlSchema.Read(CreateReader(TestData._Root + param0.ToString()), ValidationCallback);
+                XmlSchema schema = XmlSchema.Read(CreateReader(Path.Combine(TestData._Root, param0.ToString())), ValidationCallback);
 #pragma warning disable 0618
                 schema.Compile(ValidationCallback);
 #pragma warning restore 0618
@@ -296,7 +296,7 @@ namespace System.Xml.Tests
 
             try
             {
-                XmlSchema schema = XmlSchema.Read(CreateReader(TestData._Root + param0.ToString()), ValidationCallback);
+                XmlSchema schema = XmlSchema.Read(CreateReader(Path.Combine(TestData._Root, param0.ToString())), ValidationCallback);
 #pragma warning disable 0618
                 schema.Compile(ValidationCallback);
 #pragma warning restore 0618
@@ -323,7 +323,7 @@ namespace System.Xml.Tests
             xss.XmlResolver = new XmlUrlResolver();
             xss.ValidationEventHandler += ValidationCallback;
 
-            XmlReader r = CreateReader(TestData._Root + param0.ToString(), false);
+            XmlReader r = CreateReader(Path.Combine(TestData._Root, param0.ToString()), false);
             try
             {
                 xss.Add(null, r);
@@ -348,7 +348,7 @@ namespace System.Xml.Tests
 
             try
             {
-                XmlSchema schema = XmlSchema.Read(CreateReader(TestData._Root + param0.ToString(), false), ValidationCallback);
+                XmlSchema schema = XmlSchema.Read(CreateReader(Path.Combine(TestData._Root, param0.ToString()), false), ValidationCallback);
 #pragma warning disable 0618
                 schema.Compile(ValidationCallback);
 #pragma warning restore 0618
@@ -372,7 +372,7 @@ namespace System.Xml.Tests
             XmlSchemaSet xss = new XmlSchemaSet();
             xss.ValidationEventHandler += ValidationCallback;
 
-            XmlReader r = CreateReader(TestData._Root + param0.ToString(), false);
+            XmlReader r = CreateReader(Path.Combine(TestData._Root, param0.ToString()), false);
             XmlReader r2 = CreateReader(r, true);
             try
             {
@@ -396,7 +396,7 @@ namespace System.Xml.Tests
             xss.XmlResolver = new XmlUrlResolver();
             xss.ValidationEventHandler += ValidationCallback;
 
-            XmlReader r = CreateReader(TestData._Root + param0.ToString(), false);
+            XmlReader r = CreateReader(Path.Combine(TestData._Root, param0.ToString()), false);
             XmlReader r2 = CreateReader(r, true);
 
             try
@@ -423,13 +423,13 @@ namespace System.Xml.Tests
             xss.XmlResolver = new XmlUrlResolver();
             xss.ValidationEventHandler += ValidationCallback;
 
-            XmlReader r = CreateReader(TestData._Root + "bug356711.xsd", false);
+            XmlReader r = CreateReader(Path.Combine(TestData._Root, "bug356711.xsd"), false);
 
             try
             {
                 xss.Add(null, r);
                 CError.Compare(xss.Count, 2, "SchemaSet count mismatch!");
-                xss.Add(null, TestData._Root + "bug356711_b.xsd");
+                xss.Add(null, Path.Combine(TestData._Root, "bug356711_b.xsd"));
             }
             catch (XmlException e)
             {
@@ -448,8 +448,8 @@ namespace System.Xml.Tests
             XmlSchemaSet xss = new XmlSchemaSet();
             xss.ValidationEventHandler += ValidationCallback;
 
-            XmlReader r1 = CreateReader(TestData._Root + "bug356711_a.xsd");
-            XmlReader r2 = CreateReader(TestData._Root + "bug356711_b.xsd", false);
+            XmlReader r1 = CreateReader(Path.Combine(TestData._Root, "bug356711_a.xsd"));
+            XmlReader r2 = CreateReader(Path.Combine(TestData._Root, "bug356711_b.xsd"), false);
 
             try
             {
@@ -489,11 +489,11 @@ namespace System.Xml.Tests
             XmlSchemaSet xss = new XmlSchemaSet();
             xss.XmlResolver = new XmlUrlResolver();
             xss.ValidationEventHandler += ValidationCallback;
-            xss.Add(null, TestData._Root + "bug356711_root.xsd");
+            xss.Add(null, Path.Combine(TestData._Root, "bug356711_root.xsd"));
 
             try
             {
-                XmlReader reader = CreateReader(TestData._Root + param0.ToString(), xss, true);
+                XmlReader reader = CreateReader(Path.Combine(TestData._Root, param0.ToString()), xss, true);
                 while (reader.Read()) ;
             }
             catch (XmlException)
@@ -513,11 +513,11 @@ namespace System.Xml.Tests
             var xss = new XmlSchemaSet();
             xss.XmlResolver = new XmlUrlResolver();
             xss.ValidationEventHandler += ValidationCallback;
-            xss.Add(null, TestData._Root + "bug356711_root.xsd");
+            xss.Add(null, Path.Combine(TestData._Root, "bug356711_root.xsd"));
 
             try
             {
-                using (var r1 = CreateReader(TestData._Root + "bug356711_1.xml", false))
+                using (var r1 = CreateReader(Path.Combine(TestData._Root, "bug356711_1.xml"), false))
                 using (var r2 = CreateReader(r1, xss, true))
                 {
                     while (r2.Read()) { }
@@ -547,11 +547,11 @@ namespace System.Xml.Tests
             XmlSchemaSet xss = new XmlSchemaSet();
             xss.XmlResolver = new XmlUrlResolver();
             xss.ValidationEventHandler += ValidationCallback;
-            xss.Add(null, TestData._Root + "bug356711_root.xsd");
+            xss.Add(null, Path.Combine(TestData._Root, "bug356711_root.xsd"));
 
             try
             {
-                XmlReader reader = CreateReader(TestData._Root + param0.ToString(), xss, false);
+                XmlReader reader = CreateReader(Path.Combine(TestData._Root, param0.ToString()), xss, false);
                 while (reader.Read()) ;
             }
             catch (XmlException)
@@ -570,11 +570,11 @@ namespace System.Xml.Tests
             Initialize();
             XmlSchemaSet xss = new XmlSchemaSet();
             xss.ValidationEventHandler += ValidationCallback;
-            xss.Add(null, TestData._Root + "bug356711_root.xsd");
+            xss.Add(null, Path.Combine(TestData._Root, "bug356711_root.xsd"));
 
             try
             {
-                XmlReader r1 = CreateReader(TestData._Root + "bug356711_1.xml", true);
+                XmlReader r1 = CreateReader(Path.Combine(TestData._Root, "bug356711_1.xml"), true);
                 XmlReader r2 = CreateReader(r1, xss, false);
                 while (r2.Read()) ;
             }

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Remove.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Remove.cs
@@ -5,6 +5,7 @@
 using Xunit;
 using Xunit.Abstractions;
 using System;
+using System.IO;
 using System.Collections;
 using System.Xml.Schema;
 
@@ -102,7 +103,7 @@ namespace System.Xml.Tests
             try
             {
                 XmlSchema Schema1 = sc.Add(null, TestData._XsdAuthor);
-                XmlSchema Schema2 = sc.Add(null, TestData._Root + param0.ToString()); // param as filename
+                XmlSchema Schema2 = sc.Add(null, Path.Combine(TestData._Root, param0.ToString())); // param as filename
 
                 sc.Compile();
                 sc.Remove(Schema2);
@@ -134,7 +135,7 @@ namespace System.Xml.Tests
             try
             {
                 XmlSchema Schema1 = sc.Add(null, TestData._XsdAuthor);
-                XmlSchema Schema2 = sc.Add(null, TestData._Root + param0.ToString()); // param as filename
+                XmlSchema Schema2 = sc.Add(null, Path.Combine(TestData._Root, param0.ToString())); // param as filename
 
                 sc.Compile();
                 sc.Remove(Schema2);
@@ -160,8 +161,8 @@ namespace System.Xml.Tests
 
             try
             {
-                XmlSchema Schema1 = sc.Add("ns-b", TestData._Root + "import_v4_b.xsd");
-                XmlSchema Schema2 = sc.Add(null, TestData._Root + "import_v5_a.xsd"); // param as filename
+                XmlSchema Schema1 = sc.Add("ns-b", Path.Combine(TestData._Root, "import_v4_b.xsd"));
+                XmlSchema Schema2 = sc.Add(null, Path.Combine(TestData._Root, "import_v5_a.xsd")); // param as filename
                 sc.Compile();
                 sc.Remove(Schema1);
                 CError.Compare(sc.Count, 2, "Count");
@@ -189,8 +190,8 @@ namespace System.Xml.Tests
 
             try
             {
-                XmlSchema Schema1 = sc.Add("ns-b", TestData._Root + "import_v4_b.xsd");
-                XmlSchema Schema2 = sc.Add(null, TestData._Root + "import_v5_a.xsd"); // param as filename
+                XmlSchema Schema1 = sc.Add("ns-b", Path.Combine(TestData._Root, "import_v4_b.xsd"));
+                XmlSchema Schema2 = sc.Add(null, Path.Combine(TestData._Root, "import_v5_a.xsd")); // param as filename
                 sc.Compile();
                 ICollection col = sc.Schemas(String.Empty);
                 foreach (XmlSchema schema in col)
@@ -225,7 +226,7 @@ namespace System.Xml.Tests
 
             try
             {
-                XmlSchema Schema1 = sc.Add(null, TestData._Root + param0.ToString());
+                XmlSchema Schema1 = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
                 sc.Compile();
                 CError.Compare(sc.Count, 3, "Count");
 
@@ -267,7 +268,7 @@ namespace System.Xml.Tests
 
             try
             {
-                XmlSchema Schema1 = sc.Add(null, TestData._Root + param0.ToString());
+                XmlSchema Schema1 = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
                 sc.Compile();
                 CError.Compare(sc.Count, 4, "Count");
 
@@ -317,8 +318,8 @@ namespace System.Xml.Tests
             {
                 XmlSchemaSet sc = new XmlSchemaSet();
                 sc.XmlResolver = new XmlUrlResolver();
-                sc.Add(null, TestData._Root + "import_v16_b.xsd");
-                XmlSchema parent = sc.Add(null, TestData._Root + "import_v16_a.xsd");
+                sc.Add(null, Path.Combine(TestData._Root, "import_v16_b.xsd"));
+                XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v16_a.xsd"));
                 sc.Compile();
                 sc.Remove(parent);
                 CError.Compare(sc.Count, 1, "Count");
@@ -344,8 +345,8 @@ namespace System.Xml.Tests
 
             try
             {
-                XmlSchema Schema1 = sc.Add(null, TestData._Root + param0.ToString()); // param as filename
-                XmlSchema Schema2 = sc.Add(null, TestData._Root + param1.ToString()); // param as filename
+                XmlSchema Schema1 = sc.Add(null, Path.Combine(TestData._Root, param0.ToString())); // param as filename
+                XmlSchema Schema2 = sc.Add(null, Path.Combine(TestData._Root, param1.ToString())); // param as filename
                 sc.Compile();
                 CError.Compare(sc.Count, 2, "Count");
                 sc.Remove(Schema2);

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_RemoveRecursive.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_RemoveRecursive.cs
@@ -5,6 +5,7 @@
 using Xunit;
 using Xunit.Abstractions;
 using System;
+using System.IO;
 using System.Collections;
 using System.Xml.Schema;
 
@@ -123,7 +124,7 @@ namespace System.Xml.Tests
             {
                 // remove after compile
                 XmlSchema Schema1 = sc.Add(null, TestData._XsdAuthor);
-                XmlSchema Schema2 = sc.Add(null, TestData._Root + fileName); // param as filename
+                XmlSchema Schema2 = sc.Add(null, Path.Combine(TestData._Root, fileName)); // param as filename
                 sc.Compile();
                 sc.RemoveRecursive(Schema2);
                 CError.Compare(sc.Count, 1, "Count");
@@ -131,7 +132,7 @@ namespace System.Xml.Tests
                 CError.Compare(Col.Count, 1, "ICollection.Count");
 
                 //remove before compile
-                Schema2 = sc.Add(null, TestData._Root + fileName); // param as filename
+                Schema2 = sc.Add(null, Path.Combine(TestData._Root, fileName)); // param as filename
                 CError.Compare(sc.Count, 2, "Count");
                 sc.RemoveRecursive(Schema2);
                 CError.Compare(sc.Count, 1, "Count");
@@ -163,7 +164,7 @@ namespace System.Xml.Tests
                 XmlSchema Schema1 = sc.Add(null, TestData._XsdAuthor);
 
                 //remove after compile
-                XmlSchema Schema2 = sc.Add(null, TestData._Root + param0.ToString()); // param as filename
+                XmlSchema Schema2 = sc.Add(null, Path.Combine(TestData._Root, param0.ToString())); // param as filename
                 sc.Compile();
                 sc.RemoveRecursive(Schema2);
                 CError.Compare(sc.Count, param1, "Count");
@@ -171,7 +172,7 @@ namespace System.Xml.Tests
                 CError.Compare(Col.Count, param1, "ICollection.Count");
 
                 //remove before compile
-                Schema2 = sc.Add(null, TestData._Root + param0.ToString()); // param as filename
+                Schema2 = sc.Add(null, Path.Combine(TestData._Root, param0.ToString())); // param as filename
                 sc.RemoveRecursive(Schema2);
                 CError.Compare(sc.Count, param1, "Count");
                 Col = sc.Schemas();
@@ -197,8 +198,8 @@ namespace System.Xml.Tests
             try
             {
                 //after compile
-                XmlSchema Schema1 = sc.Add("ns-b", TestData._Root + "import_v4_b.xsd");
-                XmlSchema Schema2 = sc.Add(null, TestData._Root + "import_v5_a.xsd"); // param as filename
+                XmlSchema Schema1 = sc.Add("ns-b", Path.Combine(TestData._Root, "import_v4_b.xsd"));
+                XmlSchema Schema2 = sc.Add(null, Path.Combine(TestData._Root, "import_v5_a.xsd")); // param as filename
                 sc.Compile();
                 sc.RemoveRecursive(Schema1);
                 CError.Compare(sc.Count, 2, "Count");
@@ -214,8 +215,8 @@ namespace System.Xml.Tests
                 CError.Compare(sc.Contains("ns-a"), false, "Contains");
 
                 //before compile
-                Schema1 = sc.Add("ns-b", TestData._Root + "import_v4_b.xsd");
-                Schema2 = sc.Add(null, TestData._Root + "import_v5_a.xsd"); // param as filename
+                Schema1 = sc.Add("ns-b", Path.Combine(TestData._Root, "import_v4_b.xsd"));
+                Schema2 = sc.Add(null, Path.Combine(TestData._Root, "import_v5_a.xsd")); // param as filename
                 sc.RemoveRecursive(Schema1);
                 CError.Compare(sc.Count, 2, "Count");
                 CError.Compare(sc.Contains("ns-b"), false, "Contains");
@@ -250,7 +251,7 @@ namespace System.Xml.Tests
             try
             {
                 //after compile
-                XmlSchema Schema1 = sc.Add(null, TestData._Root + param0.ToString());
+                XmlSchema Schema1 = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
                 sc.Compile();
                 CError.Compare(sc.Count, 3, "Count");
                 sc.RemoveRecursive(Schema1);
@@ -260,7 +261,7 @@ namespace System.Xml.Tests
                 CError.Compare(sc.Contains(param3.ToString()), false, "Contains");
 
                 //before compile
-                Schema1 = sc.Add(null, TestData._Root + param0.ToString());
+                Schema1 = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
                 CError.Compare(sc.Count, 3, "Count");
                 sc.RemoveRecursive(Schema1);
                 CError.Compare(sc.Count, 0, "Count");
@@ -288,7 +289,7 @@ namespace System.Xml.Tests
             try
             {
                 //after compile
-                XmlSchema Schema1 = sc.Add(null, TestData._Root + param0.ToString());
+                XmlSchema Schema1 = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
                 sc.Compile();
                 CError.Compare(sc.Count, 4, "Count");
                 sc.RemoveRecursive(Schema1);
@@ -299,7 +300,7 @@ namespace System.Xml.Tests
                 CError.Compare(sc.Contains("ns-a"), false, "Contains");
 
                 //before compile
-                Schema1 = sc.Add(null, TestData._Root + param0.ToString());
+                Schema1 = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
                 CError.Compare(sc.Count, 4, "Count");
                 sc.RemoveRecursive(Schema1);
                 CError.Compare(sc.Count, 0, "Count");
@@ -325,17 +326,17 @@ namespace System.Xml.Tests
             try
             {
                 XmlSchemaSet sc = new XmlSchemaSet();
-                sc.Add(null, TestData._Root + "import_v16_b.xsd");
+                sc.Add(null, Path.Combine(TestData._Root, "import_v16_b.xsd"));
 
                 //before compile
-                XmlSchema parent = sc.Add(null, TestData._Root + "import_v16_a.xsd");
+                XmlSchema parent = sc.Add(null, Path.Combine(TestData._Root, "import_v16_a.xsd"));
                 sc.Compile();
                 sc.RemoveRecursive(parent);
                 CError.Compare(sc.Count, 1, "Count");
                 CError.Compare(sc.Contains("ns-b"), true, "Contains");
 
                 //after compile
-                parent = sc.Add(null, TestData._Root + "import_v16_a.xsd");
+                parent = sc.Add(null, Path.Combine(TestData._Root, "import_v16_a.xsd"));
                 sc.RemoveRecursive(parent);
                 CError.Compare(sc.Count, 1, "Count");
                 CError.Compare(sc.Contains("ns-b"), true, "Contains");
@@ -378,8 +379,8 @@ namespace System.Xml.Tests
             try
             {
                 //after compile
-                XmlSchema Schema1 = sc.Add(null, TestData._Root + param0.ToString());
-                XmlSchema Schema2 = sc.Add(null, TestData._Root + param1.ToString());
+                XmlSchema Schema1 = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
+                XmlSchema Schema2 = sc.Add(null, Path.Combine(TestData._Root, param1.ToString()));
                 sc.Compile();
                 CError.Compare(sc.Count, 5, "Count");
                 sc.RemoveRecursive(Schema1);
@@ -397,8 +398,8 @@ namespace System.Xml.Tests
                 CError.Compare(bErrorCallback, false, "Error Callback");
 
                 //before compile
-                Schema1 = sc.Add(null, TestData._Root + param0.ToString());
-                Schema2 = sc.Add(null, TestData._Root + param1.ToString());
+                Schema1 = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
+                Schema2 = sc.Add(null, Path.Combine(TestData._Root, param1.ToString()));
                 CError.Compare(sc.Count, 5, "Count");
                 sc.RemoveRecursive(Schema1);
                 CError.Compare(sc.Count, 5, "Count");
@@ -427,7 +428,7 @@ namespace System.Xml.Tests
             try
             {
                 //after compile
-                XmlSchema Schema1 = sc.Add(null, TestData._Root + param0.ToString());
+                XmlSchema Schema1 = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
                 sc.Compile();
                 CError.Compare(sc.Count, 4, "Count");
                 sc.RemoveRecursive(Schema1);
@@ -437,7 +438,7 @@ namespace System.Xml.Tests
                 CError.Compare(sc.GlobalTypes.Count, 0, "Global Types Count");//should contain xs:anyType
 
                 //before compile
-                Schema1 = sc.Add(null, TestData._Root + param0.ToString());
+                Schema1 = sc.Add(null, Path.Combine(TestData._Root, param0.ToString()));
                 CError.Compare(sc.Count, 4, "Count");
                 sc.RemoveRecursive(Schema1);
                 CError.Compare(sc.Count, 0, "Count");

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Reprocess.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Reprocess.cs
@@ -288,7 +288,7 @@ namespace System.Xml.Tests
             sc.XmlResolver = new XmlUrlResolver();
             sc.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
 
-            XmlSchema Schema1 = sc.Add(null, TestData._Root + "import_v1_a.xsd");
+            XmlSchema Schema1 = sc.Add(null, Path.Combine(TestData._Root, "import_v1_a.xsd"));
             CError.Compare(sc.Count, 2, "Count after add");
             CError.Compare(sc.Contains(Schema1), true, "Contains after add");
 
@@ -334,7 +334,7 @@ namespace System.Xml.Tests
 
             sc.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
 
-            XmlSchema Schema1 = sc.Add(null, TestData._Root + "reprocess_v9_a.xsd");
+            XmlSchema Schema1 = sc.Add(null, Path.Combine(TestData._Root, "reprocess_v9_a.xsd"));
             CError.Compare(sc.Count, 2, "Count after add");
             CError.Compare(sc.Contains(Schema1), true, "Contains after add");
 
@@ -376,7 +376,7 @@ namespace System.Xml.Tests
             sc.XmlResolver = new XmlUrlResolver();
             sc.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
 
-            XmlSchema Schema1 = sc.Add(null, TestData._Root + "reprocess_v9_a.xsd");
+            XmlSchema Schema1 = sc.Add(null, Path.Combine(TestData._Root, "reprocess_v9_a.xsd"));
             CError.Compare(sc.Count, 2, "Count after add");
             CError.Compare(sc.Contains(Schema1), true, "Contains after add");
 
@@ -417,7 +417,7 @@ namespace System.Xml.Tests
 
             sc.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
 
-            XmlSchema Schema1 = sc.Add(null, TestData._Root + "include_v1_a.xsd");
+            XmlSchema Schema1 = sc.Add(null, Path.Combine(TestData._Root, "include_v1_a.xsd"));
             CError.Compare(sc.Count, 1, "Count after add");
             CError.Compare(sc.Contains(Schema1), true, "Contains after add");
 
@@ -457,7 +457,7 @@ namespace System.Xml.Tests
             sc.XmlResolver = new XmlUrlResolver();
 
             sc.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            XmlSchema Schema1 = sc.Add(null, TestData._Root + "include_v1_a.xsd");
+            XmlSchema Schema1 = sc.Add(null, Path.Combine(TestData._Root, "include_v1_a.xsd"));
             CError.Compare(sc.Count, 1, "Count after add");
             CError.Compare(sc.Contains(Schema1), true, "Contains after add");
 
@@ -553,10 +553,10 @@ namespace System.Xml.Tests
             bWarningCallback = false;
             bErrorCallback = false;
 
-            string mainFile = TestData._Root + param0.ToString();
-            string include1 = TestData._Root + param1.ToString();
-            string include2 = TestData._Root + param2.ToString();
-            string xmlFile = TestData._Root + "bug382119.xml";
+            string mainFile = Path.Combine(TestData._Root, param0.ToString());
+            string include1 = Path.Combine(TestData._Root, param1.ToString());
+            string include2 = Path.Combine(TestData._Root, param2.ToString());
+            string xmlFile = Path.Combine(TestData._Root, "bug382119.xml");
             bool IsImport = (bool)param3;
 
             XmlSchemaSet set1 = new XmlSchemaSet();

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlResolver.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlResolver.cs
@@ -4,6 +4,7 @@
 
 using Xunit;
 using Xunit.Abstractions;
+using System.IO;
 using System.Net;
 using System.Xml.Schema;
 
@@ -58,7 +59,7 @@ namespace System.Xml.Tests
                 XmlSchemaSet sc = new XmlSchemaSet();
                 sc.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
                 sc.XmlResolver = null;
-                XmlSchema Schema = sc.Add(null, TestData._Root + @"XmlResolver/File/simpledtd.xml");
+                XmlSchema Schema = sc.Add(null, Path.Combine(TestData._Root, "XmlResolver", "File", "simpledtd.xml"));
             }
             catch (Exception)
             {
@@ -76,7 +77,7 @@ namespace System.Xml.Tests
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
             sc.XmlResolver = null;
-            sc.Add(null, TestData._Root + "xmlresolver_v2.xsd");
+            sc.Add(null, Path.Combine(TestData._Root, "xmlresolver_v2.xsd"));
             CError.Compare(sc.Count, 1, "SchemaSet count");
             return;
         }
@@ -88,7 +89,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            sc.Add(null, TestData._Root + "xmlresolver_v2.xsd");
+            sc.Add(null, Path.Combine(TestData._Root, "xmlresolver_v2.xsd"));
             CError.Compare(sc.Count, 1, "SchemaSet count");
             return;
         }

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/Constructor_AddSchema.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/Constructor_AddSchema.cs
@@ -98,7 +98,7 @@ namespace System.Xml.Tests
 
             if (schemaSetStatus != "empty")
             {
-                sch.Add("", TestData + XSDFILE_NO_TARGET_NAMESPACE);
+                sch.Add("", Path.Combine(TestData, XSDFILE_NO_TARGET_NAMESPACE));
                 if (schemaSetStatus == "compiled")
                     sch.Compile();
             }
@@ -340,7 +340,7 @@ namespace System.Xml.Tests
         {
             XmlSchemaValidator val;
             XmlSchemaInfo info = new XmlSchemaInfo();
-            Uri u = new Uri(Path.GetFullPath(TestData) + XSDFILE_TARGET_NAMESPACE);
+            Uri u = new Uri(Uri.UriSchemeFile + Uri.SchemeDelimiter + Path.Combine(Path.GetFullPath(TestData), XSDFILE_TARGET_NAMESPACE));
             XmlSchema s1;
             XmlSchemaSet schemas = new XmlSchemaSet();
             schemas.XmlResolver = new XmlUrlResolver();

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/GetExpectedParticles.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/GetExpectedParticles.cs
@@ -301,8 +301,8 @@ namespace System.Xml.Tests
             XmlSchemaSet schemas = new XmlSchemaSet();
             XmlSchemaParticle[] result;
 
-            schemas.Add("", TestData + XSDFILE_GET_EXPECTED_PARTICLES);
-            schemas.Add("uri:tempuri", TestData + XSDFILE_TARGET_NAMESPACE);
+            schemas.Add("", Path.Combine(TestData, XSDFILE_GET_EXPECTED_PARTICLES));
+            schemas.Add("uri:tempuri", Path.Combine(TestData, XSDFILE_TARGET_NAMESPACE));
             val = CreateValidator(schemas);
 
             val.Initialize();
@@ -338,8 +338,8 @@ namespace System.Xml.Tests
             XmlSchemaSet schemas = new XmlSchemaSet();
             XmlSchemaParticle[] result;
 
-            schemas.Add("", TestData + XSDFILE_GET_EXPECTED_PARTICLES);
-            schemas.Add("uri:tempuri", TestData + XSDFILE_TARGET_NAMESPACE);
+            schemas.Add("", Path.Combine(TestData, XSDFILE_GET_EXPECTED_PARTICLES));
+            schemas.Add("uri:tempuri", Path.Combine(TestData, XSDFILE_TARGET_NAMESPACE));
             val = CreateValidator(schemas);
 
             val.Initialize();
@@ -561,7 +561,7 @@ namespace System.Xml.Tests
                                                               "        </xs:complexType>\n" +
                                                               "    </xs:element>\n" +
                                                               "</xs:schema>")));
-            schemas.Add("uri:tempuri", TestData + XSDFILE_TARGET_NAMESPACE);
+            schemas.Add("uri:tempuri", Path.Combine(TestData, XSDFILE_TARGET_NAMESPACE));
             val = CreateValidator(schemas);
 
             val.Initialize();

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/Initialize_EndValidation.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/Initialize_EndValidation.cs
@@ -137,7 +137,7 @@ namespace System.Xml.Tests
             val.EndValidation();
 
             val.Initialize();
-            val.ValidateElement("foo", "", info, "type1", null, null, TestData + XSDFILE_NO_TARGET_NAMESPACE);
+            val.ValidateElement("foo", "", info, "type1", null, null, Path.Combine(TestData, XSDFILE_NO_TARGET_NAMESPACE));
             val.ValidateEndOfAttributes(null);
             val.ValidateElement("bar", "", info);
             val.ValidateEndOfAttributes(null);
@@ -176,7 +176,7 @@ namespace System.Xml.Tests
             XmlSchemaInfo info = new XmlSchemaInfo();
             XmlSchemaSet schemas = new XmlSchemaSet();
 
-            schemas.Add("", TestData + XSDFILE_PARTIAL_VALIDATION);
+            schemas.Add("", Path.Combine(TestData, XSDFILE_PARTIAL_VALIDATION));
             schemas.Compile();
 
             val = CreateValidator(schemas);
@@ -203,7 +203,7 @@ namespace System.Xml.Tests
             XmlSchemaInfo info = new XmlSchemaInfo();
             XmlSchemaSet schemas = new XmlSchemaSet();
 
-            schemas.Add("", TestData + XSDFILE_PARTIAL_VALIDATION);
+            schemas.Add("", Path.Combine(TestData, XSDFILE_PARTIAL_VALIDATION));
             schemas.Compile();
 
             val = CreateValidator(schemas);
@@ -246,7 +246,7 @@ namespace System.Xml.Tests
             XmlSchemaInfo info = new XmlSchemaInfo();
             XmlSchemaSet schemas = new XmlSchemaSet();
 
-            schemas.Add("", TestData + XSDFILE_PARTIAL_VALIDATION);
+            schemas.Add("", Path.Combine(TestData, XSDFILE_PARTIAL_VALIDATION));
             schemas.Compile();
 
             val = CreateValidator(schemas);
@@ -271,7 +271,7 @@ namespace System.Xml.Tests
             XmlSchemaInfo info = new XmlSchemaInfo();
             XmlSchemaSet schemas = new XmlSchemaSet();
 
-            schemas.Add("", TestData + XSDFILE_PARTIAL_VALIDATION);
+            schemas.Add("", Path.Combine(TestData, XSDFILE_PARTIAL_VALIDATION));
             schemas.Compile();
 
             val = CreateValidator(schemas);
@@ -315,7 +315,7 @@ namespace System.Xml.Tests
             XmlSchemaInfo info = new XmlSchemaInfo();
             XmlSchemaSet schemas = new XmlSchemaSet();
 
-            schemas.Add("", TestData + XSDFILE_PARTIAL_VALIDATION);
+            schemas.Add("", Path.Combine(TestData, XSDFILE_PARTIAL_VALIDATION));
             schemas.Compile();
 
             val = CreateValidator(schemas);
@@ -340,7 +340,7 @@ namespace System.Xml.Tests
             XmlSchemaInfo info = new XmlSchemaInfo();
             XmlSchemaSet schemas = new XmlSchemaSet();
 
-            schemas.Add("", TestData + XSDFILE_PARTIAL_VALIDATION);
+            schemas.Add("", Path.Combine(TestData, XSDFILE_PARTIAL_VALIDATION));
             schemas.Compile();
 
             val = CreateValidator(schemas);
@@ -364,7 +364,7 @@ namespace System.Xml.Tests
             XmlSchemaInfo info = new XmlSchemaInfo();
             XmlSchemaSet schemas = new XmlSchemaSet();
 
-            schemas.Add("", TestData + XSDFILE_PARTIAL_VALIDATION);
+            schemas.Add("", Path.Combine(TestData, XSDFILE_PARTIAL_VALIDATION));
             schemas.Compile();
 
             val = CreateValidator(schemas);
@@ -450,7 +450,7 @@ namespace System.Xml.Tests
             XmlSchemaInfo info = new XmlSchemaInfo();
             XmlSchemaSet schemas = new XmlSchemaSet();
 
-            schemas.Add("", TestData + XSDFILE_PARTIAL_VALIDATION);
+            schemas.Add("", Path.Combine(TestData, XSDFILE_PARTIAL_VALIDATION));
             schemas.Compile();
 
             val = CreateValidator(schemas);

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/PropertiesTests.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/PropertiesTests.cs
@@ -39,7 +39,7 @@ namespace System.Xml.Tests
             val.XmlResolver = new XmlUrlResolver(); //Adding this as the default resolver is null and not XmlUrlResolver anymore
 
             val.Initialize();
-            val.ValidateElement("foo", "", null, "t:type1", null, "uri:tempuri " + TestData + XSDFILE_TARGET_NAMESPACE, null);
+            val.ValidateElement("foo", "", null, "t:type1", null, "uri:tempuri " + Path.Combine(TestData, XSDFILE_TARGET_NAMESPACE), null);
             val.ValidateEndOfAttributes(null);
             val.ValidateElement("bar", "", null);
             val.ValidateEndOfAttributes(null);
@@ -74,7 +74,7 @@ namespace System.Xml.Tests
             if (schemaLocation)
             {
                 manager.AddNamespace("t", "uri:tempuri");
-                val.ValidateElement("foo", "", null, "t:type1", null, "uri:tempuri " + TestData + XSDFILE_TARGET_NAMESPACE, null);
+                val.ValidateElement("foo", "", null, "t:type1", null, "uri:tempuri " + Path.Combine(TestData, XSDFILE_TARGET_NAMESPACE), null);
             }
             else
             {
@@ -104,7 +104,7 @@ namespace System.Xml.Tests
             val.XmlResolver = res;
 
             val.Initialize();
-            val.AddSchema(XmlSchema.Read(XmlReader.Create(TestData + XSDFILE_VALIDATE_ATTRIBUTE), null)); // this schema has xs:import
+            val.AddSchema(XmlSchema.Read(XmlReader.Create(Path.Combine(TestData, XSDFILE_VALIDATE_ATTRIBUTE)), null)); // this schema has xs:import
             val.ValidateElement("NoAttributesElement", "", null);
 
             Assert.True(!holder.IsCalledResolveUri);
@@ -131,7 +131,7 @@ namespace System.Xml.Tests
             val.XmlResolver = res;
             val.Initialize();
 
-            val.ValidateElement("foo", "", null, "type1", null, null, TestData + XSDFILE_NO_TARGET_NAMESPACE);
+            val.ValidateElement("foo", "", null, "type1", null, null, Path.Combine(TestData, XSDFILE_NO_TARGET_NAMESPACE));
             val.SkipToEndElement(null);
 
             Assert.True(holder.IsCalledResolveUri);
@@ -141,7 +141,7 @@ namespace System.Xml.Tests
             holder.IsCalledGetEntity = false;
             holder.IsCalledResolveUri = false;
 
-            val.ValidateElement("foo", "", null, "type1", null, null, TestData + XSDFILE_NO_TARGET_NAMESPACE);
+            val.ValidateElement("foo", "", null, "type1", null, null, Path.Combine(TestData, XSDFILE_NO_TARGET_NAMESPACE));
 
             Assert.True(!holder.IsCalledResolveUri);
             Assert.True(!holder.IsCalledGetEntity);
@@ -167,7 +167,7 @@ namespace System.Xml.Tests
             val.XmlResolver = res;
             val.Initialize();
 
-            val.ValidateElement("foo", "", null, "type1", null, null, TestData + XSDFILE_NO_TARGET_NAMESPACE);
+            val.ValidateElement("foo", "", null, "type1", null, null, Path.Combine(TestData, XSDFILE_NO_TARGET_NAMESPACE));
             val.SkipToEndElement(null);
 
             Assert.True(holder.IsCalledResolveUri);
@@ -178,7 +178,7 @@ namespace System.Xml.Tests
 
             try
             {
-                val.ValidateElement("bar", "", null, "t:type1", null, "uri:tempuri " + TestData + XSDFILE_TARGET_NAMESPACE, null);
+                val.ValidateElement("bar", "", null, "t:type1", null, "uri:tempuri " + Path.Combine(TestData, XSDFILE_TARGET_NAMESPACE), null);
                 Assert.True(false);
             }
             catch (XmlSchemaValidationException)

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateAttribute.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateAttribute.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections;
+using System.IO;
 using System.Xml;
 using System.Xml.Schema;
 using Xunit;
@@ -161,7 +162,7 @@ namespace System.Xml.Tests
             XmlSchemaSet schemas = new XmlSchemaSet();
             XmlSchemaInfo info = new XmlSchemaInfo();
 
-            schemas.Add("", TestData + XSDFILE_200_DEF_ATTRIBUTES);
+            schemas.Add("", Path.Combine(TestData, XSDFILE_200_DEF_ATTRIBUTES));
             schemas.Compile();
             val = CreateValidator(schemas);
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateAttribute_String.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateAttribute_String.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections;
+using System.IO;
 using System.Xml;
 using System.Xml.Schema;
 using Xunit;
@@ -161,7 +162,7 @@ namespace System.Xml.Tests
             XmlSchemaSet schemas = new XmlSchemaSet();
             XmlSchemaInfo info = new XmlSchemaInfo();
 
-            schemas.Add("", TestData + XSDFILE_200_DEF_ATTRIBUTES);
+            schemas.Add("", Path.Combine(TestData, XSDFILE_200_DEF_ATTRIBUTES));
             schemas.Compile();
             val = CreateValidator(schemas);
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateElement.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateElement.cs
@@ -112,7 +112,7 @@ namespace System.Xml.Tests
             XmlSchemaInfo info = new XmlSchemaInfo();
             string name = elemType;
 
-            schemas.Add("", TestData + XSDFILE_VALIDATE_TEXT);
+            schemas.Add("", Path.Combine(TestData, XSDFILE_VALIDATE_TEXT));
             schemas.Compile();
             val = CreateValidator(schemas);
 
@@ -142,7 +142,7 @@ namespace System.Xml.Tests
             XmlSchemaSet schemas = new XmlSchemaSet();
             XmlSchemaInfo info = new XmlSchemaInfo();
 
-            schemas.Add("", TestData + XSDFILE_VALIDATE_END_ELEMENT);
+            schemas.Add("", Path.Combine(TestData, XSDFILE_VALIDATE_END_ELEMENT));
             schemas.Compile();
             val = CreateValidator(schemas);
 
@@ -188,7 +188,7 @@ namespace System.Xml.Tests
             ns.AddNamespace("t", "uri:tempuri");
 
             val.Initialize();
-            val.ValidateElement("root", "", info, "t:type1", null, "uri:tempuri " + TestData + XSDFILE_TARGET_NAMESPACE, null);
+            val.ValidateElement("root", "", info, "t:type1", null, "uri:tempuri " + Path.Combine(TestData, XSDFILE_TARGET_NAMESPACE), null);
 
             if ((int)allFlags == (int)AllFlags)
             {
@@ -223,7 +223,7 @@ namespace System.Xml.Tests
             val.ValidationEventHandler += new ValidationEventHandler(holder.CallbackA);
 
             val.Initialize();
-            val.ValidateElement("root", "", info, "type1", null, null, TestData + XSDFILE_NO_TARGET_NAMESPACE);
+            val.ValidateElement("root", "", info, "type1", null, null, Path.Combine(TestData, XSDFILE_NO_TARGET_NAMESPACE));
 
             if ((int)allFlags == (int)AllFlags)
             {
@@ -294,7 +294,7 @@ namespace System.Xml.Tests
             XmlNamespaceManager ns = new XmlNamespaceManager(new NameTable());
             XmlSchemaSet schemas = new XmlSchemaSet();
 
-            schemas.Add("uri:tempuri", TestData + XSDFILE_TARGET_NAMESPACE);
+            schemas.Add("uri:tempuri", Path.Combine(TestData, XSDFILE_TARGET_NAMESPACE));
             val = CreateValidator(schemas, ns, 0);
             ns.AddNamespace("t", "uri:tempuri");
 
@@ -312,7 +312,7 @@ namespace System.Xml.Tests
             XmlNamespaceManager ns = new XmlNamespaceManager(new NameTable());
             XmlSchemaSet schemas = new XmlSchemaSet();
 
-            schemas.Add("uri:tempuri", TestData + XSDFILE_TARGET_NAMESPACE);
+            schemas.Add("uri:tempuri", Path.Combine(TestData, XSDFILE_TARGET_NAMESPACE));
             val = CreateValidator(schemas, ns, 0);
             ns.AddNamespace("t", "uri:tempuri");
 
@@ -352,7 +352,7 @@ namespace System.Xml.Tests
             ns.AddNamespace("t", "uri:tempuri");
 
             val.Initialize();
-            val.ValidateElement("root", "", info, "t:rootType", null, "uri:tempuri " + TestData + "__NonExistingFile__.xsd", null);
+            val.ValidateElement("root", "", info, "t:rootType", null, "uri:tempuri " + Path.Combine(TestData, "__NonExistingFile__.xsd"), null);
 
             Assert.True(holder.IsCalledA);
             Assert.Equal(holder.lastSeverity, XmlSeverityType.Warning);
@@ -380,7 +380,7 @@ namespace System.Xml.Tests
             val.ValidationEventHandler += new ValidationEventHandler(holder.CallbackA);
 
             val.Initialize();
-            val.ValidateElement("root", "", info, "rootType", null, null, TestData + "__NonExistingFile__.xsd");
+            val.ValidateElement("root", "", info, "rootType", null, null, Path.Combine(TestData, "__NonExistingFile__.xsd"));
 
             Assert.True(holder.IsCalledA);
             Assert.Equal(holder.lastSeverity, XmlSeverityType.Warning);
@@ -438,7 +438,7 @@ namespace System.Xml.Tests
             XmlSchemaParticle[] actualParticles;
             string[] expectedParticles = { "eleA", "eleB", "eleC" };
 
-            schemas.Add("", TestData + @"\Bug342447.xsd");
+            schemas.Add("", Path.Combine(TestData, @"\Bug342447.xsd"));
             schemas.Compile();
             val = CreateValidator(schemas);
             val.Initialize();

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateElement.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateElement.cs
@@ -438,7 +438,7 @@ namespace System.Xml.Tests
             XmlSchemaParticle[] actualParticles;
             string[] expectedParticles = { "eleA", "eleB", "eleC" };
 
-            schemas.Add("", Path.Combine(TestData, @"\Bug342447.xsd"));
+            schemas.Add("", Path.Combine(TestData, "Bug342447.xsd"));
             schemas.Compile();
             val = CreateValidator(schemas);
             val.Initialize();

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
@@ -20,27 +20,27 @@ namespace System.Xml.Tests
             _output = output;
         }
 
-        private static string path = Path.Combine(FilePathUtil.GetStandardPath(), @"xsd10\");
+        private static string path = Path.Combine(FilePathUtil.GetStandardPath(), "xsd10");
 
         [Theory]
-        [InlineData(@"attributeGroup\attgC007.xsd", 1, 1, 1, 2)]
-        [InlineData(@"attributeGroup\attgC024.xsd", 2, 3, 2, 0)]
-        [InlineData(@"attributeGroup\attgC026.xsd", 1, 4, 1, 0)]
-        [InlineData(@"complexType\ctA001.xsd", 1, 2, 1, 0)]
-        [InlineData(@"complexType\ctA002.xsd", 1, 3, 1, 0)]
-        [InlineData(@"complexType\ctA003.xsd", 1, 3, 1, 0)]
-        [InlineData(@"particles\particlesA006.xsd", 1, 2, 1, 0)]
-        [InlineData(@"particles\particlesA002.xsd", 1, 2, 1, 0)]
-        [InlineData(@"particles\particlesA007.xsd", 1, 2, 1, 0)]
-        [InlineData(@"particles\particlesA010.xsd", 1, 2, 1, 0)]
-        [InlineData(@"simpleType\bug102159_1.xsd", 1, 2, 3, 0)]
-        [InlineData(@"simpleType\stE064.xsd", 1, 1, 1, 0)]
-        [InlineData(@"wildcards\wildG007.xsd", 1, 1, 2, 0)]
-        [InlineData(@"wildcards\wildG010.xsd", 3, 1, 5, 0)]
-        public void v1(String testFile, int expCount, int expCountGT, int expCountGE, int expCountGA)
+        [InlineData("attributeGroup", "attgC007.xsd", 1, 1, 1, 2)]
+        [InlineData("attributeGroup", "attgC024.xsd", 2, 3, 2, 0)]
+        [InlineData("attributeGroup", "attgC026.xsd", 1, 4, 1, 0)]
+        [InlineData("complexType", "ctA001.xsd", 1, 2, 1, 0)]
+        [InlineData("complexType", "ctA002.xsd", 1, 3, 1, 0)]
+        [InlineData("complexType", "ctA003.xsd", 1, 3, 1, 0)]
+        [InlineData("PARTICLES", "particlesA006.xsd", 1, 2, 1, 0)]
+        [InlineData("PARTICLES", "particlesA002.xsd", 1, 2, 1, 0)]
+        [InlineData("PARTICLES", "particlesA007.xsd", 1, 2, 1, 0)]
+        [InlineData("PARTICLES", "particlesA010.xsd", 1, 2, 1, 0)]
+        [InlineData("simpleType", "bug102159_1.xsd", 1, 2, 3, 0)]
+        [InlineData("simpleType", "stE064.xsd", 1, 1, 1, 0)]
+        [InlineData("Wildcards", "wildG007.xsd", 1, 1, 2, 0)]
+        [InlineData("Wildcards", "wildG010.xsd", 3, 1, 5, 0)]
+        public void v1(String testDir, String testFile, int expCount, int expCountGT, int expCountGE, int expCountGA)
         {
             Initialize();
-            string xsd = path + testFile;
+            string xsd = Path.Combine(path, testDir, testFile);
 
             XmlSchemaSet ss = new XmlSchemaSet();
             XmlSchema Schema = XmlSchema.Read(XmlReader.Create(xsd), ValidationCallback);
@@ -77,25 +77,25 @@ namespace System.Xml.Tests
         }
 
         [Theory]
-        [InlineData(@"attributeGroup\attgC007", 1, 1, 1, 2)]
-        [InlineData(@"attributeGroup\attgC024", 2, 3, 2, 0)]
-        [InlineData(@"attributeGroup\attgC026", 1, 4, 1, 0)]
-        [InlineData(@"complexType\ctA001", 1, 2, 1, 0)]
-        [InlineData(@"complexType\ctA002", 1, 3, 1, 0)]
-        [InlineData(@"complexType\ctA003", 1, 3, 1, 0)]
-        [InlineData(@"particles\particlesA006", 1, 2, 1, 0)]
-        [InlineData(@"particles\particlesA002", 1, 2, 1, 0)]
-        [InlineData(@"particles\particlesA007", 1, 2, 1, 0)]
-        [InlineData(@"particles\particlesA010", 1, 2, 1, 0)]
-        [InlineData(@"simpleType\bug102159_1", 1, 2, 3, 0)]
-        [InlineData(@"simpleType\stE064", 1, 1, 1, 0)]
-        [InlineData(@"wildcards\wildG007", 1, 1, 2, 0)]
-        [InlineData(@"wildcards\wildG010", 3, 1, 5, 0)]
-        public void v2(String testFile, int expCount, int expCountGT, int expCountGE, int expCountGA)
+        [InlineData("attributeGroup", "attgC007", 1, 1, 1, 2)]
+        [InlineData("attributeGroup", "attgC024", 2, 3, 2, 0)]
+        [InlineData("attributeGroup", "attgC026", 1, 4, 1, 0)]
+        [InlineData("complexType", "ctA001", 1, 2, 1, 0)]
+        [InlineData("complexType", "ctA002", 1, 3, 1, 0)]
+        [InlineData("complexType", "ctA003", 1, 3, 1, 0)]
+        [InlineData("PARTICLES", "particlesA006", 1, 2, 1, 0)]
+        [InlineData("PARTICLES", "particlesA002", 1, 2, 1, 0)]
+        [InlineData("PARTICLES", "particlesA007", 1, 2, 1, 0)]
+        [InlineData("PARTICLES", "particlesA010", 1, 2, 1, 0)]
+        [InlineData("simpleType", "bug102159_1", 1, 2, 3, 0)]
+        [InlineData("simpleType", "stE064", 1, 1, 1, 0)]
+        [InlineData("Wildcards", "wildG007", 1, 1, 2, 0)]
+        [InlineData("Wildcards", "wildG010", 3, 1, 5, 0)]
+        public void v2(String testDir, String testFile, int expCount, int expCountGT, int expCountGE, int expCountGA)
         {
             Initialize();
-            string xsd = path + testFile + ".xsd";
-            string xml = path + testFile + ".xml";
+            string xsd = Path.Combine(path, testDir, testFile + ".xsd");
+            string xml = Path.Combine(path, testDir, testFile + ".xml");
 
             XmlSchemaSet ss = new XmlSchemaSet();
             XmlSchema Schema = XmlSchema.Read(XmlReader.Create(xsd), ValidationCallback);
@@ -139,27 +139,27 @@ namespace System.Xml.Tests
             _output = output;
         }
 
-        private static string path = Path.Combine(FilePathUtil.GetStandardPath(), @"xsd10\");
+        private static string path = Path.Combine(FilePathUtil.GetStandardPath(), "xsd10");
 
         [Theory]
-        [InlineData(@"attributeGroup\attgC007.xsd", 1, 1, 1, 2, 0, 0)]
-        [InlineData(@"attributeGroup\attgC024.xsd", 2, 3, 2, 0, 1, 1)]
-        [InlineData(@"attributeGroup\attgC026.xsd", 1, 4, 1, 0, 0, 0)]
-        [InlineData(@"complexType\ctA001.xsd", 1, 2, 1, 0, 0, 0)]
-        [InlineData(@"complexType\ctA002.xsd", 1, 3, 1, 0, 0, 0)]
-        [InlineData(@"complexType\ctA003.xsd", 1, 3, 1, 0, 0, 0)]
-        [InlineData(@"particles\particlesA006.xsd", 1, 2, 1, 0, 0, 0)]
-        [InlineData(@"particles\particlesA002.xsd", 1, 2, 1, 0, 0, 0)]
-        [InlineData(@"particles\particlesA007.xsd", 1, 2, 1, 0, 0, 0)]
-        [InlineData(@"particles\particlesA010.xsd", 1, 2, 1, 0, 0, 0)]
-        [InlineData(@"simpleType\bug102159_1.xsd", 1, 2, 3, 0, 0, 0)]
-        [InlineData(@"simpleType\stE064.xsd", 1, 1, 1, 0, 0, 0)]
-        [InlineData(@"wildcards\wildG007.xsd", 1, 1, 2, 0, 0, 0)]
-        [InlineData(@"wildcards\wildG010.xsd", 3, 1, 5, 0, 3, 1)]
-        public void v1(String testFile, int expCount, int expCountGT, int expCountGE, int expCountGA, int expCountGER, int expCountGERC)
+        [InlineData("attributeGroup", "attgC007.xsd", 1, 1, 1, 2, 0, 0)]
+        [InlineData("attributeGroup", "attgC024.xsd", 2, 3, 2, 0, 1, 1)]
+        [InlineData("attributeGroup", "attgC026.xsd", 1, 4, 1, 0, 0, 0)]
+        [InlineData("complexType", "ctA001.xsd", 1, 2, 1, 0, 0, 0)]
+        [InlineData("complexType", "ctA002.xsd", 1, 3, 1, 0, 0, 0)]
+        [InlineData("complexType", "ctA003.xsd", 1, 3, 1, 0, 0, 0)]
+        [InlineData("PARTICLES", "particlesA006.xsd", 1, 2, 1, 0, 0, 0)]
+        [InlineData("PARTICLES", "particlesA002.xsd", 1, 2, 1, 0, 0, 0)]
+        [InlineData("PARTICLES", "particlesA007.xsd", 1, 2, 1, 0, 0, 0)]
+        [InlineData("PARTICLES", "particlesA010.xsd", 1, 2, 1, 0, 0, 0)]
+        [InlineData("simpleType", "bug102159_1.xsd", 1, 2, 3, 0, 0, 0)]
+        [InlineData("simpleType", "stE064.xsd", 1, 1, 1, 0, 0, 0)]
+        [InlineData("Wildcards", "wildG007.xsd", 1, 1, 2, 0, 0, 0)]
+        [InlineData("Wildcards", "wildG010.xsd", 3, 1, 5, 0, 3, 1)]
+        public void v1(String testDir, String testFile, int expCount, int expCountGT, int expCountGE, int expCountGA, int expCountGER, int expCountGERC)
         {
             Initialize();
-            string xsd = path + testFile;
+            string xsd = Path.Combine(path, testDir, testFile);
 
             XmlSchemaSet ss = new XmlSchemaSet();
             XmlSchema Schema = XmlSchema.Read(XmlReader.Create(xsd), ValidationCallback);
@@ -206,25 +206,25 @@ namespace System.Xml.Tests
         }
 
         [Theory]
-        [InlineData(@"attributeGroup\attgC007", 1, 1, 1, 2, 0, 0)]
-        [InlineData(@"attributeGroup\attgC024", 2, 3, 2, 0, 1, 1)]
-        [InlineData(@"attributeGroup\attgC026", 1, 4, 1, 0, 0, 0)]
-        [InlineData(@"complexType\ctA001", 1, 2, 1, 0, 0, 0)]
-        [InlineData(@"complexType\ctA002", 1, 3, 1, 0, 0, 0)]
-        [InlineData(@"complexType\ctA003", 1, 3, 1, 0, 0, 0)]
-        [InlineData(@"particles\particlesA006", 1, 2, 1, 0, 0, 0)]
-        [InlineData(@"particles\particlesA002", 1, 2, 1, 0, 0, 0)]
-        [InlineData(@"particles\particlesA007", 1, 2, 1, 0, 0, 0)]
-        [InlineData(@"particles\particlesA010", 1, 2, 1, 0, 0, 0)]
-        [InlineData(@"simpleType\bug102159_1", 1, 2, 3, 0, 0, 0)]
-        [InlineData(@"simpleType\stE064", 1, 1, 1, 0, 0, 0)]
-        [InlineData(@"wildcards\wildG007", 1, 1, 2, 0, 0, 0)]
-        [InlineData(@"wildcards\wildG010", 3, 1, 5, 0, 3, 1)]
-        public void v2(String testFile, int expCount, int expCountGT, int expCountGE, int expCountGA, int expCountGER, int expCountGERC)
+        [InlineData("attributeGroup", "attgC007", 1, 1, 1, 2, 0, 0)]
+        [InlineData("attributeGroup", "attgC024", 2, 3, 2, 0, 1, 1)]
+        [InlineData("attributeGroup", "attgC026", 1, 4, 1, 0, 0, 0)]
+        [InlineData("complexType", "ctA001", 1, 2, 1, 0, 0, 0)]
+        [InlineData("complexType", "ctA002", 1, 3, 1, 0, 0, 0)]
+        [InlineData("complexType", "ctA003", 1, 3, 1, 0, 0, 0)]
+        [InlineData("PARTICLES", "particlesA006", 1, 2, 1, 0, 0, 0)]
+        [InlineData("PARTICLES", "particlesA002", 1, 2, 1, 0, 0, 0)]
+        [InlineData("PARTICLES", "particlesA007", 1, 2, 1, 0, 0, 0)]
+        [InlineData("PARTICLES", "particlesA010", 1, 2, 1, 0, 0, 0)]
+        [InlineData("simpleType", "bug102159_1", 1, 2, 3, 0, 0, 0)]
+        [InlineData("simpleType", "stE064", 1, 1, 1, 0, 0, 0)]
+        [InlineData("Wildcards", "wildG007", 1, 1, 2, 0, 0, 0)]
+        [InlineData("Wildcards", "wildG010", 3, 1, 5, 0, 3, 1)]
+        public void v2(String testDir, String testFile, int expCount, int expCountGT, int expCountGE, int expCountGA, int expCountGER, int expCountGERC)
         {
             Initialize();
-            string xsd = path + testFile + ".xsd";
-            string xml = path + testFile + ".xml";
+            string xsd = Path.Combine(path, testDir, testFile + ".xsd");
+            string xml = Path.Combine(path, testDir, testFile + ".xml");
 
             XmlSchemaSet ss = new XmlSchemaSet();
             XmlSchema Schema = XmlSchema.Read(XmlReader.Create(xsd), ValidationCallback);
@@ -279,23 +279,23 @@ namespace System.Xml.Tests
             _output = output;
         }
 
-        private static string path = Path.Combine(FilePathUtil.GetStandardPath(), @"xsd10\");
+        private static string path = Path.Combine(FilePathUtil.GetStandardPath(), "xsd10");
 
         [Theory]
-        [InlineData(@"attributeGroup\attgC007.xsd", 1)]
-        [InlineData(@"attributeGroup\attgC024.xsd", 2)]
-        [InlineData(@"attributeGroup\attgC026.xsd", 1)]
-        [InlineData(@"complexType\ctA001.xsd", 1)]
-        [InlineData(@"complexType\ctA002.xsd", 1)]
-        [InlineData(@"complexType\ctA003.xsd", 1)]
-        [InlineData(@"simpleType\bug102159_1.xsd", 1)]
-        [InlineData(@"simpleType\stE064.xsd", 1)]
-        [InlineData(@"wildcards\wildG007.xsd", 1)]
-        [InlineData(@"wildcards\wildG010.xsd", 3)]
-        public void v1(String TestFile, int expCount)
+        [InlineData("attributeGroup", "attgC007.xsd", 1)]
+        [InlineData("attributeGroup", "attgC024.xsd", 2)]
+        [InlineData("attributeGroup", "attgC026.xsd", 1)]
+        [InlineData("complexType", "ctA001.xsd", 1)]
+        [InlineData("complexType", "ctA002.xsd", 1)]
+        [InlineData("complexType", "ctA003.xsd", 1)]
+        [InlineData("simpleType", "bug102159_1.xsd", 1)]
+        [InlineData("simpleType", "stE064.xsd", 1)]
+        [InlineData("Wildcards", "wildG007.xsd", 1)]
+        [InlineData("Wildcards", "wildG010.xsd", 3)]
+        public void v1(String testDir, String TestFile, int expCount)
         {
             Initialize();
-            string xsd = path + TestFile;
+            string xsd = Path.Combine(path, testDir, TestFile);
 
             XmlSchemaSet ss = new XmlSchemaSet();
             XmlSchema Schema = XmlSchema.Read(XmlReader.Create(xsd), ValidationCallback);
@@ -343,25 +343,25 @@ namespace System.Xml.Tests
         }
 
         [Theory]
-        [InlineData(@"attributeGroup\attgC007", 1)]
-        [InlineData(@"attributeGroup\attgC024", 2)]
-        [InlineData(@"attributeGroup\attgC026", 1)]
-        [InlineData(@"complexType\ctA001", 1)]
-        [InlineData(@"complexType\ctA002", 1)]
-        [InlineData(@"complexType\ctA003", 1)]
-        [InlineData(@"particles\particlesA006", 1)]
-        [InlineData(@"particles\particlesA002", 1)]
-        [InlineData(@"particles\particlesA007", 1)]
-        [InlineData(@"particles\particlesA010", 1)]
-        [InlineData(@"simpleType\bug102159_1", 1)]
-        [InlineData(@"simpleType\stE064", 1)]
-        [InlineData(@"wildcards\wildG007", 1)]
-        [InlineData(@"wildcards\wildG010", 3)]
-        public void v2(String testFile, int expCount)
+        [InlineData("attributeGroup", "attgC007", 1)]
+        [InlineData("attributeGroup", "attgC024", 2)]
+        [InlineData("attributeGroup", "attgC026", 1)]
+        [InlineData("complexType", "ctA001", 1)]
+        [InlineData("complexType", "ctA002", 1)]
+        [InlineData("complexType", "ctA003", 1)]
+        [InlineData("PARTICLES", "particlesA006", 1)]
+        [InlineData("PARTICLES", "particlesA002", 1)]
+        [InlineData("PARTICLES", "particlesA007", 1)]
+        [InlineData("PARTICLES", "particlesA010", 1)]
+        [InlineData("simpleType", "bug102159_1", 1)]
+        [InlineData("simpleType", "stE064", 1)]
+        [InlineData("Wildcards", "wildG007", 1)]
+        [InlineData("Wildcards", "wildG010", 3)]
+        public void v2(String testDir, String testFile, int expCount)
         {
             Initialize();
-            string xsd = path + testFile + ".xsd";
-            string xml = path + testFile + ".xml";
+            string xsd = Path.Combine(path, testDir, testFile + ".xsd");
+            string xml = Path.Combine(path, testDir, testFile + ".xml");
 
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
@@ -415,19 +415,19 @@ namespace System.Xml.Tests
             _output = output;
         }
 
-        private static string path = Path.Combine(FilePathUtil.GetStandardPath(), @"xsd10\");
-        private static string testData = Path.Combine(FilePathUtil.GetTestDataPath(), @"XmlSchemaCollection\");
+        private static string path = Path.Combine(FilePathUtil.GetStandardPath(), "xsd10");
+        private static string testData = Path.Combine(FilePathUtil.GetTestDataPath(), "XmlSchemaCollection");
 
         [Theory]
-        [InlineData(@"schema\schE1_a.xsd", 2, 3, 3)]
-        [InlineData(@"schema\schE3.xsd", 1, 1, 0)]
-        [InlineData(@"schema\schB8.xsd", 1, 1, 1)]
-        [InlineData(@"schema\schB1_a.xsd", 1, 3, 3)]
-        [InlineData(@"schema\schM2_a.xsd", 1, 3, 3)]
-        [InlineData(@"schema\schH2_a.xsd", 1, 3, 3)]
-        public void AddValid_Import_Include_Redefine(String testFile, int expCount, int expCountGT, int expCountGE)
+        [InlineData("SCHEMA", "schE1_a.xsd", 2, 3, 3)]
+        [InlineData("SCHEMA", "schE3.xsd", 1, 1, 0)]
+        [InlineData("SCHEMA", "schB8.xsd", 1, 1, 1)]
+        [InlineData("SCHEMA", "schB1_a.xsd", 1, 3, 3)]
+        [InlineData("SCHEMA", "schM2_a.xsd", 1, 3, 3)]
+        [InlineData("SCHEMA", "schH2_a.xsd", 1, 3, 3)]
+        public void AddValid_Import_Include_Redefine(String testDir, String testFile, int expCount, int expCountGT, int expCountGE)
         {
-            string xsd = path + testFile;
+            string xsd = Path.Combine(path, testDir, testFile);
 
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
@@ -450,11 +450,11 @@ namespace System.Xml.Tests
         }
 
         [Theory]
-        [InlineData(@"schema\schE9.xsd", 1, 1)]
-        [InlineData(@"schema\schA7_a.xsd", 2, 2)]
-        public void AddEditInvalidImport(String testFile, int expCountGT, int expCountGE)
+        [InlineData("SCHEMA", "schE9.xsd", 1, 1)]
+        [InlineData("SCHEMA", "schA7_a.xsd", 2, 2)]
+        public void AddEditInvalidImport(String testDir, String testFile, int expCountGT, int expCountGE)
         {
-            string xsd = path + testFile;
+            string xsd = Path.Combine(path, testDir, testFile);
 
             XmlSchemaSet ss = new XmlSchemaSet();
             XmlSchema Schema = XmlSchema.Read(XmlReader.Create(xsd), null);
@@ -508,7 +508,7 @@ namespace System.Xml.Tests
         [InlineData("include_v1_a.xsd", 3, 3)]
         public void AddEditInvalidIncludeSchema(String testFile, int expCountGT, int expCountGE)
         {
-            string xsd = testData + testFile;
+            string xsd = Path.Combine(testData, testFile);
 
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();
@@ -558,15 +558,15 @@ namespace System.Xml.Tests
         }
 
         [Theory]
-        [InlineData(@"schema\schH3.xsd")]
-        [InlineData(@"schema\schF3_a.xsd")]
-        [InlineData(@"schema\schE1i.xsd")]
-        [InlineData(@"schema\schB4_a.xsd")]
-        [InlineData(@"schema\schB1i.xsd")]
-        public void AddInvalid_Import_Include(String testFile)
+        [InlineData("SCHEMA", "schH3.xsd")]
+        [InlineData("SCHEMA", "schF3_a.xsd")]
+        [InlineData("SCHEMA", "schE1i.xsd")]
+        [InlineData("SCHEMA", "schB4_a.xsd")]
+        [InlineData("SCHEMA", "schB1i.xsd")]
+        public void AddInvalid_Import_Include(String testDir, String testFile)
         {
             Initialize();
-            string xsd = path + testFile;
+            string xsd = Path.Combine(path, testDir, testFile);
 
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.XmlResolver = new XmlUrlResolver();

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidatorModule.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidatorModule.cs
@@ -19,7 +19,7 @@ namespace System.Xml.Tests
             _output = output;
         }
 
-        private string m_TestData = Path.Combine(FilePathUtil.GetTestDataPath(), @"XmlSchemaValidatorApi\");
+        private string m_TestData = Path.Combine(FilePathUtil.GetTestDataPath(), "XmlSchemaValidatorAPI");
 
         public string TestData
         {
@@ -71,7 +71,7 @@ namespace System.Xml.Tests
             schemas.XmlResolver = new XmlUrlResolver();
 
             if (!path.StartsWith("file://") && !path.StartsWith("http://"))
-                path = this.TestData + path;
+                path = Path.Combine(this.TestData, path);
 
             schemas.Add(targetNamespace, path);
             schemas.Compile();

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
@@ -34,8 +34,8 @@
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
     <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\xmlDiff\XmlDiff.csproj" />
-    <ProjectReference Include="..\xslTransformApi\System.Xml.Xsl.XslTransformApi.Tests.csproj" />
+    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlDiff\XmlDiff.csproj" />
+    <ProjectReference Include="..\XslTransformApi\System.Xml.Xsl.XslTransformApi.Tests.csproj" />
     <ProjectReference Include="..\..\..\..\System.Private.Xml\pkg\System.Private.Xml.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompiledTransform.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompiledTransform.cs
@@ -278,7 +278,7 @@ namespace System.Xml.Tests
         // Q>       In CompileToType when scriptAssemblyPath is null, should we really throw ArgumentNullExc
         //          if the stylesheet does not have any scripts (but the settings are enabled)?
         //
-        // Anton>   Sergey and I think it’s acceptable behavior. Implementing the other way will require extra
+        // Anton>   Sergey and I think it\92s acceptable behavior. Implementing the other way will require extra
         //          code churn in 3 files, which we tried to avoid.
 
         //BinCompat TODO: Add this test back
@@ -479,11 +479,11 @@ namespace System.Xml.Tests
             //{
             //    /*
             //     * Anton> If staticData array is malformed, you end up with weird exceptions.
-            //     * We didn’t expect this method to be public and didn’t implement any range/sanity
+            //     * We didn\92t expect this method to be public and didn\92t implement any range/sanity
             //     * checks in deserialization code path, besides CLR implicit range checks for array indices.
             //     * You have found one such place, but there are dozens of them. Fixing all of them will cause
             //     * code churn in many files and another round of [code review/test sign-off/approval] process.
-            //     * Right now it works according to the “Garbage In, Garbage Out” principle.
+            //     * Right now it works according to the \93Garbage In, Garbage Out\94 principle.
             //     *
             //     */
             //    _output.WriteLine(e.ToString());
@@ -2150,7 +2150,7 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Load with \"\\\\\"")]
-        [PlatformSpecific(TestPlatforms.Windows)] //Not a valid path on Unix
+        [PlatformSpecific(TestPlatforms.Windows)] //Not an invalid path on Unix
         [InlineData()]
         [Theory]
         public void LoadUrl5()

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompiledTransform.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompiledTransform.cs
@@ -73,7 +73,7 @@ namespace System.Xml.Tests
                     if (!scriptTestPath.EndsWith(Path.DirectorySeparatorChar.ToString()))
                         scriptTestPath += Path.DirectorySeparatorChar;
 
-                    scriptTestPath += "Scripting\\";
+                    scriptTestPath += "Scripting" + Path.DirectorySeparatorChar;
                 }
 
                 return scriptTestPath;
@@ -99,7 +99,7 @@ namespace System.Xml.Tests
         {
             get
             {
-                String asmPath = Path.Combine(@"TestFiles\", FilePathUtil.GetTestDataPath(), @"xsltc\precompiled\bftBaseLine.dll");
+                String asmPath = Path.Combine(Path.Combine("TestFiles", FilePathUtil.GetTestDataPath(), "xsltc", "precompiled"), "bftBaseLine.dll");
                 String type = "bftBaseLine";
 
                 Assembly asm = AssemblyLoadContext.Default.LoadFromAssemblyPath(asmPath);
@@ -996,7 +996,7 @@ namespace System.Xml.Tests
         {
             try
             {
-                LoadXSL("xmlResolver_main.xsl", null);
+                LoadXSL("XmlResolver_Main.xsl", null);
                 Assert.True(false);
             }
             catch (XsltException e1)
@@ -1024,7 +1024,7 @@ namespace System.Xml.Tests
         {
             try
             {
-                LoadXSL("xmlResolver_main.xsl", null);
+                LoadXSL("XmlResolver_Main.xsl", null);
                 _output.WriteLine("No exception was thrown");
                 Assert.True(false);
             }
@@ -1052,7 +1052,7 @@ namespace System.Xml.Tests
         [Theory]
         public void XmlResolver3(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
 
             if (LoadXSL("xmlResolver_document_function.xsl") == 1)
             {
@@ -1207,14 +1207,14 @@ namespace System.Xml.Tests
         [Theory]
         public void LoadGeneric3(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             try
             {
                 LoadXSL("IDontExist.xsl");
             }
             catch (System.IO.FileNotFoundException)
             {
-                if ((LoadXSL("ShowParam.xsl") == 1) && (Transform("fruits.xml") == 1))
+                if ((LoadXSL("showParam.xsl") == 1) && (Transform("fruits.xml") == 1))
                 {
                     VerifyResult(Baseline, _strOutFile);
                     return;
@@ -1229,7 +1229,7 @@ namespace System.Xml.Tests
         [Theory]
         public void LoadGeneric4(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             if (MyXslInputType() != XslInputType.Reader)
                 LoadXSL("showParamLongName.xsl", XslInputType.Reader, new XmlUrlResolver());
             if (MyXslInputType() != XslInputType.URI)
@@ -1237,7 +1237,7 @@ namespace System.Xml.Tests
             if (MyXslInputType() != XslInputType.Navigator)
                 LoadXSL("showParamLongName.xsl", XslInputType.Navigator, new XmlUrlResolver());
 
-            if ((LoadXSL("ShowParam.xsl") == 0) || (Transform("fruits.xml") == 0))
+            if ((LoadXSL("showParam.xsl") == 0) || (Transform("fruits.xml") == 0))
                 Assert.True(false);
 
             VerifyResult(Baseline, _strOutFile);
@@ -1249,7 +1249,7 @@ namespace System.Xml.Tests
             if (MyXslInputType() != XslInputType.Reader)
                 LoadXSL("showParamLongName.xsl", XslInputType.Reader, new XmlUrlResolver());
 
-            if ((LoadXSL("ShowParam.xsl") == 1) && (Transform("fruits.xml") == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform("fruits.xml") == 1))
             {
                 VerifyResult(Baseline, _strOutFile);
                 return;
@@ -1263,7 +1263,7 @@ namespace System.Xml.Tests
         [Theory]
         public void LoadGeneric5(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             for (int i = 0; i < 100; i++)
             {
                 if (LoadXSL("showParam.xsl") != 1)
@@ -1272,7 +1272,7 @@ namespace System.Xml.Tests
                     Assert.True(false);
                 }
             }
-            if ((LoadXSL("ShowParam.xsl") == 1) && (Transform("fruits.xml") == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform("fruits.xml") == 1))
             {
                 VerifyResult(Baseline, _strOutFile);
                 return;
@@ -1306,13 +1306,13 @@ namespace System.Xml.Tests
             FileStream s2;
 
             // check immediately after load and after transform
-            if (LoadXSL("XmlResolver_main.xsl") == 1)
+            if (LoadXSL("XmlResolver_Main.xsl") == 1)
             {
-                s2 = new FileStream(FullFilePath("XmlResolver_main.xsl"), FileMode.Open, FileAccess.Read, FileShare.Read);
+                s2 = new FileStream(FullFilePath("XmlResolver_Main.xsl"), FileMode.Open, FileAccess.Read, FileShare.Read);
                 s2.Dispose();
                 if ((Transform("fruits.xml") == 1) && (CheckResult(428.8541842246) == 1))
                 {
-                    s2 = new FileStream(FullFilePath("XmlResolver_main.xsl"), FileMode.Open, FileAccess.Read, FileShare.Read);
+                    s2 = new FileStream(FullFilePath("XmlResolver_Main.xsl"), FileMode.Open, FileAccess.Read, FileShare.Read);
                     s2.Dispose();
                     return;
                 }
@@ -1330,13 +1330,13 @@ namespace System.Xml.Tests
 
             // check immediately after load and after transform
 
-            if(LoadXSL("XmlResolver_main.xsl") == TEST_PASS)
+            if(LoadXSL("XmlResolver_Main.xsl") == TEST_PASS)
             {
-                s2 = new FileStream(FullFilePath("XmlResolver_main.xsl"), FileMode.Open, FileAccess.ReadWrite);
+                s2 = new FileStream(FullFilePath("XmlResolver_Main.xsl"), FileMode.Open, FileAccess.ReadWrite);
                 s2.Dispose();
                 if((Transform("fruits.xml") == TEST_PASS) && (CheckResult(428.8541842246)== TEST_PASS))
                 {
-                    s2 = new FileStream(FullFilePath("XmlResolver_main.xsl"), FileMode.Open, FileAccess.ReadWrite);
+                    s2 = new FileStream(FullFilePath("XmlResolver_Main.xsl"), FileMode.Open, FileAccess.ReadWrite);
                     s2.Dispose();
                     return;
                 }
@@ -1354,9 +1354,9 @@ namespace System.Xml.Tests
             FileStream s2;
 
             // check immediately after load and after transform
-            if (LoadXSL("XmlResolver_main.xsl") == 1)
+            if (LoadXSL("XmlResolver_Main.xsl") == 1)
             {
-                s2 = new FileStream(FullFilePath("XmlResolver_sub.xsl"), FileMode.Open, FileAccess.Read);
+                s2 = new FileStream(FullFilePath("XmlResolver_Sub.xsl"), FileMode.Open, FileAccess.Read);
                 s2.Dispose();
                 if ((Transform("fruits.xml") == 1) && (CheckResult(428.8541842246) == 1))
                 {
@@ -1378,7 +1378,7 @@ namespace System.Xml.Tests
             FileStream s2;
 
             // check immediately after load and after transform
-            if(LoadXSL("XmlResolver_main.xsl") == TEST_PASS)
+            if(LoadXSL("XmlResolver_Main.xsl") == TEST_PASS)
             {
                 s2 = new FileStream(FullFilePath("XmlResolver_sub.xsl"), FileMode.Open, FileAccess.ReadWrite);
                 s2.Dispose();
@@ -1395,6 +1395,7 @@ namespace System.Xml.Tests
         */
 
         //[Variation(id = 11, Desc = "Load stylesheet with entity reference: Bug #68450 ")]
+        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void LoadGeneric11()
@@ -1512,10 +1513,10 @@ namespace System.Xml.Tests
         [Theory]
         public void LoadGeneric3(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             try
             {
-                LoadXSL_Resolver("ShowParam.xsl", null);
+                LoadXSL_Resolver("showParam.xsl", null);
                 Transform("fruits.xml");
                 VerifyResult(Baseline, _strOutFile);
                 return;
@@ -1540,7 +1541,7 @@ namespace System.Xml.Tests
         {
             try
             {
-                LoadXSL_Resolver("xmlResolver_main.xsl", null);
+                LoadXSL_Resolver("XmlResolver_Main.xsl", null);
                 _output.WriteLine("No exception was thrown when a null resolver is passed");
                 Assert.True(false);
             }
@@ -1571,7 +1572,7 @@ namespace System.Xml.Tests
 
             try
             {
-                LoadXSL_Resolver("xmlResolver_main.xsl", myResolver);
+                LoadXSL_Resolver("XmlResolver_Main.xsl", myResolver);
                 _output.WriteLine("No exception is thrown");
                 Assert.True(false);
             }
@@ -1609,11 +1610,11 @@ namespace System.Xml.Tests
         [Theory]
         public void LoadGeneric6(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             CustomNullResolver myResolver = new CustomNullResolver(_output);
             try
             {
-                LoadXSL_Resolver("ShowParam.xsl", myResolver);
+                LoadXSL_Resolver("showParam.xsl", myResolver);
                 Transform("fruits.xml");
                 VerifyResult(Baseline, _strOutFile);
                 return;
@@ -1647,28 +1648,28 @@ namespace System.Xml.Tests
         [Theory]
         public void LoadGeneric7(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             CustomNullResolver myResolver = new CustomNullResolver(_output);
 
             try
             {
-                LoadXSL_Resolver("xmlResolver_main.xsl", myResolver);
+                LoadXSL_Resolver("XmlResolver_Main.xsl", myResolver);
             }
             //For input types != URI
             catch (System.Xml.Xsl.XsltException e1)
             {
-                // The lovely thing about this test is that the stylesheet, XmlResolver_main.xsl, has an include. GetEntity is therefore called twice. We need to have both these
-                // checks here to ensure that both the XmlResolver_main.xsl and XmlResolver_Include.xsl GetEntity() calls are handled.
+                // The lovely thing about this test is that the stylesheet, XmlResolver_Main.xsl, has an include. GetEntity is therefore called twice. We need to have both these
+                // checks here to ensure that both the XmlResolver_Main.xsl and XmlResolver_Include.xsl GetEntity() calls are handled.
                 try
                 {
-                    CheckExpectedError(e1, "System.Xml", "Xslt_CannotLoadStylesheet", new string[] { new Uri(Path.GetFullPath(FullFilePath("XmlResolver_Include.xsl"))).ToString(), "null" });
+                    CheckExpectedError(e1, "System.Xml", "Xslt_CannotLoadStylesheet", new string[] { new Uri(Uri.UriSchemeFile + Uri.SchemeDelimiter + Path.GetFullPath(FullFilePath("XmlResolver_Include.xsl"))).ToString(), "null" });
                 }
                 catch (Xunit.Sdk.TrueException)
                 {
-                    CheckExpectedError(e1, "System.Xml", "Xslt_CannotLoadStylesheet", new string[] { new Uri(Path.GetFullPath(FullFilePath("xmlResolver_main.xsl"))).ToString(), "null" });
+                    CheckExpectedError(e1, "System.Xml", "Xslt_CannotLoadStylesheet", new string[] { new Uri(Uri.UriSchemeFile + Uri.SchemeDelimiter + Path.GetFullPath(FullFilePath("XmlResolver_Main.xsl"))).ToString(), "null" });
                 }
 
-                if (LoadXSL("xmlResolver_main.xsl") == 1)
+                if (LoadXSL("XmlResolver_Main.xsl") == 1)
                 {
                     if ((Transform("fruits.xml") == 1) && (CheckResult(428.8541842246) == 1))
                         return;
@@ -1687,14 +1688,14 @@ namespace System.Xml.Tests
             {
                 try
                 {
-                    CheckExpectedError(e2, "System.Xml", "Xslt_CannotLoadStylesheet", new string[] { new Uri(Path.GetFullPath(FullFilePath("XmlResolver_Include.xsl"))).ToString(), "null" });
+                    CheckExpectedError(e2, "System.Xml", "Xslt_CannotLoadStylesheet", new string[] { new Uri(Uri.UriSchemeFile + Uri.SchemeDelimiter + Path.GetFullPath(FullFilePath("XmlResolver_Include.xsl"))).ToString(), "null" });
                 }
                 catch (Xunit.Sdk.TrueException)
                 {
-                    CheckExpectedError(e2, "System.Xml", "Xslt_CannotLoadStylesheet", new string[] { new Uri(Path.GetFullPath(FullFilePath("xmlResolver_main.xsl"))).ToString(), "null" });
+                    CheckExpectedError(e2, "System.Xml", "Xslt_CannotLoadStylesheet", new string[] { new Uri(Uri.UriSchemeFile + Uri.SchemeDelimiter + Path.GetFullPath(FullFilePath("XmlResolver_Main.xsl"))).ToString(), "null" });
                 }
 
-                if (LoadXSL("xmlResolver_main.xsl") == 1)
+                if (LoadXSL("XmlResolver_Main.xsl") == 1)
                 {
                     if (Transform("fruits.xml") == 1)
                     {
@@ -1730,28 +1731,28 @@ namespace System.Xml.Tests
         [Theory]
         public void LoadGeneric8(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             CustomNullResolver myResolver = new CustomNullResolver(_output);
 
-            if ((LoadXSL("xmlResolver_main.xsl") == 1))
+            if ((LoadXSL("XmlResolver_Main.xsl") == 1))
             {
                 try
                 {
-                    LoadXSL_Resolver("xmlResolver_main.xsl", myResolver);
+                    LoadXSL_Resolver("XmlResolver_Main.xsl", myResolver);
                 }
                 catch (System.Xml.Xsl.XsltException e1)
                 {
-                    // The lovely thing about this test is that the stylesheet, XmlResolver_main.xsl, has an include. GetEntity is therefore called twice. We need to have both these
-                    // checks here to ensure that both the XmlResolver_main.xsl and XmlResolver_Include.xsl GetEntity() calls are handled.
+                    // The lovely thing about this test is that the stylesheet, XmlResolver_Main.xsl, has an include. GetEntity is therefore called twice. We need to have both these
+                    // checks here to ensure that both the XmlResolver_Main.xsl and XmlResolver_Include.xsl GetEntity() calls are handled.
                     // Yes, this is effetively the same test as LoadGeneric7, in that we use the NullResolver to return null from a GetEntity call.
                     try
                     {
-                        CheckExpectedError(e1, "System.Xml", "Xslt_CannotLoadStylesheet", new string[] { new Uri(Path.GetFullPath(FullFilePath("XmlResolver_Include.xsl"))).ToString(), "null" });
+                        CheckExpectedError(e1, "System.Xml", "Xslt_CannotLoadStylesheet", new string[] { new Uri(Uri.UriSchemeFile + Uri.SchemeDelimiter + Path.GetFullPath(FullFilePath("XmlResolver_Include.xsl"))).ToString(), "null" });
                         return;
                     }
                     catch (Xunit.Sdk.TrueException)
                     {
-                        CheckExpectedError(e1, "System.Xml", "Xslt_CannotLoadStylesheet", new string[] { new Uri(Path.GetFullPath(FullFilePath("xmlResolver_main.xsl"))).ToString(), "null" });
+                        CheckExpectedError(e1, "System.Xml", "Xslt_CannotLoadStylesheet", new string[] { new Uri(Uri.UriSchemeFile + Uri.SchemeDelimiter + Path.GetFullPath(FullFilePath("XmlResolver_Main.xsl"))).ToString(), "null" });
                         return;
                     }
                 }
@@ -1789,9 +1790,9 @@ namespace System.Xml.Tests
         [Theory]
         public void LoadGeneric9()
         {
-            if ((LoadXSL_Resolver("xmlResolver_Main.xsl", GetDefaultCredResolver()) == 1))
+            if ((LoadXSL_Resolver("XmlResolver_Main.xsl", GetDefaultCredResolver()) == 1))
             {
-                if ((LoadXSL("xmlResolver_Main.xsl") == 1) && (Transform("fruits.xml") == 1)
+                if ((LoadXSL("XmlResolver_Main.xsl") == 1) && (Transform("fruits.xml") == 1)
                     && (CheckResult(428.8541842246) == 1))
                     return;
             }
@@ -1914,8 +1915,8 @@ namespace System.Xml.Tests
         {
             // XsltResolverTestMain.xsl is placed in IIS virtual directory
             // which requires integrated Windows NT authentication
-            string Baseline = "baseline\\" + (string)param;
-            if ((LoadXSL_Resolver("XmlResolver/XmlResolverTestMain.xsl", GetDefaultCredResolver()) == 1) &&
+            string Baseline = Path.Combine("baseline", (string)param);
+            if ((LoadXSL_Resolver(Path.Combine("XmlResolver", "XmlResolverTestMain.xsl"), GetDefaultCredResolver()) == 1) &&
                 (Transform("fruits.xml") == 1))
             {
                 VerifyResult(Baseline, _strOutFile);
@@ -1932,7 +1933,7 @@ namespace System.Xml.Tests
         {
             try
             {
-                LoadXSL_Resolver("XmlResolver/XmlResolverTestMain.xsl", null);
+                LoadXSL_Resolver(Path.Combine("XmlResolver", "XmlResolverTestMain.xsl"), null);
             }
             catch (XsltException e)
             {
@@ -2149,6 +2150,7 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Load with \"\\\\\"")]
+        [PlatformSpecific(TestPlatforms.Windows)] //Not a valid path on Unix
         [InlineData()]
         [Theory]
         public void LoadUrl5()
@@ -2223,7 +2225,7 @@ namespace System.Xml.Tests
         [Theory]
         public void LoadNavigator1(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             xslt = new XslCompiledTransform();
             String _strXslFile = "showParam.xsl";
 
@@ -2248,7 +2250,7 @@ namespace System.Xml.Tests
         [Theory]
         public void LoadNavigator2(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             xslt = new XslCompiledTransform();
             XmlReader xrLoad = XmlReader.Create(FullFilePath("showParam.xsl"));
             XPathDocument xdTemp = new XPathDocument(xrLoad, XmlSpace.Preserve);
@@ -2272,8 +2274,8 @@ namespace System.Xml.Tests
         public void LoadNavigator3(object param)
         {
             xslt = new XslCompiledTransform();
-            string Baseline = "baseline\\" + (string)param;
-            XmlReader xrLoad = XmlReader.Create(FullFilePath("XmlResolver/XmlResolverTestMain.xsl"));
+            string Baseline = Path.Combine("baseline", (string)param);
+            XmlReader xrLoad = XmlReader.Create(FullFilePath(Path.Combine("XmlResolver", "XmlResolverTestMain.xsl")));
             //xrLoad.XmlResolver = GetDefaultCredResolver();
 
             XPathDocument xdTemp = new XPathDocument(xrLoad, XmlSpace.Preserve);
@@ -2333,7 +2335,7 @@ namespace System.Xml.Tests
         [Theory]
         public void LoadXmlReader1(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             Boolean fTEST_FAIL = false;
             xslt = new XslCompiledTransform();
 
@@ -2525,8 +2527,8 @@ namespace System.Xml.Tests
         public void LoadXmlReader7(object param)
         {
             xslt = new XslCompiledTransform();
-            string Baseline = "baseline\\" + (string)param;
-            XmlReader xrLoad = XmlReader.Create(FullFilePath("XmlResolver/XmlResolverTestMain.xsl"));
+            string Baseline = Path.Combine("baseline", (string)param);
+            XmlReader xrLoad = XmlReader.Create(FullFilePath(Path.Combine("XmlResolver", "XmlResolverTestMain.xsl")));
             //xrLoad.XmlResolver = GetDefaultCredResolver();
             xslt.Load(xrLoad, XsltSettings.TrustedXslt, GetDefaultCredResolver());
             xrLoad.Dispose();
@@ -2728,7 +2730,7 @@ namespace System.Xml.Tests
         [Theory]
         public void TransformGeneric1(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             if ((LoadXSL("showParam.xsl") == 1) && (Transform("fruits.xml") == 1))
             {
                 VerifyResult(Baseline, _strOutFile);
@@ -2743,7 +2745,7 @@ namespace System.Xml.Tests
         [Theory]
         public void TransformGeneric2(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             for (int i = 0; i < 5; i++)
             {
                 if ((LoadXSL("showParam.xsl") != 1) || (Transform("fruits.xml") != 1))
@@ -2759,7 +2761,7 @@ namespace System.Xml.Tests
         [Theory]
         public void TransformGeneric3(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             if (LoadXSL("showParam.xsl") == 1)
             {
                 for (int i = 0; i < 100; i++)
@@ -2961,7 +2963,7 @@ namespace System.Xml.Tests
         {
             try
             {
-                if (LoadXSL("xmlResolver_main.xsl") == 1)
+                if (LoadXSL("XmlResolver_Main.xsl") == 1)
                 {
                     if ((TransformResolver("fruits.xml", null) == 1) && (CheckResult(428.8541842246) == 1))
                         return;
@@ -2985,7 +2987,7 @@ namespace System.Xml.Tests
         {
             // "xmlResolver_document_function.xsl" contains
             // <xsl:for-each select="document('xmlResolver_document_function.xml')//elem">
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
 
             if (LoadXSL("xmlResolver_document_function.xsl") == 1)
             {
@@ -3011,7 +3013,7 @@ namespace System.Xml.Tests
         {
             // "xmlResolver_document_function.xsl" contains
             // <xsl:for-each select="document('xmlResolver_document_function.xml')//elem">
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             if (LoadXSL("xmlResolver_document_function.xsl") == 1)
             {
                 if (Transform("fruits.xml") == 1)
@@ -3038,7 +3040,7 @@ namespace System.Xml.Tests
             try
             {
                 string curDir = Directory.GetCurrentDirectory();
-                string testFile = curDir + "\\" + "xmlResolver_document_function.xml";
+                string testFile = Path.Combine(curDir, "xmlResolver_document_function.xml");
                 if (File.Exists(testFile))
                 {
                     File.SetAttributes(testFile, FileAttributes.Normal);
@@ -3103,7 +3105,7 @@ namespace System.Xml.Tests
         [Theory]
         public void TransformStrStr1(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             String szFullFilename = FullFilePath("fruits.xml");
 
             if (LoadXSL("showParam.xsl") == 1)
@@ -3176,6 +3178,7 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Output file is invalid")]
+        [PlatformSpecific(TestPlatforms.Windows)] //Output file name is valid on Unix
         [InlineData()]
         [Theory]
         public void TransformStrStr5()
@@ -3244,7 +3247,7 @@ namespace System.Xml.Tests
         [Theory]
         public void TransformStrStr8(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             String szFullFilename = FullFilePath("fruits.xml");
 
             for (int i = 0; i < 50; i++)
@@ -3344,7 +3347,7 @@ namespace System.Xml.Tests
             Assert.True(false);
         }
 
-        //[Variation("Output filename is \'.\', \'..\', and \'\\\\\'")]
+        //[Variation("Output filename is \'.\' and \'..\'")]
         [InlineData()]
         [Theory]
         public void TransformStrStr12()
@@ -3370,19 +3373,28 @@ namespace System.Xml.Tests
                 {
                     iCount++;
                 }
-
-                try
-                {
-                    xslt.Transform(szFullFilename, "\\\\");
-                }
-                catch (System.Exception)
-                {
-                    iCount++;
-                }
             }
 
-            if (iCount.Equals(3))
+            if (iCount.Equals(2))
                 return;
+            _output.WriteLine("Exception not generated for invalid ouput destinations");
+            Assert.True(false);
+        }
+
+        //[Variation("Output filename is \'\\\\\'")]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [InlineData()]
+        [Theory]
+        public void TransformStrStr12_win()
+        {
+            String szFullFilename = FullFilePath("fruits.xml");
+
+            if (LoadXSL("showParam.xsl") == 1)
+            {
+                    Assert.Throws<System.ArgumentException>(() => xslt.Transform(szFullFilename, "\\\\"));
+                    return;
+            }
+
             _output.WriteLine("Exception not generated for invalid ouput destinations");
             Assert.True(false);
         }
@@ -3467,7 +3479,7 @@ namespace System.Xml.Tests
             String szFullFilename = FullFilePath("fruits.xml");
             try
             {
-                if (LoadXSL("xmlResolver_main.xsl", new XmlUrlResolver()) == 1)
+                if (LoadXSL("XmlResolver_Main.xsl", new XmlUrlResolver()) == 1)
                 {
                     XmlTextReader xr = new XmlTextReader(szFullFilename);
                     XmlTextWriter xw = new XmlTextWriter("out.xml", Encoding.Unicode);
@@ -3523,7 +3535,7 @@ namespace System.Xml.Tests
             // <xsl:for-each select="document('xmlResolver_document_function.xml')//elem">
 
             String szFullFilename = FullFilePath("fruits.xml");
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
 
             if (LoadXSL("xmlResolver_document_function.xsl") == 1)
             {
@@ -3562,18 +3574,18 @@ namespace System.Xml.Tests
             public override Uri ResolveUri(Uri baseUri, string relativeUri)
             {
                 if (baseUri == null)
-                    return base.ResolveUri(new Uri(_baseUri), relativeUri);
+                    return base.ResolveUri(new Uri(Uri.UriSchemeFile + Uri.SchemeDelimiter + _baseUri), relativeUri);
                 return base.ResolveUri(baseUri, relativeUri);
             }
         }
 
         [ActiveIssue(9876)]
-        //[Variation("Import/Include, CustomXmlResolver", Pri = 0, Params = new object[] { "xmlResolver_main.xsl", "fruits.xml", "xmlResolver_main.txt", "CustomXmlResolver", true })]
-        [InlineData("xmlResolver_main.xsl", "fruits.xml", "xmlResolver_main.txt", "CustomXmlResolver", true, "IXPathNavigable")]
-        [InlineData("xmlResolver_main.xsl", "fruits.xml", "xmlResolver_main.txt", "CustomXmlResolver", true, "XmlReader")]
-        //[Variation("Import/Include, NullResolver", Pri = 0, Params = new object[] { "xmlResolver_main.xsl", "fruits.xml", "xmlResolver_main.txt", "NullResolver", false })]
-        [InlineData("xmlResolver_main.xsl", "fruits.xml", "xmlResolver_main.txt", "NullResolver", false, "IXPathNavigable")]
-        [InlineData("xmlResolver_main.xsl", "fruits.xml", "xmlResolver_main.txt", "NullResolver", false, "XmlReader")]
+        //[Variation("Import/Include, CustomXmlResolver", Pri = 0, Params = new object[] { "XmlResolver_Main.xsl", "fruits.xml", "xmlResolver_main.txt", "CustomXmlResolver", true })]
+        [InlineData("XmlResolver_Main.xsl", "fruits.xml", "xmlResolver_main.txt", "CustomXmlResolver", true, "IXPathNavigable")]
+        [InlineData("XmlResolver_Main.xsl", "fruits.xml", "xmlResolver_main.txt", "CustomXmlResolver", true, "XmlReader")]
+        //[Variation("Import/Include, NullResolver", Pri = 0, Params = new object[] { "XmlResolver_Main.xsl", "fruits.xml", "xmlResolver_main.txt", "NullResolver", false })]
+        [InlineData("XmlResolver_Main.xsl", "fruits.xml", "xmlResolver_main.txt", "NullResolver", false, "IXPathNavigable")]
+        [InlineData("XmlResolver_Main.xsl", "fruits.xml", "xmlResolver_main.txt", "NullResolver", false, "XmlReader")]
         [Theory]
         public void ValidCases_ActiveIssue9876(object param0, object param1, object param2, object param3, object param4, object param5)
         {
@@ -3587,26 +3599,26 @@ namespace System.Xml.Tests
         [InlineData("xmlResolver_document_function.xsl", "fruits.xml", "xmlResolver_document_function.txt", "XmlUrlResolver", true, "IXPathNavigable")]
         [InlineData("xmlResolver_document_function.xsl", "fruits.xml", "xmlResolver_document_function.txt", "XmlUrlResolver", true, "XmlReader")]
         //[Variation("Document function 1, NullResolver", Pri = 0, Params = new object[] { "xmlResolver_document_function.xsl", "fruits.xml", "xmlResolver_document_function.txt", "NullResolver", false })]
-        [InlineData("xmlResolver_document_function.xsl", "fruits.xml", "xmlResolver_document_function.txt", "NullResolver", false, "IXPathNavigable")]
-        [InlineData("xmlResolver_document_function.xsl", "fruits.xml", "xmlResolver_document_function.txt", "NullResolver", false, "XmlReader")]
-        //[Variation("No Import/Include, CustomXmlResolver", Pri = 0, Params = new object[] { "Bug382198.xsl", "fruits.xml", "Bug382198.txt", "CustomXmlResolver", true })]
-        [InlineData("Bug382198.xsl", "fruits.xml", "Bug382198.txt", "CustomXmlResolver", true, "IXPathNavigable")]
-        [InlineData("Bug382198.xsl", "fruits.xml", "Bug382198.txt", "CustomXmlResolver", true, "XmlReader")]
-        //[Variation("Import/Include, XmlUrlResolver", Pri = 0, Params = new object[] { "xmlResolver_main.xsl", "fruits.xml", "xmlResolver_main.txt", "XmlUrlResolver", true })]
-        [InlineData("xmlResolver_main.xsl", "fruits.xml", "xmlResolver_main.txt", "XmlUrlResolver", true, "IXPathNavigable")]
-        [InlineData("xmlResolver_main.xsl", "fruits.xml", "xmlResolver_main.txt", "XmlUrlResolver", true, "XmlReader")]
-        //[Variation("No Import/Include, XmlUrlResolver", Pri = 0, Params = new object[] { "Bug382198.xsl", "fruits.xml", "Bug382198.txt", "XmlUrlResolver", true })]
-        [InlineData("Bug382198.xsl", "fruits.xml", "Bug382198.txt", "XmlUrlResolver", true, "IXPathNavigable")]
-        [InlineData("Bug382198.xsl", "fruits.xml", "Bug382198.txt", "XmlUrlResolver", true, "XmlReader")]
-        //[Variation("No Import/Include, NullResolver", Pri = 0, Params = new object[] { "Bug382198.xsl", "fruits.xml", "Bug382198.txt", "NullResolver", true })]
-        [InlineData("Bug382198.xsl", "fruits.xml", "Bug382198.txt", "NullResolver", true, "IXPathNavigable")]
-        [InlineData("Bug382198.xsl", "fruits.xml", "Bug382198.txt", "NullResolver", true, "XmlReader")]
+       // [InlineData("xmlResolver_document_function.xsl", "fruits.xml", "xmlResolver_document_function.txt", "NullResolver", false, "IXPathNavigable")]
+       // [InlineData("xmlResolver_document_function.xsl", "fruits.xml", "xmlResolver_document_function.txt", "NullResolver", false, "XmlReader")]
+        //[Variation("No Import/Include, CustomXmlResolver", Pri = 0, Params = new object[] { "Bug382198.xsl", "fruits.xml", "bug382198.txt", "CustomXmlResolver", true })]
+        [InlineData("Bug382198.xsl", "fruits.xml", "bug382198.txt", "CustomXmlResolver", true, "IXPathNavigable")]
+        [InlineData("Bug382198.xsl", "fruits.xml", "bug382198.txt", "CustomXmlResolver", true, "XmlReader")]
+        //[Variation("Import/Include, XmlUrlResolver", Pri = 0, Params = new object[] { "XmlResolver_Main.xsl", "fruits.xml", "xmlResolver_main.txt", "XmlUrlResolver", true })]
+        [InlineData("XmlResolver_Main.xsl", "fruits.xml", "xmlResolver_main.txt", "XmlUrlResolver", true, "IXPathNavigable")]
+        [InlineData("XmlResolver_Main.xsl", "fruits.xml", "xmlResolver_main.txt", "XmlUrlResolver", true, "XmlReader")]
+        //[Variation("No Import/Include, XmlUrlResolver", Pri = 0, Params = new object[] { "Bug382198.xsl", "fruits.xml", "bug382198.txt", "XmlUrlResolver", true })]
+        [InlineData("Bug382198.xsl", "fruits.xml", "bug382198.txt", "XmlUrlResolver", true, "IXPathNavigable")]
+        [InlineData("Bug382198.xsl", "fruits.xml", "bug382198.txt", "XmlUrlResolver", true, "XmlReader")]
+        //[Variation("No Import/Include, NullResolver", Pri = 0, Params = new object[] { "Bug382198.xsl", "fruits.xml", "bug382198.txt", "NullResolver", true })]
+        [InlineData("Bug382198.xsl", "fruits.xml", "bug382198.txt", "NullResolver", true, "IXPathNavigable")]
+        [InlineData("Bug382198.xsl", "fruits.xml", "bug382198.txt", "NullResolver", true, "XmlReader")]
         [Theory]
         public void ValidCases(object param0, object param1, object param2, object param3, object param4, object param5)
         {
             string xslFile = FullFilePath(param0 as string);
             string xmlFile = FullFilePath(param1 as string);
-            string baseLineFile = @"\baseline\" + param2 as string;
+            string baseLineFile = Path.Combine("baseline", param2 as string);
             bool expectedResult = (bool)param4;
             bool actualResult = false;
 
@@ -3648,7 +3660,7 @@ namespace System.Xml.Tests
                     break;
 
                 case "CustomXmlResolver":
-                    resolver = new CustomXmlResolver(Path.GetFullPath(Path.Combine(FilePathUtil.GetTestDataPath(), @"XsltApiV2\")));
+                    resolver = new CustomXmlResolver(Path.GetFullPath(Path.Combine(FilePathUtil.GetTestDataPath(), @"XsltApiV2")));
                     break;
 
                 default:
@@ -3753,6 +3765,7 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Local parameter gets overwritten with global param value", Pri = 1)]
+        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void var1()
@@ -3767,6 +3780,7 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Local parameter gets overwritten with global variable value", Pri = 1)]
+        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void var2()
@@ -3781,6 +3795,7 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Subclassed XPathNodeIterator returned from an extension object or XsltFunction is not accepted by XPath", Pri = 1)]
+        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void var3()
@@ -3795,6 +3810,7 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Iterator using for-each over a variable is not reset correctly while using msxsl:node-set()", Pri = 1)]
+        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void var4()

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltApiV2.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltApiV2.cs
@@ -53,7 +53,7 @@ namespace System.Xml.Tests
             // These steps use to be part of javascript files and these were copied and executed as test setup step.
             // I belive this to be a much better way of accomplishing the same task.
             // Logic from CreateApiTestFiles.js
-            string sourceFile = Path.Combine(FilePathUtil.GetTestDataPath(), @"XsltApiV2\xmlResolver_document_function.xml");
+            string sourceFile = Path.Combine(FilePathUtil.GetTestDataPath(), "XsltApiV2", "xmlResolver_document_function.xml");
             string targetFile = @"c:\temp\xmlResolver_document_function.xml";
             if (!Directory.Exists(@"c:\temp"))
                 Directory.CreateDirectory(@"c:\temp");
@@ -232,9 +232,9 @@ namespace System.Xml.Tests
             _readerType = GetReaderType(InitStringValue("readertype"));
 
             //This is a temporary fix to restore the baselines. Refer to Test bug #
-            _strPath = Path.Combine(@"TestFiles\", FilePathUtil.GetTestDataPath(), @"XsltApiV2\");
-            _httpPath = FilePathUtil.GetHttpTestDataPath() + @"/XsltApiV2/";
-            _standardTests = Path.Combine(@"TestFiles\", FilePathUtil.GetHttpStandardPath() + @"/xslt10/Current/");
+            _strPath = Path.Combine("TestFiles", FilePathUtil.GetTestDataPath(), "XsltApiV2");
+            _httpPath = Path.Combine(FilePathUtil.GetHttpTestDataPath(), "XsltApiV2");
+            _standardTests = Path.Combine("TestFiles", FilePathUtil.GetHttpStandardPath(), "xslt10","Current");
 
             return;
         }
@@ -246,7 +246,7 @@ namespace System.Xml.Tests
             if (szFile.Length > 5)
             {
                 if (szFile.Substring(0, 5) != "http:")
-                    szFile = _strPath + szFile;
+                    szFile = Path.Combine(_strPath, szFile);
             }
             return szFile;
         }
@@ -255,7 +255,7 @@ namespace System.Xml.Tests
         {
             if (szFile == null || szFile == String.Empty)
                 return szFile;
-            szFile = _httpPath + szFile;
+            szFile = Path.Combine(_httpPath, szFile);
             return szFile;
         }
 
@@ -274,7 +274,7 @@ namespace System.Xml.Tests
         //  -------------------------------------------------------------------------------------------------------------
         public void CheckExpectedError(Exception ex, string assembly)
         {
-            CExceptionHandler handler = new CExceptionHandler(_strPath + "exceptions.xml", assembly, _output);
+            CExceptionHandler handler = new CExceptionHandler(Path.Combine(_strPath, "Exceptions.xml"), assembly, _output);
             bool result = handler.VerifyException(ex);
             if (handler.res != _expectedErrorCode)
             {
@@ -294,7 +294,7 @@ namespace System.Xml.Tests
         //  -------------------------------------------------------------------------------------------------------------
         public void CheckExpectedError(Exception ex, string assembly, string res, string[] strParams)
         {
-            CExceptionHandler handler = new CExceptionHandler(_strPath + "exceptions.xml", assembly, _output);
+            CExceptionHandler handler = new CExceptionHandler(Path.Combine(_strPath, "Exceptions.xml"), assembly, _output);
             if (!handler.VerifyException(ex, res, strParams))
             {
                 Assert.True(false);

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentList.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentList.cs
@@ -343,7 +343,7 @@ namespace System.Xml.Tests
                 Assert.True(false);
             }
 
-            XPathDocument xd = new XPathDocument(FullFilePath("fish.xml"));
+            XPathDocument xd = new XPathDocument(FullFilePath("Fish.xml"));
 
             m_xsltArg.AddParam("myArg5", szEmpty, ((IXPathNavigable)xd).CreateNavigator());
             retObj = m_xsltArg.GetParam("myArg5", szEmpty);
@@ -653,7 +653,7 @@ namespace System.Xml.Tests
             }
 
             string expXml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><result xmlns:myObj=\"urn:my-object\"><func1>1.Test1</func1><func2>2.Test2</func2><func3>3.Test3</func3></result>";
-            if ((LoadXSL("MyObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
                 (CheckResult(expXml) == 1))
                 return;
             else
@@ -684,7 +684,7 @@ namespace System.Xml.Tests
         [Theory]
         public void GetExtObject3(object param)
         {
-            string Baseline = "baseline\\" + param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             try
@@ -722,7 +722,7 @@ namespace System.Xml.Tests
             }
             try
             {
-                if ((LoadXSL("MyObjectDef.xsl") == 1))
+                if ((LoadXSL("myObjectDef.xsl") == 1))
                     Transform_ArgList("fruits.xml");
             }
             catch (System.Xml.Xsl.XsltException)
@@ -751,7 +751,7 @@ namespace System.Xml.Tests
             }
 
             string expXml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><result xmlns:myObj=\"http://www.microsoft.com/this/is/a/very/long/namespace/uri/to/do/the/api/testing/for/xslt/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/\"><func1>1.Test1</func1><func2>2.Test2</func2><func3>3.Test3</func3></result>";
-            if ((LoadXSL("MyObjectLongNS.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
+            if ((LoadXSL("myObjectLongNS.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
                 (CheckResult(expXml) == 1))
                 return;
             else
@@ -872,7 +872,7 @@ namespace System.Xml.Tests
             }
 
             string expXml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><result xmlns:myObj=\"urn:my-object\"><func1>1.Test1</func1><func2>2.Test2</func2><func3>3.Test3</func3></result>";
-            if ((LoadXSL("MyObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
                 (CheckResult(expXml) == 1))
                 return;
             else
@@ -903,7 +903,7 @@ namespace System.Xml.Tests
 
             try
             {
-                if ((LoadXSL("MyObjectDef.xsl") == 1))
+                if ((LoadXSL("myObjectDef.xsl") == 1))
                     Transform_ArgList("fruits.xml");
             }
             catch (System.Xml.Xsl.XsltException)
@@ -934,7 +934,7 @@ namespace System.Xml.Tests
 
             try
             {
-                if ((LoadXSL("MyObjectDef.xsl") == 1))
+                if ((LoadXSL("myObjectDef.xsl") == 1))
                     Transform_ArgList("fruits.xml");
             }
             catch (System.Xml.Xsl.XsltException)
@@ -965,7 +965,7 @@ namespace System.Xml.Tests
                 }
             }
             string expXml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><result xmlns:myObj=\"urn:my-object\"><func1>1.Test1</func1><func2>2.Test2</func2><func3>3.Test3</func3></result>";
-            if ((LoadXSL("MyObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
                 (CheckResult(expXml) == 1))
                 return;
             else
@@ -1018,7 +1018,7 @@ namespace System.Xml.Tests
         [Theory]
         public void AddParam1(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -1079,7 +1079,7 @@ namespace System.Xml.Tests
         [Theory]
         public void AddParam4(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam(szLongString, szEmpty, "Test1");
@@ -1140,7 +1140,7 @@ namespace System.Xml.Tests
         [Theory]
         public void AddParam7(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test7");
@@ -1164,7 +1164,7 @@ namespace System.Xml.Tests
         [Theory]
         public void AddParam8(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szLongNS, "Test8");
@@ -1218,7 +1218,7 @@ namespace System.Xml.Tests
         [Theory]
         public void AddParam12(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
 
             m_xsltArg = new XsltArgumentList();
 
@@ -1255,7 +1255,7 @@ namespace System.Xml.Tests
         [Theory]
         public void AddParam13(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -1291,7 +1291,7 @@ namespace System.Xml.Tests
         [Theory]
         public void AddParam14(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -1351,7 +1351,7 @@ namespace System.Xml.Tests
         [Theory]
         public void AddParam16(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
             String obj = "Test";
 
@@ -1402,7 +1402,7 @@ namespace System.Xml.Tests
         [Theory]
         public void AddParam17(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             int i = 1;
             int errCount = 0;
             m_xsltArg = new XsltArgumentList();
@@ -1457,7 +1457,7 @@ namespace System.Xml.Tests
         [Theory]
         public void AddParam18(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
             String obj = "Test";
 
@@ -1483,7 +1483,7 @@ namespace System.Xml.Tests
         [Theory]
         public void AddParam19(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
             String obj = "Test";
 
@@ -1517,7 +1517,7 @@ namespace System.Xml.Tests
         [Theory]
         public void AddParam20(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
 
             m_xsltArg = new XsltArgumentList();
 
@@ -1846,11 +1846,11 @@ namespace System.Xml.Tests
         {
             MyObject obj = new MyObject(1, _output);
             m_xsltArg = new XsltArgumentList();
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             ///nonePermSet.PermitOnly();
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
             ///CodeAccessPermission.RevertPermitOnly();
-            if ((LoadXSL("MyObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
             {
                 VerifyResult(Baseline, _strOutFile);
                 return;
@@ -1896,18 +1896,18 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Very long namespace System.Xml.Tests", Param = "myObjectLongNs.txt")]
-        [InlineData("myObjectLongNs.txt")]
+        [InlineData("myObjectLongNS.txt")]
         [Theory]
         public void AddExtObject4(object param)
         {
             m_xsltArg = new XsltArgumentList();
             MyObject obj = new MyObject(4, _output);
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             ///nonePermSet.PermitOnly(); ;
             m_xsltArg.AddExtensionObject(szLongNS, obj);
             ///CodeAccessPermission.RevertPermitOnly();
 
-            if ((LoadXSL("MyObjectLongNS.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            if ((LoadXSL("myObjectLongNS.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
             {
                 VerifyResult(Baseline, _strOutFile);
                 return;
@@ -1959,7 +1959,7 @@ namespace System.Xml.Tests
         {
             MyObject obj = new MyObject(1, _output);
             m_xsltArg = new XsltArgumentList();
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             ///nonePermSet.PermitOnly(); ;
             m_xsltArg.AddExtensionObject("urn:my-object", obj);
 
@@ -1973,7 +1973,7 @@ namespace System.Xml.Tests
             m_xsltArg.AddExtensionObject("urn:My-Object", obj);
             m_xsltArg.AddExtensionObject("urn-my:object", obj);
             ///CodeAccessPermission.RevertPermitOnly();
-            if ((LoadXSL("MyObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
             {
                 VerifyResult(Baseline, _strOutFile);
                 return;
@@ -2026,7 +2026,7 @@ namespace System.Xml.Tests
         [Theory]
         public void AddExtObject11(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             MyObject obj1 = new MyObject(100, _output);
@@ -2040,7 +2040,7 @@ namespace System.Xml.Tests
             }
 
             ///CodeAccessPermission.RevertPermitOnly();
-            if ((LoadXSL("MyObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
             {
                 VerifyResult(Baseline, _strOutFile);
                 return;
@@ -2068,7 +2068,7 @@ namespace System.Xml.Tests
 
             try
             {
-                if ((LoadXSL("MyObjectDef.xsl") == 1))
+                if ((LoadXSL("myObjectDef.xsl") == 1))
                     Transform_ArgList("fruits.xml", true);
             }
             catch (System.Xml.Xsl.XsltException)
@@ -2106,7 +2106,7 @@ namespace System.Xml.Tests
         [Theory]
         public void AddExtObject14(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             MyObject obj = new MyObject(14, _output);
             m_xsltArg = new XsltArgumentList();
             ///nonePermSet.PermitOnly(); ;
@@ -2117,7 +2117,7 @@ namespace System.Xml.Tests
             }
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
             ///CodeAccessPermission.RevertPermitOnly();
-            if ((LoadXSL("MyObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
             {
                 VerifyResult(Baseline, _strOutFile);
                 return;
@@ -2138,7 +2138,7 @@ namespace System.Xml.Tests
             ///CodeAccessPermission.RevertPermitOnly();
             try
             {
-                if ((LoadXSL("MyObjectDef.xsl") == 1))
+                if ((LoadXSL("myObjectDef.xsl") == 1))
                     Transform_ArgList("fruits.xml", true);
             }
             catch (System.Xml.Xsl.XsltException)
@@ -2205,13 +2205,13 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Recursive Functions", Param = "myObject_Recursion.txt")]
-        [InlineData("myObject_Recursion.txt")]
+        [InlineData("MyObject_Recursion.txt")]
         [Theory]
         public void AddExtObject18(object param)
         {
             MyObject obj = new MyObject(18, _output);
             m_xsltArg = new XsltArgumentList();
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             ///nonePermSet.PermitOnly(); ;
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
             ///CodeAccessPermission.RevertPermitOnly();
@@ -2229,7 +2229,7 @@ namespace System.Xml.Tests
         [Theory]
         public void AddExtObject20(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             MyObject obj = new MyObject(20, _output);
             m_xsltArg = new XsltArgumentList();
             ///nonePermSet.PermitOnly(); ;
@@ -2249,7 +2249,7 @@ namespace System.Xml.Tests
         [Theory]
         public void AddExtObject21(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             MyObject obj = new MyObject(1, _output);
             m_xsltArg = new XsltArgumentList();
             ///nonePermSet.PermitOnly(); ;
@@ -2346,7 +2346,7 @@ namespace System.Xml.Tests
         {
             MyObject obj = new MyObject(27, _output);
             m_xsltArg = new XsltArgumentList();
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             ///nonePermSet.PermitOnly(); ;
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
             ///CodeAccessPermission.RevertPermitOnly();
@@ -2367,7 +2367,7 @@ namespace System.Xml.Tests
         {
             MyObject obj = new MyObject(28, _output);
             m_xsltArg = new XsltArgumentList();
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             ///nonePermSet.PermitOnly(); ;
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
             ///CodeAccessPermission.RevertPermitOnly();
@@ -2428,8 +2428,8 @@ namespace System.Xml.Tests
         [Theory]
         public void AddExtObject32(object param)
         {
-            string Baseline1 = "baseline\\" + (string)param + "a.txt";
-            string Baseline2 = "baseline\\" + (string)param + "b.txt";
+            string Baseline1 = Path.Combine("baseline", (string)param) + "a.txt";
+            string Baseline2 = Path.Combine("baseline", (string)param) + "b.txt";
 
             if (LoadXSL("Bug78587.xsl") == 1)
             {
@@ -2485,7 +2485,7 @@ namespace System.Xml.Tests
             ExObj obj = new ExObj(0, _output);
             m_xsltArg = new XsltArgumentList();
             string xslFile = param0.ToString();
-            string Baseline = "baseline\\" + param1.ToString();
+            string Baseline = Path.Combine("baseline", param1.ToString());
             ///nonePermSet.PermitOnly(); ;
             m_xsltArg.AddExtensionObject("urn-myobject", obj);
             ///CodeAccessPermission.RevertPermitOnly();
@@ -2521,7 +2521,7 @@ namespace System.Xml.Tests
             ExObj obj = new ExObj(0, _output);
             m_xsltArg = new XsltArgumentList();
             string xslFile = param0.ToString();
-            string Baseline = "baseline\\" + param1.ToString();
+            string Baseline = "baseline" + Path.DirectorySeparatorChar + param1.ToString();
             ///nonePermSet.PermitOnly(); ;
             m_xsltArg.AddExtensionObject("urn-myobject", obj);
             ///CodeAccessPermission.RevertPermitOnly();
@@ -2605,7 +2605,7 @@ namespace System.Xml.Tests
                 Assert.True(false);
             }
 
-            _baseline = "baseline\\" + (string)param;
+            _baseline = Path.Combine("baseline", (string)param);
             if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
             {
                 VerifyResult(_baseline, "out.xml");
@@ -2635,7 +2635,7 @@ namespace System.Xml.Tests
         [Theory]
         public void RemoveParam3(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
             m_xsltArg.RemoveParam(szEmpty, szEmpty);
 
@@ -2653,7 +2653,7 @@ namespace System.Xml.Tests
         [Theory]
         public void RemoveParam4(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
             m_xsltArg.RemoveParam(szSimple, szEmpty);
 
@@ -2671,7 +2671,7 @@ namespace System.Xml.Tests
         [Theory]
         public void RemoveParam5(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
             m_xsltArg.RemoveParam(szInvalid, szEmpty);
 
@@ -2689,7 +2689,7 @@ namespace System.Xml.Tests
         [Theory]
         public void RemoveParam6(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam(szLongString, szEmpty, "Test1");
@@ -2725,7 +2725,7 @@ namespace System.Xml.Tests
         [Theory]
         public void RemoveParam8(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -2745,7 +2745,7 @@ namespace System.Xml.Tests
         [Theory]
         public void RemoveParam9(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -2765,7 +2765,7 @@ namespace System.Xml.Tests
         [Theory]
         public void RemoveParam10(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szLongString, "Test1");
@@ -2785,7 +2785,7 @@ namespace System.Xml.Tests
         [Theory]
         public void RemoveParam11(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
 
             double d1 = double.PositiveInfinity;
             double d2 = double.NegativeInfinity;
@@ -2990,7 +2990,7 @@ namespace System.Xml.Tests
         [Theory]
         public void RemoveParam12(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -3013,7 +3013,7 @@ namespace System.Xml.Tests
         [Theory]
         public void RemoveParam13(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             int i = 1;
             m_xsltArg = new XsltArgumentList();
 
@@ -3059,7 +3059,7 @@ namespace System.Xml.Tests
         [Theory]
         public void RemoveParam14(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -3120,7 +3120,7 @@ namespace System.Xml.Tests
 
             try
             {
-                if ((LoadXSL("MyObjectDef.xsl") == 1))
+                if ((LoadXSL("myObjectDef.xsl") == 1))
                     Transform_ArgList("fruits.xml", true);
             }
             catch (System.Xml.Xsl.XsltException)
@@ -3156,7 +3156,7 @@ namespace System.Xml.Tests
         [Theory]
         public void RemoveExtObj3(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             MyObject obj = new MyObject(10, _output);
             m_xsltArg = new XsltArgumentList();
             ///nonePermSet.PermitOnly(); ;
@@ -3174,18 +3174,18 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Namespace URI is non-existent", Param = "MyObjectDef.txt")]
-        [InlineData("MyObjectDef.txt")]
+        [InlineData("myObjectDef.txt")]
         [Theory]
         public void RemoveExtObj4(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             MyObject obj = new MyObject(4, _output);
             m_xsltArg = new XsltArgumentList();
             ///nonePermSet.PermitOnly(); ;
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
             m_xsltArg.RemoveExtensionObject(szSimple);
             ///CodeAccessPermission.RevertPermitOnly();
-            if ((LoadXSL("MyObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
             {
                 VerifyResult(Baseline, _strOutFile);
                 return;
@@ -3207,7 +3207,7 @@ namespace System.Xml.Tests
             ///CodeAccessPermission.RevertPermitOnly();
             try
             {
-                if ((LoadXSL("MyObjectDef.xsl") == 1))
+                if ((LoadXSL("myObjectDef.xsl") == 1))
                     Transform_ArgList("fruits.xml", true);
             }
             catch (System.Xml.Xsl.XsltException)
@@ -3223,7 +3223,7 @@ namespace System.Xml.Tests
         [Theory]
         public void RemoveExtObj6(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             MyObject obj = new MyObject(6, _output);
             m_xsltArg = new XsltArgumentList();
             ///nonePermSet.PermitOnly(); ;
@@ -3255,13 +3255,13 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Case Sensitivity", Param = "MyObjectDef.txt")]
-        [InlineData("MyObjectDef.txt")]
+        [InlineData("myObjectDef.txt")]
         [Theory]
         public void RemoveExtObj7(object param)
         {
             MyObject obj = new MyObject(7, _output);
             m_xsltArg = new XsltArgumentList();
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             ///nonePermSet.PermitOnly(); ;
             m_xsltArg.AddExtensionObject("urn:my-object", obj);
 
@@ -3270,7 +3270,7 @@ namespace System.Xml.Tests
             m_xsltArg.RemoveExtensionObject("urn-my:object");
             m_xsltArg.RemoveExtensionObject("urn:my-object ");
             ///CodeAccessPermission.RevertPermitOnly();
-            if ((LoadXSL("MyObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
             {
                 VerifyResult(Baseline, _strOutFile);
                 return;
@@ -3305,7 +3305,7 @@ namespace System.Xml.Tests
 
             try
             {
-                if ((LoadXSL("MyObjectDef.xsl") == 1))
+                if ((LoadXSL("myObjectDef.xsl") == 1))
                     Transform_ArgList("fruits.xml", true);
             }
             catch (System.Xml.Xsl.XsltException)
@@ -3321,7 +3321,7 @@ namespace System.Xml.Tests
         [Theory]
         public void RemoveExtObj9(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             MyObject obj = new MyObject(10, _output);
             m_xsltArg = new XsltArgumentList();
             ///nonePermSet.PermitOnly(); ;
@@ -3356,7 +3356,7 @@ namespace System.Xml.Tests
         [Theory]
         public void Clear1(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -3383,7 +3383,7 @@ namespace System.Xml.Tests
         [Theory]
         public void Clear2(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.Clear();
@@ -3401,7 +3401,7 @@ namespace System.Xml.Tests
         [Theory]
         public void Clear3(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -3440,7 +3440,7 @@ namespace System.Xml.Tests
                 Assert.True(false);
             }
 
-            if ((LoadXSL("MyObjectDef.xsl") == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1))
             {
                 try
                 {
@@ -3460,7 +3460,7 @@ namespace System.Xml.Tests
         [Theory]
         public void Clear5(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
             String obj = "Test";
 
@@ -3507,7 +3507,7 @@ namespace System.Xml.Tests
         [Theory]
         public void Clear6(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -3535,7 +3535,7 @@ namespace System.Xml.Tests
         [Theory]
         public void Clear7(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
             XsltArgumentList m_2 = new XsltArgumentList();
 
@@ -3560,7 +3560,7 @@ namespace System.Xml.Tests
         [Theory]
         public void Clear8(object param)
         {
-            string Baseline = "baseline\\" + (string)param;
+            string Baseline = Path.Combine("baseline", (string)param);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -3581,7 +3581,7 @@ namespace System.Xml.Tests
             m_xsltArg.RemoveExtensionObject(szDefaultNS);
             m_xsltArg.Clear();
 
-            if ((LoadXSL("MyObjectDef.xsl") == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1))
             {
                 try
                 {
@@ -3651,11 +3651,11 @@ namespace System.Xml.Tests
             XsltArgumentList argList = new XsltArgumentList();
 
             //Collect the test data
-            string SourceFile = FullFilePath("Message.xml");
+            string SourceFile = FullFilePath("message.xml");
             string XslFile = FullFilePath(param0.ToString());
             string XslMessageTerminate = param1.ToString();
             string EventHandlerExists = param2.ToString();
-            string Baseline = "baseline\\" + param3.ToString();
+            string Baseline = "baseline" + Path.DirectorySeparatorChar + param3.ToString();
             OutFile = "Message.txt";
 
             //Check if the EventHandler Exists

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTArgumentList.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTArgumentList.cs
@@ -356,7 +356,7 @@ namespace System.Xml.Tests
                 Assert.True(false);
             }
 
-            XPathDocument xd = new XPathDocument(FullFilePath("fish.xml"));
+            XPathDocument xd = new XPathDocument(FullFilePath("Fish.xml"));
 
             m_xsltArg.AddParam("myArg5", szEmpty, ((IXPathNavigable)xd).CreateNavigator());
             retObj = m_xsltArg.GetParam("myArg5", szEmpty);
@@ -638,7 +638,7 @@ namespace System.Xml.Tests
     //            Assert.True(false);
     //        }
 
-    //        if((LoadXSL("MyObjectDef.xsl") == TEST_PASS) && (Transform_ArgList("fruits.xml") == TEST_PASS) &&
+    //        if((LoadXSL("myObjectDef.xsl") == TEST_PASS) && (Transform_ArgList("fruits.xml") == TEST_PASS) &&
     //            (CheckResult(430.402026847)== TEST_PASS))
     //            return;
     //        else
@@ -701,7 +701,7 @@ namespace System.Xml.Tests
     //        }
     //        try
     //        {
-    //            if((LoadXSL("MyObjectDef.xsl") == TEST_PASS))
+    //            if((LoadXSL("myObjectDef.xsl") == TEST_PASS))
     //                Transform_ArgList("fruits.xml");
     //        }
     //        catch(System.Xml.Xsl.XsltException)
@@ -855,7 +855,7 @@ namespace System.Xml.Tests
     //            Assert.True(false);
     //        }
 
-    //        if((LoadXSL("MyObjectDef.xsl") == TEST_PASS) && (Transform_ArgList("fruits.xml") == TEST_PASS) &&
+    //        if((LoadXSL("myObjectDef.xsl") == TEST_PASS) && (Transform_ArgList("fruits.xml") == TEST_PASS) &&
     //            (CheckResult(430.402026847)== TEST_PASS))
     //            return;
     //        else
@@ -885,7 +885,7 @@ namespace System.Xml.Tests
 
     //        try
     //        {
-    //            if((LoadXSL("MyObjectDef.xsl") == TEST_PASS))
+    //            if((LoadXSL("myObjectDef.xsl") == TEST_PASS))
     //                Transform_ArgList("fruits.xml");
     //        }
     //        catch(System.Xml.Xsl.XsltException)
@@ -915,7 +915,7 @@ namespace System.Xml.Tests
 
     //        try
     //        {
-    //            if((LoadXSL("MyObjectDef.xsl") == TEST_PASS))
+    //            if((LoadXSL("myObjectDef.xsl") == TEST_PASS))
     //                Transform_ArgList("fruits.xml");
     //        }
     //        catch(System.Xml.Xsl.XsltException)
@@ -944,7 +944,7 @@ namespace System.Xml.Tests
     //                Assert.True(false);
     //            }
     //        }
-    //        if((LoadXSL("MyObjectDef.xsl") == TEST_PASS) && (Transform_ArgList("fruits.xml") == TEST_PASS) &&
+    //        if((LoadXSL("myObjectDef.xsl") == TEST_PASS) && (Transform_ArgList("fruits.xml") == TEST_PASS) &&
     //            (CheckResult(430.402026847)== TEST_PASS))
     //            return;
     //        else
@@ -1819,7 +1819,7 @@ namespace System.Xml.Tests
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
-            if ((LoadXSL("MyObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
                 (CheckResult(430.402026847) == 1))
                 return;
             else
@@ -2002,7 +2002,7 @@ namespace System.Xml.Tests
             m_xsltArg.AddExtensionObject("urn:My-Object", obj);
             m_xsltArg.AddExtensionObject("urn-my:object", obj);
 
-            if ((LoadXSL("MyObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
                 (CheckResult(430.402026847) == 1))
                 return;
             else
@@ -2062,7 +2062,7 @@ namespace System.Xml.Tests
                 MyObject obj = new MyObject(i, _output);
                 m_xsltArg.AddExtensionObject(szDefaultNS + i, obj);
             }
-            if ((LoadXSL("MyObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
                 (CheckResult(430.402026847) == 1))
                 return;
             else
@@ -2085,7 +2085,7 @@ namespace System.Xml.Tests
             }
             try
             {
-                if ((LoadXSL("MyObjectDef.xsl") == 1))
+                if ((LoadXSL("myObjectDef.xsl") == 1))
                     Transform_ArgList("fruits.xml", true);
             }
             catch (System.Xml.Xsl.XsltException)
@@ -2133,7 +2133,7 @@ namespace System.Xml.Tests
             }
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
 
-            if ((LoadXSL("MyObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
                 (CheckResult(430.402026847) == 1))
                 return;
             else
@@ -2151,7 +2151,7 @@ namespace System.Xml.Tests
             m_xsltArg.AddExtensionObject(szSimple, obj);
             try
             {
-                if ((LoadXSL("MyObjectDef.xsl") == 1))
+                if ((LoadXSL("myObjectDef.xsl") == 1))
                     Transform_ArgList("fruits.xml", true);
             }
             catch (System.Xml.Xsl.XsltException)
@@ -3001,7 +3001,7 @@ namespace System.Xml.Tests
 
             try
             {
-                if ((LoadXSL("MyObjectDef.xsl") == 1))
+                if ((LoadXSL("myObjectDef.xsl") == 1))
                     Transform_ArgList("fruits.xml", true);
             }
             catch (System.Xml.Xsl.XsltException)
@@ -3065,7 +3065,7 @@ namespace System.Xml.Tests
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
             m_xsltArg.RemoveExtensionObject(szSimple);
 
-            if ((LoadXSL("MyObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
                 (CheckResult(430.402026847) == 1))
                 return;
             else
@@ -3085,7 +3085,7 @@ namespace System.Xml.Tests
 
             try
             {
-                if ((LoadXSL("MyObjectDef.xsl") == 1))
+                if ((LoadXSL("myObjectDef.xsl") == 1))
                     Transform_ArgList("fruits.xml", true);
             }
             catch (System.Xml.Xsl.XsltException)
@@ -3146,7 +3146,7 @@ namespace System.Xml.Tests
             m_xsltArg.RemoveExtensionObject("urn-my:object");
             m_xsltArg.RemoveExtensionObject("urn:my-object ");
 
-            if ((LoadXSL("MyObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
                 (CheckResult(430.402026847) == 1))
                 return;
             else
@@ -3178,7 +3178,7 @@ namespace System.Xml.Tests
 
             try
             {
-                if ((LoadXSL("MyObjectDef.xsl") == 1))
+                if ((LoadXSL("myObjectDef.xsl") == 1))
                     Transform_ArgList("fruits.xml", true);
             }
             catch (System.Xml.Xsl.XsltException)
@@ -3305,7 +3305,7 @@ namespace System.Xml.Tests
                 Assert.True(false);
             }
 
-            if ((LoadXSL("MyObjectDef.xsl") == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1))
             {
                 try
                 {
@@ -3439,7 +3439,7 @@ namespace System.Xml.Tests
             m_xsltArg.RemoveExtensionObject(szDefaultNS);
             m_xsltArg.Clear();
 
-            if ((LoadXSL("MyObjectDef.xsl") == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1))
             {
                 try
                 {

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
@@ -377,7 +377,7 @@ namespace System.Xml.Tests
         {
             try
             {
-                if (LoadXSL("xmlResolver_main.xsl") == 1)
+                if (LoadXSL("XmlResolver_Main.xsl") == 1)
                 {
                     xslt.XmlResolver = null;
                     if ((Transform("fruits.xml") == 1) && (CheckResult(428.8541842246) == 1))
@@ -659,13 +659,13 @@ namespace System.Xml.Tests
             FileStream s2;
 
             // check immediately after load and after transform
-            if (LoadXSL("XmlResolver_main.xsl") == 1)
+            if (LoadXSL("XmlResolver_Main.xsl") == 1)
             {
-                s2 = new FileStream(FullFilePath("XmlResolver_main.xsl"), FileMode.Open, FileAccess.Read, FileShare.Read);
+                s2 = new FileStream(FullFilePath("XmlResolver_Main.xsl"), FileMode.Open, FileAccess.Read, FileShare.Read);
                 s2.Dispose();
                 if ((Transform("fruits.xml") == 1) && (CheckResult(428.8541842246) == 1))
                 {
-                    s2 = new FileStream(FullFilePath("XmlResolver_main.xsl"), FileMode.Open, FileAccess.Read, FileShare.Read);
+                    s2 = new FileStream(FullFilePath("XmlResolver_Main.xsl"), FileMode.Open, FileAccess.Read, FileShare.Read);
                     s2.Dispose();
                     return;
                 }
@@ -683,13 +683,13 @@ namespace System.Xml.Tests
 
             // check immediately after load and after transform
 
-            if(LoadXSL("XmlResolver_main.xsl") == TEST_PASS)
+            if(LoadXSL("XmlResolver_Main.xsl") == TEST_PASS)
             {
-                s2 = new FileStream(FullFilePath("XmlResolver_main.xsl"), FileMode.Open, FileAccess.ReadWrite);
+                s2 = new FileStream(FullFilePath("XmlResolver_Main.xsl"), FileMode.Open, FileAccess.ReadWrite);
                 s2.Dispose();
                 if((Transform("fruits.xml") == TEST_PASS) && (CheckResult(428.8541842246)== TEST_PASS))
                 {
-                    s2 = new FileStream(FullFilePath("XmlResolver_main.xsl"), FileMode.Open, FileAccess.ReadWrite);
+                    s2 = new FileStream(FullFilePath("XmlResolver_Main.xsl"), FileMode.Open, FileAccess.ReadWrite);
                     s2.Dispose();
                     return;
                 }
@@ -707,7 +707,7 @@ namespace System.Xml.Tests
             FileStream s2;
 
             // check immediately after load and after transform
-            if (LoadXSL("XmlResolver_main.xsl") == 1)
+            if (LoadXSL("XmlResolver_Main.xsl") == 1)
             {
                 s2 = new FileStream(FullFilePath("XmlResolver_sub.xsl"), FileMode.Open, FileAccess.Read);
                 s2.Dispose();
@@ -731,7 +731,7 @@ namespace System.Xml.Tests
             FileStream s2;
 
             // check immediately after load and after transform
-            if(LoadXSL("XmlResolver_main.xsl") == TEST_PASS)
+            if(LoadXSL("XmlResolver_Main.xsl") == TEST_PASS)
             {
                 s2 = new FileStream(FullFilePath("XmlResolver_sub.xsl"), FileMode.Open, FileAccess.ReadWrite);
                 s2.Dispose();
@@ -888,7 +888,7 @@ namespace System.Xml.Tests
         {
             try
             {
-                LoadXSL_Resolver("xmlResolver_main.xsl", null);
+                LoadXSL_Resolver("XmlResolver_Main.xsl", null);
             }
             catch (System.Xml.Xsl.XsltCompileException e)
             {
@@ -914,7 +914,7 @@ namespace System.Xml.Tests
             CustomNullResolver myResolver = new CustomNullResolver(null);
             try
             {
-                LoadXSL_Resolver("xmlResolver_main.xsl", myResolver);
+                LoadXSL_Resolver("XmlResolver_Main.xsl", myResolver);
             }
             catch (System.Xml.Xsl.XsltCompileException e)
             {
@@ -970,12 +970,12 @@ namespace System.Xml.Tests
 
             try
             {
-                LoadXSL_Resolver("xmlResolver_main.xsl", myResolver);
+                LoadXSL_Resolver("XmlResolver_Main.xsl", myResolver);
             }
             catch (System.Xml.Xsl.XsltCompileException e)
             {
                 CheckExpectedError(e.InnerException, "System.Data.Sqlxml", "Xslt_CantResolve", new string[] { new Uri(FullFilePath("XmlResolver_Include.xsl", false)).ToString() });
-                if (LoadXSL("xmlResolver_main.xsl") == 1)
+                if (LoadXSL("XmlResolver_Main.xsl") == 1)
                 {
                     if ((Transform("fruits.xml") == 1) && (CheckResult(428.8541842246) == 1))
                         return;
@@ -1006,11 +1006,11 @@ namespace System.Xml.Tests
 
             CustomNullResolver myResolver = new CustomNullResolver(null);
 
-            if ((LoadXSL("xmlResolver_main.xsl") == 1))
+            if ((LoadXSL("XmlResolver_Main.xsl") == 1))
             {
                 try
                 {
-                    LoadXSL_Resolver("xmlResolver_main.xsl", myResolver);
+                    LoadXSL_Resolver("XmlResolver_Main.xsl", myResolver);
                 }
                 catch (System.Xml.Xsl.XsltCompileException e)
                 {
@@ -1029,9 +1029,9 @@ namespace System.Xml.Tests
         [Theory(Skip = "Resolving of External URIs is no longer allowed")]
         public void LoadGeneric9()
         {
-            if ((LoadXSL_Resolver("xmlResolver_Main.xsl", GetDefaultCredResolver()) == 1))
+            if ((LoadXSL_Resolver("XmlResolver_Main.xsl", GetDefaultCredResolver()) == 1))
             {
-                if ((LoadXSL("xmlResolver_Main.xsl") == 1) && (Transform("fruits.xml") == 1)
+                if ((LoadXSL("XmlResolver_Main.xsl") == 1) && (Transform("fruits.xml") == 1)
                     && (CheckResult(428.8541842246) == 1))
                     return;
             }
@@ -1347,6 +1347,7 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Load with \"\\\\\"")]
+        [PlatformSpecific(TestPlatforms.Windows)] //Not a valid path on Unix
         [InlineData()]
         [Theory]
         public void LoadUrl5()
@@ -1925,7 +1926,7 @@ namespace System.Xml.Tests
         {
             try
             {
-                if (LoadXSL("xmlResolver_main.xsl") == 1)
+                if (LoadXSL("XmlResolver_Main.xsl") == 1)
                 {
                     if ((TransformResolver("fruits.xml", null) == 1) && (CheckResult(428.8541842246) == 1))
                         return;
@@ -2127,6 +2128,7 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Output file is invalid")]
+        [PlatformSpecific(TestPlatforms.Windows)] //Output file name is valid on Unix
         [InlineData()]
         [Theory]
         public void TransformStrStr5()
@@ -2298,7 +2300,7 @@ namespace System.Xml.Tests
             Assert.True(false);
         }
 
-        //[Variation("Output filename is \'.\', \'..\', and \'\\\\\'")]
+        //[Variation("Output filename is \'.\' and \'..\')]
         [InlineData()]
         [Theory]
         public void TransformStrStr12()
@@ -2325,19 +2327,29 @@ namespace System.Xml.Tests
                     iCount++;
                 }
 
-                try
-                {
-                    xslt.Transform(szFullFilename, "\\\\");
-                }
-                catch (System.Exception)
-                {
-                    iCount++;
-                }
             }
 
-            if (iCount.Equals(3))
+            if (iCount.Equals(2))
                 return;
             _output.WriteLine("Exception not generated for invalid ouput destinations");
+            Assert.True(false);
+        }
+
+        //[Variation("Output filename is \'\\\\\'")]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [InlineData()]
+        [Theory]
+        public void TransformStrStr12_win()
+        {
+            String szFullFilename = FullFilePath("fruits.xml");
+
+            if (LoadXSL("showParam.xsl") == 1)
+            {
+                Assert.Throws<System.ArgumentException>(() => xslt.Transform(szFullFilename, "\\\\"));
+                return;
+            }
+
+            _output.WriteLine("Exception not generated for invalid ouput destination");
             Assert.True(false);
         }
 
@@ -2421,7 +2433,7 @@ namespace System.Xml.Tests
 
             try
             {
-                if (LoadXSL("xmlResolver_main.xsl") == 1)
+                if (LoadXSL("XmlResolver_Main.xsl") == 1)
                 {
                     xslt.Transform(szFullFilename, "out.xml", null);
                     if (CheckResult(428.8541842246) == 1)

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/System.Xml.Xsl.XslTransformApi.Tests.csproj
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/System.Xml.Xsl.XslTransformApi.Tests.csproj
@@ -38,7 +38,7 @@
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
     <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\xmlDiff\XmlDiff.csproj" />
+    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlDiff\XmlDiff.csproj" />
     <ProjectReference Include="..\..\..\..\System.Private.Xml\pkg\System.Private.Xml.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/XSLTransform.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/XSLTransform.cs
@@ -207,7 +207,7 @@ namespace System.Xml.Tests
             // FullFilePath and FullHttpPath attempt to normalize file paths, however
             // as an extra step we can normalize them here, when they are first read
             // from the LTM file.
-            _strPath = Path.Combine(@"TestFiles\", FilePathUtil.GetTestDataPath(), @"XsltApi\");
+            _strPath = Path.Combine("TestFiles", FilePathUtil.GetTestDataPath(), "XsltApi");
             _httpPath = FilePathUtil.GetHttpTestDataPath() + @"/XsltApi/";
 
             return;
@@ -216,7 +216,7 @@ namespace System.Xml.Tests
         // Returns the full path of a file, based on LTM parameters
         public String FullFilePath(String szFile)
         {
-            return FullFilePath(szFile, true);
+            return FullFilePath(szFile, false);
         }
 
         // Returns the full, lower-cased path of a file, based on LTM parameters
@@ -228,7 +228,7 @@ namespace System.Xml.Tests
             if (szFile.Length > 5)
             {
                 if (szFile.Substring(0, 5) != "http:")
-                    szFile = _strPath + szFile;
+                    szFile = Path.Combine(_strPath, szFile);
             }
             if (normalizeToLower)
                 return szFile.ToLower();
@@ -252,7 +252,7 @@ namespace System.Xml.Tests
         //  -------------------------------------------------------------------------------------------------------------
         public void CheckExpectedError(Exception ex, string assembly, string res, string[] strParams)
         {
-            CExceptionHandler handler = new CExceptionHandler(Path.Combine(_strPath, "exceptions.xml"), assembly, _output);
+            CExceptionHandler handler = new CExceptionHandler(Path.Combine(_strPath, "Exceptions.xml"), assembly, _output);
             if (!handler.VerifyException(ex, res, strParams))
             {
                 Assert.True(false);
@@ -265,7 +265,7 @@ namespace System.Xml.Tests
         //  -------------------------------------------------------------------------------------------------------------
         public void CheckExpectedError(Exception ex, string assembly, string res, string[] strParams, LineInfo lInfo)
         {
-            CExceptionHandler handler = new CExceptionHandler(Path.Combine(_strPath, "exceptions.xml"), assembly, _output);
+            CExceptionHandler handler = new CExceptionHandler(Path.Combine(_strPath, "Exceptions.xml"), assembly, _output);
             if (!handler.VerifyException(ex, res, strParams, lInfo))
             {
                 Assert.True(false);

--- a/src/System.Private.Xml/tests/Xslt/XsltCompiler/XsltCompiler.Tests.csproj
+++ b/src/System.Private.Xml/tests/Xslt/XsltCompiler/XsltCompiler.Tests.csproj
@@ -42,7 +42,7 @@
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
     <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\xmlDiff\XmlDiff.csproj" />
+    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlDiff\XmlDiff.csproj" />
     <ProjectReference Include="..\..\..\..\System.Private.Xml\pkg\System.Private.Xml.pkgproj" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Resolves https://github.com/dotnet/corefx/issues/12789
Xslt and Schema tests were using file paths and wrong capitalization of file names which would work on Windows, but not on Unix-based platforms. This is fixed in this PR.
Some tests are also made windows-specific as they test cases specific to windows.

@danmosemsft @weshaggard @stephentoub 