### PR TITLE
Fix XmlSerializer Test Project's ProjectReference.

### DIFF
--- a/src/System.Private.Xml/tests/XmlSerializer/System.Xml.XmlSerializer.Tests.csproj
+++ b/src/System.Private.Xml/tests/XmlSerializer/System.Xml.XmlSerializer.Tests.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\System.Private.Xml\pkg\System.Private.Xml.pkgproj" />
+    <ProjectReference Include="..\..\..\System.Xml.XmlSerializer\pkg\System.Xml.XmlSerializer.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.settings.targets
+++ b/src/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.settings.targets
@@ -10,7 +10,7 @@
     <TestSourceFolder>$(MSBuildThisFileDirectory)\</TestSourceFolder>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceFolder)..\..\System.Private.DataContractSerialization\src\System.Private.DataContractSerialization.csproj">
+    <ProjectReference Include="$(TestSourceFolder)..\..\System.Private.DataContractSerialization\pkg\System.Private.DataContractSerialization.pkgproj">
       <Project>{6B4C1660-D158-4820-BE1C-D7A29CEBEC9B}</Project>
       <Name>System.Private.DataContractSerialization</Name>
       <KeepProjectReference>true</KeepProjectReference>
@@ -23,6 +23,8 @@
       <Project>{D62A6082-5229-4845-8BE9-75753E08C65A}</Project>
       <Name>System.Xml.XmlSerializer</Name>
     </ProjectReference>
+    <ProjectReference Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\pkg\System.Runtime.Serialization.Xml.pkgproj" />
+    <ProjectReference Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Json\pkg\System.Runtime.Serialization.Json.pkgproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(TestSourceFolder)project.json" />

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2662,7 +2662,17 @@ public static partial class DataContractSerializerTests
     public static void DCS_BasicRoundTripResolveDTOTypes()
     {
         ObjectContainer instance = new ObjectContainer(new DTOContainer());
-        Func<DataContractSerializer> serializerfunc = () => new DataContractSerializer(typeof(ObjectContainer), null, null, null, int.MaxValue, false, false, new DTOResolver());
+        Func<DataContractSerializer> serializerfunc = () =>
+        {
+            var settings = new DataContractSerializerSettings()
+            {
+                DataContractResolver = new DTOResolver()
+            };
+
+            var serializer = new DataContractSerializer(typeof(ObjectContainer), settings);
+            return serializer;
+        };
+
         string expectedxmlstring = "<ObjectContainer xmlns =\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><_data i:type=\"a:DTOContainer\" xmlns:a=\"http://www.default.com\"><nDTO i:type=\"a:DTO\"><DateTime xmlns=\"http://schemas.datacontract.org/2004/07/System\">9999-12-31T23:59:59.9999999Z</DateTime><OffsetMinutes xmlns=\"http://schemas.datacontract.org/2004/07/System\">0</OffsetMinutes></nDTO></_data></ObjectContainer>";
         ObjectContainer deserialized = SerializeAndDeserialize(instance, expectedxmlstring, null, serializerfunc, false);
         Assert.Equal(DateTimeOffset.MaxValue, ((DTOContainer)deserialized.Data).nDTO);

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.settings.targets
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.settings.targets
@@ -10,7 +10,7 @@
     <TestSourceFolder>$(MSBuildThisFileDirectory)\</TestSourceFolder>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceFolder)..\..\System.Private.DataContractSerialization\src\System.Private.DataContractSerialization.csproj">
+    <ProjectReference Include="$(TestSourceFolder)..\..\System.Private.DataContractSerialization\pkg\System.Private.DataContractSerialization.pkgproj">
       <Project>{6B4C1660-D158-4820-BE1C-D7A29CEBEC9B}</Project>
       <Name>System.Private.DataContractSerialization</Name>
       <KeepProjectReference>true</KeepProjectReference>
@@ -23,6 +23,8 @@
       <Project>{D62A6082-5229-4845-8BE9-75753E08C65A}</Project>
       <Name>System.Xml.XmlSerializer</Name>
     </ProjectReference>
+    <ProjectReference Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\pkg\System.Runtime.Serialization.Xml.pkgproj" />
+    <ProjectReference Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Json\pkg\System.Runtime.Serialization.Json.pkgproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(TestSourceFolder)project.json" />


### PR DESCRIPTION
All serialization test projects did not reference contract assembly's pkgproj. This caused the test projects not building against the latest contract assemblies built by the repo.

The other issue is that DCS and DCJS's test projects referenced the implementation assembly's csproj directly, which caused the test projects being able to use types defined in implementation assembly while the types are not in the contracts.

The fix is to make test projects reference both contract assembly and implementation assembly's pkgproj.

Fix #11135.

/cc: @StephenBonikowsky @mconnew @zhenlan can you please review the change? Thanks!