### PR TITLE
Throw null when null is passed to debug proxies.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/BindingRestrictions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/BindingRestrictions.cs
@@ -365,6 +365,7 @@ namespace System.Dynamic
 
             public BindingRestrictionsProxy(BindingRestrictions node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Expression.DebuggerProxy.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Expression.DebuggerProxy.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.ObjectModel;
+using System.Dynamic.Utils;
 using System.Reflection;
 
 namespace System.Linq.Expressions
@@ -15,6 +16,7 @@ namespace System.Linq.Expressions
 
             public BinaryExpressionProxy(BinaryExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -36,6 +38,7 @@ namespace System.Linq.Expressions
 
             public BlockExpressionProxy(BlockExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -54,6 +57,7 @@ namespace System.Linq.Expressions
 
             public CatchBlockProxy(CatchBlock node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -69,6 +73,7 @@ namespace System.Linq.Expressions
 
             public ConditionalExpressionProxy(ConditionalExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -87,6 +92,7 @@ namespace System.Linq.Expressions
 
             public ConstantExpressionProxy(ConstantExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -103,6 +109,7 @@ namespace System.Linq.Expressions
 
             public DebugInfoExpressionProxy(DebugInfoExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -124,6 +131,7 @@ namespace System.Linq.Expressions
 
             public DefaultExpressionProxy(DefaultExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -139,6 +147,7 @@ namespace System.Linq.Expressions
 
             public GotoExpressionProxy(GotoExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -157,6 +166,7 @@ namespace System.Linq.Expressions
 
             public IndexExpressionProxy(IndexExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -175,6 +185,7 @@ namespace System.Linq.Expressions
 
             public InvocationExpressionProxy(InvocationExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -192,6 +203,7 @@ namespace System.Linq.Expressions
 
             public LabelExpressionProxy(LabelExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -209,6 +221,7 @@ namespace System.Linq.Expressions
 
             public LambdaExpressionProxy(LambdaExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -229,6 +242,7 @@ namespace System.Linq.Expressions
 
             public ListInitExpressionProxy(ListInitExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -246,6 +260,7 @@ namespace System.Linq.Expressions
 
             public LoopExpressionProxy(LoopExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -264,6 +279,7 @@ namespace System.Linq.Expressions
 
             public MemberExpressionProxy(MemberExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -281,6 +297,7 @@ namespace System.Linq.Expressions
 
             public MemberInitExpressionProxy(MemberInitExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -298,6 +315,7 @@ namespace System.Linq.Expressions
 
             public MethodCallExpressionProxy(MethodCallExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -316,6 +334,7 @@ namespace System.Linq.Expressions
 
             public NewArrayExpressionProxy(NewArrayExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -332,6 +351,7 @@ namespace System.Linq.Expressions
 
             public NewExpressionProxy(NewExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -350,6 +370,7 @@ namespace System.Linq.Expressions
 
             public ParameterExpressionProxy(ParameterExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -367,6 +388,7 @@ namespace System.Linq.Expressions
 
             public RuntimeVariablesExpressionProxy(RuntimeVariablesExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -383,6 +405,7 @@ namespace System.Linq.Expressions
 
             public SwitchCaseProxy(SwitchCase node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -396,6 +419,7 @@ namespace System.Linq.Expressions
 
             public SwitchExpressionProxy(SwitchExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -415,6 +439,7 @@ namespace System.Linq.Expressions
 
             public TryExpressionProxy(TryExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -434,6 +459,7 @@ namespace System.Linq.Expressions
 
             public TypeBinaryExpressionProxy(TypeBinaryExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 
@@ -451,6 +477,7 @@ namespace System.Linq.Expressions
 
             public UnaryExpressionProxy(UnaryExpression node)
             {
+                ContractUtils.RequiresNotNull(node, nameof(node));
                 _node = node;
             }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -46,6 +46,7 @@ namespace System.Linq.Expressions.Interpreter
 
             public DebugView(InstructionArray array)
             {
+                ContractUtils.RequiresNotNull(array, nameof(array));
                 _array = array;
             }
 
@@ -90,6 +91,7 @@ namespace System.Linq.Expressions.Interpreter
 
             public DebugView(InstructionList list)
             {
+                ContractUtils.RequiresNotNull(list, nameof(list));
                 _list = list;
             }
 

--- a/src/System.Linq.Expressions/tests/DebuggerTypeProxy/ExpressionDebuggerTypeProxyTests.cs
+++ b/src/System.Linq.Expressions/tests/DebuggerTypeProxy/ExpressionDebuggerTypeProxyTests.cs
@@ -155,6 +155,53 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Theory, MemberData(nameof(OnePerType))]
+        public void ThrowOnNullToCtor(object sourceObject)
+        {
+            var type = sourceObject.GetType();
+            var viewType = GetDebugViewType(type);
+            var ctor = viewType.GetConstructors().Single();
+            var tie = Assert.Throws<TargetInvocationException>(() => ctor.Invoke(new object[] {null}));
+            ArgumentNullException ane = (ArgumentNullException)tie.InnerException;
+            Assert.Equal(ctor.GetParameters()[0].Name, ane.ParamName);
+        }
+
+        private static IEnumerable<object[]> OnePerType()
+        {
+            HashSet<Type> seenTypes = new HashSet<Type>();
+            foreach (var candidate in
+                BinaryExpressionProxy()
+                    .Concat(BlockExpressionProxy())
+                    .Concat(CatchBlockProxy())
+                    .Concat(ConditionalExpressionProxy())
+                    .Concat(ConstantExpressionProxy())
+                    .Concat(DebugInfoExpressionProxy())
+                    .Concat(DefaultExpressionProxy())
+                    .Concat(GotoExpressionProxy())
+                    .Concat(IndexExpressionProxy())
+                    .Concat(InvocationExpressionProxy())
+                    .Concat(LabelExpressionProxy())
+                    .Concat(LambdaExpressionProxy())
+                    .Concat(ListInitExpressionProxy())
+                    .Concat(LoopExpressionProxy())
+                    .Concat(MemberExpressionProxy())
+                    .Concat(MemberInitExpressionProxy())
+                    .Concat(MethodCallExpressionProxy())
+                    .Concat(NewArrayExpressionProxy())
+                    .Concat(NewExpressionProxy())
+                    .Concat(ParameterExpressionProxy())
+                    .Concat(RuntimeVariablesExpressionProxy())
+                    .Concat(SwitchCaseExpressionProxy())
+                    .Concat(SwitchExpressionProxy())
+                    .Concat(TryExpressionProxy())
+                    .Concat(TypeBinaryExpressionProxy())
+                    .Concat(UnaryExpressionProxy()))
+            {
+                if (seenTypes.Add(candidate[0].GetType()))
+                    yield return candidate;
+            }
+        }
+
         private static IEnumerable<object[]> BinaryExpressionProxy()
         {
             yield return new object[] {Expression.Assign(Expression.Variable(typeof(int)), Expression.Constant(-1))};

--- a/src/System.Linq.Expressions/tests/Dynamic/BindingRestrictionsProxyTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/BindingRestrictionsProxyTests.cs
@@ -170,5 +170,13 @@ namespace System.Dynamic.Tests
             Assert.Equal(3, notAndAlso.Count);
             Assert.True(notAndAlso.All(ex => exps.Contains(ex)));
         }
+
+        [Fact]
+        public void ThrowOnNullToCtor()
+        {
+            var tie = Assert.Throws<TargetInvocationException>(() => BindingRestrictionsProxyCtor.Invoke(new object[] {null}));
+            ArgumentNullException ane = (ArgumentNullException)tie.InnerException;
+            Assert.Equal("node", ane.ParamName);
+        }
     }
 }


### PR DESCRIPTION
Fixes #13840 with the exception of two types covered in #13839 so the fix can live with appropriate tests.