### PR TITLE
Remove a reference field from OverlappedAsyncResult

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Unix.cs
@@ -10,7 +10,7 @@ namespace System.Net.Sockets
     //
     // This class is used to take care of storage for async Socket operation
     // from the BeginSend, BeginSendTo, BeginReceive, BeginReceiveFrom calls.
-    internal sealed partial class OverlappedAsyncResult : BaseOverlappedAsyncResult
+    internal partial class OverlappedAsyncResult : BaseOverlappedAsyncResult
     {
         private int _socketAddressSize;
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Windows.cs
@@ -16,7 +16,7 @@ namespace System.Net.Sockets
     //
     // This class is used to take care of storage for async Socket operation
     // from the BeginSend, BeginSendTo, BeginReceive, BeginReceiveFrom calls.
-    internal sealed partial class OverlappedAsyncResult : BaseOverlappedAsyncResult
+    internal partial class OverlappedAsyncResult : BaseOverlappedAsyncResult
     {
         internal WSABuffer _singleBuffer;
         internal WSABuffer[] _wsaBuffers;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.cs
@@ -15,37 +15,29 @@ namespace System.Net.Sockets
     //
     // This class is used to take care of storage for async Socket operation
     // from the BeginSend, BeginSendTo, BeginReceive, BeginReceiveFrom calls.
-    internal sealed partial class OverlappedAsyncResult : BaseOverlappedAsyncResult
+    internal partial class OverlappedAsyncResult : BaseOverlappedAsyncResult
     {
         private Internals.SocketAddress _socketAddress;
-        private Internals.SocketAddress _socketAddressOriginal; // Needed for partial BeginReceiveFrom/EndReceiveFrom completion.
 
         internal OverlappedAsyncResult(Socket socket, Object asyncState, AsyncCallback asyncCallback) :
             base(socket, asyncState, asyncCallback)
-        { }
+        {
+        }
 
         internal Internals.SocketAddress SocketAddress
         {
-            get
-            {
-                return _socketAddress;
-            }
-            set
-            {
-                _socketAddress = value;
-            }
+            get { return _socketAddress; }
+            set { _socketAddress = value; }
+        }
+    }
+
+    internal sealed class OriginalAddressOverlappedAsyncResult : OverlappedAsyncResult
+    {
+        internal OriginalAddressOverlappedAsyncResult(Socket socket, Object asyncState, AsyncCallback asyncCallback) :
+            base(socket, asyncState, asyncCallback)
+        {
         }
 
-        internal Internals.SocketAddress SocketAddressOriginal
-        {
-            get
-            {
-                return _socketAddressOriginal;
-            }
-            set
-            {
-                _socketAddressOriginal = value;
-            }
-        }
+        internal Internals.SocketAddress SocketAddressOriginal { get; set; }
     }
 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3633,7 +3633,7 @@ namespace System.Net.Sockets
             Internals.SocketAddress socketAddress = SnapshotAndSerialize(ref remoteEP);
 
             // Set up the result and set it to collect the context.
-            OverlappedAsyncResult asyncResult = new OverlappedAsyncResult(this, state, callback);
+            var asyncResult = new OriginalAddressOverlappedAsyncResult(this, state, callback);
             asyncResult.StartPostingAsyncOp(false);
 
             // Start the ReceiveFrom.
@@ -3657,7 +3657,7 @@ namespace System.Net.Sockets
             return asyncResult;
         }
 
-        private void DoBeginReceiveFrom(byte[] buffer, int offset, int size, SocketFlags socketFlags, EndPoint endPointSnapshot, Internals.SocketAddress socketAddress, OverlappedAsyncResult asyncResult)
+        private void DoBeginReceiveFrom(byte[] buffer, int offset, int size, SocketFlags socketFlags, EndPoint endPointSnapshot, Internals.SocketAddress socketAddress, OriginalAddressOverlappedAsyncResult asyncResult)
         {
             EndPoint oldEndPoint = _rightEndPoint;
 


### PR DESCRIPTION
It's only relevant to async ReceiveFrom, so put it on a derived class used there.

cc: @davidsh, @cipop, @geoffkizer 