### PR TITLE
Join(string separator, params object[] values) is fixed for first null in object array

### DIFF
--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1625,6 +1625,7 @@ namespace System.Tests
             // Join does nothing if array[0] is null
             yield return new object[] { "$$", new object[] { null, "Bar", "Baz" }, "" };
 #endif
+
             // Join should ignore objects that have a null ToString() value
             yield return new object[] { "|", new object[] { new ObjectWithNullToString(), "Foo", new ObjectWithNullToString(), "Bar", new ObjectWithNullToString() }, "|Foo||Bar|" };
         }

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1630,7 +1630,7 @@ namespace System.Tests
         public static void Join_ObjectArray(string separator, object[] values, string expected)
         {
             Assert.Equal(expected, string.Join(separator, values));
-            // Join is  fixed if array[0] is null
+            // Join is fixed if array[0] is null
             //if (!(values.Length > 0 && values[0] == null))
                 Assert.Equal(expected, string.Join(separator, (IEnumerable<object>)values));
         }

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1618,13 +1618,7 @@ namespace System.Tests
             yield return new object[] { null, new object[] { "Foo", "Bar", "Baz" }, "FooBarBaz" };
             yield return new object[] { "$$", new object[] { "Foo", null, "Baz" }, "Foo$$$$Baz" };
 
-#if netstandard17
-            // Join is fixed if array[0] is null
             yield return new object[] { "$$", new object[] { null, "Bar", "Baz" }, "$$Bar$$Baz" };
-#else
-            // Join does nothing if array[0] is null
-            yield return new object[] { "$$", new object[] { null, "Bar", "Baz" }, "" };
-#endif
 
             // Join should ignore objects that have a null ToString() value
             yield return new object[] { "|", new object[] { new ObjectWithNullToString(), "Foo", new ObjectWithNullToString(), "Bar", new ObjectWithNullToString() }, "|Foo||Bar|" };
@@ -1634,15 +1628,15 @@ namespace System.Tests
         [MemberData(nameof(Join_ObjectArray_TestData))]
         public static void Join_ObjectArray(string separator, object[] values, string expected)
         {
-            Assert.Equal(expected, string.Join(separator, values));
 #if netstandard17
-            // Join is fixed if array[0] is null
-            Assert.Equal(expected, string.Join(separator, (IEnumerable<object>)values));
+            Assert.Equal(expected, string.Join(separator, values));
 #else
-            // Join does nothing if array[0] is null
-            if (!(values.Length > 0 && values[0] == null))
-                Assert.Equal(expected, string.Join(separator, (IEnumerable<object>)values));
+            if (values.Length > 0 && values[0] == null) // Join return empty string if array[0] is null
+                Assert.Equal("", string.Join(separator, values));
+            else
+                Assert.Equal(expected, string.Join(separator, values));
 #endif
+            Assert.Equal(expected, string.Join(separator, (IEnumerable<object>)values));
         }
 
         [Fact]

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1618,9 +1618,13 @@ namespace System.Tests
             yield return new object[] { null, new object[] { "Foo", "Bar", "Baz" }, "FooBarBaz" };
             yield return new object[] { "$$", new object[] { "Foo", null, "Baz" }, "Foo$$$$Baz" };
 
+#if netstandard17
             // Join is fixed if array[0] is null
             yield return new object[] { "$$", new object[] { null, "Bar", "Baz" }, "$$Bar$$Baz" };
-
+#else
+            // Join does nothing if array[0] is null
+            yield return new object[] { "$$", new object[] { null, "Bar", "Baz" }, "" };
+#endif
             // Join should ignore objects that have a null ToString() value
             yield return new object[] { "|", new object[] { new ObjectWithNullToString(), "Foo", new ObjectWithNullToString(), "Bar", new ObjectWithNullToString() }, "|Foo||Bar|" };
         }
@@ -1630,9 +1634,14 @@ namespace System.Tests
         public static void Join_ObjectArray(string separator, object[] values, string expected)
         {
             Assert.Equal(expected, string.Join(separator, values));
+#if netstandard17
             // Join is fixed if array[0] is null
-            //if (!(values.Length > 0 && values[0] == null))
+            Assert.Equal(expected, string.Join(separator, (IEnumerable<object>)values));
+#else
+            // Join does nothing if array[0] is null
+            if (!(values.Length > 0 && values[0] == null))
                 Assert.Equal(expected, string.Join(separator, (IEnumerable<object>)values));
+#endif
         }
 
         [Fact]

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1618,8 +1618,8 @@ namespace System.Tests
             yield return new object[] { null, new object[] { "Foo", "Bar", "Baz" }, "FooBarBaz" };
             yield return new object[] { "$$", new object[] { "Foo", null, "Baz" }, "Foo$$$$Baz" };
 
-            // Join does nothing if array[0] is null
-            yield return new object[] { "$$", new object[] { null, "Bar", "Baz" }, "" };
+            // Join is fixed if array[0] is null
+            yield return new object[] { "$$", new object[] { null, "Bar", "Baz" }, "$$Bar$$Baz" };
 
             // Join should ignore objects that have a null ToString() value
             yield return new object[] { "|", new object[] { new ObjectWithNullToString(), "Foo", new ObjectWithNullToString(), "Bar", new ObjectWithNullToString() }, "|Foo||Bar|" };
@@ -1630,10 +1630,9 @@ namespace System.Tests
         public static void Join_ObjectArray(string separator, object[] values, string expected)
         {
             Assert.Equal(expected, string.Join(separator, values));
-            if (!(values.Length > 0 && values[0] == null))
-            {
+            // Join is  fixed if array[0] is null
+            //if (!(values.Length > 0 && values[0] == null))
                 Assert.Equal(expected, string.Join(separator, (IEnumerable<object>)values));
-            }
         }
 
         [Fact]


### PR DESCRIPTION
Join issue for first null in object array is fixed. So calling string.Join(",", null, 1, 2, 3) now return ",1,2,3", but not empty string as before. See https://github.com/dotnet/coreclr/pull/8114