### PR TITLE
Simplify BeginEndAwaitableAdapter helper

### DIFF
--- a/src/Common/src/System/Threading/Tasks/BeginEndAwaitableAdapter.cs
+++ b/src/Common/src/System/Threading/Tasks/BeginEndAwaitableAdapter.cs
@@ -3,58 +3,25 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 
 namespace System.Threading.Tasks
 {
     /// <summary>Enables awaiting a Begin/End method pair.</summary>
-    internal sealed class BeginEndAwaitableAdapter : ICriticalNotifyCompletion
+    internal sealed class BeginEndAwaitableAdapter : RendezvousAwaitable<IAsyncResult>
     {
-        private readonly static Action CALLBACK_RAN = () => { };
-        private IAsyncResult _asyncResult;
-        private Action _continuation;
-
         public readonly static AsyncCallback Callback = asyncResult =>
         {
             Debug.Assert(asyncResult != null);
             Debug.Assert(asyncResult.IsCompleted);
             Debug.Assert(asyncResult.AsyncState is BeginEndAwaitableAdapter);
 
-            BeginEndAwaitableAdapter adapter = (BeginEndAwaitableAdapter)asyncResult.AsyncState;
-            adapter._asyncResult = asyncResult;
-
-            Action continuation = Interlocked.Exchange(ref adapter._continuation, CALLBACK_RAN);
-            if (continuation != null)
-            {
-                Debug.Assert(continuation != CALLBACK_RAN);
-                continuation();
-            }
+            var adapter = (BeginEndAwaitableAdapter)asyncResult.AsyncState;
+            adapter.SetResult(asyncResult);
         };
 
-        public BeginEndAwaitableAdapter GetAwaiter() => this;
-
-        public bool IsCompleted => _continuation == CALLBACK_RAN;
-
-        public void UnsafeOnCompleted(Action continuation) => OnCompleted(continuation);
-
-        public void OnCompleted(Action continuation)
+        public BeginEndAwaitableAdapter()
         {
-            if (_continuation == CALLBACK_RAN || Interlocked.CompareExchange(ref _continuation, continuation, null) == CALLBACK_RAN)
-            {
-                Task.Run(continuation);
-            }
+            RunContinuationsAsynchronously = false;
         }
-
-        public IAsyncResult GetResult()
-        {
-            IAsyncResult result = _asyncResult;
-            Debug.Assert(result != null && result.IsCompleted);
-
-            _asyncResult = null;
-            _continuation = null;
-
-            return result;
-        }
-
     }
 }

--- a/src/Common/src/System/Threading/Tasks/RendezvousAwaitable.cs
+++ b/src/Common/src/System/Threading/Tasks/RendezvousAwaitable.cs
@@ -10,7 +10,7 @@ namespace System.Threading.Tasks
 {
     /// <summary>Provides a reusable object that can be awaited by a consumer and manually completed by a producer.</summary>
     /// <typeparam name="TResult">The type of data being passed from producer to consumer.</typeparam>
-    internal sealed class RendezvousAwaitable<TResult> : ICriticalNotifyCompletion
+    internal class RendezvousAwaitable<TResult> : ICriticalNotifyCompletion
     {
         /// <summary>Sentinel object indicating that the operation has completed prior to OnCompleted being called.</summary>
         private static readonly Action s_completionSentinel = () => Debug.Fail("Completion sentinel should never be invoked");

--- a/src/System.Net.WebClient/src/System.Net.WebClient.csproj
+++ b/src/System.Net.WebClient/src/System.Net.WebClient.csproj
@@ -23,6 +23,9 @@
     <Compile Include="$(CommonPath)\System\Threading\Tasks\BeginEndAwaitableAdapter.cs">
       <Link>Common\System\Threading\Tasks\BeginEndAwaitableAdapter.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Threading\Tasks\RendezvousAwaitable.cs">
+      <Link>Common\System\Threading\Tasks\RendezvousAwaitable.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>


### PR DESCRIPTION
The RendezvousAwaitable I added as part of HttpClient perf work provides a superset of the functionality needed for BeginEndAwaitableAdapter.  The latter can just derive from the former, letting us delete almost all of its code.