### PR TITLE
Fix warnings in test projects

### DIFF
--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/System.Data.StressRunner.csproj
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/System.Data.StressRunner.csproj
@@ -7,6 +7,10 @@
     <AssemblyName>System.Data.StressRunner</AssemblyName>
     <OutputType>Exe</OutputType>
     <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
+    <!-- Don't attempt to publish for any runtime.  
+         Though this is an EXE it is built as netstandard and will be 
+         published for a specific framework/runtime by a referencing project. -->
+    <CopyNuGetImplementations>false</CopyNuGetImplementations>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\IMonitorLoader\IMonitorLoader.csproj" />

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -137,6 +137,7 @@
     <ProjectReference Include="VoidMainWithExitCodeApp\VoidMainWithExitCodeApp.csproj">
       <Project>{9F312D76-9AF1-4E90-B3B0-815A1EC6C346}</Project>
       <Name>VoidMainWithExitCodeApp</Name>
+      <UndefineProperties>TargetGroup;OSGroup</UndefineProperties>
     </ProjectReference>
     <ProjectReference Include="TestApp\TestApp.csproj">
       <Project>{9F312D76-9AF1-4E90-B3B0-815A1EC6C346}</Project>


### PR DESCRIPTION
One additional warning just cropped up and I hadn't completely fixed the VoidMainWithExitCodeApp warning.

/cc @JeremyKuhne 