### PR TITLE
Add CryptoConfig support

### DIFF
--- a/src/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography
 #if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
     public partial class DSA : AsymmetricAlgorithm
     {
-        public static DSA Create()
+        public static new DSA Create()
         {
             return new DSAImplementation.DSAOpenSsl();
         }

--- a/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -13,7 +13,7 @@ namespace System.Security.Cryptography
 #if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
     public partial class RSA : AsymmetricAlgorithm
     {
-        public static RSA Create()
+        public static new RSA Create()
         {
             return new RSAImplementation.RSAOpenSsl();
         }

--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -11,9 +11,8 @@ namespace System.Security.Cryptography
     public abstract partial class Aes : System.Security.Cryptography.SymmetricAlgorithm
     {
         protected Aes() { }
-        public override System.Security.Cryptography.KeySizes[] LegalBlockSizes { get { throw null; } }
-        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
         public static System.Security.Cryptography.Aes Create() { throw null; }
+        public static System.Security.Cryptography.Aes Create(string algorithmName) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     public sealed partial class AesManaged : System.Security.Cryptography.Aes
@@ -74,12 +73,23 @@ namespace System.Security.Cryptography
         public abstract byte[] GetBytes(int cb);
         public abstract void Reset();
     }
+    public partial class CryptoConfig
+    {
+        public CryptoConfig() { }
+        public static bool AllowOnlyFipsAlgorithms { get { throw null; } }
+        public static void AddAlgorithm(System.Type algorithm, params string[] names) { }
+        public static void AddOID(string oid, params string[] names) { }
+        public static object CreateFromName(string name) { throw null; }
+        public static object CreateFromName(string name, params object[] args) { throw null; }
+        public static string MapNameToOID(string name) { throw null; }
+    }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     public abstract partial class DES : System.Security.Cryptography.SymmetricAlgorithm
     {
         protected DES() { }
         public override byte[] Key { get { throw null; } set { } }
         public static System.Security.Cryptography.DES Create() { throw null; }
+        public static System.Security.Cryptography.DES Create(string algName) { throw null; }
         public static bool IsSemiWeakKey(byte[] rgbKey) { throw null; }
         public static bool IsWeakKey(byte[] rgbKey) { throw null; }
     }
@@ -87,6 +97,7 @@ namespace System.Security.Cryptography
     {
         protected DSA() { }
         public static System.Security.Cryptography.DSA Create() { throw null; }
+        public static System.Security.Cryptography.DSA Create(string algName) { throw null; }
         public abstract byte[] CreateSignature(byte[] rgbHash);
         public abstract System.Security.Cryptography.DSAParameters ExportParameters(bool includePrivateParameters);
         protected virtual byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
@@ -194,6 +205,7 @@ namespace System.Security.Cryptography
         public static System.Security.Cryptography.ECDsa Create() { throw null; }
         public static System.Security.Cryptography.ECDsa Create(System.Security.Cryptography.ECCurve curve) { throw null; }
         public static System.Security.Cryptography.ECDsa Create(System.Security.Cryptography.ECParameters parameters) { throw null; }
+        public static System.Security.Cryptography.ECDsa Create(string algorithm) { throw null; }
         public virtual System.Security.Cryptography.ECParameters ExportExplicitParameters(bool includePrivateParameters) { throw null; }
         public virtual System.Security.Cryptography.ECParameters ExportParameters(bool includePrivateParameters) { throw null; }
         public virtual void GenerateKey(System.Security.Cryptography.ECCurve curve) { }
@@ -297,11 +309,13 @@ namespace System.Security.Cryptography
     {
         protected MD5() { }
         public static System.Security.Cryptography.MD5 Create() { throw null; }
+        public static System.Security.Cryptography.MD5 Create(string algName) { throw null; }
     }
     public abstract partial class RandomNumberGenerator : System.IDisposable
     {
         protected RandomNumberGenerator() { }
         public static System.Security.Cryptography.RandomNumberGenerator Create() { throw null; }
+        public static System.Security.Cryptography.RandomNumberGenerator Create(string rngName) { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public abstract void GetBytes(byte[] data);
@@ -316,12 +330,14 @@ namespace System.Security.Cryptography
         public virtual int EffectiveKeySize { get { throw null; } set { } }
         public override int KeySize { get { throw null; } set { } }
         public static System.Security.Cryptography.RC2 Create() { throw null; }
+        public static System.Security.Cryptography.RC2 Create(string AlgName) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     public abstract partial class Rijndael : System.Security.Cryptography.SymmetricAlgorithm
     {
         protected Rijndael() { }
         public static System.Security.Cryptography.Rijndael Create() { throw null; }
+        public static System.Security.Cryptography.Rijndael Create(string algName) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     public sealed partial class RijndaelManaged : System.Security.Cryptography.Rijndael
@@ -359,6 +375,7 @@ namespace System.Security.Cryptography
     {
         protected RSA() { }
         public static System.Security.Cryptography.RSA Create() { throw null; }
+        public static System.Security.Cryptography.RSA Create(string algName) { throw null; }
         public abstract byte[] Decrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding);
         public virtual byte[] DecryptValue(byte[] rgb) { throw null; }
         public abstract byte[] Encrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding);
@@ -487,6 +504,7 @@ namespace System.Security.Cryptography
     {
         protected SHA1() { }
         public static System.Security.Cryptography.SHA1 Create() { throw null; }
+        public static System.Security.Cryptography.SHA1 Create(string hashName) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     public sealed partial class SHA1Managed : System.Security.Cryptography.SHA1
@@ -502,6 +520,7 @@ namespace System.Security.Cryptography
     {
         protected SHA256() { }
         public static System.Security.Cryptography.SHA256 Create() { throw null; }
+        public static System.Security.Cryptography.SHA256 Create(string hashName) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     public sealed partial class SHA256Managed : System.Security.Cryptography.SHA256
@@ -517,6 +536,7 @@ namespace System.Security.Cryptography
     {
         protected SHA384() { }
         public static System.Security.Cryptography.SHA384 Create() { throw null; }
+        public static System.Security.Cryptography.SHA384 Create(string hashName) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     public sealed partial class SHA384Managed : System.Security.Cryptography.SHA384
@@ -532,6 +552,7 @@ namespace System.Security.Cryptography
     {
         protected SHA512() { }
         public static System.Security.Cryptography.SHA512 Create() { throw null; }
+        public static System.Security.Cryptography.SHA512 Create(string hashName) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     public sealed partial class SHA512Managed : System.Security.Cryptography.SHA512
@@ -550,6 +571,7 @@ namespace System.Security.Cryptography
         public override System.Security.Cryptography.KeySizes[] LegalBlockSizes { get { throw null; } }
         public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
         public static System.Security.Cryptography.TripleDES Create() { throw null; }
+        public static System.Security.Cryptography.TripleDES Create(string str) { throw null; }
         public static bool IsWeakKey(byte[] rgbKey) { throw null; }
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -39,6 +39,7 @@
     <Compile Include="System\Security\Cryptography\AsymmetricKeyExchangeFormatter.cs" />
     <Compile Include="System\Security\Cryptography\AsymmetricSignatureDeformatter.cs" />
     <Compile Include="System\Security\Cryptography\AsymmetricSignatureFormatter.cs" />
+    <Compile Include="System\Security\Cryptography\CryptoConfig.cs" />
     <Compile Include="System\Security\Cryptography\DeriveBytes.cs" />
     <Compile Include="System\Security\Cryptography\DES.cs" />
     <Compile Include="System\Security\Cryptography\DSA.cs" />
@@ -427,6 +428,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- ToDo: Remove once prerelease gets updated again -->
+    <ProjectReference Include="..\..\System.Security.Cryptography.Primitives\pkg\System.Security.Cryptography.Primitives.pkgproj">
+      <Name>System.Security.Cryptography.Primitives</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Aes.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Aes.cs
@@ -19,9 +19,14 @@ namespace System.Security.Cryptography
             ModeValue = CipherMode.CBC;
         }
 
-        public static Aes Create()
+        public static new Aes Create()
         {
             return new AesImplementation();
+        }
+
+        public static new Aes Create(string algorithmName)
+        {
+            return (Aes)CryptoConfig.CreateFromName(algorithmName);
         }
 
         private static readonly KeySizes[] s_legalBlockSizes = { new KeySizes(128, 128, 0) };

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
@@ -1,0 +1,443 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace System.Security.Cryptography
+{
+    public class CryptoConfig
+    {
+        private const string AssemblyName_Cng = "System.Security.Cryptography.Cng";
+        private const string AssemblyName_Csp = "System.Security.Cryptography.Csp";
+        private const string AssemblyName_Pkcs = "System.Security.Cryptography.Pkcs";
+        private const string AssemblyName_X509Certificates = "System.Security.Cryptography.X509Certificates";
+
+        private const BindingFlags ConstructorDefault = BindingFlags.Instance | BindingFlags.Public | BindingFlags.CreateInstance;
+
+        private const string OID_RSA_SMIMEalgCMS3DESwrap = "1.2.840.113549.1.9.16.3.6";
+        private const string OID_RSA_MD5 = "1.2.840.113549.2.5";
+        private const string OID_RSA_RC2CBC = "1.2.840.113549.3.2";
+        private const string OID_RSA_DES_EDE3_CBC = "1.2.840.113549.3.7";
+        private const string OID_OIWSEC_desCBC = "1.3.14.3.2.7";
+        private const string OID_OIWSEC_SHA1 = "1.3.14.3.2.26";
+        private const string OID_OIWSEC_SHA256 = "2.16.840.1.101.3.4.2.1";
+        private const string OID_OIWSEC_SHA384 = "2.16.840.1.101.3.4.2.2";
+        private const string OID_OIWSEC_SHA512 = "2.16.840.1.101.3.4.2.3";
+        private const string OID_OIWSEC_RIPEMD160 = "1.3.36.3.2.1";
+
+        private static volatile Dictionary<string, string> s_defaultOidHT = null;
+        private static volatile Dictionary<string, object> s_defaultNameHT = null;
+
+        // CoreFx does not support AllowOnlyFipsAlgorithms
+        public static bool AllowOnlyFipsAlgorithms => false;
+
+        private static Dictionary<string, string> DefaultOidHT
+        {
+            get
+            {
+                if (s_defaultOidHT != null)
+                {
+                    return s_defaultOidHT;
+                }
+
+                Dictionary<string, string> ht = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+                ht.Add("SHA", OID_OIWSEC_SHA1);
+                ht.Add("SHA1", OID_OIWSEC_SHA1);
+                ht.Add("System.Security.Cryptography.SHA1", OID_OIWSEC_SHA1);
+                ht.Add("System.Security.Cryptography.SHA1CryptoServiceProvider", OID_OIWSEC_SHA1);
+                ht.Add("System.Security.Cryptography.SHA1Cng", OID_OIWSEC_SHA1);
+                ht.Add("System.Security.Cryptography.SHA1Managed", OID_OIWSEC_SHA1);
+
+                ht.Add("SHA256", OID_OIWSEC_SHA256);
+                ht.Add("System.Security.Cryptography.SHA256", OID_OIWSEC_SHA256);
+                ht.Add("System.Security.Cryptography.SHA256CryptoServiceProvider", OID_OIWSEC_SHA256);
+                ht.Add("System.Security.Cryptography.SHA256Cng", OID_OIWSEC_SHA256);
+                ht.Add("System.Security.Cryptography.SHA256Managed", OID_OIWSEC_SHA256);
+
+                ht.Add("SHA384", OID_OIWSEC_SHA384);
+                ht.Add("System.Security.Cryptography.SHA384", OID_OIWSEC_SHA384);
+                ht.Add("System.Security.Cryptography.SHA384CryptoServiceProvider", OID_OIWSEC_SHA384);
+                ht.Add("System.Security.Cryptography.SHA384Cng", OID_OIWSEC_SHA384);
+                ht.Add("System.Security.Cryptography.SHA384Managed", OID_OIWSEC_SHA384);
+
+                ht.Add("SHA512", OID_OIWSEC_SHA512);
+                ht.Add("System.Security.Cryptography.SHA512", OID_OIWSEC_SHA512);
+                ht.Add("System.Security.Cryptography.SHA512CryptoServiceProvider", OID_OIWSEC_SHA512);
+                ht.Add("System.Security.Cryptography.SHA512Cng", OID_OIWSEC_SHA512);
+                ht.Add("System.Security.Cryptography.SHA512Managed", OID_OIWSEC_SHA512);
+
+                ht.Add("RIPEMD160", OID_OIWSEC_RIPEMD160);
+                ht.Add("System.Security.Cryptography.RIPEMD160", OID_OIWSEC_RIPEMD160);
+                ht.Add("System.Security.Cryptography.RIPEMD160Managed", OID_OIWSEC_RIPEMD160);
+
+                ht.Add("MD5", OID_RSA_MD5);
+                ht.Add("System.Security.Cryptography.MD5", OID_RSA_MD5);
+                ht.Add("System.Security.Cryptography.MD5CryptoServiceProvider", OID_RSA_MD5);
+                ht.Add("System.Security.Cryptography.MD5Managed", OID_RSA_MD5);
+
+                ht.Add("TripleDESKeyWrap", OID_RSA_SMIMEalgCMS3DESwrap);
+
+                ht.Add("RC2", OID_RSA_RC2CBC);
+                ht.Add("System.Security.Cryptography.RC2CryptoServiceProvider", OID_RSA_RC2CBC);
+
+                ht.Add("DES", OID_OIWSEC_desCBC);
+                ht.Add("System.Security.Cryptography.DESCryptoServiceProvider", OID_OIWSEC_desCBC);
+
+                ht.Add("TripleDES", OID_RSA_DES_EDE3_CBC);
+                ht.Add("System.Security.Cryptography.TripleDESCryptoServiceProvider", OID_RSA_DES_EDE3_CBC);
+
+                s_defaultOidHT = ht;
+                return s_defaultOidHT;
+            }
+        }
+
+        private static Dictionary<string, object> DefaultNameHT
+        {
+            get
+            {
+                if (s_defaultNameHT != null)
+                {
+                    return s_defaultNameHT;
+                }
+
+                Dictionary<string, object> ht = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+                Type HMACMD5Type = typeof(System.Security.Cryptography.HMACMD5);
+                Type HMACSHA1Type = typeof(System.Security.Cryptography.HMACSHA1);
+                Type HMACSHA256Type = typeof(System.Security.Cryptography.HMACSHA256);
+                Type HMACSHA384Type = typeof(System.Security.Cryptography.HMACSHA384);
+                Type HMACSHA512Type = typeof(System.Security.Cryptography.HMACSHA512);
+                Type RijndaelManagedType = typeof(System.Security.Cryptography.RijndaelManaged);
+                Type AesManagedType = typeof(System.Security.Cryptography.AesManaged);
+                Type SHA256DefaultType = typeof(System.Security.Cryptography.SHA256Managed);
+                Type SHA384DefaultType = typeof(System.Security.Cryptography.SHA384Managed);
+                Type SHA512DefaultType = typeof(System.Security.Cryptography.SHA512Managed);
+
+                string SHA1CryptoServiceProviderType = "System.Security.Cryptography.SHA1CryptoServiceProvider, " + AssemblyName_Csp;
+                string MD5CryptoServiceProviderType = "System.Security.Cryptography.MD5CryptoServiceProvider," + AssemblyName_Csp;
+                string RSACryptoServiceProviderType = "System.Security.Cryptography.RSACryptoServiceProvider, " + AssemblyName_Csp;
+                string DSACryptoServiceProviderType = "System.Security.Cryptography.DSACryptoServiceProvider, " + AssemblyName_Csp;
+                string DESCryptoServiceProviderType = "System.Security.Cryptography.DESCryptoServiceProvider, " + AssemblyName_Csp;
+                string TripleDESCryptoServiceProviderType = "System.Security.Cryptography.TripleDESCryptoServiceProvider, " + AssemblyName_Csp;
+                string RC2CryptoServiceProviderType = "System.Security.Cryptography.RC2CryptoServiceProvider, " + AssemblyName_Csp;
+                string RNGCryptoServiceProviderType = "System.Security.Cryptography.RNGCryptoServiceProvider, " + AssemblyName_Csp;
+                string AesCryptoServiceProviderType = "System.Security.Cryptography.AesCryptoServiceProvider, " + AssemblyName_Csp;
+
+                string ECDsaCngType = "System.Security.Cryptography.ECDsaCng, " + AssemblyName_Cng;
+
+                // Random number generator
+                ht.Add("RandomNumberGenerator", RNGCryptoServiceProviderType);
+                ht.Add("System.Security.Cryptography.RandomNumberGenerator", RNGCryptoServiceProviderType);
+
+                // Hash functions
+                ht.Add("SHA", SHA1CryptoServiceProviderType);
+                ht.Add("SHA1", SHA1CryptoServiceProviderType);
+                ht.Add("System.Security.Cryptography.SHA1", SHA1CryptoServiceProviderType);
+                ht.Add("System.Security.Cryptography.HashAlgorithm", SHA1CryptoServiceProviderType);
+
+                ht.Add("MD5", MD5CryptoServiceProviderType);
+                ht.Add("System.Security.Cryptography.MD5", MD5CryptoServiceProviderType);
+
+                ht.Add("SHA256", SHA256DefaultType);
+                ht.Add("SHA-256", SHA256DefaultType);
+                ht.Add("System.Security.Cryptography.SHA256", SHA256DefaultType);
+
+                ht.Add("SHA384", SHA384DefaultType);
+                ht.Add("SHA-384", SHA384DefaultType);
+                ht.Add("System.Security.Cryptography.SHA384", SHA384DefaultType);
+
+                ht.Add("SHA512", SHA512DefaultType);
+                ht.Add("SHA-512", SHA512DefaultType);
+                ht.Add("System.Security.Cryptography.SHA512", SHA512DefaultType);
+
+                // Keyed Hash Algorithms
+                ht.Add("System.Security.Cryptography.HMAC", HMACSHA1Type);
+                ht.Add("System.Security.Cryptography.KeyedHashAlgorithm", HMACSHA1Type);
+                ht.Add("HMACMD5", HMACMD5Type);
+                ht.Add("System.Security.Cryptography.HMACMD5", HMACMD5Type);
+                ht.Add("HMACSHA1", HMACSHA1Type);
+                ht.Add("System.Security.Cryptography.HMACSHA1", HMACSHA1Type);
+                ht.Add("HMACSHA256", HMACSHA256Type);
+                ht.Add("System.Security.Cryptography.HMACSHA256", HMACSHA256Type);
+                ht.Add("HMACSHA384", HMACSHA384Type);
+                ht.Add("System.Security.Cryptography.HMACSHA384", HMACSHA384Type);
+                ht.Add("HMACSHA512", HMACSHA512Type);
+                ht.Add("System.Security.Cryptography.HMACSHA512", HMACSHA512Type);
+
+                // Asymmetric algorithms
+                ht.Add("RSA", RSACryptoServiceProviderType);
+                ht.Add("System.Security.Cryptography.RSA", RSACryptoServiceProviderType);
+                ht.Add("System.Security.Cryptography.AsymmetricAlgorithm", RSACryptoServiceProviderType);
+
+                ht.Add("DSA", DSACryptoServiceProviderType);
+                ht.Add("System.Security.Cryptography.DSA", DSACryptoServiceProviderType);
+
+                ht.Add("ECDsa", ECDsaCngType);
+                ht.Add("ECDsaCng", ECDsaCngType);
+                ht.Add("System.Security.Cryptography.ECDsaCng", ECDsaCngType);
+
+                // Symmetric algorithms
+                ht.Add("DES", DESCryptoServiceProviderType);
+                ht.Add("System.Security.Cryptography.DES", DESCryptoServiceProviderType);
+
+                ht.Add("3DES", TripleDESCryptoServiceProviderType);
+                ht.Add("TripleDES", TripleDESCryptoServiceProviderType);
+                ht.Add("Triple DES", TripleDESCryptoServiceProviderType);
+                ht.Add("System.Security.Cryptography.TripleDES", TripleDESCryptoServiceProviderType);
+
+                ht.Add("RC2", RC2CryptoServiceProviderType);
+                ht.Add("System.Security.Cryptography.RC2", RC2CryptoServiceProviderType);
+
+                ht.Add("Rijndael", RijndaelManagedType);
+                ht.Add("System.Security.Cryptography.Rijndael", RijndaelManagedType);
+                // Rijndael is the default symmetric cipher because (a) it's the strongest and (b) we know we have an implementation everywhere
+                ht.Add("System.Security.Cryptography.SymmetricAlgorithm", RijndaelManagedType);
+
+                ht.Add("AES", AesCryptoServiceProviderType);
+                ht.Add("AesCryptoServiceProvider", AesCryptoServiceProviderType);
+                ht.Add("System.Security.Cryptography.AesCryptoServiceProvider", AesCryptoServiceProviderType);
+                ht.Add("AesManaged", AesManagedType);
+                ht.Add("System.Security.Cryptography.AesManaged", AesManagedType);
+
+                // Xml Dsig/ Enc Hash algorithms
+                ht.Add("http://www.w3.org/2000/09/xmldsig#sha1", SHA1CryptoServiceProviderType);
+                // Add the other hash algorithms introduced with XML Encryption
+                ht.Add("http://www.w3.org/2001/04/xmlenc#sha256", SHA256DefaultType);
+                ht.Add("http://www.w3.org/2001/04/xmlenc#sha512", SHA512DefaultType);
+
+                // Xml Encryption symmetric keys
+                ht.Add("http://www.w3.org/2001/04/xmlenc#des-cbc", DESCryptoServiceProviderType);
+                ht.Add("http://www.w3.org/2001/04/xmlenc#tripledes-cbc", TripleDESCryptoServiceProviderType);
+                ht.Add("http://www.w3.org/2001/04/xmlenc#kw-tripledes", TripleDESCryptoServiceProviderType);
+
+                ht.Add("http://www.w3.org/2001/04/xmlenc#aes128-cbc", RijndaelManagedType);
+                ht.Add("http://www.w3.org/2001/04/xmlenc#kw-aes128", RijndaelManagedType);
+                ht.Add("http://www.w3.org/2001/04/xmlenc#aes192-cbc", RijndaelManagedType);
+                ht.Add("http://www.w3.org/2001/04/xmlenc#kw-aes192", RijndaelManagedType);
+                ht.Add("http://www.w3.org/2001/04/xmlenc#aes256-cbc", RijndaelManagedType);
+                ht.Add("http://www.w3.org/2001/04/xmlenc#kw-aes256", RijndaelManagedType);
+
+                // Xml Dsig HMAC URIs from http://www.w3.org/TR/xmldsig-core/
+                ht.Add("http://www.w3.org/2000/09/xmldsig#hmac-sha1", HMACSHA1Type);
+
+                // Xml Dsig-more Uri's as defined in http://www.ietf.org/rfc/rfc4051.txt
+                ht.Add("http://www.w3.org/2001/04/xmldsig-more#md5", MD5CryptoServiceProviderType);
+                ht.Add("http://www.w3.org/2001/04/xmldsig-more#sha384", SHA384DefaultType);
+                ht.Add("http://www.w3.org/2001/04/xmldsig-more#hmac-md5", HMACMD5Type);
+                ht.Add("http://www.w3.org/2001/04/xmldsig-more#hmac-sha256", HMACSHA256Type);
+                ht.Add("http://www.w3.org/2001/04/xmldsig-more#hmac-sha384", HMACSHA384Type);
+                ht.Add("http://www.w3.org/2001/04/xmldsig-more#hmac-sha512", HMACSHA512Type);
+                // X509 Extensions (custom decoders)
+                // Basic Constraints OID value
+                ht.Add("2.5.29.10", "System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension, " + AssemblyName_X509Certificates);
+                ht.Add("2.5.29.19", "System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension, " + AssemblyName_X509Certificates);
+                // Subject Key Identifier OID value
+                ht.Add("2.5.29.14", "System.Security.Cryptography.X509Certificates.X509SubjectKeyIdentifierExtension, " + AssemblyName_X509Certificates);
+                // Key Usage OID value
+                ht.Add("2.5.29.15", "System.Security.Cryptography.X509Certificates.X509KeyUsageExtension, " + AssemblyName_X509Certificates);
+                // Enhanced Key Usage OID value
+                ht.Add("2.5.29.37", "System.Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension, " + AssemblyName_X509Certificates);
+
+                // X509Chain class can be overridden to use a different chain engine.
+                ht.Add("X509Chain", "System.Security.Cryptography.X509Certificates.X509Chain, " + AssemblyName_X509Certificates);
+
+                // PKCS9 attributes
+                ht.Add("1.2.840.113549.1.9.3", "System.Security.Cryptography.Pkcs.Pkcs9ContentType, " + AssemblyName_Pkcs);
+                ht.Add("1.2.840.113549.1.9.4", "System.Security.Cryptography.Pkcs.Pkcs9MessageDigest, " + AssemblyName_Pkcs);
+                ht.Add("1.2.840.113549.1.9.5", "System.Security.Cryptography.Pkcs.Pkcs9SigningTime, " + AssemblyName_Pkcs);
+                ht.Add("1.3.6.1.4.1.311.88.2.1", "System.Security.Cryptography.Pkcs.Pkcs9DocumentName, " + AssemblyName_Pkcs);
+                ht.Add("1.3.6.1.4.1.311.88.2.2", "System.Security.Cryptography.Pkcs.Pkcs9DocumentDescription, " + AssemblyName_Pkcs);
+
+                s_defaultNameHT = ht;
+                return s_defaultNameHT;
+
+                // Types in Desktop but currently unsupported in CoreFx:
+                // Type HMACRIPEMD160Type = typeof(System.Security.Cryptography.HMACRIPEMD160);
+                // Type MAC3DESType = typeof(System.Security.Cryptography.MACTripleDES);
+                // Type DSASignatureDescriptionType = typeof(System.Security.Cryptography.DSASignatureDescription);
+                // Type RSAPKCS1SHA1SignatureDescriptionType = typeof(System.Security.Cryptography.RSAPKCS1SHA1SignatureDescription);
+                // Type RSAPKCS1SHA256SignatureDescriptionType = typeof(System.Security.Cryptography.RSAPKCS1SHA256SignatureDescription);
+                // Type RSAPKCS1SHA384SignatureDescriptionType = typeof(System.Security.Cryptography.RSAPKCS1SHA384SignatureDescription);
+                // Type RSAPKCS1SHA512SignatureDescriptionType = typeof(System.Security.Cryptography.RSAPKCS1SHA512SignatureDescription);
+                // string RIPEMD160ManagedType = "System.Security.Cryptography.RIPEMD160Managed" + AssemblyName_Encoding;
+                // string ECDiffieHellmanCngType = "System.Security.Cryptography.ECDiffieHellmanCng, " + AssemblyName_Cng;
+                // string MD5CngType = "System.Security.Cryptography.MD5Cng, " + AssemblyName_Cng;
+                // string SHA1CngType = "System.Security.Cryptography.SHA1Cng, " + AssemblyName_Cng;
+                // string SHA256CngType = "System.Security.Cryptography.SHA256Cng, " + AssemblyName_Cng;
+                // string SHA384CngType = "System.Security.Cryptography.SHA384Cng, " + AssemblyName_Cng;
+                // string SHA512CngType = "System.Security.Cryptography.SHA512Cng, " + AssemblyName_Cng;
+                // string SHA256CryptoServiceProviderType = "System.Security.Cryptography.SHA256CryptoServiceProvider, " + AssemblyName_Csp;
+                // string SHA384CryptoSerivceProviderType = "System.Security.Cryptography.SHA384CryptoServiceProvider, " + AssemblyName_Csp;
+                // string SHA512CryptoServiceProviderType = "System.Security.Cryptography.SHA512CryptoServiceProvider, " + AssemblyName_Csp;
+                // string DpapiDataProtectorType = "System.Security.Cryptography.DpapiDataProtector, " + AssemblyRef.SystemSecurity;
+                // Xml Dsig Transforms
+                // First arg must match the constants defined in System.Security.Cryptography.Xml.SignedXml
+                // ht.Add("http://www.w3.org/TR/2001/REC-xml-c14n-20010315", "System.Security.Cryptography.Xml.XmlDsigC14NTransform, " + AssemblyRef.SystemSecurity);
+                // ht.Add("http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments", "System.Security.Cryptography.Xml.XmlDsigC14NWithCommentsTransform, " + AssemblyRef.SystemSecurity);
+                // ht.Add("http://www.w3.org/2001/10/xml-exc-c14n#", "System.Security.Cryptography.Xml.XmlDsigExcC14NTransform, " + AssemblyRef.SystemSecurity);
+                // ht.Add("http://www.w3.org/2001/10/xml-exc-c14n#WithComments", "System.Security.Cryptography.Xml.XmlDsigExcC14NWithCommentsTransform, " + AssemblyRef.SystemSecurity);
+                // ht.Add("http://www.w3.org/2000/09/xmldsig#base64", "System.Security.Cryptography.Xml.XmlDsigBase64Transform, " + AssemblyRef.SystemSecurity);
+                // ht.Add("http://www.w3.org/TR/1999/REC-xpath-19991116", "System.Security.Cryptography.Xml.XmlDsigXPathTransform, " + AssemblyRef.SystemSecurity);
+                // ht.Add("http://www.w3.org/TR/1999/REC-xslt-19991116", "System.Security.Cryptography.Xml.XmlDsigXsltTransform, " + AssemblyRef.SystemSecurity);
+                // ht.Add("http://www.w3.org/2000/09/xmldsig#enveloped-signature", "System.Security.Cryptography.Xml.XmlDsigEnvelopedSignatureTransform, " + AssemblyRef.SystemSecurity);
+                // the decryption transform
+                // ht.Add("http://www.w3.org/2002/07/decrypt#XML", "System.Security.Cryptography.Xml.XmlDecryptionTransform, " + AssemblyRef.SystemSecurity);
+                // Xml licence transform.
+                // ht.Add("urn:mpeg:mpeg21:2003:01-REL-R-NS:licenseTransform", "System.Security.Cryptography.Xml.XmlLicenseTransform, " + AssemblyRef.SystemSecurity);
+                // Xml Dsig KeyInfo
+                // First arg (the key) is formed as elem.NamespaceURI + " " + elem.LocalName
+                // ht.Add("http://www.w3.org/2000/09/xmldsig# X509Data", "System.Security.Cryptography.Xml.KeyInfoX509Data, " + AssemblyRef.SystemSecurity);
+                // ht.Add("http://www.w3.org/2000/09/xmldsig# KeyName", "System.Security.Cryptography.Xml.KeyInfoName, " + AssemblyRef.SystemSecurity);
+                // ht.Add("http://www.w3.org/2000/09/xmldsig# KeyValue/DSAKeyValue", "System.Security.Cryptography.Xml.DSAKeyValue, " + AssemblyRef.SystemSecurity);
+                // ht.Add("http://www.w3.org/2000/09/xmldsig# KeyValue/RSAKeyValue", "System.Security.Cryptography.Xml.RSAKeyValue, " + AssemblyRef.SystemSecurity);
+                // ht.Add("http://www.w3.org/2000/09/xmldsig# RetrievalMethod", "System.Security.Cryptography.Xml.KeyInfoRetrievalMethod, " + AssemblyRef.SystemSecurity);
+                // Xml EncryptedKey
+                // ht.Add("http://www.w3.org/2001/04/xmlenc# EncryptedKey", "System.Security.Cryptography.Xml.KeyInfoEncryptedKey, " + AssemblyRef.SystemSecurity);
+                // ht.Add("http://www.w3.org/2001/04/xmldsig-more#hmac-ripemd160", HMACRIPEMD160Type);
+            }
+        }
+
+        public static void AddAlgorithm(Type algorithm, params string[] names)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public static object CreateFromName(string name, params object[] args)
+        {
+            if (name == null)
+                throw new ArgumentNullException(nameof(name));
+
+            Type retvalType = null;
+
+            // We allow the default table to Types and Strings
+            // Types get used for types in .Algorithms assembly.
+            // strings get used for delay-loaded stuff in other assemblies such as .Csp.
+            object retvalObj;
+            if (DefaultNameHT.TryGetValue(name, out retvalObj))
+            {
+                if (retvalObj is Type)
+                {
+                    retvalType = (Type)retvalObj;
+                }
+                else if (retvalObj is string)
+                {
+                    retvalType = Type.GetType((string)retvalObj, false, false);
+                    if (retvalType != null && !retvalType.IsVisible)
+                    {
+                        retvalType = null;
+                    }
+                }
+                else
+                {
+                    Debug.Fail("Unsupported Dictionary value:" + retvalObj.ToString());
+                }
+            }
+
+            // Maybe they gave us a classname.
+            if (retvalType == null)
+            {
+                retvalType = Type.GetType(name, false, false);
+                if (retvalType != null && !retvalType.IsVisible)
+                {
+                    retvalType = null;
+                }
+            }
+
+            // Still null? Then we didn't find it.
+            if (retvalType == null)
+            {
+                return null;
+            }
+
+            // Locate all constructors.
+            MethodBase[] cons = retvalType.GetConstructors(ConstructorDefault);
+            if (cons == null)
+            {
+                return null;
+            }
+
+            if (args == null)
+            {
+                args = new object[] { };
+            }
+
+            List<MethodBase> candidates = new List<MethodBase>();
+            for (int i = 0; i < cons.Length; i++)
+            {
+                MethodBase con = cons[i];
+                if (con.GetParameters().Length == args.Length)
+                {
+                    candidates.Add(con);
+                }
+            }
+
+            if (candidates.Count == 0)
+            {
+                return null;
+            }
+
+            cons = candidates.ToArray();
+
+            // Bind to matching ctor.
+            object state;
+            ConstructorInfo rci = Type.DefaultBinder.BindToMethod(
+                ConstructorDefault,
+                cons,
+                ref args,
+                null,
+                null,
+                null,
+                out state) as ConstructorInfo;
+
+            // Check for ctor we don't like (non-existant, delegate or decorated with declarative linktime demand).
+            if (rci == null || typeof(Delegate).IsAssignableFrom(rci.DeclaringType))
+            {
+                return null;
+            }
+
+            // Ctor invoke and allocation.
+            object retval = rci.Invoke(ConstructorDefault, Type.DefaultBinder, args, null);
+
+            // Reset any parameter re-ordering performed by the binder.
+            if (state != null)
+            {
+                Type.DefaultBinder.ReorderArgumentArray(ref args, state);
+            }
+
+            return retval;
+        }
+
+        public static object CreateFromName(string name)
+        {
+            return CreateFromName(name, null);
+        }
+
+        public static void AddOID(string oid, params string[] names)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public static string MapNameToOID(string name)
+        {
+            if (name == null)
+                throw new ArgumentNullException(nameof(name));
+
+            string oidName;
+            if (!DefaultOidHT.TryGetValue(name, out oidName))
+            {
+                try
+                {
+                    Oid oid = Oid.FromFriendlyName(name, OidGroup.All);
+                    oidName = oid.Value;
+                }
+                catch (CryptographicException) { }
+            }
+
+            return oidName;
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DES.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DES.cs
@@ -18,9 +18,14 @@ namespace System.Security.Cryptography
             BlockSizeValue = 64;
         }
 
-        public static DES Create()
+        public static new DES Create()
         {
             return new DesImplementation();
+        }
+
+        public static new DES Create(string algName)
+        {
+            return (DES)CryptoConfig.CreateFromName(algName);
         }
 
         public override byte[] Key

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSA.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSA.cs
@@ -14,6 +14,11 @@ namespace System.Security.Cryptography
 
         protected DSA() { }
 
+        public static new DSA Create(string algName)
+        {
+            return (DSA)CryptoConfig.CreateFromName(algName);
+        }
+
         // DSA does not encode the algorithm identifier into the signature blob, therefore CreateSignature and
         // VerifySignature do not need the HashAlgorithmName value, only SignData and VerifyData do.
         abstract public byte[] CreateSignature(byte[] rgbHash);

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSACng.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSACng.cs
@@ -9,7 +9,7 @@ namespace System.Security.Cryptography
 {
     public partial class DSA : AsymmetricAlgorithm
     {
-        public static DSA Create()
+        public static new DSA Create()
         {
             return new DSAImplementation.DSACng();
         }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsa.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsa.cs
@@ -10,6 +10,16 @@ namespace System.Security.Cryptography
     {
         protected ECDsa() { }
 
+        public static new ECDsa Create(string algorithm)
+        {
+            if (algorithm == null)
+            {
+                throw new ArgumentNullException(nameof(algorithm));
+            }
+
+            return CryptoConfig.CreateFromName(algorithm) as ECDsa;
+        }
+
         /// <summary>
         /// When overridden in a derived class, exports the named or explicit ECParameters for an ECCurve.
         /// If the curve has a name, the Curve property will contain named curve parameters otherwise it will contain explicit parameters.

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsaCng.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsaCng.cs
@@ -14,7 +14,7 @@ namespace System.Security.Cryptography
         /// <summary>
         /// Creates an instance of the platform specific implementation of the cref="ECDsa" algorithm.
         /// </summary>
-        public static ECDsa Create()
+        public static new ECDsa Create()
         {
             return new ECDsaImplementation.ECDsaCng();
         }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -9,7 +9,7 @@ namespace System.Security.Cryptography
         /// <summary>
         /// Creates an instance of the platform specific implementation of the cref="ECDsa" algorithm.
         /// </summary>
-        public static ECDsa Create()
+        public static new ECDsa Create()
         {
             return new ECDsaImplementation.ECDsaOpenSsl();
         }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/MD5.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/MD5.cs
@@ -16,9 +16,14 @@ namespace System.Security.Cryptography
     {
         protected MD5() { }
 
-        public static MD5 Create()
+        public static new MD5 Create()
         {
             return new Implementation();
+        }
+
+        static public new MD5 Create(String algName)
+        {
+            return (MD5)CryptoConfig.CreateFromName(algName);
         }
 
         private sealed class Implementation : MD5

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RC2.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RC2.cs
@@ -20,10 +20,16 @@ namespace System.Security.Cryptography
             BlockSizeValue = 64;
         }
 
-        public static RC2 Create()
+        public static new RC2 Create()
         {
             return new RC2Implementation();
         }
+
+        public static new RC2 Create(string AlgName)
+        {
+            return (RC2)CryptoConfig.CreateFromName(AlgName);
+        }
+
 
         public override int KeySize
         {

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
@@ -10,6 +10,11 @@ namespace System.Security.Cryptography
 {
     public abstract partial class RSA : AsymmetricAlgorithm
     {
+        public static new RSA Create(String algName)
+        {
+            return (RSA)CryptoConfig.CreateFromName(algName);
+        }
+
         public abstract RSAParameters ExportParameters(bool includePrivateParameters);
         public abstract void ImportParameters(RSAParameters parameters);
         public abstract byte[] Encrypt(byte[] data, RSAEncryptionPadding padding);

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSACng.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSACng.cs
@@ -10,7 +10,7 @@ namespace System.Security.Cryptography
 {
     public partial class RSA : AsymmetricAlgorithm
     {
-        public static RSA Create()
+        public static new RSA Create()
         {
             return new RSAImplementation.RSACng();
         }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RandomNumberGenerator.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RandomNumberGenerator.cs
@@ -13,6 +13,11 @@ namespace System.Security.Cryptography
             return new RandomNumberGeneratorImplementation();
         }
 
+        public static RandomNumberGenerator Create(string rngName)
+        {
+            return (RandomNumberGenerator)CryptoConfig.CreateFromName(rngName);
+        }
+
         public void Dispose()
         {
             Dispose(true);

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rijndael.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rijndael.cs
@@ -10,9 +10,14 @@ namespace System.Security.Cryptography
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class Rijndael : SymmetricAlgorithm
     {
-        public static Rijndael Create()
+        public static new Rijndael Create()
         {
             return new RijndaelImplementation();
+        }
+
+        public static new Rijndael Create(string algName)
+        {
+            return (Rijndael)CryptoConfig.CreateFromName(algName);
         }
 
         protected Rijndael()

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA1.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA1.cs
@@ -17,9 +17,14 @@ namespace System.Security.Cryptography
         protected SHA1() { }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "This is the implementaton of SHA1")]
-        public static SHA1 Create()
+        public static new SHA1 Create()
         {
             return new Implementation();
+        }
+
+        public static new SHA1 Create(string hashName)
+        {
+            return (SHA1)CryptoConfig.CreateFromName(hashName);
         }
 
         private sealed class Implementation : SHA1

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA256.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA256.cs
@@ -16,9 +16,14 @@ namespace System.Security.Cryptography
     {
         protected SHA256() { }
 
-        public static SHA256 Create()
+        public static new SHA256 Create()
         {
             return new Implementation();
+        }
+
+        public static new SHA256 Create(string hashName)
+        {
+            return (SHA256)CryptoConfig.CreateFromName(hashName);
         }
 
         private sealed class Implementation : SHA256

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA384.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA384.cs
@@ -16,9 +16,14 @@ namespace System.Security.Cryptography
     {
         protected SHA384() { }
 
-        public static SHA384 Create()
+        public static new SHA384 Create()
         {
             return new Implementation();
+        }
+
+        public static new SHA384 Create(string hashName)
+        {
+            return (SHA384)CryptoConfig.CreateFromName(hashName);
         }
 
         private sealed class Implementation : SHA384

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA512.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA512.cs
@@ -16,9 +16,14 @@ namespace System.Security.Cryptography
     {
         protected SHA512() { }
 
-        public static SHA512 Create()
+        public static new SHA512 Create()
         {
             return new Implementation();
+        }
+
+        public static new SHA512 Create(string hashName)
+        {
+            return (SHA512)CryptoConfig.CreateFromName(hashName);
         }
 
         private sealed class Implementation : SHA512

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/TripleDES.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/TripleDES.cs
@@ -20,9 +20,14 @@ namespace System.Security.Cryptography
             LegalKeySizesValue = s_legalKeySizes.CloneKeySizesArray();
         }
 
-        public static TripleDES Create()
+        public static new TripleDES Create()
         {
             return new TripleDesImplementation();
+        }
+
+        public static new TripleDES Create(string str)
+        {
+            return (TripleDES)CryptoConfig.CreateFromName(str);
         }
 
         public override byte[] Key

--- a/src/System.Security.Cryptography.Algorithms/src/project.json
+++ b/src/System.Security.Cryptography.Algorithms/src/project.json
@@ -7,6 +7,7 @@
         "System.Diagnostics.Debug": "4.4.0-beta-24717-02",
         "System.Diagnostics.Tools": "4.4.0-beta-24717-02",
         "System.IO": "4.4.0-beta-24717-02",
+        "System.Reflection": "4.4.0-beta-24717-02",
         "System.Resources.ResourceManager": "4.4.0-beta-24717-02",
         "System.Runtime": "4.4.0-beta-24717-02",
         "System.Text.Encoding": "4.4.0-beta-24717-02",

--- a/src/System.Security.Cryptography.Algorithms/tests/CryptoConfigTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/CryptoConfigTests.cs
@@ -1,0 +1,254 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.Security.Cryptography.CryptoConfigTests
+{
+    public static class CryptoConfigTests
+    {
+        [Fact]
+        public static void AllowOnlyFipsAlgorithms()
+        {
+            Assert.False(CryptoConfig.AllowOnlyFipsAlgorithms);
+        }
+
+        [Fact]
+        public static void AddOID_NotSupported()
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => CryptoConfig.AddOID(string.Empty, string.Empty));
+        }
+
+        [Fact]
+        public static void AddAlgorithm_NotSupported()
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => CryptoConfig.AddAlgorithm(typeof(CryptoConfigTests), string.Empty));
+        }
+
+        [Fact]
+        public static void StaticCreateMethods()
+        {
+            // Ensure static create methods exist and don't throw
+
+            // Some do not have public concrete types (in Algorithms assembly) so in those cases we only check for null\failure.
+            VerifyStaticCreateResult(Aes.Create(typeof(AesManaged).FullName), typeof(AesManaged));
+            Assert.Null(DES.Create(string.Empty));
+            Assert.Null(DSA.Create(string.Empty));
+            Assert.Null(ECDsa.Create(string.Empty));
+            Assert.Null(MD5.Create(string.Empty));
+            Assert.Null(RandomNumberGenerator.Create(string.Empty));
+            Assert.Null(RC2.Create(string.Empty));
+            VerifyStaticCreateResult(Rijndael.Create(typeof(RijndaelManaged).FullName), typeof(RijndaelManaged));
+            Assert.Null(RSA.Create(string.Empty));
+            Assert.Null(SHA1.Create(string.Empty));
+            VerifyStaticCreateResult(SHA256.Create(typeof(SHA256Managed).FullName), typeof(SHA256Managed));
+            VerifyStaticCreateResult(SHA384.Create(typeof(SHA384Managed).FullName), typeof(SHA384Managed));
+            VerifyStaticCreateResult(SHA512.Create(typeof(SHA512Managed).FullName), typeof(SHA512Managed));
+        }
+
+        private static void VerifyStaticCreateResult(object obj, Type expectedType)
+        {
+           Assert.NotNull(obj);
+           Assert.IsType(expectedType, obj);
+        }
+
+        [Fact]
+        public static void MapNameToOID()
+        {
+            Assert.Throws<ArgumentNullException>(() => CryptoConfig.MapNameToOID(null));
+
+            // Test some oids unique to CryptoConfig
+            Assert.Equal("1.3.14.3.2.26", CryptoConfig.MapNameToOID("SHA"));
+            Assert.Equal("1.3.14.3.2.26", CryptoConfig.MapNameToOID("sha"));
+            Assert.Equal("1.2.840.113549.3.7", CryptoConfig.MapNameToOID("TripleDES"));
+
+            // Test fallback to Oid class
+            Assert.Equal("1.3.36.3.3.2.8.1.1.8", CryptoConfig.MapNameToOID("brainpoolP256t1"));
+
+            // Invalid oid
+            Assert.Equal(null, CryptoConfig.MapNameToOID("NOT_A_VALID_OID"));
+        }
+
+        [Fact]
+        public static void CreateFromName_validation()
+        {
+            Assert.Throws<ArgumentNullException>(() => CryptoConfig.CreateFromName(null));
+            Assert.Throws<ArgumentNullException>(() => CryptoConfig.CreateFromName(null, null));
+            Assert.Throws<ArgumentNullException>(() => CryptoConfig.CreateFromName(null, string.Empty));
+            Assert.Null(CryptoConfig.CreateFromName(string.Empty, null));
+            Assert.Null(CryptoConfig.CreateFromName("SHA", 1, 2));
+        }
+
+        public static IEnumerable<object[]> AllValidNames
+        {
+            get
+            {
+                // Random number generator
+                yield return new object[] { "RandomNumberGenerator", "System.Security.Cryptography.RNGCryptoServiceProvider", false };
+                yield return new object[] { "System.Security.Cryptography.RandomNumberGenerator", "System.Security.Cryptography.RNGCryptoServiceProvider", false };
+
+                // Hash functions
+                yield return new object[] { "SHA", "System.Security.Cryptography.SHA1CryptoServiceProvider", false };
+                yield return new object[] { "SHA1", "System.Security.Cryptography.SHA1CryptoServiceProvider", false };
+                yield return new object[] { "System.Security.Cryptography.SHA1", "System.Security.Cryptography.SHA1CryptoServiceProvider", false };
+                yield return new object[] { "System.Security.Cryptography.HashAlgorithm", "System.Security.Cryptography.SHA1CryptoServiceProvider", false };
+                yield return new object[] { "MD5", "System.Security.Cryptography.MD5CryptoServiceProvider", false };
+                yield return new object[] { "System.Security.Cryptography.MD5", "System.Security.Cryptography.MD5CryptoServiceProvider", false };
+                yield return new object[] { "SHA256", typeof(SHA256Managed).FullName, true };
+                yield return new object[] { "SHA-256", typeof(SHA256Managed).FullName, true };
+                yield return new object[] { "System.Security.Cryptography.SHA256", typeof(SHA256Managed).FullName, true };
+                yield return new object[] { "SHA384", typeof(SHA384Managed).FullName, true };
+                yield return new object[] { "SHA-384", typeof(SHA384Managed).FullName, true };
+                yield return new object[] { "System.Security.Cryptography.SHA384", typeof(SHA384Managed).FullName, true };
+                yield return new object[] { "SHA512", typeof(SHA512Managed).FullName, true };
+                yield return new object[] { "SHA-512", typeof(SHA512Managed).FullName, true };
+                yield return new object[] { "System.Security.Cryptography.SHA512", typeof(SHA512Managed).FullName, true };
+
+                // Keyed Hash Algorithms
+                yield return new object[] { "System.Security.Cryptography.HMAC", "System.Security.Cryptography.HMACSHA1", true };
+                yield return new object[] { "System.Security.Cryptography.KeyedHashAlgorithm", "System.Security.Cryptography.HMACSHA1", true };
+                yield return new object[] { "HMACMD5", "System.Security.Cryptography.HMACMD5", true };
+                yield return new object[] { "System.Security.Cryptography.HMACMD5", null , true };
+                yield return new object[] { "HMACSHA1", "System.Security.Cryptography.HMACSHA1", true };
+                yield return new object[] { "System.Security.Cryptography.HMACSHA1", null , true };
+                yield return new object[] { "HMACSHA256", "System.Security.Cryptography.HMACSHA256", true };
+                yield return new object[] { "System.Security.Cryptography.HMACSHA256", null, true };
+                yield return new object[] { "HMACSHA384", "System.Security.Cryptography.HMACSHA384", true };
+                yield return new object[] { "System.Security.Cryptography.HMACSHA384", null , true };
+                yield return new object[] { "HMACSHA512", "System.Security.Cryptography.HMACSHA512", true };
+                yield return new object[] { "System.Security.Cryptography.HMACSHA512", null , true };
+
+                // Asymmetric algorithms
+                yield return new object[] { "RSA", "System.Security.Cryptography.RSACryptoServiceProvider", false };
+                yield return new object[] { "System.Security.Cryptography.RSA", "System.Security.Cryptography.RSACryptoServiceProvider", false };
+                yield return new object[] { "System.Security.Cryptography.AsymmetricAlgorithm", "System.Security.Cryptography.RSACryptoServiceProvider", false };
+                yield return new object[] { "DSA", "System.Security.Cryptography.DSACryptoServiceProvider", false };
+                yield return new object[] { "System.Security.Cryptography.DSA", "System.Security.Cryptography.DSACryptoServiceProvider", false };
+                yield return new object[] { "ECDsa", "System.Security.Cryptography.ECDsaCng", false };
+                yield return new object[] { "ECDsaCng", "System.Security.Cryptography.ECDsaCng", false };
+                yield return new object[] { "System.Security.Cryptography.ECDsaCng", null , false };
+                yield return new object[] { "DES", "System.Security.Cryptography.DESCryptoServiceProvider", false };
+                yield return new object[] { "System.Security.Cryptography.DES", "System.Security.Cryptography.DESCryptoServiceProvider", false };
+                yield return new object[] { "3DES", "System.Security.Cryptography.TripleDESCryptoServiceProvider", false };
+                yield return new object[] { "TripleDES", "System.Security.Cryptography.TripleDESCryptoServiceProvider", false };
+                yield return new object[] { "Triple DES", "System.Security.Cryptography.TripleDESCryptoServiceProvider", false };
+                yield return new object[] { "System.Security.Cryptography.TripleDES", "System.Security.Cryptography.TripleDESCryptoServiceProvider", false };
+                yield return new object[] { "RC2", "System.Security.Cryptography.RC2CryptoServiceProvider", false };
+                yield return new object[] { "System.Security.Cryptography.RC2", "System.Security.Cryptography.RC2CryptoServiceProvider", false };
+                yield return new object[] { "Rijndael", typeof(RijndaelManaged).FullName, true };
+                yield return new object[] { "System.Security.Cryptography.Rijndael", typeof(RijndaelManaged).FullName, true };
+                yield return new object[] { "System.Security.Cryptography.SymmetricAlgorithm", typeof(RijndaelManaged).FullName, true };
+                yield return new object[] { "AES", "System.Security.Cryptography.AesCryptoServiceProvider", false };
+                yield return new object[] { "AesCryptoServiceProvider", "System.Security.Cryptography.AesCryptoServiceProvider", false };
+                yield return new object[] { "System.Security.Cryptography.AesCryptoServiceProvider", "System.Security.Cryptography.AesCryptoServiceProvider", false };
+                yield return new object[] { "AesManaged", typeof(AesManaged).FullName, true };
+                yield return new object[] { "System.Security.Cryptography.AesManaged", typeof(AesManaged).FullName, true };
+
+                // Xml Dsig/ Enc Hash algorithms
+                yield return new object[] { "http://www.w3.org/2000/09/xmldsig#sha1", "System.Security.Cryptography.SHA1CryptoServiceProvider", false };
+                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#sha256", typeof(SHA256Managed).FullName, true };
+                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#sha512", typeof(SHA512Managed).FullName, true };
+
+                // Xml Encryption symmetric keys
+                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#des-cbc", "System.Security.Cryptography.DESCryptoServiceProvider", false };
+                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#tripledes-cbc", "System.Security.Cryptography.TripleDESCryptoServiceProvider", false };
+                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#kw-tripledes", "System.Security.Cryptography.TripleDESCryptoServiceProvider", false };
+                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#aes128-cbc", typeof(RijndaelManaged).FullName, true };
+                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#kw-aes128", typeof(RijndaelManaged).FullName, true };
+                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#aes192-cbc", typeof(RijndaelManaged).FullName, true };
+                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#kw-aes192", typeof(RijndaelManaged).FullName, true };
+                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#aes256-cbc", typeof(RijndaelManaged).FullName, true };
+                yield return new object[] { "http://www.w3.org/2001/04/xmlenc#kw-aes256", typeof(RijndaelManaged).FullName, true };
+
+                // Xml Dsig HMAC URIs from http://www.w3.org/TR/xmldsig-core/
+                yield return new object[] { "http://www.w3.org/2000/09/xmldsig#hmac-sha1", typeof(HMACSHA1).FullName, true };
+                yield return new object[] { "http://www.w3.org/2001/04/xmldsig-more#sha384", typeof(SHA384Managed).FullName, true };
+                yield return new object[] { "http://www.w3.org/2001/04/xmldsig-more#hmac-md5", typeof(HMACMD5).FullName, true };
+                yield return new object[] { "http://www.w3.org/2001/04/xmldsig-more#hmac-sha256", typeof(HMACSHA256).FullName, true };
+                yield return new object[] { "http://www.w3.org/2001/04/xmldsig-more#hmac-sha384", typeof(HMACSHA384).FullName, true };
+                yield return new object[] { "http://www.w3.org/2001/04/xmldsig-more#hmac-sha512", typeof(HMACSHA512).FullName, true };
+
+                // X509
+                yield return new object[] { "2.5.29.10", "System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension", true };
+                yield return new object[] { "2.5.29.19", "System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension", true };
+                yield return new object[] { "2.5.29.14", "System.Security.Cryptography.X509Certificates.X509SubjectKeyIdentifierExtension", true };
+                yield return new object[] { "2.5.29.15", "System.Security.Cryptography.X509Certificates.X509KeyUsageExtension", true };
+                yield return new object[] { "2.5.29.37", "System.Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension", true };
+                yield return new object[] { "X509Chain", "System.Security.Cryptography.X509Certificates.X509Chain", true };
+
+                // PKCS9 attributes
+                yield return new object[] { "1.2.840.113549.1.9.3", "System.Security.Cryptography.Pkcs.Pkcs9ContentType", false };
+                yield return new object[] { "1.2.840.113549.1.9.4", "System.Security.Cryptography.Pkcs.Pkcs9MessageDigest", false };
+                yield return new object[] { "1.2.840.113549.1.9.5", "System.Security.Cryptography.Pkcs.Pkcs9SigningTime", false };
+                yield return new object[] { "1.3.6.1.4.1.311.88.2.1", "System.Security.Cryptography.Pkcs.Pkcs9DocumentName", false };
+                yield return new object[] { "1.3.6.1.4.1.311.88.2.2", "System.Security.Cryptography.Pkcs.Pkcs9DocumentDescription", false };
+            }
+        }
+
+
+        [Theory, MemberData(nameof(AllValidNames))]
+        public static void CreateFromName_AllValidNames(string name, string typeName, bool supportsUnixMac)
+        {
+            if (supportsUnixMac || RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                object obj = CryptoConfig.CreateFromName(name);
+                Assert.NotNull(obj);
+
+                if (typeName == null)
+                {
+                    typeName = name;
+                }
+
+                Assert.Equal(typeName, obj.GetType().FullName);
+
+                if (obj is IDisposable)
+                {
+                    ((IDisposable)obj).Dispose();
+                }
+            }
+            else
+            {
+                // These will be the Csp types, which currently aren't supported on Mac\Unix
+                Assert.Throws<TargetInvocationException> (() => CryptoConfig.CreateFromName(name));
+            }
+        }
+
+        [Fact]
+        public static void CreateFromName_CtorArguments()
+        {
+            string className = typeof(ClassWithCtorArguments).FullName + ", System.Security.Cryptography.Algorithms.Tests";
+
+            // Pass int instead of string
+            Assert.Throws<MissingMethodException>(() => CryptoConfig.CreateFromName(className, 1));
+
+            // Valid case
+            object obj = CryptoConfig.CreateFromName(className, "Hello");
+            Assert.NotNull(obj);
+            Assert.IsType(typeof(ClassWithCtorArguments), obj);
+
+            ClassWithCtorArguments ctorObj = (ClassWithCtorArguments)obj;
+            Assert.Equal("Hello", ctorObj.MyString);
+        }
+
+        private static void VerifyCreateFromName<TExpected>(string name)
+        {
+            object obj = CryptoConfig.CreateFromName(name);
+            Assert.NotNull(obj);
+            Assert.IsType(typeof(TExpected), obj);
+        }
+
+        public class ClassWithCtorArguments
+        {
+            public ClassWithCtorArguments(string s)
+            {
+                MyString = s;
+            }
+
+            public string MyString;
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -147,6 +147,7 @@
   <ItemGroup Condition="'$(TargetGroup)'==''">
     <Compile Include="AesManagedTests.cs" />
     <Compile Include="AsymmetricSignatureFormatterTests.cs" />
+    <Compile Include="CryptoConfigTests.cs" />
     <Compile Include="DefaultDSAProvider.cs" />
     <Compile Include="DESProvider.cs" />
     <Compile Include="DESTests.cs" />

--- a/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
+++ b/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
@@ -16,6 +16,8 @@ namespace System.Security.Cryptography
         protected AsymmetricAlgorithm() { }
         public virtual int KeySize { get { throw null; } set { } }
         public virtual System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
+        public static System.Security.Cryptography.AsymmetricAlgorithm Create() { throw null; }
+        public static System.Security.Cryptography.AsymmetricAlgorithm Create(string algName) { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
     }
@@ -82,6 +84,8 @@ namespace System.Security.Cryptography
         public byte[] ComputeHash(byte[] buffer) { throw null; }
         public byte[] ComputeHash(byte[] buffer, int offset, int count) { throw null; }
         public byte[] ComputeHash(System.IO.Stream inputStream) { throw null; }
+        public static System.Security.Cryptography.HashAlgorithm Create() { throw null; }
+        public static System.Security.Cryptography.HashAlgorithm Create(string hashName) { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         protected abstract void HashCore(byte[] array, int ibStart, int cbSize);
@@ -112,6 +116,8 @@ namespace System.Security.Cryptography
         protected HMAC() { }
         public string HashName { get { throw null; } set { } }
         public override byte[] Key { get { throw null; } set { } }
+        public static new System.Security.Cryptography.HMAC Create() { throw null; }
+        public static new System.Security.Cryptography.HMAC Create(string algorithmName) { throw null; }
         protected override void Dispose(bool disposing) { }
         protected override void HashCore(byte[] rgb, int ib, int cb) { }
         protected override byte[] HashFinal() { throw null; }
@@ -131,6 +137,8 @@ namespace System.Security.Cryptography
         protected byte[] KeyValue;
         protected KeyedHashAlgorithm() { }
         public virtual byte[] Key { get { throw null; } set { } }
+        public static new System.Security.Cryptography.KeyedHashAlgorithm Create() { throw null; }
+        public static new System.Security.Cryptography.KeyedHashAlgorithm Create(string algName) { throw null; }
         protected override void Dispose(bool disposing) { }
     }
     public sealed partial class KeySizes
@@ -165,6 +173,8 @@ namespace System.Security.Cryptography
         public virtual System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
         public virtual System.Security.Cryptography.CipherMode Mode { get { throw null; } set { } }
         public virtual System.Security.Cryptography.PaddingMode Padding { get { throw null; } set { } }
+        public static System.Security.Cryptography.SymmetricAlgorithm Create() { throw null; }
+        public static System.Security.Cryptography.SymmetricAlgorithm Create(string algName) { throw null; }
         public virtual System.Security.Cryptography.ICryptoTransform CreateDecryptor() { throw null; }
         public abstract System.Security.Cryptography.ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV);
         public virtual System.Security.Cryptography.ICryptoTransform CreateEncryptor() { throw null; }

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/AsymmetricAlgorithm.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/AsymmetricAlgorithm.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-
 namespace System.Security.Cryptography
 {
     public abstract class AsymmetricAlgorithm : IDisposable
@@ -12,8 +9,16 @@ namespace System.Security.Cryptography
         protected int KeySizeValue;
         protected KeySizes[] LegalKeySizesValue;
 
-        protected AsymmetricAlgorithm()
+        protected AsymmetricAlgorithm() { }
+
+        public static AsymmetricAlgorithm Create()
         {
+            return Create("System.Security.Cryptography.AsymmetricAlgorithm");
+        }
+
+        public static AsymmetricAlgorithm Create(string algName)
+        {
+            throw new PlatformNotSupportedException();
         }
 
         public virtual int KeySize

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HMAC.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HMAC.cs
@@ -2,16 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.IO;
-using System.Diagnostics;
-
 namespace System.Security.Cryptography
 {
     public abstract class HMAC : KeyedHashAlgorithm
     {
-        protected HMAC()
+        protected HMAC() { }
+
+        static public new HMAC Create()
         {
+            return Create("System.Security.Cryptography.HMAC");
+        }
+
+        static public new HMAC Create(string algorithmName)
+        {
+            throw new PlatformNotSupportedException();
         }
 
         public String HashName

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HashAlgorithm.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HashAlgorithm.cs
@@ -10,6 +10,16 @@ namespace System.Security.Cryptography
     {
         protected HashAlgorithm() { }
 
+        public static HashAlgorithm Create()
+        {
+            return Create("System.Security.Cryptography.HashAlgorithm");
+        }
+
+        public static HashAlgorithm Create(string hashName)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
         public virtual int HashSize
         {
             get

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/KeyedHashAlgorithm.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/KeyedHashAlgorithm.cs
@@ -2,15 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-
 namespace System.Security.Cryptography
 {
     public abstract class KeyedHashAlgorithm : HashAlgorithm
     {
-        protected KeyedHashAlgorithm()
+        protected KeyedHashAlgorithm() { }
+
+        public static new KeyedHashAlgorithm Create()
         {
+            return Create("System.Security.Cryptography.KeyedHashAlgorithm");
+        }
+
+        public static new KeyedHashAlgorithm Create(string algName)
+        {
+            throw new PlatformNotSupportedException();
         }
 
         public virtual byte[] Key
@@ -43,4 +48,3 @@ namespace System.Security.Cryptography
         protected byte[] KeyValue;
     }
 }
-

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/SymmetricAlgorithm.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/SymmetricAlgorithm.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-
 namespace System.Security.Cryptography
 {
     public abstract class SymmetricAlgorithm : IDisposable
@@ -13,6 +10,16 @@ namespace System.Security.Cryptography
         {
             ModeValue = CipherMode.CBC;
             PaddingValue = PaddingMode.PKCS7;
+        }
+
+        public static SymmetricAlgorithm Create()
+        {
+            return Create("System.Security.Cryptography.SymmetricAlgorithm");
+        }
+
+        public static SymmetricAlgorithm Create(string algName)
+        {
+            throw new PlatformNotSupportedException();
         }
 
         public virtual int BlockSize

--- a/src/System.Security.Cryptography.Primitives/tests/CryptoConfigTests.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/CryptoConfigTests.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Security.Cryptography.CryptoConfigTests
+{
+    public static class CryptoConfigTests
+    {
+        [Fact]
+        public static void StaticCreateMethods()
+        {
+            // These are not supported because CryptoConfig exists in Algorithms assembly.
+            // CryptoConfig exists in Algorithms partly because it requires the Oid class in Encoding assembly.
+            Assert.Throws<PlatformNotSupportedException>(() => AsymmetricAlgorithm.Create());
+            Assert.Throws<PlatformNotSupportedException>(() => AsymmetricAlgorithm.Create(null));
+            Assert.Throws<PlatformNotSupportedException>(() => HashAlgorithm.Create());
+            Assert.Throws<PlatformNotSupportedException>(() => HashAlgorithm.Create(null));
+            Assert.Throws<PlatformNotSupportedException>(() => KeyedHashAlgorithm.Create());
+            Assert.Throws<PlatformNotSupportedException>(() => KeyedHashAlgorithm.Create(null));
+            Assert.Throws<PlatformNotSupportedException>(() => HMAC.Create());
+            Assert.Throws<PlatformNotSupportedException>(() => HMAC.Create(null));
+            Assert.Throws<PlatformNotSupportedException>(() => SymmetricAlgorithm.Create());
+            Assert.Throws<PlatformNotSupportedException>(() => SymmetricAlgorithm.Create(null));
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
+++ b/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
@@ -33,6 +33,9 @@
       <Link>CommonTest\System\IO\PositionValueStream.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp1.1'">  
+    <Compile Include="CryptoConfigTests.cs" />
+  </ItemGroup>
   <ItemGroup>
     <!-- TODO: Remove this when the package reference is ready -->
     <ProjectReference Include="..\..\System.Runtime\pkg\System.Runtime.pkgproj" />


### PR DESCRIPTION
Address issue https://github.com/dotnet/corefx/issues/12327 (Port System.Security.Cryptography.CryptoConfig)

Per offline discussion, CryptoConfig class was placed in S.S.C.Algorithms as it needs access to the Oid class in S.S.C.Encoding. This means the static Create methods added to S.S.C.Primitives throw PNSE. CryptoConfig could not be placed in S.S.C.Primitives as it wouldn't be able to reference Oid\S.S.C.Encoding without an cyclic assembly reference. There are alternatives to remove these PNSE including x-compile Oid and\or CryptoConfig, combining assemblies, moving types, etc but considered not worth the cost at this time. The workaround is to have consumers call CryptoConfig.CreateFromName directly.

@bartonjs please review.