### PR TITLE
Consistently throw ArgumentOutOfRange on IArgumentProvider.GetArgument

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
@@ -544,7 +544,7 @@ namespace System.Linq.Expressions
             switch (index)
             {
                 case 0: return ExpressionUtils.ReturnObject<Expression>(_arg0);
-                default: throw new InvalidOperationException();
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
 
@@ -603,7 +603,7 @@ namespace System.Linq.Expressions
             {
                 case 0: return ExpressionUtils.ReturnObject<Expression>(_arg0);
                 case 1: return _arg1;
-                default: throw new InvalidOperationException();
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
 
@@ -664,7 +664,7 @@ namespace System.Linq.Expressions
                 case 0: return ExpressionUtils.ReturnObject<Expression>(_arg0);
                 case 1: return _arg1;
                 case 2: return _arg2;
-                default: throw new InvalidOperationException();
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
 
@@ -727,7 +727,7 @@ namespace System.Linq.Expressions
                 case 1: return _arg1;
                 case 2: return _arg2;
                 case 3: return _arg3;
-                default: throw new InvalidOperationException();
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
@@ -162,7 +162,7 @@ namespace System.Linq.Expressions
 
         public override Expression GetArgument(int index)
         {
-            throw new InvalidOperationException();
+            throw new ArgumentOutOfRangeException(nameof(index));
         }
 
         public override int ArgumentCount => 0;
@@ -196,7 +196,7 @@ namespace System.Linq.Expressions
             switch (index)
             {
                 case 0: return ReturnObject<Expression>(_arg0);
-                default: throw new InvalidOperationException();
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
 
@@ -238,7 +238,7 @@ namespace System.Linq.Expressions
             {
                 case 0: return ReturnObject<Expression>(_arg0);
                 case 1: return _arg1;
-                default: throw new InvalidOperationException();
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
 
@@ -283,7 +283,7 @@ namespace System.Linq.Expressions
                 case 0: return ReturnObject<Expression>(_arg0);
                 case 1: return _arg1;
                 case 2: return _arg2;
-                default: throw new InvalidOperationException();
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
 
@@ -331,7 +331,7 @@ namespace System.Linq.Expressions
                 case 1: return _arg1;
                 case 2: return _arg2;
                 case 3: return _arg3;
-                default: throw new InvalidOperationException();
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
 
@@ -382,7 +382,7 @@ namespace System.Linq.Expressions
                 case 2: return _arg2;
                 case 3: return _arg3;
                 case 4: return _arg4;
-                default: throw new InvalidOperationException();
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
@@ -204,7 +204,7 @@ namespace System.Linq.Expressions
 
         public override Expression GetArgument(int index)
         {
-            throw new InvalidOperationException();
+            throw new ArgumentOutOfRangeException(nameof(index));
         }
 
         public override int ArgumentCount => 0;
@@ -238,7 +238,7 @@ namespace System.Linq.Expressions
             switch (index)
             {
                 case 0: return ReturnObject<Expression>(_arg0);
-                default: throw new InvalidOperationException();
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
 
@@ -281,7 +281,7 @@ namespace System.Linq.Expressions
             {
                 case 0: return ReturnObject<Expression>(_arg0);
                 case 1: return _arg1;
-                default: throw new InvalidOperationException();
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
 
@@ -325,7 +325,7 @@ namespace System.Linq.Expressions
                 case 0: return ReturnObject<Expression>(_arg0);
                 case 1: return _arg1;
                 case 2: return _arg2;
-                default: throw new InvalidOperationException();
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
 
@@ -371,7 +371,7 @@ namespace System.Linq.Expressions
                 case 1: return _arg1;
                 case 2: return _arg2;
                 case 3: return _arg3;
-                default: throw new InvalidOperationException();
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
 
@@ -419,7 +419,7 @@ namespace System.Linq.Expressions
                 case 2: return _arg2;
                 case 3: return _arg3;
                 case 4: return _arg4;
-                default: throw new InvalidOperationException();
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
 
@@ -453,7 +453,7 @@ namespace System.Linq.Expressions
 
         public override Expression GetArgument(int index)
         {
-            throw new InvalidOperationException();
+            throw new ArgumentOutOfRangeException(nameof(index));
         }
 
         public override int ArgumentCount => 0;
@@ -487,7 +487,7 @@ namespace System.Linq.Expressions
             switch (index)
             {
                 case 0: return ReturnObject<Expression>(_arg0);
-                default: throw new InvalidOperationException();
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
 
@@ -529,7 +529,7 @@ namespace System.Linq.Expressions
             {
                 case 0: return ReturnObject<Expression>(_arg0);
                 case 1: return _arg1;
-                default: throw new InvalidOperationException();
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
 
@@ -573,7 +573,7 @@ namespace System.Linq.Expressions
                 case 0: return ReturnObject<Expression>(_arg0);
                 case 1: return _arg1;
                 case 2: return _arg2;
-                default: throw new InvalidOperationException();
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
 

--- a/src/System.Linq.Expressions/tests/Call/CallTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallTests.cs
@@ -280,6 +280,8 @@ namespace System.Linq.Expressions.Tests
         private static MethodInfo s_method3 = typeof(NonGenericClass).GetMethod(nameof(NonGenericClass.Method3));
         private static MethodInfo s_method4 = typeof(NonGenericClass).GetMethod(nameof(NonGenericClass.Method4));
         private static MethodInfo s_method5 = typeof(NonGenericClass).GetMethod(nameof(NonGenericClass.Method5));
+        private static MethodInfo s_method6 = typeof(NonGenericClass).GetMethod(nameof(NonGenericClass.Method6));
+        private static MethodInfo s_method7 = typeof(NonGenericClass).GetMethod(nameof(NonGenericClass.Method7));
 
         public static IEnumerable<object[]> Method_Invalid_TestData()
         {
@@ -582,6 +584,54 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal("x.E2(y, z)", e9.ToString());
         }
 
+        [Fact]
+        public static void GetArguments()
+        {
+            VerifyGetArguments(Expression.Call(null, s_method0));
+            VerifyGetArguments(Expression.Call(null, s_method1, Expression.Constant(0)));
+            VerifyGetArguments(
+                Expression.Call(null, s_method2, Enumerable.Range(0, 2).Select(i => Expression.Constant(i))));
+            VerifyGetArguments(
+                Expression.Call(null, s_method3, Enumerable.Range(0, 3).Select(i => Expression.Constant(i))));
+            VerifyGetArguments(
+                Expression.Call(null, s_method4, Enumerable.Range(0, 4).Select(i => Expression.Constant(i))));
+            VerifyGetArguments(
+                Expression.Call(null, s_method5, Enumerable.Range(0, 5).Select(i => Expression.Constant(i))));
+            VerifyGetArguments(
+                Expression.Call(null, s_method6, Enumerable.Range(0, 6).Select(i => Expression.Constant(i))));
+            VerifyGetArguments(
+                Expression.Call(null, s_method7, Enumerable.Range(0, 7).Select(i => Expression.Constant(i))));
+            var site = Expression.Default(typeof(NonGenericClass));
+            VerifyGetArguments(Expression.Call(site, nameof(NonGenericClass.InstanceMethod0), null));
+            VerifyGetArguments(
+                Expression.Call(site, nameof(NonGenericClass.InstanceMethod1), null, Expression.Constant(0)));
+            VerifyGetArguments(
+                Expression.Call(
+                    site, nameof(NonGenericClass.InstanceMethod2), null,
+                    Enumerable.Range(0, 2).Select(i => Expression.Constant(i)).ToArray()));
+            VerifyGetArguments(
+                Expression.Call(
+                    site, nameof(NonGenericClass.InstanceMethod3), null,
+                    Enumerable.Range(0, 3).Select(i => Expression.Constant(i)).ToArray()));
+            VerifyGetArguments(
+                Expression.Call(
+                    site, nameof(NonGenericClass.InstanceMethod4), null,
+                    Enumerable.Range(0, 4).Select(i => Expression.Constant(i)).ToArray()));
+        }
+
+        private static void VerifyGetArguments(MethodCallExpression call)
+        {
+            var args = call.Arguments;
+            Assert.Equal(args.Count, call.ArgumentCount);
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => call.GetArgument(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => call.GetArgument(args.Count));
+            for (int i = 0; i != args.Count; ++i)
+            {
+                Assert.Same(args[i], call.GetArgument(i));
+                Assert.Equal(i, ((ConstantExpression)call.GetArgument(i)).Value);
+            }
+        }
+
         public class GenericClass<T>
         {
             public static void NonGenericMethod() { }
@@ -604,6 +654,8 @@ namespace System.Linq.Expressions.Tests
             public static void Method3(int i1, int i2, int i3) { }
             public static void Method4(int i1, int i2, int i3, int i4) { }
             public static void Method5(int i1, int i2, int i3, int i4, int i5) { }
+            public static void Method6(int i1, int i2, int i3, int i4, int i5, int i6) { }
+            public static void Method7(int i1, int i2, int i3, int i4, int i5, int i6, int i7) { }
 
             public void staticSameName(uint i1) { }
             public void instanceSameName(int i1) { }
@@ -617,7 +669,11 @@ namespace System.Linq.Expressions.Tests
             public void ConstrainedInstanceMethod<T>(T t1) where T : struct { }
             public static void ConstrainedStaticMethod<T>(T t1) where T : struct { }
 
+            public void InstanceMethod0() { }
             public void InstanceMethod1(int i1) { }
+            public void InstanceMethod2(int i1, int i2) { }
+            public void InstanceMethod3(int i1, int i2, int i3) { }
+            public void InstanceMethod4(int i1, int i2, int i3, int i4) { }
             public static void StaticMethod1(int i1) { }
         }
 

--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -102,5 +102,49 @@ namespace System.Linq.Expressions.Tests
             var e2 = Expression.Invoke(Expression.Parameter(typeof(Action<int>), "f"), Expression.Parameter(typeof(int), "x"));
             Assert.Equal("Invoke(f, x)", e2.ToString());
         }
+
+        [Fact]
+        public static void GetArguments()
+        {
+            VerifyGetArguments(Expression.Invoke(Expression.Default(typeof(Action))));
+            VerifyGetArguments(Expression.Invoke(Expression.Default(typeof(Action<int>)), Expression.Constant(0)));
+            VerifyGetArguments(
+                Expression.Invoke(
+                    Expression.Default(typeof(Action<int, int>)),
+                    Enumerable.Range(0, 2).Select(i => Expression.Constant(i))));
+            VerifyGetArguments(
+                Expression.Invoke(
+                    Expression.Default(typeof(Action<int, int, int>)),
+                    Enumerable.Range(0, 3).Select(i => Expression.Constant(i))));
+            VerifyGetArguments(
+                Expression.Invoke(
+                    Expression.Default(typeof(Action<int, int, int, int>)),
+                    Enumerable.Range(0, 4).Select(i => Expression.Constant(i))));
+            VerifyGetArguments(
+                Expression.Invoke(
+                    Expression.Default(typeof(Action<int, int, int, int, int>)),
+                    Enumerable.Range(0, 5).Select(i => Expression.Constant(i))));
+            VerifyGetArguments(
+                Expression.Invoke(
+                    Expression.Default(typeof(Action<int, int, int, int, int, int>)),
+                    Enumerable.Range(0, 6).Select(i => Expression.Constant(i))));
+            VerifyGetArguments(
+                Expression.Invoke(
+                    Expression.Default(typeof(Action<int, int, int, int, int, int, int>)),
+                    Enumerable.Range(0, 7).Select(i => Expression.Constant(i))));
+        }
+
+        private static void VerifyGetArguments(InvocationExpression invoke)
+        {
+            var args = invoke.Arguments;
+            Assert.Equal(args.Count, invoke.ArgumentCount);
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => invoke.GetArgument(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => invoke.GetArgument(args.Count));
+            for (int i = 0; i != args.Count; ++i)
+            {
+                Assert.Same(args[i], invoke.GetArgument(i));
+                Assert.Equal(i, ((ConstantExpression)invoke.GetArgument(i)).Value);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #13675

(C.f. #3901).

CC. @bartdesmet @stephentoub @VSadov 