### PR TITLE
Resolve connection leak in SNI by adding dispose for underlying TCP stream in SNITcpHandle.Dispose()

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -22,7 +22,7 @@ namespace System.Data.SqlClient.SNI
         private readonly string _targetServer;
         private readonly object _callbackObject;
         private readonly Socket _socket;
-        private readonly NetworkStream _tcpStream;
+        private NetworkStream _tcpStream;
         private readonly TaskScheduler _writeScheduler;
         private readonly TaskFactory _writeTaskFactory;
 
@@ -56,6 +56,12 @@ namespace System.Data.SqlClient.SNI
                 {
                     _sslStream.Dispose();
                     _sslStream = null;
+                }
+
+                if (_tcpStream != null)
+                {
+                    _tcpStream.Dispose();
+                    _tcpStream = null;
                 }
             }
         }


### PR DESCRIPTION
Resolves https://github.com/dotnet/corefx/issues/13422

Originally caused by https://github.com/dotnet/corefx/commit/30abd30421289509cd3bd18a9114501afdc0fb7c which removed a TcpClient.Dispose() in SNITcpHandle

CC @saurabh500 @geleems