### PR TITLE
Made DCS/DCJS Support IExtensibleDataObject

### DIFF
--- a/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -1167,4 +1167,25 @@
   <data name="ChangingFullTypeNameNotSupported" xml:space="preserve">
     <value>DataContractJsonSerializer does not support the setting of the FullTypeName of the object to be serialized to a value other than the default FullTypeName. Attempted to serialize object with full type name '{0}' and default full type name '{1}'.</value>
   </data>
+  <data name="InterfaceTypeCannotBeCreated" xml:space="preserve">
+    <value>Interface type '{0}' cannot be created. Consider replacing with a non-interface serializable type.</value>
+  </data>
+  <data name="ArraySizeAttributeIncorrect" xml:space="preserve">
+    <value>Array Size '{0}' is not equal to the number of elements found '{1}'.</value>
+  </data>
+  <data name="DuplicateExtensionDataSetMethod" xml:space="preserve">
+    <value>Invalid IExtensibleDataObject. Both '{0}' and '{1}' in type '{2}' provide property setter.</value>
+  </data>
+  <data name="ExtensionDataSetMustReturnVoid" xml:space="preserve">
+    <value>IExtensibleDataObject property setter '{1}' in type '{0}' must return void.</value>
+  </data>
+  <data name="ExtensionDataSetParameterInvalid" xml:space="preserve">
+    <value>IExtensibleDataObject property setter '{1}' in type '{0}' must have a single parameter of type '{2}'.</value>
+  </data>
+  <data name="OnlyDataContractTypesCanHaveExtensionData" xml:space="preserve">
+    <value>Type '{0}' does not have DataContractAttribute attribute and therefore cannot support IExtensibleDataObject. </value>
+  </data>
+  <data name="ParseJsonNumberReturnInvalidNumber" xml:space="preserve">
+    <value>JsonObjectDataContract.ParseJsonNumber shouldn't return a TypeCode that we're not expecting.</value>
+  </data>
 </root>

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataObject.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataObject.cs
@@ -240,6 +240,44 @@ namespace System.Runtime.Serialization
         }
     }
 
+    internal class XmlDataNode : DataNode<object>
+    {
+        private IList<XmlAttribute> _xmlAttributes;
+        private IList<XmlNode> _xmlChildNodes;
+        private XmlDocument _ownerDocument;
+
+        internal XmlDataNode()
+        {
+            dataType = Globals.TypeOfXmlDataNode;
+        }
+
+        internal IList<XmlAttribute> XmlAttributes
+        {
+            get { return _xmlAttributes; }
+            set { _xmlAttributes = value; }
+        }
+
+        internal IList<XmlNode> XmlChildNodes
+        {
+            get { return _xmlChildNodes; }
+            set { _xmlChildNodes = value; }
+        }
+
+        internal XmlDocument OwnerDocument
+        {
+            get { return _ownerDocument; }
+            set { _ownerDocument = value; }
+        }
+
+        public override void Clear()
+        {
+            base.Clear();
+            _xmlAttributes = null;
+            _xmlChildNodes = null;
+            _ownerDocument = null;
+        }
+    }
+
     internal class CollectionDataNode : DataNode<Array>
     {
         private IList<IDataNode> _items;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
@@ -558,6 +558,12 @@ namespace System.Runtime.Serialization
             }
         }
 
+        private static Type s_typeOfIExtensibleDataObject;
+        internal static Type TypeOfIExtensibleDataObject => s_typeOfIExtensibleDataObject ?? (s_typeOfIExtensibleDataObject = typeof (IExtensibleDataObject));
+
+        private static Type s_typeOfExtensionDataObject;
+        internal static Type TypeOfExtensionDataObject => s_typeOfExtensionDataObject ?? (s_typeOfExtensionDataObject = typeof (ExtensionDataObject));
+
         [SecurityCritical]
         private static Type s_typeOfISerializableDataNode;
         internal static Type TypeOfISerializableDataNode
@@ -596,6 +602,9 @@ namespace System.Runtime.Serialization
                 return s_typeOfCollectionDataNode;
             }
         }
+
+        private static Type s_typeOfXmlDataNode;
+        internal static Type TypeOfXmlDataNode => s_typeOfXmlDataNode ?? (s_typeOfXmlDataNode = typeof (XmlDataNode));
 
 #if NET_NATIVE
         [SecurityCritical]

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
@@ -17,6 +17,10 @@ namespace System.Runtime.Serialization
         [SecurityCritical]
         private static PropertyInfo s_collectionItemNameProperty;
 
+        private static ConstructorInfo s_extensionDataObjectCtor;
+
+        private static PropertyInfo s_extensionDataProperty;
+
         [SecurityCritical]
         private static MethodInfo s_getItemContractMethod;
 
@@ -119,6 +123,14 @@ namespace System.Runtime.Serialization
                 return s_collectionItemNameProperty;
             }
         }
+
+        public static ConstructorInfo ExtensionDataObjectCtor => s_extensionDataObjectCtor ??
+                                                                 (s_extensionDataObjectCtor =
+                                                                     typeof (ExtensionDataObject).GetConstructor(Globals.ScanAllMembers, null, new Type[] {}, null));
+
+        public static PropertyInfo ExtensionDataProperty => s_extensionDataProperty ??
+                                                            (s_extensionDataProperty = typeof (IExtensibleDataObject).GetProperty("ExtensionData"));
+
         public static MethodInfo GetCurrentMethod
         {
             [SecuritySafeCritical]

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
@@ -262,7 +262,26 @@ namespace System.Runtime.Serialization.Json
 
             private void ReadClass(ClassDataContract classContract)
             {
-                ReadMembers(classContract, null /*extensionDataLocal*/);
+                if (classContract.HasExtensionData)
+                {
+                    LocalBuilder extensionDataLocal = _ilg.DeclareLocal(Globals.TypeOfExtensionDataObject, "extensionData");
+                    _ilg.New(JsonFormatGeneratorStatics.ExtensionDataObjectCtor);
+                    _ilg.Store(extensionDataLocal);
+                    ReadMembers(classContract, extensionDataLocal);
+
+                    ClassDataContract currentContract = classContract;
+                    while (currentContract != null)
+                    {
+                        MethodInfo extensionDataSetMethod = currentContract.ExtensionDataSetMethod;
+                        if (extensionDataSetMethod != null)
+                            _ilg.Call(_objectLocal, extensionDataSetMethod, extensionDataLocal);
+                        currentContract = currentContract.BaseContract;
+                    }
+                }
+                else
+                {
+                    ReadMembers(classContract, null /*extensionDataLocal*/);
+                }
             }
 
             private void ReadMembers(ClassDataContract classContract, LocalBuilder extensionDataLocal)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatWriterGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatWriterGenerator.cs
@@ -193,7 +193,20 @@ namespace System.Runtime.Serialization.Json
                 }
                 else
                 {
-                    WriteMembers(classContract, null, classContract);
+                    if (classContract.HasExtensionData)
+                    {
+                        LocalBuilder extensionDataLocal = _ilg.DeclareLocal(Globals.TypeOfExtensionDataObject, "extensionData");
+                        _ilg.Load(_objectLocal);
+                        _ilg.ConvertValue(_objectLocal.LocalType, Globals.TypeOfIExtensibleDataObject);
+                        _ilg.LoadMember(JsonFormatGeneratorStatics.ExtensionDataProperty);
+                        _ilg.Store(extensionDataLocal);
+                        _ilg.Call(_contextArg, XmlFormatGeneratorStatics.WriteExtensionDataMethod, _xmlWriterArg, extensionDataLocal, -1);
+                        WriteMembers(classContract, extensionDataLocal, classContract);
+                    }
+                    else
+                    {
+                        WriteMembers(classContract, null, classContract);
+                    }
                 }
 
                 InvokeOnSerialized(classContract);
@@ -240,6 +253,12 @@ namespace System.Runtime.Serialization.Json
                         WriteValue(memberValue);
                         WriteEndElement();
                     }
+
+                    if (classContract.HasExtensionData)
+                    {
+                        _ilg.Call(_contextArg, XmlFormatGeneratorStatics.WriteExtensionDataMethod, _xmlWriterArg, extensionDataLocal, memberCount);
+                    }
+
                     if (!member.EmitDefaultValue)
                     {
                         if (member.IsRequired)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonReaderDelegator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonReaderDelegator.cs
@@ -76,7 +76,7 @@ namespace System.Runtime.Serialization.Json
             return new XmlQualifiedName(name, ns);
         }
 
-        internal char ReadContentAsChar()
+        internal override char ReadContentAsChar()
         {
             return XmlConvert.ToChar(ReadContentAsString());
         }
@@ -91,7 +91,7 @@ namespace System.Runtime.Serialization.Json
             return XmlConvert.ToChar(ReadElementContentAsString());
         }
 
-        public byte[] ReadContentAsBase64()
+        public override byte[] ReadContentAsBase64()
         {
             if (isEndOfEmptyElement)
                 return Array.Empty<byte>();
@@ -135,7 +135,7 @@ namespace System.Runtime.Serialization.Json
             return buffer;
         }
 
-        internal DateTime ReadContentAsDateTime()
+        internal override DateTime ReadContentAsDateTime()
         {
             return ParseJsonDate(ReadContentAsString(), _dateTimeFormat);
         }
@@ -291,7 +291,7 @@ namespace System.Runtime.Serialization.Json
         }
 
         // Overridden because base reader relies on XmlConvert.ToUInt64 for conversion to ulong
-        internal ulong ReadContentAsUnsignedLong()
+        internal override ulong ReadContentAsUnsignedLong()
         {
             string value = reader.ReadContentAsString();
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
@@ -11,9 +11,7 @@ using System.Security;
 using System.Runtime.Serialization.Json;
 using System.Runtime.Serialization;
 using DataContractDictionary = System.Collections.Generic.Dictionary<System.Xml.XmlQualifiedName, System.Runtime.Serialization.DataContract>;
-#if !NET_NATIVE
-using ExtensionDataObject = System.Object;
-#endif
+using System.Diagnostics;
 
 namespace System.Runtime.Serialization.Json
 {
@@ -23,6 +21,7 @@ namespace System.Runtime.Serialization.Json
     internal class XmlObjectSerializerReadContextComplexJson : XmlObjectSerializerReadContextComplex
 #endif
     {
+        private string _extensionDataValueType;
         private DataContractJsonSerializer _jsonSerializer;
         private DateTimeFormat _dateTimeFormat;
         private bool _useSimpleDictionaryFormat;
@@ -95,6 +94,69 @@ namespace System.Runtime.Serialization.Json
             get
             {
                 return _useSimpleDictionaryFormat;
+            }
+        }
+
+        protected override void StartReadExtensionDataValue(XmlReaderDelegator xmlReader)
+        {
+            _extensionDataValueType = xmlReader.GetAttribute(JsonGlobals.typeString);
+        }
+
+        protected override IDataNode ReadPrimitiveExtensionDataValue(XmlReaderDelegator xmlReader, string dataContractName, string dataContractNamespace)
+        {
+            IDataNode dataNode;
+
+            switch (_extensionDataValueType)
+            {
+                case null:
+                case JsonGlobals.stringString:
+                    dataNode = new DataNode<string>(xmlReader.ReadContentAsString());
+                    break;
+                case JsonGlobals.booleanString:
+                    dataNode = new DataNode<bool>(xmlReader.ReadContentAsBoolean());
+                    break;
+                case JsonGlobals.numberString:
+                    dataNode = ReadNumericalPrimitiveExtensionDataValue(xmlReader);
+                    break;
+                default:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                        XmlObjectSerializer.CreateSerializationException(SR.Format(SR.JsonUnexpectedAttributeValue, _extensionDataValueType)));
+            }
+
+            xmlReader.ReadEndElement();
+            return dataNode;
+        }
+
+        private IDataNode ReadNumericalPrimitiveExtensionDataValue(XmlReaderDelegator xmlReader)
+        {
+            TypeCode type;
+            object numericalValue = JsonObjectDataContract.ParseJsonNumber(xmlReader.ReadContentAsString(), out type);
+            switch (type)
+            {
+                case TypeCode.Byte:
+                    return new DataNode<byte>((byte)numericalValue);
+                case TypeCode.SByte:
+                    return new DataNode<sbyte>((sbyte)numericalValue);
+                case TypeCode.Int16:
+                    return new DataNode<short>((short)numericalValue);
+                case TypeCode.Int32:
+                    return new DataNode<int>((int)numericalValue);
+                case TypeCode.Int64:
+                    return new DataNode<long>((long)numericalValue);
+                case TypeCode.UInt16:
+                    return new DataNode<ushort>((ushort)numericalValue);
+                case TypeCode.UInt32:
+                    return new DataNode<uint>((uint)numericalValue);
+                case TypeCode.UInt64:
+                    return new DataNode<ulong>((ulong)numericalValue);
+                case TypeCode.Single:
+                    return new DataNode<float>((float)numericalValue);
+                case TypeCode.Double:
+                    return new DataNode<double>((double)numericalValue);
+                case TypeCode.Decimal:
+                    return new DataNode<decimal>((decimal)numericalValue);
+                default:
+                    throw new InvalidOperationException(SR.ParseJsonNumberReturnInvalidNumber);
             }
         }
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
@@ -302,6 +302,34 @@ namespace System.Runtime.Serialization.Json
             xmlWriter.WriteAttributeString(null, JsonGlobals.itemString, null, memberNames[index].Value);
         }
 
+        internal override void WriteExtensionDataTypeInfo(XmlWriterDelegator xmlWriter, IDataNode dataNode)
+        {
+            Type dataType = dataNode.DataType;
+            if (dataType == Globals.TypeOfClassDataNode ||
+                dataType == Globals.TypeOfISerializableDataNode)
+            {
+                xmlWriter.WriteAttributeString(null, JsonGlobals.typeString, null, JsonGlobals.objectString);
+                base.WriteExtensionDataTypeInfo(xmlWriter, dataNode);
+            }
+            else if (dataType == Globals.TypeOfCollectionDataNode)
+            {
+                xmlWriter.WriteAttributeString(null, JsonGlobals.typeString, null, JsonGlobals.arrayString);
+                // Don't write __type for collections
+            }
+            else if (dataType == Globals.TypeOfXmlDataNode)
+            {
+                // Don't write type or __type for XML types because we serialize them to strings
+            }
+            else if ((dataType == Globals.TypeOfObject) && (dataNode.Value != null))
+            {
+                DataContract dc = GetDataContract(dataNode.Value.GetType());
+                if (RequiresJsonTypeInfo(dc))
+                {
+                    base.WriteExtensionDataTypeInfo(xmlWriter, dataNode);
+                }
+            }
+        }
+
         internal static void VerifyObjectCompatibilityWithInterface(DataContract contract, object graph, Type declaredType)
         {
             Type contractType = contract.GetType();

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
@@ -85,6 +85,9 @@ namespace System.Runtime.Serialization
             }
         }
 
+        private static PropertyInfo s_extensionDataProperty;
+        internal static PropertyInfo ExtensionDataProperty => s_extensionDataProperty ?? 
+                                                              (s_extensionDataProperty = typeof(IExtensibleDataObject).GetProperty("ExtensionData"));
 
         [SecurityCritical]
         private static ConstructorInfo s_dictionaryEnumeratorCtor;
@@ -210,6 +213,11 @@ namespace System.Runtime.Serialization
                 return s_nodeTypeProperty;
             }
         }
+
+        private static ConstructorInfo s_extensionDataObjectCtor;
+        internal static ConstructorInfo ExtensionDataObjectCtor => s_extensionDataObjectCtor ??
+                                                                   (s_extensionDataObjectCtor =
+                                                                       typeof (ExtensionDataObject).GetConstructor(Globals.ScanAllMembers, null, new Type[] {}, null));
 
         [SecurityCritical]
         private static ConstructorInfo s_hashtableCtor;
@@ -863,6 +871,10 @@ namespace System.Runtime.Serialization
             }
         }
 
+        private static MethodInfo s_writeExtensionDataMethod;
+        internal static MethodInfo WriteExtensionDataMethod => s_writeExtensionDataMethod ?? 
+                                                               (s_writeExtensionDataMethod = typeof(XmlObjectSerializerWriteContext).GetMethod("WriteExtensionData", Globals.ScanAllMembers));
+
         [SecurityCritical]
         private static MethodInfo s_writeXmlValueMethod;
         internal static MethodInfo WriteXmlValueMethod
@@ -942,6 +954,10 @@ namespace System.Runtime.Serialization
                 return s_memberNamesField;
             }
         }
+
+        private static MethodInfo s_extensionDataSetExplicitMethodInfo;
+        internal static MethodInfo ExtensionDataSetExplicitMethodInfo => s_extensionDataSetExplicitMethodInfo ?? 
+                                                                         (s_extensionDataSetExplicitMethodInfo = typeof(IExtensibleDataObject).GetMethod(Globals.ExtensionDataSetMethod));
 
         [SecurityCritical]
         private static PropertyInfo s_childElementNamespacesProperty;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
@@ -337,7 +337,26 @@ namespace System.Runtime.Serialization
 
             private void ReadClass(ClassDataContract classContract)
             {
-                ReadMembers(classContract, null /*extensionDataLocal*/);
+                if (classContract.HasExtensionData)
+                {
+                    LocalBuilder extensionDataLocal = _ilg.DeclareLocal(Globals.TypeOfExtensionDataObject, "extensionData");
+                    _ilg.New(XmlFormatGeneratorStatics.ExtensionDataObjectCtor);
+                    _ilg.Store(extensionDataLocal);
+                    ReadMembers(classContract, extensionDataLocal);
+
+                    ClassDataContract currentContract = classContract;
+                    while (currentContract != null)
+                    {
+                        MethodInfo extensionDataSetMethod = currentContract.ExtensionDataSetMethod;
+                        if (extensionDataSetMethod != null)
+                            _ilg.Call(_objectLocal, extensionDataSetMethod, extensionDataLocal);
+                        currentContract = currentContract.BaseContract;
+                    }
+                }
+                else
+                {
+                    ReadMembers(classContract, null /*extensionDataLocal*/);
+                }
             }
 
             private void ReadMembers(ClassDataContract classContract, LocalBuilder extensionDataLocal)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatWriterGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatWriterGenerator.cs
@@ -257,7 +257,20 @@ namespace System.Runtime.Serialization
                         }
                     }
 
-                    WriteMembers(classContract, null, classContract);
+                    if (classContract.HasExtensionData)
+                    {
+                        LocalBuilder extensionDataLocal = _ilg.DeclareLocal(Globals.TypeOfExtensionDataObject, "extensionData");
+                        _ilg.Load(_objectLocal);
+                        _ilg.ConvertValue(_objectLocal.LocalType, Globals.TypeOfIExtensibleDataObject);
+                        _ilg.LoadMember(XmlFormatGeneratorStatics.ExtensionDataProperty);
+                        _ilg.Store(extensionDataLocal);
+                        _ilg.Call(_contextArg, XmlFormatGeneratorStatics.WriteExtensionDataMethod, _xmlWriterArg, extensionDataLocal, -1);
+                        WriteMembers(classContract, extensionDataLocal, classContract);
+                    }
+                    else
+                    {
+                        WriteMembers(classContract, null, classContract);
+                    }
                 }
                 InvokeOnSerialized(classContract);
             }
@@ -309,6 +322,13 @@ namespace System.Runtime.Serialization
                         WriteValue(memberValue, writeXsiType);
                         WriteEndElement();
                     }
+
+                    if (classContract.HasExtensionData)
+                    {
+                        _ilg.Call(_contextArg, XmlFormatGeneratorStatics.WriteExtensionDataMethod, _xmlWriterArg, extensionDataLocal, memberCount);
+                    }
+
+
                     if (!member.EmitDefaultValue)
                     {
                         if (member.IsRequired)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
@@ -23,6 +23,8 @@ namespace System.Runtime.Serialization
         internal Attributes attributes;
         private HybridObjectCache _deserializedObjects;
         private XmlSerializableReader _xmlSerializableReader;
+        private XmlDocument _xmlDocument;
+        private Attributes _attributesInXmlData;
         private object _getOnlyCollectionValue;
         private bool _isGetOnlyCollection;
 
@@ -35,6 +37,8 @@ namespace System.Runtime.Serialization
                 return _deserializedObjects;
             }
         }
+
+        private XmlDocument Document => _xmlDocument ?? (_xmlDocument = new XmlDocument());
 
 
         internal override bool IsGetOnlyCollection
@@ -316,6 +320,9 @@ namespace System.Runtime.Serialization
 
         internal void HandleUnknownElement(XmlReaderDelegator xmlReader, ExtensionDataObject extensionData, int memberIndex)
         {
+            if (extensionData.Members == null)
+                extensionData.Members = new List<ExtensionDataMember>();
+            extensionData.Members.Add(ReadExtensionDataMember(xmlReader, memberIndex));
         }
 
 #if USE_REFEMIT
@@ -436,6 +443,18 @@ namespace System.Runtime.Serialization
             object retObj = DeserializedObjects.GetObject(id);
             if (retObj == null)
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.DeserializedObjectWithIdNotFound, id)));
+            return retObj;
+        }
+
+        private object GetExistingObjectOrExtensionData(string id)
+        {
+            object retObj = DeserializedObjects.GetObject(id);
+            if (retObj == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                    XmlObjectSerializer.CreateSerializationException(SR.Format(SR.DeserializedObjectWithIdNotFound, id)));
+            }
+
             return retObj;
         }
 
@@ -606,6 +625,469 @@ namespace System.Runtime.Serialization
             return (attributes.XsiTypeName == null) ? null : ResolveDataContractFromKnownTypes(attributes.XsiTypeName, attributes.XsiTypeNamespace, null /*memberTypeContract*/);
         }
 
+        private ExtensionDataMember ReadExtensionDataMember(XmlReaderDelegator xmlReader, int memberIndex)
+        {
+            var member = new ExtensionDataMember
+            {
+                Name = xmlReader.LocalName,
+                Namespace = xmlReader.NamespaceURI,
+                MemberIndex = memberIndex
+            };
+
+            member.Value = xmlReader.UnderlyingExtensionDataReader != null ? xmlReader.UnderlyingExtensionDataReader.GetCurrentNode() : ReadExtensionDataValue(xmlReader);
+            return member;
+        }
+
+        public IDataNode ReadExtensionDataValue(XmlReaderDelegator xmlReader)
+        {
+            ReadAttributes(xmlReader);
+            IncrementItemCount(1);
+            IDataNode dataNode = null;
+            if (attributes.Ref != Globals.NewObjectId)
+            {
+                xmlReader.Skip();
+                object o = GetExistingObjectOrExtensionData(attributes.Ref);
+                dataNode = (o is IDataNode) ? (IDataNode)o : new DataNode<object>(o);
+                dataNode.Id = attributes.Ref;
+            }
+            else if (attributes.XsiNil)
+            {
+                xmlReader.Skip();
+                dataNode = null;
+            }
+            else
+            {
+                string dataContractName = null;
+                string dataContractNamespace = null;
+                if (attributes.XsiTypeName != null)
+                {
+                    dataContractName = attributes.XsiTypeName;
+                    dataContractNamespace = attributes.XsiTypeNamespace;
+                }
+
+                if (IsReadingCollectionExtensionData(xmlReader))
+                {
+                    Read(xmlReader);
+                    dataNode = ReadUnknownCollectionData(xmlReader, dataContractName, dataContractNamespace);
+                }
+                else if (attributes.FactoryTypeName != null)
+                {
+                    Read(xmlReader);
+                    dataNode = ReadUnknownISerializableData(xmlReader, dataContractName, dataContractNamespace);
+                }
+                else if (IsReadingClassExtensionData(xmlReader))
+                {
+                    Read(xmlReader);
+                    dataNode = ReadUnknownClassData(xmlReader, dataContractName, dataContractNamespace);
+                }
+                else
+                {
+                    DataContract dataContract = ResolveDataContractFromTypeName();
+
+                    if (dataContract == null)
+                        dataNode = ReadExtensionDataValue(xmlReader, dataContractName, dataContractNamespace);
+                    else if (dataContract is XmlDataContract)
+                        dataNode = ReadUnknownXmlData(xmlReader, dataContractName, dataContractNamespace);
+                    else
+                    {
+                        if (dataContract.IsISerializable)
+                        {
+                            Read(xmlReader);
+                            dataNode = ReadUnknownISerializableData(xmlReader, dataContractName, dataContractNamespace);
+                        }
+                        else if (dataContract is PrimitiveDataContract)
+                        {
+                            if (attributes.Id == Globals.NewObjectId)
+                            {
+                                Read(xmlReader);
+                                xmlReader.MoveToContent();
+                                dataNode = ReadUnknownPrimitiveData(xmlReader, dataContract.UnderlyingType, dataContractName, dataContractNamespace);
+                                xmlReader.ReadEndElement();
+                            }
+                            else
+                            {
+                                dataNode = new DataNode<object>(xmlReader.ReadElementContentAsAnyType(dataContract.UnderlyingType));
+                                InitializeExtensionDataNode(dataNode, dataContractName, dataContractNamespace);
+                            }
+                        }
+                        else if (dataContract is EnumDataContract)
+                        {
+                            dataNode = new DataNode<object>(((EnumDataContract)dataContract).ReadEnumValue(xmlReader));
+                            InitializeExtensionDataNode(dataNode, dataContractName, dataContractNamespace);
+                        }
+                        else if (dataContract is ClassDataContract)
+                        {
+                            Read(xmlReader);
+                            dataNode = ReadUnknownClassData(xmlReader, dataContractName, dataContractNamespace);
+                        }
+                        else if (dataContract is CollectionDataContract)
+                        {
+                            Read(xmlReader);
+                            dataNode = ReadUnknownCollectionData(xmlReader, dataContractName, dataContractNamespace);
+                        }
+                    }
+                }
+            }
+            return dataNode;
+        }
+
+        protected virtual void StartReadExtensionDataValue(XmlReaderDelegator xmlReader)
+        {
+        }
+
+        private IDataNode ReadExtensionDataValue(XmlReaderDelegator xmlReader, string dataContractName, string dataContractNamespace)
+        {
+            StartReadExtensionDataValue(xmlReader);
+
+            if (attributes.UnrecognizedAttributesFound)
+                return ReadUnknownXmlData(xmlReader, dataContractName, dataContractNamespace);
+
+            IDictionary<string, string> namespacesInScope = xmlReader.GetNamespacesInScope(XmlNamespaceScope.ExcludeXml);
+            Read(xmlReader);
+            xmlReader.MoveToContent();
+
+            switch (xmlReader.NodeType)
+            {
+                case XmlNodeType.Text:
+                    return ReadPrimitiveExtensionDataValue(xmlReader, dataContractName, dataContractNamespace);
+                case XmlNodeType.Element:
+                    if (xmlReader.NamespaceURI.StartsWith(Globals.DataContractXsdBaseNamespace, StringComparison.Ordinal))
+                        return ReadUnknownClassData(xmlReader, dataContractName, dataContractNamespace);
+                    else
+                        return ReadAndResolveUnknownXmlData(xmlReader, namespacesInScope, dataContractName, dataContractNamespace);
+
+                case XmlNodeType.EndElement:
+                    {
+                        // NOTE: cannot distinguish between empty class or IXmlSerializable and typeof(object) 
+                        IDataNode objNode = ReadUnknownPrimitiveData(xmlReader, Globals.TypeOfObject, dataContractName, dataContractNamespace);
+                        xmlReader.ReadEndElement();
+                        objNode.IsFinalValue = false;
+                        return objNode;
+                    }
+                default:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateUnexpectedStateException(XmlNodeType.Element, xmlReader));
+            }
+        }
+
+        protected virtual IDataNode ReadPrimitiveExtensionDataValue(XmlReaderDelegator xmlReader, string dataContractName, string dataContractNamespace)
+        {
+            Type valueType = xmlReader.ValueType;
+            if (valueType == Globals.TypeOfString)
+            {
+                // NOTE: cannot distinguish other primitives from string (default XmlReader ValueType)
+                IDataNode stringNode = new DataNode<object>(xmlReader.ReadContentAsString());
+                InitializeExtensionDataNode(stringNode, dataContractName, dataContractNamespace);
+                stringNode.IsFinalValue = false;
+                xmlReader.ReadEndElement();
+                return stringNode;
+            }
+
+            IDataNode objNode = ReadUnknownPrimitiveData(xmlReader, valueType, dataContractName, dataContractNamespace);
+            xmlReader.ReadEndElement();
+            return objNode;
+        }
+
+        protected void InitializeExtensionDataNode(IDataNode dataNode, string dataContractName, string dataContractNamespace)
+        {
+            dataNode.DataContractName = dataContractName;
+            dataNode.DataContractNamespace = dataContractNamespace;
+            dataNode.ClrAssemblyName = attributes.ClrAssembly;
+            dataNode.ClrTypeName = attributes.ClrType;
+            AddNewObject(dataNode);
+            dataNode.Id = attributes.Id;
+        }
+
+        private IDataNode ReadUnknownPrimitiveData(XmlReaderDelegator xmlReader, Type type, string dataContractName, string dataContractNamespace)
+        {
+            IDataNode dataNode = xmlReader.ReadExtensionData(type);
+            InitializeExtensionDataNode(dataNode, dataContractName, dataContractNamespace);
+            return dataNode;
+        }
+
+        private ClassDataNode ReadUnknownClassData(XmlReaderDelegator xmlReader, string dataContractName, string dataContractNamespace)
+        {
+            var dataNode = new ClassDataNode();
+            InitializeExtensionDataNode(dataNode, dataContractName, dataContractNamespace);
+
+            int memberIndex = 0;
+            XmlNodeType nodeType;
+            while ((nodeType = xmlReader.MoveToContent()) != XmlNodeType.EndElement)
+            {
+                if (nodeType != XmlNodeType.Element)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateUnexpectedStateException(XmlNodeType.Element, xmlReader));
+
+                if (dataNode.Members == null)
+                    dataNode.Members = new List<ExtensionDataMember>();
+                dataNode.Members.Add(ReadExtensionDataMember(xmlReader, memberIndex++));
+            }
+            xmlReader.ReadEndElement();
+            return dataNode;
+        }
+
+        private CollectionDataNode ReadUnknownCollectionData(XmlReaderDelegator xmlReader, string dataContractName, string dataContractNamespace)
+        {
+            var dataNode = new CollectionDataNode();
+            InitializeExtensionDataNode(dataNode, dataContractName, dataContractNamespace);
+
+            int arraySize = attributes.ArraySZSize;
+            XmlNodeType nodeType;
+            while ((nodeType = xmlReader.MoveToContent()) != XmlNodeType.EndElement)
+            {
+                if (nodeType != XmlNodeType.Element)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateUnexpectedStateException(XmlNodeType.Element, xmlReader));
+
+                if (dataNode.ItemName == null)
+                {
+                    dataNode.ItemName = xmlReader.LocalName;
+                    dataNode.ItemNamespace = xmlReader.NamespaceURI;
+                }
+                if (xmlReader.IsStartElement(dataNode.ItemName, dataNode.ItemNamespace))
+                {
+                    if (dataNode.Items == null)
+                        dataNode.Items = new List<IDataNode>();
+                    dataNode.Items.Add(ReadExtensionDataValue(xmlReader));
+                }
+                else
+                    SkipUnknownElement(xmlReader);
+            }
+            xmlReader.ReadEndElement();
+
+            if (arraySize != -1)
+            {
+                dataNode.Size = arraySize;
+                if (dataNode.Items == null)
+                {
+                    if (dataNode.Size > 0)
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.ArraySizeAttributeIncorrect, arraySize, 0)));
+                }
+                else if (dataNode.Size != dataNode.Items.Count)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.ArraySizeAttributeIncorrect, arraySize, dataNode.Items.Count)));
+            }
+            else
+            {
+                if (dataNode.Items != null)
+                {
+                    dataNode.Size = dataNode.Items.Count;
+                }
+                else
+                {
+                    dataNode.Size = 0;
+                }
+            }
+
+            return dataNode;
+        }
+
+        private ISerializableDataNode ReadUnknownISerializableData(XmlReaderDelegator xmlReader, string dataContractName, string dataContractNamespace)
+        {
+            var dataNode = new ISerializableDataNode();
+            InitializeExtensionDataNode(dataNode, dataContractName, dataContractNamespace);
+
+            dataNode.FactoryTypeName = attributes.FactoryTypeName;
+            dataNode.FactoryTypeNamespace = attributes.FactoryTypeNamespace;
+
+            XmlNodeType nodeType;
+            while ((nodeType = xmlReader.MoveToContent()) != XmlNodeType.EndElement)
+            {
+                if (nodeType != XmlNodeType.Element)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateUnexpectedStateException(XmlNodeType.Element, xmlReader));
+
+                if (xmlReader.NamespaceURI.Length != 0)
+                {
+                    SkipUnknownElement(xmlReader);
+                    continue;
+                }
+
+                var member = new ISerializableDataMember();
+                member.Name = xmlReader.LocalName;
+                member.Value = ReadExtensionDataValue(xmlReader);
+                if (dataNode.Members == null)
+                    dataNode.Members = new List<ISerializableDataMember>();
+                dataNode.Members.Add(member);
+            }
+            xmlReader.ReadEndElement();
+            return dataNode;
+        }
+
+        private IDataNode ReadUnknownXmlData(XmlReaderDelegator xmlReader, string dataContractName, string dataContractNamespace)
+        {
+            XmlDataNode dataNode = new XmlDataNode();
+            InitializeExtensionDataNode(dataNode, dataContractName, dataContractNamespace);
+            dataNode.OwnerDocument = Document;
+
+            if (xmlReader.NodeType == XmlNodeType.EndElement)
+                return dataNode;
+
+            IList<XmlAttribute> xmlAttributes = null;
+            IList<XmlNode> xmlChildNodes = null;
+
+            XmlNodeType nodeType = xmlReader.MoveToContent();
+            if (nodeType != XmlNodeType.Text)
+            {
+                while (xmlReader.MoveToNextAttribute())
+                {
+                    string ns = xmlReader.NamespaceURI;
+                    if (ns != Globals.SerializationNamespace && ns != Globals.SchemaInstanceNamespace)
+                    {
+                        if (xmlAttributes == null)
+                            xmlAttributes = new List<XmlAttribute>();
+                        xmlAttributes.Add((XmlAttribute)Document.ReadNode(xmlReader.UnderlyingReader));
+                    }
+                }
+                Read(xmlReader);
+            }
+
+            while ((nodeType = xmlReader.MoveToContent()) != XmlNodeType.EndElement)
+            {
+                if (xmlReader.EOF)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.UnexpectedEndOfFile)));
+
+                if (xmlChildNodes == null)
+                    xmlChildNodes = new List<XmlNode>();
+                xmlChildNodes.Add(Document.ReadNode(xmlReader.UnderlyingReader));
+            }
+            xmlReader.ReadEndElement();
+
+            dataNode.XmlAttributes = xmlAttributes;
+            dataNode.XmlChildNodes = xmlChildNodes;
+            return dataNode;
+        }
+
+        // Pattern-recognition logic: the method reads XML elements into DOM. To recognize as an array, it requires that 
+        // all items have the same name and namespace. To recognize as an ISerializable type, it requires that all
+        // items be unqualified. If the XML only contains elements (no attributes or other nodes) is recognized as a 
+        // class/class hierarchy. Otherwise it is deserialized as XML.
+        private IDataNode ReadAndResolveUnknownXmlData(XmlReaderDelegator xmlReader, IDictionary<string, string> namespaces,
+            string dataContractName, string dataContractNamespace)
+        {
+            bool couldBeISerializableData = true;
+            bool couldBeCollectionData = true;
+            bool couldBeClassData = true;
+            string elementNs = null, elementName = null;
+            var xmlChildNodes = new List<XmlNode>();
+            IList<XmlAttribute> xmlAttributes = null;
+            if (namespaces != null)
+            {
+                xmlAttributes = new List<XmlAttribute>();
+                foreach (KeyValuePair<string, string> prefixNsPair in namespaces)
+                {
+                    xmlAttributes.Add(AddNamespaceDeclaration(prefixNsPair.Key, prefixNsPair.Value));
+                }
+            }
+
+            XmlNodeType nodeType;
+            while ((nodeType = xmlReader.NodeType) != XmlNodeType.EndElement)
+            {
+                if (nodeType == XmlNodeType.Element)
+                {
+                    string ns = xmlReader.NamespaceURI;
+                    string name = xmlReader.LocalName;
+                    if (couldBeISerializableData)
+                        couldBeISerializableData = (ns.Length == 0);
+                    if (couldBeCollectionData)
+                    {
+                        if (elementName == null)
+                        {
+                            elementName = name;
+                            elementNs = ns;
+                        }
+                        else
+                            couldBeCollectionData = (String.CompareOrdinal(elementName, name) == 0) &&
+                                (String.CompareOrdinal(elementNs, ns) == 0);
+                    }
+                }
+                else if (xmlReader.EOF)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.UnexpectedEndOfFile)));
+                else if (IsContentNode(xmlReader.NodeType))
+                    couldBeClassData = couldBeISerializableData = couldBeCollectionData = false;
+
+                if (_attributesInXmlData == null) _attributesInXmlData = new Attributes();
+                _attributesInXmlData.Read(xmlReader);
+
+                XmlNode childNode = Document.ReadNode(xmlReader.UnderlyingReader);
+                xmlChildNodes.Add(childNode);
+
+                if (namespaces == null)
+                {
+                    if (_attributesInXmlData.XsiTypeName != null)
+                        childNode.Attributes.Append(AddNamespaceDeclaration(_attributesInXmlData.XsiTypePrefix, _attributesInXmlData.XsiTypeNamespace));
+                    if (_attributesInXmlData.FactoryTypeName != null)
+                        childNode.Attributes.Append(AddNamespaceDeclaration(_attributesInXmlData.FactoryTypePrefix, _attributesInXmlData.FactoryTypeNamespace));
+                }
+            }
+            xmlReader.ReadEndElement();
+
+            if (elementName != null && couldBeCollectionData)
+                return ReadUnknownCollectionData(CreateReaderOverChildNodes(xmlAttributes, xmlChildNodes), dataContractName, dataContractNamespace);
+            else if (couldBeISerializableData)
+                return ReadUnknownISerializableData(CreateReaderOverChildNodes(xmlAttributes, xmlChildNodes), dataContractName, dataContractNamespace);
+            else if (couldBeClassData)
+                return ReadUnknownClassData(CreateReaderOverChildNodes(xmlAttributes, xmlChildNodes), dataContractName, dataContractNamespace);
+            else
+            {
+                XmlDataNode dataNode = new XmlDataNode();
+                InitializeExtensionDataNode(dataNode, dataContractName, dataContractNamespace);
+                dataNode.OwnerDocument = Document;
+                dataNode.XmlChildNodes = xmlChildNodes;
+                dataNode.XmlAttributes = xmlAttributes;
+                return dataNode;
+            }
+        }
+
+        private bool IsContentNode(XmlNodeType nodeType)
+        {
+            switch (nodeType)
+            {
+                case XmlNodeType.Whitespace:
+                case XmlNodeType.SignificantWhitespace:
+                case XmlNodeType.Comment:
+                case XmlNodeType.ProcessingInstruction:
+                case XmlNodeType.DocumentType:
+                    return false;
+                default:
+                    return true;
+            }
+        }
+
+        internal XmlReaderDelegator CreateReaderOverChildNodes(IList<XmlAttribute> xmlAttributes, IList<XmlNode> xmlChildNodes)
+        {
+            XmlNode wrapperElement = CreateWrapperXmlElement(Document, xmlAttributes, xmlChildNodes, null, null, null);
+            XmlReaderDelegator nodeReader = CreateReaderDelegatorForReader(new XmlNodeReader(wrapperElement));
+            nodeReader.MoveToContent();
+            Read(nodeReader);
+            return nodeReader;
+        }
+
+        internal static XmlNode CreateWrapperXmlElement(XmlDocument document, IList<XmlAttribute> xmlAttributes, IList<XmlNode> xmlChildNodes, string prefix, string localName, string ns)
+        {
+            localName = localName ?? "wrapper";
+            ns = ns ?? string.Empty;
+            XmlNode wrapperElement = document.CreateElement(prefix, localName, ns);
+            if (xmlAttributes != null)
+            {
+                for (int i = 0; i < xmlAttributes.Count; i++)
+                {
+                    wrapperElement.Attributes.Append((XmlAttribute) xmlAttributes[i]);
+                }
+            }
+            if (xmlChildNodes != null)
+            {
+                for (int i = 0; i < xmlChildNodes.Count; i++)
+                {
+                    wrapperElement.AppendChild(xmlChildNodes[i]);
+                }
+            }
+            return wrapperElement;
+        }
+
+        private XmlAttribute AddNamespaceDeclaration(string prefix, string ns)
+        {
+            XmlAttribute attribute = (prefix == null || prefix.Length == 0) ?
+                Document.CreateAttribute(null, Globals.XmlnsPrefix, Globals.XmlnsNamespace) :
+                Document.CreateAttribute(Globals.XmlnsPrefix, prefix, Globals.XmlnsNamespace);
+            attribute.Value = ns;
+            return attribute;
+        }
 
 #if USE_REFEMIT
         public static Exception CreateUnexpectedStateException(XmlNodeType expectedState, XmlReaderDelegator xmlReader)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlWriterDelegator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlWriterDelegator.cs
@@ -369,6 +369,87 @@ namespace System.Runtime.Serialization
                 throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateInvalidPrimitiveTypeException(valueType));
         }
 
+        internal void WriteExtensionData(IDataNode dataNode)
+        {
+            bool handled = true;
+            Type valueType = dataNode.DataType;
+            switch (Type.GetTypeCode(valueType))
+            {
+                case TypeCode.Boolean:
+                    WriteBoolean(((DataNode<bool>)dataNode).GetValue());
+                    break;
+                case TypeCode.Char:
+                    WriteChar(((DataNode<char>)dataNode).GetValue());
+                    break;
+                case TypeCode.Byte:
+                    WriteUnsignedByte(((DataNode<byte>)dataNode).GetValue());
+                    break;
+                case TypeCode.Int16:
+                    WriteShort(((DataNode<short>)dataNode).GetValue());
+                    break;
+                case TypeCode.Int32:
+                    WriteInt(((DataNode<int>)dataNode).GetValue());
+                    break;
+                case TypeCode.Int64:
+                    WriteLong(((DataNode<long>)dataNode).GetValue());
+                    break;
+                case TypeCode.Single:
+                    WriteFloat(((DataNode<float>)dataNode).GetValue());
+                    break;
+                case TypeCode.Double:
+                    WriteDouble(((DataNode<double>)dataNode).GetValue());
+                    break;
+                case TypeCode.Decimal:
+                    WriteDecimal(((DataNode<decimal>)dataNode).GetValue());
+                    break;
+                case TypeCode.DateTime:
+                    WriteDateTime(((DataNode<DateTime>)dataNode).GetValue());
+                    break;
+                case TypeCode.String:
+                    WriteString(((DataNode<string>)dataNode).GetValue());
+                    break;
+                case TypeCode.SByte:
+                    WriteSignedByte(((DataNode<sbyte>)dataNode).GetValue());
+                    break;
+                case TypeCode.UInt16:
+                    WriteUnsignedShort(((DataNode<ushort>)dataNode).GetValue());
+                    break;
+                case TypeCode.UInt32:
+                    WriteUnsignedInt(((DataNode<uint>)dataNode).GetValue());
+                    break;
+                case TypeCode.UInt64:
+                    WriteUnsignedLong(((DataNode<ulong>)dataNode).GetValue());
+                    break;
+                case TypeCode.Empty:
+                case TypeCode.DBNull:
+                case TypeCode.Object:
+                default:
+                    if (valueType == Globals.TypeOfByteArray)
+                        WriteBase64(((DataNode<byte[]>)dataNode).GetValue());
+                    else if (valueType == Globals.TypeOfObject)
+                    {
+                        object obj = dataNode.Value;
+                        if (obj != null)
+                            WriteAnyType(obj);
+                    }
+                    else if (valueType == Globals.TypeOfTimeSpan)
+                        WriteTimeSpan(((DataNode<TimeSpan>)dataNode).GetValue());
+                    else if (valueType == Globals.TypeOfGuid)
+                        WriteGuid(((DataNode<Guid>)dataNode).GetValue());
+                    else if (valueType == Globals.TypeOfUri)
+                        WriteUri(((DataNode<Uri>)dataNode).GetValue());
+                    else if (valueType == Globals.TypeOfXmlQualifiedName)
+                        WriteQName(((DataNode<XmlQualifiedName>)dataNode).GetValue());
+                    else
+                        handled = false;
+                    break;
+            }
+
+            if (!handled)
+            {
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateInvalidPrimitiveTypeException(valueType));
+            }
+        }
 
         internal void WriteString(string value)
         {

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2280,6 +2280,63 @@ public static partial class DataContractJsonSerializerTests
         Assert.True(result.Equal, $"The serialization payload was not as expected.{Environment.NewLine}Expected: {expectedString}.{Environment.NewLine}Actual: {actualString}");
     }
 
+    [Fact]
+    public static void DCJS_ExtensionDataObjectTest()
+    {
+        var p2 = new PersonV2();
+        p2.Name = "Elizabeth";
+        p2.ID = 2006;
+
+        // Serializaze the PersonV2 object
+        var ser = new DataContractJsonSerializer(typeof(PersonV2));
+        var ms1 = new MemoryStream();
+        ser.WriteObject(ms1, p2);
+
+        // Verify the payload
+        ms1.Position = 0;
+        string actualOutput1 = new StreamReader(ms1).ReadToEnd();
+        string baseline1 = "{\"Name\":\"Elizabeth\",\"ID\":2006}";
+
+        try
+        {
+            Utils.CompareResult result = Utils.Compare(baseline1, actualOutput1);
+            Assert.True(result.Equal, $"{nameof(actualOutput1)} was not as expected: {Environment.NewLine}Expected: {baseline1}{Environment.NewLine}Actual: {actualOutput1}");
+        }
+        catch (Exception e)
+        {
+            Assert.True(false, $"Error occured when comparing results: {Environment.NewLine}{e.Message}{Environment.NewLine}Expected: {baseline1}{Environment.NewLine}Actual: {actualOutput1}");
+        }
+
+
+        // Deserialize the payload into a Person instance.
+        ms1.Position = 0;
+        var ser2 = new DataContractJsonSerializer(typeof(Person));
+        var p1 = (Person)ser2.ReadObject(ms1);
+
+        Assert.True(p1 != null, $"Variable {nameof(p1)} was null.");
+        Assert.True(p1.ExtensionData != null, $"{nameof(p1.ExtensionData)} was null.");
+        Assert.Equal(p2.Name, p1.Name);
+
+        // Serializaze the Person instance
+        var ms2 = new MemoryStream();
+        ser2.WriteObject(ms2, p1);
+
+        // Verify the payload
+        ms2.Position = 0;
+        string actualOutput2 = new StreamReader(ms2).ReadToEnd();
+        string baseline2 = "{\"Name\":\"Elizabeth\",\"ID\":2006}";
+
+        try
+        {
+            Utils.CompareResult result2 = Utils.Compare(baseline2, actualOutput2);
+            Assert.True(result2.Equal, $"{nameof(actualOutput2)} was not as expected: {Environment.NewLine}Expected: {baseline2}{Environment.NewLine}Actual: {actualOutput2}");
+        }
+        catch(Exception e)
+        {
+            Assert.True(false, $"Error occured when comparing results: {Environment.NewLine}{e.Message}{Environment.NewLine}Expected: {baseline2}{Environment.NewLine}Actual: {actualOutput2}");
+        }
+    }
+
     private static string ConstructorWithRootNameTestHelper(TypeForRootNameTest value, DataContractJsonSerializer serializer)
     {
         using (var ms = new MemoryStream())

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2290,7 +2290,7 @@ public static partial class DataContractJsonSerializerTests
         p2.Name = "Elizabeth";
         p2.ID = 2006;
 
-        // Serializaze the PersonV2 object
+        // Serialize the PersonV2 object
         var ser = new DataContractJsonSerializer(typeof(PersonV2));
         var ms1 = new MemoryStream();
         ser.WriteObject(ms1, p2);
@@ -2320,7 +2320,7 @@ public static partial class DataContractJsonSerializerTests
         Assert.True(p1.ExtensionData != null, $"{nameof(p1.ExtensionData)} was null.");
         Assert.Equal(p2.Name, p1.Name);
 
-        // Serializaze the Person instance
+        // Serialize the Person instance
         var ms2 = new MemoryStream();
         ser2.WriteObject(ms2, p1);
 

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2280,6 +2280,9 @@ public static partial class DataContractJsonSerializerTests
         Assert.True(result.Equal, $"The serialization payload was not as expected.{Environment.NewLine}Expected: {expectedString}.{Environment.NewLine}Actual: {actualString}");
     }
 
+#if ReflectionOnly
+    [ActiveIssue(13699)]
+#endif
     [Fact]
     public static void DCJS_ExtensionDataObjectTest()
     {

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2668,25 +2668,47 @@ public static partial class DataContractSerializerTests
         Assert.Equal(DateTimeOffset.MaxValue, ((DTOContainer)deserialized.Data).nDTO);
     }
 
-    [ActiveIssue(12767)]
     [Fact]
     public static void DCS_ExtensionDataObjectTest()
     {
-        PersonV2 p2 = new PersonV2();
+        var p2 = new PersonV2();
         p2.Name = "Elizabeth";
         p2.ID = 2006;
-        DataContractSerializer ser =
-                new DataContractSerializer(typeof(PersonV2));
-        MemoryStream ms = new MemoryStream();
-        ser.WriteObject(ms, p2);
-        string actualOutput = new StreamReader(ms).ReadToEnd();
-        ms.Position = 0;
-        DataContractSerializer ser2 =
-                new DataContractSerializer(typeof(Person));
-        XmlDictionaryReader reader =
-               XmlDictionaryReader.CreateTextReader(ms, new XmlDictionaryReaderQuotas());
-        Person p1 = (Person)ser2.ReadObject(reader, false);
-        Assert.NotNull(p1.ExtensionData);
+
+        // Serializaze the PersonV2 object
+        var ser = new DataContractSerializer(typeof(PersonV2));
+        var ms1 = new MemoryStream();
+        ser.WriteObject(ms1, p2);
+
+        // Verify the payload
+        ms1.Position = 0;
+        string actualOutput1 = new StreamReader(ms1).ReadToEnd();
+        string baseline1 = "<Person xmlns=\"http://www.msn.com/employees\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><Name>Elizabeth</Name><ID>2006</ID></Person>";
+
+        Utils.CompareResult result = Utils.Compare(baseline1, actualOutput1);
+        Assert.True(result.Equal, $"{nameof(actualOutput1)} was not as expected: {Environment.NewLine}Expected: {baseline1}{Environment.NewLine}Actual: {actualOutput1}");
+
+        // Deserialize the payload into a Person instance.
+        ms1.Position = 0;
+        var ser2 = new DataContractSerializer(typeof(Person));
+        XmlDictionaryReader reader = XmlDictionaryReader.CreateTextReader(ms1, new XmlDictionaryReaderQuotas());
+        var p1 = (Person)ser2.ReadObject(reader, false);
+
+        Assert.True(p1 != null, $"Variable {nameof(p1)} was null.");
+        Assert.True(p1.ExtensionData != null, $"{nameof(p1.ExtensionData)} was null.");
+        Assert.Equal(p2.Name, p1.Name);
+
+        // Serializaze the Person instance
+        var ms2 = new MemoryStream();
+        ser2.WriteObject(ms2, p1);
+
+        // Verify the payload
+        ms2.Position = 0;
+        string actualOutput2 = new StreamReader(ms2).ReadToEnd();
+        string baseline2 = "<Person xmlns=\"http://www.msn.com/employees\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><Name>Elizabeth</Name><ID>2006</ID></Person>";
+
+        Utils.CompareResult result2 = Utils.Compare(baseline2, actualOutput2);
+        Assert.True(result2.Equal, $"{nameof(actualOutput2)} was not as expected: {Environment.NewLine}Expected: {baseline2}{Environment.NewLine}Actual: {actualOutput2}");
     }
 
     [Fact]
@@ -2758,7 +2780,7 @@ public static partial class DataContractSerializerTests
         value.Member4 = "44";
 
         var actual = SerializeAndDeserialize(
-            value, 
+            value,
             "<TypeWithSerializableAttributeAndNonSerializedField xmlns=\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><Member1>11</Member1><_member2>22</_member2><_member3>33</_member3></TypeWithSerializableAttributeAndNonSerializedField>",
             skipStringCompare: false);
         Assert.NotNull(actual);

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2668,6 +2668,9 @@ public static partial class DataContractSerializerTests
         Assert.Equal(DateTimeOffset.MaxValue, ((DTOContainer)deserialized.Data).nDTO);
     }
 
+#if ReflectionOnly
+    [ActiveIssue(13699)]
+#endif
     [Fact]
     public static void DCS_ExtensionDataObjectTest()
     {

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2678,7 +2678,7 @@ public static partial class DataContractSerializerTests
         p2.Name = "Elizabeth";
         p2.ID = 2006;
 
-        // Serializaze the PersonV2 object
+        // Serialize the PersonV2 object
         var ser = new DataContractSerializer(typeof(PersonV2));
         var ms1 = new MemoryStream();
         ser.WriteObject(ms1, p2);
@@ -2701,7 +2701,7 @@ public static partial class DataContractSerializerTests
         Assert.True(p1.ExtensionData != null, $"{nameof(p1.ExtensionData)} was null.");
         Assert.Equal(p2.Name, p1.Name);
 
-        // Serializaze the Person instance
+        // Serialize the Person instance
         var ms2 = new MemoryStream();
         ser2.WriteObject(ms2, p1);
 

--- a/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
@@ -333,30 +333,14 @@ public static class XmlDictionaryWriterTest
         if (rwType != ReaderWriterFactory.ReaderWriterType.MTOM)
         {
             // stream should be released right after WriteValue
-            if (myStreamProvider.StreamReleased)
-            {
-                Console.WriteLine("Ok, stream released right after WriteValue");
-            }
-            else
-            {
-                Console.WriteLine("Error, stream not released after WriteValue");
-                return false;
-            }
+            Assert.True(myStreamProvider.StreamReleased, "Error, stream not released after WriteValue");
         }
         writer.WriteEndElement();
 
         // stream should be released now for MTOM
         if (rwType == ReaderWriterFactory.ReaderWriterType.MTOM)
         {
-            if (myStreamProvider.StreamReleased)
-            {
-                Console.WriteLine("Ok, stream released right after WriteValue");
-            }
-            else
-            {
-                Console.WriteLine("Error, stream not released after WriteValue");
-                return false;
-            }
+            Assert.True(myStreamProvider.StreamReleased, "Error, stream not released after WriteEndElement");
         }
         writer.Flush();
         return true;
@@ -368,15 +352,7 @@ public static class XmlDictionaryWriterTest
         writer.WriteStartElement("Root");
         Task writeValueAsynctask = writer.WriteValueAsync(myStreamProvider);
         writeValueAsynctask.Wait();
-        if (myStreamProvider.StreamReleased)
-        {
-            Console.WriteLine("Ok, stream released right after AsyncWriteValue");
-        }
-        else
-        {
-            Console.WriteLine("Error, stream not released after AsyncWriteValue");
-            return false;
-        }
+        Assert.True(myStreamProvider.StreamReleased, "Error, stream not released.");
         writer.WriteEndElement();
         writer.Flush();
         return true;
@@ -388,16 +364,7 @@ public static class XmlDictionaryWriterTest
         writer.WriteStartElement("Root");
         Task writeValueBase64Asynctask = writer.WriteBase64Async(byteArray, 0, byteArray.Length);
         writeValueBase64Asynctask.Wait();
-
-        if (myStreamProvider.StreamReleased)
-        {
-            Console.WriteLine("Ok, stream released right after AsyncWriteValueBase64");
-        }
-        else
-        {
-            Console.WriteLine("Error, stream not released after AsyncWriteValueBase64");
-            return false;
-        }
+        Assert.True(myStreamProvider.StreamReleased, "Error, stream not released.");
         writer.WriteEndElement();
         writer.Flush();
         return true;


### PR DESCRIPTION
Made DataContractSerializer and DataContractJsonSerializer support IExtensibleDataObject and ExtensionDataObject.

Fix #12767.