### PR TITLE
Expose ConcurrentDictionary GetOrAdd/AddOrUpdate overloads in netcoreapp1.1

### DIFF
--- a/src/System.Collections.Concurrent/pkg/System.Collections.Concurrent.pkgproj
+++ b/src/System.Collections.Concurrent/pkg/System.Collections.Concurrent.pkgproj
@@ -2,8 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <ProjectReference Include="..\ref\System.Collections.Concurrent.csproj">
-      <SupportedFramework>net46;netcore50;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
+    <ProjectReference Include="..\ref\System.Collections.Concurrent.builds">
+      <SupportedFramework>netcoreapp1.1;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Collections.Concurrent.builds" />
     <InboxOnTargetFramework Include="MonoAndroid10" />

--- a/src/System.Collections.Concurrent/ref/System.Collections.Concurrent.builds
+++ b/src/System.Collections.Concurrent/ref/System.Collections.Concurrent.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Collections.Concurrent.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Collections.Concurrent/ref/System.Collections.Concurrent.cs
+++ b/src/System.Collections.Concurrent/ref/System.Collections.Concurrent.cs
@@ -99,11 +99,13 @@ namespace System.Collections.Concurrent
         public System.Collections.Generic.ICollection<TValue> Values { get { throw null; } }
         public TValue AddOrUpdate(TKey key, TValue addValue, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
         public TValue AddOrUpdate(TKey key, System.Func<TKey, TValue> addValueFactory, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+        public TValue AddOrUpdate<TArg>(TKey key, System.Func<TKey, TArg, TValue> addValueFactory, System.Func<TKey, TValue, TArg, TValue> updateValueFactory, TArg factoryArgument) { throw null; }
         public void Clear() { }
         public bool ContainsKey(TKey key) { throw null; }
         public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> GetEnumerator() { throw null; }
         public TValue GetOrAdd(TKey key, TValue value) { throw null; }
         public TValue GetOrAdd(TKey key, System.Func<TKey, TValue> valueFactory) { throw null; }
+        public TValue GetOrAdd<TArg>(TKey key, System.Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
         void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
         bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
         void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int index) { }

--- a/src/System.Collections.Concurrent/ref/System.Collections.Concurrent.cs
+++ b/src/System.Collections.Concurrent/ref/System.Collections.Concurrent.cs
@@ -99,13 +99,17 @@ namespace System.Collections.Concurrent
         public System.Collections.Generic.ICollection<TValue> Values { get { throw null; } }
         public TValue AddOrUpdate(TKey key, TValue addValue, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
         public TValue AddOrUpdate(TKey key, System.Func<TKey, TValue> addValueFactory, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+#if netcoreapp11
         public TValue AddOrUpdate<TArg>(TKey key, System.Func<TKey, TArg, TValue> addValueFactory, System.Func<TKey, TValue, TArg, TValue> updateValueFactory, TArg factoryArgument) { throw null; }
+#endif
         public void Clear() { }
         public bool ContainsKey(TKey key) { throw null; }
         public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> GetEnumerator() { throw null; }
         public TValue GetOrAdd(TKey key, TValue value) { throw null; }
         public TValue GetOrAdd(TKey key, System.Func<TKey, TValue> valueFactory) { throw null; }
+#if netcoreapp11
         public TValue GetOrAdd<TArg>(TKey key, System.Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
+#endif
         void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
         bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
         void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int index) { }

--- a/src/System.Collections.Concurrent/ref/System.Collections.Concurrent.csproj
+++ b/src/System.Collections.Concurrent/ref/System.Collections.Concurrent.csproj
@@ -4,7 +4,8 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.10.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)'==''">.NETCoreApp,Version=v1.1</NuGetTargetMoniker>
+    <DefineConstants Condition="'$(TargetGroup)'==''">$(DefineConstants);netcoreapp11</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Collections.Concurrent.cs" />

--- a/src/System.Collections.Concurrent/ref/project.json
+++ b/src/System.Collections.Concurrent/ref/project.json
@@ -4,6 +4,7 @@
     "System.Threading.Tasks": "4.0.11"
   },
   "frameworks": {
-    "netstandard1.3": {}
+    "netstandard1.3": {},
+    "netcoreapp1.1": {}
   }
 }

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1047,6 +1047,37 @@ namespace System.Collections.Concurrent
         /// if the key does not already exist.
         /// </summary>
         /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The function used to generate a value for the key</param>
+        /// <param name="factoryArgument">An argument value to pass into <paramref name="valueFactory"/>.</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="valueFactory"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// elements.</exception>
+        /// <returns>The value for the key.  This will be either the existing value for the key if the
+        /// key is already in the dictionary, or the new value for the key as returned by valueFactory
+        /// if the key was not in the dictionary.</returns>
+        public TValue GetOrAdd<TArg>(TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument)
+        {
+            if (key == null) throw new ArgumentNullException("key");
+            if (valueFactory == null) throw new ArgumentNullException("valueFactory");
+
+            int hashcode = _comparer.GetHashCode(key);
+
+            TValue resultingValue;
+            if (!TryGetValueInternal(key, hashcode, out resultingValue))
+            {
+                TryAddInternal(key, hashcode, valueFactory(key, factoryArgument), false, true, out resultingValue);
+            }
+            return resultingValue;
+        }
+
+        /// <summary>
+        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/> 
+        /// if the key does not already exist.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
         /// <param name="value">the value to be added, if the key does not already exist</param>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
@@ -1066,6 +1097,59 @@ namespace System.Collections.Concurrent
                 TryAddInternal(key, hashcode, value, false, true, out resultingValue);
             }
             return resultingValue;
+        }
+
+        /// <summary>
+        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key does not already 
+        /// exist, or updates a key/value pair in the <see cref="ConcurrentDictionary{TKey,TValue}"/> if the key 
+        /// already exists.
+        /// </summary>
+        /// <param name="key">The key to be added or whose value should be updated</param>
+        /// <param name="addValueFactory">The function used to generate a value for an absent key</param>
+        /// <param name="updateValueFactory">The function used to generate a new value for an existing key
+        /// based on the key's existing value</param>
+        /// <param name="factoryArgument">An argument to pass into <paramref name="addValueFactory"/> and <paramref name="updateValueFactory"/>.</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="addValueFactory"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="updateValueFactory"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// elements.</exception>
+        /// <returns>The new value for the key.  This will be either be the result of addValueFactory (if the key was 
+        /// absent) or the result of updateValueFactory (if the key was present).</returns>
+        public TValue AddOrUpdate<TArg>(
+            TKey key, Func<TKey, TArg, TValue> addValueFactory, Func<TKey, TValue, TArg, TValue> updateValueFactory, TArg factoryArgument)
+        {
+            if (key == null) throw new ArgumentNullException("key");
+            if (addValueFactory == null) throw new ArgumentNullException("addValueFactory");
+            if (updateValueFactory == null) throw new ArgumentNullException("updateValueFactory");
+
+            int hashcode = _comparer.GetHashCode(key);
+
+            while (true)
+            {
+                TValue oldValue;
+                if (TryGetValueInternal(key, hashcode, out oldValue))
+                {
+                    // key exists, try to update
+                    TValue newValue = updateValueFactory(key, oldValue, factoryArgument);
+                    if (TryUpdateInternal(key, hashcode, newValue, oldValue))
+                    {
+                        return newValue;
+                    }
+                }
+                else
+                {
+                    // key doesn't exist, try to add
+                    TValue resultingValue;
+                    if (TryAddInternal(key, hashcode, addValueFactory(key, factoryArgument), false, true, out resultingValue))
+                    {
+                        return resultingValue;
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -1099,16 +1183,17 @@ namespace System.Collections.Concurrent
             {
                 TValue oldValue;
                 if (TryGetValueInternal(key, hashcode, out oldValue))
-                //key exists, try to update
                 {
+                    // key exists, try to update
                     TValue newValue = updateValueFactory(key, oldValue);
                     if (TryUpdateInternal(key, hashcode, newValue, oldValue))
                     {
                         return newValue;
                     }
                 }
-                else //try add
+                else 
                 {
+                    // key doesn't exist, try to add
                     TValue resultingValue;
                     if (TryAddInternal(key, hashcode, addValueFactory(key), false, true, out resultingValue))
                     {
@@ -1146,16 +1231,17 @@ namespace System.Collections.Concurrent
             {
                 TValue oldValue;
                 if (TryGetValueInternal(key, hashcode, out oldValue))
-                //key exists, try to update
                 {
+                    // key exists, try to update
                     TValue newValue = updateValueFactory(key, oldValue);
                     if (TryUpdateInternal(key, hashcode, newValue, oldValue))
                     {
                         return newValue;
                     }
                 }
-                else //try add
+                else 
                 {
+                    // key doesn't exist, try to add
                     TValue resultingValue;
                     if (TryAddInternal(key, hashcode, addValue, false, true, out resultingValue))
                     {

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1060,8 +1060,8 @@ namespace System.Collections.Concurrent
         /// if the key was not in the dictionary.</returns>
         public TValue GetOrAdd<TArg>(TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument)
         {
-            if (key == null) throw new ArgumentNullException("key");
-            if (valueFactory == null) throw new ArgumentNullException("valueFactory");
+            if (key == null) throw new ArgumentNullException(nameof(key));
+            if (valueFactory == null) throw new ArgumentNullException(nameof(valueFactory));
 
             int hashcode = _comparer.GetHashCode(key);
 
@@ -1122,9 +1122,9 @@ namespace System.Collections.Concurrent
         public TValue AddOrUpdate<TArg>(
             TKey key, Func<TKey, TArg, TValue> addValueFactory, Func<TKey, TValue, TArg, TValue> updateValueFactory, TArg factoryArgument)
         {
-            if (key == null) throw new ArgumentNullException("key");
-            if (addValueFactory == null) throw new ArgumentNullException("addValueFactory");
-            if (updateValueFactory == null) throw new ArgumentNullException("updateValueFactory");
+            if (key == null) throw new ArgumentNullException(nameof(key));
+            if (addValueFactory == null) throw new ArgumentNullException(nameof(addValueFactory));
+            if (updateValueFactory == null) throw new ArgumentNullException(nameof(updateValueFactory));
 
             int hashcode = _comparer.GetHashCode(key);
 

--- a/src/System.Collections.Concurrent/tests/ConcurrentDicionary/ConcurrentDictionaryExtensions.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentDicionary/ConcurrentDictionaryExtensions.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Collections.Concurrent.Tests
+{
+    // Allows the ConcurrentDictionary tests to run on targets that do not have the new GetOrAdd/AddOrUpdate overloads.
+    internal static class ConcurrentDictionaryExtensions
+    {
+        public static TValue GetOrAdd<TKey, TValue, TArg>(
+            this ConcurrentDictionary<TKey, TValue> dictionary,
+            TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+            if (valueFactory == null) throw new ArgumentNullException(nameof(valueFactory));
+
+            while (true)
+            {
+                TValue value;
+                if (dictionary.TryGetValue(key, out value))
+                    return value;
+
+                value = valueFactory(key, factoryArgument);
+                if (dictionary.TryAdd(key, value))
+                    return value;
+            }
+        }
+
+        public static TValue AddOrUpdate<TKey, TValue, TArg>(
+            this ConcurrentDictionary<TKey, TValue> dictionary,
+            TKey key, Func<TKey, TArg, TValue> addValueFactory, Func<TKey, TValue, TArg, TValue> updateValueFactory, TArg factoryArgument)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+            if (addValueFactory == null) throw new ArgumentNullException(nameof(addValueFactory));
+            if (updateValueFactory == null) throw new ArgumentNullException(nameof(updateValueFactory));
+
+            while (true)
+            {
+                TValue value;
+                if (dictionary.TryGetValue(key, out value))
+                {
+                    TValue updatedValue = updateValueFactory(key, value, factoryArgument);
+                    if (dictionary.TryUpdate(key, updatedValue, value))
+                    {
+                        return updatedValue;
+                    }
+                }
+                else
+                {
+                    value = addValueFactory(key, factoryArgument);
+                    if (dictionary.TryAdd(key, value))
+                    {
+                        return value;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/System.Collections.Concurrent/tests/ConcurrentDicionary/ConcurrentDictionaryTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentDicionary/ConcurrentDictionaryTests.cs
@@ -441,25 +441,33 @@ namespace System.Collections.Concurrent.Tests
                             {
                                 if (isAdd)
                                 {
-                                    //call either of the two overloads of GetOrAdd
-                                    if (j + ii % 2 == 0)
+                                    //call one of the overloads of GetOrAdd
+                                    switch (j % 3)
                                     {
-                                        dict.GetOrAdd(j, -j);
-                                    }
-                                    else
-                                    {
-                                        dict.GetOrAdd(j, x => -x);
+                                        case 0:
+                                            dict.GetOrAdd(j, -j);
+                                            break;
+                                        case 1:
+                                            dict.GetOrAdd(j, x => -x);
+                                            break;
+                                        case 2:
+                                            dict.GetOrAdd(j, (x,m) => x * m, -1);
+                                            break;
                                     }
                                 }
                                 else
                                 {
-                                    if (j + ii % 2 == 0)
+                                    switch (j % 3)
                                     {
-                                        dict.AddOrUpdate(j, -j, (k, v) => -j);
-                                    }
-                                    else
-                                    {
-                                        dict.AddOrUpdate(j, (k) => -k, (k, v) => -k);
+                                        case 0:
+                                            dict.AddOrUpdate(j, -j, (k, v) => -j);
+                                            break;
+                                        case 1:
+                                            dict.AddOrUpdate(j, (k) => -k, (k, v) => -k);
+                                            break;
+                                        case 2:
+                                            dict.AddOrUpdate(j, (k,m) => k*m, (k, v, m) => k * m, -1);
+                                            break;
                                     }
                                 }
                             }
@@ -616,6 +624,12 @@ namespace System.Collections.Concurrent.Tests
             // "TestExceptions:  FAILED.  this[] didn't throw ANE when null key is passed");
 
             Assert.Throws<ArgumentNullException>(
+               () => dictionary.GetOrAdd(null, (k,m) => 0, 0));
+            // "TestExceptions:  FAILED.  GetOrAdd didn't throw ANE when null key is passed");
+            Assert.Throws<ArgumentNullException>(
+               () => dictionary.GetOrAdd("1", null, 0));
+            // "TestExceptions:  FAILED.  GetOrAdd didn't throw ANE when null valueFactory is passed");
+            Assert.Throws<ArgumentNullException>(
                () => dictionary.GetOrAdd(null, (k) => 0));
             // "TestExceptions:  FAILED.  GetOrAdd didn't throw ANE when null key is passed");
             Assert.Throws<ArgumentNullException>(
@@ -625,6 +639,15 @@ namespace System.Collections.Concurrent.Tests
                () => dictionary.GetOrAdd(null, 0));
             // "TestExceptions:  FAILED.  GetOrAdd didn't throw ANE when null key is passed");
 
+            Assert.Throws<ArgumentNullException>(
+               () => dictionary.AddOrUpdate(null, (k, m) => 0, (k, v, m) => 0, 42));
+            // "TestExceptions:  FAILED.  AddOrUpdate didn't throw ANE when null key is passed");
+            Assert.Throws<ArgumentNullException>(
+               () => dictionary.AddOrUpdate("1", (k, m) => 0, null, 42));
+            // "TestExceptions:  FAILED.  AddOrUpdate didn't throw ANE when null updateFactory is passed");
+            Assert.Throws<ArgumentNullException>(
+               () => dictionary.AddOrUpdate("1", null, (k, v, m) => 0, 42));
+            // "TestExceptions:  FAILED.  AddOrUpdate didn't throw ANE when null addFactory is passed");
             Assert.Throws<ArgumentNullException>(
                () => dictionary.AddOrUpdate(null, (k) => 0, (k, v) => 0));
             // "TestExceptions:  FAILED.  AddOrUpdate didn't throw ANE when null key is passed");

--- a/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.builds
+++ b/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.builds
@@ -8,6 +8,9 @@
       <TestTFMs>netcoreapp1.0</TestTFMs>
     </Project>
     <Project Include="System.Collections.Concurrent.Tests.csproj">
+      <TargetGroup>netcoreapp1.1</TargetGroup>
+    </Project>
+    <Project Include="System.Collections.Concurrent.Tests.csproj">
       <TargetGroup>netstandard1.3</TargetGroup>
       <OSGroup>Windows_NT</OSGroup>
       <TestTFMs>netcore50;net46</TestTFMs>

--- a/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
+++ b/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
@@ -85,7 +85,10 @@
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'!=''">
+  <ItemGroup Condition="'$(TargetGroup)' != 'netcoreapp1.1'">
+    <Compile Include="ConcurrentDicionary\ConcurrentDictionaryExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'!='' and '$(TargetGroup)'!='netcoreapp1.1'">
     <Compile Include="$(CommonPath)\System\SerializableAttribute.cs">
       <Link>Common\System\SerializableAttribute.cs</Link>
     </Compile>


### PR DESCRIPTION
Port #1783 from future to master. Contributes to #2869.

I cherry-picked (and slightly tweaked) the two relevant commits from the future branch:
 - fffd49fe1c35544b388322608d1e16374f3832e6 (fixed the conflict due to moved test file)
 - ee5906f35222b80a729541683f76f43fe2c49204 (updated to use current `throw null;` style)

I then added a third commit that cleaned some things up, extracted tests, and exposed the APIs in netcoreapp1.1.

cc: @stephentoub