### PR TITLE
[release/1.1.0] Disable package build for packages not shipping

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -16,6 +16,7 @@
       "StableVersions": [
         "1.0.0",
         "1.0.1",
+        "1.0.2",
         "1.1.0"
       ],
       "BaselineVersion": "1.1.0"
@@ -1362,6 +1363,7 @@
       "StableVersions": [
         "4.0.0",
         "4.1.0",
+        "4.1.1",
         "4.3.0"
       ],
       "BaselineVersion": "4.3.0",
@@ -1386,6 +1388,7 @@
     "System.Net.Http.WinHttpHandler": {
       "StableVersions": [
         "4.0.0",
+        "4.0.1",
         "4.3.0"
       ],
       "BaselineVersion": "4.3.0",

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -5,9 +5,10 @@
   <PropertyGroup>
     <PackageReportDir Condition="'$(PackageReportDir)' == ''">$(BinDir)pkg/reports/</PackageReportDir>
     <BuildAllOSGroups Condition="'$(FilterToOSGroup)' != ''">false</BuildAllOSGroups>
+    <BuildAllPackages>false</BuildAllPackages>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(BuildAllPackages)' == 'true'" >
     <Project Include="Native\pkg\**\*.builds" Condition="'$(SkipNativePackageBuild)' != 'true'">
       <AdditionalProperties>$(AdditionalProperties);SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
       <BuildAllOSGroups>$(BuildAllOSGroups)</BuildAllOSGroups>
@@ -18,6 +19,10 @@
     <Project Include="..\pkg\*\*.builds" Condition="'$(SkipManagedPackageBuild)' != 'true'">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipManagedPackageBuild)' != 'true'" >
+    <!-- add specific builds / pkgproj's here to include in servicing builds -->
   </ItemGroup>
 
   <UsingTask TaskName="GenerateNetStandardSupportTable" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll" />

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -22,6 +22,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false' AND '$(SkipManagedPackageBuild)' != 'true'" >
+    <Project Include="..\pkg\Microsoft.Private.PackageBaseline\Microsoft.Private.PackageBaseline.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+
     <!-- add specific builds / pkgproj's here to include in servicing builds -->
   </ItemGroup>
 


### PR DESCRIPTION
Disable full package build for 1.1.0.  In servicing we only build packages we intend to ship.

Add 1.0.0 serviced packages to 1.1.0 index.  We'll harvest from these as necessary.

/cc @weshaggard @gkhanna79 @chcosta 