### PR TITLE
Converting FirstChanceExceptionEventArgs to not be sealed

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -6115,7 +6115,7 @@ namespace System.Runtime.ExceptionServices
     {
         public HandleProcessCorruptedStateExceptionsAttribute() { }
     }
-    public sealed partial class FirstChanceExceptionEventArgs : EventArgs
+    public partial class FirstChanceExceptionEventArgs : EventArgs
     {
         public FirstChanceExceptionEventArgs(Exception exception) { }
         public Exception Exception { get { throw null; } }


### PR DESCRIPTION
cc: @danmosemsft 

Marking FirstChanceExceptionEventArgs as not sealed to match netstandard.

Fixes #13700