### PR TITLE
Drawing primitives cleanup

### DIFF
--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -412,7 +412,7 @@ namespace System.Drawing
                 }
                 if (IsKnownColor)
                 {
-                    return unchecked((int)KnownColorTable.KnownColorToArgb((KnownColor)knownColor));
+                    return KnownColorTable.KnownColorToArgb((KnownColor)knownColor);
                 }
 
                 return s_notDefinedValue;

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -306,11 +306,11 @@ namespace System.Drawing
         // NOTE : The "zero" pattern (all members being 0) must represent
         //      : "not set". This allows "Color c;" to be correct.
 
-        private static short s_stateKnownColorValid = 0x0001;
-        private static short s_stateARGBValueValid = 0x0002;
-        private static short s_stateValueMask = (short)(s_stateARGBValueValid);
-        private static short s_stateNameValid = 0x0008;
-        private static long s_notDefinedValue = 0;
+        private static readonly short s_stateKnownColorValid = 0x0001;
+        private static readonly short s_stateARGBValueValid = 0x0002;
+        private static readonly short s_stateValueMask = s_stateARGBValueValid;
+        private static readonly short s_stateNameValid = 0x0008;
+        private static readonly long s_notDefinedValue = 0;
 
         /**
          * Shift count and bit mask for A, R, G, B components in ARGB mode!

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -545,10 +545,10 @@ namespace System.Drawing
             float g = G / 255.0f;
             float b = B / 255.0f;
 
-            float max, min;
-            float l, s = 0;
+            float s = 0;
 
-            max = r; min = r;
+            float max = r;
+            float min = r;
 
             if (g > max) max = g;
             if (b > max) max = b;
@@ -561,7 +561,7 @@ namespace System.Drawing
             //
             if (max != min)
             {
-                l = (max + min) / 2;
+                float l = (max + min) / 2;
 
                 if (l <= .5)
                 {

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -306,11 +306,11 @@ namespace System.Drawing
         // NOTE : The "zero" pattern (all members being 0) must represent
         //      : "not set". This allows "Color c;" to be correct.
 
-        private static readonly short s_stateKnownColorValid = 0x0001;
-        private static readonly short s_stateARGBValueValid = 0x0002;
-        private static readonly short s_stateValueMask = s_stateARGBValueValid;
-        private static readonly short s_stateNameValid = 0x0008;
-        private static readonly long s_notDefinedValue = 0;
+        private const short StateKnownColorValid = 0x0001;
+        private const short StateARGBValueValid = 0x0002;
+        private const short StateValueMask = StateARGBValueValid;
+        private const short StateNameValid = 0x0008;
+        private const long NotDefinedValue = 0;
 
         /**
          * Shift count and bit mask for A, R, G, B components in ARGB mode!
@@ -342,7 +342,7 @@ namespace System.Drawing
         internal Color(KnownColor knownColor)
         {
             value = 0;
-            state = s_stateKnownColorValid;
+            state = StateKnownColorValid;
             name = null;
             this.knownColor = unchecked((short)knownColor);
         }
@@ -363,11 +363,11 @@ namespace System.Drawing
 
         public byte A => (byte)((Value >> ARGBAlphaShift) & 0xFF);
 
-        public bool IsKnownColor => ((state & s_stateKnownColorValid) != 0);
+        public bool IsKnownColor => ((state & StateKnownColorValid) != 0);
 
         public bool IsEmpty => state == 0;
 
-        public bool IsNamedColor => ((state & s_stateNameValid) != 0) || IsKnownColor;
+        public bool IsNamedColor => ((state & StateNameValid) != 0) || IsKnownColor;
 
         public bool IsSystemColor => IsKnownColor && ((((KnownColor)knownColor) <= KnownColor.WindowText) || (((KnownColor)knownColor) > KnownColor.YellowGreen));
 
@@ -382,14 +382,13 @@ namespace System.Drawing
         {
             get
             {
-                if ((state & s_stateNameValid) != 0)
+                if ((state & StateNameValid) != 0)
                 {
                     return name;
                 }
 
                 if (IsKnownColor)
                 {
-                    // first try the table so we can avoid the (slow!) .ToString()
                     string tablename = KnownColorTable.KnownColorToName((KnownColor)knownColor);
                     Debug.Assert(tablename != null, $"Could not find known color '{(KnownColor)knownColor}' in the KnownColorTable");
 
@@ -406,7 +405,7 @@ namespace System.Drawing
         {
             get
             {
-                if ((state & s_stateValueMask) != 0)
+                if ((state & StateValueMask) != 0)
                 {
                     return value;
                 }
@@ -416,7 +415,7 @@ namespace System.Drawing
                     return KnownColorTable.KnownColorToArgb((KnownColor)knownColor);
                 }
 
-                return s_notDefinedValue;
+                return NotDefinedValue;
             }
         }
 
@@ -432,7 +431,7 @@ namespace System.Drawing
                 blue << ARGBBlueShift |
                 alpha << ARGBAlphaShift)) & 0xffffffff;
 
-        public static Color FromArgb(int argb) => new Color(argb & 0xffffffff, s_stateARGBValueValid, null, 0);
+        public static Color FromArgb(int argb) => new Color(argb & 0xffffffff, StateARGBValueValid, null, 0);
 
         public static Color FromArgb(int alpha, int red, int green, int blue)
         {
@@ -440,14 +439,14 @@ namespace System.Drawing
             CheckByte(red, nameof(red));
             CheckByte(green, nameof(green));
             CheckByte(blue, nameof(blue));
-            return new Color(MakeArgb((byte)alpha, (byte)red, (byte)green, (byte)blue), s_stateARGBValueValid, null, (KnownColor)0);
+            return new Color(MakeArgb((byte)alpha, (byte)red, (byte)green, (byte)blue), StateARGBValueValid, null, (KnownColor)0);
         }
 
         public static Color FromArgb(int alpha, Color baseColor)
         {
             CheckByte(alpha, nameof(alpha));
             // unchecked - because we already checked that alpha is a byte in CheckByte above
-            return new Color(MakeArgb(unchecked((byte)alpha), baseColor.R, baseColor.G, baseColor.B), s_stateARGBValueValid, null, (KnownColor)0);
+            return new Color(MakeArgb(unchecked((byte)alpha), baseColor.R, baseColor.G, baseColor.B), StateARGBValueValid, null, (KnownColor)0);
         }
 
         public static Color FromArgb(int red, int green, int blue) => FromArgb(255, red, green, blue);
@@ -472,7 +471,7 @@ namespace System.Drawing
                 return color;
             }
             // otherwise treat it as a named color
-            return new Color(s_notDefinedValue, s_stateNameValid, name, (KnownColor)0);
+            return new Color(NotDefinedValue, StateNameValid, name, (KnownColor)0);
         }
 
         public float GetBrightness()
@@ -581,11 +580,11 @@ namespace System.Drawing
 
         public override string ToString()
         {
-            if ((state & s_stateNameValid) != 0 || (state & s_stateKnownColorValid) != 0)
+            if ((state & StateNameValid) != 0 || (state & StateKnownColorValid) != 0)
             {
                 return nameof(Color) + " [" + Name + "]";
             }
-            else if ((state & s_stateValueMask) != 0)
+            else if ((state & StateValueMask) != 0)
             {
                 return nameof(Color) + " [A=" + A.ToString() + ", R=" + R.ToString() + ", G=" + G.ToString() + ", B=" + B.ToString() + "]";
             }

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics.Hashing;
-using System.Text;
 
 namespace System.Drawing
 {

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -391,12 +391,9 @@ namespace System.Drawing
                 {
                     // first try the table so we can avoid the (slow!) .ToString()
                     string tablename = KnownColorTable.KnownColorToName((KnownColor)knownColor);
-                    if (tablename != null)
-                        return tablename;
+                    Debug.Assert(tablename != null, $"Could not find known color '{(KnownColor)knownColor}' in the KnownColorTable");
 
-                    Debug.Assert(false, "Could not find known color '" + ((KnownColor)knownColor) + "' in the KnownColorTable");
-
-                    return ((KnownColor)knownColor).ToString();
+                    return tablename;
                 }
 
                 // if we reached here, just encode the value

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -410,6 +410,7 @@ namespace System.Drawing
                 {
                     return value;
                 }
+
                 if (IsKnownColor)
                 {
                     return KnownColorTable.KnownColorToArgb((KnownColor)knownColor);
@@ -425,18 +426,13 @@ namespace System.Drawing
                 throw new ArgumentException(SR.Format(SR.InvalidEx2BoundArgument, name, value, 0, 255));
         }
 
-        private static long MakeArgb(byte alpha, byte red, byte green, byte blue)
-        {
-            return (long)(unchecked((uint)(red << ARGBRedShift |
-                         green << ARGBGreenShift |
-                         blue << ARGBBlueShift |
-                         alpha << ARGBAlphaShift))) & 0xffffffff;
-        }
+        private static long MakeArgb(byte alpha, byte red, byte green, byte blue) =>
+            (long)unchecked((uint)(red << ARGBRedShift |
+                green << ARGBGreenShift |
+                blue << ARGBBlueShift |
+                alpha << ARGBAlphaShift)) & 0xffffffff;
 
-        public static Color FromArgb(int argb)
-        {
-            return new Color((long)argb & 0xffffffff, s_stateARGBValueValid, null, (KnownColor)0);
-        }
+        public static Color FromArgb(int argb) => new Color(argb & 0xffffffff, s_stateARGBValueValid, null, 0);
 
         public static Color FromArgb(int alpha, int red, int green, int blue)
         {
@@ -454,10 +450,7 @@ namespace System.Drawing
             return new Color(MakeArgb(unchecked((byte)alpha), baseColor.R, baseColor.G, baseColor.B), s_stateARGBValueValid, null, (KnownColor)0);
         }
 
-        public static Color FromArgb(int red, int green, int blue)
-        {
-            return FromArgb(255, red, green, blue);
-        }
+        public static Color FromArgb(int red, int green, int blue) => FromArgb(255, red, green, blue);
 
         public static Color FromKnownColor(KnownColor color)
         {
@@ -466,6 +459,7 @@ namespace System.Drawing
             {
                 return Color.FromName(color.ToString());
             }
+
             return new Color(color);
         }
 
@@ -581,15 +575,9 @@ namespace System.Drawing
             return s;
         }
 
-        public int ToArgb()
-        {
-            return unchecked((int)Value);
-        }
+        public int ToArgb() => unchecked((int)Value);
 
-        public KnownColor ToKnownColor()
-        {
-            return (KnownColor)knownColor;
-        }
+        public KnownColor ToKnownColor() => (KnownColor)knownColor;
 
         public override string ToString()
         {
@@ -607,21 +595,15 @@ namespace System.Drawing
             }
         }
 
-        public static bool operator ==(Color left, Color right)
-            => left.value == right.value
+        public static bool operator ==(Color left, Color right) =>
+            left.value == right.value
                 && left.state == right.state
                 && left.knownColor == right.knownColor
                 && left.name == right.name;
 
-        public static bool operator !=(Color left, Color right)
-        {
-            return !(left == right);
-        }
+        public static bool operator !=(Color left, Color right) => !(left == right);
 
-        public override bool Equals(object obj)
-        {
-            return obj is Color && this == (Color)obj;
-        }
+        public override bool Equals(object obj) => obj is Color && this == (Color)obj;
 
         public override int GetHashCode()
         {

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -477,9 +477,9 @@ namespace System.Drawing
 
         public float GetBrightness()
         {
-            float r = (float)R / 255.0f;
-            float g = (float)G / 255.0f;
-            float b = (float)B / 255.0f;
+            float r = R / 255.0f;
+            float g = G / 255.0f;
+            float b = B / 255.0f;
 
             float max, min;
 
@@ -500,9 +500,9 @@ namespace System.Drawing
             if (R == G && G == B)
                 return 0; // 0 makes as good an UNDEFINED value as any
 
-            float r = (float)R / 255.0f;
-            float g = (float)G / 255.0f;
-            float b = (float)B / 255.0f;
+            float r = R / 255.0f;
+            float g = G / 255.0f;
+            float b = B / 255.0f;
 
             float max, min;
             float delta;
@@ -541,9 +541,9 @@ namespace System.Drawing
 
         public float GetSaturation()
         {
-            float r = (float)R / 255.0f;
-            float g = (float)G / 255.0f;
-            float b = (float)B / 255.0f;
+            float r = R / 255.0f;
+            float g = G / 255.0f;
+            float b = B / 255.0f;
 
             float max, min;
             float l, s = 0;

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -457,7 +457,7 @@ namespace System.Drawing
             var value = (int)color;
             if (value < (int)KnownColor.ActiveBorder || value > (int)KnownColor.MenuHighlight)
             {
-                return Color.FromName(color.ToString());
+                return FromName(color.ToString());
             }
 
             return new Color(color);

--- a/src/System.Drawing.Primitives/src/System/Drawing/KnownColorTable.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/KnownColorTable.cs
@@ -21,7 +21,7 @@ namespace System.Drawing
 
         private static void InitColorTable()
         {
-            int[] values = new int[(unchecked((int)KnownColor.MenuHighlight)) + 1];
+            int[] values = new int[(int)KnownColor.MenuHighlight + 1];
 
             // system
             //
@@ -36,7 +36,7 @@ namespace System.Drawing
             values[(int)KnownColor.Aquamarine] = unchecked((int)0xFF7FFFD4);
             values[(int)KnownColor.Azure] = unchecked((int)0xFFF0FFFF);
             values[(int)KnownColor.Beige] = unchecked((int)0xFFF5F5DC);
-            values[(int)KnownColor.Bisque] = unchecked(unchecked((int)0xFFFFE4C4));
+            values[(int)KnownColor.Bisque] = unchecked((int)0xFFFFE4C4);
             values[(int)KnownColor.Black] = unchecked((int)0xFF000000);
             values[(int)KnownColor.BlanchedAlmond] = unchecked((int)0xFFFFEBCD);
             values[(int)KnownColor.Blue] = unchecked((int)0xFF0000FF);
@@ -372,7 +372,7 @@ namespace System.Drawing
             EnsureColorTable();
             if (color <= KnownColor.MenuHighlight)
             {
-                return s_colorTable[unchecked((int)color)];
+                return s_colorTable[(int)color];
             }
             else
             {
@@ -385,7 +385,7 @@ namespace System.Drawing
             EnsureColorNameTable();
             if (color <= KnownColor.MenuHighlight)
             {
-                return s_colorNameTable[unchecked((int)color)];
+                return s_colorNameTable[(int)color];
             }
             else
             {

--- a/src/System.Drawing.Primitives/src/System/Drawing/KnownColorTable.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/KnownColorTable.cs
@@ -9,18 +9,6 @@ namespace System.Drawing
         private static int[] s_colorTable;
         private static string[] s_colorNameTable;
 
-        /**
-         * Shift count and bit mask for A, R, G, B components
-         */
-        private const int AlphaShift = 24;
-        private const int RedShift = 16;
-        private const int GreenShift = 8;
-        private const int BlueShift = 0;
-
-        private const int Win32RedShift = 0;
-        private const int Win32GreenShift = 8;
-        private const int Win32BlueShift = 16;
-
         private static void EnsureColorTable()
         {
             // no need to lock... worse case is a double create of the table...

--- a/src/System.Drawing.Primitives/src/System/Drawing/Point.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Point.cs
@@ -59,27 +59,15 @@ namespace System.Drawing
         ///       Gets a value indicating whether this <see cref='System.Drawing.Point'/> is empty.
         ///    </para>
         /// </summary>
-        public bool IsEmpty
-        {
-            get
-            {
-                return _x == 0 && _y == 0;
-            }
-        }
+        public bool IsEmpty => _x == 0 && _y == 0;
 
         /// <summary>
         ///    Gets the x-coordinate of this <see cref='System.Drawing.Point'/>.
         /// </summary>
         public int X
         {
-            get
-            {
-                return _x;
-            }
-            set
-            {
-                _x = value;
-            }
+            get { return _x; }
+            set { _x = value; }
         }
 
         /// <summary>
@@ -89,14 +77,8 @@ namespace System.Drawing
         /// </summary>
         public int Y
         {
-            get
-            {
-                return _y;
-            }
-            set
-            {
-                _y = value;
-            }
+            get { return _y; }
+            set { _y = value; }
         }
 
         /// <summary>
@@ -105,40 +87,28 @@ namespace System.Drawing
         ///    <see cref='System.Drawing.Point'/> 
         /// </para>
         /// </summary>
-        public static implicit operator PointF(Point p)
-        {
-            return new PointF(p.X, p.Y);
-        }
+        public static implicit operator PointF(Point p) => new PointF(p.X, p.Y);
 
         /// <summary>
         ///    <para>
         ///       Creates a <see cref='System.Drawing.Size'/> with the coordinates of the specified <see cref='System.Drawing.Point'/> .
         ///    </para>
         /// </summary>
-        public static explicit operator Size(Point p)
-        {
-            return new Size(p.X, p.Y);
-        }
+        public static explicit operator Size(Point p) => new Size(p.X, p.Y);
 
         /// <summary>
         ///    <para>
         ///       Translates a <see cref='System.Drawing.Point'/> by a given <see cref='System.Drawing.Size'/> .
         ///    </para>
         /// </summary>        
-        public static Point operator +(Point pt, Size sz)
-        {
-            return Add(pt, sz);
-        }
+        public static Point operator +(Point pt, Size sz) => Add(pt, sz);
 
         /// <summary>
         ///    <para>
         ///       Translates a <see cref='System.Drawing.Point'/> by the negative of a given <see cref='System.Drawing.Size'/> .
         ///    </para>
         /// </summary>        
-        public static Point operator -(Point pt, Size sz)
-        {
-            return Subtract(pt, sz);
-        }
+        public static Point operator -(Point pt, Size sz) => Subtract(pt, sz);
 
         /// <summary>
         ///    <para>
@@ -147,10 +117,7 @@ namespace System.Drawing
         ///       objects are equal.
         ///    </para>
         /// </summary>
-        public static bool operator ==(Point left, Point right)
-        {
-            return left.X == right.X && left.Y == right.Y;
-        }
+        public static bool operator ==(Point left, Point right) => left.X == right.X && left.Y == right.Y;
 
         /// <summary>
         ///    <para>
@@ -160,57 +127,39 @@ namespace System.Drawing
         ///    objects are unequal.
         /// </para>
         /// </summary>
-        public static bool operator !=(Point left, Point right)
-        {
-            return !(left == right);
-        }
+        public static bool operator !=(Point left, Point right) => !(left == right);
 
         /// <summary>
         ///    <para>
         ///       Translates a <see cref='System.Drawing.Point'/> by a given <see cref='System.Drawing.Size'/> .
         ///    </para>
         /// </summary>        
-        public static Point Add(Point pt, Size sz)
-        {
-            return new Point(pt.X + sz.Width, pt.Y + sz.Height);
-        }
+        public static Point Add(Point pt, Size sz) => new Point(pt.X + sz.Width, pt.Y + sz.Height);
 
         /// <summary>
         ///    <para>
         ///       Translates a <see cref='System.Drawing.Point'/> by the negative of a given <see cref='System.Drawing.Size'/> .
         ///    </para>
         /// </summary>        
-        public static Point Subtract(Point pt, Size sz)
-        {
-            return new Point(pt.X - sz.Width, pt.Y - sz.Height);
-        }
+        public static Point Subtract(Point pt, Size sz) => new Point(pt.X - sz.Width, pt.Y - sz.Height);
 
         /// <summary>
         ///   Converts a PointF to a Point by performing a ceiling operation on
         ///   all the coordinates.
         /// </summary>
-        public static Point Ceiling(PointF value)
-        {
-            return new Point((int)Math.Ceiling(value.X), (int)Math.Ceiling(value.Y));
-        }
+        public static Point Ceiling(PointF value) => new Point((int)Math.Ceiling(value.X), (int)Math.Ceiling(value.Y));
 
         /// <summary>
         ///   Converts a PointF to a Point by performing a truncate operation on
         ///   all the coordinates.
         /// </summary>
-        public static Point Truncate(PointF value)
-        {
-            return new Point((int)value.X, (int)value.Y);
-        }
+        public static Point Truncate(PointF value) => new Point((int)value.X, (int)value.Y);
 
         /// <summary>
         ///   Converts a PointF to a Point by performing a round operation on
         ///   all the coordinates.
         /// </summary>
-        public static Point Round(PointF value)
-        {
-            return new Point((int)Math.Round(value.X), (int)Math.Round(value.Y));
-        }
+        public static Point Round(PointF value) => new Point((int)Math.Round(value.X), (int)Math.Round(value.Y));
 
         /// <summary>
         ///    <para>
@@ -245,10 +194,7 @@ namespace System.Drawing
         /// <summary>
         ///    Translates this <see cref='System.Drawing.Point'/> by the specified amount.
         /// </summary>
-        public void Offset(Point p)
-        {
-            Offset(p.X, p.Y);
-        }
+        public void Offset(Point p) =>Offset(p.X, p.Y);
 
         /// <summary>
         ///    <para>
@@ -257,19 +203,10 @@ namespace System.Drawing
         ///       string.
         ///    </para>
         /// </summary>
-        public override string ToString()
-        {
-            return "{X=" + X.ToString() + ",Y=" + Y.ToString() + "}";
-        }
+        public override string ToString() => "{X=" + X.ToString() + ",Y=" + Y.ToString() + "}";
 
-        private static short HighInt16(int n)
-        {
-            return (short)((n >> 16) & 0xffff);
-        }
+        private static short HighInt16(int n) => (short)((n >> 16) & 0xffff);
 
-        private static short LowInt16(int n)
-        {
-            return (short)(n & 0xffff);
-        }
+        private static short LowInt16(int n) => (short)(n & 0xffff);
     }
 }

--- a/src/System.Drawing.Primitives/src/System/Drawing/Point.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Point.cs
@@ -194,7 +194,7 @@ namespace System.Drawing
         /// <summary>
         ///    Translates this <see cref='System.Drawing.Point'/> by the specified amount.
         /// </summary>
-        public void Offset(Point p) =>Offset(p.X, p.Y);
+        public void Offset(Point p) => Offset(p.X, p.Y);
 
         /// <summary>
         ///    <para>

--- a/src/System.Drawing.Primitives/src/System/Drawing/PointF.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/PointF.cs
@@ -40,13 +40,7 @@ namespace System.Drawing
         ///       Gets a value indicating whether this <see cref='System.Drawing.PointF'/> is empty.
         ///    </para>
         /// </summary>
-        public bool IsEmpty
-        {
-            get
-            {
-                return _x == 0f && _y == 0f;
-            }
-        }
+        public bool IsEmpty => _x == 0f && _y == 0f;
 
         /// <summary>
         ///    <para>
@@ -55,14 +49,8 @@ namespace System.Drawing
         /// </summary>
         public float X
         {
-            get
-            {
-                return _x;
-            }
-            set
-            {
-                _x = value;
-            }
+            get { return _x; }
+            set { _x = value; }
         }
 
         /// <summary>
@@ -72,14 +60,8 @@ namespace System.Drawing
         /// </summary>
         public float Y
         {
-            get
-            {
-                return _y;
-            }
-            set
-            {
-                _y = value;
-            }
+            get { return _y; }
+            set { _y = value; }
         }
 
         /// <summary>
@@ -87,40 +69,28 @@ namespace System.Drawing
         ///       Translates a <see cref='System.Drawing.PointF'/> by a given <see cref='System.Drawing.Size'/> .
         ///    </para>
         /// </summary>
-        public static PointF operator +(PointF pt, Size sz)
-        {
-            return Add(pt, sz);
-        }
+        public static PointF operator +(PointF pt, Size sz) => Add(pt, sz);
 
         /// <summary>
         ///    <para>
         ///       Translates a <see cref='System.Drawing.PointF'/> by the negative of a given <see cref='System.Drawing.Size'/> .
         ///    </para>
         /// </summary>
-        public static PointF operator -(PointF pt, Size sz)
-        {
-            return Subtract(pt, sz);
-        }
+        public static PointF operator -(PointF pt, Size sz) => Subtract(pt, sz);
 
         /// <summary>
         ///    <para>
         ///       Translates a <see cref='System.Drawing.PointF'/> by a given <see cref='System.Drawing.SizeF'/> .
         ///    </para>
         /// </summary>
-        public static PointF operator +(PointF pt, SizeF sz)
-        {
-            return Add(pt, sz);
-        }
+        public static PointF operator +(PointF pt, SizeF sz) => Add(pt, sz);
 
         /// <summary>
         ///    <para>
         ///       Translates a <see cref='System.Drawing.PointF'/> by the negative of a given <see cref='System.Drawing.SizeF'/> .
         ///    </para>
         /// </summary>
-        public static PointF operator -(PointF pt, SizeF sz)
-        {
-            return Subtract(pt, sz);
-        }
+        public static PointF operator -(PointF pt, SizeF sz) => Subtract(pt, sz);
 
         /// <summary>
         ///    <para>
@@ -129,10 +99,7 @@ namespace System.Drawing
         ///       objects are equal.
         ///    </para>
         /// </summary>
-        public static bool operator ==(PointF left, PointF right)
-        {
-            return left.X == right.X && left.Y == right.Y;
-        }
+        public static bool operator ==(PointF left, PointF right) => left.X == right.X && left.Y == right.Y;
 
         /// <summary>
         ///    <para>
@@ -142,50 +109,35 @@ namespace System.Drawing
         ///    objects are unequal.
         /// </para>
         /// </summary>
-        public static bool operator !=(PointF left, PointF right)
-        {
-            return !(left == right);
-        }
+        public static bool operator !=(PointF left, PointF right) => !(left == right);
 
         /// <summary>
         ///    <para>
         ///       Translates a <see cref='System.Drawing.PointF'/> by a given <see cref='System.Drawing.Size'/> .
         ///    </para>
         /// </summary>
-        public static PointF Add(PointF pt, Size sz)
-        {
-            return new PointF(pt.X + sz.Width, pt.Y + sz.Height);
-        }
+        public static PointF Add(PointF pt, Size sz) => new PointF(pt.X + sz.Width, pt.Y + sz.Height);
 
         /// <summary>
         ///    <para>
         ///       Translates a <see cref='System.Drawing.PointF'/> by the negative of a given <see cref='System.Drawing.Size'/> .
         ///    </para>
         /// </summary>
-        public static PointF Subtract(PointF pt, Size sz)
-        {
-            return new PointF(pt.X - sz.Width, pt.Y - sz.Height);
-        }
+        public static PointF Subtract(PointF pt, Size sz) => new PointF(pt.X - sz.Width, pt.Y - sz.Height);
 
         /// <summary>
         ///    <para>
         ///       Translates a <see cref='System.Drawing.PointF'/> by a given <see cref='System.Drawing.SizeF'/> .
         ///    </para>
         /// </summary>
-        public static PointF Add(PointF pt, SizeF sz)
-        {
-            return new PointF(pt.X + sz.Width, pt.Y + sz.Height);
-        }
+        public static PointF Add(PointF pt, SizeF sz) => new PointF(pt.X + sz.Width, pt.Y + sz.Height);
 
         /// <summary>
         ///    <para>
         ///       Translates a <see cref='System.Drawing.PointF'/> by the negative of a given <see cref='System.Drawing.SizeF'/> .
         ///    </para>
         /// </summary>
-        public static PointF Subtract(PointF pt, SizeF sz)
-        {
-            return new PointF(pt.X - sz.Width, pt.Y - sz.Height);
-        }
+        public static PointF Subtract(PointF pt, SizeF sz) => new PointF(pt.X - sz.Width, pt.Y - sz.Height);
 
         public override bool Equals(object obj)
         {
@@ -198,9 +150,6 @@ namespace System.Drawing
 
         public override int GetHashCode() => HashHelpers.Combine(X.GetHashCode(), Y.GetHashCode());
 
-        public override string ToString()
-        {
-            return "{X=" + _x.ToString() + ", Y=" + _y.ToString() + "}";
-        }
+        public override string ToString() => "{X=" + _x.ToString() + ", Y=" + _y.ToString() + "}";
     }
 }

--- a/src/System.Drawing.Primitives/src/System/Drawing/Rectangle.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Rectangle.cs
@@ -301,7 +301,7 @@ namespace System.Drawing
         /// </summary>
         public void Intersect(Rectangle rect)
         {
-            Rectangle result = Rectangle.Intersect(rect, this);
+            Rectangle result = Intersect(rect, this);
 
             X = result.X;
             Y = result.Y;

--- a/src/System.Drawing.Primitives/src/System/Drawing/Rectangle.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Rectangle.cs
@@ -54,13 +54,8 @@ namespace System.Drawing
         ///    Creates a new <see cref='System.Drawing.Rectangle'/> with
         ///    the specified location and size.
         /// </summary>
-        public static Rectangle FromLTRB(int left, int top, int right, int bottom)
-        {
-            return new Rectangle(left,
-                                 top,
-                                 right - left,
-                                 bottom - top);
-        }
+        public static Rectangle FromLTRB(int left, int top, int right, int bottom) =>
+            new Rectangle(left, top, right - left, bottom - top);
 
         /// <summary>
         ///    <para>
@@ -70,10 +65,7 @@ namespace System.Drawing
         /// </summary>
         public Point Location
         {
-            get
-            {
-                return new Point(X, Y);
-            }
+            get { return new Point(X, Y); }
             set
             {
                 X = value.X;
@@ -86,10 +78,7 @@ namespace System.Drawing
         /// </summary>
         public Size Size
         {
-            get
-            {
-                return new Size(Width, Height);
-            }
+            get { return new Size(Width, Height); }
             set
             {
                 Width = value.Width;
@@ -103,14 +92,8 @@ namespace System.Drawing
         /// </summary>
         public int X
         {
-            get
-            {
-                return _x;
-            }
-            set
-            {
-                _x = value;
-            }
+            get { return _x; }
+            set { _x = value; }
         }
 
         /// <summary>
@@ -119,14 +102,8 @@ namespace System.Drawing
         /// </summary>
         public int Y
         {
-            get
-            {
-                return _y;
-            }
-            set
-            {
-                _y = value;
-            }
+            get { return _y; }
+            set { _y = value; }
         }
 
         /// <summary>
@@ -135,14 +112,8 @@ namespace System.Drawing
         /// </summary>
         public int Width
         {
-            get
-            {
-                return _width;
-            }
-            set
-            {
-                _width = value;
-            }
+            get { return _width; }
+            set { _width = value; }
         }
 
         /// <summary>
@@ -151,14 +122,8 @@ namespace System.Drawing
         /// </summary>
         public int Height
         {
-            get
-            {
-                return _height;
-            }
-            set
-            {
-                _height = value;
-            }
+            get { return _height; }
+            set { _height = value; }
         }
 
         /// <summary>
@@ -167,13 +132,7 @@ namespace System.Drawing
         ///       rectangular region defined by this <see cref='System.Drawing.Rectangle'/> .
         ///    </para>
         /// </summary>
-        public int Left
-        {
-            get
-            {
-                return X;
-            }
-        }
+        public int Left => X;
 
         /// <summary>
         ///    <para>
@@ -181,13 +140,7 @@ namespace System.Drawing
         ///       rectangular region defined by this <see cref='System.Drawing.Rectangle'/>.
         ///    </para>
         /// </summary>
-        public int Top
-        {
-            get
-            {
-                return Y;
-            }
-        }
+        public int Top => Y;
 
         /// <summary>
         ///    <para>
@@ -195,13 +148,7 @@ namespace System.Drawing
         ///       rectangular region defined by this <see cref='System.Drawing.Rectangle'/>.
         ///    </para>
         /// </summary>
-        public int Right
-        {
-            get
-            {
-                return X + Width;
-            }
-        }
+        public int Right => X + Width;
 
         /// <summary>
         ///    <para>
@@ -209,13 +156,7 @@ namespace System.Drawing
         ///       rectangular region defined by this <see cref='System.Drawing.Rectangle'/>.
         ///    </para>
         /// </summary>
-        public int Bottom
-        {
-            get
-            {
-                return Y + Height;
-            }
-        }
+        public int Bottom => Y + Height;
 
         /// <summary>
         ///    <para>
@@ -223,13 +164,7 @@ namespace System.Drawing
         ///       or a <see cref='System.Drawing.Rectangle.Height'/> of 0.
         ///    </para>
         /// </summary>
-        public bool IsEmpty
-        {
-            get
-            {
-                return _height == 0 && _width == 0 && _x == 0 && _y == 0;
-            }
-        }
+        public bool IsEmpty => _height == 0 && _width == 0 && _x == 0 && _y == 0;
 
         /// <summary>
         ///    <para>
@@ -253,11 +188,8 @@ namespace System.Drawing
         ///       objects have equal location and size.
         ///    </para>
         /// </summary>
-        public static bool operator ==(Rectangle left, Rectangle right)
-        {
-            return (left.X == right.X && left.Y == right.Y &&
-                left.Width == right.Width && left.Height == right.Height);
-        }
+        public static bool operator ==(Rectangle left, Rectangle right) =>
+            left.X == right.X && left.Y == right.Y && left.Width == right.Width && left.Height == right.Height;
 
         /// <summary>
         ///    <para>
@@ -265,46 +197,40 @@ namespace System.Drawing
         ///       objects differ in location or size.
         ///    </para>
         /// </summary>
-        public static bool operator !=(Rectangle left, Rectangle right)
-        {
-            return !(left == right);
-        }
+        public static bool operator !=(Rectangle left, Rectangle right) => !(left == right);
 
         /// <summary>
         ///   Converts a RectangleF to a Rectangle by performing a ceiling operation on
         ///   all the coordinates.
         /// </summary>
-        public static Rectangle Ceiling(RectangleF value)
-        {
-            return new Rectangle((int)Math.Ceiling(value.X),
-                                 (int)Math.Ceiling(value.Y),
-                                 (int)Math.Ceiling(value.Width),
-                                 (int)Math.Ceiling(value.Height));
-        }
+        public static Rectangle Ceiling(RectangleF value) =>
+            new Rectangle(
+                (int)Math.Ceiling(value.X),
+                (int)Math.Ceiling(value.Y),
+                (int)Math.Ceiling(value.Width),
+                (int)Math.Ceiling(value.Height));
 
         /// <summary>
         ///   Converts a RectangleF to a Rectangle by performing a truncate operation on
         ///   all the coordinates.
         /// </summary>
-        public static Rectangle Truncate(RectangleF value)
-        {
-            return new Rectangle((int)value.X,
-                                 (int)value.Y,
-                                 (int)value.Width,
-                                 (int)value.Height);
-        }
+        public static Rectangle Truncate(RectangleF value) =>
+            new Rectangle(
+                (int)value.X,
+                (int)value.Y,
+                (int)value.Width,
+                (int)value.Height);
 
         /// <summary>
         ///   Converts a RectangleF to a Rectangle by performing a round operation on
         ///   all the coordinates.
         /// </summary>
-        public static Rectangle Round(RectangleF value)
-        {
-            return new Rectangle((int)Math.Round(value.X),
-                                 (int)Math.Round(value.Y),
-                                 (int)Math.Round(value.Width),
-                                 (int)Math.Round(value.Height));
-        }
+        public static Rectangle Round(RectangleF value) =>
+            new Rectangle(
+                (int)Math.Round(value.X),
+                (int)Math.Round(value.Y),
+                (int)Math.Round(value.Width),
+                (int)Math.Round(value.Height));
 
         /// <summary>
         ///    <para>
@@ -313,10 +239,7 @@ namespace System.Drawing
         ///    </para>
         /// </summary>
         [Pure]
-        public bool Contains(int x, int y)
-        {
-            return X <= x && x < X + Width && Y <= y && y < Y + Height;
-        }
+        public bool Contains(int x, int y) => X <= x && x < X + Width && Y <= y && y < Y + Height;
 
         /// <summary>
         ///    <para>
@@ -325,10 +248,7 @@ namespace System.Drawing
         ///    </para>
         /// </summary>
         [Pure]
-        public bool Contains(Point pt)
-        {
-            return Contains(pt.X, pt.Y);
-        }
+        public bool Contains(Point pt) => Contains(pt.X, pt.Y);
 
         /// <summary>
         ///    <para>
@@ -338,14 +258,12 @@ namespace System.Drawing
         ///    </para>
         /// </summary>
         [Pure]
-        public bool Contains(Rectangle rect)
-        {
-            return (X <= rect.X) && ((rect.X + rect.Width) <= (X + Width)) &&
-                (Y <= rect.Y) && ((rect.Y + rect.Height) <= (Y + Height));
-        }
+        public bool Contains(Rectangle rect) =>
+            (X <= rect.X) && (rect.X + rect.Width <= X + Width) &&
+            (Y <= rect.Y) && (rect.Y + rect.Height <= Y + Height);
 
-        public override int GetHashCode()
-            => HashHelpers.Combine(HashHelpers.Combine(HashHelpers.Combine(X, Y), Width), Height);
+        public override int GetHashCode() =>
+            HashHelpers.Combine(HashHelpers.Combine(HashHelpers.Combine(X, Y), Width), Height);
 
         /// <summary>
         ///    <para>
@@ -364,10 +282,7 @@ namespace System.Drawing
         /// <summary>
         ///    Inflates this <see cref='System.Drawing.Rectangle'/> by the specified amount.
         /// </summary>
-        public void Inflate(Size size)
-        {
-            Inflate(size.Width, size.Height);
-        }
+        public void Inflate(Size size) => Inflate(size.Width, size.Height);
 
         /// <summary>
         ///    <para>
@@ -417,11 +332,9 @@ namespace System.Drawing
         ///     Determines if this rectangle intersects with rect.
         /// </summary>
         [Pure]
-        public bool IntersectsWith(Rectangle rect)
-        {
-            return (rect.X < X + Width) && (X < (rect.X + rect.Width)) &&
-                (rect.Y < Y + Height) && (Y < rect.Y + rect.Height);
-        }
+        public bool IntersectsWith(Rectangle rect) =>
+            (rect.X < X + Width) && (X < rect.X + rect.Width) &&
+            (rect.Y < Y + Height) && (Y < rect.Y + rect.Height);
 
         /// <summary>
         ///    <para>
@@ -445,10 +358,7 @@ namespace System.Drawing
         ///       Adjusts the location of this rectangle by the specified amount.
         ///    </para>
         /// </summary>
-        public void Offset(Point pos)
-        {
-            Offset(pos.X, pos.Y);
-        }
+        public void Offset(Point pos) => Offset(pos.X, pos.Y);
 
         /// <summary>
         ///    Adjusts the location of this rectangle by the specified amount.
@@ -465,10 +375,8 @@ namespace System.Drawing
         ///       human readable string.
         ///    </para>
         /// </summary>
-        public override string ToString()
-        {
-            return "{X=" + X.ToString() + ",Y=" + Y.ToString() +
-                ",Width=" + Width.ToString() + ",Height=" + Height.ToString() + "}";
-        }
+        public override string ToString() =>
+            "{X=" + X.ToString() + ",Y=" + Y.ToString() +
+            ",Width=" + Width.ToString() + ",Height=" + Height.ToString() + "}";
     }
 }

--- a/src/System.Drawing.Primitives/src/System/Drawing/RectangleF.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/RectangleF.cs
@@ -288,7 +288,7 @@ namespace System.Drawing
         /// </summary>
         public void Intersect(RectangleF rect)
         {
-            RectangleF result = RectangleF.Intersect(rect, this);
+            RectangleF result = Intersect(rect, this);
 
             X = result.X;
             Y = result.Y;

--- a/src/System.Drawing.Primitives/src/System/Drawing/RectangleF.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/RectangleF.cs
@@ -61,13 +61,8 @@ namespace System.Drawing
         ///       the specified location and size.
         ///    </para>
         /// </summary>
-        public static RectangleF FromLTRB(float left, float top, float right, float bottom)
-        {
-            return new RectangleF(left,
-                                 top,
-                                 right - left,
-                                 bottom - top);
-        }
+        public static RectangleF FromLTRB(float left, float top, float right, float bottom) =>
+            new RectangleF(left, top, right - left, bottom - top);
 
         /// <summary>
         ///    <para>
@@ -77,10 +72,7 @@ namespace System.Drawing
         /// </summary>
         public PointF Location
         {
-            get
-            {
-                return new PointF(X, Y);
-            }
+            get { return new PointF(X, Y); }
             set
             {
                 X = value.X;
@@ -95,10 +87,7 @@ namespace System.Drawing
         /// </summary>
         public SizeF Size
         {
-            get
-            {
-                return new SizeF(Width, Height);
-            }
+            get { return new SizeF(Width, Height); }
             set
             {
                 Width = value.Width;
@@ -114,14 +103,8 @@ namespace System.Drawing
         /// </summary>
         public float X
         {
-            get
-            {
-                return _x;
-            }
-            set
-            {
-                _x = value;
-            }
+            get { return _x; }
+            set { _x = value; }
         }
 
         /// <summary>
@@ -132,14 +115,8 @@ namespace System.Drawing
         /// </summary>
         public float Y
         {
-            get
-            {
-                return _y;
-            }
-            set
-            {
-                _y = value;
-            }
+            get { return _y; }
+            set { _y = value; }
         }
 
         /// <summary>
@@ -150,14 +127,8 @@ namespace System.Drawing
         /// </summary>
         public float Width
         {
-            get
-            {
-                return _width;
-            }
-            set
-            {
-                _width = value;
-            }
+            get { return _width; }
+            set { _width = value; }
         }
 
         /// <summary>
@@ -168,14 +139,8 @@ namespace System.Drawing
         /// </summary>
         public float Height
         {
-            get
-            {
-                return _height;
-            }
-            set
-            {
-                _height = value;
-            }
+            get { return _height; }
+            set { _height = value; }
         }
 
         /// <summary>
@@ -184,13 +149,7 @@ namespace System.Drawing
         ///       rectangular region defined by this <see cref='System.Drawing.RectangleF'/> .
         ///    </para>
         /// </summary>
-        public float Left
-        {
-            get
-            {
-                return X;
-            }
-        }
+        public float Left => X;
 
         /// <summary>
         ///    <para>
@@ -198,13 +157,7 @@ namespace System.Drawing
         ///       rectangular region defined by this <see cref='System.Drawing.RectangleF'/>.
         ///    </para>
         /// </summary>
-        public float Top
-        {
-            get
-            {
-                return Y;
-            }
-        }
+        public float Top => Y;
 
         /// <summary>
         ///    <para>
@@ -212,13 +165,7 @@ namespace System.Drawing
         ///       rectangular region defined by this <see cref='System.Drawing.RectangleF'/>.
         ///    </para>
         /// </summary>
-        public float Right
-        {
-            get
-            {
-                return X + Width;
-            }
-        }
+        public float Right => X + Width;
 
         /// <summary>
         ///    <para>
@@ -226,26 +173,14 @@ namespace System.Drawing
         ///       rectangular region defined by this <see cref='System.Drawing.RectangleF'/>.
         ///    </para>
         /// </summary>
-        public float Bottom
-        {
-            get
-            {
-                return Y + Height;
-            }
-        }
+        public float Bottom => Y + Height;
 
         /// <summary>
         ///    <para>
         ///       Tests whether this <see cref='System.Drawing.RectangleF'/> has a <see cref='System.Drawing.RectangleF.Width'/> or a <see cref='System.Drawing.RectangleF.Height'/> of 0.
         ///    </para>
         /// </summary>
-        public bool IsEmpty
-        {
-            get
-            {
-                return (Width <= 0) || (Height <= 0);
-            }
-        }
+        public bool IsEmpty => (Width <= 0) || (Height <= 0);
 
         /// <summary>
         ///    <para>
@@ -269,10 +204,8 @@ namespace System.Drawing
         ///       objects have equal location and size.
         ///    </para>
         /// </summary>
-        public static bool operator ==(RectangleF left, RectangleF right)
-        {
-            return (left.X == right.X && left.Y == right.Y && left.Width == right.Width && left.Height == right.Height);
-        }
+        public static bool operator ==(RectangleF left, RectangleF right) =>
+            left.X == right.X && left.Y == right.Y && left.Width == right.Width && left.Height == right.Height;
 
         /// <summary>
         ///    <para>
@@ -280,10 +213,7 @@ namespace System.Drawing
         ///       objects differ in location or size.
         ///    </para>
         /// </summary>
-        public static bool operator !=(RectangleF left, RectangleF right)
-        {
-            return !(left == right);
-        }
+        public static bool operator !=(RectangleF left, RectangleF right) => !(left == right);
 
         /// <summary>
         ///    <para>
@@ -292,10 +222,7 @@ namespace System.Drawing
         ///    </para>
         /// </summary>
         [Pure]
-        public bool Contains(float x, float y)
-        {
-            return X <= x && x < X + Width && Y <= y && y < Y + Height;
-        }
+        public bool Contains(float x, float y) => X <= x && x < X + Width && Y <= y && y < Y + Height;
 
         /// <summary>
         ///    <para>
@@ -304,10 +231,7 @@ namespace System.Drawing
         ///    </para>
         /// </summary>
         [Pure]
-        public bool Contains(PointF pt)
-        {
-            return Contains(pt.X, pt.Y);
-        }
+        public bool Contains(PointF pt) => Contains(pt.X, pt.Y);
 
         /// <summary>
         ///    <para>
@@ -317,19 +241,16 @@ namespace System.Drawing
         ///    </para>
         /// </summary>
         [Pure]
-        public bool Contains(RectangleF rect)
-        {
-            return (X <= rect.X) && ((rect.X + rect.Width) <= (X + Width)) &&
-                (Y <= rect.Y) && ((rect.Y + rect.Height) <= (Y + Height));
-        }
+        public bool Contains(RectangleF rect) =>
+            (X <= rect.X) && (rect.X + rect.Width <= X + Width) && (Y <= rect.Y) && (rect.Y + rect.Height <= Y + Height);
 
         /// <summary>
         ///    Gets the hash code for this <see cref='System.Drawing.RectangleF'/>.
         /// </summary>
-        public override int GetHashCode()
-            => HashHelpers.Combine(
-                    HashHelpers.Combine(HashHelpers.Combine(X.GetHashCode(), Y.GetHashCode()), Width.GetHashCode()),
-                    Height.GetHashCode());
+        public override int GetHashCode() =>
+            HashHelpers.Combine(
+                HashHelpers.Combine(HashHelpers.Combine(X.GetHashCode(), Y.GetHashCode()), Width.GetHashCode()),
+                Height.GetHashCode());
 
         /// <summary>
         ///    <para>
@@ -348,10 +269,7 @@ namespace System.Drawing
         /// <summary>
         ///    Inflates this <see cref='System.Drawing.Rectangle'/> by the specified amount.
         /// </summary>
-        public void Inflate(SizeF size)
-        {
-            Inflate(size.Width, size.Height);
-        }
+        public void Inflate(SizeF size) => Inflate(size.Width, size.Height);
 
         /// <summary>
         ///    <para>
@@ -402,11 +320,8 @@ namespace System.Drawing
         ///    Determines if this rectangle intersects with rect.
         /// </summary>
         [Pure]
-        public bool IntersectsWith(RectangleF rect)
-        {
-            return (rect.X < X + Width) && (X < (rect.X + rect.Width)) &&
-                (rect.Y < Y + Height) && (Y < rect.Y + rect.Height);
-        }
+        public bool IntersectsWith(RectangleF rect) =>
+            (rect.X < X + Width) && (X < rect.X + rect.Width) && (rect.Y < Y + Height) && (Y < rect.Y + rect.Height);
 
         /// <summary>
         ///    Creates a rectangle that represents the union between a and
@@ -426,10 +341,7 @@ namespace System.Drawing
         /// <summary>
         ///    Adjusts the location of this rectangle by the specified amount.
         /// </summary>
-        public void Offset(PointF pos)
-        {
-            Offset(pos.X, pos.Y);
-        }
+        public void Offset(PointF pos) => Offset(pos.X, pos.Y);
 
         /// <summary>
         ///    Adjusts the location of this rectangle by the specified amount.
@@ -444,19 +356,14 @@ namespace System.Drawing
         ///    Converts the specified <see cref='System.Drawing.Rectangle'/> to a
         /// <see cref='System.Drawing.RectangleF'/>.
         /// </summary>
-        public static implicit operator RectangleF(Rectangle r)
-        {
-            return new RectangleF(r.X, r.Y, r.Width, r.Height);
-        }
+        public static implicit operator RectangleF(Rectangle r) => new RectangleF(r.X, r.Y, r.Width, r.Height);
 
         /// <summary>
         ///    Converts the <see cref='System.Drawing.RectangleF.Location'/> and <see cref='System.Drawing.RectangleF.Size'/> of this <see cref='System.Drawing.RectangleF'/> to a
         ///    human-readable string.
         /// </summary>
-        public override string ToString()
-        {
-            return "{X=" + X.ToString() + ",Y=" + Y.ToString() + ",Width=" +
-                Width.ToString() + ",Height=" + Height.ToString() + "}";
-        }
+        public override string ToString() =>
+            "{X=" + X.ToString() + ",Y=" + Y.ToString() +
+            ",Width=" + Width.ToString() + ",Height=" + Height.ToString() + "}";
     }
 }

--- a/src/System.Drawing.Primitives/src/System/Drawing/Size.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Size.cs
@@ -56,74 +56,51 @@ namespace System.Drawing
         ///    Converts the specified <see cref='System.Drawing.Size'/> to a
         /// <see cref='System.Drawing.SizeF'/>.
         /// </summary>
-        public static implicit operator SizeF(Size p)
-        {
-            return new SizeF(p.Width, p.Height);
-        }
+        public static implicit operator SizeF(Size p) => new SizeF(p.Width, p.Height);
 
         /// <summary>
         ///    <para>
         ///       Performs vector addition of two <see cref='System.Drawing.Size'/> objects.
         ///    </para>
         /// </summary>
-        public static Size operator +(Size sz1, Size sz2)
-        {
-            return Add(sz1, sz2);
-        }
+        public static Size operator +(Size sz1, Size sz2) => Add(sz1, sz2);
 
         /// <summary>
         ///    <para>
         ///       Contracts a <see cref='System.Drawing.Size'/> by another <see cref='System.Drawing.Size'/>
         ///    </para>
         /// </summary>
-        public static Size operator -(Size sz1, Size sz2)
-        {
-            return Subtract(sz1, sz2);
-        }
+        public static Size operator -(Size sz1, Size sz2) => Subtract(sz1, sz2);
 
         /// <summary>
         ///    Tests whether two <see cref='System.Drawing.Size'/> objects
         ///    are identical.
         /// </summary>
-        public static bool operator ==(Size sz1, Size sz2)
-        {
-            return sz1.Width == sz2.Width && sz1.Height == sz2.Height;
-        }
+        public static bool operator ==(Size sz1, Size sz2) => sz1.Width == sz2.Width && sz1.Height == sz2.Height;
 
         /// <summary>
         ///    <para>
         ///       Tests whether two <see cref='System.Drawing.Size'/> objects are different.
         ///    </para>
         /// </summary>
-        public static bool operator !=(Size sz1, Size sz2)
-        {
-            return !(sz1 == sz2);
-        }
+        public static bool operator !=(Size sz1, Size sz2) => !(sz1 == sz2);
 
         /// <summary>
         ///    Converts the specified <see cref='System.Drawing.Size'/> to a
         /// <see cref='System.Drawing.Point'/>.
         /// </summary>
-        public static explicit operator Point(Size size)
-        {
-            return new Point(size.Width, size.Height);
-        }
+        public static explicit operator Point(Size size) => new Point(size.Width, size.Height);
 
         /// <summary>
         ///    Tests whether this <see cref='System.Drawing.Size'/> has zero
         ///    width and height.
         /// </summary>
-        public bool IsEmpty
-        {
-            get
-            {
-                return _width == 0 && _height == 0;
-            }
-        }
+        public bool IsEmpty => _width == 0 && _height == 0;
 
         /**
          * Horizontal dimension
          */
+
         /// <summary>
         ///    <para>
         ///       Represents the horizontal component of this
@@ -132,33 +109,22 @@ namespace System.Drawing
         /// </summary>
         public int Width
         {
-            get
-            {
-                return _width;
-            }
-            set
-            {
-                _width = value;
-            }
+            get { return _width; }
+            set { _width = value; }
         }
 
         /**
          * Vertical dimension
          */
+
         /// <summary>
         ///    Represents the vertical component of this
         /// <see cref='System.Drawing.Size'/>.
         /// </summary>
         public int Height
         {
-            get
-            {
-                return _height;
-            }
-            set
-            {
-                _height = value;
-            }
+            get { return _height; }
+            set { _height = value; }
         }
 
         /// <summary>
@@ -166,47 +132,32 @@ namespace System.Drawing
         ///       Performs vector addition of two <see cref='System.Drawing.Size'/> objects.
         ///    </para>
         /// </summary>
-        public static Size Add(Size sz1, Size sz2)
-        {
-            return new Size(sz1.Width + sz2.Width, sz1.Height + sz2.Height);
-        }
+        public static Size Add(Size sz1, Size sz2) => new Size(sz1.Width + sz2.Width, sz1.Height + sz2.Height);
 
         /// <summary>
         ///   Converts a SizeF to a Size by performing a ceiling operation on
         ///   all the coordinates.
         /// </summary>
-        public static Size Ceiling(SizeF value)
-        {
-            return new Size((int)Math.Ceiling(value.Width), (int)Math.Ceiling(value.Height));
-        }
+        public static Size Ceiling(SizeF value) => new Size((int)Math.Ceiling(value.Width), (int)Math.Ceiling(value.Height));
 
         /// <summary>
         ///    <para>
         ///       Contracts a <see cref='System.Drawing.Size'/> by another <see cref='System.Drawing.Size'/> .
         ///    </para>
         /// </summary>
-        public static Size Subtract(Size sz1, Size sz2)
-        {
-            return new Size(sz1.Width - sz2.Width, sz1.Height - sz2.Height);
-        }
+        public static Size Subtract(Size sz1, Size sz2) => new Size(sz1.Width - sz2.Width, sz1.Height - sz2.Height);
 
         /// <summary>
         ///   Converts a SizeF to a Size by performing a truncate operation on
         ///   all the coordinates.
         /// </summary>
-        public static Size Truncate(SizeF value)
-        {
-            return new Size((int)value.Width, (int)value.Height);
-        }
+        public static Size Truncate(SizeF value) => new Size((int)value.Width, (int)value.Height);
 
         /// <summary>
         ///   Converts a SizeF to a Size by performing a round operation on
         ///   all the coordinates.
         /// </summary>
-        public static Size Round(SizeF value)
-        {
-            return new Size((int)Math.Round(value.Width), (int)Math.Round(value.Height));
-        }
+        public static Size Round(SizeF value) => new Size((int)Math.Round(value.Width), (int)Math.Round(value.Height));
 
         /// <summary>
         ///    <para>
@@ -237,9 +188,6 @@ namespace System.Drawing
         ///    <see cref='System.Drawing.Size'/>.
         ///    </para>
         /// </summary>
-        public override string ToString()
-        {
-            return "{Width=" + _width.ToString() + ", Height=" + _height.ToString() + "}";
-        }
+        public override string ToString() => "{Width=" + _width.ToString() + ", Height=" + _height.ToString() + "}";
     }
 }

--- a/src/System.Drawing.Primitives/src/System/Drawing/SizeF.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/SizeF.cs
@@ -73,39 +73,27 @@ namespace System.Drawing
         ///       Performs vector addition of two <see cref='System.Drawing.SizeF'/> objects.
         ///    </para>
         /// </summary>
-        public static SizeF operator +(SizeF sz1, SizeF sz2)
-        {
-            return Add(sz1, sz2);
-        }
+        public static SizeF operator +(SizeF sz1, SizeF sz2) => Add(sz1, sz2);
 
         /// <summary>
         ///    <para>
         ///       Contracts a <see cref='System.Drawing.SizeF'/> by another <see cref='System.Drawing.SizeF'/>
         ///    </para>
         /// </summary>        
-        public static SizeF operator -(SizeF sz1, SizeF sz2)
-        {
-            return Subtract(sz1, sz2);
-        }
+        public static SizeF operator -(SizeF sz1, SizeF sz2) => Subtract(sz1, sz2);
 
         /// <summary>
         ///    Tests whether two <see cref='System.Drawing.SizeF'/> objects
         ///    are identical.
         /// </summary>
-        public static bool operator ==(SizeF sz1, SizeF sz2)
-        {
-            return sz1.Width == sz2.Width && sz1.Height == sz2.Height;
-        }
+        public static bool operator ==(SizeF sz1, SizeF sz2) => sz1.Width == sz2.Width && sz1.Height == sz2.Height;
 
         /// <summary>
         ///    <para>
         ///       Tests whether two <see cref='System.Drawing.SizeF'/> objects are different.
         ///    </para>
         /// </summary>
-        public static bool operator !=(SizeF sz1, SizeF sz2)
-        {
-            return !(sz1 == sz2);
-        }
+        public static bool operator !=(SizeF sz1, SizeF sz2) => !(sz1 == sz2);
 
         /// <summary>
         ///    <para>
@@ -113,10 +101,7 @@ namespace System.Drawing
         ///    <see cref='System.Drawing.PointF'/>.
         ///    </para>
         /// </summary>
-        public static explicit operator PointF(SizeF size)
-        {
-            return new PointF(size.Width, size.Height);
-        }
+        public static explicit operator PointF(SizeF size) => new PointF(size.Width, size.Height);
 
         /// <summary>
         ///    <para>
@@ -124,17 +109,12 @@ namespace System.Drawing
         ///       width and height.
         ///    </para>
         /// </summary>
-        public bool IsEmpty
-        {
-            get
-            {
-                return _width == 0 && _height == 0;
-            }
-        }
+        public bool IsEmpty => _width == 0 && _height == 0;
 
         /**
          * Horizontal dimension
          */
+
         /// <summary>
         ///    <para>
         ///       Represents the horizontal component of this
@@ -143,19 +123,14 @@ namespace System.Drawing
         /// </summary>
         public float Width
         {
-            get
-            {
-                return _width;
-            }
-            set
-            {
-                _width = value;
-            }
+            get { return _width; }
+            set { _width = value; }
         }
 
         /**
          * Vertical dimension
          */
+
         /// <summary>
         ///    <para>
         ///       Represents the vertical component of this
@@ -164,14 +139,8 @@ namespace System.Drawing
         /// </summary>
         public float Height
         {
-            get
-            {
-                return _height;
-            }
-            set
-            {
-                _height = value;
-            }
+            get { return _height; }
+            set { _height = value; }
         }
 
         /// <summary>
@@ -179,10 +148,7 @@ namespace System.Drawing
         ///       Performs vector addition of two <see cref='System.Drawing.SizeF'/> objects.
         ///    </para>
         /// </summary>
-        public static SizeF Add(SizeF sz1, SizeF sz2)
-        {
-            return new SizeF(sz1.Width + sz2.Width, sz1.Height + sz2.Height);
-        }
+        public static SizeF Add(SizeF sz1, SizeF sz2) => new SizeF(sz1.Width + sz2.Width, sz1.Height + sz2.Height);
 
         /// <summary>
         ///    <para>
@@ -190,10 +156,7 @@ namespace System.Drawing
         ///       .
         ///    </para>
         /// </summary>        
-        public static SizeF Subtract(SizeF sz1, SizeF sz2)
-        {
-            return new SizeF(sz1.Width - sz2.Width, sz1.Height - sz2.Height);
-        }
+        public static SizeF Subtract(SizeF sz1, SizeF sz2) => new SizeF(sz1.Width - sz2.Width, sz1.Height - sz2.Height);
 
         /// <summary>
         ///    <para>
@@ -214,15 +177,9 @@ namespace System.Drawing
 
         public override int GetHashCode() => HashHelpers.Combine(Width.GetHashCode(), Height.GetHashCode());
 
-        public PointF ToPointF()
-        {
-            return (PointF)this;
-        }
+        public PointF ToPointF() => (PointF)this;
 
-        public Size ToSize()
-        {
-            return Size.Truncate(this);
-        }
+        public Size ToSize() => Size.Truncate(this);
 
         /// <summary>
         ///    <para>
@@ -230,10 +187,7 @@ namespace System.Drawing
         ///    <see cref='System.Drawing.SizeF'/>.
         ///    </para>
         /// </summary>
-        public override string ToString()
-        {
-            return "{Width=" + _width.ToString() + ", Height=" + _height.ToString() + "}";
-        }
+        public override string ToString() => "{Width=" + _width.ToString() + ", Height=" + _height.ToString() + "}";
     }
 }
 

--- a/src/System.Drawing.Primitives/tests/ColorTests.cs
+++ b/src/System.Drawing.Primitives/tests/ColorTests.cs
@@ -4,9 +4,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Runtime.Serialization.Formatters.Binary;
 using Xunit;
 
 namespace System.Drawing.Primitives.Tests

--- a/src/System.Drawing.Primitives/tests/RectangleFTests.cs
+++ b/src/System.Drawing.Primitives/tests/RectangleFTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Globalization;
 
 using Xunit;

--- a/src/System.Drawing.Primitives/tests/SerializationTests.cs
+++ b/src/System.Drawing.Primitives/tests/SerializationTests.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Runtime.Serialization.Formatters.Tests;
 using Xunit;
 


### PR DESCRIPTION
These are tiny commits to make it easier to just undo one during review. They should definitely be squashed into one.

Remove unused using directives.

Remove unused constants

Assert on impossible value on first obtaining, rather than after it should have been used.

Remove `unchecked` context when can't overflow.
(Left some that match with neighbouring lines).

Make init-only fields `readonly`.

Consistently use expression bodies on single-expression members.

<s>Use string interpolation in `ToString()` methods.</s>

Remove some redundant casts where the result is clear.

Remove unnecessary qualifiers and make internal fields `private` when only accessed privately.

Move declaration of variables to where they are initialised.