### PR TITLE
Compile System.Runtime.Serialization.FormattersCompile for netcoreapp1.1

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/src/System.Runtime.Serialization.Formatters.builds
+++ b/src/System.Runtime.Serialization.Formatters/src/System.Runtime.Serialization.Formatters.builds
@@ -6,6 +6,9 @@
     <Project Include="System.Runtime.Serialization.Formatters.csproj">
       <TargetGroup>net463</TargetGroup>
     </Project>
+    <Project Include="System.Runtime.Serialization.Formatters.csproj">
+      <TargetGroup>netcoreapp1.1</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime.Serialization.Formatters/src/System.Runtime.Serialization.Formatters.csproj
+++ b/src/System.Runtime.Serialization.Formatters/src/System.Runtime.Serialization.Formatters.csproj
@@ -7,11 +7,12 @@
     <RootNamespace>System.Runtime.Serialization.Formatters</RootNamespace>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net463'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp1.1'">$(DefineConstants);netcoreapp11</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
-  <ItemGroup Condition="'$(TargetGroup)' == ''">
+  <ItemGroup Condition="'$(TargetGroup)' == '' Or '$(TargetGroup)' == 'netcoreapp1.1'">
     <Compile Include="System.Runtime.Serialization.Formatters.TypeForwards.cs" />
     <Compile Include="System\TemporaryStubs.cs" />
     <Compile Include="System\Runtime\Serialization\DeserializationEventHandler.cs" />

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs
@@ -67,12 +67,13 @@ namespace System.Runtime.Serialization
             // nop
         }
 
-        // TODO #8133: Fix this to avoid reflection
+#if !netcoreapp11
         private static readonly Func<Type, object> s_getUninitializedObjectDelegate = (Func<Type, object>)
             typeof(string).Assembly
             .GetType("System.Runtime.Serialization.FormatterServices")
             .GetMethod("GetUninitializedObject", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
             .CreateDelegate(typeof(Func<Type, object>));
+#endif // netcoreapp11
 
         public static object GetUninitializedObject(Type type)
         {
@@ -80,8 +81,11 @@ namespace System.Runtime.Serialization
             {
                 throw new ArgumentNullException(nameof(type));
             }
-
+#if netcoreapp11
+            return RuntimeHelpers.GetUninitializedObject(type);
+#else
             return s_getUninitializedObjectDelegate(type);
+#endif // netcoreapp11
         }
 
         public static object GetSafeUninitializedObject(Type type) => GetUninitializedObject(type);

--- a/src/System.Runtime.Serialization.Formatters/src/project.json
+++ b/src/System.Runtime.Serialization.Formatters/src/project.json
@@ -26,6 +26,27 @@
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }
+    },
+    "netcoreapp1.1": {
+      "dependencies": {
+        "System.Collections": "4.4.0-beta-24714-01",
+        "System.Collections.NonGeneric": "4.4.0-beta-24714-01",
+        "System.Collections.Concurrent": "4.4.0-beta-24714-01",
+        "System.Diagnostics.Debug": "4.4.0-beta-24714-01",
+        "System.Reflection": "4.4.0-beta-24714-01",
+        "System.IO": "4.4.0-beta-24714-01",
+        "System.Reflection.Extensions": "4.4.0-beta-24714-01",
+        "System.Reflection.TypeExtensions": "4.4.0-beta-24714-01",
+        "System.Resources.ResourceManager": "4.4.0-beta-24714-01",
+        "System.Runtime": "4.4.0-beta-24714-01",
+        "System.Runtime.Extensions": "4.4.0-beta-24714-01",
+        "System.Runtime.Serialization.Primitives": "4.4.0-beta-24714-01",
+        "System.Globalization": "4.4.0-beta-24714-01",
+        "System.Text.Encoding.Extensions": "4.4.0-beta-24714-01",
+        "System.Text.Encoding": "4.4.0-beta-24714-01",
+        "System.Threading": "4.4.0-beta-24714-01",
+        "System.Threading.Tasks": "4.4.0-beta-24714-01"
+      }
     }
   }
 }


### PR DESCRIPTION
We are doing that so we can have the implementation of GetUninitializedObject to use RuntimeHelpers.GetUninitializedObject instead of using the reflection