### PR TITLE
Handle equality on operatorless nullables correctly in interpreter

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -366,9 +366,6 @@
   <data name="ExpressionNotSupportedForType" xml:space="preserve">
     <value>The expression '{0}' is not supported for type '{1}'</value>
   </data>
-  <data name="ExpressionNotSupportedForNullableType" xml:space="preserve">
-    <value>The expression '{0}' is not supported for nullable type '{1}'</value>
-  </data>
   <data name="UnsupportedExpressionType" xml:space="preserve">
     <value>The expression type '{0}' is not supported</value>
   </data>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -1592,13 +1592,11 @@ namespace System.Linq.Expressions
             {
                 throw Error.OperandTypesDoNotMatchParameters(nodeType, conversion.ToString());
             }
-            if (method != null)
+            Debug.Assert(method != null);
+            // The parameter type of conversion lambda must be the same as the return type of the overload method
+            if (!TypeUtils.AreEquivalent(pms[0].ParameterType, method.ReturnType))
             {
-                // The parameter type of conversion lambda must be the same as the return type of the overload method
-                if (!TypeUtils.AreEquivalent(pms[0].ParameterType, method.ReturnType))
-                {
-                    throw Error.OverloadOperatorTypeDoesNotMatchConversionType(nodeType, conversion.ToString());
-                }
+                throw Error.OverloadOperatorTypeDoesNotMatchConversionType(nodeType, conversion.ToString());
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -839,13 +839,7 @@ namespace System.Linq.Expressions
         {
             return new PlatformNotSupportedException(Strings.ExpressionNotSupportedForType(p0, p1));
         }
-        /// <summary>
-        /// PlatformNotSupportedException with message like "The instruction '{0}' is not supported for nullable type '{1}'"
-        /// </summary>
-        internal static Exception ExpressionNotSupportedForNullableType(object p0, object p1)
-        {
-            return new PlatformNotSupportedException(Strings.ExpressionNotSupportedForNullableType(p0, p1));
-        }
+
         /// <summary>
         /// ArgumentException with message like "ParameterExpression of type '{0}' cannot be used for delegate parameter of type '{1}'"
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Dynamic.Utils;
 using System.Reflection;
 
@@ -585,17 +586,11 @@ namespace System.Linq.Expressions.Interpreter
                     case TypeCode.Single: return s_single ?? (s_single = new EqualSingle());
                     case TypeCode.Double: return s_double ?? (s_double = new EqualDouble());
 
-                    case TypeCode.String:
-                    case TypeCode.Object:
-                        if (!type.GetTypeInfo().IsValueType)
-                        {
-                            return s_reference ?? (s_reference = new EqualReference());
-                        }
-                        // TODO: Nullable<T>
-                        throw Error.ExpressionNotSupportedForNullableType("Equal", type);
-
                     default:
-                        throw Error.ExpressionNotSupportedForType("Equal", type);
+                        // Nullable only valid if one operand is constant null, so this assert is slightly too broad.
+                        Debug.Assert(type.IsNullableOrReferenceType());
+                        return s_reference ?? (s_reference = new EqualReference());
+
                 }
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -969,9 +969,25 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
+#if DEBUG
+        private static bool IsNullComparison(Expression left, Expression right)
+        {
+            return IsNullConstant(left)
+                ? !IsNullConstant(right) && right.Type.IsNullableType()
+                : IsNullConstant(right) && left.Type.IsNullableType();
+        }
+
+        private static bool IsNullConstant(Expression e)
+        {
+            var c = e as ConstantExpression;
+            return c != null && c.Value == null;
+        }
+#endif
         private void CompileEqual(Expression left, Expression right, bool liftedToNull)
         {
-            Debug.Assert(left.Type == right.Type || !left.Type.GetTypeInfo().IsValueType && !right.Type.GetTypeInfo().IsValueType);
+#if DEBUG
+            Debug.Assert(IsNullComparison(left, right) || left.Type == right.Type || !left.Type.GetTypeInfo().IsValueType && !right.Type.GetTypeInfo().IsValueType);
+#endif
             Compile(left);
             Compile(right);
             _instructions.EmitEqual(left.Type, liftedToNull);
@@ -979,7 +995,9 @@ namespace System.Linq.Expressions.Interpreter
 
         private void CompileNotEqual(Expression left, Expression right, bool liftedToNull)
         {
-            Debug.Assert(left.Type == right.Type || !left.Type.GetTypeInfo().IsValueType && !right.Type.GetTypeInfo().IsValueType);
+#if DEBUG
+            Debug.Assert(IsNullComparison(left, right) || left.Type == right.Type || !left.Type.GetTypeInfo().IsValueType && !right.Type.GetTypeInfo().IsValueType);
+#endif
             Compile(left);
             Compile(right);
             _instructions.EmitNotEqual(left.Type, liftedToNull);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Dynamic.Utils;
 using System.Reflection;
 
@@ -577,16 +578,10 @@ namespace System.Linq.Expressions.Interpreter
                     case TypeCode.Single: return s_single ?? (s_single = new NotEqualSingle());
                     case TypeCode.Double: return s_double ?? (s_double = new NotEqualDouble());
 
-                    case TypeCode.String:
-                    case TypeCode.Object:
-                        if (!type.GetTypeInfo().IsValueType)
-                        {
-                            return s_reference ?? (s_reference = new NotEqualReference());
-                        }
-                        // TODO: Nullable<T>
-                        throw Error.ExpressionNotSupportedForNullableType("NotEqual", type);
                     default:
-                        throw Error.ExpressionNotSupportedForType("NotEqual", type);
+                        // Nullable only valid if one operand is constant null, so this assert is slightly too broad.
+                        Debug.Assert(type.IsNullableOrReferenceType());
+                        return s_reference ?? (s_reference = new NotEqualReference());
                 }
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
@@ -12,7 +12,7 @@ namespace System.Linq.Expressions.Interpreter
     {
         // Perf: EqualityComparer<T> but is 3/2 to 2 times slower.
         private static Instruction s_reference, s_boolean, s_SByte, s_int16, s_char, s_int32, s_int64, s_byte, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
-        private static Instruction s_referenceLiftedToNull, s_booleanLiftedToNull, s_SByteLiftedToNull, s_int16LiftedToNull, s_charLiftedToNull, s_int32LiftedToNull, s_int64LiftedToNull, s_byteLiftedToNull, s_UInt16LiftedToNull, s_UInt32LiftedToNull, s_UInt64LiftedToNull, s_singleLiftedToNull, s_doubleLiftedToNull;
+        private static Instruction s_booleanLiftedToNull, s_SByteLiftedToNull, s_int16LiftedToNull, s_charLiftedToNull, s_int32LiftedToNull, s_int64LiftedToNull, s_byteLiftedToNull, s_UInt16LiftedToNull, s_UInt32LiftedToNull, s_UInt64LiftedToNull, s_singleLiftedToNull, s_doubleLiftedToNull;
 
         public override int ConsumedStack => 2;
         public override int ProducedStack => 1;
@@ -293,7 +293,6 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-
         private sealed class NotEqualBooleanLiftedToNull : NotEqualInstruction
         {
             public override int Run(InterpretedFrame frame)
@@ -510,23 +509,14 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private sealed class NotEqualReferenceLiftedToNull : NotEqualInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                frame.Push(frame.Pop() != frame.Pop());
-                return +1;
-            }
-        }
-
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         public static Instruction Create(Type type, bool liftedToNull)
         {
+            // Boxed enums can be unboxed as their underlying types:
+            Type underlyingType = type.GetTypeInfo().IsEnum ? Enum.GetUnderlyingType(type) : type.GetNonNullableType();
+
             if (liftedToNull)
             {
-                // Boxed enums can be unboxed as their underlying types:
-                Type underlyingType = type.GetTypeInfo().IsEnum ? Enum.GetUnderlyingType(type) : type.GetNonNullableType();
-
                 switch (underlyingType.GetTypeCode())
                 {
                     case TypeCode.Boolean: return s_booleanLiftedToNull ?? (s_booleanLiftedToNull = new NotEqualBooleanLiftedToNull());
@@ -542,25 +532,13 @@ namespace System.Linq.Expressions.Interpreter
                     case TypeCode.UInt64: return s_UInt64LiftedToNull ?? (s_UInt64LiftedToNull = new NotEqualUInt64LiftedToNull());
 
                     case TypeCode.Single: return s_singleLiftedToNull ?? (s_singleLiftedToNull = new NotEqualSingleLiftedToNull());
-                    case TypeCode.Double: return s_doubleLiftedToNull ?? (s_doubleLiftedToNull = new NotEqualDoubleLiftedToNull());
-
-                    case TypeCode.String:
-                    case TypeCode.Object:
-                        if (!type.GetTypeInfo().IsValueType)
-                        {
-                            return s_referenceLiftedToNull ?? (s_referenceLiftedToNull = new NotEqualReferenceLiftedToNull());
-                        }
-                        // TODO: Nullable<T>
-                        throw Error.ExpressionNotSupportedForNullableType("NotEqual", type);
                     default:
-                        throw Error.ExpressionNotSupportedForType("NotEqual", type);
+                        Debug.Assert(underlyingType.GetTypeCode() == TypeCode.Double);
+                        return s_doubleLiftedToNull ?? (s_doubleLiftedToNull = new NotEqualDoubleLiftedToNull());
                 }
             }
             else
             {
-                // Boxed enums can be unboxed as their underlying types:
-                Type underlyingType = type.GetTypeInfo().IsEnum ? Enum.GetUnderlyingType(type) : type.GetNonNullableType();
-
                 switch (underlyingType.GetTypeCode())
                 {
                     case TypeCode.Boolean: return s_boolean ?? (s_boolean = new NotEqualBoolean());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -515,11 +515,6 @@ namespace System.Linq.Expressions
         internal static string ExpressionNotSupportedForType(object p0, object p1) => SR.Format(SR.ExpressionNotSupportedForType, p0, p1);
 
         /// <summary>
-        /// A string like "The expression '{0}' is not supported for nullable type '{1}'"
-        /// </summary>
-        internal static string ExpressionNotSupportedForNullableType(object p0, object p1) => SR.Format(SR.ExpressionNotSupportedForNullableType, p0, p1);
-
-        /// <summary>
         /// A string like "ParameterExpression of type '{0}' cannot be used for delegate parameter of type '{1}'"
         /// </summary>
         internal static string ParameterExpressionNotValidAsDelegate(object p0, object p1) => SR.Format(SR.ParameterExpressionNotValidAsDelegate, p0, p1);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/OpAssign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/OpAssign.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Xunit;
@@ -341,6 +340,271 @@ namespace System.Linq.Expressions.Tests
             yield return Tuple.Create(ExpressionType.OrAssign, "||=", typeof(bool));
             yield return Tuple.Create(ExpressionType.ExclusiveOrAssign, "^=", typeof(int));
             yield return Tuple.Create(ExpressionType.ExclusiveOrAssign, "^=", typeof(bool));
+        }
+
+        private static IEnumerable<ExpressionType> AssignExpressionTypes
+        {
+            get
+            {
+                yield return ExpressionType.AddAssign;
+                yield return ExpressionType.SubtractAssign;
+                yield return ExpressionType.MultiplyAssign;
+                yield return ExpressionType.AddAssignChecked;
+                yield return ExpressionType.SubtractAssignChecked;
+                yield return ExpressionType.MultiplyAssignChecked;
+                yield return ExpressionType.DivideAssign;
+                yield return ExpressionType.ModuloAssign;
+                yield return ExpressionType.PowerAssign;
+                yield return ExpressionType.AndAssign;
+                yield return ExpressionType.OrAssign;
+                yield return ExpressionType.RightShiftAssign;
+                yield return ExpressionType.LeftShiftAssign;
+                yield return ExpressionType.ExclusiveOrAssign;
+            }
+        }
+
+        private static IEnumerable<Func<Expression, Expression, MethodInfo, BinaryExpression>> AssignExpressionMethodInfoUsingFactories
+        {
+            get
+            {
+                yield return Expression.AddAssign;
+                yield return Expression.SubtractAssign;
+                yield return Expression.MultiplyAssign;
+                yield return Expression.AddAssignChecked;
+                yield return Expression.SubtractAssignChecked;
+                yield return Expression.MultiplyAssignChecked;
+                yield return Expression.DivideAssign;
+                yield return Expression.ModuloAssign;
+                yield return Expression.PowerAssign;
+                yield return Expression.AndAssign;
+                yield return Expression.OrAssign;
+                yield return Expression.RightShiftAssign;
+                yield return Expression.LeftShiftAssign;
+                yield return Expression.ExclusiveOrAssign;
+            }
+        }
+
+        public static IEnumerable<object[]> AssignExpressionTypesArguments
+            => AssignExpressionTypes.Select(t => new object[] {t});
+
+        public static IEnumerable<object[]> AssignExpressionMethodInfoUsingFactoriesArguments =
+            AssignExpressionMethodInfoUsingFactories.Select(f => new object[] {f});
+
+        private static IEnumerable<LambdaExpression> NonUnaryLambdas
+        {
+            get
+            {
+                yield return Expression.Lambda<Action>(Expression.Empty());
+                Expression<Func<int, int, int>> exp = (x, y) => x + y;
+                yield return exp;
+            }
+        }
+
+        public static IEnumerable<object[]> AssignExpressionTypesAndNonUnaryLambdas =>
+            AssignExpressionTypes.SelectMany(t => NonUnaryLambdas, (t, l) => new object[] {t, l});
+
+        private static IEnumerable<LambdaExpression> NonIntegerReturnUnaryIntegerLambdas
+        {
+            get
+            {
+                ParameterExpression param = Expression.Parameter(typeof(int));
+                yield return Expression.Lambda<Action<int>>(Expression.Empty(), param);
+                Expression<Func<int, long>> convL = x => x;
+                yield return convL;
+                Expression<Func<int, string>> toString = x => x.ToString();
+                yield return toString;
+            }
+        }
+
+        public static IEnumerable<object[]> AssignExpressionTypesAndNonIntegerReturnUnaryIntegerLambdas
+            => AssignExpressionTypes.SelectMany(t => NonIntegerReturnUnaryIntegerLambdas, (t, l) => new object[] {t, l});
+
+        private static IEnumerable<LambdaExpression> NonIntegerTakingUnaryIntegerReturningLambda
+        {
+            get
+            {
+                Expression<Func<long, int>> fromL = x => (int)x;
+                yield return fromL;
+                Expression<Func<string, int>> fromS = x => x.Length;
+                yield return fromS;
+            }
+        }
+
+        public static IEnumerable<object[]> AssignExpressionTypesAndNonIntegerTakingUnaryIntegerReturningLambda
+            =>
+                AssignExpressionTypes.SelectMany(
+                    t => NonIntegerTakingUnaryIntegerReturningLambda, (t, l) => new object[] {t, l});
+
+        [Theory, MemberData(nameof(AssignExpressionTypesArguments))]
+        public void CannotHaveConversionOnAssignWithoutMethod(ExpressionType type)
+        {
+            var lhs = Expression.Variable(typeof(int));
+            var rhs = Expression.Constant(0);
+            Expression<Func<int, int>> identity = x => x;
+            Assert.Throws<InvalidOperationException>(() => Expression.MakeBinary(type, lhs, rhs, false, null, identity));
+            Assert.Throws<InvalidOperationException>(() => Expression.MakeBinary(type, lhs, rhs, true, null, identity));
+        }
+
+        public static int FiftyNinthBear(int x, int y)
+        {
+            // Ensure numbers add up to 40. Then ignore that and return 59.
+            if (x + y != 40) throw new ArgumentException();
+            return 59;
+        }
+
+        [Theory, PerCompilationType(nameof(AssignExpressionTypesArguments))]
+        public void ConvertAssignment(ExpressionType type, bool useInterpreter)
+        {
+            var lhs = Expression.Parameter(typeof(int));
+            var rhs = Expression.Constant(25);
+            Expression<Func<int, int>> doubleIt = x => 2 * x;
+            var lambda = Expression.Lambda<Func<int, int>>(
+                Expression.MakeBinary(type, lhs, rhs, false, GetType().GetMethod(nameof(FiftyNinthBear)), doubleIt),
+                lhs
+                );
+            var func = lambda.Compile(useInterpreter);
+            Assert.Equal(118, func(15));
+        }
+
+        [Theory, MemberData(nameof(AssignExpressionTypesAndNonUnaryLambdas))]
+        public void ConversionMustBeUnary(ExpressionType type, LambdaExpression conversion)
+        {
+            var lhs = Expression.Parameter(typeof(int));
+            var rhs = Expression.Constant(25);
+            MethodInfo meth = GetType().GetMethod(nameof(FiftyNinthBear));
+            Assert.Throws<ArgumentException>(
+                "conversion", () => Expression.MakeBinary(type, lhs, rhs, false, meth, conversion));
+        }
+
+        [Theory, MemberData(nameof(AssignExpressionTypesAndNonIntegerReturnUnaryIntegerLambdas))]
+        public void ConversionMustConvertToLHSType(ExpressionType type, LambdaExpression conversion)
+        {
+            var lhs = Expression.Parameter(typeof(int));
+            var rhs = Expression.Constant(25);
+            MethodInfo meth = GetType().GetMethod(nameof(FiftyNinthBear));
+            Assert.Throws<InvalidOperationException>(() => Expression.MakeBinary(type, lhs, rhs, false, meth, conversion));
+        }
+
+        [Theory, MemberData(nameof(AssignExpressionTypesAndNonIntegerTakingUnaryIntegerReturningLambda))]
+        public void ConversionMustConvertFromRHSType(ExpressionType type, LambdaExpression conversion)
+        {
+            var lhs = Expression.Parameter(typeof(int));
+            var rhs = Expression.Constant(25);
+            MethodInfo meth = GetType().GetMethod(nameof(FiftyNinthBear));
+            Assert.Throws<InvalidOperationException>(() => Expression.MakeBinary(type, lhs, rhs, false, meth, conversion));
+        }
+
+        private class AddsToSomethingElse : IEquatable<AddsToSomethingElse>
+        {
+            public int Value { get; }
+
+            public AddsToSomethingElse(int value)
+            {
+                Value = value;
+            }
+
+            public static int operator +(AddsToSomethingElse x, AddsToSomethingElse y) => x.Value + y.Value;
+
+            public bool Equals(AddsToSomethingElse other) => Value == other?.Value;
+
+            public override bool Equals(object obj) => Equals(obj as AddsToSomethingElse);
+
+            public override int GetHashCode() => Value;
+        }
+
+        private static string StringAddition(int x, int y) => (x + y).ToString();
+
+        [Fact]
+        public void CannotAssignOpIfOpReturnNotAssignable()
+        {
+            var lhs = Expression.Parameter(typeof(AddsToSomethingElse));
+            var rhs = Expression.Constant(new AddsToSomethingElse(3));
+            Assert.Throws<ArgumentException>(null, () => Expression.AddAssign(lhs, rhs));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void CanAssignOpIfOpReturnNotAssignableButConversionFixes(bool useInterpreter)
+        {
+            var lhs = Expression.Parameter(typeof(AddsToSomethingElse));
+            var rhs = Expression.Constant(new AddsToSomethingElse(3));
+            Expression<Func<int, AddsToSomethingElse>> conversion = x => new AddsToSomethingElse(x);
+            var exp = Expression.Lambda<Func<AddsToSomethingElse, AddsToSomethingElse>>(
+                Expression.AddAssign(lhs, rhs, null, conversion),
+                lhs
+                );
+            var func = exp.Compile(useInterpreter);
+            Assert.Equal(new AddsToSomethingElse(10), func(new AddsToSomethingElse(7)));
+        }
+
+        [Theory, PerCompilationType(nameof(AssignExpressionTypesArguments))]
+        public void ConvertOpAssignToMember(ExpressionType type, bool useInterpreter)
+        {
+            Box<int> box = new Box<int>(25);
+            Expression<Func<int, int>> doubleIt = x => x * 2;
+            var exp = Expression.Lambda<Func<int>>(
+                Expression.MakeBinary(
+                    type,
+                    Expression.Property(Expression.Constant(box), "Value"),
+                    Expression.Constant(15),
+                    false,
+                    GetType().GetMethod(nameof(FiftyNinthBear)),
+                    doubleIt
+                    )
+                );
+            var act = exp.Compile(useInterpreter);
+            Assert.Equal(118, act());
+            Assert.Equal(118, box.Value);
+        }
+
+        [Theory, PerCompilationType(nameof(AssignExpressionTypesArguments))]
+        public void ConvertOpAssignToArrayIndex(ExpressionType type, bool useInterpreter)
+        {
+            int[] array = {0, 0, 25, 0};
+            Expression<Func<int, int>> doubleIt = x => x * 2;
+            var exp = Expression.Lambda<Func<int>>(
+                Expression.MakeBinary(
+                    type,
+                    Expression.ArrayAccess(Expression.Constant(array), Expression.Constant(2)),
+                    Expression.Constant(15),
+                    false,
+                    GetType().GetMethod(nameof(FiftyNinthBear)),
+                    doubleIt
+                    )
+                );
+            var act = exp.Compile(useInterpreter);
+            Assert.Equal(118, act());
+            Assert.Equal(118, array[2]);
+        }
+
+        private delegate int ByRefInts(ref int x, int y);
+
+        private delegate int BothByRefInts(ref int x, ref int y);
+
+        [Theory, PerCompilationType(nameof(AssignExpressionMethodInfoUsingFactoriesArguments))]
+        public void MethodNoConvertOpWriteByRefParameter(Func<Expression, Expression, MethodInfo, BinaryExpression> factory, bool useInterpreter)
+        {
+            var pX = Expression.Parameter(typeof(int).MakeByRefType());
+            var pY = Expression.Parameter(typeof(int));
+            var exp = Expression.Lambda<ByRefInts>(factory(pX, pY, GetType().GetMethod(nameof(FiftyNinthBear))), pX, pY);
+            var del = exp.Compile(useInterpreter);
+            int arg = 5;
+            Assert.Equal(59, del(ref arg, 35));
+            Assert.Equal(59, arg);
+        }
+
+        private delegate AddsToSomethingElse ByRefSomeElse(ref AddsToSomethingElse x, AddsToSomethingElse y);
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void ConvertOpWriteByRefParameterOverloadedOperator(bool useInterpreter)
+        {
+            var pX = Expression.Parameter(typeof(AddsToSomethingElse).MakeByRefType());
+            var pY = Expression.Parameter(typeof(AddsToSomethingElse));
+            Expression<Func<int, AddsToSomethingElse>> conv = x => new AddsToSomethingElse(x);
+            var exp = Expression.Lambda<ByRefSomeElse>(Expression.AddAssign(pX, pY, null, conv), pX, pY);
+            var del = exp.Compile(useInterpreter);
+            AddsToSomethingElse arg = new AddsToSomethingElse(5);
+            AddsToSomethingElse result = del(ref arg, new AddsToSomethingElse(35));
+            Assert.Equal(result, arg);
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/EqualNotEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/EqualNotEqualTests.cs
@@ -213,7 +213,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => Expression.NotEqual(uvConst, uvConst));
         }
 
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void CanPerformEqualityOnNullableWithoutOperatorsToConstantNull(bool useInterpreter)
         {
             var nullConst = Expression.Constant(null, typeof(UselessValue?));
@@ -227,13 +227,7 @@ namespace System.Linq.Expressions.Tests
             Assert.False(func());
         }
 
-        [Fact, ActiveIssue(13670)]
-        public static void CanPerformEqualityOnNullableWithoutOperatorsToConstantNullInterpreter()
-        {
-            CanPerformEqualityOnNullableWithoutOperatorsToConstantNull(true);
-        }
-
-        [Theory, InlineData(false)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void CanPerformInequalityOnNullableWithoutOperatorsToConstantNull(bool useInterpreter)
         {
             var nullConst = Expression.Constant(null, typeof(UselessValue?));
@@ -245,12 +239,6 @@ namespace System.Linq.Expressions.Tests
             exp = Expression.Lambda<Func<bool>>(Expression.NotEqual(uvConst, nullConst));
             func = exp.Compile(useInterpreter);
             Assert.True(func());
-        }
-
-        [Fact, ActiveIssue(13670)]
-        public static void CanPerformInequalityOnNullableWithoutOperatorsToConstantNullInterpreter()
-        {
-            CanPerformInequalityOnNullableWithoutOperatorsToConstantNull(true);
         }
 
         [Fact]


### PR DESCRIPTION
Correctly handle comparisons between nullable types (which don't have relevant operators) and null constants in the interpreter.

Fixes #13670 

Also more binary expression tests, going beyond just those for this fix. mostly focusing on op-assigns with conversions and equality expressions. Contributes to #1198

Remove `EqualReferenceLiftedToNull` and `NotEqualReferenceLiftedToNull`

An operator with reference type operands can never be lifted to null, so these types can never be used.

Also exception conditions tested for are impossible to reach. Remove related exception.

Also move code repeated for both branches of an if-else above the branch.

Contributes to #3836