### PR TITLE
Disable SSLv3 default test on older libcurls

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -117,7 +117,7 @@ namespace System.Net.Http.Functional.Tests
         // instead of local ones.  We're keeping it for now (as outerloop) because it helps
         // to validate against another SSL implementation that what we mean by a particular
         // TLS version matches that other implementation.
-        [OuterLoop] // avoid www.ssllabs.com dependency in innerloop
+        [OuterLoop("Avoid www.ssllabs.com dependency in innerloop.")]
         [Theory]
         [MemberData(nameof(SupportedSSLVersionServers))]
         public async Task GetAsync_SupportedSSLVersion_Succeeds(string name, string url)
@@ -138,8 +138,8 @@ namespace System.Net.Http.Functional.Tests
         // explicitly disallow creating SslStream with SSLv2/3.  Since we explicitly throw
         // when trying to use such an SslStream, we can't stand up a localhost server that
         // only speaks those protocols.
-        [OuterLoop] // avoid www.ssllabs.com dependency in innerloop
-        [Theory]
+        [OuterLoop("Avoid www.ssllabs.com dependency in innerloop.")]
+        [ConditionalTheory(nameof(SSLv3DisabledByDefault))]
         [MemberData(nameof(NotSupportedSSLVersionServers))]
         public async Task GetAsync_UnsupportedSSLVersion_Throws(string name, string url)
         {
@@ -237,6 +237,13 @@ namespace System.Net.Http.Functional.Tests
         private static bool BackendSupportsSslConfiguration =>
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
             (CurlSslVersionDescription()?.StartsWith("OpenSSL") ?? false);
+
+        private static bool SSLv3DisabledByDefault =>
+            BackendSupportsSslConfiguration ||
+            Version.Parse(CurlVersionDescription()) >= new Version(7, 39); // libcurl disables SSLv3 by default starting in v7.39
+
+        [DllImport("System.Net.Http.Native", EntryPoint = "HttpNative_GetVersionDescription")]
+        private static extern string CurlVersionDescription();
 
         [DllImport("System.Net.Http.Native", EntryPoint = "HttpNative_GetSslVersionDescription")]
         private static extern string CurlSslVersionDescription();


### PR DESCRIPTION
libcurl prior to v7.39 allows SSLv3 by default.  Since we've switched our defaults to accepting whatever the platform defaults are, this commit disables our SSLv3-disabled-by-default test on libcurl versions earlier than 7.39.