### PR TITLE
Test Debug Proxies of Expression  and Dynamic objects

### DIFF
--- a/src/System.Linq.Expressions/tests/DebuggerTypeProxy/ExpressionDebuggerTypeProxyTests.cs
+++ b/src/System.Linq.Expressions/tests/DebuggerTypeProxy/ExpressionDebuggerTypeProxyTests.cs
@@ -1,0 +1,410 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class ExpressionDebuggerTypeProxyTests
+    {
+        private class Inner
+        {
+            public int Value { get; set; }
+        }
+
+        private class Outer
+        {
+            public Inner InnerProperty { get; set; } = new Inner();
+        }
+
+        private static readonly PropertyInfo DebugViewProperty = typeof(Expression).GetProperty(
+            "DebugView", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+
+        // Available via Arguments and Expressions properties
+        private static readonly string[] ExcludedPropertyNames = {"ArgumentCount", "ExpressionCount"};
+
+        private Type GetDebugViewType(Type type)
+        {
+            var att =
+                (DebuggerTypeProxyAttribute)
+                    type.GetCustomAttributes().Single(at => at.TypeId.Equals(typeof(DebuggerTypeProxyAttribute)));
+            var proxyName = att.ProxyTypeName;
+            proxyName = proxyName.Substring(0, proxyName.IndexOf(','));
+            return type.GetTypeInfo().Assembly.GetType(proxyName);
+        }
+
+        private void AssertIsReadOnly<T>(ICollection<T> collection)
+        {
+            Assert.True(collection.IsReadOnly);
+            Assert.Throws<NotSupportedException>(() => collection.Clear());
+            Assert.Throws<NotSupportedException>(() => collection.Add(default(T)));
+            Assert.Throws<NotSupportedException>(() => collection.Remove(default(T)));
+        }
+
+        [Theory]
+        [MemberData(nameof(BinaryExpressionProxy))]
+        [MemberData(nameof(BlockExpressionProxy))]
+        [MemberData(nameof(CatchBlockProxy))]
+        [MemberData(nameof(ConditionalExpressionProxy))]
+        [MemberData(nameof(ConstantExpressionProxy))]
+        [MemberData(nameof(DebugInfoExpressionProxy))]
+        [MemberData(nameof(DefaultExpressionProxy))]
+        [MemberData(nameof(GotoExpressionProxy))]
+        [MemberData(nameof(IndexExpressionProxy))]
+        [MemberData(nameof(InvocationExpressionProxy))]
+        [MemberData(nameof(LabelExpressionProxy))]
+        [MemberData(nameof(LambdaExpressionProxy))]
+        [MemberData(nameof(ListInitExpressionProxy))]
+        [MemberData(nameof(LoopExpressionProxy))]
+        [MemberData(nameof(MemberExpressionProxy))]
+        [MemberData(nameof(MemberInitExpressionProxy))]
+        [MemberData(nameof(MethodCallExpressionProxy))]
+        [MemberData(nameof(NewArrayExpressionProxy))]
+        [MemberData(nameof(NewExpressionProxy))]
+        [MemberData(nameof(ParameterExpressionProxy))]
+        [MemberData(nameof(RuntimeVariablesExpressionProxy))]
+        [MemberData(nameof(SwitchCaseExpressionProxy))]
+        [MemberData(nameof(SwitchExpressionProxy))]
+        [MemberData(nameof(TryExpressionProxy))]
+        [MemberData(nameof(TypeBinaryExpressionProxy))]
+        [MemberData(nameof(UnaryExpressionProxy))]
+        public void VerifyDebugView(object obj)
+        {
+            var type = obj.GetType();
+            var viewType = GetDebugViewType(type);
+            var view = viewType.GetConstructors().Single().Invoke(new[] {obj});
+            var properties =
+                type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy)
+                    .Where(pr => !ExcludedPropertyNames.Contains(pr.Name) && pr.CanRead);
+            if (obj is Expression)
+            {
+                properties = properties.Append(DebugViewProperty);
+            }
+            foreach (var property in properties)
+            {
+                string name = property.Name;
+                var proxyProperty = viewType.GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
+                Assert.True(proxyProperty != null, $"Could not find property {name} in proxy for {type}");
+                Assert.True(proxyProperty.CanRead);
+                Assert.False(proxyProperty.CanWrite);
+                object value;
+                try
+                {
+                    value = property.GetValue(obj);
+                }
+                catch (Exception ex)
+                {
+                    Exception proxyEx = Assert.ThrowsAny<Exception>(() => proxyProperty.GetValue(view));
+                    Assert.IsType(ex.GetType(), proxyEx);
+                    continue;
+                }
+
+                var proxyValue = proxyProperty.GetValue(view);
+                Assert.Equal(value, proxyValue);
+                if (!(proxyValue is string) && proxyValue is IEnumerable)
+                {
+                    var exCol = proxyValue as ICollection<Expression>;
+                    if (exCol != null)
+                    {
+                        AssertIsReadOnly(exCol);
+                        continue;
+                    }
+
+                    var parCol = proxyValue as ICollection<ParameterExpression>;
+                    if (parCol != null)
+                    {
+                        AssertIsReadOnly(parCol);
+                        continue;
+                    }
+
+                    var elCol = proxyValue as ICollection<ElementInit>;
+                    if (elCol != null)
+                    {
+                        AssertIsReadOnly(elCol);
+                        continue;
+                    }
+
+                    var mbCol = proxyValue as ICollection<MemberBinding>;
+                    if (mbCol != null)
+                    {
+                        AssertIsReadOnly(mbCol);
+                        continue;
+                    }
+
+                    var miCol = proxyValue as ICollection<MemberInfo>;
+                    if (miCol != null)
+                    {
+                        AssertIsReadOnly(miCol);
+                        continue;
+                    }
+
+                    var scCol = proxyValue as ICollection<SwitchCase>;
+                    if (scCol != null)
+                    {
+                        AssertIsReadOnly(scCol);
+                        continue;
+                    }
+
+                    AssertIsReadOnly((ICollection<CatchBlock>)proxyValue);
+                }
+            }
+        }
+
+        private static IEnumerable<object[]> BinaryExpressionProxy()
+        {
+            yield return new object[] {Expression.Assign(Expression.Variable(typeof(int)), Expression.Constant(-1))};
+            yield return new object[] {Expression.Equal(Expression.Constant(false), Expression.Constant(true))};
+            yield return new object[] {Expression.AddAssign(Expression.Parameter(typeof(int)), Expression.Constant(2))};
+            yield return new object[] {Expression.Assign(Expression.Parameter(typeof(int)), Expression.Constant(2))};
+        }
+
+        private static IEnumerable<object[]> BlockExpressionProxy()
+        {
+            for (int paramCount = 0; paramCount != 4; ++paramCount)
+            {
+                var parameters = Enumerable.Range(0, paramCount).Select(x => Expression.Parameter(typeof(int))).ToList();
+                for (int count = 0; count != 7; ++count)
+                {
+                    yield return
+                        new object[]
+                        {Expression.Block(parameters, Enumerable.Range(0, count).Select(x => Expression.Constant(x)))};
+                }
+            }
+        }
+
+        private static IEnumerable<object[]> CatchBlockProxy()
+        {
+            yield return new object[] {Expression.Catch(typeof(InvalidFilterCriteriaException), Expression.Empty())};
+            yield return
+                new object[]
+                {Expression.Catch(typeof(InvalidCastException), Expression.Constant(3), Expression.Constant(false))};
+            yield return
+                new object[]
+                {Expression.Catch(Expression.Variable(typeof(InvalidFilterCriteriaException)), Expression.Empty())};
+            yield return
+                new object[]
+                {
+                    Expression.Catch(
+                        Expression.Variable(typeof(InvalidCastException)), Expression.Constant(3),
+                        Expression.Constant(false))
+                };
+        }
+
+        private static IEnumerable<object[]> ConditionalExpressionProxy()
+        {
+            yield return new object[] {Expression.IfThen(Expression.Constant(false), Expression.Constant(1))};
+            yield return
+                new object[]
+                {Expression.IfThenElse(Expression.Constant(false), Expression.Constant(2), Expression.Constant(3))};
+            yield return
+                new object[]
+                {Expression.Condition(Expression.Constant(true), Expression.Constant(4), Expression.Constant(5))};
+            yield return
+                new object[]
+                {
+                    Expression.Condition(
+                        Expression.Constant(true), Expression.Constant(""), Expression.Constant(""), typeof(object))
+                };
+        }
+
+        private static IEnumerable<object[]> ConstantExpressionProxy()
+        {
+            yield return new object[] {Expression.Constant(DateTime.UtcNow)};
+            yield return new object[] {Expression.Constant(null)};
+            yield return new object[] {Expression.Constant(null, typeof(int?))};
+        }
+
+        private static IEnumerable<object[]> DebugInfoExpressionProxy()
+        {
+            yield return new object[] {Expression.ClearDebugInfo(Expression.SymbolDocument(""))};
+            yield return new object[] {Expression.DebugInfo(Expression.SymbolDocument(""), 1, 2, 3, 4)};
+        }
+
+        private static IEnumerable<object[]> DefaultExpressionProxy()
+        {
+            yield return new object[] {Expression.Empty()};
+            yield return new object[] {Expression.Default(typeof(int))};
+        }
+
+        private static IEnumerable<object[]> GotoExpressionProxy()
+        {
+            yield return new object[] {Expression.Continue(Expression.Label(typeof(void)))};
+            yield return new object[] {Expression.Break(Expression.Label(typeof(void)), typeof(void))};
+            yield return
+                new object[]
+                {Expression.Return(Expression.Label(typeof(object)), Expression.Constant(""), typeof(object))};
+        }
+
+        private static IEnumerable<object[]> IndexExpressionProxy()
+        {
+            yield return
+                new object[] {Expression.ArrayAccess(Expression.Constant(new[] {1, 2, 3}), Expression.Constant(2))};
+            yield return
+                new object[]
+                {
+                    Expression.Property(
+                        Expression.Default(typeof(Dictionary<string, int>)), "Item", Expression.Constant("key"))
+                };
+        }
+
+        private static IEnumerable<object[]> InvocationExpressionProxy()
+        {
+            Func<int, int, int> addFunc = (x, y) => x + y;
+            yield return
+                new object[]
+                {Expression.Invoke(Expression.Constant(addFunc), Expression.Constant(4), Expression.Constant(5))};
+
+            for (int i = 0; i != 7; ++i)
+            {
+                var parameters = Enumerable.Range(0, i).Select(_ => Expression.Parameter(typeof(int))).ToArray();
+                var arguments = Enumerable.Range(0, i).Select(x => (Expression)Expression.Constant(x)).ToArray();
+                yield return
+                    new object[] {Expression.Invoke(Expression.Lambda(Expression.Empty(), parameters), arguments)};
+                yield return
+                    new object[] {Expression.Invoke(Expression.Lambda(Expression.Constant(0), parameters), arguments)};
+            }
+        }
+
+        private static IEnumerable<object[]> LabelExpressionProxy()
+        {
+            yield return new object[] {Expression.Label(Expression.Label(typeof(void)))};
+            yield return new object[] {Expression.Label(Expression.Label(typeof(string)), Expression.Constant("!"))};
+        }
+
+        private static IEnumerable<object[]> LambdaExpressionProxy()
+        {
+            Expression<Func<int, int, int>> add = (x, y) => x + y;
+            yield return new object[] {add};
+            yield return new object[] {Expression.Lambda(Expression.Empty())};
+        }
+
+        private static IEnumerable<object[]> ListInitExpressionProxy()
+        {
+            Expression<Func<List<int>>> exp = () => new List<int> {1, 2, 3};
+            yield return new object[] {exp.Body};
+        }
+
+        private static IEnumerable<object[]> LoopExpressionProxy()
+        {
+            yield return new object[] {Expression.Loop(Expression.Empty())};
+            yield return new object[] {Expression.Loop(Expression.Empty(), Expression.Label(typeof(void)))};
+            yield return
+                new object[]
+                {Expression.Loop(Expression.Empty(), Expression.Label(typeof(void)), Expression.Label(typeof(void)))};
+        }
+
+        private static IEnumerable<object[]> MemberExpressionProxy()
+        {
+            yield return new object[] {Expression.Field(null, typeof(ExpressionDebuggerTypeProxyTests), nameof(DebugViewProperty))};
+            yield return new object[] {Expression.Property(Expression.Constant(""), "Length")};
+        }
+
+        private static IEnumerable<object[]> MemberInitExpressionProxy()
+        {
+            yield return
+                new object[]
+                {
+                    Expression.MemberInit(
+                        Expression.New(typeof(Outer)),
+                        Expression.MemberBind(
+                            typeof(Outer).GetProperty(nameof(Outer.InnerProperty)),
+                            Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(3))))
+                };
+        }
+
+        private static IEnumerable<object[]> MethodCallExpressionProxy()
+        {
+            yield return new object[] {Expression.Call(Expression.Constant(1), "ToString", new Type[0])};
+            Expression<Func<bool>> exp = () => 1.Equals(2);
+            yield return new object[] {exp.Body};
+        }
+
+        private static IEnumerable<object[]> NewArrayExpressionProxy()
+        {
+            yield return
+                new object[] {Expression.NewArrayBounds(typeof(int), Expression.Constant(2), Expression.Constant(2))};
+            yield return
+                new object[]
+                {Expression.NewArrayInit(typeof(string), Expression.Constant("A"), Expression.Constant("B"))};
+        }
+
+        private static IEnumerable<object[]> NewExpressionProxy()
+        {
+            yield return new object[] {Expression.New(typeof(object))};
+            yield return
+                new object[]
+                {
+                    Expression.New(
+                        typeof(string).GetConstructors().First(c => c.GetParameters().Length == 2),
+                        Expression.Constant('x'), Expression.Constant(3))
+                };
+        }
+
+        private static IEnumerable<object[]> ParameterExpressionProxy()
+        {
+            yield return new object[] {Expression.Variable(typeof(int))};
+            yield return new object[] {Expression.Parameter(typeof(Expression))};
+            yield return new object[] {Expression.Parameter(typeof(int).MakeByRefType())};
+        }
+
+        private static IEnumerable<object[]> RuntimeVariablesExpressionProxy()
+        {
+            yield return new object[] {Expression.RuntimeVariables(Expression.Variable(typeof(int)))};
+            yield return new object[] {Expression.RuntimeVariables()};
+        }
+
+        private static IEnumerable<object[]> SwitchCaseExpressionProxy()
+        {
+            yield return new object[] {Expression.SwitchCase(Expression.Empty(), Expression.Constant(0))};
+        }
+
+        private static IEnumerable<object[]> SwitchExpressionProxy()
+        {
+            yield return new object[] {Expression.Switch(Expression.Constant(2))};
+            yield return
+                new object[]
+                {
+                    Expression.Switch(
+                        Expression.Constant(2), Expression.Constant("!"),
+                        Expression.SwitchCase(Expression.Constant("X"), Expression.Constant(1)))
+                };
+        }
+
+        private static IEnumerable<object[]> TryExpressionProxy()
+        {
+            yield return new object[] {Expression.TryFault(Expression.Empty(), Expression.Empty())};
+            yield return new object[] {Expression.TryFinally(Expression.Empty(), Expression.Empty())};
+            yield return
+                new object[]
+                {
+                    Expression.TryCatch(
+                        Expression.Constant(1), Expression.Catch(typeof(Exception), Expression.Constant(2)))
+                };
+            yield return
+                new object[]
+                {
+                    Expression.TryCatchFinally(
+                        Expression.Constant(1), Expression.Empty(),
+                        Expression.Catch(typeof(Exception), Expression.Constant(2)))
+                };
+        }
+
+        private static IEnumerable<object[]> TypeBinaryExpressionProxy()
+        {
+            yield return new object[] {Expression.TypeIs(Expression.Constant(2), typeof(string))};
+            yield return new object[] {Expression.TypeAs(Expression.Constant("", typeof(object)), typeof(string))};
+        }
+
+        private static IEnumerable<object[]> UnaryExpressionProxy()
+        {
+            yield return new object[] {Expression.Not(Expression.Constant(true))};
+            yield return new object[] {Expression.Increment(Expression.Variable(typeof(int)))};
+            yield return new object[] {Expression.OnesComplement(Expression.Constant(23))};
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Dynamic/BindingRestrictionsProxyTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/BindingRestrictionsProxyTests.cs
@@ -1,0 +1,174 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace System.Dynamic.Tests
+{
+    public class BindingRestrictionsProxyTests
+    {
+        private class BindingRestrictionsProxyProxy
+        {
+            // Proxy the proxy, to not have to make the same reflection calls repeatedly.
+
+            private static PropertyInfo _isEmpty;
+            private static PropertyInfo _test;
+            private static PropertyInfo _restrictions;
+            private static readonly MethodInfo ToStringMeth = typeof(object).GetMethod("ToString");
+
+            private readonly object _proxy;
+
+            public BindingRestrictionsProxyProxy(object proxy)
+            {
+                _proxy = proxy;
+                if (_isEmpty == null)
+                {
+                    Type type = _proxy.GetType();
+                    _isEmpty = type.GetProperty("IsEmpty");
+                    _test = type.GetProperty("Test");
+                    _restrictions = type.GetProperty("Restrictions");
+                }
+            }
+
+            public bool IsEmpty => (bool)_isEmpty.GetValue(_proxy);
+
+            public Expression Test => (Expression)_test.GetValue(_proxy);
+
+            public BindingRestrictions[] Restrictions => (BindingRestrictions[])_restrictions.GetValue(_proxy);
+
+            public override string ToString() => (string)ToStringMeth.Invoke(_proxy, new object[0]);
+        }
+
+        private static readonly ConstructorInfo BindingRestrictionsProxyCtor =
+            GetDebugViewType(typeof(BindingRestrictions)).GetConstructors().Single();
+
+        private static Type GetDebugViewType(Type type)
+        {
+            var att =
+                (DebuggerTypeProxyAttribute)
+                    type.GetCustomAttributes().Single(at => at.TypeId.Equals(typeof(DebuggerTypeProxyAttribute)));
+            var proxyName = att.ProxyTypeName;
+            proxyName = proxyName.Substring(0, proxyName.IndexOf(','));
+            return type.GetTypeInfo().Assembly.GetType(proxyName);
+        }
+
+        private static BindingRestrictionsProxyProxy GetDebugViewObject(object obj)
+            => new BindingRestrictionsProxyProxy(BindingRestrictionsProxyCtor.Invoke(new[] {obj}));
+
+        [Fact]
+        public void EmptyRestiction()
+        {
+            var empty = BindingRestrictions.Empty;
+            var view = GetDebugViewObject(empty);
+            Assert.True(view.IsEmpty);
+            var restrictions = view.Restrictions;
+            Assert.Equal(1, restrictions.Length);
+            Assert.Same(empty, restrictions[0]);
+            Assert.Same(empty.ToExpression(), view.Test);
+            Assert.Equal(empty.ToExpression().ToString(), view.ToString());
+        }
+
+        [Fact]
+        public void CustomRestriction()
+        {
+            var exp = Expression.Constant(false);
+            var custom = BindingRestrictions.GetExpressionRestriction(exp);
+            var view = GetDebugViewObject(custom);
+            Assert.False(view.IsEmpty);
+            var restrictions = view.Restrictions;
+            Assert.Equal(1, restrictions.Length);
+            Assert.Same(custom, restrictions[0]);
+            Assert.NotSame(BindingRestrictions.Empty.ToExpression(), view.Test);
+            Assert.Same(exp, view.Test);
+            Assert.Equal(exp.ToString(), view.ToString());
+        }
+
+        [Fact]
+        public void MergedRestrictionsProperties()
+        {
+            var exps = new Expression[]
+            {
+                Expression.Constant(false), Expression.Constant(true),
+                Expression.Equal(Expression.Constant(2), Expression.Constant(3))
+            };
+
+            var br = BindingRestrictions.Empty;
+            var restrictions = new List<BindingRestrictions>();
+            foreach (var exp in exps)
+            {
+                var res = BindingRestrictions.GetExpressionRestriction(exp);
+                restrictions.Add(res);
+                br = br.Merge(res);
+            }
+
+            var view = GetDebugViewObject(br);
+            Assert.False(view.IsEmpty);
+
+            Assert.Equal(br.ToExpression().ToString(), view.ToString());
+
+            var viewedRestrictions = view.Restrictions;
+
+            // Check equal to source restrictions, but not insisting on order.
+            Assert.Equal(3, viewedRestrictions.Length);
+            Assert.True(viewedRestrictions.All(r => restrictions.Contains(r)));
+        }
+
+        [Fact]
+        public void MergedRestrictionsExpressions()
+        {
+            var exps = new Expression[]
+            {
+                Expression.Constant(false), Expression.Constant(true),
+                Expression.Equal(Expression.Constant(2), Expression.Constant(3))
+            };
+
+            var br = BindingRestrictions.Empty;
+            foreach (var exp in exps)
+            {
+                br = br.Merge(BindingRestrictions.GetExpressionRestriction(exp));
+            }
+
+            var view = GetDebugViewObject(br);
+
+            // The expression in the view will be a tree of AndAlso nodes.
+            // If we examine the expression of the restriction a new AndAlso
+            // will be created, so we strip out the leaf expressions and compare
+            // with the initial set.
+
+            var notAndAlso = new List<Expression>();
+            var vExp = view.Test;
+            Assert.Equal(ExpressionType.AndAlso, vExp.NodeType);
+
+            Stack<Expression> toSplit = new Stack<Expression>();
+            for (;;)
+            {
+                if (vExp.NodeType == ExpressionType.AndAlso)
+                {
+                    var bin = (BinaryExpression)vExp;
+                    toSplit.Push(bin.Left);
+                    vExp = bin.Right;
+                }
+                else
+                {
+                    notAndAlso.Add(vExp);
+                    if (toSplit.Count == 0)
+                    {
+                        break;
+                    }
+
+                    vExp = toSplit.Pop();
+                }
+            }
+
+            // Check equal to source expressions, but not insisting on order.
+            Assert.Equal(3, notAndAlso.Count);
+            Assert.True(notAndAlso.All(ex => exps.Contains(ex)));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="DelegateType\DelegateCreationTests.cs" />
     <Compile Include="DelegateType\FuncTypeTests.cs" />
     <Compile Include="DelegateType\GetDelegateTypeTests.cs" />
+    <Compile Include="Dynamic\BindingRestrictionsProxyTests.cs" />
     <Compile Include="Dynamic\BindingRestrictionsTests.cs" />
     <Compile Include="Dynamic\DynamicObjectDefaultBehaviorTests.cs" />
     <Compile Include="ExceptionHandling\ExceptionHandlingExpressions.cs" />

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Convert\ConvertTests.cs" />
     <Compile Include="DebugInfo\DebugInfoExpressionTests.cs" />
     <Compile Include="DebugInfo\SymbolDocumentInfoTests.cs" />
+    <Compile Include="DebuggerTypeProxy\ExpressionDebuggerTypeProxyTests.cs" />
     <Compile Include="Default\DefaultTests.cs" />
     <Compile Include="DelegateType\ActionTypeTests.cs" />
     <Compile Include="DelegateType\DelegateCreationTests.cs" />


### PR DESCRIPTION
For various types of expression, obtain the `DebuggerTypeProxy` through similar means as that used by a debugger (examine the `DebuggerTypeProxyAttribute` and instantiate the type), then compare the properties obtainable through the proxy with the properties of the expression object itself.

Failure to find a debug property for any public property is considered a failure, with the explicit exceptions of `ArgumentCount` and `ExpressionCount`.

Similar tests for `BindingRestrictions`' proxy, though with differences as it doesn't have the same one-to-one mapping.

Debugger proxies not included:

1. `ExpandoObject`'s keys and values collections. Will do this after #13595 fixes `ExpandoObject`'s dynamic behaviour, #13634 tests it directly, and probably some more tests on `ExpandoObject` itself (maybe at the same time.

2. `InstructionArray` and `InstructionList`. As there's no way to peek through the delegate to the instructions (is there?) testing this would require some particularly artificial use of reflection to create the llists, as well as their proxies. Maybe it'd be better just to exclude these types from coverage.