### PR TITLE
Remove [SecureSafeCritical] and [SecurityCritical] in System.Private.DataContractSerialization

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Attributes.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Attributes.cs
@@ -6,34 +6,15 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Xml;
-using System.Security;
-
 
 namespace System.Runtime.Serialization
 {
     internal class Attributes
     {
-        /// <SecurityNote>
-        /// Critical - Static field used to store the attribute names to read during deserialization.
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
-        [SecurityCritical]
         private static XmlDictionaryString[] s_serializationLocalNames;
 
-        /// <SecurityNote>
-        /// Critical - Static field used to store the attribute names to read during deserialization.
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
-        [SecurityCritical]
         private static XmlDictionaryString[] s_schemaInstanceLocalNames;
 
-        /// <SecurityNote>
-        /// Critical - initializes critical static fields
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         static Attributes()
         {
             s_serializationLocalNames = new XmlDictionaryString[]
@@ -66,7 +47,6 @@ namespace System.Runtime.Serialization
         internal string FactoryTypePrefix;
         internal bool UnrecognizedAttributesFound;
 
-        [SecuritySafeCritical]
         internal void Read(XmlReaderDelegator reader)
         {
             Reset();

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Security;
+
 namespace System.Runtime.Serialization
 {
     using System;
@@ -14,7 +16,6 @@ namespace System.Runtime.Serialization
     using System.Threading;
     using System.Xml;
     using DataContractDictionary = System.Collections.Generic.Dictionary<System.Xml.XmlQualifiedName, DataContract>;
-    using System.Security;
     using System.Linq;
 
 #if USE_REFEMIT || NET_NATIVE
@@ -23,40 +24,14 @@ namespace System.Runtime.Serialization
     internal sealed class ClassDataContract : DataContract
 #endif
     {
-        /// <SecurityNote>
-        /// Review - XmlDictionaryString(s) representing the XML namespaces for class members.
-        ///          statically cached and used from IL generated code. should ideally be Critical.
-        ///          marked SecurityRequiresReview to be callable from transparent IL generated code. 
-        ///          not changed to property to avoid regressing performance; any changes to initialization should be reviewed.
-        /// </SecurityNote>
         public XmlDictionaryString[] ContractNamespaces;
-        /// <SecurityNote>
-        /// Review - XmlDictionaryString(s) representing the XML element names for class members.
-        ///          statically cached and used from IL generated code. should ideally be Critical.
-        ///          marked SecurityRequiresReview to be callable from transparent IL generated code. 
-        ///          not changed to property to avoid regressing performance; any changes to initialization should be reviewed.
-        /// </SecurityNote>
-        public XmlDictionaryString[] MemberNames;
-        /// <SecurityNote>
-        /// Review - XmlDictionaryString(s) representing the XML namespaces for class members.
-        ///          statically cached and used when calling IL generated code. should ideally be Critical.
-        ///          marked SecurityRequiresReview to be callable from transparent code. 
-        ///          not changed to property to avoid regressing performance; any changes to initialization should be reviewed.
-        /// </SecurityNote>
-        public XmlDictionaryString[] MemberNamespaces;
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - XmlDictionaryString representing the XML namespaces for members of class.
-        ///            statically cached and used from IL generated code.
-        /// </SecurityNote>
-        private XmlDictionaryString[] _childElementNamespaces;
-        [SecurityCritical]
 
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
+        public XmlDictionaryString[] MemberNames;
+
+        public XmlDictionaryString[] MemberNamespaces;
+
+        private XmlDictionaryString[] _childElementNamespaces;
+
         private ClassDataContractCriticalHelper _helper;
 
         private bool _isScriptObject;
@@ -68,30 +43,16 @@ namespace System.Runtime.Serialization
         }
 #endif
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal ClassDataContract(Type type) : base(new ClassDataContractCriticalHelper(type))
         {
             InitClassDataContract();
         }
-        [SecuritySafeCritical]
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
         private ClassDataContract(Type type, XmlDictionaryString ns, string[] memberNames) : base(new ClassDataContractCriticalHelper(type, ns, memberNames))
         {
             InitClassDataContract();
         }
-        [SecurityCritical]
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical fields; called from all constructors
-        /// </SecurityNote>
         private void InitClassDataContract()
         {
             _helper = base.Helper as ClassDataContractCriticalHelper;
@@ -103,33 +64,16 @@ namespace System.Runtime.Serialization
 
         internal ClassDataContract BaseContract
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical baseContract property
-            /// Safe - baseContract only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
-            get
-            { return _helper.BaseContract; }
+            get { return _helper.BaseContract; }
         }
 
         internal List<DataMember> Members
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical members property
-            /// Safe - members only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
-            get
-            { return _helper.Members; }
+            get { return _helper.Members; }
         }
 
         public XmlDictionaryString[] ChildElementNamespaces
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical childElementNamespaces property
-            /// Safe - childElementNamespaces only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (_childElementNamespaces == null)
@@ -158,44 +102,24 @@ namespace System.Runtime.Serialization
 
         internal MethodInfo OnSerializing
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical onSerializing property
-            /// Safe - onSerializing only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.OnSerializing; }
         }
 
         internal MethodInfo OnSerialized
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical onSerialized property
-            /// Safe - onSerialized only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.OnSerialized; }
         }
 
         internal MethodInfo OnDeserializing
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical onDeserializing property
-            /// Safe - onDeserializing only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.OnDeserializing; }
         }
 
         internal MethodInfo OnDeserialized
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical onDeserialized property
-            /// Safe - onDeserialized only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.OnDeserialized; }
         }
@@ -208,11 +132,6 @@ namespace System.Runtime.Serialization
 #if !NET_NATIVE
         public override DataContractDictionary KnownDataContracts
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical knownDataContracts property
-            /// Safe - knownDataContracts only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.KnownDataContracts; }
         }
@@ -226,11 +145,6 @@ namespace System.Runtime.Serialization
 
         internal bool IsNonAttributedType
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical IsNonAttributedType property
-            /// Safe - IsNonAttributedType only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.IsNonAttributedType; }
         }
@@ -238,7 +152,6 @@ namespace System.Runtime.Serialization
 #if NET_NATIVE
         public bool HasDataContract
         {
-            [SecuritySafeCritical]
             get
             { return _helper.HasDataContract; }
             set { _helper.HasDataContract = value; }
@@ -246,7 +159,6 @@ namespace System.Runtime.Serialization
 #endif
         public bool HasExtensionData
         {
-            [SecuritySafeCritical]
             get
             { return _helper.HasExtensionData; }
             set { _helper.HasExtensionData = value; }
@@ -254,28 +166,24 @@ namespace System.Runtime.Serialization
 
         internal bool IsKeyValuePairAdapter
         {
-            [SecuritySafeCritical]
             get
             { return _helper.IsKeyValuePairAdapter; }
         }
 
         internal Type[] KeyValuePairGenericArguments
         {
-            [SecuritySafeCritical]
             get
             { return _helper.KeyValuePairGenericArguments; }
         }
 
         internal ConstructorInfo KeyValuePairAdapterConstructorInfo
         {
-            [SecuritySafeCritical]
             get
             { return _helper.KeyValuePairAdapterConstructorInfo; }
         }
 
         internal MethodInfo GetKeyValuePairMethodInfo
         {
-            [SecuritySafeCritical]
             get
             { return _helper.GetKeyValuePairMethodInfo; }
         }
@@ -287,11 +195,6 @@ namespace System.Runtime.Serialization
 
         private ConstructorInfo _nonAttributedTypeConstructor;
 
-        /// <SecurityNote>
-        /// Critical - fetches information about which constructor should be used to initialize non-attributed types that are valid for serialization
-        /// Safe - only needs to be protected for write
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal ConstructorInfo GetNonAttributedTypeConstructor()
         {
             if (_nonAttributedTypeConstructor == null)
@@ -346,11 +249,6 @@ namespace System.Runtime.Serialization
         internal XmlFormatClassWriterDelegate XmlFormatWriterDelegate
 #endif
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical xmlFormatWriterDelegate property
-            /// Safe - xmlFormatWriterDelegate only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
 #if NET_NATIVE
@@ -389,11 +287,6 @@ namespace System.Runtime.Serialization
         internal XmlFormatClassReaderDelegate XmlFormatReaderDelegate
 #endif
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical xmlFormatReaderDelegate property
-            /// Safe - xmlFormatReaderDelegate only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
 #if NET_NATIVE
@@ -601,12 +494,7 @@ namespace System.Runtime.Serialization
 
             return childElementNamespaces;
         }
-        [SecuritySafeCritical]
 
-        /// <SecurityNote>
-        /// Critical - calls critical method on helper
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
         private void EnsureMethodsImported()
         {
             _helper.EnsureMethodsImported();
@@ -823,12 +711,7 @@ namespace System.Runtime.Serialization
 
             return false;
         }
-        [SecurityCritical]
 
-        /// <SecurityNote>
-        /// Critical - holds all state used for (de)serializing classes.
-        ///            since the data is cached statically, we lock down access to it.
-        /// </SecurityNote>
         private class ClassDataContractCriticalHelper : DataContract.DataContractCriticalHelper
         {
             private static Type[] s_serInfoCtorArgs;
@@ -1282,13 +1165,6 @@ namespace System.Runtime.Serialization
                 }
             }
 
-            /// <SecurityNote>
-            /// Critical - sets the critical hasDataContract field
-            /// Safe - uses a trusted critical API (DataContract.GetStableName) to calculate the value
-            ///        does not accept the value from the caller
-            /// </SecurityNote>
-            //CSD16748
-            //[SecuritySafeCritical]
             private XmlQualifiedName GetStableNameAndSetHasDataContract(Type type)
             {
                 return DataContract.GetStableName(type, out _hasDataContract);
@@ -1451,7 +1327,6 @@ namespace System.Runtime.Serialization
 
             internal override DataContractDictionary KnownDataContracts
             {
-                [SecurityCritical]
                 get
                 {
                     if (_knownDataContracts != null)
@@ -1473,7 +1348,7 @@ namespace System.Runtime.Serialization
                     }
                     return _knownDataContracts;
                 }
-                [SecurityCritical]
+
                 set
                 { _knownDataContracts = value; }
             }
@@ -1616,7 +1491,6 @@ namespace System.Runtime.Serialization
 
             internal class DataMemberConflictComparer : IComparer<Member>
             {
-                [SecuritySafeCritical]
                 public int Compare(Member x, Member y)
                 {
                     int nsCompare = String.CompareOrdinal(x.ns, y.ns);
@@ -1663,7 +1537,6 @@ namespace System.Runtime.Serialization
                 return clonedHelper;
             }
         }
-
 
         internal class DataMemberComparer : IComparer<DataMember>
         {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CodeGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CodeGenerator.cs
@@ -18,19 +18,9 @@ namespace System.Runtime.Serialization
 {
     internal class CodeGenerator
     {
-        /// <SecurityNote>
-        /// Critical - Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
-        [SecurityCritical]
         private static MethodInfo s_getTypeFromHandle;
         private static MethodInfo GetTypeFromHandle
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical getTypeFromHandle field
-            /// Safe - get-only properties only needs to be protected for write; initialized in getter if null.
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (s_getTypeFromHandle == null)
@@ -42,19 +32,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
-        [SecurityCritical]
         private static MethodInfo s_objectEquals;
         private static MethodInfo ObjectEquals
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical objectEquals field
-            /// Safe - get-only properties only needs to be protected for write; initialized in getter if null.
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (s_objectEquals == null)
@@ -65,19 +45,10 @@ namespace System.Runtime.Serialization
                 return s_objectEquals;
             }
         }
-        /// <SecurityNote>
-        /// Critical - Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
-        [SecurityCritical]
+
         private static MethodInfo s_arraySetValue;
         private static MethodInfo ArraySetValue
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical arraySetValue field
-            /// Safe - get-only properties only needs to be protected for write; initialized in getter if null.
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (s_arraySetValue == null)
@@ -90,11 +61,9 @@ namespace System.Runtime.Serialization
         }
 
 #if !NET_NATIVE
-        [SecurityCritical]
         private static MethodInfo s_objectToString;
         private static MethodInfo ObjectToString
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_objectToString == null)
@@ -109,7 +78,6 @@ namespace System.Runtime.Serialization
         private static MethodInfo s_stringFormat;
         private static MethodInfo StringFormat
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_stringFormat == null)
@@ -131,19 +99,9 @@ namespace System.Runtime.Serialization
         static int typeCounter;
         MethodBuilder methodBuilder;
 #else
-        /// <SecurityNote>
-        /// Critical - Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
-        [SecurityCritical]
         private static Module s_serializationModule;
         private static Module SerializationModule
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical serializationModule field
-            /// Safe - get-only properties only needs to be protected for write; initialized in getter if null.
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (s_serializationModule == null)
@@ -197,7 +155,6 @@ namespace System.Runtime.Serialization
             BeginMethod(signature.ReturnType, methodName, paramTypes, allowPrivateMemberAccess);
             _delegateType = delegateType;
         }
-        [SecuritySafeCritical]
 
         private void BeginMethod(Type returnType, string methodName, Type[] argTypes, bool allowPrivateMemberAccess)
         {
@@ -1559,7 +1516,6 @@ namespace System.Runtime.Serialization
         }
 
 #if USE_REFEMIT
-        [SecuritySafeCritical]
         void InitAssemblyBuilder(string methodName)
         {
             AssemblyName name = new AssemblyName();

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
@@ -36,14 +36,8 @@ namespace System.Runtime.Serialization
         [DataMember(Name = "key")]
         public K Key
         {
-            get
-            {
-                return _kvpKey;
-            }
-            set
-            {
-                _kvpKey = value;
-            }
+            get { return _kvpKey; }
+            set { _kvpKey = value; }
         }
 
         [DataMember(Name = "value")]
@@ -147,85 +141,41 @@ namespace System.Runtime.Serialization
     internal sealed class CollectionDataContract : DataContract
 #endif
     {
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - XmlDictionaryString representing the XML element name for collection items.
-        ///            statically cached and used from IL generated code.
-        /// </SecurityNote>
         private XmlDictionaryString _collectionItemName;
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - XmlDictionaryString representing the XML namespace for collection items.
-        ///            statically cached and used from IL generated code.
-        /// </SecurityNote>
+        
         private XmlDictionaryString _childElementNamespace;
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - internal DataContract representing the contract for collection items.
-        ///            statically cached and used from IL generated code.
-        /// </SecurityNote>
+        
         private DataContract _itemContract;
-        [SecurityCritical]
 
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
         private CollectionDataContractCriticalHelper _helper;
 
-        [SecuritySafeCritical]
         public CollectionDataContract(CollectionKind kind) : base(new CollectionDataContractCriticalHelper(kind))
         {
             InitCollectionDataContract(this);
         }
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal CollectionDataContract(Type type) : base(new CollectionDataContractCriticalHelper(type))
         {
             InitCollectionDataContract(this);
         }
-        [SecuritySafeCritical]
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
         private CollectionDataContract(Type type, CollectionKind kind, Type itemType, MethodInfo getEnumeratorMethod, MethodInfo addMethod, ConstructorInfo constructor)
                     : base(new CollectionDataContractCriticalHelper(type, kind, itemType, getEnumeratorMethod, addMethod, constructor))
         {
             InitCollectionDataContract(GetSharedTypeContract(type));
         }
-        [SecuritySafeCritical]
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
         private CollectionDataContract(Type type, CollectionKind kind, Type itemType, MethodInfo getEnumeratorMethod, MethodInfo addMethod, ConstructorInfo constructor, bool isConstructorCheckRequired)
                     : base(new CollectionDataContractCriticalHelper(type, kind, itemType, getEnumeratorMethod, addMethod, constructor, isConstructorCheckRequired))
         {
             InitCollectionDataContract(GetSharedTypeContract(type));
         }
-        [SecuritySafeCritical]
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
         private CollectionDataContract(Type type, string invalidCollectionInSharedContractMessage) : base(new CollectionDataContractCriticalHelper(type, invalidCollectionInSharedContractMessage))
         {
             InitCollectionDataContract(GetSharedTypeContract(type));
         }
-        [SecurityCritical]
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical fields; called from all constructors
-        /// </SecurityNote>
         private void InitCollectionDataContract(DataContract sharedTypeContract)
         {
             _helper = base.Helper as CollectionDataContractCriticalHelper;
@@ -239,33 +189,18 @@ namespace System.Runtime.Serialization
 
         private static Type[] KnownInterfaces
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical knownInterfaces property
-            /// Safe - knownInterfaces only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return CollectionDataContractCriticalHelper.KnownInterfaces; }
         }
 
         internal CollectionKind Kind
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical kind property
-            /// Safe - kind only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.Kind; }
         }
 
         public Type ItemType
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical itemType property
-            /// Safe - itemType only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.ItemType; }
             set { _helper.ItemType = value; }
@@ -273,19 +208,11 @@ namespace System.Runtime.Serialization
 
         public DataContract ItemContract
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical itemContract property
-            /// Safe - itemContract only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 return _itemContract ?? _helper.ItemContract;
             }
-            /// <SecurityNote>
-            /// Critical - sets the critical itemContract property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             {
                 _itemContract = value;
@@ -295,74 +222,39 @@ namespace System.Runtime.Serialization
 
         internal DataContract SharedTypeContract
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical sharedTypeContract property
-            /// Safe - sharedTypeContract only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.SharedTypeContract; }
         }
 
         public string ItemName
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical itemName property
-            /// Safe - itemName only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.ItemName; }
-            /// <SecurityNote>
-            /// Critical - sets the critical itemName property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.ItemName = value; }
         }
 
         public XmlDictionaryString CollectionItemName
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical collectionItemName property
-            /// Safe - collectionItemName only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
-            get
-            { return _collectionItemName; }
+            get { return _collectionItemName; }
             set { _collectionItemName = value; }
         }
 
         public string KeyName
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical keyName property
-            /// Safe - keyName only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.KeyName; }
-            /// <SecurityNote>
-            /// Critical - sets the critical keyName property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.KeyName = value; }
         }
 
         public string ValueName
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical valueName property
-            /// Safe - valueName only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.ValueName; }
-            /// <SecurityNote>
-            /// Critical - sets the critical valueName property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.ValueName = value; }
         }
@@ -374,11 +266,6 @@ namespace System.Runtime.Serialization
 
         public XmlDictionaryString ChildElementNamespace
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical childElementNamespace property
-            /// Safe - childElementNamespace only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (_childElementNamespace == null)
@@ -403,78 +290,42 @@ namespace System.Runtime.Serialization
 
         internal bool IsConstructorCheckRequired
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical isConstructorCheckRequired property
-            /// Safe - isConstructorCheckRequired only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.IsConstructorCheckRequired; }
-            /// <SecurityNote>
-            /// Critical - sets the critical isConstructorCheckRequired property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.IsConstructorCheckRequired = value; }
         }
 
         internal MethodInfo GetEnumeratorMethod
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical getEnumeratorMethod property
-            /// Safe - getEnumeratorMethod only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.GetEnumeratorMethod; }
         }
 
         internal MethodInfo AddMethod
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical addMethod property
-            /// Safe - addMethod only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.AddMethod; }
         }
 
         internal ConstructorInfo Constructor
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical constructor property
-            /// Safe - constructor only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.Constructor; }
         }
 
         public override DataContractDictionary KnownDataContracts
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical knownDataContracts property
-            /// Safe - knownDataContracts only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.KnownDataContracts; }
-            /// <SecurityNote>
-            /// Critical - sets the critical knownDataContracts property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.KnownDataContracts = value; }
         }
 
         internal string InvalidCollectionInSharedContractMessage
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical invalidCollectionInSharedContractMessage property
-            /// Safe - invalidCollectionInSharedContractMessage only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.InvalidCollectionInSharedContractMessage; }
         }
@@ -486,11 +337,6 @@ namespace System.Runtime.Serialization
         internal XmlFormatCollectionWriterDelegate XmlFormatWriterDelegate
 #endif
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical xmlFormatWriterDelegate property
-            /// Safe - xmlFormatWriterDelegate only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
 #if NET_NATIVE
@@ -529,11 +375,6 @@ namespace System.Runtime.Serialization
         internal XmlFormatCollectionReaderDelegate XmlFormatReaderDelegate
 #endif
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical xmlFormatReaderDelegate property
-            /// Safe - xmlFormatReaderDelegate only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
 #if NET_NATIVE
@@ -572,11 +413,6 @@ namespace System.Runtime.Serialization
         internal XmlFormatGetOnlyCollectionReaderDelegate XmlFormatGetOnlyCollectionReaderDelegate
 #endif
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical xmlFormatReaderDelegate property
-            /// Safe - xmlFormatReaderDelegate only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
 #if NET_NATIVE
@@ -623,11 +459,6 @@ namespace System.Runtime.Serialization
             return _helper.GetEnumeratorForCollection(obj, out enumeratorReturnType);
         }
 
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds all state used for (de)serializing collections.
-        ///            since the data is cached statically, we lock down access to it.
-        /// </SecurityNote>
         private class CollectionDataContractCriticalHelper : DataContract.DataContractCriticalHelper
         {
             private static Type[] s_knownInterfaces;
@@ -858,10 +689,7 @@ namespace System.Runtime.Serialization
                 set { _valueName = value; }
             }
 
-            internal bool IsDictionary
-            {
-                get { return KeyName != null; }
-            }
+            internal bool IsDictionary => KeyName != null;
 
             public XmlDictionaryString ChildElementNamespace
             {
@@ -869,24 +697,14 @@ namespace System.Runtime.Serialization
                 set { _childElementNamespace = value; }
             }
 
-            internal MethodInfo GetEnumeratorMethod
-            {
-                get { return _getEnumeratorMethod; }
-            }
+            internal MethodInfo GetEnumeratorMethod => _getEnumeratorMethod;
 
-            internal MethodInfo AddMethod
-            {
-                get { return _addMethod; }
-            }
+            internal MethodInfo AddMethod => _addMethod;
 
-            internal ConstructorInfo Constructor
-            {
-                get { return _constructor; }
-            }
+            internal ConstructorInfo Constructor => _constructor;
 
             internal override DataContractDictionary KnownDataContracts
             {
-                [SecurityCritical]
                 get
                 {
                     if (!_isKnownTypeAttributeChecked && UnderlyingType != null)
@@ -903,20 +721,14 @@ namespace System.Runtime.Serialization
                     }
                     return _knownDataContracts;
                 }
-                [SecurityCritical]
+
                 set
                 { _knownDataContracts = value; }
             }
 
-            internal string InvalidCollectionInSharedContractMessage
-            {
-                get { return _invalidCollectionInSharedContractMessage; }
-            }
+            internal string InvalidCollectionInSharedContractMessage => _invalidCollectionInSharedContractMessage;
 
-            internal bool ItemNameSetExplicit
-            {
-                get { return _itemNameSetExplicit; }
-            }
+            internal bool ItemNameSetExplicit => _itemNameSetExplicit;
 
             internal XmlFormatCollectionWriterDelegate XmlFormatWriterDelegate
             {
@@ -1501,10 +1313,6 @@ namespace System.Runtime.Serialization
             return this;
         }
 
-        /// <SecurityNote>
-        /// Critical - sets the critical IsConstructorCheckRequired property on CollectionDataContract 
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private void CheckConstructor()
         {
             if (this.Constructor == null)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -12,7 +12,6 @@ namespace System.Runtime.Serialization
     using System.Text;
     using System.Xml;
     using DataContractDictionary = System.Collections.Generic.Dictionary<System.Xml.XmlQualifiedName, DataContract>;
-    using System.Security;
     using System.Text.RegularExpressions;
     using System.Runtime.CompilerServices;
     using System.Linq;
@@ -24,17 +23,8 @@ namespace System.Runtime.Serialization
     internal abstract class DataContract
 #endif
     {
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - XmlDictionaryString representing the type name.
-        ///            statically cached and used from IL generated code.
-        /// </SecurityNote>
         private XmlDictionaryString _name;
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - XmlDictionaryString representing the type namespace.
-        ///            statically cached and used from IL generated code.
-        /// </SecurityNote>
+
         private XmlDictionaryString _ns;
 
         // this the global dictionary for data contracts introduced for multi-file.
@@ -45,19 +35,8 @@ namespace System.Runtime.Serialization
             return s_dataContracts;
         }
 
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
         private DataContractCriticalHelper _helper;
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal DataContract(DataContractCriticalHelper helper)
         {
             _helper = helper;
@@ -136,11 +115,6 @@ namespace System.Runtime.Serialization
             return dataContract.GetValidContract(mode);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up DataContract 
-        /// Safe - read only access
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static DataContract GetDataContractSkipValidation(int id, RuntimeTypeHandle typeHandle, Type type)
         {
             return DataContractCriticalHelper.GetDataContractSkipValidation(id, typeHandle, type);
@@ -157,61 +131,31 @@ namespace System.Runtime.Serialization
             return dataContract;
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up DataContract 
-        /// Safe - read only access
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static DataContract GetGetOnlyCollectionDataContractSkipValidation(int id, RuntimeTypeHandle typeHandle, Type type)
         {
             return DataContractCriticalHelper.GetGetOnlyCollectionDataContractSkipValidation(id, typeHandle, type);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up DataContract 
-        /// Safe - read only access; doesn't modify any static information
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static DataContract GetDataContractForInitialization(int id)
         {
             return DataContractCriticalHelper.GetDataContractForInitialization(id);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up id for DataContract 
-        /// Safe - read only access; doesn't modify any static information
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static int GetIdForInitialization(ClassDataContract classContract)
         {
             return DataContractCriticalHelper.GetIdForInitialization(classContract);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up id assigned to a particular type
-        /// Safe - read only access
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static int GetId(RuntimeTypeHandle typeHandle)
         {
             return DataContractCriticalHelper.GetId(typeHandle);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up DataContract 
-        /// Safe - read only access
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         public static DataContract GetBuiltInDataContract(Type type)
         {
             return DataContractCriticalHelper.GetBuiltInDataContract(type);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up DataContract 
-        /// Safe - read only access
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         public static DataContract GetBuiltInDataContract(string name, string ns)
         {
             return DataContractCriticalHelper.GetBuiltInDataContract(name, ns);
@@ -222,31 +166,16 @@ namespace System.Runtime.Serialization
             return DataContractCriticalHelper.GetBuiltInDataContract(typeName);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up string reference to use for a namespace string
-        /// Safe - read only access
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static string GetNamespace(string key)
         {
             return DataContractCriticalHelper.GetNamespace(key);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to look up XmlDictionaryString for a string
-        /// Safe - read only access
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static XmlDictionaryString GetClrTypeString(string key)
         {
             return DataContractCriticalHelper.GetClrTypeString(key);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical static cache to remove invalid DataContract if it has been added to cache
-        /// Safe - doesn't leak any information
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static void ThrowInvalidDataContractException(string message, Type type)
         {
             DataContractCriticalHelper.ThrowInvalidDataContractException(message, type);
@@ -258,23 +187,12 @@ namespace System.Runtime.Serialization
         protected DataContractCriticalHelper Helper
 #endif
         {
-            /// <SecurityNote>
-            /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-            ///            Static fields are marked SecurityCritical or readonly to prevent
-            ///            data from being modified or leaked to other components in appdomain.
-            /// </SecurityNote>
-            [SecurityCritical]
             get
             { return _helper; }
         }
 
         public Type UnderlyingType
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical UnderlyingType property
-            /// Safe - underlyingType only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.UnderlyingType; }
             set { _helper.UnderlyingType = value; }
@@ -288,11 +206,6 @@ namespace System.Runtime.Serialization
 
         public virtual bool IsBuiltInDataContract
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical isBuiltInDataContract property
-            /// Safe - isBuiltInDataContract only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.IsBuiltInDataContract; }
             set { }
@@ -300,11 +213,6 @@ namespace System.Runtime.Serialization
 
         internal Type TypeForInitialization
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical typeForInitialization property
-            /// Safe - typeForInitialization only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.TypeForInitialization; }
         }
@@ -342,68 +250,36 @@ namespace System.Runtime.Serialization
 
         public bool IsValueType
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical isValueType property
-            /// Safe - isValueType only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.IsValueType; }
-            /// <SecurityNote>
-            /// Critical - sets the critical IsValueType property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.IsValueType = value; }
         }
 
         public bool IsReference
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical isReference property
-            /// Safe - isReference only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.IsReference; }
-            /// <SecurityNote>
-            /// Critical - sets the critical IsReference property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.IsReference = value; }
         }
 
         public XmlQualifiedName StableName
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical StableName property
-            /// Safe - StableName only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.StableName; }
-            /// <SecurityNote>
-            /// Critical - sets the critical StableName property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.StableName = value; }
         }
 
         public virtual DataContractDictionary KnownDataContracts
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical KnownDataContracts property
-            /// Safe - KnownDataContracts only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.KnownDataContracts; }
-            /// <SecurityNote>
-            /// Critical - sets the critical KnownDataContracts property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.KnownDataContracts = value; }
         }
@@ -417,11 +293,6 @@ namespace System.Runtime.Serialization
 
         public XmlDictionaryString Name
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical Name property
-            /// Safe - Name only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _name; }
             set { _name = value; }
@@ -429,11 +300,6 @@ namespace System.Runtime.Serialization
 
         public virtual XmlDictionaryString Namespace
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical Namespace property
-            /// Safe - Namespace only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _ns; }
             set { _ns = value; }
@@ -441,51 +307,27 @@ namespace System.Runtime.Serialization
 
         public virtual bool HasRoot
         {
-            /// <SecurityNote>
-            /// Critical - in case derived classes want to override and set a critical field
-            /// Safe - expectation is readonly access is safe
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return true; }
-            /// <SecurityNote>
-            /// Critical - in case derived classes want to override and set a critical field
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { }
         }
 
         public virtual XmlDictionaryString TopLevelElementName
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical Name property
-            /// Safe - Name only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.TopLevelElementName; }
-            /// <SecurityNote>
-            /// Critical - sets the critical Name property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.TopLevelElementName = value; }
         }
 
         public virtual XmlDictionaryString TopLevelElementNamespace
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical Namespace property
-            /// Safe - Namespace only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.TopLevelElementNamespace; }
-            /// <SecurityNote>
-            /// Critical - sets the critical Namespace property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.TopLevelElementNamespace = value; }
         }
@@ -529,11 +371,6 @@ namespace System.Runtime.Serialization
             return true;
         }
 
-        /// <SecurityNote>
-        /// Critical - holds all state used for (de)serializing types.
-        ///            since the data is cached statically, we lock down access to it.
-        /// </SecurityNote>
-        [SecurityCritical]
         internal class DataContractCriticalHelper
         {
             private static Dictionary<TypeHandleRef, IntRef> s_typeToIDCache = new Dictionary<TypeHandleRef, IntRef>(new TypeHandleRefEqualityComparer());
@@ -1220,12 +1057,6 @@ namespace System.Runtime.Serialization
                 get { return _typeForInitialization; }
             }
 
-            /// <SecurityNote>
-            /// Critical - sets the critical typeForInitialization field
-            /// Safe - validates input data, sets field correctly
-            /// </SecurityNote>
-            //CSD16748
-            //[SecuritySafeCritical]
             private void SetTypeForInitialization(Type classType)
             {
                 //if (classType.IsSerializable || classType.IsDefined(Globals.TypeOfDataContractAttribute, false))
@@ -1485,13 +1316,6 @@ namespace System.Runtime.Serialization
             return GetStableName(type, out hasDataContract);
         }
 
-        /// <SecurityNote>
-        /// RequiresReview - marked SRR because callers may need to depend on hasDataContract for a security decision
-        ///            hasDataContract must be calculated correctly
-        ///            GetStableName is factored into sub-methods so as to isolate the DataContractAttribute calculation and
-        ///            reduce SecurityCritical surface area
-        /// Safe - does not let caller influence hasDataContract calculation; no harm in leaking value
-        /// </SecurityNote>
         internal static XmlQualifiedName GetStableName(Type type, out bool hasDataContract)
         {
             type = UnwrapRedundantNullableType(type);
@@ -1593,11 +1417,6 @@ namespace System.Runtime.Serialization
             return stableName != null;
         }
 
-        /// <SecurityNote>
-        /// Critical - marked SecurityCritical because callers may need to base security decisions on the presence (or absence) of the DC attribute
-        /// Safe - does not let caller influence calculation and the result is not a protected value
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal static bool TryGetDCAttribute(Type type, out DataContractAttribute dataContractAttribute)
         {
             dataContractAttribute = null;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataMember.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataMember.cs
@@ -19,39 +19,18 @@ namespace System.Runtime.Serialization
     internal class DataMember
 #endif
     {
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
         private CriticalHelper _helper;
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         public DataMember()
         {
             _helper = new CriticalHelper();
         }
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal DataMember(MemberInfo memberInfo)
         {
             _helper = new CriticalHelper(memberInfo);
         }
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal DataMember(DataContract memberTypeContract, string name, bool isNullable, bool isRequired, bool emitDefaultValue, int order)
         {
             _helper = new CriticalHelper(memberTypeContract, name, isNullable, isRequired, emitDefaultValue, order);
@@ -59,81 +38,72 @@ namespace System.Runtime.Serialization
 
         internal MemberInfo MemberInfo
         {
-            [SecuritySafeCritical]
             get
             { return _helper.MemberInfo; }
         }
 
         public string Name
         {
-            [SecuritySafeCritical]
             get
             { return _helper.Name; }
-            [SecurityCritical]
+
             set
             { _helper.Name = value; }
         }
 
         public int Order
         {
-            [SecuritySafeCritical]
             get
             { return _helper.Order; }
-            [SecurityCritical]
+
             set
             { _helper.Order = value; }
         }
 
         public bool IsRequired
         {
-            [SecuritySafeCritical]
             get
             { return _helper.IsRequired; }
-            [SecurityCritical]
+            
             set
             { _helper.IsRequired = value; }
         }
 
         public bool EmitDefaultValue
         {
-            [SecuritySafeCritical]
             get
             { return _helper.EmitDefaultValue; }
-            [SecurityCritical]
+            
             set
             { _helper.EmitDefaultValue = value; }
         }
 
         public bool IsNullable
         {
-            [SecuritySafeCritical]
             get
             { return _helper.IsNullable; }
-            [SecurityCritical]
+
             set
             { _helper.IsNullable = value; }
         }
 
         public bool IsGetOnlyCollection
         {
-            [SecuritySafeCritical]
             get
             { return _helper.IsGetOnlyCollection; }
-            [SecurityCritical]
+
             set
             { _helper.IsGetOnlyCollection = value; }
         }
 
         internal Type MemberType
         {
-            [SecuritySafeCritical]
             get
             { return _helper.MemberType; }
         }
 
         internal DataContract MemberTypeContract
         {
-            [SecuritySafeCritical]
             get
             { return _helper.MemberTypeContract; }
         }
@@ -148,20 +118,18 @@ namespace System.Runtime.Serialization
 
         public bool HasConflictingNameAndType
         {
-            [SecuritySafeCritical]
             get
             { return _helper.HasConflictingNameAndType; }
-            [SecurityCritical]
+
             set
             { _helper.HasConflictingNameAndType = value; }
         }
 
         internal DataMember ConflictingMember
         {
-            [SecuritySafeCritical]
             get
             { return _helper.ConflictingMember; }
-            [SecurityCritical]
+
             set
             { _helper.ConflictingMember = value; }
         }
@@ -180,7 +148,6 @@ namespace System.Runtime.Serialization
             }
         }
 
-
         private FastInvokerBuilder.Setter _setter;
         internal FastInvokerBuilder.Setter Setter
         {
@@ -195,11 +162,6 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
-
-        /// <SecurityNote>
-        /// Critical
-        /// </SecurityNote>
         private class CriticalHelper
         {
             private DataContract _memberTypeContract;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DictionaryGlobals.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DictionaryGlobals.cs
@@ -5,16 +5,9 @@
 using System;
 using System.Xml;
 using System.Xml.Schema;
-using System.Security;
-
 
 namespace System.Runtime.Serialization
 {
-    /// <SecurityNote>
-    /// Review - Static fields are marked SecurityCritical or readonly to prevent
-    ///          data from being modified or leaked to other components in appdomain.
-    ///          changes to static fields could affect serialization/deserialization; should be reviewed.
-    /// </SecurityNote>
 #if USE_REFEMIT
     public static class DictionaryGlobals
 #else

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/EnumDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/EnumDataContract.cs
@@ -22,19 +22,8 @@ namespace System.Runtime.Serialization
     internal sealed class EnumDataContract : DataContract
 #endif
     {
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
         private EnumDataContractCriticalHelper _helper;
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         public EnumDataContract() : base(new EnumDataContractCriticalHelper())
         {
             _helper = base.Helper as EnumDataContractCriticalHelper;
@@ -42,22 +31,12 @@ namespace System.Runtime.Serialization
 
         public XmlQualifiedName BaseContractName { get; set; }
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal EnumDataContract(Type type) : base(new EnumDataContractCriticalHelper(type))
         {
             _helper = base.Helper as EnumDataContractCriticalHelper;
         }
         public List<DataMember> Members
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical Members property
-            /// Safe - Members only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.Members; }
             set { _helper.Members = value; }
@@ -65,11 +44,6 @@ namespace System.Runtime.Serialization
 
         public List<long> Values
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical Values property
-            /// Safe - Values only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.Values; }
             set { _helper.Values = value; }
@@ -77,11 +51,6 @@ namespace System.Runtime.Serialization
 
         public bool IsFlags
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical IsFlags property
-            /// Safe - IsFlags only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.IsFlags; }
             set { _helper.IsFlags = value; }
@@ -89,11 +58,6 @@ namespace System.Runtime.Serialization
 
         public bool IsULong
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical IsULong property
-            /// Safe - IsULong only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.IsULong; }
             set { _helper.IsULong = value; }
@@ -101,11 +65,6 @@ namespace System.Runtime.Serialization
 
         public XmlDictionaryString[] ChildElementNames
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical ChildElementNames property
-            /// Safe - ChildElementNames only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.ChildElementNames; }
             set { _helper.ChildElementNames = value; }
@@ -115,12 +74,7 @@ namespace System.Runtime.Serialization
         {
             get { return false; }
         }
-        [SecurityCritical]
 
-        /// <SecurityNote>
-        /// Critical - holds all state used for (de)serializing enums.
-        ///            since the data is cached statically, we lock down access to it.
-        /// </SecurityNote>
         private class EnumDataContractCriticalHelper : DataContract.DataContractCriticalHelper
         {
             private static Dictionary<Type, XmlQualifiedName> s_typeToName;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataReader.cs
@@ -4,7 +4,6 @@
 
 using System.Xml;
 using System.Collections.Generic;
-using System.Security;
 
 namespace System.Runtime.Serialization
 {
@@ -45,13 +44,10 @@ namespace System.Runtime.Serialization
         private Queue<IDataNode> _deserializedDataNodes;
         private XmlObjectSerializerReadContext _context;
 
-        [SecurityCritical]
         private static Dictionary<string, string> s_nsToPrefixTable;
 
-        [SecurityCritical]
         private static Dictionary<string, string> s_prefixToNsTable;
 
-        [SecurityCritical]
         static ExtensionDataReader()
         {
             s_nsToPrefixTable = new Dictionary<string, string>();
@@ -224,7 +220,6 @@ namespace System.Runtime.Serialization
             _attributeIndex = -1;
         }
 
-        [SecuritySafeCritical]
         public override string LookupNamespace(string prefix)
         {
             if (IsXmlDataNode)
@@ -510,7 +505,6 @@ namespace System.Runtime.Serialization
                 ? new ElementData() : _elements[nextDepth];
         }
 
-        [SecuritySafeCritical]
         internal static string GetPrefix(string ns)
         {
             string prefix;
@@ -529,7 +523,6 @@ namespace System.Runtime.Serialization
             return prefix;
         }
 
-        [SecuritySafeCritical]
         private static void AddPrefix(string prefix, string ns)
         {
             s_nsToPrefixTable.Add(ns, prefix);
@@ -589,4 +582,3 @@ namespace System.Runtime.Serialization
         }
     }
 }
-

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/GenericParameterDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/GenericParameterDataContract.cs
@@ -4,16 +4,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Security;
 
 namespace System.Runtime.Serialization
 {
     internal sealed class GenericParameterDataContract : DataContract
     {
-        [SecurityCritical]
         private GenericParameterDataContractCriticalHelper _helper;
 
-        [SecuritySafeCritical]
         internal GenericParameterDataContract(Type type)
             : base(new GenericParameterDataContractCriticalHelper(type))
         {
@@ -22,7 +19,6 @@ namespace System.Runtime.Serialization
 
         internal int ParameterPosition
         {
-            [SecuritySafeCritical]
             get
             { return _helper.ParameterPosition; }
         }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
@@ -10,19 +10,12 @@ using System.Xml.Serialization;
 using System.Reflection;
 using System.Collections;
 using System.Collections.Generic;
-using System.Security;
 using System.Linq;
 using System.Diagnostics;
 
 
 namespace System.Runtime.Serialization
 {
-    /// <SecurityNote>
-    /// Critical - Class holds static instances used in serializer. 
-    ///            Static fields are marked SecurityCritical or readonly to prevent
-    ///            data from being modified or leaked to other components in appdomain.
-    /// Safe - All get-only properties marked safe since they only need to be protected for write.
-    /// </SecurityNote>
     internal static class Globals
     {
         /// <SecurityNote>
@@ -30,11 +23,9 @@ namespace System.Runtime.Serialization
         /// </SecurityNote>
         internal const BindingFlags ScanAllMembers = BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
 
-        [SecurityCritical]
         private static XmlQualifiedName s_idQualifiedName;
         internal static XmlQualifiedName IdQualifiedName
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_idQualifiedName == null)
@@ -43,11 +34,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static XmlQualifiedName s_refQualifiedName;
         internal static XmlQualifiedName RefQualifiedName
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_refQualifiedName == null)
@@ -56,11 +45,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfObject;
         internal static Type TypeOfObject
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfObject == null)
@@ -69,11 +56,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfValueType;
         internal static Type TypeOfValueType
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfValueType == null)
@@ -82,11 +67,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfArray;
         internal static Type TypeOfArray
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfArray == null)
@@ -95,11 +78,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfException;
         internal static Type TypeOfException
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfException == null)
@@ -108,11 +89,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfString;
         internal static Type TypeOfString
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfString == null)
@@ -121,11 +100,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfInt;
         internal static Type TypeOfInt
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfInt == null)
@@ -134,11 +111,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfULong;
         internal static Type TypeOfULong
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfULong == null)
@@ -147,11 +122,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfVoid;
         internal static Type TypeOfVoid
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfVoid == null)
@@ -160,11 +133,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfByteArray;
         internal static Type TypeOfByteArray
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfByteArray == null)
@@ -173,11 +144,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfTimeSpan;
         internal static Type TypeOfTimeSpan
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfTimeSpan == null)
@@ -186,11 +155,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfGuid;
         internal static Type TypeOfGuid
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfGuid == null)
@@ -199,11 +166,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfDateTimeOffset;
         internal static Type TypeOfDateTimeOffset
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfDateTimeOffset == null)
@@ -212,11 +177,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfDateTimeOffsetAdapter;
         internal static Type TypeOfDateTimeOffsetAdapter
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfDateTimeOffsetAdapter == null)
@@ -225,11 +188,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfUri;
         internal static Type TypeOfUri
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfUri == null)
@@ -238,11 +199,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfTypeEnumerable;
         internal static Type TypeOfTypeEnumerable
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfTypeEnumerable == null)
@@ -251,11 +210,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfStreamingContext;
         internal static Type TypeOfStreamingContext
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfStreamingContext == null)
@@ -286,11 +243,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlFormatClassWriterDelegate;
         internal static Type TypeOfXmlFormatClassWriterDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlFormatClassWriterDelegate == null)
@@ -299,11 +254,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlFormatCollectionWriterDelegate;
         internal static Type TypeOfXmlFormatCollectionWriterDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlFormatCollectionWriterDelegate == null)
@@ -312,11 +265,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlFormatClassReaderDelegate;
         internal static Type TypeOfXmlFormatClassReaderDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlFormatClassReaderDelegate == null)
@@ -325,11 +276,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlFormatCollectionReaderDelegate;
         internal static Type TypeOfXmlFormatCollectionReaderDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlFormatCollectionReaderDelegate == null)
@@ -338,11 +287,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlFormatGetOnlyCollectionReaderDelegate;
         internal static Type TypeOfXmlFormatGetOnlyCollectionReaderDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlFormatGetOnlyCollectionReaderDelegate == null)
@@ -351,11 +298,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfKnownTypeAttribute;
         internal static Type TypeOfKnownTypeAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfKnownTypeAttribute == null)
@@ -364,18 +309,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - attribute type used in security decision
-        /// </SecurityNote>
-        [SecurityCritical]
         private static Type s_typeOfDataContractAttribute;
         internal static Type TypeOfDataContractAttribute
         {
-            /// <SecurityNote>
-            /// Critical - accesses critical field for attribute type
-            /// Safe - controls inputs and logic
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfDataContractAttribute == null)
@@ -384,11 +320,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfDataMemberAttribute;
         internal static Type TypeOfDataMemberAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfDataMemberAttribute == null)
@@ -397,11 +331,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfEnumMemberAttribute;
         internal static Type TypeOfEnumMemberAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfEnumMemberAttribute == null)
@@ -410,11 +342,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfCollectionDataContractAttribute;
         internal static Type TypeOfCollectionDataContractAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfCollectionDataContractAttribute == null)
@@ -437,11 +367,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfObjectArray;
         internal static Type TypeOfObjectArray
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfObjectArray == null)
@@ -450,12 +378,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-
-        [SecurityCritical]
         private static Type s_typeOfOnSerializingAttribute;
         internal static Type TypeOfOnSerializingAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfOnSerializingAttribute == null)
@@ -464,11 +389,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfOnSerializedAttribute;
         internal static Type TypeOfOnSerializedAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfOnSerializedAttribute == null)
@@ -477,11 +400,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfOnDeserializingAttribute;
         internal static Type TypeOfOnDeserializingAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfOnDeserializingAttribute == null)
@@ -490,11 +411,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfOnDeserializedAttribute;
         internal static Type TypeOfOnDeserializedAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfOnDeserializedAttribute == null)
@@ -503,12 +422,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-
-        [SecurityCritical]
         private static Type s_typeOfFlagsAttribute;
         internal static Type TypeOfFlagsAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfFlagsAttribute == null)
@@ -517,11 +433,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIXmlSerializable;
         internal static Type TypeOfIXmlSerializable
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIXmlSerializable == null)
@@ -530,11 +444,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlSchemaProviderAttribute;
         internal static Type TypeOfXmlSchemaProviderAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlSchemaProviderAttribute == null)
@@ -543,11 +455,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlRootAttribute;
         internal static Type TypeOfXmlRootAttribute
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlRootAttribute == null)
@@ -556,11 +466,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlQualifiedName;
         internal static Type TypeOfXmlQualifiedName
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlQualifiedName == null)
@@ -579,7 +487,6 @@ namespace System.Runtime.Serialization
         private static Type s_typeOfISerializableDataNode;
         internal static Type TypeOfISerializableDataNode
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfISerializableDataNode == null)
@@ -588,11 +495,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfClassDataNode;
         internal static Type TypeOfClassDataNode
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfClassDataNode == null)
@@ -601,11 +506,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfCollectionDataNode;
         internal static Type TypeOfCollectionDataNode
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfCollectionDataNode == null)
@@ -618,12 +521,10 @@ namespace System.Runtime.Serialization
         internal static Type TypeOfXmlDataNode => s_typeOfXmlDataNode ?? (s_typeOfXmlDataNode = typeof (XmlDataNode));
 
 #if NET_NATIVE
-        [SecurityCritical]
         private static Type s_typeOfSafeSerializationManager;
         private static bool s_typeOfSafeSerializationManagerSet;
         internal static Type TypeOfSafeSerializationManager
         {
-            [SecuritySafeCritical]
             get
             {
                 if (!s_typeOfSafeSerializationManagerSet)
@@ -636,11 +537,9 @@ namespace System.Runtime.Serialization
         }
 #endif
 
-        [SecurityCritical]
         private static Type s_typeOfNullable;
         internal static Type TypeOfNullable
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfNullable == null)
@@ -649,11 +548,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIDictionaryGeneric;
         internal static Type TypeOfIDictionaryGeneric
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIDictionaryGeneric == null)
@@ -662,11 +559,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIDictionary;
         internal static Type TypeOfIDictionary
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIDictionary == null)
@@ -675,11 +570,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIListGeneric;
         internal static Type TypeOfIListGeneric
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIListGeneric == null)
@@ -688,11 +581,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIList;
         internal static Type TypeOfIList
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIList == null)
@@ -701,11 +592,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfICollectionGeneric;
         internal static Type TypeOfICollectionGeneric
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfICollectionGeneric == null)
@@ -714,11 +603,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfICollection;
         internal static Type TypeOfICollection
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfICollection == null)
@@ -727,11 +614,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIEnumerableGeneric;
         internal static Type TypeOfIEnumerableGeneric
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIEnumerableGeneric == null)
@@ -740,11 +625,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIEnumerable;
         internal static Type TypeOfIEnumerable
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIEnumerable == null)
@@ -753,11 +636,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIEnumeratorGeneric;
         internal static Type TypeOfIEnumeratorGeneric
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIEnumeratorGeneric == null)
@@ -766,11 +647,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIEnumerator;
         internal static Type TypeOfIEnumerator
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIEnumerator == null)
@@ -779,11 +658,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfKeyValuePair;
         internal static Type TypeOfKeyValuePair
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfKeyValuePair == null)
@@ -792,11 +669,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfKeyValuePairAdapter;
         internal static Type TypeOfKeyValuePairAdapter
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfKeyValuePairAdapter == null)
@@ -805,11 +680,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfKeyValue;
         internal static Type TypeOfKeyValue
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfKeyValue == null)
@@ -818,11 +691,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfIDictionaryEnumerator;
         internal static Type TypeOfIDictionaryEnumerator
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfIDictionaryEnumerator == null)
@@ -831,11 +702,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfDictionaryEnumerator;
         internal static Type TypeOfDictionaryEnumerator
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfDictionaryEnumerator == null)
@@ -844,11 +713,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfGenericDictionaryEnumerator;
         internal static Type TypeOfGenericDictionaryEnumerator
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfGenericDictionaryEnumerator == null)
@@ -857,11 +724,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfDictionaryGeneric;
         internal static Type TypeOfDictionaryGeneric
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfDictionaryGeneric == null)
@@ -870,11 +735,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfHashtable;
         internal static Type TypeOfHashtable
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfHashtable == null)
@@ -883,11 +746,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfListGeneric;
         internal static Type TypeOfListGeneric
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfListGeneric == null)
@@ -896,11 +757,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlElement;
         internal static Type TypeOfXmlElement
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlElement == null)
@@ -909,11 +768,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Type s_typeOfXmlNodeArray;
         internal static Type TypeOfXmlNodeArray
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfXmlNodeArray == null)
@@ -924,11 +781,9 @@ namespace System.Runtime.Serialization
 
         private static bool s_shouldGetDBNullType = true;
 
-        [SecurityCritical]
         private static Type s_typeOfDBNull;
         internal static Type TypeOfDBNull
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfDBNull == null && s_shouldGetDBNullType)
@@ -940,11 +795,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static object s_valueOfDBNull;
         internal static object ValueOfDBNull
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_valueOfDBNull == null && TypeOfDBNull != null)
@@ -958,11 +811,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static Uri s_dataContractXsdBaseNamespaceUri;
         internal static Uri DataContractXsdBaseNamespaceUri
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_dataContractXsdBaseNamespaceUri == null)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
@@ -483,7 +483,6 @@ namespace System.Runtime.Serialization
         private static Type s_typeOfExtensionDataObject;
         internal static Type TypeOfExtensionDataObject => s_typeOfExtensionDataObject ?? (s_typeOfExtensionDataObject = typeof (ExtensionDataObject));
 
-        [SecurityCritical]
         private static Type s_typeOfISerializableDataNode;
         internal static Type TypeOfISerializableDataNode
         {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
@@ -6,16 +6,13 @@ using System.Threading;
 using System.Xml;
 using System.Diagnostics;
 using System.Collections.Generic;
-using System.Security;
 
 namespace System.Runtime.Serialization.Json
 {
     internal class JsonClassDataContract : JsonDataContract
     {
-        [SecurityCritical]
         private JsonClassDataContractCriticalHelper _helper;
 
-        [SecuritySafeCritical]
         public JsonClassDataContract(ClassDataContract traditionalDataContract)
             : base(new JsonClassDataContractCriticalHelper(traditionalDataContract))
         {
@@ -24,7 +21,6 @@ namespace System.Runtime.Serialization.Json
 
         internal JsonFormatClassReaderDelegate JsonFormatReaderDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (_helper.JsonFormatReaderDelegate == null)
@@ -68,7 +64,6 @@ namespace System.Runtime.Serialization.Json
 
         internal JsonFormatClassWriterDelegate JsonFormatWriterDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (_helper.JsonFormatWriterDelegate == null)
@@ -110,27 +105,11 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
-        internal XmlDictionaryString[] MemberNames
-        {
-            [SecuritySafeCritical]
-            get
-            { return _helper.MemberNames; }
-        }
+        internal XmlDictionaryString[] MemberNames => _helper.MemberNames;
 
-        internal override string TypeName
-        {
-            [SecuritySafeCritical]
-            get
-            { return _helper.TypeName; }
-        }
+        internal override string TypeName => _helper.TypeName;
 
-
-        private ClassDataContract TraditionalClassDataContract
-        {
-            [SecuritySafeCritical]
-            get
-            { return _helper.TraditionalClassDataContract; }
-        }
+        private ClassDataContract TraditionalClassDataContract => _helper.TraditionalClassDataContract;
 
         public override object ReadJsonValueCore(XmlReaderDelegator jsonReader, XmlObjectSerializerReadContextComplexJson context)
         {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
@@ -5,16 +5,13 @@
 using System.Reflection;
 using System.Threading;
 using System.Xml;
-using System.Security;
 
 namespace System.Runtime.Serialization.Json
 {
     internal class JsonCollectionDataContract : JsonDataContract
     {
-        [SecurityCritical]
         private JsonCollectionDataContractCriticalHelper _helper;
 
-        [SecuritySafeCritical]
         public JsonCollectionDataContract(CollectionDataContract traditionalDataContract)
             : base(new JsonCollectionDataContractCriticalHelper(traditionalDataContract))
         {
@@ -23,7 +20,6 @@ namespace System.Runtime.Serialization.Json
 
         internal JsonFormatCollectionReaderDelegate JsonFormatReaderDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (_helper.JsonFormatReaderDelegate == null)
@@ -67,7 +63,6 @@ namespace System.Runtime.Serialization.Json
 
         internal JsonFormatGetOnlyCollectionReaderDelegate JsonFormatGetOnlyReaderDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (_helper.JsonFormatGetOnlyReaderDelegate == null)
@@ -117,7 +112,6 @@ namespace System.Runtime.Serialization.Json
 
         internal JsonFormatCollectionWriterDelegate JsonFormatWriterDelegate
         {
-            [SecuritySafeCritical]
             get
             {
                 if (_helper.JsonFormatWriterDelegate == null)
@@ -159,12 +153,7 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
-        private CollectionDataContract TraditionalCollectionDataContract
-        {
-            [SecuritySafeCritical]
-            get
-            { return _helper.TraditionalCollectionDataContract; }
-        }
+        private CollectionDataContract TraditionalCollectionDataContract => _helper.TraditionalCollectionDataContract;
 
         public override object ReadJsonValueCore(XmlReaderDelegator jsonReader, XmlObjectSerializerReadContextComplexJson context)
         {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonDataContract.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Runtime;
 using System.Runtime.Serialization;
-using System.Security;
 using System.Reflection;
 using System.Xml;
 
@@ -13,46 +12,25 @@ namespace System.Runtime.Serialization.Json
 {
     internal class JsonDataContract
     {
-        [SecurityCritical]
         private JsonDataContractCriticalHelper _helper;
 
-        [SecuritySafeCritical]
         protected JsonDataContract(DataContract traditionalDataContract)
         {
             _helper = new JsonDataContractCriticalHelper(traditionalDataContract);
         }
 
-        [SecuritySafeCritical]
         protected JsonDataContract(JsonDataContractCriticalHelper helper)
         {
             _helper = helper;
         }
 
-        internal virtual string TypeName
-        {
-            get { return null; }
-        }
+        internal virtual string TypeName => null;
 
-        protected JsonDataContractCriticalHelper Helper
-        {
-            [SecurityCritical]
-            get
-            { return _helper; }
-        }
+        protected JsonDataContractCriticalHelper Helper => _helper;
 
-        protected DataContract TraditionalDataContract
-        {
-            [SecuritySafeCritical]
-            get
-            { return _helper.TraditionalDataContract; }
-        }
+        protected DataContract TraditionalDataContract => _helper.TraditionalDataContract;
 
-        private Dictionary<XmlQualifiedName, DataContract> KnownDataContracts
-        {
-            [SecuritySafeCritical]
-            get
-            { return _helper.KnownDataContracts; }
-        }
+        private Dictionary<XmlQualifiedName, DataContract> KnownDataContracts => _helper.KnownDataContracts;
 
         public static JsonReadWriteDelegates GetGeneratedReadWriteDelegates(DataContract c)
         {
@@ -91,7 +69,6 @@ namespace System.Runtime.Serialization.Json
             return result;
         }
 
-        [SecuritySafeCritical]
         public static JsonDataContract GetJsonDataContract(DataContract traditionalDataContract)
         {
             return JsonDataContractCriticalHelper.GetJsonDataContract(traditionalDataContract);
@@ -178,20 +155,11 @@ namespace System.Runtime.Serialization.Json
                 _typeName = string.IsNullOrEmpty(traditionalDataContract.Namespace.Value) ? traditionalDataContract.Name.Value : string.Concat(traditionalDataContract.Name.Value, JsonGlobals.NameValueSeparatorString, XmlObjectSerializerWriteContextComplexJson.TruncateDefaultDataContractNamespace(traditionalDataContract.Namespace.Value));
             }
 
-            internal Dictionary<XmlQualifiedName, DataContract> KnownDataContracts
-            {
-                get { return _knownDataContracts; }
-            }
+            internal Dictionary<XmlQualifiedName, DataContract> KnownDataContracts => _knownDataContracts;
 
-            internal DataContract TraditionalDataContract
-            {
-                get { return _traditionalDataContract; }
-            }
+            internal DataContract TraditionalDataContract => _traditionalDataContract;
 
-            internal virtual string TypeName
-            {
-                get { return _typeName; }
-            }
+            internal virtual string TypeName => _typeName;
 
             public static JsonDataContract GetJsonDataContract(DataContract traditionalDataContract)
             {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEnumDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEnumDataContract.cs
@@ -2,29 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Xml;
-using System.Security;
-
 namespace System.Runtime.Serialization.Json
 {
     internal class JsonEnumDataContract : JsonDataContract
     {
-        [SecurityCritical]
         private JsonEnumDataContractCriticalHelper _helper;
 
-        [SecuritySafeCritical]
         public JsonEnumDataContract(EnumDataContract traditionalDataContract)
             : base(new JsonEnumDataContractCriticalHelper(traditionalDataContract))
         {
             _helper = base.Helper as JsonEnumDataContractCriticalHelper;
         }
 
-        public bool IsULong
-        {
-            [SecuritySafeCritical]
-            get
-            { return _helper.IsULong; }
-        }
+        public bool IsULong => _helper.IsULong;
 
         public override object ReadJsonValueCore(XmlReaderDelegator jsonReader, XmlObjectSerializerReadContextComplexJson context)
         {
@@ -59,7 +49,7 @@ namespace System.Runtime.Serialization.Json
 
         private class JsonEnumDataContractCriticalHelper : JsonDataContractCriticalHelper
         {
-            private bool _isULong;
+            private readonly bool _isULong;
 
             public JsonEnumDataContractCriticalHelper(EnumDataContract traditionalEnumDataContract)
                 : base(traditionalEnumDataContract)
@@ -67,10 +57,7 @@ namespace System.Runtime.Serialization.Json
                 _isULong = traditionalEnumDataContract.IsULong;
             }
 
-            public bool IsULong
-            {
-                get { return _isULong; }
-            }
+            public bool IsULong => _isULong;
         }
     }
 }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections;
 using System.Reflection;
 using System.Runtime.Serialization.Json;
-using System.Security;
 using System.Xml;
 using System.Diagnostics;
 
@@ -14,106 +13,76 @@ namespace System.Runtime.Serialization
 {
     public static class JsonFormatGeneratorStatics
     {
-        [SecurityCritical]
         private static PropertyInfo s_collectionItemNameProperty;
 
         private static ConstructorInfo s_extensionDataObjectCtor;
 
         private static PropertyInfo s_extensionDataProperty;
 
-        [SecurityCritical]
         private static MethodInfo s_getItemContractMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_getJsonDataContractMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_getJsonMemberIndexMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_getRevisedItemContractMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_getUninitializedObjectMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_ienumeratorGetCurrentMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_ienumeratorMoveNextMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_isStartElementMethod0;
 
-        [SecurityCritical]
         private static MethodInfo s_isStartElementMethod2;
 
-        [SecurityCritical]
         private static PropertyInfo s_localNameProperty;
 
-        [SecurityCritical]
         private static PropertyInfo s_namespaceProperty;
 
-        [SecurityCritical]
         private static MethodInfo s_moveToContentMethod;
 
-        [SecurityCritical]
         private static PropertyInfo s_nodeTypeProperty;
 
         private static MethodInfo s_onDeserializationMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_readJsonValueMethod;
 
-        [SecurityCritical]
         private static ConstructorInfo s_serializationExceptionCtor;
 
         private static Type[] s_serInfoCtorArgs;
 
-        [SecurityCritical]
         private static MethodInfo s_throwDuplicateMemberExceptionMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_throwMissingRequiredMembersMethod;
 
-        [SecurityCritical]
         private static PropertyInfo s_typeHandleProperty;
 
-        [SecurityCritical]
         private static PropertyInfo s_useSimpleDictionaryFormatReadProperty;
 
-        [SecurityCritical]
         private static PropertyInfo s_useSimpleDictionaryFormatWriteProperty;
 
-        [SecurityCritical]
         private static MethodInfo s_writeAttributeStringMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_writeEndElementMethod;
 
         private static MethodInfo s_writeJsonISerializableMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_writeJsonNameWithMappingMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_writeJsonValueMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_writeStartElementMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_writeStartElementStringMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_parseEnumMethod;
 
-        [SecurityCritical]
         private static MethodInfo s_getJsonMemberNameMethod;
 
         public static PropertyInfo CollectionItemNameProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_collectionItemNameProperty == null)
@@ -135,7 +104,6 @@ namespace System.Runtime.Serialization
 
         public static MethodInfo GetCurrentMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_ienumeratorGetCurrentMethod == null)
@@ -148,7 +116,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo GetItemContractMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getItemContractMethod == null)
@@ -161,7 +128,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo GetJsonDataContractMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getJsonDataContractMethod == null)
@@ -174,7 +140,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo GetJsonMemberIndexMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getJsonMemberIndexMethod == null)
@@ -187,7 +152,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo GetRevisedItemContractMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getRevisedItemContractMethod == null)
@@ -200,7 +164,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo GetUninitializedObjectMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getUninitializedObjectMethod == null)
@@ -214,7 +177,6 @@ namespace System.Runtime.Serialization
 
         public static MethodInfo IsStartElementMethod0
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_isStartElementMethod0 == null)
@@ -227,7 +189,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo IsStartElementMethod2
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_isStartElementMethod2 == null)
@@ -240,7 +201,6 @@ namespace System.Runtime.Serialization
         }
         public static PropertyInfo LocalNameProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_localNameProperty == null)
@@ -253,7 +213,6 @@ namespace System.Runtime.Serialization
         }
         public static PropertyInfo NamespaceProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_namespaceProperty == null)
@@ -266,7 +225,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo MoveNextMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_ienumeratorMoveNextMethod == null)
@@ -279,7 +237,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo MoveToContentMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_moveToContentMethod == null)
@@ -292,7 +249,6 @@ namespace System.Runtime.Serialization
         }
         public static PropertyInfo NodeTypeProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_nodeTypeProperty == null)
@@ -305,7 +261,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo OnDeserializationMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_onDeserializationMethod == null)
@@ -317,7 +272,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo ReadJsonValueMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_readJsonValueMethod == null)
@@ -330,7 +284,6 @@ namespace System.Runtime.Serialization
         }
         public static ConstructorInfo SerializationExceptionCtor
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_serializationExceptionCtor == null)
@@ -342,7 +295,6 @@ namespace System.Runtime.Serialization
         }
         public static Type[] SerInfoCtorArgs
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_serInfoCtorArgs == null)
@@ -354,7 +306,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo ThrowDuplicateMemberExceptionMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_throwDuplicateMemberExceptionMethod == null)
@@ -367,7 +318,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo ThrowMissingRequiredMembersMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_throwMissingRequiredMembersMethod == null)
@@ -380,7 +330,6 @@ namespace System.Runtime.Serialization
         }
         public static PropertyInfo TypeHandleProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeHandleProperty == null)
@@ -393,7 +342,6 @@ namespace System.Runtime.Serialization
         }
         public static PropertyInfo UseSimpleDictionaryFormatReadProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_useSimpleDictionaryFormatReadProperty == null)
@@ -406,7 +354,6 @@ namespace System.Runtime.Serialization
         }
         public static PropertyInfo UseSimpleDictionaryFormatWriteProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_useSimpleDictionaryFormatWriteProperty == null)
@@ -419,7 +366,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo WriteAttributeStringMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeAttributeStringMethod == null)
@@ -432,7 +378,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo WriteEndElementMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeEndElementMethod == null)
@@ -445,7 +390,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo WriteJsonISerializableMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeJsonISerializableMethod == null)
@@ -457,7 +401,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo WriteJsonNameWithMappingMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeJsonNameWithMappingMethod == null)
@@ -470,7 +413,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo WriteJsonValueMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeJsonValueMethod == null)
@@ -483,7 +425,6 @@ namespace System.Runtime.Serialization
         }
         public static MethodInfo WriteStartElementMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeStartElementMethod == null)
@@ -497,7 +438,6 @@ namespace System.Runtime.Serialization
 
         public static MethodInfo WriteStartElementStringMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeStartElementStringMethod == null)
@@ -511,7 +451,6 @@ namespace System.Runtime.Serialization
 
         public static MethodInfo ParseEnumMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_parseEnumMethod == null)
@@ -524,7 +463,6 @@ namespace System.Runtime.Serialization
 
         public static MethodInfo GetJsonMemberNameMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getJsonMemberNameMethod == null)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
@@ -29,28 +29,23 @@ namespace System.Runtime.Serialization.Json
 
     internal sealed class JsonFormatReaderGenerator
     {
-        [SecurityCritical]
         private CriticalHelper _helper;
 
-        [SecurityCritical]
         public JsonFormatReaderGenerator()
         {
             _helper = new CriticalHelper();
         }
 
-        [SecurityCritical]
         public JsonFormatClassReaderDelegate GenerateClassReader(ClassDataContract classContract)
         {
             return _helper.GenerateClassReader(classContract);
         }
 
-        [SecurityCritical]
         public JsonFormatCollectionReaderDelegate GenerateCollectionReader(CollectionDataContract collectionContract)
         {
             return _helper.GenerateCollectionReader(collectionContract);
         }
 
-        [SecurityCritical]
         public JsonFormatGetOnlyCollectionReaderDelegate GenerateGetOnlyCollectionReader(CollectionDataContract collectionContract)
         {
             return _helper.GenerateGetOnlyCollectionReader(collectionContract);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatWriterGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatWriterGenerator.cs
@@ -26,22 +26,18 @@ namespace System.Runtime.Serialization.Json
 
     internal class JsonFormatWriterGenerator
     {
-        [SecurityCritical]
         private CriticalHelper _helper;
 
-        [SecurityCritical]
         public JsonFormatWriterGenerator()
         {
             _helper = new CriticalHelper();
         }
 
-        [SecurityCritical]
         internal JsonFormatClassWriterDelegate GenerateClassWriter(ClassDataContract classContract)
         {
             return _helper.GenerateClassWriter(classContract);
         }
 
-        [SecurityCritical]
         internal JsonFormatCollectionWriterDelegate GenerateCollectionWriter(CollectionDataContract collectionContract)
         {
             return _helper.GenerateCollectionWriter(collectionContract);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.IO;
 using System.Runtime;
 using System.Runtime.Serialization;
-using System.Security;
 using System.Text;
 using System.Xml;
 
@@ -33,7 +32,6 @@ namespace System.Runtime.Serialization.Json
         // This array was part of a perf improvement for escaping characters < WHITESPACE.
         private static readonly string[] s_escapedJsonStringTable = CreateEscapedJsonStringTable();
 
-        [SecurityCritical]
         private static BinHexEncoding s_binHexEncoding;
 
         private string _attributeText;
@@ -156,7 +154,6 @@ namespace System.Runtime.Serialization.Json
 
         private static BinHexEncoding BinHexEncoding
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_binHexEncoding == null)
@@ -167,38 +164,17 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
-        private bool HasOpenAttribute
-        {
-            get
-            {
-                return (_isWritingDataTypeAttribute || _isWritingServerTypeAttribute || IsWritingNameAttribute || _isWritingXmlnsAttribute);
-            }
-        }
+        private bool HasOpenAttribute => (_isWritingDataTypeAttribute || _isWritingServerTypeAttribute || IsWritingNameAttribute || _isWritingXmlnsAttribute);
 
-        private bool IsClosed
-        {
-            get { return (WriteState == WriteState.Closed); }
-        }
+        private bool IsClosed => (WriteState == WriteState.Closed);
 
-        private bool IsWritingCollection
-        {
-            get { return (_depth > 0) && (_scopes[_depth] == JsonNodeType.Collection); }
-        }
+        private bool IsWritingCollection => (_depth > 0) && (_scopes[_depth] == JsonNodeType.Collection);
 
-        private bool IsWritingNameAttribute
-        {
-            get { return (_nameState & NameState.IsWritingNameAttribute) == NameState.IsWritingNameAttribute; }
-        }
+        private bool IsWritingNameAttribute => (_nameState & NameState.IsWritingNameAttribute) == NameState.IsWritingNameAttribute;
 
-        private bool IsWritingNameWithMapping
-        {
-            get { return (_nameState & NameState.IsWritingNameWithMapping) == NameState.IsWritingNameWithMapping; }
-        }
+        private bool IsWritingNameWithMapping => (_nameState & NameState.IsWritingNameWithMapping) == NameState.IsWritingNameWithMapping;
 
-        private bool WrittenNameWithMapping
-        {
-            get { return (_nameState & NameState.WrittenNameWithMapping) == NameState.WrittenNameWithMapping; }
-        }
+        private bool WrittenNameWithMapping => (_nameState & NameState.WrittenNameWithMapping) == NameState.WrittenNameWithMapping;
 
         protected override void Dispose(bool disposing)
         {
@@ -1394,7 +1370,6 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
-        [SecuritySafeCritical]
         private unsafe void WriteEscapedJsonString(string str)
         {
             fixed (char* chars = str)
@@ -1617,7 +1592,6 @@ namespace System.Runtime.Serialization.Json
 
         private class JsonNodeWriter : XmlUTF8NodeWriter
         {
-            [SecurityCritical]
             internal unsafe void WriteChars(char* chars, int charCount)
             {
                 base.UnsafeWriteUTF8Chars(chars, charCount);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Text;
 using System.Reflection;
 using System.Xml;
-using System.Security;
 using System.Runtime.Serialization.Json;
 using System.Runtime.Serialization;
 using DataContractDictionary = System.Collections.Generic.Dictionary<System.Xml.XmlQualifiedName, System.Runtime.Serialization.DataContract>;
@@ -390,7 +389,6 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
-        [SecuritySafeCritical]
         private static bool IsBitSet(byte[] bytes, int bitIndex)
         {
             return BitFlagsGenerator.IsBitSet(bytes, bitIndex);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ObjectToIdCache.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ObjectToIdCache.cs
@@ -5,8 +5,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Security;
-
 
 namespace System.Runtime.Serialization
 {
@@ -173,11 +171,6 @@ namespace System.Runtime.Serialization
             return min;
         }
 
-
-        /// <SecurityNote>
-        /// Review - Static fields are marked SecurityCritical or readonly to prevent
-        ///          data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
         internal static readonly int[] primes =
         {
             3, 7, 17, 37, 89, 197, 431, 919, 1931, 4049, 8419, 17519, 36353,

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/PrimitiveDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/PrimitiveDataContract.cs
@@ -8,8 +8,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Xml;
-using System.Security;
-
 
 namespace System.Runtime.Serialization
 {
@@ -21,19 +19,8 @@ namespace System.Runtime.Serialization
     {
         internal static readonly PrimitiveDataContract NullContract = new NullPrimitiveDataContract();
 
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
         private PrimitiveDataContractCriticalHelper _helper;
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         protected PrimitiveDataContract(Type type, XmlDictionaryString name, XmlDictionaryString ns) : base(new PrimitiveDataContractCriticalHelper(type, name, ns))
         {
             _helper = base.Helper as PrimitiveDataContractCriticalHelper;
@@ -54,46 +41,21 @@ namespace System.Runtime.Serialization
 
         public override XmlDictionaryString TopLevelElementNamespace
         {
-            /// <SecurityNote>
-            /// Critical - for consistency with base class
-            /// Safe - for consistency with base class
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return DictionaryGlobals.SerializationNamespace; }
-            /// <SecurityNote>
-            /// Critical - for consistency with base class
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { }
         }
 
-        internal override bool CanContainReferences
-        {
-            get { return false; }
-        }
+        internal override bool CanContainReferences => false;
 
-        internal override bool IsPrimitive
-        {
-            get { return true; }
-        }
+        internal override bool IsPrimitive => true;
 
-        public override bool IsBuiltInDataContract
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool IsBuiltInDataContract => true;
 
         internal MethodInfo XmlFormatWriterMethod
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical XmlFormatWriterMethod property
-            /// Safe - XmlFormatWriterMethod only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (_helper.XmlFormatWriterMethod == null)
@@ -109,11 +71,6 @@ namespace System.Runtime.Serialization
 
         internal MethodInfo XmlFormatContentWriterMethod
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical XmlFormatContentWriterMethod property
-            /// Safe - XmlFormatContentWriterMethod only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (_helper.XmlFormatContentWriterMethod == null)
@@ -129,11 +86,6 @@ namespace System.Runtime.Serialization
 
         internal MethodInfo XmlFormatReaderMethod
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical XmlFormatReaderMethod property
-            /// Safe - XmlFormatReaderMethod only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (_helper.XmlFormatReaderMethod == null)
@@ -168,11 +120,7 @@ namespace System.Runtime.Serialization
             }
             return false;
         }
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds all state used for (de)serializing primitives.
-        ///            since the data is cached statically, we lock down access to it.
-        /// </SecurityNote>
+
         private class PrimitiveDataContractCriticalHelper : DataContract.DataContractCriticalHelper
         {
             private MethodInfo _xmlFormatWriterMethod;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SpecialTypeDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SpecialTypeDataContract.cs
@@ -2,46 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Xml;
-using System.Security;
 
 namespace System.Runtime.Serialization
 {
     internal sealed class SpecialTypeDataContract : DataContract
     {
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
         private SpecialTypeDataContractCriticalHelper _helper;
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
+
         public SpecialTypeDataContract(Type type, XmlDictionaryString name, XmlDictionaryString ns) : base(new SpecialTypeDataContractCriticalHelper(type, name, ns))
         {
             _helper = base.Helper as SpecialTypeDataContractCriticalHelper;
         }
 
-        public override bool IsBuiltInDataContract
-        {
-            get
-            {
-                return true;
-            }
-        }
-        [SecurityCritical]
+        public override bool IsBuiltInDataContract => true;
 
-        /// <SecurityNote>
-        /// Critical - holds all state used for (de)serializing known types like System.Enum, System.ValueType, etc.
-        ///            since the data is cached statically, we lock down access to it.
-        /// </SecurityNote>
         private class SpecialTypeDataContractCriticalHelper : DataContract.DataContractCriticalHelper
         {
             internal SpecialTypeDataContractCriticalHelper(Type type, XmlDictionaryString name, XmlDictionaryString ns) : base(type)
@@ -51,4 +26,3 @@ namespace System.Runtime.Serialization
         }
     }
 }
-

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
@@ -23,29 +23,13 @@ namespace System.Runtime.Serialization
     internal sealed class XmlDataContract : DataContract
 #endif
     {
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that is cached statically for serialization. 
-        ///            Static fields are marked SecurityCritical or readonly to prevent
-        ///            data from being modified or leaked to other components in appdomain.
-        /// </SecurityNote>
         private XmlDataContractCriticalHelper _helper;
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         public XmlDataContract() : base(new XmlDataContractCriticalHelper())
         {
             _helper = base.Helper as XmlDataContractCriticalHelper;
         }
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// Safe - doesn't leak anything
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal XmlDataContract(Type type) : base(new XmlDataContractCriticalHelper(type))
         {
             _helper = base.Helper as XmlDataContractCriticalHelper;
@@ -53,17 +37,9 @@ namespace System.Runtime.Serialization
 
         public override DataContractDictionary KnownDataContracts
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical KnownDataContracts property 
-            /// Safe - KnownDataContracts only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.KnownDataContracts; }
-            /// <SecurityNote>
-            /// Critical - sets the critical KnownDataContracts property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.KnownDataContracts = value; }
         }
@@ -77,62 +53,33 @@ namespace System.Runtime.Serialization
 
         internal bool IsAnonymous
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical IsAnonymous property
-            /// Safe - IsAnonymous only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.IsAnonymous; }
         }
 
         public override bool HasRoot
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical HasRoot property
-            /// Safe - HasRoot only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.HasRoot; }
-            /// <SecurityNote>
-            /// Critical - sets the critical HasRoot property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.HasRoot = value; }
         }
 
         public override XmlDictionaryString TopLevelElementName
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical TopLevelElementName property
-            /// Safe - TopLevelElementName only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.TopLevelElementName; }
-            /// <SecurityNote>
-            /// Critical - sets the critical TopLevelElementName property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.TopLevelElementName = value; }
         }
 
         public override XmlDictionaryString TopLevelElementNamespace
         {
-            /// <SecurityNote>
-            /// Critical - fetches the critical TopLevelElementNamespace property
-            /// Safe - TopLevelElementNamespace only needs to be protected for write
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             { return _helper.TopLevelElementNamespace; }
-            /// <SecurityNote>
-            /// Critical - sets the critical TopLevelElementNamespace property
-            /// </SecurityNote>
-            [SecurityCritical]
+
             set
             { _helper.TopLevelElementNamespace = value; }
         }
@@ -145,11 +92,6 @@ namespace System.Runtime.Serialization
 #endif
         {
 #if !NET_NATIVE
-            /// <SecurityNote>
-            /// Critical - fetches the critical CreateXmlSerializableDelegate property
-            /// Safe - CreateXmlSerializableDelegate only needs to be protected for write; initialized in getter if null
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 // We create XmlSerializableDelegate via CodeGen when CodeGen is enabled;
@@ -191,24 +133,10 @@ namespace System.Runtime.Serialization
 #endif            
         }
 
-        internal override bool CanContainReferences
-        {
-            get { return false; }
-        }
+        internal override bool CanContainReferences => false;
 
-        public override bool IsBuiltInDataContract
-        {
-            get
-            {
-                return UnderlyingType == Globals.TypeOfXmlElement || UnderlyingType == Globals.TypeOfXmlNodeArray;
-            }
-        }
-        [SecurityCritical]
+        public override bool IsBuiltInDataContract => UnderlyingType == Globals.TypeOfXmlElement || UnderlyingType == Globals.TypeOfXmlNodeArray;
 
-        /// <SecurityNote>
-        /// Critical - holds all state used for (de)serializing XML types.
-        ///            since the data is cached statically, we lock down access to it.
-        /// </SecurityNote>
         private class XmlDataContractCriticalHelper : DataContract.DataContractCriticalHelper
         {
             private DataContractDictionary _knownDataContracts;
@@ -266,7 +194,6 @@ namespace System.Runtime.Serialization
 
             internal override DataContractDictionary KnownDataContracts
             {
-                [SecurityCritical]
                 get
                 {
                     if (!_isKnownTypeAttributeChecked && UnderlyingType != null)
@@ -283,7 +210,7 @@ namespace System.Runtime.Serialization
                     }
                     return _knownDataContracts;
                 }
-                [SecurityCritical]
+
                 set
                 { _knownDataContracts = value; }
             }
@@ -294,38 +221,29 @@ namespace System.Runtime.Serialization
                 set { _xsdType = value; }
             }
 
-            internal bool IsAnonymous
-            {
-                get { return _xsdType != null; }
-            }
+            internal bool IsAnonymous => _xsdType != null;
 
             internal override bool HasRoot
             {
-                [SecurityCritical]
                 get
                 { return _hasRoot; }
 
-                [SecurityCritical]
                 set
                 { _hasRoot = value; }
             }
 
             internal override XmlDictionaryString TopLevelElementName
             {
-                [SecurityCritical]
                 get
                 { return _topLevelElementName; }
-                [SecurityCritical]
                 set
                 { _topLevelElementName = value; }
             }
 
             internal override XmlDictionaryString TopLevelElementNamespace
             {
-                [SecurityCritical]
                 get
                 { return _topLevelElementNamespace; }
-                [SecurityCritical]
                 set
                 { _topLevelElementNamespace = value; }
             }
@@ -351,11 +269,6 @@ namespace System.Runtime.Serialization
         }
 
 #if !NET_NATIVE
-        /// <SecurityNote>
-        /// Critical - calls CodeGenerator.BeginMethod which is SecurityCritical
-        /// Safe - self-contained: returns the delegate to the generated IL but otherwise all IL generation is self-contained here
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         internal CreateXmlSerializableDelegate GenerateCreateXmlSerializableDelegate()
         {
             Type type = this.UnderlyingType;
@@ -498,4 +411,3 @@ namespace System.Runtime.Serialization
         }
     }
 }
-

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
@@ -2,30 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
-using System.Security;
 using System.Xml;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
-
 
 namespace System.Runtime.Serialization
 {
-    /// <SecurityNote>
-    /// Critical - Class holds static instances used for code generation during serialization. 
-    ///            Static fields are marked SecurityCritical or readonly to prevent
-    ///            data from being modified or leaked to other components in appdomain.
-    /// Safe - All get-only properties marked safe since they only need to be protected for write.
-    /// </SecurityNote>
     internal static class XmlFormatGeneratorStatics
     {
-        [SecurityCritical]
         private static MethodInfo s_writeStartElementMethod2;
         internal static MethodInfo WriteStartElementMethod2
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeStartElementMethod2 == null)
@@ -37,11 +25,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_writeStartElementMethod3;
         internal static MethodInfo WriteStartElementMethod3
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeStartElementMethod3 == null)
@@ -53,11 +39,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_writeEndElementMethod;
         internal static MethodInfo WriteEndElementMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeEndElementMethod == null)
@@ -69,11 +53,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_writeNamespaceDeclMethod;
         internal static MethodInfo WriteNamespaceDeclMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeNamespaceDeclMethod == null)
@@ -89,11 +71,9 @@ namespace System.Runtime.Serialization
         internal static PropertyInfo ExtensionDataProperty => s_extensionDataProperty ?? 
                                                               (s_extensionDataProperty = typeof(IExtensibleDataObject).GetProperty("ExtensionData"));
 
-        [SecurityCritical]
         private static ConstructorInfo s_dictionaryEnumeratorCtor;
         internal static ConstructorInfo DictionaryEnumeratorCtor
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_dictionaryEnumeratorCtor == null)
@@ -102,11 +82,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_ienumeratorMoveNextMethod;
         internal static MethodInfo MoveNextMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_ienumeratorMoveNextMethod == null)
@@ -118,11 +96,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_ienumeratorGetCurrentMethod;
         internal static MethodInfo GetCurrentMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_ienumeratorGetCurrentMethod == null)
@@ -134,11 +110,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getItemContractMethod;
         internal static MethodInfo GetItemContractMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getItemContractMethod == null)
@@ -150,11 +124,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_isStartElementMethod2;
         internal static MethodInfo IsStartElementMethod2
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_isStartElementMethod2 == null)
@@ -166,11 +138,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_isStartElementMethod0;
         internal static MethodInfo IsStartElementMethod0
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_isStartElementMethod0 == null)
@@ -182,11 +152,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getUninitializedObjectMethod;
         internal static MethodInfo GetUninitializedObjectMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getUninitializedObjectMethod == null)
@@ -209,11 +177,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static PropertyInfo s_nodeTypeProperty;
         internal static PropertyInfo NodeTypeProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_nodeTypeProperty == null)
@@ -230,11 +196,9 @@ namespace System.Runtime.Serialization
                                                                    (s_extensionDataObjectCtor =
                                                                        typeof (ExtensionDataObject).GetConstructor(Globals.ScanAllMembers, null, new Type[] {}, null));
 
-        [SecurityCritical]
         private static ConstructorInfo s_hashtableCtor;
         internal static ConstructorInfo HashtableCtor
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_hashtableCtor == null)
@@ -243,11 +207,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getStreamingContextMethod;
         internal static MethodInfo GetStreamingContextMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getStreamingContextMethod == null)
@@ -259,11 +221,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getCollectionMemberMethod;
         internal static MethodInfo GetCollectionMemberMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getCollectionMemberMethod == null)
@@ -275,11 +235,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_storeCollectionMemberInfoMethod;
         internal static MethodInfo StoreCollectionMemberInfoMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_storeCollectionMemberInfoMethod == null)
@@ -291,11 +249,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_storeIsGetOnlyCollectionMethod;
         internal static MethodInfo StoreIsGetOnlyCollectionMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_storeIsGetOnlyCollectionMethod == null)
@@ -307,11 +263,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_throwNullValueReturnedForGetOnlyCollectionExceptionMethod;
         internal static MethodInfo ThrowNullValueReturnedForGetOnlyCollectionExceptionMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_throwNullValueReturnedForGetOnlyCollectionExceptionMethod == null)
@@ -326,7 +280,6 @@ namespace System.Runtime.Serialization
         private static MethodInfo s_throwArrayExceededSizeExceptionMethod;
         internal static MethodInfo ThrowArrayExceededSizeExceptionMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_throwArrayExceededSizeExceptionMethod == null)
@@ -338,11 +291,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_incrementItemCountMethod;
         internal static MethodInfo IncrementItemCountMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_incrementItemCountMethod == null)
@@ -354,12 +305,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-
-        [SecurityCritical]
         private static MethodInfo s_internalDeserializeMethod;
         internal static MethodInfo InternalDeserializeMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_internalDeserializeMethod == null)
@@ -371,11 +319,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_moveToNextElementMethod;
         internal static MethodInfo MoveToNextElementMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_moveToNextElementMethod == null)
@@ -387,11 +333,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getMemberIndexMethod;
         internal static MethodInfo GetMemberIndexMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getMemberIndexMethod == null)
@@ -403,11 +347,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getMemberIndexWithRequiredMembersMethod;
         internal static MethodInfo GetMemberIndexWithRequiredMembersMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getMemberIndexWithRequiredMembersMethod == null)
@@ -419,11 +361,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_throwRequiredMemberMissingExceptionMethod;
         internal static MethodInfo ThrowRequiredMemberMissingExceptionMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_throwRequiredMemberMissingExceptionMethod == null)
@@ -435,11 +375,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_skipUnknownElementMethod;
         internal static MethodInfo SkipUnknownElementMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_skipUnknownElementMethod == null)
@@ -451,11 +389,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_readIfNullOrRefMethod;
         internal static MethodInfo ReadIfNullOrRefMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_readIfNullOrRefMethod == null)
@@ -467,11 +403,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_readAttributesMethod;
         internal static MethodInfo ReadAttributesMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_readAttributesMethod == null)
@@ -483,11 +417,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_resetAttributesMethod;
         internal static MethodInfo ResetAttributesMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_resetAttributesMethod == null)
@@ -499,11 +431,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getObjectIdMethod;
         internal static MethodInfo GetObjectIdMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getObjectIdMethod == null)
@@ -515,11 +445,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getArraySizeMethod;
         internal static MethodInfo GetArraySizeMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getArraySizeMethod == null)
@@ -531,11 +459,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_addNewObjectMethod;
         internal static MethodInfo AddNewObjectMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_addNewObjectMethod == null)
@@ -547,11 +473,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_addNewObjectWithIdMethod;
         internal static MethodInfo AddNewObjectWithIdMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_addNewObjectWithIdMethod == null)
@@ -563,11 +487,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getExistingObjectMethod;
         internal static MethodInfo GetExistingObjectMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getExistingObjectMethod == null)
@@ -579,11 +501,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_ensureArraySizeMethod;
         internal static MethodInfo EnsureArraySizeMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_ensureArraySizeMethod == null)
@@ -595,11 +515,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_trimArraySizeMethod;
         internal static MethodInfo TrimArraySizeMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_trimArraySizeMethod == null)
@@ -611,11 +529,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_checkEndOfArrayMethod;
         internal static MethodInfo CheckEndOfArrayMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_checkEndOfArrayMethod == null)
@@ -627,12 +543,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-
-        [SecurityCritical]
         private static MethodInfo s_getArrayLengthMethod;
         internal static MethodInfo GetArrayLengthMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getArrayLengthMethod == null)
@@ -644,11 +557,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_createSerializationExceptionMethod;
         internal static MethodInfo CreateSerializationExceptionMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_createSerializationExceptionMethod == null)
@@ -663,7 +574,6 @@ namespace System.Runtime.Serialization
         private static MethodInfo s_readSerializationInfoMethod;
         internal static MethodInfo ReadSerializationInfoMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_readSerializationInfoMethod == null)
@@ -672,11 +582,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_createUnexpectedStateExceptionMethod;
         internal static MethodInfo CreateUnexpectedStateExceptionMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_createUnexpectedStateExceptionMethod == null)
@@ -688,11 +596,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_internalSerializeReferenceMethod;
         internal static MethodInfo InternalSerializeReferenceMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_internalSerializeReferenceMethod == null)
@@ -704,11 +610,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_internalSerializeMethod;
         internal static MethodInfo InternalSerializeMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_internalSerializeMethod == null)
@@ -720,11 +624,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_writeNullMethod;
         internal static MethodInfo WriteNullMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeNullMethod == null)
@@ -736,11 +638,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_incrementArrayCountMethod;
         internal static MethodInfo IncrementArrayCountMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_incrementArrayCountMethod == null)
@@ -752,11 +652,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_incrementCollectionCountMethod;
         internal static MethodInfo IncrementCollectionCountMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_incrementCollectionCountMethod == null)
@@ -768,11 +666,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_incrementCollectionCountGenericMethod;
         internal static MethodInfo IncrementCollectionCountGenericMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_incrementCollectionCountGenericMethod == null)
@@ -784,11 +680,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getDefaultValueMethod;
         internal static MethodInfo GetDefaultValueMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getDefaultValueMethod == null)
@@ -805,11 +699,9 @@ namespace System.Runtime.Serialization
             return GetDefaultValueMethod.MakeGenericMethod(type).Invoke(null, Array.Empty<object>());
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getNullableValueMethod;
         internal static MethodInfo GetNullableValueMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getNullableValueMethod == null)
@@ -821,11 +713,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_throwRequiredMemberMustBeEmittedMethod;
         internal static MethodInfo ThrowRequiredMemberMustBeEmittedMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_throwRequiredMemberMustBeEmittedMethod == null)
@@ -837,11 +727,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getHasValueMethod;
         internal static MethodInfo GetHasValueMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getHasValueMethod == null)
@@ -856,7 +744,6 @@ namespace System.Runtime.Serialization
         private static MethodInfo s_writeISerializableMethod;
         internal static MethodInfo WriteISerializableMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeISerializableMethod == null)
@@ -866,11 +753,9 @@ namespace System.Runtime.Serialization
         }
 
 
-        [SecurityCritical]
         private static MethodInfo s_isMemberTypeSameAsMemberValue;
         internal static MethodInfo IsMemberTypeSameAsMemberValue
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_isMemberTypeSameAsMemberValue == null)
@@ -886,11 +771,9 @@ namespace System.Runtime.Serialization
         internal static MethodInfo WriteExtensionDataMethod => s_writeExtensionDataMethod ?? 
                                                                (s_writeExtensionDataMethod = typeof(XmlObjectSerializerWriteContext).GetMethod("WriteExtensionData", Globals.ScanAllMembers));
 
-        [SecurityCritical]
         private static MethodInfo s_writeXmlValueMethod;
         internal static MethodInfo WriteXmlValueMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_writeXmlValueMethod == null)
@@ -902,11 +785,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_readXmlValueMethod;
         internal static MethodInfo ReadXmlValueMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_readXmlValueMethod == null)
@@ -918,11 +799,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static PropertyInfo s_namespaceProperty;
         internal static PropertyInfo NamespaceProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_namespaceProperty == null)
@@ -934,11 +813,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static FieldInfo s_contractNamespacesField;
         internal static FieldInfo ContractNamespacesField
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_contractNamespacesField == null)
@@ -950,11 +827,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static FieldInfo s_memberNamesField;
         internal static FieldInfo MemberNamesField
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_memberNamesField == null)
@@ -970,11 +845,9 @@ namespace System.Runtime.Serialization
         internal static MethodInfo ExtensionDataSetExplicitMethodInfo => s_extensionDataSetExplicitMethodInfo ?? 
                                                                          (s_extensionDataSetExplicitMethodInfo = typeof(IExtensibleDataObject).GetMethod(Globals.ExtensionDataSetMethod));
 
-        [SecurityCritical]
         private static PropertyInfo s_childElementNamespacesProperty;
         internal static PropertyInfo ChildElementNamespacesProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_childElementNamespacesProperty == null)
@@ -986,11 +859,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static PropertyInfo s_collectionItemNameProperty;
         internal static PropertyInfo CollectionItemNameProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_collectionItemNameProperty == null)
@@ -1002,11 +873,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static PropertyInfo s_childElementNamespaceProperty;
         internal static PropertyInfo ChildElementNamespaceProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_childElementNamespaceProperty == null)
@@ -1018,11 +887,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getDateTimeOffsetMethod;
         internal static MethodInfo GetDateTimeOffsetMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getDateTimeOffsetMethod == null)
@@ -1034,11 +901,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_getDateTimeOffsetAdapterMethod;
         internal static MethodInfo GetDateTimeOffsetAdapterMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_getDateTimeOffsetAdapterMethod == null)
@@ -1079,11 +944,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static MethodInfo s_throwInvalidDataContractExceptionMethod;
         internal static MethodInfo ThrowInvalidDataContractExceptionMethod
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_throwInvalidDataContractExceptionMethod == null)
@@ -1095,11 +958,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static PropertyInfo s_serializeReadOnlyTypesProperty;
         internal static PropertyInfo SerializeReadOnlyTypesProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_serializeReadOnlyTypesProperty == null)
@@ -1111,11 +972,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static PropertyInfo s_classSerializationExceptionMessageProperty;
         internal static PropertyInfo ClassSerializationExceptionMessageProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_classSerializationExceptionMessageProperty == null)
@@ -1127,11 +986,9 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
         private static PropertyInfo s_collectionSerializationExceptionMessageProperty;
         internal static PropertyInfo CollectionSerializationExceptionMessageProperty
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_collectionSerializationExceptionMessageProperty == null)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
@@ -41,43 +41,23 @@ namespace System.Runtime.Serialization
 
         private static readonly ConcurrentDictionary<Type, bool> s_typeHasDefaultConstructorMap = new ConcurrentDictionary<Type, bool>();
 
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that was produced within an assert
-        /// </SecurityNote>
         private CriticalHelper _helper;
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// </SecurityNote>
-        [SecurityCritical]
         public XmlFormatReaderGenerator()
         {
             _helper = new CriticalHelper();
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical helper class 'CriticalHelper'
-        /// </SecurityNote>
-        [SecurityCritical]
         public XmlFormatClassReaderDelegate GenerateClassReader(ClassDataContract classContract)
         {
             return _helper.GenerateClassReader(classContract);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical helper class 'CriticalHelper'
-        /// </SecurityNote>
-        [SecurityCritical]
         public XmlFormatCollectionReaderDelegate GenerateCollectionReader(CollectionDataContract collectionContract)
         {
             return _helper.GenerateCollectionReader(collectionContract);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical helper class 'CriticalHelper'
-        /// </SecurityNote>
-        [SecurityCritical]
         public XmlFormatGetOnlyCollectionReaderDelegate GenerateGetOnlyCollectionReader(CollectionDataContract collectionContract)
         {
             return _helper.GenerateGetOnlyCollectionReader(collectionContract);
@@ -957,7 +937,6 @@ namespace System.Runtime.Serialization
 #endif
         }
 
-        [SecuritySafeCritical]
         static internal object UnsafeGetUninitializedObject(Type type)
         {
 #if !NET_NATIVE
@@ -979,7 +958,6 @@ namespace System.Runtime.Serialization
         /// Safe - marked as such so that it's callable from transparent generated IL. Takes id as parameter which 
         ///        is guaranteed to be in internal serialization cache. 
         /// </SecurityNote>
-        [SecuritySafeCritical]
 #if USE_REFEMIT
         public static object UnsafeGetUninitializedObject(int id)
 #else

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatWriterGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatWriterGenerator.cs
@@ -25,34 +25,18 @@ namespace System.Runtime.Serialization
     internal sealed class XmlFormatWriterGenerator
 #endif
     {
-        [SecurityCritical]
-        /// <SecurityNote>
-        /// Critical - holds instance of CriticalHelper which keeps state that was produced within an assert
-        /// </SecurityNote>
         private CriticalHelper _helper;
 
-        /// <SecurityNote>
-        /// Critical - initializes SecurityCritical field 'helper'
-        /// </SecurityNote>
-        [SecurityCritical]
         public XmlFormatWriterGenerator()
         {
             _helper = new CriticalHelper();
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical helper class 'CriticalHelper'
-        /// </SecurityNote>
-        [SecurityCritical]
         internal XmlFormatClassWriterDelegate GenerateClassWriter(ClassDataContract classContract)
         {
             return _helper.GenerateClassWriter(classContract);
         }
 
-        /// <SecurityNote>
-        /// Critical - accesses SecurityCritical helper class 'CriticalHelper'
-        /// </SecurityNote>
-        [SecurityCritical]
         internal XmlFormatCollectionWriterDelegate GenerateCollectionWriter(CollectionDataContract collectionContract)
         {
             return _helper.GenerateCollectionWriter(collectionContract);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
@@ -298,7 +298,6 @@ namespace System.Runtime.Serialization
             throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.JsonDuplicateMemberInInput, DataContract.GetClrTypeFullName(obj.GetType()), memberNames[memberIndex])));
         }
 
-        [SecuritySafeCritical]
         private static bool IsBitSet(byte[] bytes, int bitIndex)
         {
             throw new NotImplementedException();

--- a/src/System.Private.DataContractSerialization/src/System/Text/Base64Encoding.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Text/Base64Encoding.cs
@@ -6,8 +6,6 @@ using System.Text;
 using System.Diagnostics;
 using System.Runtime.Serialization; //For SR
 using System.Globalization;
-using System.Security;
-
 
 namespace System.Text
 {
@@ -55,11 +53,6 @@ namespace System.Text
             return !(v3 == 64 && v4 != 64);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override int GetByteCount(char[] chars, int index, int count)
         {
             if (chars == null)
@@ -114,11 +107,6 @@ namespace System.Text
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
         {
             if (chars == null)
@@ -198,11 +186,6 @@ namespace System.Text
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public virtual int GetBytes(byte[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
         {
             if (chars == null)
@@ -291,11 +274,6 @@ namespace System.Text
             return GetMaxCharCount(count);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
         {
             if (bytes == null)
@@ -385,11 +363,6 @@ namespace System.Text
             return charCount;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public int GetChars(byte[] bytes, int byteIndex, int byteCount, byte[] chars, int charIndex)
         {
             if (bytes == null)

--- a/src/System.Private.DataContractSerialization/src/System/Text/BinHexEncoding.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Text/BinHexEncoding.cs
@@ -4,7 +4,6 @@
 
 using System.Globalization;
 using System.Runtime;
-using System.Security;
 
 namespace System.Text
 {
@@ -46,7 +45,6 @@ namespace System.Text
             return GetMaxByteCount(count);
         }
 
-        [SecuritySafeCritical]
         unsafe public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
         {
             if (chars == null)
@@ -117,7 +115,6 @@ namespace System.Text
             return GetMaxCharCount(count);
         }
 
-        [SecuritySafeCritical]
         unsafe public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
         {
             if (bytes == null)

--- a/src/System.Private.DataContractSerialization/src/System/Xml/UniqueId.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/UniqueId.cs
@@ -2,23 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Xml;
-using System.Text;
-using System.Diagnostics;
-using System.Runtime.Serialization;
-using System.Security;
-
-
 namespace System.Xml
 {
     public class UniqueId
     {
         private Int64 _idLow;
         private Int64 _idHigh;
-        [SecurityCritical]
-        /// <SecurityNote>
-        ///   Critical - some SecurityCritical unsafe code assumes that this field has been validated
-        /// </SecurityNote>
         private string _s;
         private const int guidLength = 16;
         private const int uuidLength = 45;
@@ -74,11 +63,6 @@ namespace System.Xml
         {
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public UniqueId(byte[] guid, int offset)
         {
             if (guid == null)
@@ -96,11 +80,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public UniqueId(string value)
         {
             if (value == null)
@@ -114,11 +93,6 @@ namespace System.Xml
             _s = value;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public UniqueId(char[] chars, int offset, int count)
         {
             if (chars == null)
@@ -146,11 +120,6 @@ namespace System.Xml
 
         public int CharArrayLength
         {
-            /// <SecurityNote>
-            ///   Critical - accesses critical field 's'. 
-            ///   Safe - doesn't leak any control or data
-            /// </SecurityNote>
-            [SecuritySafeCritical]
             get
             {
                 if (_s != null)
@@ -160,11 +129,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe int UnsafeDecode(short* char2val, char ch1, char ch2)
         {
             if ((ch1 | ch2) >= 0x80)
@@ -173,34 +137,14 @@ namespace System.Xml
             return char2val[ch1] | char2val[0x80 + ch2];
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeEncode(char* val2char, byte b, char* pch)
         {
             pch[0] = val2char[b >> 4];
             pch[1] = val2char[b & 0x0F];
         }
 
-        public bool IsGuid
-        {
-            get
-            {
-                return ((_idLow | _idHigh) != 0);
-            }
-        }
+        public bool IsGuid => ((_idLow | _idHigh) != 0);
 
-        // It must be the case that comparing UniqueId's as strings yields the same result as comparing UniqueId's as
-        // their binary equivalent.  This means that there must be a 1-1 relationship between a string and its binary
-        // equivalent.  Therefore, for example, we cannot accept both upper and lower case hex chars since there would
-        // then be more than 1 string that mapped to a binary equivalent.
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeParse(char* chars, int charCount)
         {
             //           1         2         3         4
@@ -255,11 +199,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public int ToCharArray(char[] chars, int offset)
         {
             int count = CharArrayLength;
@@ -341,11 +280,6 @@ namespace System.Xml
             return true;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public bool TryGetGuid(byte[] buffer, int offset)
         {
             if (!IsGuid)
@@ -371,11 +305,6 @@ namespace System.Xml
             return true;
         }
 
-        /// <SecurityNote>
-        ///   Critical - accesses critical field 's'. 
-        ///   Safe - doesn't allow unchecked write access to the field
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override string ToString()
         {
             if (_s == null)
@@ -428,11 +357,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe Int64 UnsafeGetInt64(byte* pb)
         {
             Int32 idLow = UnsafeGetInt32(pb);
@@ -440,11 +364,6 @@ namespace System.Xml
             return (((Int64)idHigh) << 32) | ((UInt32)idLow);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe Int32 UnsafeGetInt32(byte* pb)
         {
             int value = pb[3];
@@ -457,22 +376,12 @@ namespace System.Xml
             return value;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeSetInt64(Int64 value, byte* pb)
         {
             UnsafeSetInt32((int)value, pb);
             UnsafeSetInt32((int)(value >> 32), &pb[4]);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeSetInt32(Int32 value, byte* pb)
         {
             pb[0] = (byte)value;

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReader.cs
@@ -2,17 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
-using System.Xml;
-using System.Collections;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
-using System.Globalization;
 using System.Runtime.Serialization;
-
 
 namespace System.Xml
 {
@@ -1232,12 +1223,6 @@ namespace System.Xml
                 throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException(nameof(count), SR.Format(SR.SizeExceedsRemainingBufferSpace, array.Length - offset)));
         }
 
-        // bool
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private unsafe int ReadArray(bool[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
@@ -1264,12 +1249,6 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        // Int16
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private unsafe int ReadArray(Int16[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
@@ -1296,12 +1275,6 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        // Int32
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private unsafe int ReadArray(Int32[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
@@ -1328,12 +1301,6 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        // Int64
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private unsafe int ReadArray(Int64[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
@@ -1360,12 +1327,6 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        // float
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private unsafe int ReadArray(float[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
@@ -1392,12 +1353,6 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        // double
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private unsafe int ReadArray(double[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
@@ -1424,12 +1379,6 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        // decimal
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private unsafe int ReadArray(decimal[] array, int offset, int count)
         {
             CheckArray(array, offset, count);

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
@@ -13,8 +13,6 @@ using System.Diagnostics;
 using System.Runtime.Serialization;
 using System.Globalization;
 using System.Collections.Generic;
-using System.Security;
-
 
 namespace System.Xml
 {
@@ -377,11 +375,6 @@ namespace System.Xml
             WriteMultiByteInt32(key);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         private unsafe void WriteName(string s)
         {
             int length = s.Length;
@@ -398,11 +391,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeWriteName(char* chars, int charCount)
         {
             if (charCount < 128 / maxBytesPerChar)
@@ -615,11 +603,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteText(string value)
         {
             if (_inAttribute)
@@ -642,11 +625,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteText(char[] chars, int offset, int count)
         {
             if (_inAttribute)
@@ -675,11 +653,6 @@ namespace System.Xml
             WriteBytes(chars, charOffset, charCount);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeWriteText(char* chars, int charCount)
         {
             // Callers should handle zero
@@ -774,11 +747,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteFloatText(float f)
         {
             long l;
@@ -800,11 +768,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteDoubleText(double d)
         {
             float f;
@@ -830,11 +793,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteDecimalText(decimal d)
         {
             int offset;
@@ -933,22 +891,12 @@ namespace System.Xml
             WriteMultiByteInt32(count);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         unsafe public void UnsafeWriteArray(XmlBinaryNodeType nodeType, int count, byte* array, byte* arrayMax)
         {
             WriteArrayInfo(nodeType, count);
             UnsafeWriteArray(array, (int)(arrayMax - array));
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeWriteArray(byte* array, int byteCount)
         {
             base.UnsafeWriteBytes(array, byteCount);
@@ -1242,11 +1190,6 @@ namespace System.Xml
             EndArray();
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeWriteArray(string prefix, string localName, string namespaceUri,
                                XmlBinaryNodeType nodeType, int count, byte* array, byte* arrayMax)
         {
@@ -1255,11 +1198,6 @@ namespace System.Xml
             WriteEndArray();
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeWriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri,
                                XmlBinaryNodeType nodeType, int count, byte* array, byte* arrayMax)
         {
@@ -1282,12 +1220,6 @@ namespace System.Xml
                 throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException(nameof(count), SR.Format(SR.SizeExceedsRemainingBufferSpace, array.Length - offset)));
         }
 
-        // bool
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, string localName, string namespaceUri, bool[] array, int offset, int count)
         {
             {
@@ -1302,11 +1234,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, bool[] array, int offset, int count)
         {
             {
@@ -1321,12 +1248,6 @@ namespace System.Xml
             }
         }
 
-        // Int16
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, string localName, string namespaceUri, Int16[] array, int offset, int count)
         {
             {
@@ -1341,11 +1262,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, Int16[] array, int offset, int count)
         {
             {
@@ -1360,12 +1276,6 @@ namespace System.Xml
             }
         }
 
-        // Int32
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, string localName, string namespaceUri, Int32[] array, int offset, int count)
         {
             {
@@ -1380,11 +1290,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, Int32[] array, int offset, int count)
         {
             {
@@ -1399,12 +1304,6 @@ namespace System.Xml
             }
         }
 
-        // Int64
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, string localName, string namespaceUri, Int64[] array, int offset, int count)
         {
             {
@@ -1419,11 +1318,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, Int64[] array, int offset, int count)
         {
             {
@@ -1438,12 +1332,6 @@ namespace System.Xml
             }
         }
 
-        // float
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, string localName, string namespaceUri, float[] array, int offset, int count)
         {
             {
@@ -1458,11 +1346,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, float[] array, int offset, int count)
         {
             {
@@ -1477,12 +1360,6 @@ namespace System.Xml
             }
         }
 
-        // double
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, string localName, string namespaceUri, double[] array, int offset, int count)
         {
             {
@@ -1497,11 +1374,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, double[] array, int offset, int count)
         {
             {
@@ -1516,12 +1388,6 @@ namespace System.Xml
             }
         }
 
-        // decimal
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, string localName, string namespaceUri, decimal[] array, int offset, int count)
         {
             {
@@ -1536,11 +1402,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public override void WriteArray(string prefix, XmlDictionaryString localName, XmlDictionaryString namespaceUri, decimal[] array, int offset, int count)
         {
             {

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
@@ -8,13 +8,11 @@ using System.Xml;
 using System.Collections;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Security;
 using System.Text;
 using System.Globalization;
 using System.Runtime.Serialization;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-
 
 namespace System.Xml
 {
@@ -391,11 +389,6 @@ namespace System.Xml
             return (hi << 32) + lo;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public float ReadSingle()
         {
             int offset;
@@ -411,11 +404,6 @@ namespace System.Xml
             return value;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public double ReadDouble()
         {
             int offset;
@@ -435,11 +423,6 @@ namespace System.Xml
             return value;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public decimal ReadDecimal()
         {
             int offset;
@@ -525,21 +508,11 @@ namespace System.Xml
             return value;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         unsafe public void UnsafeReadArray(byte* dst, byte* dstMax)
         {
             UnsafeReadArray(dst, (int)(dstMax - dst));
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         private unsafe void UnsafeReadArray(byte* dst, int length)
         {
             if (_stream != null)
@@ -948,11 +921,6 @@ namespace System.Xml
             return true;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public bool Equals2(int offset1, int length1, string s2)
         {
             int byteLength = length1;
@@ -1071,11 +1039,6 @@ namespace System.Xml
             return (ulong)GetInt64(offset);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public float GetSingle(int offset)
         {
             byte[] buffer = _buffer;
@@ -1089,11 +1052,6 @@ namespace System.Xml
             return value;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe public double GetDouble(int offset)
         {
             byte[] buffer = _buffer;
@@ -1111,11 +1069,6 @@ namespace System.Xml
             return value;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         public unsafe decimal GetDecimal(int offset)
         {
             byte[] buffer = _buffer;

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlConverter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlConverter.cs
@@ -740,7 +740,6 @@ namespace System.Xml
             return count + ToCharsR((int)value, chars, offset);
         }
 
-        [SecuritySafeCritical]
         private static unsafe bool IsNegativeZero(float value)
         {
             // Simple equals function will report that -0 is equal to +0, so compare bits instead
@@ -748,7 +747,6 @@ namespace System.Xml
             return (*(Int32*)&value == *(Int32*)&negativeZero);
         }
 
-        [SecuritySafeCritical]
         private static unsafe bool IsNegativeZero(double value)
         {
             // Simple equals function will report that -0 is equal to +0, so compare bits instead

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlStreamNodeWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlStreamNodeWriter.cs
@@ -5,7 +5,6 @@
 using System.IO;
 using System.Text;
 using System.Runtime.Serialization;
-using System.Security;
 using System.Threading.Tasks;
 
 namespace System.Xml
@@ -244,11 +243,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         unsafe protected void UnsafeWriteBytes(byte* bytes, int byteCount)
         {
             FlushBuffer();
@@ -268,11 +262,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe protected void WriteUTF8Char(int ch)
         {
             if (ch < 0x80)
@@ -311,11 +300,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        /// Safe - unsafe code is effectively encapsulated, all inputs are validated
-        /// </SecurityNote>
-        [SecuritySafeCritical]
         unsafe protected void WriteUTF8Chars(string value)
         {
             int count = value.Length;
@@ -328,11 +312,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         unsafe protected void UnsafeWriteUTF8Chars(char* chars, int charCount)
         {
             const int charChunkSize = bufferLength / maxBytesPerChar;
@@ -355,11 +334,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         unsafe protected void UnsafeWriteUnicodeChars(char* chars, int charCount)
         {
             const int charChunkSize = bufferLength / 2;
@@ -382,11 +356,6 @@ namespace System.Xml
             }
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         unsafe protected int UnsafeGetUnicodeChars(char* chars, int charCount, byte[] buffer, int offset)
         {
             char* charsMax = chars + charCount;
@@ -400,11 +369,6 @@ namespace System.Xml
             return charCount * 2;
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         unsafe protected int UnsafeGetUTF8Length(char* chars, int charCount)
         {
             char* charsMax = chars + charCount;
@@ -427,11 +391,6 @@ namespace System.Xml
             return (int)(chars - (charsMax - charCount)) + GetByteCount(chArray);
         }
 
-        /// <SecurityNote>
-        /// Critical - contains unsafe code
-        ///            caller needs to validate arguments
-        /// </SecurityNote>
-        [SecurityCritical]
         unsafe protected int UnsafeGetUTF8Chars(char* chars, int charCount, byte[] buffer, int offset)
         {
             if (charCount > 0)

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextWriter.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
-using System.Security;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -436,7 +435,6 @@ namespace System.Xml
             WriteEscapedText(s.Value);
         }
 
-        [SecuritySafeCritical]
         unsafe public override void WriteEscapedText(string s)
         {
             int count = s.Length;
@@ -449,7 +447,6 @@ namespace System.Xml
             }
         }
 
-        [SecuritySafeCritical]
         unsafe public override void WriteEscapedText(char[] s, int offset, int count)
         {
             if (count > 0)
@@ -461,7 +458,6 @@ namespace System.Xml
             }
         }
 
-        [SecurityCritical]
         private unsafe void UnsafeWriteEscapedText(char* chars, int count)
         {
             bool[] isEscapedChar = (_inAttribute ? _isEscapedAttributeChar : _isEscapedElementChar);
@@ -522,7 +518,6 @@ namespace System.Xml
             WriteUTF8Chars(chars, offset, count);
         }
 
-        [SecuritySafeCritical]
         unsafe public override void WriteText(char[] chars, int offset, int count)
         {
             if (count > 0)


### PR DESCRIPTION
Removed usage of both [SecureSafeCritical] and [SecurityCritical] as well as removing unused references where it seemed appropriate.

Fix #13190

(I am sending out the PR on behalf of @stephenmichaelf. The original PR #13803 had been reviewed but got conflicts.)