### PR TITLE
Reduce logic of Expression.IsNullComparison

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -751,15 +751,9 @@ namespace System.Linq.Expressions
             // nullable but not null, then this is treated as a call to x.HasValue
             // and is legal even if there is no equality operator defined on the
             // type of x.
-            if (IsNullConstant(left) && !IsNullConstant(right) && right.Type.IsNullableType())
-            {
-                return true;
-            }
-            if (IsNullConstant(right) && !IsNullConstant(left) && left.Type.IsNullableType())
-            {
-                return true;
-            }
-            return false;
+            return IsNullConstant(left)
+                ? !IsNullConstant(right) && right.Type.IsNullableType()
+                : IsNullConstant(right) && left.Type.IsNullableType();
         }
 
         // Note: this has different meaning than ConstantCheck.IsNull


### PR DESCRIPTION
If `IsNullConstant(left)` is true in the first check it's false in the second, and vice versa. Either way the rest of the expression need be evaluated only once.