### PR TITLE
Remove dead branches in Color.op_Equality

### DIFF
--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -612,26 +612,10 @@ namespace System.Drawing
         }
 
         public static bool operator ==(Color left, Color right)
-        {
-            if (left.value == right.value
+            => left.value == right.value
                 && left.state == right.state
-                && left.knownColor == right.knownColor)
-            {
-                if (left.name == right.name)
-                {
-                    return true;
-                }
-
-                if (ReferenceEquals(left.name, null) || ReferenceEquals(right.name, null))
-                {
-                    return false;
-                }
-
-                return left.name.Equals(right.name);
-            }
-
-            return false;
-        }
+                && left.knownColor == right.knownColor
+                && left.name == right.name;
 
         public static bool operator !=(Color left, Color right)
         {

--- a/src/System.Drawing.Primitives/tests/ColorTests.cs
+++ b/src/System.Drawing.Primitives/tests/ColorTests.cs
@@ -493,6 +493,10 @@ namespace System.Drawing.Primitives.Tests
             yield return new object[] { Color.FromName("SomeName"), Color.FromName("SomeOtherName"), false };
 
             yield return new object[] { Color.FromArgb(0, 0, 0), default(Color), false };
+
+            string someNameConstructed = string.Join("", "Some", "Name");
+            Assert.NotSame("SomeName", someNameConstructed); // If this fails the above must be changed so this test is correct.
+            yield return new object[] {Color.FromName("SomeName"), Color.FromName(someNameConstructed), true};
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // desktop incorrectly does "name.Equals(name)" in Equals


### PR DESCRIPTION
`Color.op_Equality` uses the common pattern for the name field of:
1. Return true on left is same instance as right.
2. Return false on left or right are null, since both null is considered above
3. Do fuller equality test.

However since `==` is overloaded for `string`, step 1 is not as intended.
Since `string` `==` does the same logic as above anyway, the rest are just three branches that will all return false.

Cut out these branches, and just use `string` `==` directly.

Also add test case for Color objects with equal, but not same-instance, names, as this case isn't covered in current tests.