### PR TITLE
Reduce allocations in HttpClient.GetString/ByteArrayAsync

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.IO;
@@ -20,7 +21,7 @@ namespace System.Net.Http
         private Task<Stream> _contentReadStream;
         private bool _canCalculateLength;
 
-        internal const long MaxBufferSize = Int32.MaxValue;
+        internal const int MaxBufferSize = int.MaxValue;
         internal static readonly Encoding DefaultStringEncoding = Encoding.UTF8;
 
         private const int UTF8CodePage = 65001;
@@ -165,7 +166,7 @@ namespace System.Net.Http
             return WaitAndReturnAsync(LoadIntoBufferAsync(), this, s => s.ReadBufferedContentAsString());
         }
 
-        internal string ReadBufferedContentAsString()
+        private string ReadBufferedContentAsString()
         {
             Debug.Assert(IsBuffered);
 
@@ -174,6 +175,17 @@ namespace System.Net.Http
                 return string.Empty;
             }
 
+            ArraySegment<byte> buffer;
+            if (!TryGetBuffer(out buffer))
+            {
+                buffer = new ArraySegment<byte>(_bufferedContent.ToArray());
+            }
+
+            return ReadBufferAsString(buffer, Headers);
+        }
+
+        internal static string ReadBufferAsString(ArraySegment<byte> buffer, HttpContentHeaders headers)
+        {
             // We don't validate the Content-Encoding header: If the content was encoded, it's the caller's 
             // responsibility to make sure to only call ReadAsString() on already decoded content. E.g. if the 
             // Content-Encoding is 'gzip' the user should set HttpClientHandler.AutomaticDecompression to get a 
@@ -182,19 +194,13 @@ namespace System.Net.Http
             Encoding encoding = null;
             int bomLength = -1;
 
-            ArraySegment<byte> buffer;
-            if (!TryGetBuffer(out buffer))
-            {
-                buffer = new ArraySegment<byte>(_bufferedContent.ToArray());
-            }
-
             // If we do have encoding information in the 'Content-Type' header, use that information to convert
             // the content to a string.
-            if ((Headers.ContentType != null) && (Headers.ContentType.CharSet != null))
+            if ((headers.ContentType != null) && (headers.ContentType.CharSet != null))
             {
                 try
                 {
-                    encoding = Encoding.GetEncoding(Headers.ContentType.CharSet);
+                    encoding = Encoding.GetEncoding(headers.ContentType.CharSet);
 
                     // Byte-order-mark (BOM) characters may be present even if a charset was specified.
                     bomLength = GetPreambleLength(buffer, encoding);
@@ -629,6 +635,11 @@ namespace System.Net.Http
             return returnFunc(state);
         }
 
+        private static Exception CreateOverCapacityException(int maxBufferSize)
+        {
+            return new HttpRequestException(SR.Format(SR.net_http_content_buffersize_exceeded, maxBufferSize));
+        }
+
         internal sealed class LimitMemoryStream : MemoryStream
         {
             private readonly int _maxSize;
@@ -641,6 +652,14 @@ namespace System.Net.Http
             }
 
             public int MaxSize => _maxSize;
+
+            public byte[] GetSizedBuffer()
+            {
+                ArraySegment<byte> buffer;
+                return TryGetBuffer(out buffer) && buffer.Offset == 0 && buffer.Count == buffer.Array.Length ?
+                    buffer.Array :
+                    ToArray();
+            }
 
             public override void Write(byte[] buffer, int offset, int count)
             {
@@ -682,9 +701,135 @@ namespace System.Net.Http
             {
                 if (_maxSize - Length < countToAdd)
                 {
-                    throw new HttpRequestException(string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_content_buffersize_exceeded, _maxSize));
+                    throw CreateOverCapacityException(_maxSize);
                 }
             }
+        }
+
+        internal sealed class LimitArrayPoolWriteStream : Stream
+        {
+            private const int MaxByteArrayLength = 0x7FFFFFC7;
+            private const int InitialLength = 256;
+
+            private readonly int _maxBufferSize;
+            private byte[] _buffer;
+            private int _length;
+
+            public LimitArrayPoolWriteStream(int maxBufferSize) : this(maxBufferSize, InitialLength) { }
+
+            public LimitArrayPoolWriteStream(int maxBufferSize, long capacity)
+            {
+                if (capacity < InitialLength)
+                {
+                    capacity = InitialLength;
+                }
+                else if (capacity > maxBufferSize)
+                {
+                    throw CreateOverCapacityException(maxBufferSize);
+                }
+
+                _maxBufferSize = maxBufferSize;
+                _buffer = ArrayPool<byte>.Shared.Rent((int)capacity);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                Debug.Assert(_buffer != null);
+
+                ArrayPool<byte>.Shared.Return(_buffer);
+                _buffer = null;
+
+                base.Dispose(disposing);
+            }
+
+            public ArraySegment<byte> GetBuffer() => new ArraySegment<byte>(_buffer, 0, _length);
+
+            public byte[] ToArray()
+            {
+                var arr = new byte[_length];
+                Buffer.BlockCopy(_buffer, 0, arr, 0, _length);
+                return arr;
+            }
+
+            private void EnsureCapacity(int value)
+            {
+                if (value > _buffer.Length)
+                {
+                    Grow(value);
+                }
+                else if (value < 0) // overflow
+                {
+                    throw CreateOverCapacityException(_maxBufferSize);
+                }
+            }
+
+            private void Grow(int value)
+            {
+                Debug.Assert(value > _buffer.Length);
+                if (value > _maxBufferSize)
+                {
+                    throw CreateOverCapacityException(_maxBufferSize);
+                }
+
+                // Extract the current buffer to be replaced.
+                byte[] currentBuffer = _buffer;
+                _buffer = null;
+
+                // Determine the capacity to request for the new buffer.  It should be
+                // at least twice as long as the current one, if not more if the requested
+                // value is more than that.  If the new value would put it longer than the max
+                // allowed byte array, than shrink to that (and if the required length is actually
+                // longer than that, we'll let the runtime throw).
+                uint twiceLength = 2 * (uint)currentBuffer.Length;
+                int newCapacity = twiceLength > MaxByteArrayLength ?
+                    (value > MaxByteArrayLength ? value : MaxByteArrayLength) :
+                    Math.Max(value, (int)twiceLength);
+
+                // Get a new buffer, copy the current one to it, return the current one, and
+                // set the new buffer as current.
+                byte[] newBuffer = ArrayPool<byte>.Shared.Rent(newCapacity);
+                Buffer.BlockCopy(currentBuffer, 0, newBuffer, 0, _length);
+                ArrayPool<byte>.Shared.Return(currentBuffer);
+                _buffer = newBuffer;
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                Debug.Assert(buffer != null);
+                Debug.Assert(offset >= 0);
+                Debug.Assert(count >= 0);
+
+                EnsureCapacity(_buffer.Length + count);
+                Buffer.BlockCopy(buffer, offset, _buffer, _length, count);
+                _length += count;
+            }
+
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                Write(buffer, offset, count);
+                return Task.CompletedTask;
+            }
+
+            public override void WriteByte(byte value)
+            {
+                int newLength = _buffer.Length + 1;
+                EnsureCapacity(newLength);
+                _buffer[_length] = value;
+                _length = newLength;
+            }
+
+            public override void Flush() { }
+            public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public override long Length => _length;
+            public override bool CanWrite => true;
+            public override bool CanRead => false;
+            public override bool CanSeek => false;
+
+            public override long Position { get { throw new NotSupportedException(); } set { throw new NotSupportedException(); } }
+            public override int Read(byte[] buffer, int offset, int count) { throw new NotSupportedException(); }
+            public override long Seek(long offset, SeekOrigin origin) { throw new NotSupportedException(); }
+            public override void SetLength(long value) { throw new NotSupportedException(); }
         }
     }
 }

--- a/src/System.Net.Http/tests/UnitTests/project.json
+++ b/src/System.Net.Http/tests/UnitTests/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.2.0-beta-24717-02",
+    "System.Buffers": "4.4.0-beta-24717-02",
     "System.Diagnostics.Contracts": "4.4.0-beta-24717-02",
     "System.Diagnostics.Tools": "4.4.0-beta-24717-02",
     "System.Diagnostics.Tracing": "4.4.0-beta-24717-02",


### PR DESCRIPTION
Today, HttpClient.GetStringAsync and GetByteArrayAsync copy all of the response data to a MemoryStream.  For strings, that buffer is never exposed, so it ends up being temporary garbage.  For byte arrays, the data is extracted from the MemoryStream with ToArray, which means double the allocations.

This commit does three things:
    - It introduces a helper Stream based on ArrayPool, where all buffers come from the shared pool.
    - GetStringAsync uses that stream as the target, such that the byte[]s used are recycled with the pool, avoiding per-request allocations.
    - GetByteArrayAsync uses that stream as the target if a content length couldn't be determined, so that the byte[]s incurred as the stream grows are recycled.  And if a content length can be determined, it uses a MemoryStream and then returns that MemoryStream's buffer directly to the caller, avoiding the extra buffer allocation and copy.

As an example, this program is concurrently downloading a 12K web page a thousand times:
```C#
using System;
using System.IO;
using System.Linq;
using System.Net.Http;
using System.Threading;
using System.Threading.Tasks;

class Program
{
    static void Main()
    {
        var client = new HttpClient() { Timeout = Timeout.InfiniteTimeSpan };
        var uri = new Uri("http://localhost:8080/");
        Task.WaitAll(Enumerable.Range(0, 1000).Select(_ => client.GetByteArrayAsync(uri)).ToArray());
    }
}
```
Before the change the program allocates ~27.5MB, and after the change it allocates ~16.2MB (~40% reduction).  Similarly, if the GetByteArrayAsync above is changed to GetStringAsync, before the change the program allocates ~39.5MB, and after the change the program allocates ~28.8MB (~30% reduction).

Contributes to #13589
cc: @davidsh, @cipop, @geoffkizer 