### PR TITLE
Cleanup after System.IO move

### DIFF
--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.builds
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.builds
@@ -5,13 +5,10 @@
     <Project Include="System.Runtime.WindowsRuntime.csproj">
       <OSGroup>Windows_NT</OSGroup>
     </Project>
-<!--
-    Need to take a new CoreFX drop so we can pull the new packages and avoid direct csproj references to System.Runtime/Extensions
     <Project Include="System.Runtime.WindowsRuntime.csproj">
       <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>uap101aot</TargetGroup>
     </Project>
--->
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
@@ -67,7 +67,7 @@
       <TargetGroup>uap101aot</TargetGroup>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Runtime.Extensions\ref\System.Runtime.Extensions.csproj">
-      <UndefineProperties>%(ProjectReference.UndefineProperties);TargetGroup</UndefineProperties>
+      <UndefineProperties>TargetGroup</UndefineProperties>
       <Aliases>System_Runtime_Extensions</Aliases>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Resources.ResourceManager\src\System.Resources.ResourceManager.csproj">

--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
@@ -33,6 +33,7 @@
     <!-- Needed for the compiler to resolve IObservableMap.MapChanged. -->
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Runtime.Extensions\ref\System.Runtime.Extensions.csproj">
+      <UndefineProperties>TargetGroup</UndefineProperties>
       <Aliases>System_Runtime_Extensions</Aliases>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj" />

--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
@@ -33,7 +33,7 @@
     <!-- Needed for the compiler to resolve IObservableMap.MapChanged. -->
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Runtime.Extensions\ref\System.Runtime.Extensions.csproj">
-      <UndefineProperties>TargetGroup</UndefineProperties>
+      <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>
       <Aliases>System_Runtime_Extensions</Aliases>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj" />
@@ -68,7 +68,7 @@
       <TargetGroup>uap101aot</TargetGroup>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Runtime.Extensions\ref\System.Runtime.Extensions.csproj">
-      <UndefineProperties>TargetGroup</UndefineProperties>
+      <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>
       <Aliases>System_Runtime_Extensions</Aliases>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Resources.ResourceManager\src\System.Resources.ResourceManager.csproj">

--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
@@ -25,22 +25,18 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap101aot_Debug|AnyCPU'" />  
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap101aot_Release|AnyCPU'" />  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap101aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap101aot_Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)'==''">
     <TargetingPackReference Include="System.Private.CoreLib" />
     <ProjectReference Include="$(SourceDir)\mscorlib.WinRT-Facade\mscorlib.WinRT-Facade.csproj" />
     <!-- Needed for the compiler to resolve IObservableMap.MapChanged. -->
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
-    <ProjectReference Include="..\..\System.Runtime.Extensions\src\System.Runtime.Extensions.csproj">
-       <Aliases>System_Runtime_Extensions</Aliases>
+    <ProjectReference Include="..\..\System.Runtime.Extensions\ref\System.Runtime.Extensions.csproj">
+      <Aliases>System_Runtime_Extensions</Aliases>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj" />
     <ProjectReference Include="..\..\System.Diagnostics.Tools\src\System.Diagnostics.Tools.csproj" />
-    <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.csproj" />
-    <ProjectReference Include="..\..\System.IO\src\System.IO.csproj">
-      <UndefineProperties>OSGroup</UndefineProperties>
-    </ProjectReference>
     <ProjectReference Include="..\..\System.Runtime.InteropServices.WindowsRuntime\src\System.Runtime.InteropServices.WindowsRuntime.csproj">
       <UndefineProperties>OSGroup</UndefineProperties>
     </ProjectReference>
@@ -63,12 +59,16 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'uap101aot'">
     <TargetingPackReference Include="System.Private.Interop" />
     <TargetingPackReference Include="System.Private.Corelib" />
-    <TargetingPackReference Include="System.Private.Threading" /> 
+    <TargetingPackReference Include="System.Private.Threading" />
     <TargetingPackReference Include="Windows" />
     <ProjectReference Include="$(SourceDir)\mscorlib.WinRT-Facade\mscorlib.WinRT-Facade.csproj" />
     <TargetingPackReference Include="System.Private.CoreLib.WinRTInterop" />
-    <ProjectReference Include="..\..\System.IO\src\System.IO.csproj">
+    <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj">
       <TargetGroup>uap101aot</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="..\..\System.Runtime.Extensions\ref\System.Runtime.Extensions.csproj">
+      <UndefineProperties>%(ProjectReference.UndefineProperties);TargetGroup</UndefineProperties>
+      <Aliases>System_Runtime_Extensions</Aliases>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Resources.ResourceManager\src\System.Resources.ResourceManager.csproj">
       <TargetGroup>uap101aot</TargetGroup>

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/NetFxToWinRtStreamAdapter.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/NetFxToWinRtStreamAdapter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+extern alias System_Runtime_Extensions;
+
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices.WindowsRuntime;
@@ -11,6 +13,8 @@ using System.Threading.Tasks;
 using System.Threading;
 using Windows.Foundation;
 using Windows.Storage.Streams;
+
+using MemoryStream = System_Runtime_Extensions::System.IO.MemoryStream;
 
 namespace System.IO
 {

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/StreamOperationsImplementation.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/StreamOperationsImplementation.cs
@@ -13,6 +13,8 @@ using System.Threading;
 using Windows.Foundation;
 using Windows.Storage.Streams;
 
+// Type aliases cannot match existing typenames. In this file our code is in System.IO, which would
+// create two MemoryStream definitions that are in scope if we defined as MemoryStream.
 using SREMemoryStream = System_Runtime_Extensions::System.IO.MemoryStream;
 
 namespace System.IO

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/StreamOperationsImplementation.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/StreamOperationsImplementation.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+extern alias System_Runtime_Extensions;
+
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices.WindowsRuntime;
@@ -10,6 +12,8 @@ using System.Threading.Tasks;
 using System.Threading;
 using Windows.Foundation;
 using Windows.Storage.Streams;
+
+using SREMemoryStream = System_Runtime_Extensions::System.IO.MemoryStream;
 
 namespace System.IO
 {
@@ -27,7 +31,7 @@ namespace System.IO
         internal static IAsyncOperationWithProgress<IBuffer, UInt32> ReadAsync_MemoryStream(Stream stream, IBuffer buffer, UInt32 count)
         {
             Debug.Assert(stream != null);
-            Debug.Assert(stream is MemoryStream);
+            Debug.Assert(stream is SREMemoryStream);
             Debug.Assert(stream.CanRead);
             Debug.Assert(stream.CanSeek);
             Debug.Assert(buffer != null);
@@ -42,7 +46,7 @@ namespace System.IO
             // The user specified buffer will not have any data put into it:
             buffer.Length = 0;
 
-            MemoryStream memStream = stream as MemoryStream;
+            SREMemoryStream memStream = stream as SREMemoryStream;
             Debug.Assert(memStream != null);
 
             try

--- a/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeBufferExtensions.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeBufferExtensions.cs
@@ -2,12 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+extern alias System_Runtime_Extensions;
+
 using System.Diagnostics.Contracts;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.WindowsRuntime.Internal;
 using Windows.Foundation;
 using Windows.Storage.Streams;
+
+using MemoryStream = System_Runtime_Extensions::System.IO.MemoryStream;
 
 namespace System.Runtime.InteropServices.WindowsRuntime
 {

--- a/src/System.Runtime.WindowsRuntime/src/System/Threading/WindowsRuntimeSynchronizationContext.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Threading/WindowsRuntimeSynchronizationContext.cs
@@ -134,7 +134,7 @@ namespace System.Threading
                     // that IAsyncInfo, because there's nothing Post can do with it (since Post returns void).
                     // So, to avoid these exceptions being lost forever, we post them to the ThreadPool.
                     //
-                    if (!(ex is ThreadAbortException) && !(ex.GetType().Name.EndsWith("AppDomainUnloadedException")))
+                    if (!(ex is ThreadAbortException) && !(ex is AppDomainUnloadedException))
                     {
                         if (!WindowsRuntimeMarshal.ReportUnhandledError(ex))
                         {


### PR DESCRIPTION
Undo the temporary workarounds to System.Runtime.WindowsRuntime

@joperezr, @ericstj, @weshaggard 