### PR TITLE
Remove Invalid Debug Assertion from BlockExpression

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -30,14 +30,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the last expression in this block.
         /// </summary>
-        public Expression Result
-        {
-            get
-            {
-                Debug.Assert(ExpressionCount > 0);
-                return GetExpression(ExpressionCount - 1);
-            }
-        }
+        public Expression Result => GetExpression(ExpressionCount - 1);
 
         internal BlockExpression()
         {

--- a/src/System.Linq.Expressions/tests/Block/BlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockTests.cs
@@ -162,6 +162,7 @@ namespace System.Linq.Expressions.Tests
         {
             var block = Expression.Block();
             Assert.Equal(typeof(void), block.Type);
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => block.Result);
             Action nop = Expression.Lambda<Action>(block).Compile(useInterpreter);
             nop();
         }
@@ -172,6 +173,7 @@ namespace System.Linq.Expressions.Tests
         {
             var block = Expression.Block(typeof(void));
             Assert.Equal(typeof(void), block.Type);
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => block.Result);
             Action nop = Expression.Lambda<Action>(block).Compile(useInterpreter);
             nop();
         }
@@ -188,6 +190,7 @@ namespace System.Linq.Expressions.Tests
         {
             var scope = Expression.Block(new[] { Expression.Parameter(typeof(int), "x") }, new Expression[0]);
             Assert.Equal(typeof(void), scope.Type);
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => scope.Result);
             Action nop = Expression.Lambda<Action>(scope).Compile(useInterpreter);
             nop();
         }
@@ -198,6 +201,7 @@ namespace System.Linq.Expressions.Tests
         {
             var scope = Expression.Block(typeof(void), new[] { Expression.Parameter(typeof(int), "x") }, new Expression[0]);
             Assert.Equal(typeof(void), scope.Type);
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => scope.Result);
             Action nop = Expression.Lambda<Action>(scope).Compile(useInterpreter);
             nop();
         }


### PR DESCRIPTION
There is an assertion that `ExpressionCount > 0` in `Result` that has not been valid for some time. Remove it.

Add tests for the `ArgumentOutOfRangeException` when it's accessed in this state.