### PR TITLE
Fix ExceptionVerifier bug in XSLT tests

### DIFF
--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/ExceptionVerifier.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/ExceptionVerifier.cs
@@ -134,9 +134,8 @@ namespace System.Xml.Tests
                 {
                     try
                     {
-                        throw new NotImplementedException("Cannot Load Satellite assembly");
                         // load satellite assembly
-                        //locAsm = asm.GetSatelliteAssembly(new CultureInfo(CultureInfo.CurrentCulture.Parent.IetfLanguageTag));
+                        _locAsm = _asm.GetSatelliteAssembly(new CultureInfo(CultureInfo.CurrentCulture.Parent.IetfLanguageTag));
                     }
                     catch (FileNotFoundException e1)
                     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/13706. In cultures other than en_US locale the `ExceptionVerifer` class needs to load satellite assembly, which was removed at the time of porting tests due to the API not being available.

cc: @danmosemsft @stephentoub 