### PR TITLE
Add missing FileSystemWatcher methods

### DIFF
--- a/src/System.IO.FileSystem.Watcher/ref/System.IO.FileSystem.Watcher.cs
+++ b/src/System.IO.FileSystem.Watcher/ref/System.IO.FileSystem.Watcher.cs
@@ -22,7 +22,7 @@ namespace System.IO
         public string Name { get { throw null; } }
     }
     public delegate void FileSystemEventHandler(object sender, System.IO.FileSystemEventArgs e);
-    public partial class FileSystemWatcher : System.ComponentModel.Component
+    public partial class FileSystemWatcher : System.ComponentModel.Component, System.ComponentModel.ISupportInitialize
     {
         public FileSystemWatcher() { }
         public FileSystemWatcher(string path) { }
@@ -45,6 +45,11 @@ namespace System.IO
         protected void OnRenamed(System.IO.RenamedEventArgs e) { }
         public System.IO.WaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType) { throw null; }
         public System.IO.WaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType, int timeout) { throw null; }
+        public override System.ComponentModel.ISite Site { get { throw null; } set { } }
+        public System.ComponentModel.ISynchronizeInvoke SynchronizingObject { get { throw null; } set { } }
+        public void BeginInit() { }
+        protected override void Dispose(bool disposing) { }
+        public void EndInit() { }
     }
     [Serializable]
     public partial class InternalBufferOverflowException : System.SystemException

--- a/src/System.IO.FileSystem.Watcher/ref/project.json
+++ b/src/System.IO.FileSystem.Watcher/ref/project.json
@@ -1,7 +1,8 @@
 {
   "dependencies": {
     "System.Runtime": "4.4.0-beta-24715-03",
-    "System.ComponentModel.Primitives": "4.4.0-beta-24715-03"
+    "System.ComponentModel.Primitives": "4.4.0-beta-24715-03",
+    "System.ComponentModel.TypeConverter": "4.4.0-beta-24715-03"
   },
   "frameworks": {
     "netstandard1.7": {}

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -19,6 +19,13 @@ namespace System.IO
         /// <summary>Starts a new watch operation if one is not currently running.</summary>
         private void StartRaisingEvents()
         {
+            // If we're called when "Initializing" is true, set enabled to true
+            if (IsSuspended())
+            {
+                _enabled = true;
+                return;
+            }
+
             // If we already have a cancellation object, we're already running.
             if (_cancellation != null)
             {
@@ -87,6 +94,9 @@ namespace System.IO
         private void StopRaisingEvents()
         {
             _enabled = false;
+
+            if (IsSuspended())
+                return;
 
             // If there's an active cancellation token, cancel and release it.
             // The cancellation token and the processing task respond to cancellation

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -27,6 +27,13 @@ namespace System.IO
 
         private void StartRaisingEvents()
         {
+            // If we're called when "Initializing" is true, set enabled to true
+            if (IsSuspended())
+            {
+                _enabled = true;
+                return;
+            }
+
             // Don't start another instance if one is already runnings
             if (_cancellation != null)
             {
@@ -52,6 +59,9 @@ namespace System.IO
         private void StopRaisingEvents()
         {
             _enabled = false;
+
+            if (IsSuspended())
+                return;
 
             CancellationTokenSource token = _cancellation;
             if (token != null)

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
@@ -14,6 +14,13 @@ namespace System.IO
         /// <summary>Start monitoring the current directory.</summary>
         private void StartRaisingEvents()
         {
+            // If we're called when "Initializing" is true, set enabled to true
+            if (IsSuspended())
+            {
+                _enabled = true;
+                return;
+            }
+
             // If we're already running, don't do anything.
             if (!IsHandleInvalid(_directoryHandle))
                 return;
@@ -66,6 +73,9 @@ namespace System.IO
         private void StopRaisingEvents()
         {
             _enabled = false;
+
+            if (IsSuspended())
+                return;
 
             // If we're not running, do nothing.
             if (IsHandleInvalid(_directoryHandle))

--- a/src/System.IO.FileSystem.Watcher/src/project.json
+++ b/src/System.IO.FileSystem.Watcher/src/project.json
@@ -6,6 +6,7 @@
         "Microsoft.Win32.Primitives": "4.4.0-beta-24715-03",
         "System.Collections": "4.4.0-beta-24715-03",
         "System.ComponentModel.Primitives": "4.4.0-beta-24715-03",
+        "System.ComponentModel.TypeConverter": "4.4.0-beta-24715-03",
         "System.Diagnostics.Debug": "4.4.0-beta-24715-03",
         "System.Diagnostics.Tools": "4.4.0-beta-24715-03",
         "System.IO": "4.4.0-beta-24715-03",

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.netstandard17.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.netstandard17.cs
@@ -1,0 +1,269 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class FileSystemWatcherTests_netstandard17 : FileSystemWatcherTest
+    {
+        public class TestSite : ISite
+        {
+            public bool designMode;
+            public bool DesignMode => designMode;
+            public IComponent Component => null;
+            public IContainer Container => null;
+            public string Name { get; set; }
+            public object GetService(Type serviceType) => null;
+        }
+
+        [Fact]
+        public void Site_GetSetRoundtrips()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var watcher = new TestFileSystemWatcher(testDirectory.Path, "*"))
+            {
+                TestSite site = new TestSite();
+                Assert.Null(watcher.Site);
+                watcher.Site = site;
+                Assert.Equal(site, watcher.Site);
+                watcher.Site = null;
+                Assert.Null(watcher.Site);
+                Assert.False(watcher.EnableRaisingEvents);
+            }
+        }
+
+        /// <summary>
+        /// When the FSW Site is set to a nonnull Site with DesignMode enabled, Event raising will be set to true
+        /// </summary>
+        [Fact]
+        public void Site_NonNullSetEnablesRaisingEvents()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var watcher = new TestFileSystemWatcher(testDirectory.Path, "*"))
+            {
+                TestSite site = new TestSite() { designMode = true };
+                watcher.Site = site;
+                Assert.True(watcher.EnableRaisingEvents);
+            }
+        }
+
+        internal class TestISynchronizeInvoke : ISynchronizeInvoke
+        {
+            public bool BeginInvoke_Called;
+            public Delegate ExpectedDelegate;
+
+            public IAsyncResult BeginInvoke(Delegate method, object[] args)
+            {
+                Assert.Equal(ExpectedDelegate, method);
+                BeginInvoke_Called = true;
+                return null;
+            }
+
+            public bool InvokeRequired => true;
+            public object EndInvoke(IAsyncResult result) => null;
+            public object Invoke(Delegate method, object[] args) => null;
+        }
+
+        [Fact]
+        public void SynchronizingObject_GetSetRoundtrips()
+        {
+            TestISynchronizeInvoke invoker = new TestISynchronizeInvoke() { };
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var watcher = new TestFileSystemWatcher(testDirectory.Path, "*"))
+            {
+                Assert.Null(watcher.SynchronizingObject);
+                watcher.SynchronizingObject = invoker;
+                Assert.Equal(invoker, watcher.SynchronizingObject);
+                watcher.SynchronizingObject = null;
+                Assert.Null(watcher.SynchronizingObject);
+            }
+        }
+
+        /// <summary>
+        /// Ensure that the SynchronizeObject is invoked when an event occurs
+        /// </summary>
+        [Theory]
+        [InlineData(WatcherChangeTypes.Changed)]
+        [InlineData(WatcherChangeTypes.Deleted)]
+        [InlineData(WatcherChangeTypes.Created)]
+        public void SynchronizingObject_CalledOnEvent(WatcherChangeTypes expectedChangeType)
+        {
+            FileSystemEventHandler dele = (sender, e) => { Assert.Equal(expectedChangeType, e.ChangeType); };
+            TestISynchronizeInvoke invoker = new TestISynchronizeInvoke() { ExpectedDelegate = dele };
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var watcher = new TestFileSystemWatcher(testDirectory.Path, "*"))
+            {
+                watcher.SynchronizingObject = invoker;
+                if (expectedChangeType == WatcherChangeTypes.Created)
+                {
+                    watcher.Created += dele;
+                    watcher.CallOnCreated(new FileSystemEventArgs(WatcherChangeTypes.Created, "test", "name"));
+                }
+                else if (expectedChangeType == WatcherChangeTypes.Deleted)
+                {
+                    watcher.Deleted += dele;
+                    watcher.CallOnDeleted(new FileSystemEventArgs(WatcherChangeTypes.Deleted, "test", "name"));
+                }
+                else if (expectedChangeType == WatcherChangeTypes.Changed)
+                {
+                    watcher.Changed += dele;
+                    watcher.CallOnChanged(new FileSystemEventArgs(WatcherChangeTypes.Changed, "test", "name"));
+                }
+                Assert.True(invoker.BeginInvoke_Called);
+            }
+        }
+
+        /// <summary>
+        /// Ensure that the SynchronizeObject is invoked when an Renamed event occurs
+        /// </summary>
+        [Fact]
+        public void SynchronizingObject_CalledOnRenamed()
+        {
+            RenamedEventHandler dele = (sender, e) => { Assert.Equal(WatcherChangeTypes.Renamed, e.ChangeType); };
+            TestISynchronizeInvoke invoker = new TestISynchronizeInvoke() { ExpectedDelegate = dele };
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var watcher = new TestFileSystemWatcher(testDirectory.Path, "*"))
+            {
+                watcher.SynchronizingObject = invoker;
+                watcher.Renamed += dele;
+                watcher.CallOnRenamed(new RenamedEventArgs(WatcherChangeTypes.Changed, "test", "name", "oldname"));
+                Assert.True(invoker.BeginInvoke_Called);
+            }
+        }
+
+        /// <summary>
+        /// Ensure that the SynchronizeObject is invoked when an Error event occurs
+        /// </summary>
+        [Fact]
+        public void SynchronizingObject_CalledOnError()
+        {
+            ErrorEventHandler dele = (sender, e) => { Assert.IsType<FileNotFoundException>(e.GetException()); };
+            TestISynchronizeInvoke invoker = new TestISynchronizeInvoke() { ExpectedDelegate = dele };
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var watcher = new TestFileSystemWatcher(testDirectory.Path, "*"))
+            {
+                watcher.SynchronizingObject = invoker;
+                watcher.Error += dele;
+                watcher.CallOnError(new ErrorEventArgs(new FileNotFoundException()));
+                Assert.True(invoker.BeginInvoke_Called);
+            }
+        }
+
+        /// <summary>
+        /// Calling BeginInit and EndInit in a loop is fine. If events are enabled, they will start and stop in the loop as well.
+        /// </summary>
+        [Fact]
+        public void BeginEndInit_Repeated()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var watcher = new TestFileSystemWatcher(testDirectory.Path, "*"))
+            {
+                watcher.BeginInit();
+                watcher.EndInit();
+                watcher.BeginInit();
+                watcher.EndInit();
+                Assert.False(watcher.EnableRaisingEvents);
+            }
+        }
+
+        /// <summary>
+        /// BeginInit followed by a EnableRaisingEvents=true does not cause the watcher to begin.
+        /// </summary>
+        [Fact]
+        public void BeginInit_PausesEnableRaisingEvents()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var watcher = new TestFileSystemWatcher(testDirectory.Path, "*"))
+            {
+                watcher.Created += (obj, e) => { Assert.False(true, "Created event should not occur"); };
+                watcher.Deleted += (obj, e) => { Assert.False(true, "Deleted event should not occur"); };
+                watcher.BeginInit();
+                watcher.EnableRaisingEvents = true;
+                new TempFile(Path.Combine(testDirectory.Path, GetTestFileName())).Dispose();
+                Thread.Sleep(WaitForExpectedEventTimeout);
+            }
+        }
+
+        /// <summary>
+        /// EndInit will begin EnableRaisingEvents if we previously set EnableRaisingEvents=true
+        /// </summary>
+        [Fact]
+        public void EndInit_ResumesPausedEnableRaisingEvents()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var watcher = new TestFileSystemWatcher(testDirectory.Path, "*"))
+            {
+                watcher.BeginInit();
+                watcher.EnableRaisingEvents = true;
+                watcher.EndInit();
+                ExpectEvent(watcher, WatcherChangeTypes.Created | WatcherChangeTypes.Deleted, () => new TempFile(Path.Combine(testDirectory.Path, GetTestFileName())).Dispose(), null);
+            }
+        }
+
+        /// <summary>
+        /// EndInit will begin EnableRaisingEvents if we previously set EnableRaisingEvents=true
+        /// </summary>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void EndInit_ResumesPausedEnableRaisingEvents(bool setBeforeBeginInit)
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var watcher = new TestFileSystemWatcher(testDirectory.Path, "*"))
+            {
+                if (setBeforeBeginInit)
+                    watcher.EnableRaisingEvents = true;
+                watcher.BeginInit();
+                if (!setBeforeBeginInit)
+                    watcher.EnableRaisingEvents = true;
+                watcher.EndInit();
+                ExpectEvent(watcher, WatcherChangeTypes.Created | WatcherChangeTypes.Deleted, () => new TempFile(Path.Combine(testDirectory.Path, GetTestFileName())).Dispose(), null);
+            }
+        }
+
+        /// <summary>
+        /// Stopping events during the initialization period will prevent the watcher from restarting after EndInit()
+        /// </summary>
+        [Fact]
+        public void EndRaisingEventsDuringPause()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var watcher = new TestFileSystemWatcher(testDirectory.Path, "*"))
+            {
+                watcher.EnableRaisingEvents = true;
+                watcher.BeginInit();
+                watcher.EnableRaisingEvents = false;
+                watcher.EndInit();
+                new TempFile(Path.Combine(testDirectory.Path, GetTestFileName())).Dispose();
+                Thread.Sleep(WaitForExpectedEventTimeout);
+            }
+        }
+
+        /// <summary>
+        /// EndInit will not start event raising unless EnableRaisingEvents was set to true.
+        /// </summary>
+        [Fact]
+        public void EndInit_DoesNotEnableEventRaisedEvents()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var watcher = new TestFileSystemWatcher(testDirectory.Path, "*"))
+            {
+                watcher.Created += (obj, e) => { Assert.False(true, "Created event should not occur"); };
+                watcher.Deleted += (obj, e) => { Assert.False(true, "Deleted event should not occur"); };
+                watcher.BeginInit();
+                watcher.EndInit();
+                new TempFile(Path.Combine(testDirectory.Path, GetTestFileName())).Dispose();
+                Thread.Sleep(WaitForExpectedEventTimeout);
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
+++ b/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
@@ -21,6 +21,13 @@
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == ''">
+    <Compile Include="FileSystemWatcher.netstandard17.cs" />
+    <Compile Include="InternalBufferOverflowException.cs" />
+    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+      <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
+    </Compile>
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="Args.ErrorEventArgs.cs" />
     <Compile Include="Args.FileSystemEventArgs.cs" />
@@ -38,9 +45,10 @@
     <Compile Include="FileSystemWatcher.InternalBufferSize.cs" />
     <Compile Include="FileSystemWatcher.WaitForChanged.cs" />
     <Compile Include="FileSystemWatcher.unit.cs" />
-    <Compile Include="InternalBufferOverflowException.cs" Condition="'$(TargetGroup)' == ''" />
     <!-- Helpers -->
-    <Compile Include="Utility\TestFileSystemWatcher.cs" />
+    <Compile Include="Utility\TestFileSystemWatcher.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Utility\FileSystemWatcherTest.cs" />
     <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
       <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
@@ -53,9 +61,6 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\System\PlatformDetection.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs" Condition="'$(TargetGroup)' == ''">
-      <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.IO.FileSystem.Watcher/tests/Utility/TestFileSystemWatcher.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/Utility/TestFileSystemWatcher.cs
@@ -9,6 +9,14 @@ namespace System.IO.Tests
     /// </summary>
     public class TestFileSystemWatcher : FileSystemWatcher
     {
+        public TestFileSystemWatcher() : base()
+        {
+        }
+
+        public TestFileSystemWatcher(string path, string filter) : base(path, filter)
+        {
+        }
+
         public void CallOnChanged(FileSystemEventArgs e)
         {
             this.OnChanged(e);


### PR DESCRIPTION
Adds source and tests for the remaining missing members in FileSystemWatcher. This required that FileSystemWatcher take a dependency on System.ComponentModel.TypeConverter.

resolves https://github.com/dotnet/corefx/issues/13491

@AlexGhiondea @danmosemsft @joperezr @alexperovich @JeremyKuhne 