### PR TITLE
Remove [SecureSafeCritical] and [SecurityCritical] in System.Private.DataContractSerialization

### DIFF
--- a/Documentation/coding-guidelines/buildingvertical.md
+++ b/Documentation/coding-guidelines/buildingvertical.md
@@ -1,0 +1,118 @@
+# Building a Vertical Implementation Details #
+
+**Definitions**
+
+*VerticalTargetGroup*
+
+`VerticalTargetGroup` - We need a property to define the vertical target group, but we don't want to set "TargetGroup" explicitly or we won't be able to build the "" TargetGroups for projects.
+  If `VerticalTargetGroup != ""`, we import buildvertical.targets which will contain our additional targets.
+
+*SupportedGroups*
+
+For each ref project and src project, we define `SupportedGroups`. `SupportedGroups` is a tuple for the supported `TargetGroups` and `OSGroups`.
+
+
+ie
+
+ref\System.Runtime.csproj
+```MSBuild
+<PropertyGroup>
+  <SupportedGroups>
+    netstandard1.7_Windows_NT;
+    netstandard1.7_OSX;
+    netstandard1.7_Linux;
+    netcoreapp1.1_Windows_NT;
+    netcoreapp1.1_OSX;
+    netcoreapp1.1_Linux
+  </SupportedGroups>
+<PropertyGroup>
+```
+
+*Contract Layer*
+
+We have a contract layer (msbuild task).
+
+Inputs:
+
+        SupportedGroups
+        VerticalTargetGroup
+        OSGroup
+Output:
+
+        VerticalTargets (ItemTask)
+            metadata: TargetGroup
+                      OSGroup
+
+Given the supported target and OS groups, and the desired vertical target and OS groups, return the closest supported group or empty metadata items.
+How should we handle determining the target / os groups, fallback groups, etc...?  The simplest solution is to use the NuGet api's for targets.  We can use platforms\runtime.json for os groups, or try to use the already existent os group filtering instead of adding it to the contract layer.
+
+Options:
+
+1. Use NuGet API's
+
+2. Make use of inormation we already have and develop our own resolution algorithm.
+
+The current plan is to use the NuGet API's.  We know that there is an intrinsic problem with the NuGet API's, in that we (CoreFx) define the targets (tfm's), but NuGet contains the data / logic, so anytime we want to create a new tfm, we have to go make an update to NuGet.  This is an existent problem.  For now, it is much simpler to utilize NuGet instead of deriving a second solution.  When we break free of the NuGet dependency and wholly define our tfm graph, then we should utilize that solution for this work.
+
+**Building a vertical implementation steps**
+
+1 - Include all projects, we don't need to build the .builds files for each library, because we only want to build each project at most once for a given vertical.
+
+```MSBuild
+<ItemGroup>
+  <Project Include="**\ref\*proj" />
+  <Project Include="**\src\*proj" />
+</ItemGroup>
+```
+
+2 - Iterate all projects through the contract layer, removing (and logging) any projects which return null metadata (not supported).
+
+3 - Build `OutputPath` is set to drop all binaries into a single folder
+
+Current standard `OutputPath`
+
+```MSBuild
+<OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)$(OSPlatformConfig)/$(MSBuildProjectName)/$(TargetOutputRelPath)$(OutputPathSubfolder)</OutputPath>
+```
+Example: E:\gh\chcosta\corefx\bin/AnyOS.AnyCPU.Debug/System.Buffers/netcoreapp1.1/
+
+Proposed vertical `OutputPath`
+
+```MSBuild
+<OutputPath Condition="'$(OutputPath)'==''">$(BinDir)/$(VerticalTargetGroup)/$(OSPlatformConfig)</OutputPath>
+```
+Example: E:\gh\chcosta\corefx\bin/netcoreapp1.7/AnyOS.AnyCPU.Debug
+
+Traditionally, the output path contains the `TargetGroup` as a part of the path.  The flat structure means we don't have to play games with the `TargetPath` to figure out when, for example, "System.Buffers" ("netstandard1.1") is trying to find the "System.Runtime" reference ("netstandard1.7"), that there is no path for "System.Runtime.dll" containing the "netstandard1.1" target group.
+
+4 - Build all reference assemblies.  The reference assembly projects, which were not trimmed in step 2, are all built.  TBD, should we again use the contract layer during the build to determine the targets for the project, or should we capture that as metadata for the project in step 2?
+
+5 - Build all src assemblies into the "OutputPath". The src assembly projects, which were not trimmed in step 2. are all built.
+
+6 - build packages, TBD
+
+**Building a library**
+
+In addition to the ability to build an entire vertical, we require the ability to build a single library.  This, single library build should utilize context to determine TargetGroup and OSGroup.  ie, If a vertical build completes, and you want to build an individual library, it should use the group values from the vertical build unless you specify otherwise.  If you specify otherwise, then those settings become the new settings.  If no context is available, then the library should be built with a set of commond default values.
+
+When building an individual library, or project, its P2P references must be queried to determine supported configurations for building that refernce and then the best configuration must be chosen.
+
+**Additional issues**
+
+- building specific folders (filter by partition)?
+
+- building / running tests for a vertical
+
+  - building tests against packages
+
+- Official builds?
+
+- CI testing?
+
+- Validation
+
+  - Is it an error condition if any library does not contribute to the latest standard vertical?
+
+  - Is it an error condition if a library does not contribute to any OS group? probably
+
+

--- a/Documentation/coding-guidelines/netstandard20-corefx-infra.md
+++ b/Documentation/coding-guidelines/netstandard20-corefx-infra.md
@@ -1,0 +1,96 @@
+##dotnet/CoreFx
+###Libraries in NETStandard
+- ref
+  - Default targetgroup should be NETCoreApp build
+  - P2P references to other reference assembly CSProjs.
+  - System.Runtime core assembly.
+  - Cross-compiles for concrete frameworks (if different)
+    - EG: exposes types/members not in NETStandard on NETCoreApp, but not on UWP
+- src
+  - Default targetgroup should be NETCoreApp build
+  - depends on System.Runtime?
+    - Yes: P2P to ref CSProjs
+    - No: P2P to implementation projects
+  - **Issue:** what if dependency is not in NETStandard?  EG: Buffers
+    - P2P reference to pkgproj
+    - Reference to NETStandard.dll facade for NETCoreApp
+- pkg
+  - No individual package builds.
+  - We will have a single package for all of NETCore.App's netstandard.library implementation.  Below TBD.
+    - framework split packages
+      - ref\netcoreappN - all refs for NETCoreApp,Version=vN
+    - runtime split packages
+      - runtime\{RID}\lib\netcoreappN - all impl for NETCoreApp,Version=vN, cross-gen'ed for RID
+- tests
+  - By default get all of NETStandard.Library for a specific version that they target (auto-referenced by targets)
+  - Use P2P references to pkgproj for things not in NETStandard.Library
+  - Implementation is automatically injected by targets.
+
+###Libraries above NETStandard
+- ref
+  - Only required if component is inbox somewhere or has multiple implementations for same NETStandard version.
+  - Build against NETStandard.Library package
+  - P2P references to pkgproj for things not in NETStandard.Library
+  - For builds that support older platforms (eg: netstandard1.0-1.6) we'll be building against the older contract-based NETStandard, we will need a story for this for build-from-source.
+- src
+  - Build against NETStandard.Library package
+  - P2P references to pkgproj for things not in NETStandard.Library
+  - For builds that support older platforms (eg: netstandard1.0-1.6) we'll be building against the older contract-based NETStandard, we will need a story for this for build-from-source.
+- pkg
+  - Not in NETCore.App: as today
+  - In NETCore.App: package in NETCore.App package as above
+    - If the library also ships in a package, it will also build a package as today.  This package may or may-not include the same binaries as are used by NETCore.App, for instance if the library builds against older NETStandard versions.
+- tests
+  - By default get all of NETStandard.Library for a specific version that they target (auto-referenced by targets)
+  - Use P2P references for things not in NETStandard.Library
+  - Implementation is automatically injected by targets.
+
+###NETStandard  compatibility facade
+Provides compatibility between NETCore.App and libraries built against NETStandard.
+- ref
+  - Should adapt supported NETStandard.dll to contract reference assemblies.
+  - EG: `GenFacades -contracts:<netstandard.dll> -seeds:<allNetCoreAppReferenceAssemblies>`
+- src
+  - Should adapt supported NETStandard.dll to implementation assemblies.
+  - EG: `GenFacades -contracts:<netstandard.dll> -seeds:<allNetCoreAppImplementationAssemblies>`
+- pkg
+  - No individual package builds.
+  - Should be included in NETCoreApp package as above
+
+###Desktop compatibility facades
+- ref
+  - Should adapt latest desktop surface to contract reference assemblies for anything that has type-overlap with desktop, including assemblies like Microsoft.Win32.Registry which are not in NETStandard.Library.
+  - EG: `GenFacades -contracts:<desktopReferenceAssemblies> -seeds:<allNetCoreAppReferenceAssemblies>`
+- src
+  - Should adapt latest desktop surface to netcore app implementation for anything that has type-overlap with desktop, including assemblies like Microsoft.Win32.Registry which are not in NETStandard.Library.
+  - EG: `GenFacades -contracts:<desktopReferenceAssemblies> -seeds:<allNetCoreAppImplementationAssemblies>`
+- pkg
+  - No individual package builds.
+  - Should be included in NETCoreApp package as above
+
+###Native shims
+- pkg
+  - No individual package builds.
+  - As with libraries in NETStandard the shims will be included in the runtime specific packages for NETCoreApp
+
+##Transition
+
+###End goal
+
+- CoreFx does not build any reference assemblies for NETStandard.
+- For every library in NETStandard.Library, the only configurations in CoreFx are framework-specific.  EG: NETCoreApp1.2, UAP10.1
+- For every library in NETCore.App but not in NETStandard.Library there must be a framework-specific configuration for NETCoreApp1.2.  Other configurations may exist to ship in a package, but those will not be built by folks building just NETCore.App.
+
+###Getting there (WIP)
+
+Folks still consume our current packages so we need to keep building those until we transition.
+
+1. Create a new NETCore.App package: Microsoft.Private.CoreFx.NETCore.App.  This will be an identity package with every ref that targets NETCore.App and runtime-specific packages that have all runtime impl's that apply to NETCore.App.
+2. Filter the content of Microsoft.Private.CoreFx.NETCore.App to just the things that are part of NETCore, and their closure.
+3. Transition tests to use Microsoft.Private.CoreFx.NETCore.App.
+4. Delete packages for things that are only part of Microsoft.Private.CoreFx.NETCore.App and don't ship independently.
+  - Delete configurations for libraries that are no longer used
+  - As packages are deleted we'll need to opt-in to Microsoft.Private.CoreFx.NETCore.App in some way.
+    - proposal:
+      - each CSProj is evaluated for layout path in the context of all of its build configurations.
+      - We'll determine applicability similar to how we do for pkgprojs to idenitify which config to binplace.

--- a/Documentation/project-docs/issue-guide.md
+++ b/Documentation/project-docs/issue-guide.md
@@ -46,14 +46,14 @@ Areas are tracked by labels area-&#42; (e.g. area-System.Collections). Each area
 | [area-Meta](https://github.com/dotnet/corefx/labels/area-Meta)                                | [@tarekgh](https://github.com/tarekgh) | Issues without clear association to any specific API/contract, e.g. <ul><li>new contract proposals</li><li>cross-cutting code/test pattern changes (e.g. FxCop failures)</li><li>project-wide docs</li></ul> **Pending triage** |
 | [area-Serialization](https://github.com/dotnet/corefx/labels/area-Serialization)              | [@shmao](https://github.com/shmao), [@zhenlan](https://github.com/zhenlan) | Packages:<ul><li>System.Runtime.Serialization.Xml</li><li>System.Runtime.Serialization.Json</li><li>System.Private.DataContractSerialization</li><li>System.Xml.XmlSerialization</li></ul> Excluded:<ul><li>System.Runtime.Serialization.Formatters</li></ul> |
 | **System contract assemblies** | | |
-| [System.AppContext](https://github.com/dotnet/corefx/labels/area-System.AppContext)           | [@AlexGhiondea](https://github.com/AlexGhiondea) | **Pending triage** |  |
+| [System.AppContext](https://github.com/dotnet/corefx/labels/area-System.AppContext)           | [@AlexGhiondea](https://github.com/AlexGhiondea) |  |  |
 | [System.Buffers](https://github.com/dotnet/corefx/labels/area-System.Buffers)                 | [@alexperovich](https://github.com/alexperovich),  [@safern](https://github.com/safern) |  |
-| [System.CodeDom](https://github.com/dotnet/corefx/labels/area-System.CodeDom)                 | [@Priya91](https://github.com/Priya91) | **Pending triage** |
+| [System.CodeDom](https://github.com/dotnet/corefx/labels/area-System.CodeDom)                 | [@Priya91](https://github.com/Priya91) |  |
 | [System.Collections](https://github.com/dotnet/corefx/labels/area-System.Collections)         | [@Priya91](https://github.com/Priya91), [@ianhays](https://github.com/ianhays) |  |
-| [System.ComponentModel](https://github.com/dotnet/corefx/labels/area-System.ComponentModel)   |  [@safern](https://github.com/safern), [@AlexGhiondea](https://github.com/AlexGhiondea) | **Pending triage** |
+| [System.ComponentModel](https://github.com/dotnet/corefx/labels/area-System.ComponentModel)   |  [@safern](https://github.com/safern), [@AlexGhiondea](https://github.com/AlexGhiondea) |  |
 | [System.ComponentModel.DataAnnotations](https://github.com/dotnet/corefx/labels/area-System.ComponentModel.DataAnnotations) | [@lajones](https://github.com/lajones), [@divega](https://github.com/divega) | **Pending triage** |
 | [System.Composition](https://github.com/dotnet/corefx/labels/area-System.Composition)         | [@AlexGhiondea](https://github.com/AlexGhiondea) | **Pending triage** |
-| [System.Console](https://github.com/dotnet/corefx/labels/area-System.Console)                 | [@ianhays](https://github.com/ianhays) | **Pending triage** |
+| [System.Console](https://github.com/dotnet/corefx/labels/area-System.Console)                 | [@ianhays](https://github.com/ianhays) |  |
 | [System.Data](https://github.com/dotnet/corefx/labels/area-System.Data)                       | [@saurabh500](https://github.com/saurabh500), [@YoungGah](https://github.com/YoungGah) |  |
 | [System.Data.SqlClient](https://github.com/dotnet/corefx/labels/area-System.Data.SqlClient)   | [@saurabh500](https://github.com/saurabh500), [@YoungGah](https://github.com/YoungGah) | **Pending triage** |
 | [System.Diagnostics](https://github.com/dotnet/corefx/labels/area-System.Diagnostics)         | [@joperezr](https://github.com/dotnet/joperezr) |  |
@@ -67,15 +67,15 @@ Areas are tracked by labels area-&#42; (e.g. area-System.Collections). Each area
 | [System.IO.Compression](https://github.com/dotnet/corefx/labels/area-System.IO.Compression)   | [@ianhays](https://github.com/ianhays) |  |
 | [System.Linq](https://github.com/dotnet/corefx/labels/area-System.Linq)                       | [@VSadov](https://github.com/VSadov), [@OmarTawfik](https://github.com/OmarTawfik) | **Pending triage** |
 | [System.Linq.Expressions](https://github.com/dotnet/corefx/labels/area-System.Linq.Expressions)   | [@VSadov](https://github.com/VSadov), [@OmarTawfik](https://github.com/OmarTawfik) | **Pending triage** |
-| [System.Linq.Parallel](https://github.com/dotnet/corefx/labels/area-System.Linq.Parallel)     | [@alexperovich](https://github.com/alexperovich), [@kouvel](https://github.com/kouvel) | **Pending triage** |
+| [System.Linq.Parallel](https://github.com/dotnet/corefx/labels/area-System.Linq.Parallel)     | [@alexperovich](https://github.com/alexperovich), [@kouvel](https://github.com/kouvel) |  |
 | [System.Net](https://github.com/dotnet/corefx/labels/area-System.Net)                         |  | **Pending triage** |
 | [System.Numerics](https://github.com/dotnet/corefx/labels/area-System.Numerics)               | [@mellinoe](https://github.com/mellinoe) |  |
 | [System.Reflection](https://github.com/dotnet/corefx/labels/area-System.Reflection)           |  | **Pending triage** |
 | [System.Reflection.Emit](https://github.com/dotnet/corefx/labels/area-System.Reflection.Emit) |  | **Pending triage** |
-| [System.Reflection.Metadata](https://github.com/dotnet/corefx/labels/area-System.Reflection.Metadata) | [@tmat](https://github.com/tmat), [@nguerrera](https://github.com/nguerrera) | **Pending triage** |
+| [System.Reflection.Metadata](https://github.com/dotnet/corefx/labels/area-System.Reflection.Metadata) | [@tmat](https://github.com/tmat), [@nguerrera](https://github.com/nguerrera) |  |
 | [System.Resources](https://github.com/dotnet/corefx/labels/area-System.Resources)             | [@ramarag](https://github.com/ramarag), [@tarekgh](https://github.com/tarekgh) | **Pending triage** |
 | [System.Runtime](https://github.com/dotnet/corefx/labels/area-System.Runtime)                 | [@AlexGhiondea](https://github.com/AlexGhiondea), [@joperezr](https://github.com/dotnet/joperezr) | Included:<ul><li>System.Runtime.Serialization.Formatters</li><li>System.Runtime.InteropServices.RuntimeInfo</li></ul>Excluded:<ul><li>Path -> System.IO</li><li>StopWatch -> System.Diagnostics</li><li>WebUtility -> System.Net</li></ul> **Pending triage** |
-| [System.Runtime.CompilerServices](https://github.com/dotnet/corefx/labels/area-System.Runtime.CompilerServices)   | [@AlexGhiondea](https://github.com/AlexGhiondea), [@joperezr](https://github.com/dotnet/joperezr) | **Pending triage** |
+| [System.Runtime.CompilerServices](https://github.com/dotnet/corefx/labels/area-System.Runtime.CompilerServices)   | [@AlexGhiondea](https://github.com/AlexGhiondea), [@joperezr](https://github.com/dotnet/joperezr) |  |
 | [System.Runtime.Extensions](https://github.com/dotnet/corefx/labels/area-System.Runtime.Extensions)   | [@AlexGhiondea](https://github.com/AlexGhiondea), [@joperezr](https://github.com/dotnet/joperezr) | **Pending triage** |
 | [System.Runtime.InteropServices](https://github.com/dotnet/corefx/labels/area-System.Runtime.InteropServices) | [@tijoytom](https://github.com/tijoytom), [@yizhang82](https://github.com/yizhang82) | Excluded:<ul><li>System.Runtime.InteropServices.RuntimeInfo</li></ul> |
 | [System.Security](https://github.com/dotnet/corefx/labels/area-System.Security)               | [@bartonjs](https://github.com/bartonjs), [@steveharter](https://github.com/steveharter) | **Pending triage** |

--- a/src/Common/tests/System/Threading/ThreadTestHelpers.cs
+++ b/src/Common/tests/System/Threading/ThreadTestHelpers.cs
@@ -39,7 +39,7 @@ namespace System.Threading.Tests
                     Interlocked.MemoryBarrier();
                     if (backgroundEx != null)
                     {
-                        throw new Exception("Background thread exception", backgroundEx);
+                        throw new AggregateException(backgroundEx);
                     }
                 };
             waitForThread =
@@ -79,7 +79,7 @@ namespace System.Threading.Tests
                     Interlocked.MemoryBarrier();
                     if (backgroundEx != null)
                     {
-                        throw new Exception("Background thread exception", backgroundEx);
+                        throw new AggregateException(backgroundEx);
                     }
                 };
             waitForThread =
@@ -123,6 +123,11 @@ namespace System.Threading.Tests
         public static void CheckedWait(this WaitHandle wh)
         {
             Assert.True(wh.WaitOne(UnexpectedTimeoutMilliseconds));
+        }
+
+        public static void CheckedWait(this ManualResetEventSlim e)
+        {
+            Assert.True(e.Wait(UnexpectedTimeoutMilliseconds));
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/Drawing/PointConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Drawing/PointConverterTests.cs
@@ -153,7 +153,8 @@ namespace System.ComponentModel.TypeConverterTests
         [Fact]
         public void ConvertTo_NullCulture()
         {
-            Assert.Equal("1, 1", Converter.ConvertTo(null, null, new Point(1, 1), typeof(string)));
+            string listSep = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
+            Assert.Equal($"1{listSep} 1", Converter.ConvertTo(null, null, new Point(1, 1), typeof(string)));
         }
 
         [Fact]

--- a/src/System.ComponentModel.TypeConverter/tests/Drawing/SizeConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Drawing/SizeConverterTests.cs
@@ -153,7 +153,8 @@ namespace System.ComponentModel.TypeConverterTests
         [Fact]
         public void ConvertTo_NullCulture()
         {
-            Assert.Equal("1, 1", Converter.ConvertTo(null, null, new Size(1, 1), typeof(string)));
+            string listSep = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
+            Assert.Equal($"1{listSep} 1", Converter.ConvertTo(null, null, new Size(1, 1), typeof(string)));
         }
 
         [Fact]

--- a/src/System.ComponentModel.TypeConverter/tests/Drawing/SizeFConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Drawing/SizeFConverterTests.cs
@@ -153,7 +153,8 @@ namespace System.ComponentModel.TypeConverterTests
         [Fact]
         public void ConvertTo_NullCulture()
         {
-            Assert.Equal("1, 1", Converter.ConvertTo(null, null, new SizeF(1, 1), typeof(string)));
+            string listSep = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
+            Assert.Equal($"1{listSep} 1", Converter.ConvertTo(null, null, new SizeF(1, 1), typeof(string)));
         }
 
         [Fact]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -117,7 +117,7 @@ namespace System.Net.Http.Functional.Tests
         // instead of local ones.  We're keeping it for now (as outerloop) because it helps
         // to validate against another SSL implementation that what we mean by a particular
         // TLS version matches that other implementation.
-        [OuterLoop] // avoid www.ssllabs.com dependency in innerloop
+        [OuterLoop("Avoid www.ssllabs.com dependency in innerloop.")]
         [Theory]
         [MemberData(nameof(SupportedSSLVersionServers))]
         public async Task GetAsync_SupportedSSLVersion_Succeeds(string name, string url)
@@ -138,8 +138,8 @@ namespace System.Net.Http.Functional.Tests
         // explicitly disallow creating SslStream with SSLv2/3.  Since we explicitly throw
         // when trying to use such an SslStream, we can't stand up a localhost server that
         // only speaks those protocols.
-        [OuterLoop] // avoid www.ssllabs.com dependency in innerloop
-        [Theory]
+        [OuterLoop("Avoid www.ssllabs.com dependency in innerloop.")]
+        [ConditionalTheory(nameof(SSLv3DisabledByDefault))]
         [MemberData(nameof(NotSupportedSSLVersionServers))]
         public async Task GetAsync_UnsupportedSSLVersion_Throws(string name, string url)
         {
@@ -237,6 +237,13 @@ namespace System.Net.Http.Functional.Tests
         private static bool BackendSupportsSslConfiguration =>
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
             (CurlSslVersionDescription()?.StartsWith("OpenSSL") ?? false);
+
+        private static bool SSLv3DisabledByDefault =>
+            BackendSupportsSslConfiguration ||
+            Version.Parse(CurlVersionDescription()) >= new Version(7, 39); // libcurl disables SSLv3 by default starting in v7.39
+
+        [DllImport("System.Net.Http.Native", EntryPoint = "HttpNative_GetVersionDescription")]
+        private static extern string CurlVersionDescription();
 
         [DllImport("System.Net.Http.Native", EntryPoint = "HttpNative_GetSslVersionDescription")]
         private static extern string CurlSslVersionDescription();

--- a/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -1167,4 +1167,25 @@
   <data name="ChangingFullTypeNameNotSupported" xml:space="preserve">
     <value>DataContractJsonSerializer does not support the setting of the FullTypeName of the object to be serialized to a value other than the default FullTypeName. Attempted to serialize object with full type name '{0}' and default full type name '{1}'.</value>
   </data>
+  <data name="InterfaceTypeCannotBeCreated" xml:space="preserve">
+    <value>Interface type '{0}' cannot be created. Consider replacing with a non-interface serializable type.</value>
+  </data>
+  <data name="ArraySizeAttributeIncorrect" xml:space="preserve">
+    <value>Array Size '{0}' is not equal to the number of elements found '{1}'.</value>
+  </data>
+  <data name="DuplicateExtensionDataSetMethod" xml:space="preserve">
+    <value>Invalid IExtensibleDataObject. Both '{0}' and '{1}' in type '{2}' provide property setter.</value>
+  </data>
+  <data name="ExtensionDataSetMustReturnVoid" xml:space="preserve">
+    <value>IExtensibleDataObject property setter '{1}' in type '{0}' must return void.</value>
+  </data>
+  <data name="ExtensionDataSetParameterInvalid" xml:space="preserve">
+    <value>IExtensibleDataObject property setter '{1}' in type '{0}' must have a single parameter of type '{2}'.</value>
+  </data>
+  <data name="OnlyDataContractTypesCanHaveExtensionData" xml:space="preserve">
+    <value>Type '{0}' does not have DataContractAttribute attribute and therefore cannot support IExtensibleDataObject. </value>
+  </data>
+  <data name="ParseJsonNumberReturnInvalidNumber" xml:space="preserve">
+    <value>JsonObjectDataContract.ParseJsonNumber shouldn't return a TypeCode that we're not expecting.</value>
+  </data>
 </root>

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Attributes.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Attributes.cs
@@ -6,34 +6,15 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Xml;
-using System.Security;
-
 
 namespace System.Runtime.Serialization
 {
     internal class Attributes
     {
-        /// <SecurityNote>
-        /// Critical - Static field used to store the attribute names to read during deserialization.
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
-        [SecurityCritical]
         private static XmlDictionaryString[] s_serializationLocalNames;
 
-        /// <SecurityNote>
-        /// Critical - Static field used to store the attribute names to read during deserialization.
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
-        [SecurityCritical]
         private static XmlDictionaryString[] s_schemaInstanceLocalNames;
 
-        /// <SecurityNote>
-        /// Critical - initializes critical static fields
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         static Attributes()
         {
             s_serializationLocalNames = new XmlDictionaryString[]
@@ -66,7 +47,6 @@ namespace System.Runtime.Serialization
         internal string FactoryTypePrefix;
         internal bool UnrecognizedAttributesFound;
 
-        [SecuritySafeCritical]
         internal void Read(XmlReaderDelegator reader)
         {
             Reset();

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Security;
+
 namespace System.Runtime.Serialization
 {
     using System;
@@ -14,7 +16,6 @@ namespace System.Runtime.Serialization
     using System.Threading;
     using System.Xml;
     using DataContractDictionary = System.Collections.Generic.Dictionary<System.Xml.XmlQualifiedName, DataContract>;
-    using System.Security;
     using System.Linq;
 
 #if USE_REFEMIT || NET_NATIVE
@@ -23,40 +24,14 @@ namespace System.Runtime.Serialization
     internal sealed class ClassDataContract : DataContract
 #endif
     {
-        /// <SecurityNote>
-        /// Review - XmlDictionaryString(s) representing the XML namespaces for class members.
-        ///          statically cached and used from IL generated code. should ideally be Critical.
-        ///          marked SecurityRequiresReview to be callable from transparent IL generated code. 
-        ///          not changed to property to avoid regressing performance; any changes to initialization should be reviewed.
-        /// </SecurityNote>
         public XmlDictionaryString[] ContractNamespaces;
-        /// <SecurityNote>
-        /// Review - XmlDictionaryString(s) representing the XML element names for class members.
-        ///          statically cached and used from IL generated code. should ideally be Critical.
-        ///          marked SecurityRequiresReview to be callable from transparent IL generated code. 
-        ///          not changed to property to avoid regressing performance; any changes to initialization should be reviewed.
-        /// </SecurityNote>
-        public XmlDictionaryString[] MemberNames;
-        /// <SecurityNote>
-        /// Review - XmlDictionaryString(s) representing the XML namespaces for class members.
-        ///          statically cached and used when calling IL generated code. should ideally be Critical.
-        ///          marked SecurityRequiresReview to be callable from transparent code. 
-        ///          not changed to property to avoid regressing performance; any changes to initialization should be reviewed.
-        /// </SecurityNote>
-        public XmlDictionaryString[] MemberNamespaces;
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - XmlDictionaryString representing the XML namespaces for members of class.
-        ///            statically cached and used from IL generated code.
-        /// </SecurityNote>
-        private XmlDictionaryString[] _childElementNamespaces;
-        [SecurityCritical]
 
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
+        public XmlDictionaryString[] MemberNames;
+
+        public XmlDictionaryString[] MemberNamespaces;
+
+        private XmlDictionaryString[] _childElementNamespaces;
+
         private ClassDataContractCriticalHelper _helper;
 
         private bool _isScriptObject;
@@ -68,30 +43,16 @@ namespace System.Runtime.Serialization
         }
 #endif
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal ClassDataContract(Type type) : base(new ClassDataContractCriticalHelper(type))
         {
             InitClassDataContract();
         }
-        [SecuritySafeCritical]
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
         private ClassDataContract(Type type, XmlDictionaryString ns, string[] memberNames) : base(new ClassDataContractCriticalHelper(type, ns, memberNames))
         {
             InitClassDataContract();
         }
-        [SecurityCritical]
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical fields; called from all constructors
-        /// </SecurityNote>
         private void InitClassDataContract()
         {
             _helper = base.Helper as ClassDataContractCriticalHelper;
@@ -103,33 +64,16 @@ namespace System.Runtime.Serialization
 
         internal ClassDataContract BaseContract
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical baseContract property
-            /// Safe - baseContract only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
-            get
-            { return _helper.BaseContract; }
+            get { return _helper.BaseContract; }
         }
 
         internal List<DataMember> Members
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical members property
-            /// Safe - members only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
-            get
-            { return _helper.Members; }
+            get { return _helper.Members; }
         }
 
         public XmlDictionaryString[] ChildElementNamespaces
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical childElementNamespaces property
-            /// Safe - childElementNamespaces only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (_childElementNamespaces == null)
@@ -158,44 +102,24 @@ namespace System.Runtime.Serialization
 
         internal MethodInfo OnSerializing
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical onSerializing property
-            /// Safe - onSerializing only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.OnSerializing; }
         }
 
         internal MethodInfo OnSerialized
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical onSerialized property
-            /// Safe - onSerialized only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.OnSerialized; }
         }
 
         internal MethodInfo OnDeserializing
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical onDeserializing property
-            /// Safe - onDeserializing only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.OnDeserializing; }
         }
 
         internal MethodInfo OnDeserialized
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical onDeserialized property
-            /// Safe - onDeserialized only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.OnDeserialized; }
         }
@@ -208,11 +132,6 @@ namespace System.Runtime.Serialization
 #if !NET_NATIVE
         public override DataContractDictionary KnownDataContracts
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical knownDataContracts property
-            /// Safe - knownDataContracts only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.KnownDataContracts; }
         }
@@ -226,11 +145,6 @@ namespace System.Runtime.Serialization
 
         internal bool IsNonAttributedType
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical IsNonAttributedType property
-            /// Safe - IsNonAttributedType only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.IsNonAttributedType; }
         }
@@ -238,7 +152,6 @@ namespace System.Runtime.Serialization
 #if NET_NATIVE
         public bool HasDataContract
         {
-            [SecuritySafeCritical]
             get
             { return _helper.HasDataContract; }
             set { _helper.HasDataContract = value; }
@@ -246,7 +159,6 @@ namespace System.Runtime.Serialization
 #endif
         public bool HasExtensionData
         {
-            [SecuritySafeCritical]
             get
             { return _helper.HasExtensionData; }
             set { _helper.HasExtensionData = value; }
@@ -254,28 +166,24 @@ namespace System.Runtime.Serialization
 
         internal bool IsKeyValuePairAdapter
         {
-            [SecuritySafeCritical]
             get
             { return _helper.IsKeyValuePairAdapter; }
         }
 
         internal Type[] KeyValuePairGenericArguments
         {
-            [SecuritySafeCritical]
             get
             { return _helper.KeyValuePairGenericArguments; }
         }
 
         internal ConstructorInfo KeyValuePairAdapterConstructorInfo
         {
-            [SecuritySafeCritical]
             get
             { return _helper.KeyValuePairAdapterConstructorInfo; }
         }
 
         internal MethodInfo GetKeyValuePairMethodInfo
         {
-            [SecuritySafeCritical]
             get
             { return _helper.GetKeyValuePairMethodInfo; }
         }
@@ -287,11 +195,6 @@ namespace System.Runtime.Serialization
 
         private ConstructorInfo _nonAttributedTypeConstructor;
 
-        /// <SecurityNote>
-        /// Critical - fetches information about which constructor should be used to initialize non-attributed types that are valid for serialization
-        /// Safe - only needs to be protected for write
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal ConstructorInfo GetNonAttributedTypeConstructor()
         {
             if (_nonAttributedTypeConstructor == null)
@@ -346,11 +249,6 @@ namespace System.Runtime.Serialization
         internal XmlFormatClassWriterDelegate XmlFormatWriterDelegate
 #endif
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical xmlFormatWriterDelegate property
-            /// Safe - xmlFormatWriterDelegate only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
 #if NET_NATIVE
@@ -389,11 +287,6 @@ namespace System.Runtime.Serialization
         internal XmlFormatClassReaderDelegate XmlFormatReaderDelegate
 #endif
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical xmlFormatReaderDelegate property
-            /// Safe - xmlFormatReaderDelegate only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
 #if NET_NATIVE
@@ -601,12 +494,7 @@ namespace System.Runtime.Serialization
 
             return childElementNamespaces;
         }
-        [SecuritySafeCritical]
 
-        /// <SecurityNote>
-        /// Critical - calls critical method on helper
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
         private void EnsureMethodsImported()
         {
             _helper.EnsureMethodsImported();
@@ -823,12 +711,7 @@ namespace System.Runtime.Serialization
 
             return false;
         }
-        [SecurityCritical]
 
-        /// <SecurityNote>
-        /// Critical - holds all state used for (de)serializing classes.
-        ///            since the data is cached statically, we lock down access to it.
-        /// </SecurityNote>
         private class ClassDataContractCriticalHelper : DataContract.DataContractCriticalHelper
         {
             private static Type[] s_serInfoCtorArgs;
@@ -1282,13 +1165,6 @@ namespace System.Runtime.Serialization
                 }
             }
 
-            /// <SecurityNote>
-            /// Critical - sets the critical hasDataContract field
-            /// Safe - uses a trusted critical API (DataContract.GetStableName) to calculate the value
-            ///        does not accept the value from the caller
-            /// </SecurityNote>
-            //CSD16748
-            //[SecuritySafeCritical]
             private XmlQualifiedName GetStableNameAndSetHasDataContract(Type type)
             {
                 return DataContract.GetStableName(type, out _hasDataContract);
@@ -1451,7 +1327,6 @@ namespace System.Runtime.Serialization
 
             internal override DataContractDictionary KnownDataContracts
             {
-                [SecurityCritical]
                 get
                 {
                     if (_knownDataContracts != null)
@@ -1473,7 +1348,7 @@ namespace System.Runtime.Serialization
                     }
                     return _knownDataContracts;
                 }
-                [SecurityCritical]
+
                 set
                 { _knownDataContracts = value; }
             }
@@ -1616,7 +1491,6 @@ namespace System.Runtime.Serialization
 
             internal class DataMemberConflictComparer : IComparer<Member>
             {
-                [SecuritySafeCritical]
                 public int Compare(Member x, Member y)
                 {
                     int nsCompare = String.CompareOrdinal(x.ns, y.ns);
@@ -1663,7 +1537,6 @@ namespace System.Runtime.Serialization
                 return clonedHelper;
             }
         }
-
 
         internal class DataMemberComparer : IComparer<DataMember>
         {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CodeGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CodeGenerator.cs
@@ -18,19 +18,9 @@ namespace System.Runtime.Serialization
 {
     internal class CodeGenerator
     {
-        /// <SecurityNote>
-        /// Critical - Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
-        [SecurityCritical]
         private static MethodInfo s_getTypeFromHandle;
         private static MethodInfo GetTypeFromHandle
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical getTypeFromHandle field
-            /// Safe - get-only properties only needs to be protected for write; initialized in getter if null.
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (s_getTypeFromHandle == null)
@@ -42,19 +32,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
-        [SecurityCritical]
         private static MethodInfo s_objectEquals;
         private static MethodInfo ObjectEquals
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical objectEquals field
-            /// Safe - get-only properties only needs to be protected for write; initialized in getter if null.
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (s_objectEquals == null)
@@ -65,19 +45,10 @@ namespace System.Runtime.Serialization
                 return s_objectEquals;
             }
         }
-        /// <SecurityNote>
-        /// Critical - Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
-        [SecurityCritical]
+
         private static MethodInfo s_arraySetValue;
         private static MethodInfo ArraySetValue
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical arraySetValue field
-            /// Safe - get-only properties only needs to be protected for write; initialized in getter if null.
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (s_arraySetValue == null)
@@ -90,11 +61,9 @@ namespace System.Runtime.Serialization
         }
 
 #if !NET_NATIVE
-        [SecurityCritical]
         private static MethodInfo s_objectToString;
         private static MethodInfo ObjectToString
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_objectToString == null)
@@ -109,7 +78,6 @@ namespace System.Runtime.Serialization
         private static MethodInfo s_stringFormat;
         private static MethodInfo StringFormat
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_stringFormat == null)
@@ -131,19 +99,9 @@ namespace System.Runtime.Serialization
         static int typeCounter;
         MethodBuilder methodBuilder;
 #else
-        /// <SecurityNote>
-        /// Critical - Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
-        [SecurityCritical]
         private static Module s_serializationModule;
         private static Module SerializationModule
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical serializationModule field
-            /// Safe - get-only properties only needs to be protected for write; initialized in getter if null.
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (s_serializationModule == null)
@@ -197,7 +155,6 @@ namespace System.Runtime.Serialization
             BeginMethod(signature.ReturnType, methodName, paramTypes, allowPrivateMemberAccess);
             _delegateType = delegateType;
         }
-        [SecuritySafeCritical]
 
         private void BeginMethod(Type returnType, string methodName, Type[] argTypes, bool allowPrivateMemberAccess)
         {
@@ -1559,7 +1516,6 @@ namespace System.Runtime.Serialization
         }
 
 #if USE_REFEMIT
-        [SecuritySafeCritical]
         void InitAssemblyBuilder(string methodName)
         {
             AssemblyName name = new AssemblyName();

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
@@ -36,14 +36,8 @@ namespace System.Runtime.Serialization
         [DataMember(Name = "key")]
         public K Key
         {
-            get
-            {
-                return _kvpKey;
-            }
-            set
-            {
-                _kvpKey = value;
-            }
+            get { return _kvpKey; }
+            set { _kvpKey = value; }
         }
 
         [DataMember(Name = "value")]
@@ -147,85 +141,41 @@ namespace System.Runtime.Serialization
     internal sealed class CollectionDataContract : DataContract
 #endif
     {
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - XmlDictionaryString representing the XML element name for collection items.
-        ///            statically cached and used from IL generated code.
-        /// </SecurityNote>
         private XmlDictionaryString _collectionItemName;
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - XmlDictionaryString representing the XML namespace for collection items.
-        ///            statically cached and used from IL generated code.
-        /// </SecurityNote>
+        
         private XmlDictionaryString _childElementNamespace;
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - internal DataContract representing the contract for collection items.
-        ///            statically cached and used from IL generated code.
-        /// </SecurityNote>
+        
         private DataContract _itemContract;
-        [SecurityCritical]
 
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
         private CollectionDataContractCriticalHelper _helper;
 
-        [SecuritySafeCritical]
         public CollectionDataContract(CollectionKind kind) : base(new CollectionDataContractCriticalHelper(kind))
         {
             InitCollectionDataContract(this);
         }
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal CollectionDataContract(Type type) : base(new CollectionDataContractCriticalHelper(type))
         {
             InitCollectionDataContract(this);
         }
-        [SecuritySafeCritical]
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
         private CollectionDataContract(Type type, CollectionKind kind, Type itemType, MethodInfo getEnumeratorMethod, MethodInfo addMethod, ConstructorInfo constructor)
                     : base(new CollectionDataContractCriticalHelper(type, kind, itemType, getEnumeratorMethod, addMethod, constructor))
         {
             InitCollectionDataContract(GetSharedTypeContract(type));
         }
-        [SecuritySafeCritical]
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
         private CollectionDataContract(Type type, CollectionKind kind, Type itemType, MethodInfo getEnumeratorMethod, MethodInfo addMethod, ConstructorInfo constructor, bool isConstructorCheckRequired)
                     : base(new CollectionDataContractCriticalHelper(type, kind, itemType, getEnumeratorMethod, addMethod, constructor, isConstructorCheckRequired))
         {
             InitCollectionDataContract(GetSharedTypeContract(type));
         }
-        [SecuritySafeCritical]
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
         private CollectionDataContract(Type type, string invalidCollectionInSharedContractMessage) : base(new CollectionDataContractCriticalHelper(type, invalidCollectionInSharedContractMessage))
         {
             InitCollectionDataContract(GetSharedTypeContract(type));
         }
-        [SecurityCritical]
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical fields; called from all constructors
-        /// </SecurityNote>
         private void InitCollectionDataContract(DataContract sharedTypeContract)
         {
             _helper = base.Helper as CollectionDataContractCriticalHelper;
@@ -239,33 +189,18 @@ namespace System.Runtime.Serialization
 
         private static Type[] KnownInterfaces
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical knownInterfaces property
-            /// Safe - knownInterfaces only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return CollectionDataContractCriticalHelper.KnownInterfaces; }
         }
 
         internal CollectionKind Kind
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical kind property
-            /// Safe - kind only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.Kind; }
         }
 
         public Type ItemType
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical itemType property
-            /// Safe - itemType only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.ItemType; }
             set { _helper.ItemType = value; }
@@ -273,19 +208,11 @@ namespace System.Runtime.Serialization
 
         public DataContract ItemContract
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical itemContract property
-            /// Safe - itemContract only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 return _itemContract ?? _helper.ItemContract;
             }
-            /// <SecurityNote>
-            /// Critical - sets the critical itemContract property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             {
                 _itemContract = value;
@@ -295,74 +222,39 @@ namespace System.Runtime.Serialization
 
         internal DataContract SharedTypeContract
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical sharedTypeContract property
-            /// Safe - sharedTypeContract only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.SharedTypeContract; }
         }
 
         public string ItemName
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical itemName property
-            /// Safe - itemName only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.ItemName; }
-            /// <SecurityNote>
-            /// Critical - sets the critical itemName property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.ItemName = value; }
         }
 
         public XmlDictionaryString CollectionItemName
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical collectionItemName property
-            /// Safe - collectionItemName only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
-            get
-            { return _collectionItemName; }
+            get { return _collectionItemName; }
             set { _collectionItemName = value; }
         }
 
         public string KeyName
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical keyName property
-            /// Safe - keyName only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.KeyName; }
-            /// <SecurityNote>
-            /// Critical - sets the critical keyName property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.KeyName = value; }
         }
 
         public string ValueName
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical valueName property
-            /// Safe - valueName only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.ValueName; }
-            /// <SecurityNote>
-            /// Critical - sets the critical valueName property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.ValueName = value; }
         }
@@ -374,11 +266,6 @@ namespace System.Runtime.Serialization
 
         public XmlDictionaryString ChildElementNamespace
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical childElementNamespace property
-            /// Safe - childElementNamespace only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (_childElementNamespace == null)
@@ -403,78 +290,42 @@ namespace System.Runtime.Serialization
 
         internal bool IsConstructorCheckRequired
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical isConstructorCheckRequired property
-            /// Safe - isConstructorCheckRequired only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.IsConstructorCheckRequired; }
-            /// <SecurityNote>
-            /// Critical - sets the critical isConstructorCheckRequired property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.IsConstructorCheckRequired = value; }
         }
 
         internal MethodInfo GetEnumeratorMethod
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical getEnumeratorMethod property
-            /// Safe - getEnumeratorMethod only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.GetEnumeratorMethod; }
         }
 
         internal MethodInfo AddMethod
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical addMethod property
-            /// Safe - addMethod only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.AddMethod; }
         }
 
         internal ConstructorInfo Constructor
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical constructor property
-            /// Safe - constructor only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.Constructor; }
         }
 
         public override DataContractDictionary KnownDataContracts
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical knownDataContracts property
-            /// Safe - knownDataContracts only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.KnownDataContracts; }
-            /// <SecurityNote>
-            /// Critical - sets the critical knownDataContracts property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.KnownDataContracts = value; }
         }
 
         internal string InvalidCollectionInSharedContractMessage
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical invalidCollectionInSharedContractMessage property
-            /// Safe - invalidCollectionInSharedContractMessage only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.InvalidCollectionInSharedContractMessage; }
         }
@@ -486,11 +337,6 @@ namespace System.Runtime.Serialization
         internal XmlFormatCollectionWriterDelegate XmlFormatWriterDelegate
 #endif
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical xmlFormatWriterDelegate property
-            /// Safe - xmlFormatWriterDelegate only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
 #if NET_NATIVE
@@ -529,11 +375,6 @@ namespace System.Runtime.Serialization
         internal XmlFormatCollectionReaderDelegate XmlFormatReaderDelegate
 #endif
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical xmlFormatReaderDelegate property
-            /// Safe - xmlFormatReaderDelegate only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
 #if NET_NATIVE
@@ -572,11 +413,6 @@ namespace System.Runtime.Serialization
         internal XmlFormatGetOnlyCollectionReaderDelegate XmlFormatGetOnlyCollectionReaderDelegate
 #endif
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical xmlFormatReaderDelegate property
-            /// Safe - xmlFormatReaderDelegate only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
 #if NET_NATIVE
@@ -623,11 +459,6 @@ namespace System.Runtime.Serialization
             return _helper.GetEnumeratorForCollection(obj, out enumeratorReturnType);
         }
 
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds all state used for (de)serializing collections.
-        ///            since the data is cached statically, we lock down access to it.
-        /// </SecurityNote>
         private class CollectionDataContractCriticalHelper : DataContract.DataContractCriticalHelper
         {
             private static Type[] s_knownInterfaces;
@@ -858,10 +689,7 @@ namespace System.Runtime.Serialization
                 set { _valueName = value; }
             }
 
-            internal bool IsDictionary
-            {
-                get { return KeyName != null; }
-            }
+            internal bool IsDictionary => KeyName != null;
 
             public XmlDictionaryString ChildElementNamespace
             {
@@ -869,24 +697,14 @@ namespace System.Runtime.Serialization
                 set { _childElementNamespace = value; }
             }
 
-            internal MethodInfo GetEnumeratorMethod
-            {
-                get { return _getEnumeratorMethod; }
-            }
+            internal MethodInfo GetEnumeratorMethod => _getEnumeratorMethod;
 
-            internal MethodInfo AddMethod
-            {
-                get { return _addMethod; }
-            }
+            internal MethodInfo AddMethod => _addMethod;
 
-            internal ConstructorInfo Constructor
-            {
-                get { return _constructor; }
-            }
+            internal ConstructorInfo Constructor => _constructor;
 
             internal override DataContractDictionary KnownDataContracts
             {
-                [SecurityCritical]
                 get
                 {
                     if (!_isKnownTypeAttributeChecked && UnderlyingType != null)
@@ -903,20 +721,14 @@ namespace System.Runtime.Serialization
                     }
                     return _knownDataContracts;
                 }
-                [SecurityCritical]
+
                 set
                 { _knownDataContracts = value; }
             }
 
-            internal string InvalidCollectionInSharedContractMessage
-            {
-                get { return _invalidCollectionInSharedContractMessage; }
-            }
+            internal string InvalidCollectionInSharedContractMessage => _invalidCollectionInSharedContractMessage;
 
-            internal bool ItemNameSetExplicit
-            {
-                get { return _itemNameSetExplicit; }
-            }
+            internal bool ItemNameSetExplicit => _itemNameSetExplicit;
 
             internal XmlFormatCollectionWriterDelegate XmlFormatWriterDelegate
             {
@@ -1501,10 +1313,6 @@ namespace System.Runtime.Serialization
             return this;
         }
 
-        /// <SecurityNote>
-        /// Critical - sets the critical IsConstructorCheckRequired property on CollectionDataContract 
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private void CheckConstructor()
         {
             if (this.Constructor == null)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -12,7 +12,6 @@ namespace System.Runtime.Serialization
     using System.Text;
     using System.Xml;
     using DataContractDictionary = System.Collections.Generic.Dictionary<System.Xml.XmlQualifiedName, DataContract>;
-    using System.Security;
     using System.Text.RegularExpressions;
     using System.Runtime.CompilerServices;
     using System.Linq;
@@ -24,17 +23,8 @@ namespace System.Runtime.Serialization
     internal abstract class DataContract
 #endif
     {
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - XmlDictionaryString representing the type name.
-        ///            statically cached and used from IL generated code.
-        /// </SecurityNote>
         private XmlDictionaryString _name;
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - XmlDictionaryString representing the type namespace.
-        ///            statically cached and used from IL generated code.
-        /// </SecurityNote>
+
         private XmlDictionaryString _ns;
 
         // this the global dictionary for data contracts introduced for multi-file.
@@ -45,19 +35,8 @@ namespace System.Runtime.Serialization
             return s_dataContracts;
         }
 
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
         private DataContractCriticalHelper _helper;
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal DataContract(DataContractCriticalHelper helper)
         {
             _helper = helper;
@@ -136,11 +115,6 @@ namespace System.Runtime.Serialization
             return dataContract.GetValidContract(mode);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up DataContract 
-        /// Safe - read only access
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static DataContract GetDataContractSkipValidation(int id, RuntimeTypeHandle typeHandle, Type type)
         {
             return DataContractCriticalHelper.GetDataContractSkipValidation(id, typeHandle, type);
@@ -157,61 +131,31 @@ namespace System.Runtime.Serialization
             return dataContract;
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up DataContract 
-        /// Safe - read only access
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static DataContract GetGetOnlyCollectionDataContractSkipValidation(int id, RuntimeTypeHandle typeHandle, Type type)
         {
             return DataContractCriticalHelper.GetGetOnlyCollectionDataContractSkipValidation(id, typeHandle, type);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up DataContract 
-        /// Safe - read only access; doesn't modify any static information
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static DataContract GetDataContractForInitialization(int id)
         {
             return DataContractCriticalHelper.GetDataContractForInitialization(id);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up id for DataContract 
-        /// Safe - read only access; doesn't modify any static information
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static int GetIdForInitialization(ClassDataContract classContract)
         {
             return DataContractCriticalHelper.GetIdForInitialization(classContract);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up id assigned to a particular type
-        /// Safe - read only access
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static int GetId(RuntimeTypeHandle typeHandle)
         {
             return DataContractCriticalHelper.GetId(typeHandle);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up DataContract 
-        /// Safe - read only access
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         public static DataContract GetBuiltInDataContract(Type type)
         {
             return DataContractCriticalHelper.GetBuiltInDataContract(type);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up DataContract 
-        /// Safe - read only access
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         public static DataContract GetBuiltInDataContract(string name, string ns)
         {
             return DataContractCriticalHelper.GetBuiltInDataContract(name, ns);
@@ -222,31 +166,16 @@ namespace System.Runtime.Serialization
             return DataContractCriticalHelper.GetBuiltInDataContract(typeName);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up string reference to use for a namespace string
-        /// Safe - read only access
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static string GetNamespace(string key)
         {
             return DataContractCriticalHelper.GetNamespace(key);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up XmlDictionaryString for a string
-        /// Safe - read only access
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static XmlDictionaryString GetClrTypeString(string key)
         {
             return DataContractCriticalHelper.GetClrTypeString(key);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to remove invalid DataContract if it has been added to cache
-        /// Safe - doesn't leak any information
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static void ThrowInvalidDataContractException(string message, Type type)
         {
             DataContractCriticalHelper.ThrowInvalidDataContractException(message, type);
@@ -258,23 +187,12 @@ namespace System.Runtime.Serialization
         protected DataContractCriticalHelper Helper
 #endif
         {
-            /// <SecurityNote>
-            /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-            ///            Static fields are marked SecurityCritical or readonly to prevent
-            ///            data from being modified or leaked to other components in appdomain.
-            /// </SecurityNote>
-            [SecurityCritical]
             get
             { return _helper; }
         }
 
         public Type UnderlyingType
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical UnderlyingType property
-            /// Safe - underlyingType only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.UnderlyingType; }
             set { _helper.UnderlyingType = value; }
@@ -288,11 +206,6 @@ namespace System.Runtime.Serialization
 
         public virtual bool IsBuiltInDataContract
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical isBuiltInDataContract property
-            /// Safe - isBuiltInDataContract only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.IsBuiltInDataContract; }
             set { }
@@ -300,11 +213,6 @@ namespace System.Runtime.Serialization
 
         internal Type TypeForInitialization
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical typeForInitialization property
-            /// Safe - typeForInitialization only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.TypeForInitialization; }
         }
@@ -342,68 +250,36 @@ namespace System.Runtime.Serialization
 
         public bool IsValueType
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical isValueType property
-            /// Safe - isValueType only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.IsValueType; }
-            /// <SecurityNote>
-            /// Critical - sets the critical IsValueType property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.IsValueType = value; }
         }
 
         public bool IsReference
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical isReference property
-            /// Safe - isReference only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.IsReference; }
-            /// <SecurityNote>
-            /// Critical - sets the critical IsReference property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.IsReference = value; }
         }
 
         public XmlQualifiedName StableName
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical StableName property
-            /// Safe - StableName only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.StableName; }
-            /// <SecurityNote>
-            /// Critical - sets the critical StableName property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.StableName = value; }
         }
 
         public virtual DataContractDictionary KnownDataContracts
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical KnownDataContracts property
-            /// Safe - KnownDataContracts only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.KnownDataContracts; }
-            /// <SecurityNote>
-            /// Critical - sets the critical KnownDataContracts property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.KnownDataContracts = value; }
         }
@@ -417,11 +293,6 @@ namespace System.Runtime.Serialization
 
         public XmlDictionaryString Name
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical Name property
-            /// Safe - Name only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _name; }
             set { _name = value; }
@@ -429,11 +300,6 @@ namespace System.Runtime.Serialization
 
         public virtual XmlDictionaryString Namespace
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical Namespace property
-            /// Safe - Namespace only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _ns; }
             set { _ns = value; }
@@ -441,51 +307,27 @@ namespace System.Runtime.Serialization
 
         public virtual bool HasRoot
         {
-            /// <SecurityNote>
-            /// Critical - in case derived classes want to override and set a critical field
-            /// Safe - expectation is readonly access is safe
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return true; }
-            /// <SecurityNote>
-            /// Critical - in case derived classes want to override and set a critical field
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { }
         }
 
         public virtual XmlDictionaryString TopLevelElementName
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical Name property
-            /// Safe - Name only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.TopLevelElementName; }
-            /// <SecurityNote>
-            /// Critical - sets the critical Name property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.TopLevelElementName = value; }
         }
 
         public virtual XmlDictionaryString TopLevelElementNamespace
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical Namespace property
-            /// Safe - Namespace only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.TopLevelElementNamespace; }
-            /// <SecurityNote>
-            /// Critical - sets the critical Namespace property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.TopLevelElementNamespace = value; }
         }
@@ -529,11 +371,6 @@ namespace System.Runtime.Serialization
             return true;
         }
 
-        /// <SecurityNote>
-        /// Critical - holds all state used for (de)serializing types.
-        ///            since the data is cached statically, we lock down access to it.
-        /// </SecurityNote>
-        [SecurityCritical]
         internal class DataContractCriticalHelper
         {
             private static Dictionary<TypeHandleRef, IntRef> s_typeToIDCache = new Dictionary<TypeHandleRef, IntRef>(new TypeHandleRefEqualityComparer());
@@ -1220,12 +1057,6 @@ namespace System.Runtime.Serialization
                 get { return _typeForInitialization; }
             }
 
-            /// <SecurityNote>
-            /// Critical - sets the critical typeForInitialization field
-            /// Safe - validates input data, sets field correctly
-            /// </SecurityNote>
-            //CSD16748
-            //[SecuritySafeCritical]
             private void SetTypeForInitialization(Type classType)
             {
                 //if (classType.IsSerializable || classType.IsDefined(Globals.TypeOfDataContractAttribute, false))
@@ -1485,13 +1316,6 @@ namespace System.Runtime.Serialization
             return GetStableName(type, out hasDataContract);
         }
 
-        /// <SecurityNote>
-        /// RequiresReview - marked SRR because callers may need to depend on hasDataContract for a security decision
-        ///            hasDataContract must be calculated correctly
-        ///            GetStableName is factored into sub-methods so as to isolate the DataContractAttribute calculation and
-        ///            reduce SecurityCritical surface area
-        /// Safe - does not let caller influence hasDataContract calculation; no harm in leaking value
-        /// </SecurityNote>
         internal static XmlQualifiedName GetStableName(Type type, out bool hasDataContract)
         {
             type = UnwrapRedundantNullableType(type);
@@ -1593,11 +1417,6 @@ namespace System.Runtime.Serialization
             return stableName != null;
         }
 
-        /// <SecurityNote>
-        /// Critical - marked SecurityCritical because callers may need to base security decisions on the presence (or absence) of the DC attribute
-        /// Safe - does not let caller influence calculation and the result is not a protected value
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static bool TryGetDCAttribute(Type type, out DataContractAttribute dataContractAttribute)
         {
             dataContractAttribute = null;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataMember.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataMember.cs
@@ -19,39 +19,18 @@ namespace System.Runtime.Serialization
     internal class DataMember
 #endif
     {
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
         private CriticalHelper _helper;
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         public DataMember()
         {
             _helper = new CriticalHelper();
         }
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal DataMember(MemberInfo memberInfo)
         {
             _helper = new CriticalHelper(memberInfo);
         }
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal DataMember(DataContract memberTypeContract, string name, bool isNullable, bool isRequired, bool emitDefaultValue, int order)
         {
             _helper = new CriticalHelper(memberTypeContract, name, isNullable, isRequired, emitDefaultValue, order);
@@ -59,81 +38,72 @@ namespace System.Runtime.Serialization
 
         internal MemberInfo MemberInfo
         {
-            [SecuritySafeCritical]
             get
             { return _helper.MemberInfo; }
         }
 
         public string Name
         {
-            [SecuritySafeCritical]
             get
             { return _helper.Name; }
-            [SecurityCritical]
+
             set
             { _helper.Name = value; }
         }
 
         public int Order
         {
-            [SecuritySafeCritical]
             get
             { return _helper.Order; }
-            [SecurityCritical]
+
             set
             { _helper.Order = value; }
         }
 
         public bool IsRequired
         {
-            [SecuritySafeCritical]
             get
             { return _helper.IsRequired; }
-            [SecurityCritical]
+            
             set
             { _helper.IsRequired = value; }
         }
 
         public bool EmitDefaultValue
         {
-            [SecuritySafeCritical]
             get
             { return _helper.EmitDefaultValue; }
-            [SecurityCritical]
+            
             set
             { _helper.EmitDefaultValue = value; }
         }
 
         public bool IsNullable
         {
-            [SecuritySafeCritical]
             get
             { return _helper.IsNullable; }
-            [SecurityCritical]
+
             set
             { _helper.IsNullable = value; }
         }
 
         public bool IsGetOnlyCollection
         {
-            [SecuritySafeCritical]
             get
             { return _helper.IsGetOnlyCollection; }
-            [SecurityCritical]
+
             set
             { _helper.IsGetOnlyCollection = value; }
         }
 
         internal Type MemberType
         {
-            [SecuritySafeCritical]
             get
             { return _helper.MemberType; }
         }
 
         internal DataContract MemberTypeContract
         {
-            [SecuritySafeCritical]
             get
             { return _helper.MemberTypeContract; }
         }
@@ -148,20 +118,18 @@ namespace System.Runtime.Serialization
 
         public bool HasConflictingNameAndType
         {
-            [SecuritySafeCritical]
             get
             { return _helper.HasConflictingNameAndType; }
-            [SecurityCritical]
+
             set
             { _helper.HasConflictingNameAndType = value; }
         }
 
         internal DataMember ConflictingMember
         {
-            [SecuritySafeCritical]
             get
             { return _helper.ConflictingMember; }
-            [SecurityCritical]
+
             set
             { _helper.ConflictingMember = value; }
         }
@@ -180,7 +148,6 @@ namespace System.Runtime.Serialization
             }
         }
 
-
         private FastInvokerBuilder.Setter _setter;
         internal FastInvokerBuilder.Setter Setter
         {
@@ -195,11 +162,6 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
-
-        /// <SecurityNote>
-        /// Critical
-        /// </SecurityNote>
         private class CriticalHelper
         {
             private DataContract _memberTypeContract;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DictionaryGlobals.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DictionaryGlobals.cs
@@ -5,16 +5,9 @@
 using System;
 using System.Xml;
 using System.Xml.Schema;
-using System.Security;
-
 
 namespace System.Runtime.Serialization
 {
-    /// <SecurityNote>
-    /// Review - Static fields are marked SecurityCritical or readonly to prevent
-    ///          data from being modified or leaked to other components in appdomain.
-    ///          changes to static fields could affect serialization/deserialization; should be reviewed.
-    /// </SecurityNote>
 #if USE_REFEMIT
     public static class DictionaryGlobals
 #else

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/EnumDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/EnumDataContract.cs
@@ -22,19 +22,8 @@ namespace System.Runtime.Serialization
     internal sealed class EnumDataContract : DataContract
 #endif
     {
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
         private EnumDataContractCriticalHelper _helper;
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         public EnumDataContract() : base(new EnumDataContractCriticalHelper())
         {
             _helper = base.Helper as EnumDataContractCriticalHelper;
@@ -42,22 +31,12 @@ namespace System.Runtime.Serialization
 
         public XmlQualifiedName BaseContractName { get; set; }
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal EnumDataContract(Type type) : base(new EnumDataContractCriticalHelper(type))
         {
             _helper = base.Helper as EnumDataContractCriticalHelper;
         }
         public List<DataMember> Members
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical Members property
-            /// Safe - Members only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.Members; }
             set { _helper.Members = value; }
@@ -65,11 +44,6 @@ namespace System.Runtime.Serialization
 
         public List<long> Values
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical Values property
-            /// Safe - Values only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.Values; }
             set { _helper.Values = value; }
@@ -77,11 +51,6 @@ namespace System.Runtime.Serialization
 
         public bool IsFlags
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical IsFlags property
-            /// Safe - IsFlags only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.IsFlags; }
             set { _helper.IsFlags = value; }
@@ -89,11 +58,6 @@ namespace System.Runtime.Serialization
 
         public bool IsULong
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical IsULong property
-            /// Safe - IsULong only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.IsULong; }
             set { _helper.IsULong = value; }
@@ -101,11 +65,6 @@ namespace System.Runtime.Serialization
 
         public XmlDictionaryString[] ChildElementNames
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical ChildElementNames property
-            /// Safe - ChildElementNames only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.ChildElementNames; }
             set { _helper.ChildElementNames = value; }
@@ -115,12 +74,7 @@ namespace System.Runtime.Serialization
         {
             get { return false; }
         }
-        [SecurityCritical]
 
-        /// <SecurityNote>
-        /// Critical - holds all state used for (de)serializing enums.
-        ///            since the data is cached statically, we lock down access to it.
-        /// </SecurityNote>
         private class EnumDataContractCriticalHelper : DataContract.DataContractCriticalHelper
         {
             private static Dictionary<Type, XmlQualifiedName> s_typeToName;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataObject.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataObject.cs
@@ -240,6 +240,44 @@ namespace System.Runtime.Serialization
         }
     }
 
+    internal class XmlDataNode : DataNode<object>
+    {
+        private IList<XmlAttribute> _xmlAttributes;
+        private IList<XmlNode> _xmlChildNodes;
+        private XmlDocument _ownerDocument;
+
+        internal XmlDataNode()
+        {
+            dataType = Globals.TypeOfXmlDataNode;
+        }
+
+        internal IList<XmlAttribute> XmlAttributes
+        {
+            get { return _xmlAttributes; }
+            set { _xmlAttributes = value; }
+        }
+
+        internal IList<XmlNode> XmlChildNodes
+        {
+            get { return _xmlChildNodes; }
+            set { _xmlChildNodes = value; }
+        }
+
+        internal XmlDocument OwnerDocument
+        {
+            get { return _ownerDocument; }
+            set { _ownerDocument = value; }
+        }
+
+        public override void Clear()
+        {
+            base.Clear();
+            _xmlAttributes = null;
+            _xmlChildNodes = null;
+            _ownerDocument = null;
+        }
+    }
+
     internal class CollectionDataNode : DataNode<Array>
     {
         private IList<IDataNode> _items;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataReader.cs
@@ -4,7 +4,6 @@
 
 using System.Xml;
 using System.Collections.Generic;
-using System.Security;
 
 namespace System.Runtime.Serialization
 {
@@ -45,13 +44,10 @@ namespace System.Runtime.Serialization
         private Queue<IDataNode> _deserializedDataNodes;
         private XmlObjectSerializerReadContext _context;
 
-        [SecurityCritical]
         private static Dictionary<string, string> s_nsToPrefixTable;
 
-        [SecurityCritical]
         private static Dictionary<string, string> s_prefixToNsTable;
 
-        [SecurityCritical]
         static ExtensionDataReader()
         {
             s_nsToPrefixTable = new Dictionary<string, string>();
@@ -224,7 +220,6 @@ namespace System.Runtime.Serialization
             _attributeIndex = -1;
         }
 
-        [SecuritySafeCritical]
         public override string LookupNamespace(string prefix)
         {
             if (IsXmlDataNode)
@@ -510,7 +505,6 @@ namespace System.Runtime.Serialization
                 ? new ElementData() : _elements[nextDepth];
         }
 
-        [SecuritySafeCritical]
         internal static string GetPrefix(string ns)
         {
             string prefix;
@@ -529,7 +523,6 @@ namespace System.Runtime.Serialization
             return prefix;
         }
 
-        [SecuritySafeCritical]
         private static void AddPrefix(string prefix, string ns)
         {
             s_nsToPrefixTable.Add(ns, prefix);
@@ -589,4 +582,3 @@ namespace System.Runtime.Serialization
         }
     }
 }
-

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/GenericParameterDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/GenericParameterDataContract.cs
@@ -4,16 +4,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Security;
 
 namespace System.Runtime.Serialization
 {
     internal sealed class GenericParameterDataContract : DataContract
     {
-        [SecurityCritical]
         private GenericParameterDataContractCriticalHelper _helper;
 
-        [SecuritySafeCritical]
         internal GenericParameterDataContract(Type type)
             : base(new GenericParameterDataContractCriticalHelper(type))
         {
@@ -22,7 +19,6 @@ namespace System.Runtime.Serialization
 
         internal int ParameterPosition
         {
-            [SecuritySafeCritical]
             get
             { return _helper.ParameterPosition; }
         }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
@@ -10,19 +10,12 @@ using System.Xml.Serialization;
 using System.Reflection;
 using System.Collections;
 using System.Collections.Generic;
-using System.Security;
 using System.Linq;
 using System.Diagnostics;
 
 
 namespace System.Runtime.Serialization
 {
-    /// <SecurityNote>
-    /// Critical - Class holds static instances used in serializer. 
-    ///            Static fields are marked SecurityCritical or readonly to prevent
-    ///            data from being modified or leaked to other components in appdomain.
-    /// Safe - All get-only properties marked safe since they only need to be protected for write.
-    /// </SecurityNote>
     internal static class Globals
     {
         /// <SecurityNote>
@@ -30,11 +23,9 @@ namespace System.Runtime.Serialization
         /// </SecurityNote>
         internal const BindingFlags ScanAllMembers = BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
 
-        [SecurityCritical]
         private static XmlQualifiedName s_idQualifiedName;
         internal static XmlQualifiedName IdQualifiedName
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_idQualifiedName == null)
@@ -43,11 +34,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static XmlQualifiedName s_refQualifiedName;
         internal static XmlQualifiedName RefQualifiedName
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_refQualifiedName == null)
@@ -56,11 +45,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfObject;
         internal static Type TypeOfObject
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfObject == null)
@@ -69,11 +56,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfValueType;
         internal static Type TypeOfValueType
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfValueType == null)
@@ -82,11 +67,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfArray;
         internal static Type TypeOfArray
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfArray == null)
@@ -95,11 +78,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfException;
         internal static Type TypeOfException
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfException == null)
@@ -108,11 +89,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfString;
         internal static Type TypeOfString
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfString == null)
@@ -121,11 +100,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfInt;
         internal static Type TypeOfInt
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfInt == null)
@@ -134,11 +111,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfULong;
         internal static Type TypeOfULong
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfULong == null)
@@ -147,11 +122,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfVoid;
         internal static Type TypeOfVoid
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfVoid == null)
@@ -160,11 +133,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfByteArray;
         internal static Type TypeOfByteArray
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfByteArray == null)
@@ -173,11 +144,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfTimeSpan;
         internal static Type TypeOfTimeSpan
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfTimeSpan == null)
@@ -186,11 +155,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfGuid;
         internal static Type TypeOfGuid
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfGuid == null)
@@ -199,11 +166,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfDateTimeOffset;
         internal static Type TypeOfDateTimeOffset
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfDateTimeOffset == null)
@@ -212,11 +177,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfDateTimeOffsetAdapter;
         internal static Type TypeOfDateTimeOffsetAdapter
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfDateTimeOffsetAdapter == null)
@@ -225,11 +188,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfUri;
         internal static Type TypeOfUri
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfUri == null)
@@ -238,11 +199,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfTypeEnumerable;
         internal static Type TypeOfTypeEnumerable
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfTypeEnumerable == null)
@@ -251,11 +210,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfStreamingContext;
         internal static Type TypeOfStreamingContext
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfStreamingContext == null)
@@ -286,11 +243,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlFormatClassWriterDelegate;
         internal static Type TypeOfXmlFormatClassWriterDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlFormatClassWriterDelegate == null)
@@ -299,11 +254,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlFormatCollectionWriterDelegate;
         internal static Type TypeOfXmlFormatCollectionWriterDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlFormatCollectionWriterDelegate == null)
@@ -312,11 +265,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlFormatClassReaderDelegate;
         internal static Type TypeOfXmlFormatClassReaderDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlFormatClassReaderDelegate == null)
@@ -325,11 +276,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlFormatCollectionReaderDelegate;
         internal static Type TypeOfXmlFormatCollectionReaderDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlFormatCollectionReaderDelegate == null)
@@ -338,11 +287,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlFormatGetOnlyCollectionReaderDelegate;
         internal static Type TypeOfXmlFormatGetOnlyCollectionReaderDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlFormatGetOnlyCollectionReaderDelegate == null)
@@ -351,11 +298,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfKnownTypeAttribute;
         internal static Type TypeOfKnownTypeAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfKnownTypeAttribute == null)
@@ -364,18 +309,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - attribute type used in security decision
-        /// </SecurityNote>
-        [SecurityCritical]
         private static Type s_typeOfDataContractAttribute;
         internal static Type TypeOfDataContractAttribute
         {
-            /// <SecurityNote>
-            /// Critical - accesses critical field for attribute type
-            /// Safe - controls inputs and logic
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfDataContractAttribute == null)
@@ -384,11 +320,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfDataMemberAttribute;
         internal static Type TypeOfDataMemberAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfDataMemberAttribute == null)
@@ -397,11 +331,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfEnumMemberAttribute;
         internal static Type TypeOfEnumMemberAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfEnumMemberAttribute == null)
@@ -410,11 +342,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfCollectionDataContractAttribute;
         internal static Type TypeOfCollectionDataContractAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfCollectionDataContractAttribute == null)
@@ -437,11 +367,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfObjectArray;
         internal static Type TypeOfObjectArray
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfObjectArray == null)
@@ -450,12 +378,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-
-        [SecurityCritical]
         private static Type s_typeOfOnSerializingAttribute;
         internal static Type TypeOfOnSerializingAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfOnSerializingAttribute == null)
@@ -464,11 +389,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfOnSerializedAttribute;
         internal static Type TypeOfOnSerializedAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfOnSerializedAttribute == null)
@@ -477,11 +400,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfOnDeserializingAttribute;
         internal static Type TypeOfOnDeserializingAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfOnDeserializingAttribute == null)
@@ -490,11 +411,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfOnDeserializedAttribute;
         internal static Type TypeOfOnDeserializedAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfOnDeserializedAttribute == null)
@@ -503,12 +422,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-
-        [SecurityCritical]
         private static Type s_typeOfFlagsAttribute;
         internal static Type TypeOfFlagsAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfFlagsAttribute == null)
@@ -517,11 +433,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIXmlSerializable;
         internal static Type TypeOfIXmlSerializable
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIXmlSerializable == null)
@@ -530,11 +444,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlSchemaProviderAttribute;
         internal static Type TypeOfXmlSchemaProviderAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlSchemaProviderAttribute == null)
@@ -543,11 +455,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlRootAttribute;
         internal static Type TypeOfXmlRootAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlRootAttribute == null)
@@ -556,11 +466,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlQualifiedName;
         internal static Type TypeOfXmlQualifiedName
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlQualifiedName == null)
@@ -575,11 +483,9 @@ namespace System.Runtime.Serialization
         private static Type s_typeOfExtensionDataObject;
         internal static Type TypeOfExtensionDataObject => s_typeOfExtensionDataObject ?? (s_typeOfExtensionDataObject = typeof (ExtensionDataObject));
 
-        [SecurityCritical]
         private static Type s_typeOfISerializableDataNode;
         internal static Type TypeOfISerializableDataNode
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfISerializableDataNode == null)
@@ -588,11 +494,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfClassDataNode;
         internal static Type TypeOfClassDataNode
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfClassDataNode == null)
@@ -601,11 +505,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfCollectionDataNode;
         internal static Type TypeOfCollectionDataNode
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfCollectionDataNode == null)
@@ -618,12 +520,10 @@ namespace System.Runtime.Serialization
         internal static Type TypeOfXmlDataNode => s_typeOfXmlDataNode ?? (s_typeOfXmlDataNode = typeof (XmlDataNode));
 
 #if NET_NATIVE
-        [SecurityCritical]
         private static Type s_typeOfSafeSerializationManager;
         private static bool s_typeOfSafeSerializationManagerSet;
         internal static Type TypeOfSafeSerializationManager
         {
-            [SecuritySafeCritical]
             get
             {
                 if (!s_typeOfSafeSerializationManagerSet)
@@ -636,11 +536,9 @@ namespace System.Runtime.Serialization
         }
 #endif
 
-        [SecurityCritical]
         private static Type s_typeOfNullable;
         internal static Type TypeOfNullable
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfNullable == null)
@@ -649,11 +547,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIDictionaryGeneric;
         internal static Type TypeOfIDictionaryGeneric
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIDictionaryGeneric == null)
@@ -662,11 +558,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIDictionary;
         internal static Type TypeOfIDictionary
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIDictionary == null)
@@ -675,11 +569,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIListGeneric;
         internal static Type TypeOfIListGeneric
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIListGeneric == null)
@@ -688,11 +580,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIList;
         internal static Type TypeOfIList
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIList == null)
@@ -701,11 +591,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfICollectionGeneric;
         internal static Type TypeOfICollectionGeneric
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfICollectionGeneric == null)
@@ -714,11 +602,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfICollection;
         internal static Type TypeOfICollection
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfICollection == null)
@@ -727,11 +613,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIEnumerableGeneric;
         internal static Type TypeOfIEnumerableGeneric
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIEnumerableGeneric == null)
@@ -740,11 +624,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIEnumerable;
         internal static Type TypeOfIEnumerable
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIEnumerable == null)
@@ -753,11 +635,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIEnumeratorGeneric;
         internal static Type TypeOfIEnumeratorGeneric
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIEnumeratorGeneric == null)
@@ -766,11 +646,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIEnumerator;
         internal static Type TypeOfIEnumerator
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIEnumerator == null)
@@ -779,11 +657,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfKeyValuePair;
         internal static Type TypeOfKeyValuePair
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfKeyValuePair == null)
@@ -792,11 +668,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfKeyValuePairAdapter;
         internal static Type TypeOfKeyValuePairAdapter
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfKeyValuePairAdapter == null)
@@ -805,11 +679,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfKeyValue;
         internal static Type TypeOfKeyValue
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfKeyValue == null)
@@ -818,11 +690,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIDictionaryEnumerator;
         internal static Type TypeOfIDictionaryEnumerator
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIDictionaryEnumerator == null)
@@ -831,11 +701,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfDictionaryEnumerator;
         internal static Type TypeOfDictionaryEnumerator
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfDictionaryEnumerator == null)
@@ -844,11 +712,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfGenericDictionaryEnumerator;
         internal static Type TypeOfGenericDictionaryEnumerator
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfGenericDictionaryEnumerator == null)
@@ -857,11 +723,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfDictionaryGeneric;
         internal static Type TypeOfDictionaryGeneric
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfDictionaryGeneric == null)
@@ -870,11 +734,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfHashtable;
         internal static Type TypeOfHashtable
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfHashtable == null)
@@ -883,11 +745,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfListGeneric;
         internal static Type TypeOfListGeneric
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfListGeneric == null)
@@ -896,11 +756,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlElement;
         internal static Type TypeOfXmlElement
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlElement == null)
@@ -909,11 +767,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlNodeArray;
         internal static Type TypeOfXmlNodeArray
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlNodeArray == null)
@@ -924,11 +780,9 @@ namespace System.Runtime.Serialization
 
         private static bool s_shouldGetDBNullType = true;
 
-        [SecurityCritical]
         private static Type s_typeOfDBNull;
         internal static Type TypeOfDBNull
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfDBNull == null && s_shouldGetDBNullType)
@@ -940,11 +794,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static object s_valueOfDBNull;
         internal static object ValueOfDBNull
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_valueOfDBNull == null && TypeOfDBNull != null)
@@ -958,11 +810,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Uri s_dataContractXsdBaseNamespaceUri;
         internal static Uri DataContractXsdBaseNamespaceUri
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_dataContractXsdBaseNamespaceUri == null)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
@@ -569,6 +569,12 @@ namespace System.Runtime.Serialization
             }
         }
 
+        private static Type s_typeOfIExtensibleDataObject;
+        internal static Type TypeOfIExtensibleDataObject => s_typeOfIExtensibleDataObject ?? (s_typeOfIExtensibleDataObject = typeof (IExtensibleDataObject));
+
+        private static Type s_typeOfExtensionDataObject;
+        internal static Type TypeOfExtensionDataObject => s_typeOfExtensionDataObject ?? (s_typeOfExtensionDataObject = typeof (ExtensionDataObject));
+
         [SecurityCritical]
         private static Type s_typeOfISerializableDataNode;
         internal static Type TypeOfISerializableDataNode
@@ -607,6 +613,9 @@ namespace System.Runtime.Serialization
                 return s_typeOfCollectionDataNode;
             }
         }
+
+        private static Type s_typeOfXmlDataNode;
+        internal static Type TypeOfXmlDataNode => s_typeOfXmlDataNode ?? (s_typeOfXmlDataNode = typeof (XmlDataNode));
 
 #if NET_NATIVE
         [SecurityCritical]

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
@@ -6,16 +6,13 @@ using System.Threading;
 using System.Xml;
 using System.Diagnostics;
 using System.Collections.Generic;
-using System.Security;
 
 namespace System.Runtime.Serialization.Json
 {
     internal class JsonClassDataContract : JsonDataContract
     {
-        [SecurityCritical]
         private JsonClassDataContractCriticalHelper _helper;
 
-        [SecuritySafeCritical]
         public JsonClassDataContract(ClassDataContract traditionalDataContract)
             : base(new JsonClassDataContractCriticalHelper(traditionalDataContract))
         {
@@ -24,7 +21,6 @@ namespace System.Runtime.Serialization.Json
 
         internal JsonFormatClassReaderDelegate JsonFormatReaderDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (_helper.JsonFormatReaderDelegate == null)
@@ -68,7 +64,6 @@ namespace System.Runtime.Serialization.Json
 
         internal JsonFormatClassWriterDelegate JsonFormatWriterDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (_helper.JsonFormatWriterDelegate == null)
@@ -110,27 +105,11 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
-        internal XmlDictionaryString[] MemberNames
-        {
-            [SecuritySafeCritical]
-            get
-            { return _helper.MemberNames; }
-        }
+        internal XmlDictionaryString[] MemberNames => _helper.MemberNames;
 
-        internal override string TypeName
-        {
-            [SecuritySafeCritical]
-            get
-            { return _helper.TypeName; }
-        }
+        internal override string TypeName => _helper.TypeName;
 
-
-        private ClassDataContract TraditionalClassDataContract
-        {
-            [SecuritySafeCritical]
-            get
-            { return _helper.TraditionalClassDataContract; }
-        }
+        private ClassDataContract TraditionalClassDataContract => _helper.TraditionalClassDataContract;
 
         public override object ReadJsonValueCore(XmlReaderDelegator jsonReader, XmlObjectSerializerReadContextComplexJson context)
         {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
@@ -5,16 +5,13 @@
 using System.Reflection;
 using System.Threading;
 using System.Xml;
-using System.Security;
 
 namespace System.Runtime.Serialization.Json
 {
     internal class JsonCollectionDataContract : JsonDataContract
     {
-        [SecurityCritical]
         private JsonCollectionDataContractCriticalHelper _helper;
 
-        [SecuritySafeCritical]
         public JsonCollectionDataContract(CollectionDataContract traditionalDataContract)
             : base(new JsonCollectionDataContractCriticalHelper(traditionalDataContract))
         {
@@ -23,7 +20,6 @@ namespace System.Runtime.Serialization.Json
 
         internal JsonFormatCollectionReaderDelegate JsonFormatReaderDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (_helper.JsonFormatReaderDelegate == null)
@@ -67,7 +63,6 @@ namespace System.Runtime.Serialization.Json
 
         internal JsonFormatGetOnlyCollectionReaderDelegate JsonFormatGetOnlyReaderDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (_helper.JsonFormatGetOnlyReaderDelegate == null)
@@ -117,7 +112,6 @@ namespace System.Runtime.Serialization.Json
 
         internal JsonFormatCollectionWriterDelegate JsonFormatWriterDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (_helper.JsonFormatWriterDelegate == null)
@@ -159,12 +153,7 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
-        private CollectionDataContract TraditionalCollectionDataContract
-        {
-            [SecuritySafeCritical]
-            get
-            { return _helper.TraditionalCollectionDataContract; }
-        }
+        private CollectionDataContract TraditionalCollectionDataContract => _helper.TraditionalCollectionDataContract;
 
         public override object ReadJsonValueCore(XmlReaderDelegator jsonReader, XmlObjectSerializerReadContextComplexJson context)
         {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonDataContract.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Runtime;
 using System.Runtime.Serialization;
-using System.Security;
 using System.Reflection;
 using System.Xml;
 
@@ -13,46 +12,25 @@ namespace System.Runtime.Serialization.Json
 {
     internal class JsonDataContract
     {
-        [SecurityCritical]
         private JsonDataContractCriticalHelper _helper;
 
-        [SecuritySafeCritical]
         protected JsonDataContract(DataContract traditionalDataContract)
         {
             _helper = new JsonDataContractCriticalHelper(traditionalDataContract);
         }
 
-        [SecuritySafeCritical]
         protected JsonDataContract(JsonDataContractCriticalHelper helper)
         {
             _helper = helper;
         }
 
-        internal virtual string TypeName
-        {
-            get { return null; }
-        }
+        internal virtual string TypeName => null;
 
-        protected JsonDataContractCriticalHelper Helper
-        {
-            [SecurityCritical]
-            get
-            { return _helper; }
-        }
+        protected JsonDataContractCriticalHelper Helper => _helper;
 
-        protected DataContract TraditionalDataContract
-        {
-            [SecuritySafeCritical]
-            get
-            { return _helper.TraditionalDataContract; }
-        }
+        protected DataContract TraditionalDataContract => _helper.TraditionalDataContract;
 
-        private Dictionary<XmlQualifiedName, DataContract> KnownDataContracts
-        {
-            [SecuritySafeCritical]
-            get
-            { return _helper.KnownDataContracts; }
-        }
+        private Dictionary<XmlQualifiedName, DataContract> KnownDataContracts => _helper.KnownDataContracts;
 
         public static JsonReadWriteDelegates GetGeneratedReadWriteDelegates(DataContract c)
         {
@@ -91,7 +69,6 @@ namespace System.Runtime.Serialization.Json
             return result;
         }
 
-        [SecuritySafeCritical]
         public static JsonDataContract GetJsonDataContract(DataContract traditionalDataContract)
         {
             return JsonDataContractCriticalHelper.GetJsonDataContract(traditionalDataContract);
@@ -178,20 +155,11 @@ namespace System.Runtime.Serialization.Json
                 _typeName = string.IsNullOrEmpty(traditionalDataContract.Namespace.Value) ? traditionalDataContract.Name.Value : string.Concat(traditionalDataContract.Name.Value, JsonGlobals.NameValueSeparatorString, XmlObjectSerializerWriteContextComplexJson.TruncateDefaultDataContractNamespace(traditionalDataContract.Namespace.Value));
             }
 
-            internal Dictionary<XmlQualifiedName, DataContract> KnownDataContracts
-            {
-                get { return _knownDataContracts; }
-            }
+            internal Dictionary<XmlQualifiedName, DataContract> KnownDataContracts => _knownDataContracts;
 
-            internal DataContract TraditionalDataContract
-            {
-                get { return _traditionalDataContract; }
-            }
+            internal DataContract TraditionalDataContract => _traditionalDataContract;
 
-            internal virtual string TypeName
-            {
-                get { return _typeName; }
-            }
+            internal virtual string TypeName => _typeName;
 
             public static JsonDataContract GetJsonDataContract(DataContract traditionalDataContract)
             {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEnumDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEnumDataContract.cs
@@ -2,29 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Xml;
-using System.Security;
-
 namespace System.Runtime.Serialization.Json
 {
     internal class JsonEnumDataContract : JsonDataContract
     {
-        [SecurityCritical]
         private JsonEnumDataContractCriticalHelper _helper;
 
-        [SecuritySafeCritical]
         public JsonEnumDataContract(EnumDataContract traditionalDataContract)
             : base(new JsonEnumDataContractCriticalHelper(traditionalDataContract))
         {
             _helper = base.Helper as JsonEnumDataContractCriticalHelper;
         }
 
-        public bool IsULong
-        {
-            [SecuritySafeCritical]
-            get
-            { return _helper.IsULong; }
-        }
+        public bool IsULong => _helper.IsULong;
 
         public override object ReadJsonValueCore(XmlReaderDelegator jsonReader, XmlObjectSerializerReadContextComplexJson context)
         {
@@ -59,7 +49,7 @@ namespace System.Runtime.Serialization.Json
 
         private class JsonEnumDataContractCriticalHelper : JsonDataContractCriticalHelper
         {
-            private bool _isULong;
+            private readonly bool _isULong;
 
             public JsonEnumDataContractCriticalHelper(EnumDataContract traditionalEnumDataContract)
                 : base(traditionalEnumDataContract)
@@ -67,10 +57,7 @@ namespace System.Runtime.Serialization.Json
                 _isULong = traditionalEnumDataContract.IsULong;
             }
 
-            public bool IsULong
-            {
-                get { return _isULong; }
-            }
+            public bool IsULong => _isULong;
         }
     }
 }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections;
 using System.Reflection;
 using System.Runtime.Serialization.Json;
-using System.Security;
 using System.Xml;
 using System.Diagnostics;
 
@@ -14,106 +13,76 @@ namespace System.Runtime.Serialization
 {
     public static class JsonFormatGeneratorStatics
     {
-        [SecurityCritical]
         private static PropertyInfo s_collectionItemNameProperty;
 
         private static ConstructorInfo s_extensionDataObjectCtor;
 
         private static PropertyInfo s_extensionDataProperty;
 
-        [SecurityCritical]
         private static MethodInfo s_getItemContractMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_getJsonDataContractMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_getJsonMemberIndexMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_getRevisedItemContractMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_getUninitializedObjectMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_ienumeratorGetCurrentMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_ienumeratorMoveNextMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_isStartElementMethod0;
 
-        [SecurityCritical]
         private static MethodInfo s_isStartElementMethod2;
 
-        [SecurityCritical]
         private static PropertyInfo s_localNameProperty;
 
-        [SecurityCritical]
         private static PropertyInfo s_namespaceProperty;
 
-        [SecurityCritical]
         private static MethodInfo s_moveToContentMethod;
 
-        [SecurityCritical]
         private static PropertyInfo s_nodeTypeProperty;
 
         private static MethodInfo s_onDeserializationMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_readJsonValueMethod;
 
-        [SecurityCritical]
         private static ConstructorInfo s_serializationExceptionCtor;
 
         private static Type[] s_serInfoCtorArgs;
 
-        [SecurityCritical]
         private static MethodInfo s_throwDuplicateMemberExceptionMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_throwMissingRequiredMembersMethod;
 
-        [SecurityCritical]
         private static PropertyInfo s_typeHandleProperty;
 
-        [SecurityCritical]
         private static PropertyInfo s_useSimpleDictionaryFormatReadProperty;
 
-        [SecurityCritical]
         private static PropertyInfo s_useSimpleDictionaryFormatWriteProperty;
 
-        [SecurityCritical]
         private static MethodInfo s_writeAttributeStringMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_writeEndElementMethod;
 
         private static MethodInfo s_writeJsonISerializableMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_writeJsonNameWithMappingMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_writeJsonValueMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_writeStartElementMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_writeStartElementStringMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_parseEnumMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_getJsonMemberNameMethod;
 
         public static PropertyInfo CollectionItemNameProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_collectionItemNameProperty == null)
@@ -135,7 +104,6 @@ namespace System.Runtime.Serialization
 
         public static MethodInfo GetCurrentMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_ienumeratorGetCurrentMethod == null)
@@ -148,7 +116,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo GetItemContractMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getItemContractMethod == null)
@@ -161,7 +128,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo GetJsonDataContractMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getJsonDataContractMethod == null)
@@ -174,7 +140,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo GetJsonMemberIndexMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getJsonMemberIndexMethod == null)
@@ -187,7 +152,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo GetRevisedItemContractMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getRevisedItemContractMethod == null)
@@ -200,7 +164,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo GetUninitializedObjectMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getUninitializedObjectMethod == null)
@@ -214,7 +177,6 @@ namespace System.Runtime.Serialization
 
         public static MethodInfo IsStartElementMethod0
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_isStartElementMethod0 == null)
@@ -227,7 +189,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo IsStartElementMethod2
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_isStartElementMethod2 == null)
@@ -240,7 +201,6 @@ namespace System.Runtime.Serialization
         }
         public static PropertyInfo LocalNameProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_localNameProperty == null)
@@ -253,7 +213,6 @@ namespace System.Runtime.Serialization
         }
         public static PropertyInfo NamespaceProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_namespaceProperty == null)
@@ -266,7 +225,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo MoveNextMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_ienumeratorMoveNextMethod == null)
@@ -279,7 +237,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo MoveToContentMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_moveToContentMethod == null)
@@ -292,7 +249,6 @@ namespace System.Runtime.Serialization
         }
         public static PropertyInfo NodeTypeProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_nodeTypeProperty == null)
@@ -305,7 +261,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo OnDeserializationMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_onDeserializationMethod == null)
@@ -317,7 +272,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo ReadJsonValueMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_readJsonValueMethod == null)
@@ -330,7 +284,6 @@ namespace System.Runtime.Serialization
         }
         public static ConstructorInfo SerializationExceptionCtor
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_serializationExceptionCtor == null)
@@ -342,7 +295,6 @@ namespace System.Runtime.Serialization
         }
         public static Type[] SerInfoCtorArgs
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_serInfoCtorArgs == null)
@@ -354,7 +306,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo ThrowDuplicateMemberExceptionMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_throwDuplicateMemberExceptionMethod == null)
@@ -367,7 +318,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo ThrowMissingRequiredMembersMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_throwMissingRequiredMembersMethod == null)
@@ -380,7 +330,6 @@ namespace System.Runtime.Serialization
         }
         public static PropertyInfo TypeHandleProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeHandleProperty == null)
@@ -393,7 +342,6 @@ namespace System.Runtime.Serialization
         }
         public static PropertyInfo UseSimpleDictionaryFormatReadProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_useSimpleDictionaryFormatReadProperty == null)
@@ -406,7 +354,6 @@ namespace System.Runtime.Serialization
         }
         public static PropertyInfo UseSimpleDictionaryFormatWriteProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_useSimpleDictionaryFormatWriteProperty == null)
@@ -419,7 +366,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo WriteAttributeStringMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeAttributeStringMethod == null)
@@ -432,7 +378,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo WriteEndElementMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeEndElementMethod == null)
@@ -445,7 +390,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo WriteJsonISerializableMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeJsonISerializableMethod == null)
@@ -457,7 +401,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo WriteJsonNameWithMappingMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeJsonNameWithMappingMethod == null)
@@ -470,7 +413,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo WriteJsonValueMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeJsonValueMethod == null)
@@ -483,7 +425,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo WriteStartElementMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeStartElementMethod == null)
@@ -497,7 +438,6 @@ namespace System.Runtime.Serialization
 
         public static MethodInfo WriteStartElementStringMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeStartElementStringMethod == null)
@@ -511,7 +451,6 @@ namespace System.Runtime.Serialization
 
         public static MethodInfo ParseEnumMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_parseEnumMethod == null)
@@ -524,7 +463,6 @@ namespace System.Runtime.Serialization
 
         public static MethodInfo GetJsonMemberNameMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getJsonMemberNameMethod == null)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
@@ -17,6 +17,10 @@ namespace System.Runtime.Serialization
         [SecurityCritical]
         private static PropertyInfo s_collectionItemNameProperty;
 
+        private static ConstructorInfo s_extensionDataObjectCtor;
+
+        private static PropertyInfo s_extensionDataProperty;
+
         [SecurityCritical]
         private static MethodInfo s_getItemContractMethod;
 
@@ -121,6 +125,14 @@ namespace System.Runtime.Serialization
                 return s_collectionItemNameProperty;
             }
         }
+
+        public static ConstructorInfo ExtensionDataObjectCtor => s_extensionDataObjectCtor ??
+                                                                 (s_extensionDataObjectCtor =
+                                                                     typeof (ExtensionDataObject).GetConstructor(Globals.ScanAllMembers, null, new Type[] {}, null));
+
+        public static PropertyInfo ExtensionDataProperty => s_extensionDataProperty ??
+                                                            (s_extensionDataProperty = typeof (IExtensibleDataObject).GetProperty("ExtensionData"));
+
         public static MethodInfo GetCurrentMethod
         {
             [SecuritySafeCritical]

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
@@ -29,28 +29,23 @@ namespace System.Runtime.Serialization.Json
 
     internal sealed class JsonFormatReaderGenerator
     {
-        [SecurityCritical]
         private CriticalHelper _helper;
 
-        [SecurityCritical]
         public JsonFormatReaderGenerator()
         {
             _helper = new CriticalHelper();
         }
 
-        [SecurityCritical]
         public JsonFormatClassReaderDelegate GenerateClassReader(ClassDataContract classContract)
         {
             return _helper.GenerateClassReader(classContract);
         }
 
-        [SecurityCritical]
         public JsonFormatCollectionReaderDelegate GenerateCollectionReader(CollectionDataContract collectionContract)
         {
             return _helper.GenerateCollectionReader(collectionContract);
         }
 
-        [SecurityCritical]
         public JsonFormatGetOnlyCollectionReaderDelegate GenerateGetOnlyCollectionReader(CollectionDataContract collectionContract)
         {
             return _helper.GenerateGetOnlyCollectionReader(collectionContract);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatWriterGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatWriterGenerator.cs
@@ -26,22 +26,18 @@ namespace System.Runtime.Serialization.Json
 
     internal class JsonFormatWriterGenerator
     {
-        [SecurityCritical]
         private CriticalHelper _helper;
 
-        [SecurityCritical]
         public JsonFormatWriterGenerator()
         {
             _helper = new CriticalHelper();
         }
 
-        [SecurityCritical]
         internal JsonFormatClassWriterDelegate GenerateClassWriter(ClassDataContract classContract)
         {
             return _helper.GenerateClassWriter(classContract);
         }
 
-        [SecurityCritical]
         internal JsonFormatCollectionWriterDelegate GenerateCollectionWriter(CollectionDataContract collectionContract)
         {
             return _helper.GenerateCollectionWriter(collectionContract);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatWriterGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatWriterGenerator.cs
@@ -193,7 +193,20 @@ namespace System.Runtime.Serialization.Json
                 }
                 else
                 {
-                    WriteMembers(classContract, null, classContract);
+                    if (classContract.HasExtensionData)
+                    {
+                        LocalBuilder extensionDataLocal = _ilg.DeclareLocal(Globals.TypeOfExtensionDataObject, "extensionData");
+                        _ilg.Load(_objectLocal);
+                        _ilg.ConvertValue(_objectLocal.LocalType, Globals.TypeOfIExtensibleDataObject);
+                        _ilg.LoadMember(JsonFormatGeneratorStatics.ExtensionDataProperty);
+                        _ilg.Store(extensionDataLocal);
+                        _ilg.Call(_contextArg, XmlFormatGeneratorStatics.WriteExtensionDataMethod, _xmlWriterArg, extensionDataLocal, -1);
+                        WriteMembers(classContract, extensionDataLocal, classContract);
+                    }
+                    else
+                    {
+                        WriteMembers(classContract, null, classContract);
+                    }
                 }
 
                 InvokeOnSerialized(classContract);
@@ -240,6 +253,12 @@ namespace System.Runtime.Serialization.Json
                         WriteValue(memberValue);
                         WriteEndElement();
                     }
+
+                    if (classContract.HasExtensionData)
+                    {
+                        _ilg.Call(_contextArg, XmlFormatGeneratorStatics.WriteExtensionDataMethod, _xmlWriterArg, extensionDataLocal, memberCount);
+                    }
+
                     if (!member.EmitDefaultValue)
                     {
                         if (member.IsRequired)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonReaderDelegator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonReaderDelegator.cs
@@ -76,7 +76,7 @@ namespace System.Runtime.Serialization.Json
             return new XmlQualifiedName(name, ns);
         }
 
-        internal char ReadContentAsChar()
+        internal override char ReadContentAsChar()
         {
             return XmlConvert.ToChar(ReadContentAsString());
         }
@@ -91,7 +91,7 @@ namespace System.Runtime.Serialization.Json
             return XmlConvert.ToChar(ReadElementContentAsString());
         }
 
-        public byte[] ReadContentAsBase64()
+        public override byte[] ReadContentAsBase64()
         {
             if (isEndOfEmptyElement)
                 return Array.Empty<byte>();
@@ -135,7 +135,7 @@ namespace System.Runtime.Serialization.Json
             return buffer;
         }
 
-        internal DateTime ReadContentAsDateTime()
+        internal override DateTime ReadContentAsDateTime()
         {
             return ParseJsonDate(ReadContentAsString(), _dateTimeFormat);
         }
@@ -291,7 +291,7 @@ namespace System.Runtime.Serialization.Json
         }
 
         // Overridden because base reader relies on XmlConvert.ToUInt64 for conversion to ulong
-        internal ulong ReadContentAsUnsignedLong()
+        internal override ulong ReadContentAsUnsignedLong()
         {
             string value = reader.ReadContentAsString();
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.IO;
 using System.Runtime;
 using System.Runtime.Serialization;
-using System.Security;
 using System.Text;
 using System.Xml;
 
@@ -33,7 +32,6 @@ namespace System.Runtime.Serialization.Json
         // This array was part of a perf improvement for escaping characters < WHITESPACE.
         private static readonly string[] s_escapedJsonStringTable = CreateEscapedJsonStringTable();
 
-        [SecurityCritical]
         private static BinHexEncoding s_binHexEncoding;
 
         private string _attributeText;
@@ -156,7 +154,6 @@ namespace System.Runtime.Serialization.Json
 
         private static BinHexEncoding BinHexEncoding
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_binHexEncoding == null)
@@ -167,38 +164,17 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
-        private bool HasOpenAttribute
-        {
-            get
-            {
-                return (_isWritingDataTypeAttribute || _isWritingServerTypeAttribute || IsWritingNameAttribute || _isWritingXmlnsAttribute);
-            }
-        }
+        private bool HasOpenAttribute => (_isWritingDataTypeAttribute || _isWritingServerTypeAttribute || IsWritingNameAttribute || _isWritingXmlnsAttribute);
 
-        private bool IsClosed
-        {
-            get { return (WriteState == WriteState.Closed); }
-        }
+        private bool IsClosed => (WriteState == WriteState.Closed);
 
-        private bool IsWritingCollection
-        {
-            get { return (_depth > 0) && (_scopes[_depth] == JsonNodeType.Collection); }
-        }
+        private bool IsWritingCollection => (_depth > 0) && (_scopes[_depth] == JsonNodeType.Collection);
 
-        private bool IsWritingNameAttribute
-        {
-            get { return (_nameState & NameState.IsWritingNameAttribute) == NameState.IsWritingNameAttribute; }
-        }
+        private bool IsWritingNameAttribute => (_nameState & NameState.IsWritingNameAttribute) == NameState.IsWritingNameAttribute;
 
-        private bool IsWritingNameWithMapping
-        {
-            get { return (_nameState & NameState.IsWritingNameWithMapping) == NameState.IsWritingNameWithMapping; }
-        }
+        private bool IsWritingNameWithMapping => (_nameState & NameState.IsWritingNameWithMapping) == NameState.IsWritingNameWithMapping;
 
-        private bool WrittenNameWithMapping
-        {
-            get { return (_nameState & NameState.WrittenNameWithMapping) == NameState.WrittenNameWithMapping; }
-        }
+        private bool WrittenNameWithMapping => (_nameState & NameState.WrittenNameWithMapping) == NameState.WrittenNameWithMapping;
 
         protected override void Dispose(bool disposing)
         {
@@ -1394,7 +1370,6 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
-        [SecuritySafeCritical]
         private unsafe void WriteEscapedJsonString(string str)
         {
             fixed (char* chars = str)
@@ -1617,7 +1592,6 @@ namespace System.Runtime.Serialization.Json
 
         private class JsonNodeWriter : XmlUTF8NodeWriter
         {
-            [SecurityCritical]
             internal unsafe void WriteChars(char* chars, int charCount)
             {
                 base.UnsafeWriteUTF8Chars(chars, charCount);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Text;
 using System.Reflection;
 using System.Xml;
-using System.Security;
 using System.Runtime.Serialization.Json;
 using System.Runtime.Serialization;
 using DataContractDictionary = System.Collections.Generic.Dictionary<System.Xml.XmlQualifiedName, System.Runtime.Serialization.DataContract>;
@@ -390,7 +389,6 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
-        [SecuritySafeCritical]
         private static bool IsBitSet(byte[] bytes, int bitIndex)
         {
             return BitFlagsGenerator.IsBitSet(bytes, bitIndex);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
@@ -11,9 +11,7 @@ using System.Security;
 using System.Runtime.Serialization.Json;
 using System.Runtime.Serialization;
 using DataContractDictionary = System.Collections.Generic.Dictionary<System.Xml.XmlQualifiedName, System.Runtime.Serialization.DataContract>;
-#if !NET_NATIVE
-using ExtensionDataObject = System.Object;
-#endif
+using System.Diagnostics;
 
 namespace System.Runtime.Serialization.Json
 {
@@ -23,6 +21,7 @@ namespace System.Runtime.Serialization.Json
     internal class XmlObjectSerializerReadContextComplexJson : XmlObjectSerializerReadContextComplex
 #endif
     {
+        private string _extensionDataValueType;
         private DataContractJsonSerializer _jsonSerializer;
         private DateTimeFormat _dateTimeFormat;
         private bool _useSimpleDictionaryFormat;
@@ -95,6 +94,69 @@ namespace System.Runtime.Serialization.Json
             get
             {
                 return _useSimpleDictionaryFormat;
+            }
+        }
+
+        protected override void StartReadExtensionDataValue(XmlReaderDelegator xmlReader)
+        {
+            _extensionDataValueType = xmlReader.GetAttribute(JsonGlobals.typeString);
+        }
+
+        protected override IDataNode ReadPrimitiveExtensionDataValue(XmlReaderDelegator xmlReader, string dataContractName, string dataContractNamespace)
+        {
+            IDataNode dataNode;
+
+            switch (_extensionDataValueType)
+            {
+                case null:
+                case JsonGlobals.stringString:
+                    dataNode = new DataNode<string>(xmlReader.ReadContentAsString());
+                    break;
+                case JsonGlobals.booleanString:
+                    dataNode = new DataNode<bool>(xmlReader.ReadContentAsBoolean());
+                    break;
+                case JsonGlobals.numberString:
+                    dataNode = ReadNumericalPrimitiveExtensionDataValue(xmlReader);
+                    break;
+                default:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                        XmlObjectSerializer.CreateSerializationException(SR.Format(SR.JsonUnexpectedAttributeValue, _extensionDataValueType)));
+            }
+
+            xmlReader.ReadEndElement();
+            return dataNode;
+        }
+
+        private IDataNode ReadNumericalPrimitiveExtensionDataValue(XmlReaderDelegator xmlReader)
+        {
+            TypeCode type;
+            object numericalValue = JsonObjectDataContract.ParseJsonNumber(xmlReader.ReadContentAsString(), out type);
+            switch (type)
+            {
+                case TypeCode.Byte:
+                    return new DataNode<byte>((byte)numericalValue);
+                case TypeCode.SByte:
+                    return new DataNode<sbyte>((sbyte)numericalValue);
+                case TypeCode.Int16:
+                    return new DataNode<short>((short)numericalValue);
+                case TypeCode.Int32:
+                    return new DataNode<int>((int)numericalValue);
+                case TypeCode.Int64:
+                    return new DataNode<long>((long)numericalValue);
+                case TypeCode.UInt16:
+                    return new DataNode<ushort>((ushort)numericalValue);
+                case TypeCode.UInt32:
+                    return new DataNode<uint>((uint)numericalValue);
+                case TypeCode.UInt64:
+                    return new DataNode<ulong>((ulong)numericalValue);
+                case TypeCode.Single:
+                    return new DataNode<float>((float)numericalValue);
+                case TypeCode.Double:
+                    return new DataNode<double>((double)numericalValue);
+                case TypeCode.Decimal:
+                    return new DataNode<decimal>((decimal)numericalValue);
+                default:
+                    throw new InvalidOperationException(SR.ParseJsonNumberReturnInvalidNumber);
             }
         }
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
@@ -302,6 +302,34 @@ namespace System.Runtime.Serialization.Json
             xmlWriter.WriteAttributeString(null, JsonGlobals.itemString, null, memberNames[index].Value);
         }
 
+        internal override void WriteExtensionDataTypeInfo(XmlWriterDelegator xmlWriter, IDataNode dataNode)
+        {
+            Type dataType = dataNode.DataType;
+            if (dataType == Globals.TypeOfClassDataNode ||
+                dataType == Globals.TypeOfISerializableDataNode)
+            {
+                xmlWriter.WriteAttributeString(null, JsonGlobals.typeString, null, JsonGlobals.objectString);
+                base.WriteExtensionDataTypeInfo(xmlWriter, dataNode);
+            }
+            else if (dataType == Globals.TypeOfCollectionDataNode)
+            {
+                xmlWriter.WriteAttributeString(null, JsonGlobals.typeString, null, JsonGlobals.arrayString);
+                // Don't write __type for collections
+            }
+            else if (dataType == Globals.TypeOfXmlDataNode)
+            {
+                // Don't write type or __type for XML types because we serialize them to strings
+            }
+            else if ((dataType == Globals.TypeOfObject) && (dataNode.Value != null))
+            {
+                DataContract dc = GetDataContract(dataNode.Value.GetType());
+                if (RequiresJsonTypeInfo(dc))
+                {
+                    base.WriteExtensionDataTypeInfo(xmlWriter, dataNode);
+                }
+            }
+        }
+
         internal static void VerifyObjectCompatibilityWithInterface(DataContract contract, object graph, Type declaredType)
         {
             Type contractType = contract.GetType();

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ObjectToIdCache.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ObjectToIdCache.cs
@@ -5,8 +5,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Security;
-
 
 namespace System.Runtime.Serialization
 {
@@ -173,11 +171,6 @@ namespace System.Runtime.Serialization
             return min;
         }
 
-
-        /// <SecurityNote>
-        /// Review - Static fields are marked SecurityCritical or readonly to prevent
-        ///          data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
         internal static readonly int[] primes =
         {
             3, 7, 17, 37, 89, 197, 431, 919, 1931, 4049, 8419, 17519, 36353,

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/PrimitiveDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/PrimitiveDataContract.cs
@@ -8,8 +8,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Xml;
-using System.Security;
-
 
 namespace System.Runtime.Serialization
 {
@@ -21,19 +19,8 @@ namespace System.Runtime.Serialization
     {
         internal static readonly PrimitiveDataContract NullContract = new NullPrimitiveDataContract();
 
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
         private PrimitiveDataContractCriticalHelper _helper;
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         protected PrimitiveDataContract(Type type, XmlDictionaryString name, XmlDictionaryString ns) : base(new PrimitiveDataContractCriticalHelper(type, name, ns))
         {
             _helper = base.Helper as PrimitiveDataContractCriticalHelper;
@@ -54,46 +41,21 @@ namespace System.Runtime.Serialization
 
         public override XmlDictionaryString TopLevelElementNamespace
         {
-            /// <SecurityNote>
-            /// Critical - for consistency with base class
-            /// Safe - for consistency with base class
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return DictionaryGlobals.SerializationNamespace; }
-            /// <SecurityNote>
-            /// Critical - for consistency with base class
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { }
         }
 
-        internal override bool CanContainReferences
-        {
-            get { return false; }
-        }
+        internal override bool CanContainReferences => false;
 
-        internal override bool IsPrimitive
-        {
-            get { return true; }
-        }
+        internal override bool IsPrimitive => true;
 
-        public override bool IsBuiltInDataContract
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool IsBuiltInDataContract => true;
 
         internal MethodInfo XmlFormatWriterMethod
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical XmlFormatWriterMethod property
-            /// Safe - XmlFormatWriterMethod only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (_helper.XmlFormatWriterMethod == null)
@@ -109,11 +71,6 @@ namespace System.Runtime.Serialization
 
         internal MethodInfo XmlFormatContentWriterMethod
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical XmlFormatContentWriterMethod property
-            /// Safe - XmlFormatContentWriterMethod only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (_helper.XmlFormatContentWriterMethod == null)
@@ -129,11 +86,6 @@ namespace System.Runtime.Serialization
 
         internal MethodInfo XmlFormatReaderMethod
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical XmlFormatReaderMethod property
-            /// Safe - XmlFormatReaderMethod only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (_helper.XmlFormatReaderMethod == null)
@@ -168,11 +120,7 @@ namespace System.Runtime.Serialization
             }
             return false;
         }
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds all state used for (de)serializing primitives.
-        ///            since the data is cached statically, we lock down access to it.
-        /// </SecurityNote>
+
         private class PrimitiveDataContractCriticalHelper : DataContract.DataContractCriticalHelper
         {
             private MethodInfo _xmlFormatWriterMethod;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SpecialTypeDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SpecialTypeDataContract.cs
@@ -2,46 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Xml;
-using System.Security;
 
 namespace System.Runtime.Serialization
 {
     internal sealed class SpecialTypeDataContract : DataContract
     {
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
         private SpecialTypeDataContractCriticalHelper _helper;
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
+
         public SpecialTypeDataContract(Type type, XmlDictionaryString name, XmlDictionaryString ns) : base(new SpecialTypeDataContractCriticalHelper(type, name, ns))
         {
             _helper = base.Helper as SpecialTypeDataContractCriticalHelper;
         }
 
-        public override bool IsBuiltInDataContract
-        {
-            get
-            {
-                return true;
-            }
-        }
-        [SecurityCritical]
+        public override bool IsBuiltInDataContract => true;
 
-        /// <SecurityNote>
-        /// Critical - holds all state used for (de)serializing known types like System.Enum, System.ValueType, etc.
-        ///            since the data is cached statically, we lock down access to it.
-        /// </SecurityNote>
         private class SpecialTypeDataContractCriticalHelper : DataContract.DataContractCriticalHelper
         {
             internal SpecialTypeDataContractCriticalHelper(Type type, XmlDictionaryString name, XmlDictionaryString ns) : base(type)
@@ -51,4 +26,3 @@ namespace System.Runtime.Serialization
         }
     }
 }
-

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
@@ -23,29 +23,13 @@ namespace System.Runtime.Serialization
     internal sealed class XmlDataContract : DataContract
 #endif
     {
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
         private XmlDataContractCriticalHelper _helper;
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         public XmlDataContract() : base(new XmlDataContractCriticalHelper())
         {
             _helper = base.Helper as XmlDataContractCriticalHelper;
         }
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal XmlDataContract(Type type) : base(new XmlDataContractCriticalHelper(type))
         {
             _helper = base.Helper as XmlDataContractCriticalHelper;
@@ -53,17 +37,9 @@ namespace System.Runtime.Serialization
 
         public override DataContractDictionary KnownDataContracts
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical KnownDataContracts property 
-            /// Safe - KnownDataContracts only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.KnownDataContracts; }
-            /// <SecurityNote>
-            /// Critical - sets the critical KnownDataContracts property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.KnownDataContracts = value; }
         }
@@ -77,62 +53,33 @@ namespace System.Runtime.Serialization
 
         internal bool IsAnonymous
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical IsAnonymous property
-            /// Safe - IsAnonymous only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.IsAnonymous; }
         }
 
         public override bool HasRoot
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical HasRoot property
-            /// Safe - HasRoot only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.HasRoot; }
-            /// <SecurityNote>
-            /// Critical - sets the critical HasRoot property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.HasRoot = value; }
         }
 
         public override XmlDictionaryString TopLevelElementName
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical TopLevelElementName property
-            /// Safe - TopLevelElementName only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.TopLevelElementName; }
-            /// <SecurityNote>
-            /// Critical - sets the critical TopLevelElementName property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.TopLevelElementName = value; }
         }
 
         public override XmlDictionaryString TopLevelElementNamespace
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical TopLevelElementNamespace property
-            /// Safe - TopLevelElementNamespace only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.TopLevelElementNamespace; }
-            /// <SecurityNote>
-            /// Critical - sets the critical TopLevelElementNamespace property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.TopLevelElementNamespace = value; }
         }
@@ -145,11 +92,6 @@ namespace System.Runtime.Serialization
 #endif
         {
 #if !NET_NATIVE
-            /// <SecurityNote>
-            /// Critical - fetches the critical CreateXmlSerializableDelegate property
-            /// Safe - CreateXmlSerializableDelegate only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 // We create XmlSerializableDelegate via CodeGen when CodeGen is enabled;
@@ -191,24 +133,10 @@ namespace System.Runtime.Serialization
 #endif            
         }
 
-        internal override bool CanContainReferences
-        {
-            get { return false; }
-        }
+        internal override bool CanContainReferences => false;
 
-        public override bool IsBuiltInDataContract
-        {
-            get
-            {
-                return UnderlyingType == Globals.TypeOfXmlElement || UnderlyingType == Globals.TypeOfXmlNodeArray;
-            }
-        }
-        [SecurityCritical]
+        public override bool IsBuiltInDataContract => UnderlyingType == Globals.TypeOfXmlElement || UnderlyingType == Globals.TypeOfXmlNodeArray;
 
-        /// <SecurityNote>
-        /// Critical - holds all state used for (de)serializing XML types.
-        ///            since the data is cached statically, we lock down access to it.
-        /// </SecurityNote>
         private class XmlDataContractCriticalHelper : DataContract.DataContractCriticalHelper
         {
             private DataContractDictionary _knownDataContracts;
@@ -266,7 +194,6 @@ namespace System.Runtime.Serialization
 
             internal override DataContractDictionary KnownDataContracts
             {
-                [SecurityCritical]
                 get
                 {
                     if (!_isKnownTypeAttributeChecked && UnderlyingType != null)
@@ -283,7 +210,7 @@ namespace System.Runtime.Serialization
                     }
                     return _knownDataContracts;
                 }
-                [SecurityCritical]
+
                 set
                 { _knownDataContracts = value; }
             }
@@ -294,38 +221,29 @@ namespace System.Runtime.Serialization
                 set { _xsdType = value; }
             }
 
-            internal bool IsAnonymous
-            {
-                get { return _xsdType != null; }
-            }
+            internal bool IsAnonymous => _xsdType != null;
 
             internal override bool HasRoot
             {
-                [SecurityCritical]
                 get
                 { return _hasRoot; }
 
-                [SecurityCritical]
                 set
                 { _hasRoot = value; }
             }
 
             internal override XmlDictionaryString TopLevelElementName
             {
-                [SecurityCritical]
                 get
                 { return _topLevelElementName; }
-                [SecurityCritical]
                 set
                 { _topLevelElementName = value; }
             }
 
             internal override XmlDictionaryString TopLevelElementNamespace
             {
-                [SecurityCritical]
                 get
                 { return _topLevelElementNamespace; }
-                [SecurityCritical]
                 set
                 { _topLevelElementNamespace = value; }
             }
@@ -351,11 +269,6 @@ namespace System.Runtime.Serialization
         }
 
 #if !NET_NATIVE
-        /// <SecurityNote>
-        /// Critical - calls CodeGenerator.BeginMethod which is SecurityCritical
-        /// Safe - self-contained: returns the delegate to the generated IL but otherwise all IL generation is self-contained here
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal CreateXmlSerializableDelegate GenerateCreateXmlSerializableDelegate()
         {
             Type type = this.UnderlyingType;
@@ -498,4 +411,3 @@ namespace System.Runtime.Serialization
         }
     }
 }
-

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
@@ -85,6 +85,9 @@ namespace System.Runtime.Serialization
             }
         }
 
+        private static PropertyInfo s_extensionDataProperty;
+        internal static PropertyInfo ExtensionDataProperty => s_extensionDataProperty ?? 
+                                                              (s_extensionDataProperty = typeof(IExtensibleDataObject).GetProperty("ExtensionData"));
 
         [SecurityCritical]
         private static ConstructorInfo s_dictionaryEnumeratorCtor;
@@ -221,6 +224,11 @@ namespace System.Runtime.Serialization
                 return s_nodeTypeProperty;
             }
         }
+
+        private static ConstructorInfo s_extensionDataObjectCtor;
+        internal static ConstructorInfo ExtensionDataObjectCtor => s_extensionDataObjectCtor ??
+                                                                   (s_extensionDataObjectCtor =
+                                                                       typeof (ExtensionDataObject).GetConstructor(Globals.ScanAllMembers, null, new Type[] {}, null));
 
         [SecurityCritical]
         private static ConstructorInfo s_hashtableCtor;
@@ -874,6 +882,10 @@ namespace System.Runtime.Serialization
             }
         }
 
+        private static MethodInfo s_writeExtensionDataMethod;
+        internal static MethodInfo WriteExtensionDataMethod => s_writeExtensionDataMethod ?? 
+                                                               (s_writeExtensionDataMethod = typeof(XmlObjectSerializerWriteContext).GetMethod("WriteExtensionData", Globals.ScanAllMembers));
+
         [SecurityCritical]
         private static MethodInfo s_writeXmlValueMethod;
         internal static MethodInfo WriteXmlValueMethod
@@ -953,6 +965,10 @@ namespace System.Runtime.Serialization
                 return s_memberNamesField;
             }
         }
+
+        private static MethodInfo s_extensionDataSetExplicitMethodInfo;
+        internal static MethodInfo ExtensionDataSetExplicitMethodInfo => s_extensionDataSetExplicitMethodInfo ?? 
+                                                                         (s_extensionDataSetExplicitMethodInfo = typeof(IExtensibleDataObject).GetMethod(Globals.ExtensionDataSetMethod));
 
         [SecurityCritical]
         private static PropertyInfo s_childElementNamespacesProperty;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
@@ -2,30 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
-using System.Security;
 using System.Xml;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
-
 
 namespace System.Runtime.Serialization
 {
-    /// <SecurityNote>
-    /// Critical - Class holds static instances used for code generation during serialization. 
-    ///            Static fields are marked SecurityCritical or readonly to prevent
-    ///            data from being modified or leaked to other components in appdomain.
-    /// Safe - All get-only properties marked safe since they only need to be protected for write.
-    /// </SecurityNote>
     internal static class XmlFormatGeneratorStatics
     {
-        [SecurityCritical]
         private static MethodInfo s_writeStartElementMethod2;
         internal static MethodInfo WriteStartElementMethod2
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeStartElementMethod2 == null)
@@ -37,11 +25,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_writeStartElementMethod3;
         internal static MethodInfo WriteStartElementMethod3
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeStartElementMethod3 == null)
@@ -53,11 +39,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_writeEndElementMethod;
         internal static MethodInfo WriteEndElementMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeEndElementMethod == null)
@@ -69,11 +53,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_writeNamespaceDeclMethod;
         internal static MethodInfo WriteNamespaceDeclMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeNamespaceDeclMethod == null)
@@ -89,11 +71,9 @@ namespace System.Runtime.Serialization
         internal static PropertyInfo ExtensionDataProperty => s_extensionDataProperty ?? 
                                                               (s_extensionDataProperty = typeof(IExtensibleDataObject).GetProperty("ExtensionData"));
 
-        [SecurityCritical]
         private static ConstructorInfo s_dictionaryEnumeratorCtor;
         internal static ConstructorInfo DictionaryEnumeratorCtor
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_dictionaryEnumeratorCtor == null)
@@ -102,11 +82,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_ienumeratorMoveNextMethod;
         internal static MethodInfo MoveNextMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_ienumeratorMoveNextMethod == null)
@@ -118,11 +96,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_ienumeratorGetCurrentMethod;
         internal static MethodInfo GetCurrentMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_ienumeratorGetCurrentMethod == null)
@@ -134,11 +110,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getItemContractMethod;
         internal static MethodInfo GetItemContractMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getItemContractMethod == null)
@@ -150,11 +124,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_isStartElementMethod2;
         internal static MethodInfo IsStartElementMethod2
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_isStartElementMethod2 == null)
@@ -166,11 +138,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_isStartElementMethod0;
         internal static MethodInfo IsStartElementMethod0
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_isStartElementMethod0 == null)
@@ -182,11 +152,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getUninitializedObjectMethod;
         internal static MethodInfo GetUninitializedObjectMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getUninitializedObjectMethod == null)
@@ -209,11 +177,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static PropertyInfo s_nodeTypeProperty;
         internal static PropertyInfo NodeTypeProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_nodeTypeProperty == null)
@@ -230,11 +196,9 @@ namespace System.Runtime.Serialization
                                                                    (s_extensionDataObjectCtor =
                                                                        typeof (ExtensionDataObject).GetConstructor(Globals.ScanAllMembers, null, new Type[] {}, null));
 
-        [SecurityCritical]
         private static ConstructorInfo s_hashtableCtor;
         internal static ConstructorInfo HashtableCtor
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_hashtableCtor == null)
@@ -243,11 +207,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getStreamingContextMethod;
         internal static MethodInfo GetStreamingContextMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getStreamingContextMethod == null)
@@ -259,11 +221,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getCollectionMemberMethod;
         internal static MethodInfo GetCollectionMemberMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getCollectionMemberMethod == null)
@@ -275,11 +235,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_storeCollectionMemberInfoMethod;
         internal static MethodInfo StoreCollectionMemberInfoMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_storeCollectionMemberInfoMethod == null)
@@ -291,11 +249,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_storeIsGetOnlyCollectionMethod;
         internal static MethodInfo StoreIsGetOnlyCollectionMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_storeIsGetOnlyCollectionMethod == null)
@@ -307,11 +263,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_throwNullValueReturnedForGetOnlyCollectionExceptionMethod;
         internal static MethodInfo ThrowNullValueReturnedForGetOnlyCollectionExceptionMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_throwNullValueReturnedForGetOnlyCollectionExceptionMethod == null)
@@ -326,7 +280,6 @@ namespace System.Runtime.Serialization
         private static MethodInfo s_throwArrayExceededSizeExceptionMethod;
         internal static MethodInfo ThrowArrayExceededSizeExceptionMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_throwArrayExceededSizeExceptionMethod == null)
@@ -338,11 +291,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_incrementItemCountMethod;
         internal static MethodInfo IncrementItemCountMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_incrementItemCountMethod == null)
@@ -354,12 +305,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-
-        [SecurityCritical]
         private static MethodInfo s_internalDeserializeMethod;
         internal static MethodInfo InternalDeserializeMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_internalDeserializeMethod == null)
@@ -371,11 +319,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_moveToNextElementMethod;
         internal static MethodInfo MoveToNextElementMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_moveToNextElementMethod == null)
@@ -387,11 +333,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getMemberIndexMethod;
         internal static MethodInfo GetMemberIndexMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getMemberIndexMethod == null)
@@ -403,11 +347,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getMemberIndexWithRequiredMembersMethod;
         internal static MethodInfo GetMemberIndexWithRequiredMembersMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getMemberIndexWithRequiredMembersMethod == null)
@@ -419,11 +361,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_throwRequiredMemberMissingExceptionMethod;
         internal static MethodInfo ThrowRequiredMemberMissingExceptionMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_throwRequiredMemberMissingExceptionMethod == null)
@@ -435,11 +375,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_skipUnknownElementMethod;
         internal static MethodInfo SkipUnknownElementMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_skipUnknownElementMethod == null)
@@ -451,11 +389,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_readIfNullOrRefMethod;
         internal static MethodInfo ReadIfNullOrRefMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_readIfNullOrRefMethod == null)
@@ -467,11 +403,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_readAttributesMethod;
         internal static MethodInfo ReadAttributesMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_readAttributesMethod == null)
@@ -483,11 +417,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_resetAttributesMethod;
         internal static MethodInfo ResetAttributesMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_resetAttributesMethod == null)
@@ -499,11 +431,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getObjectIdMethod;
         internal static MethodInfo GetObjectIdMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getObjectIdMethod == null)
@@ -515,11 +445,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getArraySizeMethod;
         internal static MethodInfo GetArraySizeMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getArraySizeMethod == null)
@@ -531,11 +459,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_addNewObjectMethod;
         internal static MethodInfo AddNewObjectMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_addNewObjectMethod == null)
@@ -547,11 +473,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_addNewObjectWithIdMethod;
         internal static MethodInfo AddNewObjectWithIdMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_addNewObjectWithIdMethod == null)
@@ -563,11 +487,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getExistingObjectMethod;
         internal static MethodInfo GetExistingObjectMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getExistingObjectMethod == null)
@@ -579,11 +501,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_ensureArraySizeMethod;
         internal static MethodInfo EnsureArraySizeMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_ensureArraySizeMethod == null)
@@ -595,11 +515,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_trimArraySizeMethod;
         internal static MethodInfo TrimArraySizeMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_trimArraySizeMethod == null)
@@ -611,11 +529,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_checkEndOfArrayMethod;
         internal static MethodInfo CheckEndOfArrayMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_checkEndOfArrayMethod == null)
@@ -627,12 +543,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-
-        [SecurityCritical]
         private static MethodInfo s_getArrayLengthMethod;
         internal static MethodInfo GetArrayLengthMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getArrayLengthMethod == null)
@@ -644,11 +557,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_createSerializationExceptionMethod;
         internal static MethodInfo CreateSerializationExceptionMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_createSerializationExceptionMethod == null)
@@ -663,7 +574,6 @@ namespace System.Runtime.Serialization
         private static MethodInfo s_readSerializationInfoMethod;
         internal static MethodInfo ReadSerializationInfoMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_readSerializationInfoMethod == null)
@@ -672,11 +582,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_createUnexpectedStateExceptionMethod;
         internal static MethodInfo CreateUnexpectedStateExceptionMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_createUnexpectedStateExceptionMethod == null)
@@ -688,11 +596,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_internalSerializeReferenceMethod;
         internal static MethodInfo InternalSerializeReferenceMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_internalSerializeReferenceMethod == null)
@@ -704,11 +610,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_internalSerializeMethod;
         internal static MethodInfo InternalSerializeMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_internalSerializeMethod == null)
@@ -720,11 +624,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_writeNullMethod;
         internal static MethodInfo WriteNullMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeNullMethod == null)
@@ -736,11 +638,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_incrementArrayCountMethod;
         internal static MethodInfo IncrementArrayCountMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_incrementArrayCountMethod == null)
@@ -752,11 +652,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_incrementCollectionCountMethod;
         internal static MethodInfo IncrementCollectionCountMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_incrementCollectionCountMethod == null)
@@ -768,11 +666,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_incrementCollectionCountGenericMethod;
         internal static MethodInfo IncrementCollectionCountGenericMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_incrementCollectionCountGenericMethod == null)
@@ -784,11 +680,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getDefaultValueMethod;
         internal static MethodInfo GetDefaultValueMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getDefaultValueMethod == null)
@@ -805,11 +699,9 @@ namespace System.Runtime.Serialization
             return GetDefaultValueMethod.MakeGenericMethod(type).Invoke(null, Array.Empty<object>());
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getNullableValueMethod;
         internal static MethodInfo GetNullableValueMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getNullableValueMethod == null)
@@ -821,11 +713,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_throwRequiredMemberMustBeEmittedMethod;
         internal static MethodInfo ThrowRequiredMemberMustBeEmittedMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_throwRequiredMemberMustBeEmittedMethod == null)
@@ -837,11 +727,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getHasValueMethod;
         internal static MethodInfo GetHasValueMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getHasValueMethod == null)
@@ -856,7 +744,6 @@ namespace System.Runtime.Serialization
         private static MethodInfo s_writeISerializableMethod;
         internal static MethodInfo WriteISerializableMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeISerializableMethod == null)
@@ -866,11 +753,9 @@ namespace System.Runtime.Serialization
         }
 
 
-        [SecurityCritical]
         private static MethodInfo s_isMemberTypeSameAsMemberValue;
         internal static MethodInfo IsMemberTypeSameAsMemberValue
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_isMemberTypeSameAsMemberValue == null)
@@ -886,11 +771,9 @@ namespace System.Runtime.Serialization
         internal static MethodInfo WriteExtensionDataMethod => s_writeExtensionDataMethod ?? 
                                                                (s_writeExtensionDataMethod = typeof(XmlObjectSerializerWriteContext).GetMethod("WriteExtensionData", Globals.ScanAllMembers));
 
-        [SecurityCritical]
         private static MethodInfo s_writeXmlValueMethod;
         internal static MethodInfo WriteXmlValueMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeXmlValueMethod == null)
@@ -902,11 +785,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_readXmlValueMethod;
         internal static MethodInfo ReadXmlValueMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_readXmlValueMethod == null)
@@ -918,11 +799,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static PropertyInfo s_namespaceProperty;
         internal static PropertyInfo NamespaceProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_namespaceProperty == null)
@@ -934,11 +813,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static FieldInfo s_contractNamespacesField;
         internal static FieldInfo ContractNamespacesField
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_contractNamespacesField == null)
@@ -950,11 +827,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static FieldInfo s_memberNamesField;
         internal static FieldInfo MemberNamesField
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_memberNamesField == null)
@@ -969,12 +844,9 @@ namespace System.Runtime.Serialization
         private static MethodInfo s_extensionDataSetExplicitMethodInfo;
         internal static MethodInfo ExtensionDataSetExplicitMethodInfo => s_extensionDataSetExplicitMethodInfo ?? 
                                                                          (s_extensionDataSetExplicitMethodInfo = typeof(IExtensibleDataObject).GetMethod(Globals.ExtensionDataSetMethod));
-
-        [SecurityCritical]
         private static PropertyInfo s_childElementNamespacesProperty;
         internal static PropertyInfo ChildElementNamespacesProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_childElementNamespacesProperty == null)
@@ -986,11 +858,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static PropertyInfo s_collectionItemNameProperty;
         internal static PropertyInfo CollectionItemNameProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_collectionItemNameProperty == null)
@@ -1002,11 +872,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static PropertyInfo s_childElementNamespaceProperty;
         internal static PropertyInfo ChildElementNamespaceProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_childElementNamespaceProperty == null)
@@ -1018,11 +886,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getDateTimeOffsetMethod;
         internal static MethodInfo GetDateTimeOffsetMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getDateTimeOffsetMethod == null)
@@ -1034,11 +900,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getDateTimeOffsetAdapterMethod;
         internal static MethodInfo GetDateTimeOffsetAdapterMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getDateTimeOffsetAdapterMethod == null)
@@ -1079,11 +943,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_throwInvalidDataContractExceptionMethod;
         internal static MethodInfo ThrowInvalidDataContractExceptionMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_throwInvalidDataContractExceptionMethod == null)
@@ -1095,11 +957,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static PropertyInfo s_serializeReadOnlyTypesProperty;
         internal static PropertyInfo SerializeReadOnlyTypesProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_serializeReadOnlyTypesProperty == null)
@@ -1111,11 +971,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static PropertyInfo s_classSerializationExceptionMessageProperty;
         internal static PropertyInfo ClassSerializationExceptionMessageProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_classSerializationExceptionMessageProperty == null)
@@ -1127,11 +985,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static PropertyInfo s_collectionSerializationExceptionMessageProperty;
         internal static PropertyInfo CollectionSerializationExceptionMessageProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_collectionSerializationExceptionMessageProperty == null)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
@@ -844,6 +844,7 @@ namespace System.Runtime.Serialization
         private static MethodInfo s_extensionDataSetExplicitMethodInfo;
         internal static MethodInfo ExtensionDataSetExplicitMethodInfo => s_extensionDataSetExplicitMethodInfo ?? 
                                                                          (s_extensionDataSetExplicitMethodInfo = typeof(IExtensibleDataObject).GetMethod(Globals.ExtensionDataSetMethod));
+
         private static PropertyInfo s_childElementNamespacesProperty;
         internal static PropertyInfo ChildElementNamespacesProperty
         {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
@@ -41,43 +41,23 @@ namespace System.Runtime.Serialization
 
         private static readonly ConcurrentDictionary<Type, bool> s_typeHasDefaultConstructorMap = new ConcurrentDictionary<Type, bool>();
 
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that was produced within an assert
-        /// </SecurityNote>
         private CriticalHelper _helper;
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// </SecurityNote>
-        [SecurityCritical]
         public XmlFormatReaderGenerator()
         {
             _helper = new CriticalHelper();
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical helper class 'CriticalHelper'
-        /// </SecurityNote>
-        [SecurityCritical]
         public XmlFormatClassReaderDelegate GenerateClassReader(ClassDataContract classContract)
         {
             return _helper.GenerateClassReader(classContract);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical helper class 'CriticalHelper'
-        /// </SecurityNote>
-        [SecurityCritical]
         public XmlFormatCollectionReaderDelegate GenerateCollectionReader(CollectionDataContract collectionContract)
         {
             return _helper.GenerateCollectionReader(collectionContract);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical helper class 'CriticalHelper'
-        /// </SecurityNote>
-        [SecurityCritical]
         public XmlFormatGetOnlyCollectionReaderDelegate GenerateGetOnlyCollectionReader(CollectionDataContract collectionContract)
         {
             return _helper.GenerateGetOnlyCollectionReader(collectionContract);
@@ -957,7 +937,6 @@ namespace System.Runtime.Serialization
 #endif
         }
 
-        [SecuritySafeCritical]
         static internal object UnsafeGetUninitializedObject(Type type)
         {
 #if !NET_NATIVE
@@ -979,7 +958,6 @@ namespace System.Runtime.Serialization
         /// Safe - marked as such so that it's callable from transparent generated IL. Takes id as parameter which 
         ///        is guaranteed to be in internal serialization cache. 
         /// </SecurityNote>
-        [SecuritySafeCritical]
 #if USE_REFEMIT
         public static object UnsafeGetUninitializedObject(int id)
 #else

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatWriterGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatWriterGenerator.cs
@@ -257,7 +257,20 @@ namespace System.Runtime.Serialization
                         }
                     }
 
-                    WriteMembers(classContract, null, classContract);
+                    if (classContract.HasExtensionData)
+                    {
+                        LocalBuilder extensionDataLocal = _ilg.DeclareLocal(Globals.TypeOfExtensionDataObject, "extensionData");
+                        _ilg.Load(_objectLocal);
+                        _ilg.ConvertValue(_objectLocal.LocalType, Globals.TypeOfIExtensibleDataObject);
+                        _ilg.LoadMember(XmlFormatGeneratorStatics.ExtensionDataProperty);
+                        _ilg.Store(extensionDataLocal);
+                        _ilg.Call(_contextArg, XmlFormatGeneratorStatics.WriteExtensionDataMethod, _xmlWriterArg, extensionDataLocal, -1);
+                        WriteMembers(classContract, extensionDataLocal, classContract);
+                    }
+                    else
+                    {
+                        WriteMembers(classContract, null, classContract);
+                    }
                 }
                 InvokeOnSerialized(classContract);
             }
@@ -309,6 +322,13 @@ namespace System.Runtime.Serialization
                         WriteValue(memberValue, writeXsiType);
                         WriteEndElement();
                     }
+
+                    if (classContract.HasExtensionData)
+                    {
+                        _ilg.Call(_contextArg, XmlFormatGeneratorStatics.WriteExtensionDataMethod, _xmlWriterArg, extensionDataLocal, memberCount);
+                    }
+
+
                     if (!member.EmitDefaultValue)
                     {
                         if (member.IsRequired)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatWriterGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatWriterGenerator.cs
@@ -25,34 +25,18 @@ namespace System.Runtime.Serialization
     internal sealed class XmlFormatWriterGenerator
 #endif
     {
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that was produced within an assert
-        /// </SecurityNote>
         private CriticalHelper _helper;
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// </SecurityNote>
-        [SecurityCritical]
         public XmlFormatWriterGenerator()
         {
             _helper = new CriticalHelper();
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical helper class 'CriticalHelper'
-        /// </SecurityNote>
-        [SecurityCritical]
         internal XmlFormatClassWriterDelegate GenerateClassWriter(ClassDataContract classContract)
         {
             return _helper.GenerateClassWriter(classContract);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical helper class 'CriticalHelper'
-        /// </SecurityNote>
-        [SecurityCritical]
         internal XmlFormatCollectionWriterDelegate GenerateCollectionWriter(CollectionDataContract collectionContract)
         {
             return _helper.GenerateCollectionWriter(collectionContract);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
@@ -23,6 +23,8 @@ namespace System.Runtime.Serialization
         internal Attributes attributes;
         private HybridObjectCache _deserializedObjects;
         private XmlSerializableReader _xmlSerializableReader;
+        private XmlDocument _xmlDocument;
+        private Attributes _attributesInXmlData;
         private object _getOnlyCollectionValue;
         private bool _isGetOnlyCollection;
 
@@ -35,6 +37,8 @@ namespace System.Runtime.Serialization
                 return _deserializedObjects;
             }
         }
+
+        private XmlDocument Document => _xmlDocument ?? (_xmlDocument = new XmlDocument());
 
 
         internal override bool IsGetOnlyCollection
@@ -316,6 +320,9 @@ namespace System.Runtime.Serialization
 
         internal void HandleUnknownElement(XmlReaderDelegator xmlReader, ExtensionDataObject extensionData, int memberIndex)
         {
+            if (extensionData.Members == null)
+                extensionData.Members = new List<ExtensionDataMember>();
+            extensionData.Members.Add(ReadExtensionDataMember(xmlReader, memberIndex));
         }
 
 #if USE_REFEMIT
@@ -436,6 +443,18 @@ namespace System.Runtime.Serialization
             object retObj = DeserializedObjects.GetObject(id);
             if (retObj == null)
                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.DeserializedObjectWithIdNotFound, id)));
+            return retObj;
+        }
+
+        private object GetExistingObjectOrExtensionData(string id)
+        {
+            object retObj = DeserializedObjects.GetObject(id);
+            if (retObj == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                    XmlObjectSerializer.CreateSerializationException(SR.Format(SR.DeserializedObjectWithIdNotFound, id)));
+            }
+
             return retObj;
         }
 
@@ -606,6 +625,469 @@ namespace System.Runtime.Serialization
             return (attributes.XsiTypeName == null) ? null : ResolveDataContractFromKnownTypes(attributes.XsiTypeName, attributes.XsiTypeNamespace, null /*memberTypeContract*/);
         }
 
+        private ExtensionDataMember ReadExtensionDataMember(XmlReaderDelegator xmlReader, int memberIndex)
+        {
+            var member = new ExtensionDataMember
+            {
+                Name = xmlReader.LocalName,
+                Namespace = xmlReader.NamespaceURI,
+                MemberIndex = memberIndex
+            };
+
+            member.Value = xmlReader.UnderlyingExtensionDataReader != null ? xmlReader.UnderlyingExtensionDataReader.GetCurrentNode() : ReadExtensionDataValue(xmlReader);
+            return member;
+        }
+
+        public IDataNode ReadExtensionDataValue(XmlReaderDelegator xmlReader)
+        {
+            ReadAttributes(xmlReader);
+            IncrementItemCount(1);
+            IDataNode dataNode = null;
+            if (attributes.Ref != Globals.NewObjectId)
+            {
+                xmlReader.Skip();
+                object o = GetExistingObjectOrExtensionData(attributes.Ref);
+                dataNode = (o is IDataNode) ? (IDataNode)o : new DataNode<object>(o);
+                dataNode.Id = attributes.Ref;
+            }
+            else if (attributes.XsiNil)
+            {
+                xmlReader.Skip();
+                dataNode = null;
+            }
+            else
+            {
+                string dataContractName = null;
+                string dataContractNamespace = null;
+                if (attributes.XsiTypeName != null)
+                {
+                    dataContractName = attributes.XsiTypeName;
+                    dataContractNamespace = attributes.XsiTypeNamespace;
+                }
+
+                if (IsReadingCollectionExtensionData(xmlReader))
+                {
+                    Read(xmlReader);
+                    dataNode = ReadUnknownCollectionData(xmlReader, dataContractName, dataContractNamespace);
+                }
+                else if (attributes.FactoryTypeName != null)
+                {
+                    Read(xmlReader);
+                    dataNode = ReadUnknownISerializableData(xmlReader, dataContractName, dataContractNamespace);
+                }
+                else if (IsReadingClassExtensionData(xmlReader))
+                {
+                    Read(xmlReader);
+                    dataNode = ReadUnknownClassData(xmlReader, dataContractName, dataContractNamespace);
+                }
+                else
+                {
+                    DataContract dataContract = ResolveDataContractFromTypeName();
+
+                    if (dataContract == null)
+                        dataNode = ReadExtensionDataValue(xmlReader, dataContractName, dataContractNamespace);
+                    else if (dataContract is XmlDataContract)
+                        dataNode = ReadUnknownXmlData(xmlReader, dataContractName, dataContractNamespace);
+                    else
+                    {
+                        if (dataContract.IsISerializable)
+                        {
+                            Read(xmlReader);
+                            dataNode = ReadUnknownISerializableData(xmlReader, dataContractName, dataContractNamespace);
+                        }
+                        else if (dataContract is PrimitiveDataContract)
+                        {
+                            if (attributes.Id == Globals.NewObjectId)
+                            {
+                                Read(xmlReader);
+                                xmlReader.MoveToContent();
+                                dataNode = ReadUnknownPrimitiveData(xmlReader, dataContract.UnderlyingType, dataContractName, dataContractNamespace);
+                                xmlReader.ReadEndElement();
+                            }
+                            else
+                            {
+                                dataNode = new DataNode<object>(xmlReader.ReadElementContentAsAnyType(dataContract.UnderlyingType));
+                                InitializeExtensionDataNode(dataNode, dataContractName, dataContractNamespace);
+                            }
+                        }
+                        else if (dataContract is EnumDataContract)
+                        {
+                            dataNode = new DataNode<object>(((EnumDataContract)dataContract).ReadEnumValue(xmlReader));
+                            InitializeExtensionDataNode(dataNode, dataContractName, dataContractNamespace);
+                        }
+                        else if (dataContract is ClassDataContract)
+                        {
+                            Read(xmlReader);
+                            dataNode = ReadUnknownClassData(xmlReader, dataContractName, dataContractNamespace);
+                        }
+                        else if (dataContract is CollectionDataContract)
+                        {
+                            Read(xmlReader);
+                            dataNode = ReadUnknownCollectionData(xmlReader, dataContractName, dataContractNamespace);
+                        }
+                    }
+                }
+            }
+            return dataNode;
+        }
+
+        protected virtual void StartReadExtensionDataValue(XmlReaderDelegator xmlReader)
+        {
+        }
+
+        private IDataNode ReadExtensionDataValue(XmlReaderDelegator xmlReader, string dataContractName, string dataContractNamespace)
+        {
+            StartReadExtensionDataValue(xmlReader);
+
+            if (attributes.UnrecognizedAttributesFound)
+                return ReadUnknownXmlData(xmlReader, dataContractName, dataContractNamespace);
+
+            IDictionary<string, string> namespacesInScope = xmlReader.GetNamespacesInScope(XmlNamespaceScope.ExcludeXml);
+            Read(xmlReader);
+            xmlReader.MoveToContent();
+
+            switch (xmlReader.NodeType)
+            {
+                case XmlNodeType.Text:
+                    return ReadPrimitiveExtensionDataValue(xmlReader, dataContractName, dataContractNamespace);
+                case XmlNodeType.Element:
+                    if (xmlReader.NamespaceURI.StartsWith(Globals.DataContractXsdBaseNamespace, StringComparison.Ordinal))
+                        return ReadUnknownClassData(xmlReader, dataContractName, dataContractNamespace);
+                    else
+                        return ReadAndResolveUnknownXmlData(xmlReader, namespacesInScope, dataContractName, dataContractNamespace);
+
+                case XmlNodeType.EndElement:
+                    {
+                        // NOTE: cannot distinguish between empty class or IXmlSerializable and typeof(object) 
+                        IDataNode objNode = ReadUnknownPrimitiveData(xmlReader, Globals.TypeOfObject, dataContractName, dataContractNamespace);
+                        xmlReader.ReadEndElement();
+                        objNode.IsFinalValue = false;
+                        return objNode;
+                    }
+                default:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateUnexpectedStateException(XmlNodeType.Element, xmlReader));
+            }
+        }
+
+        protected virtual IDataNode ReadPrimitiveExtensionDataValue(XmlReaderDelegator xmlReader, string dataContractName, string dataContractNamespace)
+        {
+            Type valueType = xmlReader.ValueType;
+            if (valueType == Globals.TypeOfString)
+            {
+                // NOTE: cannot distinguish other primitives from string (default XmlReader ValueType)
+                IDataNode stringNode = new DataNode<object>(xmlReader.ReadContentAsString());
+                InitializeExtensionDataNode(stringNode, dataContractName, dataContractNamespace);
+                stringNode.IsFinalValue = false;
+                xmlReader.ReadEndElement();
+                return stringNode;
+            }
+
+            IDataNode objNode = ReadUnknownPrimitiveData(xmlReader, valueType, dataContractName, dataContractNamespace);
+            xmlReader.ReadEndElement();
+            return objNode;
+        }
+
+        protected void InitializeExtensionDataNode(IDataNode dataNode, string dataContractName, string dataContractNamespace)
+        {
+            dataNode.DataContractName = dataContractName;
+            dataNode.DataContractNamespace = dataContractNamespace;
+            dataNode.ClrAssemblyName = attributes.ClrAssembly;
+            dataNode.ClrTypeName = attributes.ClrType;
+            AddNewObject(dataNode);
+            dataNode.Id = attributes.Id;
+        }
+
+        private IDataNode ReadUnknownPrimitiveData(XmlReaderDelegator xmlReader, Type type, string dataContractName, string dataContractNamespace)
+        {
+            IDataNode dataNode = xmlReader.ReadExtensionData(type);
+            InitializeExtensionDataNode(dataNode, dataContractName, dataContractNamespace);
+            return dataNode;
+        }
+
+        private ClassDataNode ReadUnknownClassData(XmlReaderDelegator xmlReader, string dataContractName, string dataContractNamespace)
+        {
+            var dataNode = new ClassDataNode();
+            InitializeExtensionDataNode(dataNode, dataContractName, dataContractNamespace);
+
+            int memberIndex = 0;
+            XmlNodeType nodeType;
+            while ((nodeType = xmlReader.MoveToContent()) != XmlNodeType.EndElement)
+            {
+                if (nodeType != XmlNodeType.Element)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateUnexpectedStateException(XmlNodeType.Element, xmlReader));
+
+                if (dataNode.Members == null)
+                    dataNode.Members = new List<ExtensionDataMember>();
+                dataNode.Members.Add(ReadExtensionDataMember(xmlReader, memberIndex++));
+            }
+            xmlReader.ReadEndElement();
+            return dataNode;
+        }
+
+        private CollectionDataNode ReadUnknownCollectionData(XmlReaderDelegator xmlReader, string dataContractName, string dataContractNamespace)
+        {
+            var dataNode = new CollectionDataNode();
+            InitializeExtensionDataNode(dataNode, dataContractName, dataContractNamespace);
+
+            int arraySize = attributes.ArraySZSize;
+            XmlNodeType nodeType;
+            while ((nodeType = xmlReader.MoveToContent()) != XmlNodeType.EndElement)
+            {
+                if (nodeType != XmlNodeType.Element)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateUnexpectedStateException(XmlNodeType.Element, xmlReader));
+
+                if (dataNode.ItemName == null)
+                {
+                    dataNode.ItemName = xmlReader.LocalName;
+                    dataNode.ItemNamespace = xmlReader.NamespaceURI;
+                }
+                if (xmlReader.IsStartElement(dataNode.ItemName, dataNode.ItemNamespace))
+                {
+                    if (dataNode.Items == null)
+                        dataNode.Items = new List<IDataNode>();
+                    dataNode.Items.Add(ReadExtensionDataValue(xmlReader));
+                }
+                else
+                    SkipUnknownElement(xmlReader);
+            }
+            xmlReader.ReadEndElement();
+
+            if (arraySize != -1)
+            {
+                dataNode.Size = arraySize;
+                if (dataNode.Items == null)
+                {
+                    if (dataNode.Size > 0)
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.ArraySizeAttributeIncorrect, arraySize, 0)));
+                }
+                else if (dataNode.Size != dataNode.Items.Count)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.ArraySizeAttributeIncorrect, arraySize, dataNode.Items.Count)));
+            }
+            else
+            {
+                if (dataNode.Items != null)
+                {
+                    dataNode.Size = dataNode.Items.Count;
+                }
+                else
+                {
+                    dataNode.Size = 0;
+                }
+            }
+
+            return dataNode;
+        }
+
+        private ISerializableDataNode ReadUnknownISerializableData(XmlReaderDelegator xmlReader, string dataContractName, string dataContractNamespace)
+        {
+            var dataNode = new ISerializableDataNode();
+            InitializeExtensionDataNode(dataNode, dataContractName, dataContractNamespace);
+
+            dataNode.FactoryTypeName = attributes.FactoryTypeName;
+            dataNode.FactoryTypeNamespace = attributes.FactoryTypeNamespace;
+
+            XmlNodeType nodeType;
+            while ((nodeType = xmlReader.MoveToContent()) != XmlNodeType.EndElement)
+            {
+                if (nodeType != XmlNodeType.Element)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateUnexpectedStateException(XmlNodeType.Element, xmlReader));
+
+                if (xmlReader.NamespaceURI.Length != 0)
+                {
+                    SkipUnknownElement(xmlReader);
+                    continue;
+                }
+
+                var member = new ISerializableDataMember();
+                member.Name = xmlReader.LocalName;
+                member.Value = ReadExtensionDataValue(xmlReader);
+                if (dataNode.Members == null)
+                    dataNode.Members = new List<ISerializableDataMember>();
+                dataNode.Members.Add(member);
+            }
+            xmlReader.ReadEndElement();
+            return dataNode;
+        }
+
+        private IDataNode ReadUnknownXmlData(XmlReaderDelegator xmlReader, string dataContractName, string dataContractNamespace)
+        {
+            XmlDataNode dataNode = new XmlDataNode();
+            InitializeExtensionDataNode(dataNode, dataContractName, dataContractNamespace);
+            dataNode.OwnerDocument = Document;
+
+            if (xmlReader.NodeType == XmlNodeType.EndElement)
+                return dataNode;
+
+            IList<XmlAttribute> xmlAttributes = null;
+            IList<XmlNode> xmlChildNodes = null;
+
+            XmlNodeType nodeType = xmlReader.MoveToContent();
+            if (nodeType != XmlNodeType.Text)
+            {
+                while (xmlReader.MoveToNextAttribute())
+                {
+                    string ns = xmlReader.NamespaceURI;
+                    if (ns != Globals.SerializationNamespace && ns != Globals.SchemaInstanceNamespace)
+                    {
+                        if (xmlAttributes == null)
+                            xmlAttributes = new List<XmlAttribute>();
+                        xmlAttributes.Add((XmlAttribute)Document.ReadNode(xmlReader.UnderlyingReader));
+                    }
+                }
+                Read(xmlReader);
+            }
+
+            while ((nodeType = xmlReader.MoveToContent()) != XmlNodeType.EndElement)
+            {
+                if (xmlReader.EOF)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.UnexpectedEndOfFile)));
+
+                if (xmlChildNodes == null)
+                    xmlChildNodes = new List<XmlNode>();
+                xmlChildNodes.Add(Document.ReadNode(xmlReader.UnderlyingReader));
+            }
+            xmlReader.ReadEndElement();
+
+            dataNode.XmlAttributes = xmlAttributes;
+            dataNode.XmlChildNodes = xmlChildNodes;
+            return dataNode;
+        }
+
+        // Pattern-recognition logic: the method reads XML elements into DOM. To recognize as an array, it requires that 
+        // all items have the same name and namespace. To recognize as an ISerializable type, it requires that all
+        // items be unqualified. If the XML only contains elements (no attributes or other nodes) is recognized as a 
+        // class/class hierarchy. Otherwise it is deserialized as XML.
+        private IDataNode ReadAndResolveUnknownXmlData(XmlReaderDelegator xmlReader, IDictionary<string, string> namespaces,
+            string dataContractName, string dataContractNamespace)
+        {
+            bool couldBeISerializableData = true;
+            bool couldBeCollectionData = true;
+            bool couldBeClassData = true;
+            string elementNs = null, elementName = null;
+            var xmlChildNodes = new List<XmlNode>();
+            IList<XmlAttribute> xmlAttributes = null;
+            if (namespaces != null)
+            {
+                xmlAttributes = new List<XmlAttribute>();
+                foreach (KeyValuePair<string, string> prefixNsPair in namespaces)
+                {
+                    xmlAttributes.Add(AddNamespaceDeclaration(prefixNsPair.Key, prefixNsPair.Value));
+                }
+            }
+
+            XmlNodeType nodeType;
+            while ((nodeType = xmlReader.NodeType) != XmlNodeType.EndElement)
+            {
+                if (nodeType == XmlNodeType.Element)
+                {
+                    string ns = xmlReader.NamespaceURI;
+                    string name = xmlReader.LocalName;
+                    if (couldBeISerializableData)
+                        couldBeISerializableData = (ns.Length == 0);
+                    if (couldBeCollectionData)
+                    {
+                        if (elementName == null)
+                        {
+                            elementName = name;
+                            elementNs = ns;
+                        }
+                        else
+                            couldBeCollectionData = (String.CompareOrdinal(elementName, name) == 0) &&
+                                (String.CompareOrdinal(elementNs, ns) == 0);
+                    }
+                }
+                else if (xmlReader.EOF)
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.UnexpectedEndOfFile)));
+                else if (IsContentNode(xmlReader.NodeType))
+                    couldBeClassData = couldBeISerializableData = couldBeCollectionData = false;
+
+                if (_attributesInXmlData == null) _attributesInXmlData = new Attributes();
+                _attributesInXmlData.Read(xmlReader);
+
+                XmlNode childNode = Document.ReadNode(xmlReader.UnderlyingReader);
+                xmlChildNodes.Add(childNode);
+
+                if (namespaces == null)
+                {
+                    if (_attributesInXmlData.XsiTypeName != null)
+                        childNode.Attributes.Append(AddNamespaceDeclaration(_attributesInXmlData.XsiTypePrefix, _attributesInXmlData.XsiTypeNamespace));
+                    if (_attributesInXmlData.FactoryTypeName != null)
+                        childNode.Attributes.Append(AddNamespaceDeclaration(_attributesInXmlData.FactoryTypePrefix, _attributesInXmlData.FactoryTypeNamespace));
+                }
+            }
+            xmlReader.ReadEndElement();
+
+            if (elementName != null && couldBeCollectionData)
+                return ReadUnknownCollectionData(CreateReaderOverChildNodes(xmlAttributes, xmlChildNodes), dataContractName, dataContractNamespace);
+            else if (couldBeISerializableData)
+                return ReadUnknownISerializableData(CreateReaderOverChildNodes(xmlAttributes, xmlChildNodes), dataContractName, dataContractNamespace);
+            else if (couldBeClassData)
+                return ReadUnknownClassData(CreateReaderOverChildNodes(xmlAttributes, xmlChildNodes), dataContractName, dataContractNamespace);
+            else
+            {
+                XmlDataNode dataNode = new XmlDataNode();
+                InitializeExtensionDataNode(dataNode, dataContractName, dataContractNamespace);
+                dataNode.OwnerDocument = Document;
+                dataNode.XmlChildNodes = xmlChildNodes;
+                dataNode.XmlAttributes = xmlAttributes;
+                return dataNode;
+            }
+        }
+
+        private bool IsContentNode(XmlNodeType nodeType)
+        {
+            switch (nodeType)
+            {
+                case XmlNodeType.Whitespace:
+                case XmlNodeType.SignificantWhitespace:
+                case XmlNodeType.Comment:
+                case XmlNodeType.ProcessingInstruction:
+                case XmlNodeType.DocumentType:
+                    return false;
+                default:
+                    return true;
+            }
+        }
+
+        internal XmlReaderDelegator CreateReaderOverChildNodes(IList<XmlAttribute> xmlAttributes, IList<XmlNode> xmlChildNodes)
+        {
+            XmlNode wrapperElement = CreateWrapperXmlElement(Document, xmlAttributes, xmlChildNodes, null, null, null);
+            XmlReaderDelegator nodeReader = CreateReaderDelegatorForReader(new XmlNodeReader(wrapperElement));
+            nodeReader.MoveToContent();
+            Read(nodeReader);
+            return nodeReader;
+        }
+
+        internal static XmlNode CreateWrapperXmlElement(XmlDocument document, IList<XmlAttribute> xmlAttributes, IList<XmlNode> xmlChildNodes, string prefix, string localName, string ns)
+        {
+            localName = localName ?? "wrapper";
+            ns = ns ?? string.Empty;
+            XmlNode wrapperElement = document.CreateElement(prefix, localName, ns);
+            if (xmlAttributes != null)
+            {
+                for (int i = 0; i < xmlAttributes.Count; i++)
+                {
+                    wrapperElement.Attributes.Append((XmlAttribute) xmlAttributes[i]);
+                }
+            }
+            if (xmlChildNodes != null)
+            {
+                for (int i = 0; i < xmlChildNodes.Count; i++)
+                {
+                    wrapperElement.AppendChild(xmlChildNodes[i]);
+                }
+            }
+            return wrapperElement;
+        }
+
+        private XmlAttribute AddNamespaceDeclaration(string prefix, string ns)
+        {
+            XmlAttribute attribute = (prefix == null || prefix.Length == 0) ?
+                Document.CreateAttribute(null, Globals.XmlnsPrefix, Globals.XmlnsNamespace) :
+                Document.CreateAttribute(Globals.XmlnsPrefix, prefix, Globals.XmlnsNamespace);
+            attribute.Value = ns;
+            return attribute;
+        }
 
 #if USE_REFEMIT
         public static Exception CreateUnexpectedStateException(XmlNodeType expectedState, XmlReaderDelegator xmlReader)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
@@ -298,7 +298,6 @@ namespace System.Runtime.Serialization
             throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.JsonDuplicateMemberInInput, DataContract.GetClrTypeFullName(obj.GetType()), memberNames[memberIndex])));
         }
 
-        [SecuritySafeCritical]
         private static bool IsBitSet(byte[] bytes, int bitIndex)
         {
             throw new NotImplementedException();

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlWriterDelegator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlWriterDelegator.cs
@@ -369,6 +369,87 @@ namespace System.Runtime.Serialization
                 throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateInvalidPrimitiveTypeException(valueType));
         }
 
+        internal void WriteExtensionData(IDataNode dataNode)
+        {
+            bool handled = true;
+            Type valueType = dataNode.DataType;
+            switch (Type.GetTypeCode(valueType))
+            {
+                case TypeCode.Boolean:
+                    WriteBoolean(((DataNode<bool>)dataNode).GetValue());
+                    break;
+                case TypeCode.Char:
+                    WriteChar(((DataNode<char>)dataNode).GetValue());
+                    break;
+                case TypeCode.Byte:
+                    WriteUnsignedByte(((DataNode<byte>)dataNode).GetValue());
+                    break;
+                case TypeCode.Int16:
+                    WriteShort(((DataNode<short>)dataNode).GetValue());
+                    break;
+                case TypeCode.Int32:
+                    WriteInt(((DataNode<int>)dataNode).GetValue());
+                    break;
+                case TypeCode.Int64:
+                    WriteLong(((DataNode<long>)dataNode).GetValue());
+                    break;
+                case TypeCode.Single:
+                    WriteFloat(((DataNode<float>)dataNode).GetValue());
+                    break;
+                case TypeCode.Double:
+                    WriteDouble(((DataNode<double>)dataNode).GetValue());
+                    break;
+                case TypeCode.Decimal:
+                    WriteDecimal(((DataNode<decimal>)dataNode).GetValue());
+                    break;
+                case TypeCode.DateTime:
+                    WriteDateTime(((DataNode<DateTime>)dataNode).GetValue());
+                    break;
+                case TypeCode.String:
+                    WriteString(((DataNode<string>)dataNode).GetValue());
+                    break;
+                case TypeCode.SByte:
+                    WriteSignedByte(((DataNode<sbyte>)dataNode).GetValue());
+                    break;
+                case TypeCode.UInt16:
+                    WriteUnsignedShort(((DataNode<ushort>)dataNode).GetValue());
+                    break;
+                case TypeCode.UInt32:
+                    WriteUnsignedInt(((DataNode<uint>)dataNode).GetValue());
+                    break;
+                case TypeCode.UInt64:
+                    WriteUnsignedLong(((DataNode<ulong>)dataNode).GetValue());
+                    break;
+                case TypeCode.Empty:
+                case TypeCode.DBNull:
+                case TypeCode.Object:
+                default:
+                    if (valueType == Globals.TypeOfByteArray)
+                        WriteBase64(((DataNode<byte[]>)dataNode).GetValue());
+                    else if (valueType == Globals.TypeOfObject)
+                    {
+                        object obj = dataNode.Value;
+                        if (obj != null)
+                            WriteAnyType(obj);
+                    }
+                    else if (valueType == Globals.TypeOfTimeSpan)
+                        WriteTimeSpan(((DataNode<TimeSpan>)dataNode).GetValue());
+                    else if (valueType == Globals.TypeOfGuid)
+                        WriteGuid(((DataNode<Guid>)dataNode).GetValue());
+                    else if (valueType == Globals.TypeOfUri)
+                        WriteUri(((DataNode<Uri>)dataNode).GetValue());
+                    else if (valueType == Globals.TypeOfXmlQualifiedName)
+                        WriteQName(((DataNode<XmlQualifiedName>)dataNode).GetValue());
+                    else
+                        handled = false;
+                    break;
+            }
+
+            if (!handled)
+            {
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateInvalidPrimitiveTypeException(valueType));
+            }
+        }
 
         internal void WriteString(string value)
         {

--- a/src/System.Private.DataContractSerialization/src/System/Text/Base64Encoding.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Text/Base64Encoding.cs
@@ -6,8 +6,6 @@ using System.Text;
 using System.Diagnostics;
 using System.Runtime.Serialization; //For SR
 using System.Globalization;
-using System.Security;
-
 
 namespace System.Text
 {
@@ -55,11 +53,6 @@ namespace System.Text
             return !(v3 == 64 && v4 != 64);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override int GetByteCount(char[] chars, int index, int count)
         {
             if (chars == null)
@@ -114,11 +107,6 @@ namespace System.Text
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
         {
             if (chars == null)
@@ -198,11 +186,6 @@ namespace System.Text
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public virtual int GetBytes(byte[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
         {
             if (chars == null)
@@ -291,11 +274,6 @@ namespace System.Text
             return GetMaxCharCount(count);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
         {
             if (bytes == null)
@@ -385,11 +363,6 @@ namespace System.Text
             return charCount;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public int GetChars(byte[] bytes, int byteIndex, int byteCount, byte[] chars, int charIndex)
         {
             if (bytes == null)

--- a/src/System.Private.DataContractSerialization/src/System/Text/BinHexEncoding.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Text/BinHexEncoding.cs
@@ -4,7 +4,6 @@
 
 using System.Globalization;
 using System.Runtime;
-using System.Security;
 
 namespace System.Text
 {
@@ -46,7 +45,6 @@ namespace System.Text
             return GetMaxByteCount(count);
         }
 
-        [SecuritySafeCritical]
         unsafe public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
         {
             if (chars == null)
@@ -117,7 +115,6 @@ namespace System.Text
             return GetMaxCharCount(count);
         }
 
-        [SecuritySafeCritical]
         unsafe public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
         {
             if (bytes == null)

--- a/src/System.Private.DataContractSerialization/src/System/Xml/UniqueId.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/UniqueId.cs
@@ -2,23 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Xml;
-using System.Text;
-using System.Diagnostics;
-using System.Runtime.Serialization;
-using System.Security;
-
-
 namespace System.Xml
 {
     public class UniqueId
     {
         private Int64 _idLow;
         private Int64 _idHigh;
-        [SecurityCritical]
-        /// <SecurityNote>
-        ///   Critical - some SecurityCritical unsafe code assumes that this field has been validated
-        /// </SecurityNote>
         private string _s;
         private const int guidLength = 16;
         private const int uuidLength = 45;
@@ -74,11 +63,6 @@ namespace System.Xml
         {
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public UniqueId(byte[] guid, int offset)
         {
             if (guid == null)
@@ -96,11 +80,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public UniqueId(string value)
         {
             if (value == null)
@@ -114,11 +93,6 @@ namespace System.Xml
             _s = value;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public UniqueId(char[] chars, int offset, int count)
         {
             if (chars == null)
@@ -146,11 +120,6 @@ namespace System.Xml
 
         public int CharArrayLength
         {
-            /// <SecurityNote>
-            ///   Critical - accesses critical field 's'. 
-            ///   Safe - doesn't leak any control or data
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (_s != null)
@@ -160,11 +129,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe int UnsafeDecode(short* char2val, char ch1, char ch2)
         {
             if ((ch1 | ch2) >= 0x80)
@@ -173,34 +137,14 @@ namespace System.Xml
             return char2val[ch1] | char2val[0x80 + ch2];
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeEncode(char* val2char, byte b, char* pch)
         {
             pch[0] = val2char[b >> 4];
             pch[1] = val2char[b & 0x0F];
         }
 
-        public bool IsGuid
-        {
-            get
-            {
-                return ((_idLow | _idHigh) != 0);
-            }
-        }
+        public bool IsGuid => ((_idLow | _idHigh) != 0);
 
-        // It must be the case that comparing UniqueId's as strings yields the same result as comparing UniqueId's as
-        // their binary equivalent.  This means that there must be a 1-1 relationship between a string and its binary
-        // equivalent.  Therefore, for example, we cannot accept both upper and lower case hex chars since there would
-        // then be more than 1 string that mapped to a binary equivalent.
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeParse(char* chars, int charCount)
         {
             //           1         2         3         4
@@ -255,11 +199,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public int ToCharArray(char[] chars, int offset)
         {
             int count = CharArrayLength;
@@ -341,11 +280,6 @@ namespace System.Xml
             return true;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public bool TryGetGuid(byte[] buffer, int offset)
         {
             if (!IsGuid)
@@ -371,11 +305,6 @@ namespace System.Xml
             return true;
         }
 
-        /// <SecurityNote>
-        ///   Critical - accesses critical field 's'. 
-        ///   Safe - doesn't allow unchecked write access to the field
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override string ToString()
         {
             if (_s == null)
@@ -428,11 +357,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe Int64 UnsafeGetInt64(byte* pb)
         {
             Int32 idLow = UnsafeGetInt32(pb);
@@ -440,11 +364,6 @@ namespace System.Xml
             return (((Int64)idHigh) << 32) | ((UInt32)idLow);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe Int32 UnsafeGetInt32(byte* pb)
         {
             int value = pb[3];
@@ -457,22 +376,12 @@ namespace System.Xml
             return value;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeSetInt64(Int64 value, byte* pb)
         {
             UnsafeSetInt32((int)value, pb);
             UnsafeSetInt32((int)(value >> 32), &pb[4]);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeSetInt32(Int32 value, byte* pb)
         {
             pb[0] = (byte)value;

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReader.cs
@@ -2,17 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
-using System.Xml;
-using System.Collections;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
-using System.Globalization;
 using System.Runtime.Serialization;
-
 
 namespace System.Xml
 {
@@ -1232,12 +1223,6 @@ namespace System.Xml
                 throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException(nameof(count), SR.Format(SR.SizeExceedsRemainingBufferSpace, array.Length - offset)));
         }
 
-        // bool
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private unsafe int ReadArray(bool[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
@@ -1264,12 +1249,6 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        // Int16
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private unsafe int ReadArray(Int16[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
@@ -1296,12 +1275,6 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        // Int32
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private unsafe int ReadArray(Int32[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
@@ -1328,12 +1301,6 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        // Int64
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private unsafe int ReadArray(Int64[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
@@ -1360,12 +1327,6 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        // float
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private unsafe int ReadArray(float[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
@@ -1392,12 +1353,6 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        // double
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private unsafe int ReadArray(double[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
@@ -1424,12 +1379,6 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        // decimal
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private unsafe int ReadArray(decimal[] array, int offset, int count)
         {
             CheckArray(array, offset, count);

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
@@ -13,8 +13,6 @@ using System.Diagnostics;
 using System.Runtime.Serialization;
 using System.Globalization;
 using System.Collections.Generic;
-using System.Security;
-
 
 namespace System.Xml
 {
@@ -377,11 +375,6 @@ namespace System.Xml
             WriteMultiByteInt32(key);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private unsafe void WriteName(string s)
         {
             int length = s.Length;
@@ -398,11 +391,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeWriteName(char* chars, int charCount)
         {
             if (charCount < 128 / maxBytesPerChar)
@@ -615,11 +603,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteText(string value)
         {
             if (_inAttribute)
@@ -642,11 +625,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteText(char[] chars, int offset, int count)
         {
             if (_inAttribute)
@@ -675,11 +653,6 @@ namespace System.Xml
             WriteBytes(chars, charOffset, charCount);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeWriteText(char* chars, int charCount)
         {
             // Callers should handle zero
@@ -774,11 +747,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteFloatText(float f)
         {
             long l;
@@ -800,11 +768,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteDoubleText(double d)
         {
             float f;
@@ -830,11 +793,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteDecimalText(decimal d)
         {
             int offset;
@@ -933,22 +891,12 @@ namespace System.Xml
             WriteMultiByteInt32(count);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         unsafe public void UnsafeWriteArray(XmlBinaryNodeType nodeType, int count, byte* array, byte* arrayMax)
         {
             WriteArrayInfo(nodeType, count);
             UnsafeWriteArray(array, (int)(arrayMax - array));
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeWriteArray(byte* array, int byteCount)
         {
             base.UnsafeWriteBytes(array, byteCount);
@@ -1242,11 +1190,6 @@ namespace System.Xml
             EndArray();
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeWriteArray(string prefix, string localName, string namespaceUri,
                                XmlBinaryNodeType nodeType, int count, byte* array, byte* arrayMax)
         {
@@ -1255,11 +1198,6 @@ namespace System.Xml
             WriteEndArray();
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeWriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri,
                                XmlBinaryNodeType nodeType, int count, byte* array, byte* arrayMax)
         {
@@ -1282,12 +1220,6 @@ namespace System.Xml
                 throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException(nameof(count), SR.Format(SR.SizeExceedsRemainingBufferSpace, array.Length - offset)));
         }
 
-        // bool
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, string localName, string namespaceUri, bool[] array, int offset, int count)
         {
             {
@@ -1302,11 +1234,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, bool[] array, int offset, int count)
         {
             {
@@ -1321,12 +1248,6 @@ namespace System.Xml
             }
         }
 
-        // Int16
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, string localName, string namespaceUri, Int16[] array, int offset, int count)
         {
             {
@@ -1341,11 +1262,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, Int16[] array, int offset, int count)
         {
             {
@@ -1360,12 +1276,6 @@ namespace System.Xml
             }
         }
 
-        // Int32
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, string localName, string namespaceUri, Int32[] array, int offset, int count)
         {
             {
@@ -1380,11 +1290,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, Int32[] array, int offset, int count)
         {
             {
@@ -1399,12 +1304,6 @@ namespace System.Xml
             }
         }
 
-        // Int64
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, string localName, string namespaceUri, Int64[] array, int offset, int count)
         {
             {
@@ -1419,11 +1318,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, Int64[] array, int offset, int count)
         {
             {
@@ -1438,12 +1332,6 @@ namespace System.Xml
             }
         }
 
-        // float
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, string localName, string namespaceUri, float[] array, int offset, int count)
         {
             {
@@ -1458,11 +1346,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, float[] array, int offset, int count)
         {
             {
@@ -1477,12 +1360,6 @@ namespace System.Xml
             }
         }
 
-        // double
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, string localName, string namespaceUri, double[] array, int offset, int count)
         {
             {
@@ -1497,11 +1374,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, double[] array, int offset, int count)
         {
             {
@@ -1516,12 +1388,6 @@ namespace System.Xml
             }
         }
 
-        // decimal
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, string localName, string namespaceUri, decimal[] array, int offset, int count)
         {
             {
@@ -1536,11 +1402,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, decimal[] array, int offset, int count)
         {
             {

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
@@ -8,13 +8,11 @@ using System.Xml;
 using System.Collections;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Security;
 using System.Text;
 using System.Globalization;
 using System.Runtime.Serialization;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-
 
 namespace System.Xml
 {
@@ -391,11 +389,6 @@ namespace System.Xml
             return (hi << 32) + lo;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public float ReadSingle()
         {
             int offset;
@@ -411,11 +404,6 @@ namespace System.Xml
             return value;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public double ReadDouble()
         {
             int offset;
@@ -435,11 +423,6 @@ namespace System.Xml
             return value;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public decimal ReadDecimal()
         {
             int offset;
@@ -525,21 +508,11 @@ namespace System.Xml
             return value;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         unsafe public void UnsafeReadArray(byte* dst, byte* dstMax)
         {
             UnsafeReadArray(dst, (int)(dstMax - dst));
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeReadArray(byte* dst, int length)
         {
             if (_stream != null)
@@ -948,11 +921,6 @@ namespace System.Xml
             return true;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public bool Equals2(int offset1, int length1, string s2)
         {
             int byteLength = length1;
@@ -1071,11 +1039,6 @@ namespace System.Xml
             return (ulong)GetInt64(offset);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public float GetSingle(int offset)
         {
             byte[] buffer = _buffer;
@@ -1089,11 +1052,6 @@ namespace System.Xml
             return value;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public double GetDouble(int offset)
         {
             byte[] buffer = _buffer;
@@ -1111,11 +1069,6 @@ namespace System.Xml
             return value;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         public unsafe decimal GetDecimal(int offset)
         {
             byte[] buffer = _buffer;

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlConverter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlConverter.cs
@@ -740,7 +740,6 @@ namespace System.Xml
             return count + ToCharsR((int)value, chars, offset);
         }
 
-        [SecuritySafeCritical]
         private static unsafe bool IsNegativeZero(float value)
         {
             // Simple equals function will report that -0 is equal to +0, so compare bits instead
@@ -748,7 +747,6 @@ namespace System.Xml
             return (*(Int32*)&value == *(Int32*)&negativeZero);
         }
 
-        [SecuritySafeCritical]
         private static unsafe bool IsNegativeZero(double value)
         {
             // Simple equals function will report that -0 is equal to +0, so compare bits instead

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlStreamNodeWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlStreamNodeWriter.cs
@@ -5,7 +5,6 @@
 using System.IO;
 using System.Text;
 using System.Runtime.Serialization;
-using System.Security;
 using System.Threading.Tasks;
 
 namespace System.Xml
@@ -244,11 +243,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         unsafe protected void UnsafeWriteBytes(byte* bytes, int byteCount)
         {
             FlushBuffer();
@@ -268,11 +262,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe protected void WriteUTF8Char(int ch)
         {
             if (ch < 0x80)
@@ -311,11 +300,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe protected void WriteUTF8Chars(string value)
         {
             int count = value.Length;
@@ -328,11 +312,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         unsafe protected void UnsafeWriteUTF8Chars(char* chars, int charCount)
         {
             const int charChunkSize = bufferLength / maxBytesPerChar;
@@ -355,11 +334,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         unsafe protected void UnsafeWriteUnicodeChars(char* chars, int charCount)
         {
             const int charChunkSize = bufferLength / 2;
@@ -382,11 +356,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         unsafe protected int UnsafeGetUnicodeChars(char* chars, int charCount, byte[] buffer, int offset)
         {
             char* charsMax = chars + charCount;
@@ -400,11 +369,6 @@ namespace System.Xml
             return charCount * 2;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         unsafe protected int UnsafeGetUTF8Length(char* chars, int charCount)
         {
             char* charsMax = chars + charCount;
@@ -427,11 +391,6 @@ namespace System.Xml
             return (int)(chars - (charsMax - charCount)) + GetByteCount(chArray);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         unsafe protected int UnsafeGetUTF8Chars(char* chars, int charCount, byte[] buffer, int offset)
         {
             if (charCount > 0)

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextWriter.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
-using System.Security;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -436,7 +435,6 @@ namespace System.Xml
             WriteEscapedText(s.Value);
         }
 
-        [SecuritySafeCritical]
         unsafe public override void WriteEscapedText(string s)
         {
             int count = s.Length;
@@ -449,7 +447,6 @@ namespace System.Xml
             }
         }
 
-        [SecuritySafeCritical]
         unsafe public override void WriteEscapedText(char[] s, int offset, int count)
         {
             if (count > 0)
@@ -461,7 +458,6 @@ namespace System.Xml
             }
         }
 
-        [SecurityCritical]
         private unsafe void UnsafeWriteEscapedText(char* chars, int count)
         {
             bool[] isEscapedChar = (_inAttribute ? _isEscapedAttributeChar : _isEscapedElementChar);
@@ -522,7 +518,6 @@ namespace System.Xml
             WriteUTF8Chars(chars, offset, count);
         }
 
-        [SecuritySafeCritical]
         unsafe public override void WriteText(char[] chars, int offset, int count)
         {
             if (count > 0)

--- a/src/System.Reflection/tests/MethodInfoTests.cs
+++ b/src/System.Reflection/tests/MethodInfoTests.cs
@@ -685,7 +685,7 @@ namespace System.Reflection.Tests
             float single = 9.1f,
             double dbl = 11.12)
         {
-            return $"{boolean}, {str}, {character}, {unsignedbyte}, {signedbyte}, {int16}, {uint16}, {int32}, {uint32}, {int64}, {uint64}, {single}, {dbl}";
+            return FormattableString.Invariant($"{boolean}, {str}, {character}, {unsignedbyte}, {signedbyte}, {int16}, {uint16}, {int32}, {uint32}, {int64}, {uint64}, {single}, {dbl}");
         }
 
         public string String(string parameter = "test") => parameter;
@@ -719,12 +719,12 @@ namespace System.Reflection.Tests
 
         string MethodInfoDefaultParametersInterface.InterfaceMethod(int p1, string p2, decimal p3)
         {
-            return $"{p1}, {p2}, {p3}";
+            return FormattableString.Invariant($"{p1}, {p2}, {p3}");
         }
 
         public static string StaticMethod(int p1 = 1, string p2 = "test", decimal p3 = 3.14m)
         {
-            return $"{p1}, {p2}, {p3}";
+            return FormattableString.Invariant($"{p1}, {p2}, {p3}");
         }
 
         public object OptionalObjectParameter([Optional]object parameter) => parameter;

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -1461,7 +1461,7 @@ namespace System.IO
         public virtual System.Threading.Tasks.Task FlushAsync() { throw null; }
         public static System.IO.TextWriter Synchronized(System.IO.TextWriter writer) { throw null; }
         public virtual void Write(bool value) { }
-        public abstract void Write(char value);
+        public virtual void Write(char value) { }
         public virtual void Write(char[] buffer) { }
         public virtual void Write(char[] buffer, int index, int count) { }
         public virtual void Write(decimal value) { }

--- a/src/System.Runtime.Extensions/src/System/IO/TextWriter.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/TextWriter.cs
@@ -109,7 +109,9 @@ namespace System.IO
         // but descendant classes can override the method to provide the
         // appropriate functionality.
         //
-        public abstract void Write(char value);
+        public virtual void Write(char value)
+        {
+        }
 
         // Writes a character array to the text stream. This default method calls
         // Write(char) for each of the characters in the character array.

--- a/src/System.Runtime.Handles/tests/CriticalHandle.cs
+++ b/src/System.Runtime.Handles/tests/CriticalHandle.cs
@@ -38,15 +38,27 @@ public partial class CriticalHandle_4000_Tests
     public static void CriticalHandle_invalid()
     {
         MyCriticalHandle mch = new MyCriticalHandle();
-        Assert.Equal(false, mch.IsClosed);
-        Assert.Equal(true, mch.IsInvalid);
+        Assert.False(mch.IsClosed);
+        Assert.True(mch.IsInvalid);
+        Assert.False(mch.IsReleased);
+
+        mch.Dispose();
+        Assert.True(mch.IsClosed);
+        Assert.True(mch.IsInvalid);
+        Assert.False(mch.IsReleased);
     }
 
     [Fact]
     public static void CriticalHandle_valid()
     {
         MyCriticalHandle mch = new MyCriticalHandle(new IntPtr(1));
-        Assert.Equal(false, mch.IsClosed);
-        Assert.Equal(false, mch.IsInvalid);
+        Assert.False(mch.IsClosed);
+        Assert.False(mch.IsInvalid);
+        Assert.False(mch.IsReleased);
+
+        mch.Dispose();
+        Assert.True(mch.IsClosed);
+        Assert.False(mch.IsInvalid);
+        Assert.True(mch.IsReleased);
     }
 }

--- a/src/System.Runtime.Handles/tests/CriticalHandle.netstandard1.7.cs
+++ b/src/System.Runtime.Handles/tests/CriticalHandle.netstandard1.7.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+public partial class CriticalHandle_4000_Tests
+{
+    [Fact]
+    public static void CriticalHandle_invalid_close()
+    {
+        MyCriticalHandle mch = new MyCriticalHandle();
+        mch.Close();
+        Assert.True(mch.IsClosed);
+        Assert.True(mch.IsInvalid);
+        Assert.False(mch.IsReleased);
+    }
+
+    [Fact]
+    public static void CriticalHandle_valid_close()
+    {
+        MyCriticalHandle mch = new MyCriticalHandle(new IntPtr(1));
+        mch.Close();
+        Assert.True(mch.IsClosed);
+        Assert.False(mch.IsInvalid);
+        Assert.True(mch.IsReleased);
+    }
+}

--- a/src/System.Runtime.Handles/tests/SafeHandle.cs
+++ b/src/System.Runtime.Handles/tests/SafeHandle.cs
@@ -38,15 +38,27 @@ public partial class SafeHandle_4000_Tests
     public static void SafeHandle_invalid()
     {
         MySafeHandle mch = new MySafeHandle();
-        Assert.Equal(false, mch.IsClosed);
-        Assert.Equal(true, mch.IsInvalid);
+        Assert.False(mch.IsClosed);
+        Assert.True(mch.IsInvalid);
+        Assert.False(mch.IsReleased);
+
+        mch.Dispose();
+        Assert.True(mch.IsClosed);
+        Assert.True(mch.IsInvalid);
+        Assert.False(mch.IsReleased);
     }
 
     [Fact]
     public static void SafeHandle_valid()
     {
         MySafeHandle mch = new MySafeHandle(new IntPtr(1));
-        Assert.Equal(false, mch.IsClosed);
-        Assert.Equal(false, mch.IsInvalid);
+        Assert.False(mch.IsClosed);
+        Assert.False(mch.IsInvalid);
+        Assert.False(mch.IsReleased);
+
+        mch.Dispose();
+        Assert.True(mch.IsClosed);
+        Assert.False(mch.IsInvalid);
+        Assert.True(mch.IsReleased);
     }
 }

--- a/src/System.Runtime.Handles/tests/SafeHandle.netstandard1.7.cs
+++ b/src/System.Runtime.Handles/tests/SafeHandle.netstandard1.7.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+public partial class SafeHandle_4000_Tests
+{
+    [Fact]
+    public static void SafeHandle_invalid_close()
+    {
+        MySafeHandle mch = new MySafeHandle();
+        mch.Close();
+        Assert.True(mch.IsClosed);
+        Assert.True(mch.IsInvalid);
+        Assert.False(mch.IsReleased);
+    }
+
+    [Fact]
+    public static void SafeHandle_valid_close()
+    {
+        MySafeHandle mch = new MySafeHandle(new IntPtr(1));
+        mch.Close();
+        Assert.True(mch.IsClosed);
+        Assert.False(mch.IsInvalid);
+        Assert.True(mch.IsReleased);
+    }
+}

--- a/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -510,6 +510,7 @@ namespace System.Runtime.InteropServices
         public static bool AreComObjectsAvailableForCleanup() { throw null; }
         public static object BindToMoniker(string monikerName) { throw null; }
         public static void ChangeWrapperHandleStrength(object otp, bool fIsWeak) { }        
+        public static void CleanupUnusedObjectsInCurrentContext() { }
         public static void Copy(byte[] source, int startIndex, System.IntPtr destination, int length) { }
         public static void Copy(char[] source, int startIndex, System.IntPtr destination, int length) { }
         public static void Copy(double[] source, int startIndex, System.IntPtr destination, int length) { }

--- a/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -594,7 +594,8 @@ namespace System.Runtime.InteropServices
         public static System.IntPtr OffsetOf<T>(string fieldName) { throw null; }
         public static void Prelink(System.Reflection.MethodInfo m) { }
         public static void PrelinkAll(Type c) { }
-        public static string PtrToStringAuto(System.IntPtr ptr) { throw null; }        
+        public static string PtrToStringAuto(System.IntPtr ptr) { throw null; }
+        public static string PtrToStringAuto(System.IntPtr ptr, int length) { throw null; }        
         public static string PtrToStringAnsi(System.IntPtr ptr) { throw null; }
         public static string PtrToStringAnsi(System.IntPtr ptr, int len) { throw null; }
         public static string PtrToStringBSTR(System.IntPtr ptr) { throw null; }

--- a/src/System.Runtime.InteropServices/src/ApiCompatBaseline.uap101aot.txt
+++ b/src/System.Runtime.InteropServices/src/ApiCompatBaseline.uap101aot.txt
@@ -52,5 +52,6 @@ MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.PtrToStringAut
 MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.SetComObjectData(System.Object, System.Object, System.Object)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.BindToMoniker(System.String)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.ChangeWrapperHandleStrength(System.Object, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.CleanupUnusedObjectsInCurrentContext()' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Runtime.InteropServices.ProgIdAttribute' does not exist in the implementation but it does exist in the contract.
-Total Issues: 53
+Total Issues: 54

--- a/src/System.Runtime.InteropServices/src/ApiCompatBaseline.uap101aot.txt
+++ b/src/System.Runtime.InteropServices/src/ApiCompatBaseline.uap101aot.txt
@@ -48,6 +48,7 @@ MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetHINSTANCE(S
 MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetIDispatchForObject(System.Object)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetTypedObjectForIUnknown(System.IntPtr, System.Type)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.PtrToStringAuto(System.IntPtr)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.PtrToStringAuto(System.IntPtr, System.Int32)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.SetComObjectData(System.Object, System.Object, System.Object)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.BindToMoniker(System.String)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.ChangeWrapperHandleStrength(System.Object, System.Boolean)' does not exist in the implementation but it does exist in the contract.

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/MarshalTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/MarshalTests.cs
@@ -230,6 +230,22 @@ namespace System.Runtime.InteropServices
         }
 
         [Fact]
+        public static void PtrToStringAutoWithLength()
+        {
+            Assert.Throws<ArgumentNullException>(() => Marshal.PtrToStringAuto(IntPtr.Zero, 0));
+
+            String s = "Hello World";
+            int len = 5;
+            IntPtr ptr = Marshal.StringToCoTaskMemAuto(s);
+
+            
+            String s2 = Marshal.PtrToStringAuto(ptr, len);
+            Assert.Equal(s.Substring(0, len), s2);
+
+            Marshal.FreeCoTaskMem(ptr);  
+        }
+
+        [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Net46)]
         public static void SetComObjectData()
         {

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2280,6 +2280,66 @@ public static partial class DataContractJsonSerializerTests
         Assert.True(result.Equal, $"The serialization payload was not as expected.{Environment.NewLine}Expected: {expectedString}.{Environment.NewLine}Actual: {actualString}");
     }
 
+#if ReflectionOnly
+    [ActiveIssue(13699)]
+#endif
+    [Fact]
+    public static void DCJS_ExtensionDataObjectTest()
+    {
+        var p2 = new PersonV2();
+        p2.Name = "Elizabeth";
+        p2.ID = 2006;
+
+        // Serialize the PersonV2 object
+        var ser = new DataContractJsonSerializer(typeof(PersonV2));
+        var ms1 = new MemoryStream();
+        ser.WriteObject(ms1, p2);
+
+        // Verify the payload
+        ms1.Position = 0;
+        string actualOutput1 = new StreamReader(ms1).ReadToEnd();
+        string baseline1 = "{\"Name\":\"Elizabeth\",\"ID\":2006}";
+
+        try
+        {
+            Utils.CompareResult result = Utils.Compare(baseline1, actualOutput1);
+            Assert.True(result.Equal, $"{nameof(actualOutput1)} was not as expected: {Environment.NewLine}Expected: {baseline1}{Environment.NewLine}Actual: {actualOutput1}");
+        }
+        catch (Exception e)
+        {
+            Assert.True(false, $"Error occured when comparing results: {Environment.NewLine}{e.Message}{Environment.NewLine}Expected: {baseline1}{Environment.NewLine}Actual: {actualOutput1}");
+        }
+
+
+        // Deserialize the payload into a Person instance.
+        ms1.Position = 0;
+        var ser2 = new DataContractJsonSerializer(typeof(Person));
+        var p1 = (Person)ser2.ReadObject(ms1);
+
+        Assert.True(p1 != null, $"Variable {nameof(p1)} was null.");
+        Assert.True(p1.ExtensionData != null, $"{nameof(p1.ExtensionData)} was null.");
+        Assert.Equal(p2.Name, p1.Name);
+
+        // Serialize the Person instance
+        var ms2 = new MemoryStream();
+        ser2.WriteObject(ms2, p1);
+
+        // Verify the payload
+        ms2.Position = 0;
+        string actualOutput2 = new StreamReader(ms2).ReadToEnd();
+        string baseline2 = "{\"Name\":\"Elizabeth\",\"ID\":2006}";
+
+        try
+        {
+            Utils.CompareResult result2 = Utils.Compare(baseline2, actualOutput2);
+            Assert.True(result2.Equal, $"{nameof(actualOutput2)} was not as expected: {Environment.NewLine}Expected: {baseline2}{Environment.NewLine}Actual: {actualOutput2}");
+        }
+        catch(Exception e)
+        {
+            Assert.True(false, $"Error occured when comparing results: {Environment.NewLine}{e.Message}{Environment.NewLine}Expected: {baseline2}{Environment.NewLine}Actual: {actualOutput2}");
+        }
+    }
+
     private static string ConstructorWithRootNameTestHelper(TypeForRootNameTest value, DataContractJsonSerializer serializer)
     {
         using (var ms = new MemoryStream())

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2678,25 +2678,50 @@ public static partial class DataContractSerializerTests
         Assert.Equal(DateTimeOffset.MaxValue, ((DTOContainer)deserialized.Data).nDTO);
     }
 
-    [ActiveIssue(12767)]
+#if ReflectionOnly
+    [ActiveIssue(13699)]
+#endif
     [Fact]
     public static void DCS_ExtensionDataObjectTest()
     {
-        PersonV2 p2 = new PersonV2();
+        var p2 = new PersonV2();
         p2.Name = "Elizabeth";
         p2.ID = 2006;
-        DataContractSerializer ser =
-                new DataContractSerializer(typeof(PersonV2));
-        MemoryStream ms = new MemoryStream();
-        ser.WriteObject(ms, p2);
-        string actualOutput = new StreamReader(ms).ReadToEnd();
-        ms.Position = 0;
-        DataContractSerializer ser2 =
-                new DataContractSerializer(typeof(Person));
-        XmlDictionaryReader reader =
-               XmlDictionaryReader.CreateTextReader(ms, new XmlDictionaryReaderQuotas());
-        Person p1 = (Person)ser2.ReadObject(reader, false);
-        Assert.NotNull(p1.ExtensionData);
+
+        // Serialize the PersonV2 object
+        var ser = new DataContractSerializer(typeof(PersonV2));
+        var ms1 = new MemoryStream();
+        ser.WriteObject(ms1, p2);
+
+        // Verify the payload
+        ms1.Position = 0;
+        string actualOutput1 = new StreamReader(ms1).ReadToEnd();
+        string baseline1 = "<Person xmlns=\"http://www.msn.com/employees\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><Name>Elizabeth</Name><ID>2006</ID></Person>";
+
+        Utils.CompareResult result = Utils.Compare(baseline1, actualOutput1);
+        Assert.True(result.Equal, $"{nameof(actualOutput1)} was not as expected: {Environment.NewLine}Expected: {baseline1}{Environment.NewLine}Actual: {actualOutput1}");
+
+        // Deserialize the payload into a Person instance.
+        ms1.Position = 0;
+        var ser2 = new DataContractSerializer(typeof(Person));
+        XmlDictionaryReader reader = XmlDictionaryReader.CreateTextReader(ms1, new XmlDictionaryReaderQuotas());
+        var p1 = (Person)ser2.ReadObject(reader, false);
+
+        Assert.True(p1 != null, $"Variable {nameof(p1)} was null.");
+        Assert.True(p1.ExtensionData != null, $"{nameof(p1.ExtensionData)} was null.");
+        Assert.Equal(p2.Name, p1.Name);
+
+        // Serialize the Person instance
+        var ms2 = new MemoryStream();
+        ser2.WriteObject(ms2, p1);
+
+        // Verify the payload
+        ms2.Position = 0;
+        string actualOutput2 = new StreamReader(ms2).ReadToEnd();
+        string baseline2 = "<Person xmlns=\"http://www.msn.com/employees\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><Name>Elizabeth</Name><ID>2006</ID></Person>";
+
+        Utils.CompareResult result2 = Utils.Compare(baseline2, actualOutput2);
+        Assert.True(result2.Equal, $"{nameof(actualOutput2)} was not as expected: {Environment.NewLine}Expected: {baseline2}{Environment.NewLine}Actual: {actualOutput2}");
     }
 
     [Fact]
@@ -2768,7 +2793,7 @@ public static partial class DataContractSerializerTests
         value.Member4 = "44";
 
         var actual = SerializeAndDeserialize(
-            value, 
+            value,
             "<TypeWithSerializableAttributeAndNonSerializedField xmlns=\"http://schemas.datacontract.org/2004/07/\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><Member1>11</Member1><_member2>22</_member2><_member3>33</_member3></TypeWithSerializableAttributeAndNonSerializedField>",
             skipStringCompare: false);
         Assert.NotNull(actual);

--- a/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
@@ -361,30 +361,14 @@ public static class XmlDictionaryWriterTest
         if (rwType != ReaderWriterFactory.ReaderWriterType.MTOM)
         {
             // stream should be released right after WriteValue
-            if (myStreamProvider.StreamReleased)
-            {
-                Console.WriteLine("Ok, stream released right after WriteValue");
-            }
-            else
-            {
-                Console.WriteLine("Error, stream not released after WriteValue");
-                return false;
-            }
+            Assert.True(myStreamProvider.StreamReleased, "Error, stream not released after WriteValue");
         }
         writer.WriteEndElement();
 
         // stream should be released now for MTOM
         if (rwType == ReaderWriterFactory.ReaderWriterType.MTOM)
         {
-            if (myStreamProvider.StreamReleased)
-            {
-                Console.WriteLine("Ok, stream released right after WriteValue");
-            }
-            else
-            {
-                Console.WriteLine("Error, stream not released after WriteValue");
-                return false;
-            }
+            Assert.True(myStreamProvider.StreamReleased, "Error, stream not released after WriteEndElement");
         }
         writer.Flush();
         return true;
@@ -396,15 +380,7 @@ public static class XmlDictionaryWriterTest
         writer.WriteStartElement("Root");
         Task writeValueAsynctask = writer.WriteValueAsync(myStreamProvider);
         writeValueAsynctask.Wait();
-        if (myStreamProvider.StreamReleased)
-        {
-            Console.WriteLine("Ok, stream released right after AsyncWriteValue");
-        }
-        else
-        {
-            Console.WriteLine("Error, stream not released after AsyncWriteValue");
-            return false;
-        }
+        Assert.True(myStreamProvider.StreamReleased, "Error, stream not released.");
         writer.WriteEndElement();
         writer.Flush();
         return true;
@@ -416,16 +392,7 @@ public static class XmlDictionaryWriterTest
         writer.WriteStartElement("Root");
         Task writeValueBase64Asynctask = writer.WriteBase64Async(byteArray, 0, byteArray.Length);
         writeValueBase64Asynctask.Wait();
-
-        if (myStreamProvider.StreamReleased)
-        {
-            Console.WriteLine("Ok, stream released right after AsyncWriteValueBase64");
-        }
-        else
-        {
-            Console.WriteLine("Error, stream not released after AsyncWriteValueBase64");
-            return false;
-        }
+        Assert.True(myStreamProvider.StreamReleased, "Error, stream not released.");
         writer.WriteEndElement();
         writer.Flush();
         return true;

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -4711,6 +4711,7 @@ namespace System.Reflection
         protected Assembly() { }
         public virtual System.Collections.Generic.IEnumerable<System.Reflection.CustomAttributeData> CustomAttributes { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Reflection.TypeInfo> DefinedTypes { get; }
+        public virtual string EscapedCodeBase { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Type> ExportedTypes { get { throw null; } }
         public virtual MethodInfo EntryPoint { get { throw null; } }
         public virtual string FullName { get { throw null; } }
@@ -4728,6 +4729,9 @@ namespace System.Reflection
         public static bool operator !=(System.Reflection.Assembly left, System.Reflection.Assembly right) { throw null; }
         public static System.Reflection.Assembly GetAssembly(System.Type type) { throw null; }
         public static System.Reflection.Assembly GetCallingAssembly() { throw null; }
+        public virtual System.IO.FileStream GetFile(string name) { throw null; }
+        public virtual System.IO.FileStream[] GetFiles() { throw null; }
+        public virtual System.IO.FileStream[] GetFiles(bool getResourceModules) { throw null; }
         public override int GetHashCode() { throw null; }
         public virtual System.Reflection.ManifestResourceInfo GetManifestResourceInfo(string resourceName) { throw null; }
         public virtual string[] GetManifestResourceNames() { throw null; }
@@ -4749,7 +4753,7 @@ namespace System.Reflection
         public static System.Reflection.Assembly LoadFrom(String assemblyFile) { throw null; }
         public static Assembly LoadFrom(string assemblyFile, byte[] hashValue, System.Configuration.Assemblies.AssemblyHashAlgorithm hashAlgorithm) { throw null; }
         public System.Reflection.Module LoadModule(String moduleName, byte[] rawModule) { throw null; }
-        public System.Reflection.Module LoadModule(String moduleName, byte[] rawModule, byte[] rawSymbolStore) { throw null; }
+        public virtual System.Reflection.Module LoadModule(String moduleName, byte[] rawModule, byte[] rawSymbolStore) { throw null; }
         [ObsoleteAttribute("This method has been deprecated. Please use Assembly.Load() instead.")]
         public static Assembly LoadWithPartialName(string partialName) { throw null; }
         public static System.Reflection.Assembly GetEntryAssembly() { throw null; }
@@ -4885,6 +4889,7 @@ namespace System.Reflection
         public System.Reflection.AssemblyContentType ContentType { get { throw null; } set { } }
         public System.Globalization.CultureInfo CultureInfo { get { throw null; } set { } }
         public string CultureName { get { throw null; } set { } }
+        public string EscapedCodeBase { get { throw null; } }
         public System.Reflection.AssemblyNameFlags Flags { get { throw null; } set { } }
         public string FullName { get { throw null; } }
         public System.Configuration.Assemblies.AssemblyHashAlgorithm HashAlgorithm { get { throw null; } set { } }
@@ -5369,6 +5374,7 @@ namespace System.Reflection
         public bool IsStatic { get { throw null; } }
         public bool IsVirtual { get { throw null; } }
         public virtual bool IsSecurityCritical { get { throw null; } }
+        public virtual bool IsSecuritySafeCritical { get { throw null; } }
         public virtual bool IsSecurityTransparent { get { throw null; } }
         public abstract System.RuntimeMethodHandle MethodHandle { get; }
         public virtual System.Reflection.MethodImplAttributes MethodImplementationFlags { get { throw null; } }

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -3188,7 +3188,6 @@ namespace System.Runtime.ConstrainedExecution
 
 namespace System.Runtime.InteropServices
 {
-    [System.Security.SecurityCriticalAttribute]
     public abstract partial class CriticalHandle : System.Runtime.ConstrainedExecution.CriticalFinalizerObject, System.IDisposable
     {
         protected System.IntPtr handle;
@@ -3196,9 +3195,7 @@ namespace System.Runtime.InteropServices
         public bool IsClosed { get { throw null; } }
         public abstract bool IsInvalid { get; }
         public void Close() { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public void Dispose() { }
-        [System.Security.SecurityCriticalAttribute]
         protected virtual void Dispose(bool disposing) { }
         ~CriticalHandle() { }
         protected abstract bool ReleaseHandle();

--- a/src/System.Runtime/src/ApiCompatBaseline.uap101aot.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.uap101aot.txt
@@ -650,4 +650,9 @@ MembersMustExist : Member 'System.TimeZone.ToLocalTime(System.DateTime)' does no
 MembersMustExist : Member 'System.TimeZone.CurrentTimeZone.get()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.TimeZone.ToLocalTime(System.DateTime)' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Globalization.IdnMapping' does not exist in the implementation but it does exist in the contract.
-Total Issues: 651
+MembersMustExist : Member 'System.Reflection.Assembly.EscapedCodeBase.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetFile(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetFiles()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.Assembly.GetFiles(System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.AssemblyName.EscapedCodeBase.get()' does not exist in the implementation but it does exist in the contract.
+Total Issues: 656

--- a/src/System.Runtime/tests/System/DelegateTests.cs
+++ b/src/System.Runtime/tests/System/DelegateTests.cs
@@ -5,7 +5,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 using Xunit;
 
 namespace System.Tests
@@ -496,21 +495,7 @@ namespace System.Tests
             Single single,
             Double dbl)
         {
-            StringBuilder builder = new StringBuilder();
-            builder.Append(boolean.ToString() + ", ");
-            builder.Append(str + ", ");
-            builder.Append(character.ToString() + ", ");
-            builder.Append(unsignedbyte.ToString() + ", ");
-            builder.Append(signedbyte.ToString() + ", ");
-            builder.Append(int16.ToString() + ", ");
-            builder.Append(uint16.ToString() + ", ");
-            builder.Append(int32.ToString() + ", ");
-            builder.Append(uint32.ToString() + ", ");
-            builder.Append(int64.ToString() + ", ");
-            builder.Append(uint64.ToString() + ", ");
-            builder.Append(single.ToString() + ", ");
-            builder.Append(dbl);
-            return builder.ToString();
+            return FormattableString.Invariant($"{boolean}, {str}, {character}, {unsignedbyte}, {signedbyte}, {int16}, {uint16}, {int32}, {uint32}, {int64}, {uint64}, {single}, {dbl}");
         }
 
         private delegate string StringParameter(string parameter);

--- a/src/System.Runtime/tests/System/Reflection/AssemblyNameTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/AssemblyNameTests.cs
@@ -30,6 +30,20 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        public static void Verify_EscapedCodeBase()
+        {
+            AssemblyName n = new AssemblyName("MyAssemblyName");
+            Assert.Null(n.EscapedCodeBase);
+
+            n.CodeBase = @"file:///d:/temp/MyAssemblyName1.dll";
+            Assert.NotNull(n.EscapedCodeBase);
+            Assert.Equal(n.EscapedCodeBase, n.CodeBase);
+
+            n.CodeBase = @"file:///c:/program files/MyAssemblyName.dll";
+            Assert.Equal(n.EscapedCodeBase, Uri.EscapeUriString(n.CodeBase));
+        }
+
+        [Fact]
         public static void Verify_HashAlgorithm()
         {
             AssemblyName an = new AssemblyName("MyAssemblyName");

--- a/src/System.Runtime/tests/System/Reflection/AssemblyTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/AssemblyTests.cs
@@ -346,6 +346,24 @@ namespace System.Reflection.Tests
             Assert.Throws<ArgumentNullException>("assemblyFile", () => Assembly.UnsafeLoadFrom(null));
         }        
 
+        [Fact]
+        public void GetFile()
+        {
+            Assert.Throws<ArgumentNullException>(() => typeof(AssemblyTests).Assembly.GetFile(null));
+            Assert.Throws<ArgumentException>(() => typeof(AssemblyTests).Assembly.GetFile(""));
+            Assert.Null(typeof(AssemblyTests).Assembly.GetFile("NonExistentfile.dll"));
+            Assert.NotNull(typeof(AssemblyTests).Assembly.GetFile("System.Runtime.Tests.dll"));
+            Assert.Equal(typeof(AssemblyTests).Assembly.GetFile("System.Runtime.Tests.dll").Name, typeof(AssemblyTests).Assembly.Location);
+        }
+
+        [Fact]
+        public void GetFiles()
+        {
+            Assert.NotNull(typeof(AssemblyTests).Assembly.GetFiles());
+            Assert.Equal(typeof(AssemblyTests).Assembly.GetFiles().Length, 1);
+            Assert.Equal(typeof(AssemblyTests).Assembly.GetFiles()[0].Name, typeof(AssemblyTests).Assembly.Location);
+        }
+
         // Helpers
         private static Assembly GetGetCallingAssembly()
         {

--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -11,8 +11,8 @@ namespace System.Security.Cryptography
     public abstract partial class Aes : System.Security.Cryptography.SymmetricAlgorithm
     {
         protected Aes() { }
-        public static System.Security.Cryptography.Aes Create() { throw null; }
-        public static System.Security.Cryptography.Aes Create(string algorithmName) { throw null; }
+        public static new System.Security.Cryptography.Aes Create() { throw null; }
+        public static new System.Security.Cryptography.Aes Create(string algorithmName) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     public sealed partial class AesManaged : System.Security.Cryptography.Aes
@@ -88,16 +88,16 @@ namespace System.Security.Cryptography
     {
         protected DES() { }
         public override byte[] Key { get { throw null; } set { } }
-        public static System.Security.Cryptography.DES Create() { throw null; }
-        public static System.Security.Cryptography.DES Create(string algName) { throw null; }
+        public static new System.Security.Cryptography.DES Create() { throw null; }
+        public static new System.Security.Cryptography.DES Create(string algName) { throw null; }
         public static bool IsSemiWeakKey(byte[] rgbKey) { throw null; }
         public static bool IsWeakKey(byte[] rgbKey) { throw null; }
     }
     public abstract partial class DSA : System.Security.Cryptography.AsymmetricAlgorithm
     {
         protected DSA() { }
-        public static System.Security.Cryptography.DSA Create() { throw null; }
-        public static System.Security.Cryptography.DSA Create(string algName) { throw null; }
+        public static new System.Security.Cryptography.DSA Create() { throw null; }
+        public static new System.Security.Cryptography.DSA Create(string algName) { throw null; }
         public abstract byte[] CreateSignature(byte[] rgbHash);
         public abstract System.Security.Cryptography.DSAParameters ExportParameters(bool includePrivateParameters);
         protected virtual byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
@@ -202,10 +202,10 @@ namespace System.Security.Cryptography
     public abstract partial class ECDsa : System.Security.Cryptography.AsymmetricAlgorithm
     {
         protected ECDsa() { }
-        public static System.Security.Cryptography.ECDsa Create() { throw null; }
+        public static new System.Security.Cryptography.ECDsa Create() { throw null; }
         public static System.Security.Cryptography.ECDsa Create(System.Security.Cryptography.ECCurve curve) { throw null; }
         public static System.Security.Cryptography.ECDsa Create(System.Security.Cryptography.ECParameters parameters) { throw null; }
-        public static System.Security.Cryptography.ECDsa Create(string algorithm) { throw null; }
+        public static new System.Security.Cryptography.ECDsa Create(string algorithm) { throw null; }
         public virtual System.Security.Cryptography.ECParameters ExportExplicitParameters(bool includePrivateParameters) { throw null; }
         public virtual System.Security.Cryptography.ECParameters ExportParameters(bool includePrivateParameters) { throw null; }
         public virtual void GenerateKey(System.Security.Cryptography.ECCurve curve) { }
@@ -308,8 +308,8 @@ namespace System.Security.Cryptography
     public abstract partial class MD5 : System.Security.Cryptography.HashAlgorithm
     {
         protected MD5() { }
-        public static System.Security.Cryptography.MD5 Create() { throw null; }
-        public static System.Security.Cryptography.MD5 Create(string algName) { throw null; }
+        public static new System.Security.Cryptography.MD5 Create() { throw null; }
+        public static new System.Security.Cryptography.MD5 Create(string algName) { throw null; }
     }
     public abstract partial class RandomNumberGenerator : System.IDisposable
     {
@@ -329,15 +329,15 @@ namespace System.Security.Cryptography
         protected RC2() { }
         public virtual int EffectiveKeySize { get { throw null; } set { } }
         public override int KeySize { get { throw null; } set { } }
-        public static System.Security.Cryptography.RC2 Create() { throw null; }
-        public static System.Security.Cryptography.RC2 Create(string AlgName) { throw null; }
+        public static new System.Security.Cryptography.RC2 Create() { throw null; }
+        public static new System.Security.Cryptography.RC2 Create(string AlgName) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     public abstract partial class Rijndael : System.Security.Cryptography.SymmetricAlgorithm
     {
         protected Rijndael() { }
-        public static System.Security.Cryptography.Rijndael Create() { throw null; }
-        public static System.Security.Cryptography.Rijndael Create(string algName) { throw null; }
+        public static new System.Security.Cryptography.Rijndael Create() { throw null; }
+        public static new System.Security.Cryptography.Rijndael Create(string algName) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     public sealed partial class RijndaelManaged : System.Security.Cryptography.Rijndael
@@ -374,8 +374,8 @@ namespace System.Security.Cryptography
     public abstract partial class RSA : System.Security.Cryptography.AsymmetricAlgorithm
     {
         protected RSA() { }
-        public static System.Security.Cryptography.RSA Create() { throw null; }
-        public static System.Security.Cryptography.RSA Create(string algName) { throw null; }
+        public static new System.Security.Cryptography.RSA Create() { throw null; }
+        public static new System.Security.Cryptography.RSA Create(string algName) { throw null; }
         public virtual byte[] Decrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding) { throw null; }
         public virtual byte[] DecryptValue(byte[] rgb) { throw null; }
         public virtual byte[] Encrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding) { throw null; }
@@ -503,8 +503,8 @@ namespace System.Security.Cryptography
     public abstract partial class SHA1 : System.Security.Cryptography.HashAlgorithm
     {
         protected SHA1() { }
-        public static System.Security.Cryptography.SHA1 Create() { throw null; }
-        public static System.Security.Cryptography.SHA1 Create(string hashName) { throw null; }
+        public static new System.Security.Cryptography.SHA1 Create() { throw null; }
+        public static new System.Security.Cryptography.SHA1 Create(string hashName) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     public sealed partial class SHA1Managed : System.Security.Cryptography.SHA1
@@ -519,8 +519,8 @@ namespace System.Security.Cryptography
     public abstract partial class SHA256 : System.Security.Cryptography.HashAlgorithm
     {
         protected SHA256() { }
-        public static System.Security.Cryptography.SHA256 Create() { throw null; }
-        public static System.Security.Cryptography.SHA256 Create(string hashName) { throw null; }
+        public static new System.Security.Cryptography.SHA256 Create() { throw null; }
+        public static new System.Security.Cryptography.SHA256 Create(string hashName) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     public sealed partial class SHA256Managed : System.Security.Cryptography.SHA256
@@ -535,8 +535,8 @@ namespace System.Security.Cryptography
     public abstract partial class SHA384 : System.Security.Cryptography.HashAlgorithm
     {
         protected SHA384() { }
-        public static System.Security.Cryptography.SHA384 Create() { throw null; }
-        public static System.Security.Cryptography.SHA384 Create(string hashName) { throw null; }
+        public static new System.Security.Cryptography.SHA384 Create() { throw null; }
+        public static new System.Security.Cryptography.SHA384 Create(string hashName) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     public sealed partial class SHA384Managed : System.Security.Cryptography.SHA384
@@ -551,8 +551,8 @@ namespace System.Security.Cryptography
     public abstract partial class SHA512 : System.Security.Cryptography.HashAlgorithm
     {
         protected SHA512() { }
-        public static System.Security.Cryptography.SHA512 Create() { throw null; }
-        public static System.Security.Cryptography.SHA512 Create(string hashName) { throw null; }
+        public static new System.Security.Cryptography.SHA512 Create() { throw null; }
+        public static new System.Security.Cryptography.SHA512 Create(string hashName) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
     public sealed partial class SHA512Managed : System.Security.Cryptography.SHA512
@@ -570,9 +570,8 @@ namespace System.Security.Cryptography
         public override byte[] Key { get { throw null; } set { } }
         public override System.Security.Cryptography.KeySizes[] LegalBlockSizes { get { throw null; } }
         public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
-        public static System.Security.Cryptography.TripleDES Create() { throw null; }
-        public static System.Security.Cryptography.TripleDES Create(string str) { throw null; }
+        public static new System.Security.Cryptography.TripleDES Create() { throw null; }
+        public static new System.Security.Cryptography.TripleDES Create(string str) { throw null; }
         public static bool IsWeakKey(byte[] rgbKey) { throw null; }
     }
 }
-

--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.csproj
@@ -11,5 +11,9 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
+    <ProjectReference Include="..\..\System.Security.Cryptography.Primitives\ref\System.Security.Cryptography.Primitives.csproj" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Threading.Thread/ref/System.Threading.Thread.cs
+++ b/src/System.Threading.Thread/ref/System.Threading.Thread.cs
@@ -21,6 +21,15 @@ namespace System.Threading
         STA = 0,
         Unknown = 2,
     }
+    public sealed partial class CompressedStack : System.Runtime.Serialization.ISerializable
+    {
+        private CompressedStack() { }
+        public static System.Threading.CompressedStack Capture() { throw null; }
+        public System.Threading.CompressedStack CreateCopy() { throw null; }
+        public static System.Threading.CompressedStack GetCompressedStack() { throw null; }
+        public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public static void Run(System.Threading.CompressedStack compressedStack, System.Threading.ContextCallback callback, object state) { }
+    }
     [System.Runtime.InteropServices.ComVisibleAttribute(false)]
     public delegate void ParameterizedThreadStart(object obj);
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
@@ -50,11 +59,14 @@ namespace System.Threading
         public static System.LocalDataStoreSlot AllocateNamedDataSlot(string name) { throw null; }
         public static void BeginCriticalRegion() { }
         public static void BeginThreadAffinity() { }
+        public void DisableComObjectEagerCleanup() { }
         public static void EndCriticalRegion() { }
         public static void EndThreadAffinity() { }
         ~Thread() { }
         public static void FreeNamedDataSlot(string name) { }
         public System.Threading.ApartmentState GetApartmentState() { throw null; }
+        [System.ObsoleteAttribute("Thread.GetCompressedStack is no longer supported. Please use the System.Threading.CompressedStack class")]
+        public System.Threading.CompressedStack GetCompressedStack() { throw null; }
         public static object GetData(System.LocalDataStoreSlot slot) { throw null; }
         public static System.AppDomain GetDomain() { throw null; }
         public static int GetDomainID() { throw null; }
@@ -69,6 +81,8 @@ namespace System.Threading
         [System.ObsoleteAttribute("Thread.Resume has been deprecated.  Please use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.  http://go.microsoft.com/fwlink/?linkid=14202", false)]
         public void Resume() { }
         public void SetApartmentState(System.Threading.ApartmentState state) { }
+        [System.ObsoleteAttribute("Thread.SetCompressedStack is no longer supported. Please use the System.Threading.CompressedStack class")]
+        public void SetCompressedStack(System.Threading.CompressedStack stack) { }
         public static void SetData(System.LocalDataStoreSlot slot, object data) { }
         public static void Sleep(int millisecondsTimeout) { }
         public static void Sleep(System.TimeSpan timeout) { }

--- a/src/System.Threading.Thread/src/Resources/Strings.resx
+++ b/src/System.Threading.Thread/src/Resources/Strings.resx
@@ -132,4 +132,7 @@
   <data name="ArgumentOutOfRange_NeedNonnegativeNumber" xml:space="preserve">
     <value>Nonnegative number required.</value>
   </data>
+  <data name="Thread_GetSetCompressedStack_NotSupported" xml:space="preserve">
+    <value>Use CompressedStack.(Capture/Run) instead.</value>
+  </data>
 </root>

--- a/src/System.Threading.Thread/src/System.Threading.Thread.csproj
+++ b/src/System.Threading.Thread/src/System.Threading.Thread.csproj
@@ -26,6 +26,7 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net463'">
     <Compile Include="System\LocalDataStoreSlot.cs" />
+    <Compile Include="System\Threading\CompressedStack.cs" />
     <Compile Include="System\Threading\Thread.cs" />
     <Compile Include="System\Threading\Thread.Unix.cs" Condition="'$(TargetsUnix)' == 'true'" />
     <Compile Include="System\Threading\Thread.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />

--- a/src/System.Threading.Thread/src/System/Threading/CompressedStack.cs
+++ b/src/System.Threading.Thread/src/System/Threading/CompressedStack.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+
+namespace System.Threading
+{
+    [Serializable]
+    public sealed class CompressedStack : ISerializable
+    {
+        private CompressedStack()
+        {
+        }
+
+        private CompressedStack(SerializationInfo info, StreamingContext context)
+        {
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+        }
+
+        public static CompressedStack Capture()
+        {
+            return GetCompressedStack();
+        }
+
+        public CompressedStack CreateCopy()
+        {
+            return this;
+        }
+
+        public static CompressedStack GetCompressedStack()
+        {
+            return new CompressedStack();
+        }
+
+        public static void Run(CompressedStack compressedStack, ContextCallback callback, object state)
+        {
+            if (compressedStack == null)
+            {
+                throw new ArgumentNullException(nameof(compressedStack));
+            }
+
+            // The original code was not checking for a null callback and would throw NullReferenceException
+            callback(state);
+        }
+    }
+}

--- a/src/System.Threading.Thread/src/System/Threading/Thread.Unix.cs
+++ b/src/System.Threading.Thread/src/System/Threading/Thread.Unix.cs
@@ -8,19 +8,10 @@ namespace System.Threading
 {
     public sealed partial class Thread
     {
-        public ApartmentState GetApartmentState()
-        {
-            return ApartmentState.Unknown;
-        }
+        public ApartmentState GetApartmentState() => ApartmentState.Unknown;
+        private static Exception GetApartmentStateChangeFailedException() => new PlatformNotSupportedException();
+        private bool TrySetApartmentStateUnchecked(ApartmentState state) => state == GetApartmentState();
 
-        private static Exception GetApartmentStateChangeFailedException()
-        {
-            return new PlatformNotSupportedException();
-        }
-
-        private bool TrySetApartmentStateUnchecked(ApartmentState state)
-        {
-            return state == GetApartmentState();
-        }
+        public void DisableComObjectEagerCleanup() { }
     }
 }

--- a/src/System.Threading.Thread/src/System/Threading/Thread.Windows.cs
+++ b/src/System.Threading.Thread/src/System/Threading/Thread.Windows.cs
@@ -8,19 +8,11 @@ namespace System.Threading
 {
     public sealed partial class Thread
     {
-        public ApartmentState GetApartmentState()
-        {
-            return _runtimeThread.GetApartmentState();
-        }
+        public ApartmentState GetApartmentState() => _runtimeThread.GetApartmentState();
+        private static Exception GetApartmentStateChangeFailedException() =>
+            new InvalidOperationException(SR.Thread_ApartmentState_ChangeFailed);
+        private bool TrySetApartmentStateUnchecked(ApartmentState state) => _runtimeThread.TrySetApartmentState(state);
 
-        private static Exception GetApartmentStateChangeFailedException()
-        {
-            return new InvalidOperationException(SR.Thread_ApartmentState_ChangeFailed);
-        }
-
-        private bool TrySetApartmentStateUnchecked(ApartmentState state)
-        {
-            return _runtimeThread.TrySetApartmentState(state);
-        }
+        public void DisableComObjectEagerCleanup() => _runtimeThread.DisableComObjectEagerCleanup();
     }
 }

--- a/src/System.Threading.Thread/src/System/Threading/Thread.cs
+++ b/src/System.Threading.Thread/src/System/Threading/Thread.cs
@@ -277,6 +277,18 @@ namespace System.Threading
             return (int)timeoutMilliseconds;
         }
 
+        [Obsolete("Thread.GetCompressedStack is no longer supported. Please use the System.Threading.CompressedStack class")]
+        public CompressedStack GetCompressedStack()
+        {
+            throw new InvalidOperationException(SR.Thread_GetSetCompressedStack_NotSupported);
+        }
+
+        [Obsolete("Thread.SetCompressedStack is no longer supported. Please use the System.Threading.CompressedStack class")]
+        public void SetCompressedStack(CompressedStack stack)
+        {
+            throw new InvalidOperationException(SR.Thread_GetSetCompressedStack_NotSupported);
+        }
+
 #if !NETNATIVE
         public static AppDomain GetDomain() => AppDomain.CurrentDomain;
         public static int GetDomainID() => GetDomain().Id;

--- a/src/System.Threading.Thread/tests/CompressedStackTests.cs
+++ b/src/System.Threading.Thread/tests/CompressedStackTests.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using Xunit;
+
+namespace System.Threading.Tests
+{
+    public static class CompressedStackTests
+    {
+        [Fact]
+        public static void Capture_GetCompressedStack_CreateCopy_Test()
+        {
+            CompressedStack compressedStack = CompressedStack.Capture();
+            Assert.NotNull(compressedStack);
+            Assert.NotNull(compressedStack.CreateCopy());
+            Assert.NotNull(CompressedStack.GetCompressedStack());
+            Assert.NotNull(CompressedStack.GetCompressedStack().CreateCopy());
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // desktop framework throws ArgumentException
+        public static void RunTest_SkipOnDesktopFramework()
+        {
+            Assert.Throws<ArgumentNullException>(() => CompressedStack.Run(null, state => { }, null));
+        }
+
+        [Fact]
+        public static void RunTest()
+        {
+            CompressedStack compressedStack = CompressedStack.Capture();
+            Assert.Throws<NullReferenceException>(() => CompressedStack.Run(compressedStack, null, null));
+
+            var obj = new object();
+            Thread mainThread = Thread.CurrentThread;
+            bool callbackRan = false;
+            CompressedStack.Run(
+                compressedStack,
+                state =>
+                {
+                    Assert.Same(obj, state);
+                    Assert.Same(mainThread, Thread.CurrentThread);
+                    callbackRan = true;
+                },
+                obj);
+            Assert.True(callbackRan);
+        }
+
+        [Fact]
+        public static void SerializationTest()
+        {
+            CompressedStack compressedStack = CompressedStack.Capture();
+            Assert.Throws<ArgumentNullException>(() => compressedStack.GetObjectData(null, new StreamingContext()));
+
+            var binaryFormatter = new BinaryFormatter();
+            var memoryStream = new MemoryStream();
+            binaryFormatter.Serialize(memoryStream, compressedStack);
+            memoryStream.Close();
+            byte[] binaryData = memoryStream.ToArray();
+
+            memoryStream = new MemoryStream(binaryData);
+            compressedStack = (CompressedStack)binaryFormatter.Deserialize(memoryStream);
+            memoryStream.Close();
+        }
+    }
+}

--- a/src/System.Threading.Thread/tests/System.Threading.Thread.Tests.csproj
+++ b/src/System.Threading.Thread/tests/System.Threading.Thread.Tests.csproj
@@ -10,13 +10,15 @@
     <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="CompressedStackTests.cs" />
     <Compile Include="ExceptionTests.cs" />
     <Compile Include="ThreadExceptionEventArgsTests.cs" />
+    <Compile Include="ThreadTests.netstandard1.7.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\Threading\ThreadTestHelpers.cs">
@@ -27,11 +29,11 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <!-- Compile tests against the System.Runtime contract, but copy our local-built implementation for testing -->
     <ProjectReference Include="..\pkg\System.Threading.Thread.pkgproj">
       <OSGroup>$(InputOSGroup)</OSGroup>
     </ProjectReference>
-    <ProjectReference Include="..\..\System.Threading\tests\System.Threading.Tests.csproj" />
+    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
+    <ProjectReference Include="..\..\System.Runtime.InteropServices\pkg\System.Runtime.InteropServices.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Threading.ThreadPool/ref/System.Threading.ThreadPool.cs
+++ b/src/System.Threading.ThreadPool/ref/System.Threading.ThreadPool.cs
@@ -19,6 +19,9 @@ namespace System.Threading
         public static bool BindHandle(System.IntPtr osHandle) { throw null; }
         [System.Security.SecurityCriticalAttribute]
         public static bool BindHandle(System.Runtime.InteropServices.SafeHandle osHandle) { throw null; }
+        public static void GetAvailableThreads(out int workerThreads, out int completionPortThreads) { throw null; }
+        public static void GetMaxThreads(out int workerThreads, out int completionPortThreads) { throw null; }
+        public static void GetMinThreads(out int workerThreads, out int completionPortThreads) { throw null; }
         public static bool QueueUserWorkItem(System.Threading.WaitCallback callBack) { throw null; }
         public static bool QueueUserWorkItem(System.Threading.WaitCallback callBack, object state) { throw null; }
         public static System.Threading.RegisteredWaitHandle RegisterWaitForSingleObject(System.Threading.WaitHandle waitObject, System.Threading.WaitOrTimerCallback callBack, object state, int millisecondsTimeOutInterval, bool executeOnlyOnce) { throw null; }
@@ -26,8 +29,16 @@ namespace System.Threading
         public static System.Threading.RegisteredWaitHandle RegisterWaitForSingleObject(System.Threading.WaitHandle waitObject, System.Threading.WaitOrTimerCallback callBack, object state, System.TimeSpan timeout, bool executeOnlyOnce) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static System.Threading.RegisteredWaitHandle RegisterWaitForSingleObject(System.Threading.WaitHandle waitObject, System.Threading.WaitOrTimerCallback callBack, object state, uint millisecondsTimeOutInterval, bool executeOnlyOnce) { throw null; }
+        public static bool SetMaxThreads(int workerThreads, int completionPortThreads) { throw null; }
+        public static bool SetMinThreads(int workerThreads, int completionPortThreads) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe static bool UnsafeQueueNativeOverlapped(System.Threading.NativeOverlapped* overlapped) { throw null; }
+        public static bool UnsafeQueueUserWorkItem(System.Threading.WaitCallback callBack, object state) { throw null; }
+        public static System.Threading.RegisteredWaitHandle UnsafeRegisterWaitForSingleObject(System.Threading.WaitHandle waitObject, System.Threading.WaitOrTimerCallback callBack, object state, int millisecondsTimeOutInterval, bool executeOnlyOnce) { throw null; }
+        public static System.Threading.RegisteredWaitHandle UnsafeRegisterWaitForSingleObject(System.Threading.WaitHandle waitObject, System.Threading.WaitOrTimerCallback callBack, object state, long millisecondsTimeOutInterval, bool executeOnlyOnce) { throw null; }
+        public static System.Threading.RegisteredWaitHandle UnsafeRegisterWaitForSingleObject(System.Threading.WaitHandle waitObject, System.Threading.WaitOrTimerCallback callBack, object state, System.TimeSpan timeout, bool executeOnlyOnce) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.Threading.RegisteredWaitHandle UnsafeRegisterWaitForSingleObject(System.Threading.WaitHandle waitObject, System.Threading.WaitOrTimerCallback callBack, object state, uint millisecondsTimeOutInterval, bool executeOnlyOnce) { throw null; }
     }
     public delegate void WaitCallback(object state);
     public delegate void WaitOrTimerCallback(object state, bool timedOut);

--- a/src/System.Threading.ThreadPool/tests/System.Threading.ThreadPool.Tests.builds
+++ b/src/System.Threading.ThreadPool/tests/System.Threading.ThreadPool.Tests.builds
@@ -2,8 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Threading.Thread.Tests.csproj" />
-    <Project Include="System.Threading.Thread.Tests.csproj">
+    <Project Include="System.Threading.ThreadPool.Tests.csproj" />
+    <Project Include="System.Threading.ThreadPool.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>net463</TestTFMs>
     </Project>

--- a/src/System.Threading.ThreadPool/tests/System.Threading.ThreadPool.Tests.csproj
+++ b/src/System.Threading.ThreadPool/tests/System.Threading.ThreadPool.Tests.csproj
@@ -5,8 +5,9 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
-    <ProjectGuid>{9C77C3CA-7067-4D45-BDFE-CC62AB5C1ED5}</ProjectGuid>
-    <NugetTargetMoniker Condition="'$(TargetGroup)'==''">.NETStandard,Version=v1.7</NugetTargetMoniker>
+    <AssemblyName>System.Threading.ThreadPool.Tests</AssemblyName>
+    <ProjectGuid>{403AD1B8-6F95-4A2E-92A2-727606ABD866}</ProjectGuid>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -14,19 +15,15 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Release|AnyCPU'" />
   <ItemGroup>
-    <ProjectReference Include="..\pkg\System.Runtime.Handles.pkgproj" />
-    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
-    <ProjectReference Include="..\..\System.Runtime\pkg\System.Runtime.pkgproj" />
+    <Compile Include="ThreadPoolTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="CriticalHandle.cs" />
-    <Compile Include="SafeHandle.cs" />
-    <Compile Include="SafeWaitHandle.cs" />
-    <Compile Include="SafeWaitHandleExtensions.cs" />
+    <Compile Include="$(CommonTestPath)\System\Threading\ThreadTestHelpers.cs">
+      <Link>CommonTest\System\Threading\ThreadTestHelpers.cs</Link>
+    </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == ''">
-    <Compile Include="CriticalHandle.netstandard1.7.cs" />
-    <Compile Include="SafeHandle.netstandard1.7.cs" />
+  <ItemGroup>
+    <ProjectReference Include="..\pkg\System.Threading.ThreadPool.pkgproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -1,0 +1,262 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using System.Threading.Tests;
+using Xunit;
+
+namespace System.Threading.ThreadPools.Tests
+{
+    public static class ThreadPoolTests
+    {
+        private const int UnexpectedTimeoutMilliseconds = ThreadTestHelpers.UnexpectedTimeoutMilliseconds;
+        private const int ExpectedTimeoutMilliseconds = ThreadTestHelpers.ExpectedTimeoutMilliseconds;
+        private const int MaxPossibleThreadCount = 0x7fff;
+
+        [Fact]
+        public static void GetMinMaxThreadsTest()
+        {
+            int minw, minc;
+            ThreadPool.GetMinThreads(out minw, out minc);
+            Assert.True(minw > 0);
+            Assert.True(minc > 0);
+
+            int maxw, maxc;
+            ThreadPool.GetMaxThreads(out maxw, out maxc);
+            Assert.True(minw <= maxw);
+            Assert.True(minc <= maxc);
+        }
+
+        [Fact]
+        public static void GetAvailableThreadsTest()
+        {
+            int w, c;
+            ThreadPool.GetAvailableThreads(out w, out c);
+            Assert.True(w >= 0);
+            Assert.True(c >= 0);
+
+            int maxw, maxc;
+            ThreadPool.GetMaxThreads(out maxw, out maxc);
+            Assert.True(w <= maxw);
+            Assert.True(c <= maxc);
+        }
+
+        [Fact]
+        public static void SetMinMaxThreadsTest()
+        {
+            int minw, minc, maxw, maxc;
+            ThreadPool.GetMinThreads(out minw, out minc);
+            ThreadPool.GetMaxThreads(out maxw, out maxc);
+            Action resetThreadCounts =
+                () =>
+                {
+                    Assert.True(ThreadPool.SetMaxThreads(maxw, maxc));
+                    VerifyMaxThreads(maxw, maxc);
+                    Assert.True(ThreadPool.SetMinThreads(minw, minc));
+                    VerifyMinThreads(minw, minc);
+                };
+
+            try
+            {
+                int mint = Environment.ProcessorCount * 2;
+                int maxt = mint + 1;
+                ThreadPool.SetMinThreads(mint, mint);
+                ThreadPool.SetMaxThreads(maxt, maxt);
+
+                Assert.False(ThreadPool.SetMinThreads(maxt + 1, mint));
+                Assert.False(ThreadPool.SetMinThreads(mint, maxt + 1));
+                Assert.False(ThreadPool.SetMinThreads(MaxPossibleThreadCount, mint));
+                Assert.False(ThreadPool.SetMinThreads(mint, MaxPossibleThreadCount));
+                Assert.False(ThreadPool.SetMinThreads(MaxPossibleThreadCount + 1, mint));
+                Assert.False(ThreadPool.SetMinThreads(mint, MaxPossibleThreadCount + 1));
+                Assert.False(ThreadPool.SetMinThreads(-1, mint));
+                Assert.False(ThreadPool.SetMinThreads(mint, -1));
+
+                Assert.False(ThreadPool.SetMaxThreads(mint - 1, maxt));
+                Assert.False(ThreadPool.SetMaxThreads(maxt, mint - 1));
+
+                VerifyMinThreads(mint, mint);
+                VerifyMaxThreads(maxt, maxt);
+
+                Assert.True(ThreadPool.SetMaxThreads(MaxPossibleThreadCount, MaxPossibleThreadCount));
+                VerifyMaxThreads(MaxPossibleThreadCount, MaxPossibleThreadCount);
+                Assert.True(ThreadPool.SetMaxThreads(MaxPossibleThreadCount + 1, MaxPossibleThreadCount + 1));
+                VerifyMaxThreads(MaxPossibleThreadCount, MaxPossibleThreadCount);
+                Assert.True(ThreadPool.SetMaxThreads(-1, -1));
+                VerifyMaxThreads(MaxPossibleThreadCount, MaxPossibleThreadCount);
+
+                Assert.True(ThreadPool.SetMinThreads(MaxPossibleThreadCount, MaxPossibleThreadCount));
+                VerifyMinThreads(MaxPossibleThreadCount, MaxPossibleThreadCount);
+
+                Assert.False(ThreadPool.SetMinThreads(MaxPossibleThreadCount + 1, MaxPossibleThreadCount));
+                Assert.False(ThreadPool.SetMinThreads(MaxPossibleThreadCount, MaxPossibleThreadCount + 1));
+                Assert.False(ThreadPool.SetMinThreads(-1, MaxPossibleThreadCount));
+                Assert.False(ThreadPool.SetMinThreads(MaxPossibleThreadCount, -1));
+                VerifyMinThreads(MaxPossibleThreadCount, MaxPossibleThreadCount);
+
+                Assert.True(ThreadPool.SetMinThreads(0, 0));
+                VerifyMinThreads(0, 0);
+                Assert.True(ThreadPool.SetMaxThreads(0, 0));
+                VerifyMaxThreads(0, 0);
+            }
+            finally
+            {
+                resetThreadCounts();
+            }
+        }
+
+        private static void VerifyMinThreads(int expectedMinw, int expectedMinc)
+        {
+            int minw, minc;
+            ThreadPool.GetMinThreads(out minw, out minc);
+            Assert.Equal(expectedMinw, minw);
+            Assert.Equal(expectedMinc, minc);
+        }
+
+        private static void VerifyMaxThreads(int expectedMaxw, int expectedMaxc)
+        {
+            int maxw, maxc;
+            ThreadPool.GetMaxThreads(out maxw, out maxc);
+            Assert.Equal(expectedMaxw, maxw);
+            Assert.Equal(expectedMaxc, maxc);
+        }
+
+        [Fact]
+        public static void QueueRegisterPositiveAndFlowTest()
+        {
+            var asyncLocal = new AsyncLocal<int>();
+            asyncLocal.Value = 1;
+
+            var obj = new object();
+            var registerWaitEvent = new AutoResetEvent(false);
+            var threadDone = new AutoResetEvent(false);
+            RegisteredWaitHandle registeredWaitHandle = null;
+            Exception backgroundEx = null;
+            int backgroundAsyncLocalValue = 0;
+
+            Action<bool, Action> commonBackgroundTest =
+                (isRegisteredWaitCallback, test) =>
+                {
+                    try
+                    {
+                        if (isRegisteredWaitCallback)
+                        {
+                            RegisteredWaitHandle toUnregister = registeredWaitHandle;
+                            registeredWaitHandle = null;
+                            Assert.True(toUnregister.Unregister(threadDone));
+                        }
+                        test();
+                        backgroundAsyncLocalValue = asyncLocal.Value;
+                    }
+                    catch (Exception ex)
+                    {
+                        backgroundEx = ex;
+                    }
+                    finally
+                    {
+                        if (!isRegisteredWaitCallback)
+                        {
+                            threadDone.Set();
+                        }
+                    }
+                };
+            Action<bool> waitForBackgroundWork =
+                isWaitForRegisteredWaitCallback =>
+                {
+                    if (isWaitForRegisteredWaitCallback)
+                    {
+                        registerWaitEvent.Set();
+                    }
+                    threadDone.CheckedWait();
+                    if (backgroundEx != null)
+                    {
+                        throw new AggregateException(backgroundEx);
+                    }
+                };
+
+            ThreadPool.QueueUserWorkItem(
+                state =>
+                {
+                    commonBackgroundTest(false, () =>
+                    {
+                        Assert.Same(obj, state);
+                    });
+                },
+                obj);
+            waitForBackgroundWork(false);
+            Assert.Equal(1, backgroundAsyncLocalValue);
+
+            ThreadPool.UnsafeQueueUserWorkItem(
+                state =>
+                {
+                    commonBackgroundTest(false, () =>
+                    {
+                        Assert.Same(obj, state);
+                    });
+                },
+                obj);
+            waitForBackgroundWork(false);
+            Assert.Equal(0, backgroundAsyncLocalValue);
+
+            registeredWaitHandle =
+                ThreadPool.RegisterWaitForSingleObject(
+                    registerWaitEvent,
+                    (state, timedOut) =>
+                    {
+                        commonBackgroundTest(true, () =>
+                        {
+                            Assert.Same(obj, state);
+                            Assert.False(timedOut);
+                        });
+                    },
+                    obj,
+                    UnexpectedTimeoutMilliseconds,
+                    false);
+            waitForBackgroundWork(true);
+            Assert.Equal(1, backgroundAsyncLocalValue);
+
+            registeredWaitHandle =
+                ThreadPool.UnsafeRegisterWaitForSingleObject(
+                    registerWaitEvent,
+                    (state, timedOut) =>
+                    {
+                        commonBackgroundTest(true, () =>
+                        {
+                            Assert.Same(obj, state);
+                            Assert.False(timedOut);
+                        });
+                    },
+                    obj,
+                    UnexpectedTimeoutMilliseconds,
+                    false);
+            waitForBackgroundWork(true);
+            Assert.Equal(0, backgroundAsyncLocalValue);
+        }
+
+        [Fact]
+        public static void QueueRegisterNegativeTest()
+        {
+            Assert.Throws<ArgumentNullException>(() => ThreadPool.QueueUserWorkItem(null));
+            Assert.Throws<ArgumentNullException>(() => ThreadPool.UnsafeQueueUserWorkItem(null, null));
+
+            WaitHandle waitHandle = new ManualResetEvent(true);
+            WaitOrTimerCallback callback = (state, timedOut) => { };
+            Assert.Throws<ArgumentNullException>(() => ThreadPool.RegisterWaitForSingleObject(null, callback, null, 0, true));
+            Assert.Throws<ArgumentNullException>(() => ThreadPool.RegisterWaitForSingleObject(waitHandle, null, null, 0, true));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                ThreadPool.RegisterWaitForSingleObject(waitHandle, callback, null, -2, true));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                ThreadPool.RegisterWaitForSingleObject(waitHandle, callback, null, (long)-2, true));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                ThreadPool.RegisterWaitForSingleObject(waitHandle, callback, null, TimeSpan.FromMilliseconds(-2), true));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                ThreadPool.RegisterWaitForSingleObject(
+                    waitHandle,
+                    callback,
+                    null,
+                    TimeSpan.FromMilliseconds((double)int.MaxValue + 1),
+                    true));
+        }
+    }
+}

--- a/src/System.Threading/ref/System.Threading.cs
+++ b/src/System.Threading/ref/System.Threading.cs
@@ -20,6 +20,16 @@ namespace System.Threading
         public System.Threading.Mutex Mutex { get { throw null; } }
         public int MutexIndex { get { throw null; } }
     }
+    public partial struct AsyncFlowControl : System.IDisposable
+    {
+        public void Dispose() { }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Threading.AsyncFlowControl obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Threading.AsyncFlowControl a, System.Threading.AsyncFlowControl b) { throw null; }
+        public static bool operator !=(System.Threading.AsyncFlowControl a, System.Threading.AsyncFlowControl b) { throw null; }
+        public void Undo() { }
+    }
     public sealed partial class AsyncLocal<T>
     {
         public AsyncLocal() { }
@@ -110,12 +120,33 @@ namespace System.Threading
         [System.Security.SecurityCriticalAttribute]
         public static bool TryOpenExisting(string name, out System.Threading.EventWaitHandle result) { throw null; }
     }
-    public sealed partial class ExecutionContext
+    public sealed partial class ExecutionContext : System.IDisposable, System.Runtime.Serialization.ISerializable
     {
-        internal ExecutionContext() { }
+        private ExecutionContext() { }
         public static System.Threading.ExecutionContext Capture() { throw null; }
-        [System.Security.SecurityCriticalAttribute]
+        public System.Threading.ExecutionContext CreateCopy() { throw null; }
+        public void Dispose() { }
+        public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public static bool IsFlowSuppressed() { throw null; }
+        public static void RestoreFlow() { }
         public static void Run(System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, object state) { }
+        public static System.Threading.AsyncFlowControl SuppressFlow() { throw null; }
+    }
+    public partial class HostExecutionContext : System.IDisposable
+    {
+        public HostExecutionContext() { }
+        public HostExecutionContext(object state) { }
+        protected internal object State { get { throw null; } set { } }
+        public virtual System.Threading.HostExecutionContext CreateCopy() { throw null; }
+        public void Dispose() { }
+        public virtual void Dispose(bool disposing) { }
+    }
+    public partial class HostExecutionContextManager
+    {
+        public HostExecutionContextManager() { }
+        public virtual System.Threading.HostExecutionContext Capture() { throw null; }
+        public virtual void Revert(object previousState) { }
+        public virtual object SetHostExecutionContext(System.Threading.HostExecutionContext hostExecutionContext) { throw null; }
     }
     public static partial class Interlocked
     {
@@ -346,12 +377,19 @@ namespace System.Threading
         public SynchronizationContext() { }
         public static System.Threading.SynchronizationContext Current { get { throw null; } }
         public virtual System.Threading.SynchronizationContext CreateCopy() { throw null; }
+        public bool IsWaitNotificationRequired() { throw null; }
         public virtual void OperationCompleted() { }
         public virtual void OperationStarted() { }
         public virtual void Post(System.Threading.SendOrPostCallback d, object state) { }
         public virtual void Send(System.Threading.SendOrPostCallback d, object state) { }
-        [System.Security.SecurityCriticalAttribute]
         public static void SetSynchronizationContext(System.Threading.SynchronizationContext syncContext) { }
+        protected void SetWaitNotificationRequired() { }
+        [System.CLSCompliantAttribute(false)]
+        [System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute]
+        public virtual int Wait(System.IntPtr[] waitHandles, bool waitAll, int millisecondsTimeout) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        [System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute]
+        protected static int WaitHelper(System.IntPtr[] waitHandles, bool waitAll, int millisecondsTimeout) { throw null; }
     }
     public partial class SynchronizationLockException : System.SystemException
     {

--- a/src/System.Threading/src/Resources/Strings.resx
+++ b/src/System.Threading/src/Resources/Strings.resx
@@ -219,4 +219,13 @@
   <data name="ReaderWriterLock_RestoreLockWithOwnedLocks" xml:space="preserve">
     <value>ReaderWriterLock.RestoreLock was called without releasing all locks acquired since the call to ReleaseLock.</value>
   </data>
+  <data name="HostExecutionContextManager_InvalidOperation_NotNewCaptureContext" xml:space="preserve">
+    <value>Cannot apply a context that has been marshaled across AppDomains, that was not acquired through a Capture operation or that has already been the argument to a Set call.</value>
+  </data>
+  <data name="HostExecutionContextManager_InvalidOperation_CannotOverrideSetWithoutRevert" xml:space="preserve">
+    <value>Must override both HostExecutionContextManager.SetHostExecutionContext and HostExecutionContextManager.Revert.</value>
+  </data>
+  <data name="HostExecutionContextManager_InvalidOperation_CannotUseSwitcherOtherThread" xml:space="preserve">
+    <value>Undo operation must be performed on the thread where the corresponding context was Set.</value>
+  </data>
 </root>

--- a/src/System.Threading/src/System.Threading.csproj
+++ b/src/System.Threading/src/System.Threading.csproj
@@ -24,6 +24,8 @@
     <Compile Include="System\Threading\ReaderWriterLockSlim.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net463'">
+    <Compile Include="System\Threading\HostExecutionContext.cs" />
+    <Compile Include="System\Threading\HostExecutionContextManager.cs" />
     <Compile Include="System\Threading\LockCookie.cs" />
     <Compile Include="System\Threading\ReaderWriterLock.cs" />
   </ItemGroup>

--- a/src/System.Threading/src/System/Threading/HostExecutionContext.cs
+++ b/src/System.Threading/src/System/Threading/HostExecutionContext.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Threading
+{
+    public class HostExecutionContext : IDisposable
+    {
+        public HostExecutionContext()
+        {
+        }
+
+        public HostExecutionContext(object state)
+        {
+            State = state;
+        }
+
+        protected internal object State
+        {
+            get;
+            set;
+        }
+
+        public virtual HostExecutionContext CreateCopy()
+        {
+            return new HostExecutionContext(State);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        public virtual void Dispose(bool disposing)
+        {
+        }
+    }
+}

--- a/src/System.Threading/src/System/Threading/HostExecutionContextManager.cs
+++ b/src/System.Threading/src/System/Threading/HostExecutionContextManager.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Threading
+{
+    public class HostExecutionContextManager
+    {
+        /// <summary>
+        /// Normally, the current <see cref="HostExecutionContext"/> would be stored on the <see cref="ExecutionContext"/>.
+        /// Since this feature is not fully hooked up, this class just immitates the behavior of the desktop framework, while
+        /// separating itself from the <see cref="ExecutionContext"/> to minimize unnecessary additions there.
+        /// </summary>
+        [ThreadStatic]
+        private static HostExecutionContext t_currentContext;
+
+        public virtual HostExecutionContext Capture()
+        {
+            // Not hosted, so always capture null
+            return null;
+        }
+
+        public virtual object SetHostExecutionContext(HostExecutionContext hostExecutionContext)
+        {
+            if (hostExecutionContext == null)
+            {
+                throw new InvalidOperationException(SR.HostExecutionContextManager_InvalidOperation_NotNewCaptureContext);
+            }
+
+            var switcher = new HostExecutionContextSwitcher(hostExecutionContext);
+            t_currentContext = hostExecutionContext;
+            return switcher;
+        }
+
+        public virtual void Revert(object previousState)
+        {
+            var switcher = previousState as HostExecutionContextSwitcher;
+            if (switcher == null)
+            {
+                throw new InvalidOperationException(
+                    SR.HostExecutionContextManager_InvalidOperation_CannotOverrideSetWithoutRevert);
+            }
+
+            if (t_currentContext != switcher._currentContext || switcher._asyncLocal == null || !switcher._asyncLocal.Value)
+            {
+                throw new InvalidOperationException(
+                    SR.HostExecutionContextManager_InvalidOperation_CannotUseSwitcherOtherThread);
+            }
+            switcher._asyncLocal = null; // cannot be reused
+
+            // Revert always reverts to a null host execution context when not hosted
+            t_currentContext = null;
+        }
+
+        private sealed class HostExecutionContextSwitcher
+        {
+            public readonly HostExecutionContext _currentContext;
+            public AsyncLocal<bool> _asyncLocal;
+
+            public HostExecutionContextSwitcher(HostExecutionContext currentContext)
+            {
+                _currentContext = currentContext;
+
+                // Tie this instance with the current execution context for Revert validation (it must fail if an incompatible
+                // execution context is applied to the thread)
+                _asyncLocal = new AsyncLocal<bool>();
+                _asyncLocal.Value = true;
+            }
+        }
+    }
+}

--- a/src/System.Threading/tests/ExecutionContextTests.netstandard1.7.cs
+++ b/src/System.Threading/tests/ExecutionContextTests.netstandard1.7.cs
@@ -1,0 +1,293 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using Xunit;
+
+namespace System.Threading.Tests
+{
+    public static class ExecutionContextTests
+    {
+        [Fact]
+        public static void CreateCopyTest()
+        {
+            ThreadTestHelpers.RunTestInBackgroundThread(() =>
+            {
+                var asyncLocal = new AsyncLocal<int>();
+                ExecutionContext executionContext = ExecutionContext.Capture();
+                VerifyExecutionContext(executionContext, asyncLocal, 0);
+                executionContext = ExecutionContext.Capture();
+                ExecutionContext executionContextCopy0 = executionContext.CreateCopy();
+                asyncLocal.Value = 1;
+                executionContext = ExecutionContext.Capture();
+                VerifyExecutionContext(executionContext, asyncLocal, 1);
+                VerifyExecutionContext(executionContextCopy0, asyncLocal, 0);
+                executionContext = ExecutionContext.Capture();
+                ExecutionContext executionContextCopy1 = executionContext.CreateCopy();
+                VerifyExecutionContext(executionContextCopy1, asyncLocal, 1);
+            });
+        }
+
+        [Fact]
+        public static void DisposeTest()
+        {
+            ExecutionContext executionContext = ExecutionContext.Capture();
+            executionContext.CreateCopy().Dispose();
+            executionContext.CreateCopy().Dispose();
+        }
+
+        [Fact]
+        public static void SerializationTest()
+        {
+            ThreadTestHelpers.RunTestInBackgroundThread(() =>
+            {
+                var asyncLocal = new AsyncLocal<int>();
+                asyncLocal.Value = 1;
+                ExecutionContext executionContext = ExecutionContext.Capture();
+                VerifyExecutionContext(executionContext, asyncLocal, 1);
+
+                Assert.Throws<ArgumentNullException>(() => executionContext.GetObjectData(null, new StreamingContext()));
+
+                var binaryFormatter = new BinaryFormatter();
+                var memoryStream = new MemoryStream();
+                binaryFormatter.Serialize(memoryStream, executionContext);
+                memoryStream.Close();
+                byte[] binaryData = memoryStream.ToArray();
+
+                memoryStream = new MemoryStream(binaryData);
+                executionContext = (ExecutionContext)binaryFormatter.Deserialize(memoryStream);
+                memoryStream.Close();
+            });
+        }
+
+        [Fact]
+        public static void FlowTest()
+        {
+            ThreadTestHelpers.RunTestInBackgroundThread(() =>
+            {
+                var asyncLocal = new AsyncLocal<int>();
+                asyncLocal.Value = 1;
+
+                var asyncFlowControl = default(AsyncFlowControl);
+                Action<Action, Action> verifySuppressRestore =
+                    (suppressFlow, restoreFlow) =>
+                    {
+                        VerifyExecutionContextFlow(asyncLocal, 1);
+                        ExecutionContext executionContext2 = ExecutionContext.Capture();
+
+                        suppressFlow();
+                        VerifyExecutionContextFlow(asyncLocal, 0);
+                        VerifyExecutionContext(executionContext2, asyncLocal, 1);
+                        executionContext2 = ExecutionContext.Capture();
+
+                        restoreFlow();
+                        VerifyExecutionContextFlow(asyncLocal, 1);
+                        VerifyExecutionContext(executionContext2, asyncLocal, 0);
+                    };
+
+                verifySuppressRestore(
+                    () => asyncFlowControl = ExecutionContext.SuppressFlow(),
+                    () => asyncFlowControl.Undo());
+                verifySuppressRestore(
+                    () => asyncFlowControl = ExecutionContext.SuppressFlow(),
+                    () => asyncFlowControl.Dispose());
+                verifySuppressRestore(
+                    () => ExecutionContext.SuppressFlow(),
+                    () => ExecutionContext.RestoreFlow());
+
+                Assert.Throws<InvalidOperationException>(() => ExecutionContext.RestoreFlow());
+                asyncFlowControl = ExecutionContext.SuppressFlow();
+                Assert.Throws<InvalidOperationException>(() => ExecutionContext.SuppressFlow());
+
+                ThreadTestHelpers.RunTestInBackgroundThread(() =>
+                {
+                    ExecutionContext.SuppressFlow();
+                    Assert.Throws<InvalidOperationException>(() => asyncFlowControl.Undo());
+                    Assert.Throws<InvalidOperationException>(() => asyncFlowControl.Dispose());
+                    ExecutionContext.RestoreFlow();
+                });
+
+                asyncFlowControl.Undo();
+                Assert.Throws<InvalidOperationException>(() => asyncFlowControl.Undo());
+                Assert.Throws<InvalidOperationException>(() => asyncFlowControl.Dispose());
+
+                // Changing an async local value does not prevent undoing a flow-suppressed execution context. In .NET Core, the
+                // execution context is immutable, so changing an async local value changes the execution context instance,
+                // contrary to the desktop framework.
+                asyncFlowControl = ExecutionContext.SuppressFlow();
+                asyncLocal.Value = 2;
+                asyncFlowControl.Undo();
+                VerifyExecutionContextFlow(asyncLocal, 2);
+                asyncFlowControl = ExecutionContext.SuppressFlow();
+                asyncLocal.Value = 3;
+                asyncFlowControl.Dispose();
+                VerifyExecutionContextFlow(asyncLocal, 3);
+                ExecutionContext.SuppressFlow();
+                asyncLocal.Value = 4;
+                ExecutionContext.RestoreFlow();
+                VerifyExecutionContextFlow(asyncLocal, 4);
+
+                // An async flow control cannot be undone when a different execution context is applied. The desktop framework
+                // mutates the execution context when its state changes, and only changes the instance when an execution context
+                // is applied (for instance, through ExecutionContext.Run). The framework prevents a suppressed-flow execution
+                // context from being applied by returning null from ExecutionContext.Capture, so the only type of execution
+                // context that can be applied is one whose flow is not suppressed. After suppressing flow and changing an async
+                // local's value, the desktop framework verifies that a different execution context has not been applied by
+                // checking the execution context instance against the one saved from when flow was suppressed. In .NET Core,
+                // since the execution context instance will change after changing the async local's value, it verifies that a
+                // different execution context has not been applied, by instead ensuring that the current execution context's
+                // flow is suppressed.
+                {
+                    ExecutionContext executionContext = null;
+                    Action verifyCannotUndoAsyncFlowControlAfterChangingExecutionContext =
+                        () =>
+                        {
+                            ExecutionContext.Run(
+                                executionContext,
+                                state =>
+                                {
+                                    Assert.Throws<InvalidOperationException>(() => asyncFlowControl.Undo());
+                                    Assert.Throws<InvalidOperationException>(() => asyncFlowControl.Dispose());
+                                },
+                                null);
+                        };
+
+                    executionContext = ExecutionContext.Capture();
+                    asyncFlowControl = ExecutionContext.SuppressFlow();
+                    verifyCannotUndoAsyncFlowControlAfterChangingExecutionContext();
+                    asyncFlowControl.Undo();
+
+                    executionContext = ExecutionContext.Capture();
+                    asyncFlowControl = ExecutionContext.SuppressFlow();
+                    asyncLocal.Value = 5;
+                    verifyCannotUndoAsyncFlowControlAfterChangingExecutionContext();
+                    asyncFlowControl.Undo();
+                    VerifyExecutionContextFlow(asyncLocal, 5);
+                }
+            });
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // desktop framework has a bug
+        public static void CaptureThenSuppressThenRunFlowTest()
+        {
+            ThreadTestHelpers.RunTestInBackgroundThread(() =>
+            {
+                var asyncLocal = new AsyncLocal<int>();
+                asyncLocal.Value = 1;
+
+                ExecutionContext executionContext = ExecutionContext.Capture();
+                ExecutionContext.SuppressFlow();
+                ExecutionContext.Run(
+                    executionContext,
+                    state =>
+                    {
+                        Assert.Equal(1, asyncLocal.Value);
+                        VerifyExecutionContextFlow(asyncLocal, 1);
+                    },
+                    null);
+                Assert.Equal(1, asyncLocal.Value);
+                VerifyExecutionContextFlow(asyncLocal, 0);
+                ExecutionContext.RestoreFlow();
+                VerifyExecutionContextFlow(asyncLocal, 1);
+
+                executionContext = ExecutionContext.Capture();
+                asyncLocal.Value = 2;
+                ExecutionContext.SuppressFlow();
+                Assert.True(ExecutionContext.IsFlowSuppressed());
+                ExecutionContext.Run(
+                    executionContext,
+                    state =>
+                    {
+                        Assert.Equal(1, asyncLocal.Value);
+                        VerifyExecutionContextFlow(asyncLocal, 1);
+                    },
+                    null);
+                Assert.Equal(2, asyncLocal.Value);
+                VerifyExecutionContextFlow(asyncLocal, 0);
+                ExecutionContext.RestoreFlow();
+                VerifyExecutionContextFlow(asyncLocal, 2);
+            });
+        }
+
+        private static void VerifyExecutionContext(
+            ExecutionContext executionContext,
+            AsyncLocal<int> asyncLocal,
+            int expectedValue)
+        {
+            int actualValue = 0;
+            Action run = () => ExecutionContext.Run(executionContext, state => actualValue = asyncLocal.Value, null);
+            if (executionContext == null)
+            {
+                Assert.Throws<InvalidOperationException>(() => run());
+            }
+            else
+            {
+                run();
+            }
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        private static void VerifyExecutionContextFlow(AsyncLocal<int> asyncLocal, int expectedValue)
+        {
+            Assert.Equal(expectedValue == 0, ExecutionContext.IsFlowSuppressed());
+            if (ExecutionContext.IsFlowSuppressed())
+            {
+                Assert.Null(ExecutionContext.Capture());
+            }
+            VerifyExecutionContext(ExecutionContext.Capture(), asyncLocal, expectedValue);
+
+            int asyncLocalValue = -1;
+            var done = new ManualResetEvent(false);
+            ThreadPool.QueueUserWorkItem(
+                state =>
+                {
+                    asyncLocalValue = asyncLocal.Value;
+                    done.Set();
+                });
+            done.CheckedWait();
+            Assert.Equal(expectedValue, asyncLocalValue);
+        }
+
+        [Fact]
+        public static void AsyncFlowControlTest()
+        {
+            ThreadTestHelpers.RunTestInBackgroundThread(() =>
+            {
+                Action<AsyncFlowControl, AsyncFlowControl, bool> verifyEquality =
+                    (afc0, afc1, areExpectedToBeEqual) =>
+                    {
+                        Assert.Equal(areExpectedToBeEqual, afc0.Equals(afc1));
+                        Assert.Equal(areExpectedToBeEqual, afc0.Equals((object)afc1));
+                        Assert.Equal(areExpectedToBeEqual, afc0 == afc1);
+                        Assert.NotEqual(areExpectedToBeEqual, afc0 != afc1);
+                    };
+
+                AsyncFlowControl asyncFlowControl0 = ExecutionContext.SuppressFlow();
+                ExecutionContext.RestoreFlow();
+                AsyncFlowControl asyncFlowControl1 = ExecutionContext.SuppressFlow();
+                ExecutionContext.RestoreFlow();
+                verifyEquality(asyncFlowControl0, asyncFlowControl1, true);
+                verifyEquality(asyncFlowControl1, asyncFlowControl0, true);
+
+                var asyncLocal = new AsyncLocal<int>();
+                asyncLocal.Value = 1;
+                asyncFlowControl1 = ExecutionContext.SuppressFlow();
+                ExecutionContext.RestoreFlow();
+                verifyEquality(asyncFlowControl0, asyncFlowControl1, true);
+                verifyEquality(asyncFlowControl1, asyncFlowControl0, true);
+
+                asyncFlowControl1 = new AsyncFlowControl();
+                verifyEquality(asyncFlowControl0, asyncFlowControl1, false);
+                verifyEquality(asyncFlowControl1, asyncFlowControl0, false);
+
+                ThreadTestHelpers.RunTestInBackgroundThread(() => asyncFlowControl1 = ExecutionContext.SuppressFlow());
+                verifyEquality(asyncFlowControl0, asyncFlowControl1, false);
+                verifyEquality(asyncFlowControl1, asyncFlowControl0, false);
+            });
+        }
+    }
+}

--- a/src/System.Threading/tests/HostExecutionContextManagerTests.cs
+++ b/src/System.Threading/tests/HostExecutionContextManagerTests.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Threading.Tests
+{
+    public static class HostExecutionContextManagerTests
+    {
+        [Fact]
+        public static void BasicTest()
+        {
+            ThreadTestHelpers.RunTestInBackgroundThread(() =>
+            {
+                var hecm = new HostExecutionContextManager();
+                Assert.Null(hecm.Capture());
+                Assert.Throws<InvalidOperationException>(() => hecm.SetHostExecutionContext(null));
+
+                var hec0 = new HostExecutionContext();
+                var hec1 = new HostExecutionContext();
+                object previousState0 = hecm.SetHostExecutionContext(hec0);
+                ExecutionContext ec = ExecutionContext.Capture();
+                object previousState1 = hecm.SetHostExecutionContext(hec1);
+
+                Assert.Throws<InvalidOperationException>(() => hecm.Revert(null));
+                Assert.Throws<InvalidOperationException>(() => hecm.Revert(new object()));
+                Assert.Throws<InvalidOperationException>(() => hecm.Revert(previousState0));
+
+                object otherThreadState = null;
+                ThreadTestHelpers.RunTestInBackgroundThread(
+                    () => otherThreadState = hecm.SetHostExecutionContext(new HostExecutionContext()));
+                Assert.Throws<InvalidOperationException>(() => hecm.Revert(otherThreadState));
+
+                ExecutionContext.Run(
+                    ec,
+                    state => Assert.Throws<InvalidOperationException>(() => hecm.Revert(previousState1)),
+                    null);
+
+                hecm.Revert(previousState1);
+                Assert.Throws<InvalidOperationException>(() => hecm.Revert(previousState1));
+
+                // Revert always reverts to a null host execution context when it's not hosted
+                Assert.Throws<InvalidOperationException>(() => hecm.Revert(previousState0));
+            });
+        }
+    }
+}

--- a/src/System.Threading/tests/HostExecutionContextTests.cs
+++ b/src/System.Threading/tests/HostExecutionContextTests.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Threading.Tests
+{
+    public static class HostExecutionContextTests
+    {
+        [Fact]
+        public static void BasicTest()
+        {
+            var hec = new TestHostExecutionContext();
+            Assert.Null(hec.State);
+
+            var obj = new object();
+            hec = new TestHostExecutionContext(obj);
+            Assert.Same(obj, hec.State);
+
+            obj = new object();
+            hec.State = obj;
+            Assert.Same(obj, hec.State);
+            Assert.NotNull(hec.CreateCopy());
+
+            hec.State = null;
+            Assert.Null(hec.State);
+            Assert.NotNull(hec.CreateCopy());
+
+            Assert.False(hec.DisposeTrueCalled);
+            hec.Dispose();
+            Assert.True(hec.DisposeTrueCalled);
+
+            // Dispose(bool) is public
+            new HostExecutionContext().Dispose(true);
+        }
+
+        private class TestHostExecutionContext : HostExecutionContext
+        {
+            public bool DisposeTrueCalled { get; private set; }
+
+            public TestHostExecutionContext()
+            {
+            }
+
+            public TestHostExecutionContext(object state)
+                : base(state)
+            {
+            }
+
+            public new object State
+            {
+                get
+                {
+                    return base.State;
+                }
+                set
+                {
+                    base.State = value;
+                }
+            }
+
+            public override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    DisposeTrueCalled = true;
+                }
+                base.Dispose(disposing);
+            }
+        }
+    }
+}

--- a/src/System.Threading/tests/SynchronizationContextTests.netstandard1.7.cs
+++ b/src/System.Threading/tests/SynchronizationContextTests.netstandard1.7.cs
@@ -1,0 +1,143 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Threading.Tests
+{
+    public static class SynchronizationContextTests
+    {
+        [Fact]
+        public static void WaitTest()
+        {
+            var tsc = new TestSynchronizationContext();
+            Assert.Throws<ArgumentNullException>(() => tsc.Wait(null, false, 0));
+
+            var e = new ManualResetEvent(false);
+            IntPtr eventHandle = e.SafeWaitHandle.DangerousGetHandle();
+            var handles = new IntPtr[] { eventHandle, eventHandle };
+            Assert.Equal(WaitHandle.WaitTimeout, tsc.Wait(handles, false, 0));
+            Assert.Throws<DuplicateWaitObjectException>(() => tsc.Wait(handles, true, 0));
+
+            var e2 = new ManualResetEvent(false);
+            handles = new IntPtr[] { eventHandle, e2.SafeWaitHandle.DangerousGetHandle() };
+            Assert.Equal(WaitHandle.WaitTimeout, tsc.Wait(handles, false, 0));
+            Assert.Equal(WaitHandle.WaitTimeout, tsc.Wait(handles, true, 0));
+
+            e.Set();
+            Assert.Equal(0, tsc.Wait(handles, false, 0));
+            Assert.Equal(WaitHandle.WaitTimeout, tsc.Wait(handles, true, 0));
+
+            e2.Set();
+            Assert.Equal(0, tsc.Wait(handles, false, 0));
+            Assert.Equal(0, tsc.Wait(handles, true, 0));
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // desktop framework does not check for null and crashes
+        public static void WaitTest_ChangedInDotNetCore()
+        {
+            Assert.Throws<ArgumentNullException>(() => TestSynchronizationContext.WaitHelper(null, false, 0));
+        }
+
+        [Fact]
+        public static void WaitNotificationTest()
+        {
+            ThreadTestHelpers.RunTestInBackgroundThread(() =>
+            {
+                var tsc = new TestSynchronizationContext();
+                SynchronizationContext.SetSynchronizationContext(tsc);
+                Assert.Same(tsc, SynchronizationContext.Current);
+
+                var e = new ManualResetEvent(false);
+                tsc.WaitAction = () => e.Set();
+                Assert.False(tsc.IsWaitNotificationRequired());
+                Assert.False(e.WaitOne(0));
+                tsc.SetWaitNotificationRequired();
+                Assert.True(tsc.IsWaitNotificationRequired());
+                Assert.True(e.WaitOne(0));
+
+                var mres = new ManualResetEventSlim();
+                tsc.WaitAction = () => mres.Set();
+                mres.Reset();
+                mres.CheckedWait();
+
+                e.Reset();
+                tsc.WaitAction = () => e.Set();
+                SynchronizationContext.SetSynchronizationContext(new TestSynchronizationContext());
+                Assert.False(e.WaitOne(0));
+                SynchronizationContext.SetSynchronizationContext(tsc);
+                Assert.True(e.WaitOne(0));
+                e.Reset();
+                e.CheckedWait();
+
+                e.Reset();
+                var lockObj = new object();
+                var lockAcquiredFromBackground = new AutoResetEvent(false);
+                Action waitForThread;
+                Thread t =
+                    ThreadTestHelpers.CreateGuardedThread(out waitForThread, () =>
+                    {
+                        lock (lockObj)
+                        {
+                            lockAcquiredFromBackground.Set();
+                            e.CheckedWait();
+                        }
+                    });
+                t.IsBackground = true;
+                t.Start();
+                lockAcquiredFromBackground.CheckedWait();
+                Assert.True(Monitor.TryEnter(lockObj, ThreadTestHelpers.UnexpectedTimeoutMilliseconds));
+                Monitor.Exit(lockObj);
+                waitForThread();
+
+                e.Reset();
+                var m = new Mutex();
+                t = ThreadTestHelpers.CreateGuardedThread(out waitForThread, () =>
+                {
+                    m.CheckedWait();
+                    try
+                    {
+                        lockAcquiredFromBackground.Set();
+                        e.CheckedWait();
+                    }
+                    finally
+                    {
+                        m.ReleaseMutex();
+                    }
+                });
+                t.IsBackground = true;
+                t.Start();
+                lockAcquiredFromBackground.CheckedWait();
+                m.CheckedWait();
+                m.ReleaseMutex();
+                waitForThread();
+            });
+        }
+
+        private class TestSynchronizationContext : SynchronizationContext
+        {
+            public Action WaitAction { get; set; }
+
+            public new void SetWaitNotificationRequired()
+            {
+                base.SetWaitNotificationRequired();
+            }
+
+            public override int Wait(IntPtr[] waitHandles, bool waitAll, int millisecondsTimeout)
+            {
+                if (WaitAction != null)
+                {
+                    WaitAction();
+                }
+                return base.Wait(waitHandles, waitAll, millisecondsTimeout);
+            }
+
+            public static new int WaitHelper(IntPtr[] waitHandles, bool waitAll, int millisecondsTimeout)
+            {
+                return SynchronizationContext.WaitHelper(waitHandles, waitAll, millisecondsTimeout);
+            }
+        }
+    }
+}

--- a/src/System.Threading/tests/System.Threading.Tests.builds
+++ b/src/System.Threading/tests/System.Threading.Tests.builds
@@ -9,6 +9,11 @@
     </Project>
     <Project Include="System.Threading.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
+      <TestTFMs>net463</TestTFMs>
+    </Project>
+    <Project Include="System.Threading.Tests.csproj">
+      <TargetGroup>netstandard1.3</TargetGroup>
+      <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>net46</TestTFMs>
     </Project>
     <Project Include="Performance\System.Threading.Performance.Tests.csproj" />

--- a/src/System.Threading/tests/System.Threading.Tests.csproj
+++ b/src/System.Threading/tests/System.Threading.Tests.csproj
@@ -12,6 +12,12 @@
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.3_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_netstandard1.3_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_NT_netstandard1.3_Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="AsyncLocalTests.cs" />
     <Compile Include="AutoResetEventTests.cs" />
@@ -46,10 +52,14 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == ''">
+    <Compile Include="ExecutionContextTests.netstandard1.7.cs" />
+    <Compile Include="HostExecutionContextTests.cs" />
+    <Compile Include="HostExecutionContextManagerTests.cs" />
     <Compile Include="MonitorTests.netstandard1.7.cs" />
     <Compile Include="ReaderWriterLockTests.cs" />
+    <Compile Include="SynchronizationContextTests.netstandard1.7.cs" />
     <Compile Include="$(CommonTestPath)\System\Threading\ThreadTestHelpers.cs">
-      <Link>CommonTest\System\Threading\ThreadPoolHelpers.cs</Link>
+      <Link>CommonTest\System\Threading\ThreadTestHelpers.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>
@@ -57,7 +67,6 @@
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
       <Name>RemoteExecutorConsoleApp</Name>
     </ProjectReference>
-    <!-- Compile tests against the System.Runtime contract, but copy our local-built implementation for testing -->
     <ProjectReference Include="..\pkg\System.Threading.pkgproj"/>
     <ProjectReference Include="..\..\System.Diagnostics.Debug\pkg\System.Diagnostics.Debug.pkgproj" />
   </ItemGroup>


### PR DESCRIPTION
Removed usage of both [SecureSafeCritical] and [SecurityCritical] as well as removing unused references where it seemed appropriate.

@shmao 

Fix #13190