### PR TITLE
Add System.Memory package to common\test-runtime\project.json

### DIFF
--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -67,6 +67,7 @@
     "System.Linq.Expressions": "4.4.0-beta-24715-03",
     "System.Linq.Parallel": "4.4.0-beta-24715-03",
     "System.Linq.Queryable": "4.4.0-beta-24715-03",
+    "System.Memory": "4.4.0-beta-24715-03",
     "System.Net.Http": "4.4.0-beta-24715-03",
     "System.Net.NameResolution": "4.4.0-beta-24715-03",
     "System.Net.NetworkInformation": "4.4.0-beta-24715-03",


### PR DESCRIPTION
FYI @karajas 

This is needed to unblock our official test builds. 