### PR TITLE
Test DebuggerTypeProxy for ExpandoObject's keys and values and throw on null

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
@@ -325,7 +325,7 @@ namespace System.Dynamic
 
             public KeyCollectionDebugView(ICollection<string> collection)
             {
-                Debug.Assert(collection != null);
+                ContractUtils.RequiresNotNull(collection, nameof(collection));
                 _collection = collection;
             }
 
@@ -464,7 +464,7 @@ namespace System.Dynamic
 
             public ValueCollectionDebugView(ICollection<object> collection)
             {
-                Debug.Assert(collection != null);
+                ContractUtils.RequiresNotNull(collection, nameof(collection));
                 _collection = collection;
             }
 

--- a/src/System.Linq.Expressions/tests/Dynamic/ExpandoObjectProxyTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/ExpandoObjectProxyTests.cs
@@ -1,0 +1,104 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace System.Dynamic.Tests
+{
+    public class ExpandoObjectProxyTests
+    {
+        private static Type GetDebugViewType(Type type)
+        {
+            var att =
+                (DebuggerTypeProxyAttribute)
+                    type.GetCustomAttributes().Single(at => at.TypeId.Equals(typeof(DebuggerTypeProxyAttribute)));
+            var proxyName = att.ProxyTypeName;
+            proxyName = proxyName.Substring(0, proxyName.IndexOf(','));
+            return type.GetTypeInfo().Assembly.GetType(proxyName);
+        }
+
+        private static object GetDebugViewObject(object obj)
+            => GetDebugViewType(obj.GetType()).GetConstructors().Single().Invoke(new[] {obj});
+
+        private static IEnumerable<IDictionary<string, object>> TestExpandos()
+        {
+            yield return new ExpandoObject();
+
+            dynamic dyn0 = new ExpandoObject();
+            dyn0.X = 2;
+            yield return dyn0;
+
+            dynamic dyn1 = new ExpandoObject();
+            dyn1.X = "hello";
+            yield return dyn1;
+
+            dynamic dyn2 = new ExpandoObject();
+            dyn2.X = "hello";
+            dyn2.Y = 42;
+            dyn2.Greet = (Func<string>)(() => $"{dyn2.Salutation} {dyn2.Recipient}!");
+            yield return dyn2;
+
+            dynamic dyn3 = new ExpandoObject();
+            dyn3.X = "hello";
+            dyn3.Y = 42;
+            dyn3.Greet = (Func<string>)(() => $"{dyn3.Salutation} {dyn3.Recipient}!");
+            dyn3.Salutation = "Hello";
+            dyn3.Recipient = "World";
+            yield return dyn3;
+
+            dynamic dyn4 = new ExpandoObject();
+            dyn4.X = "hello";
+            dyn4.Y = 42;
+            dyn4.Greet = (Func<string>)(() => $"{dyn4.Salutation} {dyn4.Recipient}!");
+            dyn4.Salutation = "Hello";
+            dyn4.Recipient = "World";
+            ((IDictionary<string, object>)dyn4).Remove("Y");
+            yield return dyn4;
+        }
+
+        private static IEnumerable<object[]> KeyCollections() => TestExpandos().Select(dict => new object[] {dict.Keys});
+
+        private static IEnumerable<object[]> ValueCollections()
+            => TestExpandos().Select(dict => new object[] {dict.Values});
+
+        private static void AssertSameCollectionIgnoreOrder<T>(ICollection<T> expected, ICollection<T> actual)
+        {
+            Assert.Equal(actual.Count, expected.Count);
+            foreach(T item in actual)
+                Assert.Contains(item, expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(KeyCollections))]
+        [MemberData(nameof(ValueCollections))]
+        public void ItemsAreRootHidden(object eo)
+        {
+            var itemsProp = GetDebugViewObject(eo).GetType().GetProperty("Items");
+            var browsable = (DebuggerBrowsableAttribute)itemsProp.GetCustomAttribute(typeof(DebuggerBrowsableAttribute));
+            Assert.Equal(DebuggerBrowsableState.RootHidden, browsable.State);
+        }
+
+        [Theory, MemberData(nameof(KeyCollections))]
+        public void KeyCollectionCorrectlyViewed(ICollection<string> keys)
+        {
+            object view = GetDebugViewObject(keys);
+            var itemsProp = view.GetType().GetProperty("Items");
+            string[] items = (string[])itemsProp.GetValue(view);
+            AssertSameCollectionIgnoreOrder(keys, items);
+        }
+
+        [Theory, MemberData(nameof(ValueCollections))]
+        public void ValueCollectionCorrectlyViewed(ICollection<object> keys)
+        {
+            object view = GetDebugViewObject(keys);
+            var itemsProp = view.GetType().GetProperty("Items");
+            object[] items = (object[])itemsProp.GetValue(view);
+            AssertSameCollectionIgnoreOrder(keys, items);
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Dynamic\BindingRestrictionsTests.cs" />
     <Compile Include="Dynamic\CallInfoTests.cs" />
     <Compile Include="Dynamic\DynamicObjectDefaultBehaviorTests.cs" />
+    <Compile Include="Dynamic\ExpandoObjectProxyTests.cs" />
     <Compile Include="Dynamic\UnaryOperationTests.cs .cs" />
     <Compile Include="ExceptionHandling\ExceptionHandlingExpressions.cs" />
     <Compile Include="ExpressionTests.cs" />


### PR DESCRIPTION
Throw if null is passed to the constructor of either of these types.

Contributes to #13840

Also test these types thoroughly, beyond that necessary to confirm this fix.