### PR TITLE
Deleted System.Security.Permissions dependency from Diagnostics.TraceSource

### DIFF
--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceEventCache.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceEventCache.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Text;
 using System.Collections;
 using System.Globalization;
-using System.Security.Permissions;
 
 namespace System.Diagnostics
 {

--- a/src/System.Diagnostics.TraceSource/src/project.json
+++ b/src/System.Diagnostics.TraceSource/src/project.json
@@ -15,8 +15,7 @@
         "System.Runtime.Extensions": "4.4.0-beta-24715-03",
         "System.Runtime.InteropServices": "4.4.0-beta-24715-03",
         "System.Threading": "4.4.0-beta-24715-03",
-        "System.Threading.Tasks": "4.4.0-beta-24715-03",
-        "System.Security.Permissions": "4.4.0-beta-24715-03"
+        "System.Threading.Tasks": "4.4.0-beta-24715-03"
       }
     },
     "net463": {


### PR DESCRIPTION
Fixes #13721

cc @danmosemsft  @weshaggard @joperezr 