### PR TITLE
Fix Possible NRE in CExceptionHandler

### DIFF
--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltApiV2.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltApiV2.cs
@@ -967,7 +967,7 @@ namespace System.Xml.Tests
 
         public CExceptionHandler(string strXmlFile, string ns, ITestOutputHelper output)
         {
-            _exVer = new ExceptionVerifier(ns, ExceptionVerificationFlags.IgnoreMultipleDots, _output);
+            _exVer = new ExceptionVerifier(ns, ExceptionVerificationFlags.IgnoreMultipleDots, output);
 
             _doc = new XPathDocument(strXmlFile);
             _nav = ((IXPathNavigable)_doc).CreateNavigator();


### PR DESCRIPTION
The current implementation of CExceptionHandler passed uninitialized
_output as an argument of ExceptionVerifier.

This will lead to NullReferenceException if _output is accessed inside
ExceptionVerifier (Currently this doesn't happen since _output is accessed 
only when an internal exception is raised).

This commit passes output instead of _output to prevent NRE.