### PR TITLE
Made DCS/DCJS Support IDeserializationCallback.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
@@ -275,6 +275,17 @@ namespace System.Runtime.Serialization
             }
         }
 
+        private static Type s_typeOfIDeserializationCallback;
+        internal static Type TypeOfIDeserializationCallback
+        {
+            get
+            {
+                if (s_typeOfIDeserializationCallback == null)
+                    s_typeOfIDeserializationCallback = typeof(IDeserializationCallback);
+                return s_typeOfIDeserializationCallback;
+            }
+        }
+
         [SecurityCritical]
         private static Type s_typeOfXmlFormatClassWriterDelegate;
         internal static Type TypeOfXmlFormatClassWriterDelegate

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
@@ -56,6 +56,8 @@ namespace System.Runtime.Serialization
         [SecurityCritical]
         private static PropertyInfo s_nodeTypeProperty;
 
+        private static MethodInfo s_onDeserializationMethod;
+
         [SecurityCritical]
         private static MethodInfo s_readJsonValueMethod;
 
@@ -287,6 +289,18 @@ namespace System.Runtime.Serialization
                     Debug.Assert(s_nodeTypeProperty != null);
                 }
                 return s_nodeTypeProperty;
+            }
+        }
+        public static MethodInfo OnDeserializationMethod
+        {
+            [SecuritySafeCritical]
+            get
+            {
+                if (s_onDeserializationMethod == null)
+                {
+                    s_onDeserializationMethod = typeof(IDeserializationCallback).GetMethod("OnDeserialization");
+                }
+                return s_onDeserializationMethod;
             }
         }
         public static MethodInfo ReadJsonValueMethod

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
@@ -94,6 +94,12 @@ namespace System.Runtime.Serialization.Json
                     ReadISerializable(classContract);
                 else
                     ReadClass(classContract);
+
+                if (Globals.TypeOfIDeserializationCallback.IsAssignableFrom(classContract.UnderlyingType))
+                {
+                    _ilg.Call(_objectLocal, JsonFormatGeneratorStatics.OnDeserializationMethod, null);
+                }
+
                 InvokeOnDeserialized(classContract);
                 if (!InvokeFactoryMethod(classContract))
                 {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionReader.cs
@@ -35,12 +35,7 @@ namespace System.Runtime.Serialization
 
             ReflectionReadMembers(xmlReader, context, memberNames, memberNamespaces, classContract, ref obj);
             obj = ResolveAdapterObject(obj, classContract);
-
-            if (Globals.TypeOfIDeserializationCallback.IsAssignableFrom(classContract.UnderlyingType))
-            {
-                XmlFormatGeneratorStatics.OnDeserializationMethod.Invoke(obj, new object[] { null });
-            }
-
+            InvokeDeserializationCallback(obj);
             InvokeOnDeserialized(context, classContract, obj);
 
             return obj;
@@ -352,6 +347,12 @@ namespace System.Runtime.Serialization
                 var contextArg = context.GetStreamingContext();
                 classContract.OnDeserialized.Invoke(obj, new object[] { contextArg });
             }
+        }
+
+        private void InvokeDeserializationCallback(object obj)
+        {
+            var deserializationCallbackObject = obj as IDeserializationCallback;
+            deserializationCallbackObject?.OnDeserialization(null);
         }
 
         private static object CreateObject(ClassDataContract classContract)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionReader.cs
@@ -36,6 +36,11 @@ namespace System.Runtime.Serialization
             ReflectionReadMembers(xmlReader, context, memberNames, memberNamespaces, classContract, ref obj);
             obj = ResolveAdapterObject(obj, classContract);
 
+            if (Globals.TypeOfIDeserializationCallback.IsAssignableFrom(classContract.UnderlyingType))
+            {
+                XmlFormatGeneratorStatics.OnDeserializationMethod.Invoke(obj, new object[] { null });
+            }
+
             InvokeOnDeserialized(context, classContract, obj);
 
             return obj;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
@@ -195,6 +195,17 @@ namespace System.Runtime.Serialization
             }
         }
 
+        private static MethodInfo s_onDeserializationMethod;
+        internal static MethodInfo OnDeserializationMethod
+        {
+            get
+            {
+                if (s_onDeserializationMethod == null)
+                    s_onDeserializationMethod = typeof(IDeserializationCallback).GetMethod("OnDeserialization");
+                return s_onDeserializationMethod;
+            }
+        }
+
         [SecurityCritical]
         private static PropertyInfo s_nodeTypeProperty;
         internal static PropertyInfo NodeTypeProperty

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
@@ -150,6 +150,11 @@ namespace System.Runtime.Serialization
                         ReadClass(classContract);
                     }
 
+                    if (Globals.TypeOfIDeserializationCallback.IsAssignableFrom(classContract.UnderlyingType))
+                    {
+                        _ilg.Call(_objectLocal, XmlFormatGeneratorStatics.OnDeserializationMethod, null);
+                    }
+
                     InvokeOnDeserialized(classContract);
                     if (objectId == null)
                     {

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2330,6 +2330,15 @@ public static partial class DataContractJsonSerializerTests
         Assert.Equal(0, deserialized.Member2);
     }
 
+    [Fact]
+    public static void DCJS_SquareWithDeserializationCallback()
+    {
+        var value = new SquareWithDeserializationCallback(2);
+        var actual = SerializeAndDeserialize(value, "{\"Edge\":2}");
+        Assert.NotNull(actual);
+        Assert.Equal(value.Area, actual.Area);
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractJsonSerializerSettings settings = null, Func<DataContractJsonSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractJsonSerializer dcjs;

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2811,6 +2811,15 @@ public static partial class DataContractSerializerTests
         Assert.Throws<SerializationException>(() => SerializeAndDeserialize(value2, ""));
     }
 
+    [Fact]
+    public static void DCS_SquareWithDeserializationCallback()
+    {
+        var value = new SquareWithDeserializationCallback(2);
+        var actual = SerializeAndDeserialize(value, "<SquareWithDeserializationCallback xmlns=\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><Edge>2</Edge></SquareWithDeserializationCallback>");
+        Assert.NotNull(actual);
+        Assert.Equal(value.Area, actual.Area);
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractSerializer dcs;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -4115,3 +4115,28 @@ public class MyXmlTextParser : IXmlTextParser
         }
     }
 }
+
+[Serializable]
+public class SquareWithDeserializationCallback : IDeserializationCallback
+{
+
+    public int Edge;
+
+    [NonSerialized]
+    private int _area;
+
+    public int Area => _area;
+
+    public SquareWithDeserializationCallback(int edge)
+    {
+        Edge = edge;
+        _area = edge * edge;
+    }
+
+    void IDeserializationCallback.OnDeserialization(object sender)
+    {
+        // After being deserialized, initialize the _area field 
+        // using the deserialized Radius value.
+        _area = Edge * Edge;
+    }
+}


### PR DESCRIPTION
Made DataContractSerializer and DataContractJsonSerializer to support IDeserializationCallback.

Fix #13368.