### PR TITLE
Improve hash codes in Drawing Primitives

### DIFF
--- a/src/System.Drawing.Primitives/src/System.Drawing.Primitives.csproj
+++ b/src/System.Drawing.Primitives/src/System.Drawing.Primitives.csproj
@@ -29,6 +29,9 @@
     <Compile Include="$(CommonPath)\System\Drawing\ColorTable.cs">
       <Link>System\Drawing\ColorTable.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Numerics\Hashing\HashHelpers.cs">
+      <Link>Common\System\Numerics\Hashing\HashHelpers.cs</Link>
+    </Compile>
     <Compile Include="System\Drawing\KnownColor.cs" />
     <Compile Include="System\Drawing\KnownColorTable.cs" />
     <Compile Include="System\Drawing\SystemColors.cs" />

--- a/src/System.Drawing.Primitives/src/System/Drawing/Point.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Point.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Numerics.Hashing;
+
 namespace System.Drawing
 {
     /// <summary>
@@ -229,10 +231,7 @@ namespace System.Drawing
         ///       Returns a hash code.
         ///    </para>
         /// </summary>
-        public override int GetHashCode()
-        {
-            return _x ^ _y;
-        }
+        public override int GetHashCode() => HashHelpers.Combine(X, Y);
 
         /// <summary>
         ///    Translates this <see cref='System.Drawing.Point'/> by the specified amount.

--- a/src/System.Drawing.Primitives/src/System/Drawing/PointF.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/PointF.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Numerics.Hashing;
+
 namespace System.Drawing
 {
     /// <summary>
@@ -194,10 +196,7 @@ namespace System.Drawing
             return comp.X == X && comp.Y == Y;
         }
 
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
+        public override int GetHashCode() => HashHelpers.Combine(X.GetHashCode(), Y.GetHashCode());
 
         public override string ToString()
         {

--- a/src/System.Drawing.Primitives/src/System/Drawing/Rectangle.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Rectangle.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.Contracts;
+using System.Numerics.Hashing;
 
 namespace System.Drawing
 {
@@ -344,10 +345,7 @@ namespace System.Drawing
         }
 
         public override int GetHashCode()
-        {
-            return (int)((uint)X ^ (((uint)Y << 13) | ((uint)Y >> 19)) ^
-                (((uint)Width << 26) | ((uint)Width >> 6)) ^ (((uint)Height << 7) | ((uint)Height >> 25)));
-        }
+            => HashHelpers.Combine(HashHelpers.Combine(HashHelpers.Combine(X, Y), Width), Height);
 
         /// <summary>
         ///    <para>

--- a/src/System.Drawing.Primitives/src/System/Drawing/RectangleF.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/RectangleF.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.Contracts;
+using System.Numerics.Hashing;
 
 namespace System.Drawing
 {
@@ -326,10 +327,9 @@ namespace System.Drawing
         ///    Gets the hash code for this <see cref='System.Drawing.RectangleF'/>.
         /// </summary>
         public override int GetHashCode()
-        {
-            return (int)((uint)X ^ (((uint)Y << 13) | ((uint)Y >> 19)) ^
-                (((uint)Width << 26) | ((uint)Width >> 6)) ^ (((uint)Height << 7) | ((uint)Height >> 25)));
-        }
+            => HashHelpers.Combine(
+                    HashHelpers.Combine(HashHelpers.Combine(X.GetHashCode(), Y.GetHashCode()), Width.GetHashCode()),
+                    Height.GetHashCode());
 
         /// <summary>
         ///    <para>

--- a/src/System.Drawing.Primitives/src/System/Drawing/Size.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Size.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Numerics.Hashing;
+
 namespace System.Drawing
 {
     /**
@@ -227,10 +229,7 @@ namespace System.Drawing
         ///       Returns a hash code.
         ///    </para>
         /// </summary>
-        public override int GetHashCode()
-        {
-            return _width ^ _height;
-        }
+        public override int GetHashCode() => HashHelpers.Combine(Width, Height);
 
         /// <summary>
         ///    <para>

--- a/src/System.Drawing.Primitives/src/System/Drawing/SizeF.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/SizeF.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Numerics.Hashing;
+
 namespace System.Drawing
 {
     /**
@@ -210,10 +212,7 @@ namespace System.Drawing
             return (comp.Width == Width) && (comp.Height == Height);
         }
 
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
+        public override int GetHashCode() => HashHelpers.Combine(Width.GetHashCode(), Height.GetHashCode());
 
         public PointF ToPointF()
         {


### PR DESCRIPTION
Closes #5256

There's no perfect balance of hash quality and speed but this takes a moderate mult-and-add with 31 as the multiplier. Better bit-mixing could certainly be done, but taking more time.

`Rectangle` was left alone, but `RectangleF` changed to take the hash of each single-precision float rather than casting to `uint` and losing bits.

Also changed some `&&` to `&` in tests where avoiding the branch is likely cheaper than avoiding the rhs field access.