### PR TITLE
Make sure the new AppContext APIs are not part of netstandard2.0

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -83,8 +83,10 @@ namespace System
         public static string BaseDirectory { get { throw null; } }
         public static void SetSwitch(string switchName, bool isEnabled) { }
         public static bool TryGetSwitch(string switchName, out bool isEnabled) { throw null; }
+#if netcoreapp11
         public static string TargetFrameworkName { get { throw null; } }
         public static object GetData(string name) { throw null; }
+#endif
     }
     
     public partial class EntryPointNotFoundException : System.TypeLoadException

--- a/src/System.Runtime/src/ApiCompatBaseline.net463.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.net463.txt
@@ -1,4 +1,0 @@
-Compat issues with assembly System.Runtime:
-MembersMustExist : Member 'System.AppContext.GetData(System.String)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.AppContext.TargetFrameworkName.get()' does not exist in the implementation but it does exist in the contract.
-Total Issues: 2


### PR DESCRIPTION
Fixes #11682 