### PR TITLE
Enable ApiCompat in S.R.WinRT by updating WinRT targeting pack

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -101,7 +101,7 @@
     </StaticDependency>
 
     <StaticDependency Include="Microsoft.TargetingPack.Private.WinRT">
-      <Version>1.0.2</Version>
+      <Version>1.0.3</Version>
     </StaticDependency>
 
     <XUnitDependency Include="xunit"/>

--- a/src/System.AppContext/src/netcore50aot/project.json
+++ b/src/System.AppContext/src/netcore50aot/project.json
@@ -4,7 +4,7 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
         "Microsoft.NETCore.Targets": "1.0.1",
-        "Microsoft.TargetingPack.Private.WinRT": "1.0.2",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.3",
         "System.Collections": "4.0.11",
         "System.Resources.ResourceManager": "4.0.1",
         "System.Runtime": "4.1.0",

--- a/src/System.IO.FileSystem/src/netcore50/project.json
+++ b/src/System.IO.FileSystem/src/netcore50/project.json
@@ -25,7 +25,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24714-00",
-        "Microsoft.TargetingPack.Private.WinRT": "1.0.2",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.3",
         "System.Globalization": "4.0.11",
         "System.Reflection": "4.1.0",
         "System.Reflection.Primitives": "4.0.1",

--- a/src/System.IO.IsolatedStorage/src/project.json
+++ b/src/System.IO.IsolatedStorage/src/project.json
@@ -28,7 +28,7 @@
         "Microsoft.NETCore.Platforms": "1.0.1",
         "Microsoft.NETCore.Targets": "1.0.1",
         "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24714-00",
-        "Microsoft.TargetingPack.Private.WinRT": "1.0.2",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.3",
         "System.Collections": "4.0.11",
         "System.IO": "4.4.0-beta-24714-01",
         "System.IO.FileSystem": "4.0.1",

--- a/src/System.Net.Http/src/project.json
+++ b/src/System.Net.Http/src/project.json
@@ -29,7 +29,7 @@
     },
     "uap10.1": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.WinRT": "1.0.2",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.3",
         "System.Collections": "4.4.0-beta-24714-01",
         "System.Diagnostics.Contracts": "4.4.0-beta-24714-01",
         "System.Diagnostics.Debug": "4.4.0-beta-24714-01",

--- a/src/System.Net.NameResolution/src/netcore50/project.json
+++ b/src/System.Net.NameResolution/src/netcore50/project.json
@@ -4,7 +4,7 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
         "Microsoft.NETCore.Targets": "1.0.1",
-        "Microsoft.TargetingPack.Private.WinRT": "1.0.2",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.3",
         "System.Collections": "4.0.11",
         "System.Diagnostics.Contracts": "4.0.1",
         "System.Diagnostics.Debug": "4.0.11",

--- a/src/System.Net.NetworkInformation/src/project.json
+++ b/src/System.Net.NetworkInformation/src/project.json
@@ -27,7 +27,7 @@
     },
     "uap10.1": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.WinRT": "1.0.2",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.3",
         "Microsoft.Win32.Primitives": "4.4.0-beta-24714-01",
         "System.Diagnostics.Debug": "4.4.0-beta-24714-01",
         "System.Diagnostics.Tracing": "4.4.0-beta-24714-01",

--- a/src/System.Net.Primitives/src/project.json
+++ b/src/System.Net.Primitives/src/project.json
@@ -19,7 +19,7 @@
     },
     "uap10.1": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.WinRT": "1.0.2",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.3",
         "Microsoft.Win32.Primitives": "4.4.0-beta-24714-01",
         "System.Collections": "4.4.0-beta-24714-01",
         "System.Diagnostics.Contracts": "4.4.0-beta-24714-01",

--- a/src/System.Net.Sockets/src/netcore50/project.json
+++ b/src/System.Net.Sockets/src/netcore50/project.json
@@ -4,7 +4,7 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
         "Microsoft.NETCore.Targets": "1.0.1",
-        "Microsoft.TargetingPack.Private.WinRT": "1.0.2",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.3",
         "System.Buffers": "4.0.0",
         "System.Collections": "4.0.11",
         "System.Diagnostics.Debug": "4.0.11",

--- a/src/System.Net.WebSockets.Client/src/netcore50/project.json
+++ b/src/System.Net.WebSockets.Client/src/netcore50/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.WinRT": "1.0.2",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.3",
         "System.Collections": "4.0.11",
         "System.Diagnostics.Debug": "4.0.11",
         "System.Diagnostics.Tools": "4.0.1",

--- a/src/System.Resources.ResourceManager/src/project.json
+++ b/src/System.Resources.ResourceManager/src/project.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1",
         "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24714-00",
-        "Microsoft.TargetingPack.Private.WinRT": "1.0.2",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.3",
         "System.Diagnostics.Debug": "4.4.0-beta-24714-01",
         "System.Diagnostics.Tools": "4.4.0-beta-24714-01",
         "System.Diagnostics.Tracing": "4.4.0-beta-24714-01",

--- a/src/System.Runtime.Extensions/src/project.json
+++ b/src/System.Runtime.Extensions/src/project.json
@@ -23,7 +23,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24714-00",
-        "Microsoft.TargetingPack.Private.WinRT": "1.0.2"
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.3"
       }
     }
   }

--- a/src/System.Runtime.WindowsRuntime/ref/project.json
+++ b/src/System.Runtime.WindowsRuntime/ref/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.TargetingPack.Private.WinRT": "1.0.2",
+    "Microsoft.TargetingPack.Private.WinRT": "1.0.3",
     "System.Runtime": "4.1.0",
     "System.IO": "4.1.0",
     "System.Threading.Tasks": "4.0.11"

--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
@@ -17,8 +17,6 @@
     <PackageTargetRuntime>win8</PackageTargetRuntime>
     <PackageTargetRuntime Condition="'$(TargetGroup)' == 'uap101aot'">win8-aot</PackageTargetRuntime>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
-    <!-- windows.winmd is lower-case, see issue: https://github.com/dotnet/corefx/issues/13599 -->
-    <RunApiCompat Condition="'$(OSEnvironment)' != 'Windows_NT'">false</RunApiCompat>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)'==''">
     <DefineConstants>$(DefineConstants);netstandard;FEATURE_APPX</DefineConstants>

--- a/src/System.Runtime.WindowsRuntime/src/project.json
+++ b/src/System.Runtime.WindowsRuntime/src/project.json
@@ -3,13 +3,13 @@
     "netstandard1.7": {
       "dependencies": {
         "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24709-03",
-        "Microsoft.TargetingPack.Private.WinRT": "1.0.2"
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.3"
       }
     },
     "uap10.1": {
       "dependencies": {
         "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24714-00",
-        "Microsoft.TargetingPack.Private.WinRT": "1.0.2"
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.3"
       }
     }
   }


### PR DESCRIPTION
The new WinRT targeting pack has fixed issue #13599 (Thanks @ericstj!), so we can safely enable ApiCompat for all platforms in this project.