### PR TITLE
S.R.CS.Unsafe: Add CopyBlock/CopyBlockUnaligned and InitBlock/InitBlockUnaligned for ref byte

### DIFF
--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.il
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.il
@@ -141,16 +141,24 @@
         ret
   } // end of method Unsafe::CopyBlock
 
-  .method public hidebysig static void CopyBlock<T>(!!T& destination, !!T& source, int32 elementCount) cil managed aggressiveinlining
+  .method public hidebysig static void CopyBlock(uint8& destination, uint8& source, uint32 byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 4
+        .maxstack 3
         ldarg.0
         ldarg.1
         ldarg.2
-        sizeof !!T
-        conv.i
-        mul
+        cpblk
+        ret
+  } // end of method Unsafe::CopyBlock
+
+  .method public hidebysig static void CopyBlock(uint8& destination, uint8& source, native unsigned int byteCount) cil managed aggressiveinlining
+  {
+        .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
+        .maxstack 3
+        ldarg.0
+        ldarg.1
+        ldarg.2
         cpblk
         ret
   } // end of method Unsafe::CopyBlock
@@ -179,20 +187,29 @@
         ret
   } // end of method Unsafe::CopyBlockUnaligned
 
-  .method public hidebysig static void CopyBlockUnaligned<T>(!!T& destination, !!T& source, int32 elementCount) cil managed aggressiveinlining
+  .method public hidebysig static void CopyBlockUnaligned(uint8& destination, uint8& source, uint32 byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 4
+        .maxstack 3
         ldarg.0
         ldarg.1
         ldarg.2
-        sizeof !!T
-        conv.i
-        mul
         unaligned. 0x1
         cpblk
         ret
-  } // end of method Unsafe::CopyBlock
+  } // end of method Unsafe::CopyBlockUnaligned
+
+  .method public hidebysig static void CopyBlockUnaligned(uint8& destination, uint8& source, native unsigned int byteCount) cil managed aggressiveinlining
+  {
+        .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
+        .maxstack 3
+        ldarg.0
+        ldarg.1
+        ldarg.2
+        unaligned. 0x1
+        cpblk
+        ret
+  } // end of method Unsafe::CopyBlockUnaligned
 
   .method public hidebysig static void InitBlock(void* startAddress, uint8 'value', uint32 byteCount) cil managed aggressiveinlining
   {
@@ -216,6 +233,28 @@
         ret
   } // end of method Unsafe::InitBlock
 
+  .method public hidebysig static void InitBlock(uint8& startAddress, uint8 'value', uint32 byteCount) cil managed aggressiveinlining
+  {
+        .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
+        .maxstack 3
+        ldarg.0
+        ldarg.1
+        ldarg.2
+        initblk
+        ret
+  } // end of method Unsafe::InitBlock
+
+  .method public hidebysig static void InitBlock(uint8& startAddress, uint8 'value', native unsigned int byteCount) cil managed aggressiveinlining
+  {
+        .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
+        .maxstack 3
+        ldarg.0
+        ldarg.1
+        ldarg.2
+        initblk
+        ret
+  } // end of method Unsafe::InitBlock
+
   .method public hidebysig static void InitBlockUnaligned(void* startAddress, uint8 'value', uint32 byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
@@ -229,6 +268,30 @@
   } // end of method Unsafe::InitBlockUnaligned
 
   .method public hidebysig static void InitBlockUnaligned(void* startAddress, uint8 'value', native unsigned int byteCount) cil managed aggressiveinlining
+  {
+        .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
+        .maxstack 3
+        ldarg.0
+        ldarg.1
+        ldarg.2
+        unaligned. 0x1
+        initblk
+        ret
+  } // end of method Unsafe::InitBlockUnaligned
+
+  .method public hidebysig static void InitBlockUnaligned(uint8& startAddress, uint8 'value', uint32 byteCount) cil managed aggressiveinlining
+  {
+        .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
+        .maxstack 3
+        ldarg.0
+        ldarg.1
+        ldarg.2
+        unaligned. 0x1
+        initblk
+        ret
+  } // end of method Unsafe::InitBlockUnaligned
+
+  .method public hidebysig static void InitBlockUnaligned(uint8& startAddress, uint8 'value', native unsigned int byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
         .maxstack 3

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.il
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.il
@@ -141,6 +141,20 @@
         ret
   } // end of method Unsafe::CopyBlock
 
+  .method public hidebysig static void CopyBlock<T>(!!T& destination, !!T& source, int32 elementCount) cil managed aggressiveinlining
+  {
+        .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
+        .maxstack 4
+        ldarg.0
+        ldarg.1
+        ldarg.2
+        sizeof !!T
+        conv.i
+        mul
+        cpblk
+        ret
+  } // end of method Unsafe::CopyBlock
+
   .method public hidebysig static void CopyBlockUnaligned(void* destination, void* source, uint32 byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
@@ -164,6 +178,21 @@
         cpblk
         ret
   } // end of method Unsafe::CopyBlockUnaligned
+
+  .method public hidebysig static void CopyBlockUnaligned<T>(!!T& destination, !!T& source, int32 elementCount) cil managed aggressiveinlining
+  {
+        .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
+        .maxstack 4
+        ldarg.0
+        ldarg.1
+        ldarg.2
+        sizeof !!T
+        conv.i
+        mul
+        unaligned. 0x1
+        cpblk
+        ret
+  } // end of method Unsafe::CopyBlock
 
   .method public hidebysig static void InitBlock(void* startAddress, uint8 'value', uint32 byteCount) cil managed aggressiveinlining
   {

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.il
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.il
@@ -130,17 +130,6 @@
         ret
   } // end of method Unsafe::CopyBlock
 
-  .method public hidebysig static void CopyBlock(void* destination, void* source, native unsigned int byteCount) cil managed aggressiveinlining
-  {
-        .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
-        ldarg.0
-        ldarg.1
-        ldarg.2
-        cpblk
-        ret
-  } // end of method Unsafe::CopyBlock
-
   .method public hidebysig static void CopyBlock(uint8& destination, uint8& source, uint32 byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
@@ -152,30 +141,7 @@
         ret
   } // end of method Unsafe::CopyBlock
 
-  .method public hidebysig static void CopyBlock(uint8& destination, uint8& source, native unsigned int byteCount) cil managed aggressiveinlining
-  {
-        .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
-        ldarg.0
-        ldarg.1
-        ldarg.2
-        cpblk
-        ret
-  } // end of method Unsafe::CopyBlock
-
   .method public hidebysig static void CopyBlockUnaligned(void* destination, void* source, uint32 byteCount) cil managed aggressiveinlining
-  {
-        .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
-        ldarg.0
-        ldarg.1
-        ldarg.2
-        unaligned. 0x1
-        cpblk
-        ret
-  } // end of method Unsafe::CopyBlockUnaligned
-
-  .method public hidebysig static void CopyBlockUnaligned(void* destination, void* source, native unsigned int byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
         .maxstack 3
@@ -199,18 +165,6 @@
         ret
   } // end of method Unsafe::CopyBlockUnaligned
 
-  .method public hidebysig static void CopyBlockUnaligned(uint8& destination, uint8& source, native unsigned int byteCount) cil managed aggressiveinlining
-  {
-        .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
-        ldarg.0
-        ldarg.1
-        ldarg.2
-        unaligned. 0x1
-        cpblk
-        ret
-  } // end of method Unsafe::CopyBlockUnaligned
-
   .method public hidebysig static void InitBlock(void* startAddress, uint8 'value', uint32 byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
@@ -222,29 +176,7 @@
         ret
   } // end of method Unsafe::InitBlock
 
-  .method public hidebysig static void InitBlock(void* startAddress, uint8 'value', native unsigned int byteCount) cil managed aggressiveinlining
-  {
-        .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
-        ldarg.0
-        ldarg.1
-        ldarg.2
-        initblk
-        ret
-  } // end of method Unsafe::InitBlock
-
   .method public hidebysig static void InitBlock(uint8& startAddress, uint8 'value', uint32 byteCount) cil managed aggressiveinlining
-  {
-        .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
-        ldarg.0
-        ldarg.1
-        ldarg.2
-        initblk
-        ret
-  } // end of method Unsafe::InitBlock
-
-  .method public hidebysig static void InitBlock(uint8& startAddress, uint8 'value', native unsigned int byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
         .maxstack 3
@@ -267,31 +199,7 @@
         ret
   } // end of method Unsafe::InitBlockUnaligned
 
-  .method public hidebysig static void InitBlockUnaligned(void* startAddress, uint8 'value', native unsigned int byteCount) cil managed aggressiveinlining
-  {
-        .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
-        ldarg.0
-        ldarg.1
-        ldarg.2
-        unaligned. 0x1
-        initblk
-        ret
-  } // end of method Unsafe::InitBlockUnaligned
-
   .method public hidebysig static void InitBlockUnaligned(uint8& startAddress, uint8 'value', uint32 byteCount) cil managed aggressiveinlining
-  {
-        .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
-        ldarg.0
-        ldarg.1
-        ldarg.2
-        unaligned. 0x1
-        initblk
-        ret
-  } // end of method Unsafe::InitBlockUnaligned
-
-  .method public hidebysig static void InitBlockUnaligned(uint8& startAddress, uint8 'value', native unsigned int byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
         .maxstack 3

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.xml
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.xml
@@ -170,7 +170,7 @@
         </member>
         <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlock``1(``0@,``0@,System.Int32)">
             <summary>
-            Copies elements from the source address to the destination address.
+            Copies the specified number of elements from the source address to the destination address.
             </summary>
             <param name="destination">The destination address to copy to.</param>
             <param name="source">The source address to copy from.</param>
@@ -196,7 +196,7 @@
         </member>
         <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned``1(``0@,``0@,System.Int32)">
             <summary>
-            Copies elements from the source address to the destination address.
+            Copies the specified number of elements from the source address to the destination address 
             without assuming architecture dependent alignment of the addresses.
             </summary>
             <param name="destination">The destination address to copy to.</param>

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.xml
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.xml
@@ -168,13 +168,21 @@
             <param name="source">The source address to copy from.</param>
             <param name="byteCount">The number of bytes to copy.</param>
         </member>
-        <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlock``1(``0@,``0@,System.Int32)">
+        <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlock(System.Byte@,System.Byte@,System.UInt32)">
             <summary>
-            Copies the specified number of elements from the source address to the destination address.
+            Copies bytes from the source address to the destination address.
             </summary>
             <param name="destination">The destination address to copy to.</param>
             <param name="source">The source address to copy from.</param>
-            <param name="elementCount">The number of elements to copy.</param>
+            <param name="byteCount">The number of bytes to copy.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlock(System.Byte@,System.Byte@,System.UIntPtr)">
+            <summary>
+            Copies bytes from the source address to the destination address.
+            </summary>
+            <param name="destination">The destination address to copy to.</param>
+            <param name="source">The source address to copy from.</param>
+            <param name="byteCount">The number of bytes to copy.</param>
         </member>
         <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned(System.Void*,System.Void*,System.UInt32)">
             <summary>
@@ -194,14 +202,23 @@
             <param name="source">The source address to copy from.</param>
             <param name="byteCount">The number of bytes to copy.</param>
         </member>
-        <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned``1(``0@,``0@,System.Int32)">
+        <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned(System.Byte@,System.Byte@,System.UInt32)">
             <summary>
-            Copies the specified number of elements from the source address to the destination address 
+            Copies bytes from the source address to the destination address 
             without assuming architecture dependent alignment of the addresses.
             </summary>
             <param name="destination">The destination address to copy to.</param>
             <param name="source">The source address to copy from.</param>
-            <param name="elementCount">The number of elements to copy.</param>
+            <param name="byteCount">The number of bytes to copy.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned(System.Byte@,System.Byte@,System.UIntPtr)">
+            <summary>
+            Copies bytes from the source address to the destination address 
+            without assuming architecture dependent alignment of the addresses.
+            </summary>
+            <param name="destination">The destination address to copy to.</param>
+            <param name="source">The source address to copy from.</param>
+            <param name="byteCount">The number of bytes to copy.</param>
         </member>
         <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlock(System.Void*,System.Byte,System.UInt32)">
             <summary>
@@ -219,6 +236,22 @@
             <param name="value">The value to initialize the block to.</param>
             <param name="byteCount">The number of bytes to initialize.</param>
         </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlock(System.Byte@,System.Byte,System.UInt32)">
+            <summary>
+            Initializes a block of memory at the given location with a given initial value.
+            </summary>
+            <param name="startAddress">The address of the start of the memory block to initialize.</param>
+            <param name="value">The value to initialize the block to.</param>
+            <param name="byteCount">The number of bytes to initialize.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlock(System.Byte@,System.Byte,System.UIntPtr)">
+            <summary>
+            Initializes a block of memory at the given location with a given initial value.
+            </summary>
+            <param name="startAddress">The address of the start of the memory block to initialize.</param>
+            <param name="value">The value to initialize the block to.</param>
+            <param name="byteCount">The number of bytes to initialize.</param>
+        </member>
         <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlockUnaligned(System.Void*,System.Byte,System.UInt32)">
             <summary>
             Initializes a block of memory at the given location with a given initial value 
@@ -229,6 +262,24 @@
             <param name="byteCount">The number of bytes to initialize.</param>
         </member>
         <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlockUnaligned(System.Void*,System.Byte,System.UIntPtr)">
+            <summary>
+            Initializes a block of memory at the given location with a given initial value 
+            without assuming architecture dependent alignment of the address.
+            </summary>
+            <param name="startAddress">The address of the start of the memory block to initialize.</param>
+            <param name="value">The value to initialize the block to.</param>
+            <param name="byteCount">The number of bytes to initialize.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlockUnaligned(System.Byte@,System.Byte,System.UInt32)">
+            <summary>
+            Initializes a block of memory at the given location with a given initial value 
+            without assuming architecture dependent alignment of the address.
+            </summary>
+            <param name="startAddress">The address of the start of the memory block to initialize.</param>
+            <param name="value">The value to initialize the block to.</param>
+            <param name="byteCount">The number of bytes to initialize.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlockUnaligned(System.Byte@,System.Byte,System.UIntPtr)">
             <summary>
             Initializes a block of memory at the given location with a given initial value 
             without assuming architecture dependent alignment of the address.

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.xml
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.xml
@@ -160,23 +160,7 @@
             <param name="source">The source address to copy from.</param>
             <param name="byteCount">The number of bytes to copy.</param>
         </member>
-        <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlock(System.Void*,System.Void*,System.UIntPtr)">
-            <summary>
-            Copies bytes from the source address to the destination address.
-            </summary>
-            <param name="destination">The destination address to copy to.</param>
-            <param name="source">The source address to copy from.</param>
-            <param name="byteCount">The number of bytes to copy.</param>
-        </member>
         <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlock(System.Byte@,System.Byte@,System.UInt32)">
-            <summary>
-            Copies bytes from the source address to the destination address.
-            </summary>
-            <param name="destination">The destination address to copy to.</param>
-            <param name="source">The source address to copy from.</param>
-            <param name="byteCount">The number of bytes to copy.</param>
-        </member>
-        <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlock(System.Byte@,System.Byte@,System.UIntPtr)">
             <summary>
             Copies bytes from the source address to the destination address.
             </summary>
@@ -193,25 +177,7 @@
             <param name="source">The source address to copy from.</param>
             <param name="byteCount">The number of bytes to copy.</param>
         </member>
-        <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned(System.Void*,System.Void*,System.UIntPtr)">
-            <summary>
-            Copies bytes from the source address to the destination address 
-            without assuming architecture dependent alignment of the addresses.
-            </summary>
-            <param name="destination">The destination address to copy to.</param>
-            <param name="source">The source address to copy from.</param>
-            <param name="byteCount">The number of bytes to copy.</param>
-        </member>
         <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned(System.Byte@,System.Byte@,System.UInt32)">
-            <summary>
-            Copies bytes from the source address to the destination address 
-            without assuming architecture dependent alignment of the addresses.
-            </summary>
-            <param name="destination">The destination address to copy to.</param>
-            <param name="source">The source address to copy from.</param>
-            <param name="byteCount">The number of bytes to copy.</param>
-        </member>
-        <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned(System.Byte@,System.Byte@,System.UIntPtr)">
             <summary>
             Copies bytes from the source address to the destination address 
             without assuming architecture dependent alignment of the addresses.

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.xml
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.xml
@@ -228,23 +228,7 @@
             <param name="value">The value to initialize the block to.</param>
             <param name="byteCount">The number of bytes to initialize.</param>
         </member>
-        <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlock(System.Void*,System.Byte,System.UIntPtr)">
-            <summary>
-            Initializes a block of memory at the given location with a given initial value.
-            </summary>
-            <param name="startAddress">The address of the start of the memory block to initialize.</param>
-            <param name="value">The value to initialize the block to.</param>
-            <param name="byteCount">The number of bytes to initialize.</param>
-        </member>
         <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlock(System.Byte@,System.Byte,System.UInt32)">
-            <summary>
-            Initializes a block of memory at the given location with a given initial value.
-            </summary>
-            <param name="startAddress">The address of the start of the memory block to initialize.</param>
-            <param name="value">The value to initialize the block to.</param>
-            <param name="byteCount">The number of bytes to initialize.</param>
-        </member>
-        <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlock(System.Byte@,System.Byte,System.UIntPtr)">
             <summary>
             Initializes a block of memory at the given location with a given initial value.
             </summary>
@@ -261,25 +245,7 @@
             <param name="value">The value to initialize the block to.</param>
             <param name="byteCount">The number of bytes to initialize.</param>
         </member>
-        <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlockUnaligned(System.Void*,System.Byte,System.UIntPtr)">
-            <summary>
-            Initializes a block of memory at the given location with a given initial value 
-            without assuming architecture dependent alignment of the address.
-            </summary>
-            <param name="startAddress">The address of the start of the memory block to initialize.</param>
-            <param name="value">The value to initialize the block to.</param>
-            <param name="byteCount">The number of bytes to initialize.</param>
-        </member>
         <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlockUnaligned(System.Byte@,System.Byte,System.UInt32)">
-            <summary>
-            Initializes a block of memory at the given location with a given initial value 
-            without assuming architecture dependent alignment of the address.
-            </summary>
-            <param name="startAddress">The address of the start of the memory block to initialize.</param>
-            <param name="value">The value to initialize the block to.</param>
-            <param name="byteCount">The number of bytes to initialize.</param>
-        </member>
-        <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlockUnaligned(System.Byte@,System.Byte,System.UIntPtr)">
             <summary>
             Initializes a block of memory at the given location with a given initial value 
             without assuming architecture dependent alignment of the address.

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.xml
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.xml
@@ -168,6 +168,14 @@
             <param name="source">The source address to copy from.</param>
             <param name="byteCount">The number of bytes to copy.</param>
         </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlock``1(``0@,``0@,System.Int32)">
+            <summary>
+            Copies elements from the source address to the destination address.
+            </summary>
+            <param name="destination">The destination address to copy to.</param>
+            <param name="source">The source address to copy from.</param>
+            <param name="elementCount">The number of elements to copy.</param>
+        </member>
         <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned(System.Void*,System.Void*,System.UInt32)">
             <summary>
             Copies bytes from the source address to the destination address 
@@ -185,6 +193,15 @@
             <param name="destination">The destination address to copy to.</param>
             <param name="source">The source address to copy from.</param>
             <param name="byteCount">The number of bytes to copy.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned``1(``0@,``0@,System.Int32)">
+            <summary>
+            Copies elements from the source address to the destination address.
+            without assuming architecture dependent alignment of the addresses.
+            </summary>
+            <param name="destination">The destination address to copy to.</param>
+            <param name="source">The source address to copy from.</param>
+            <param name="elementCount">The number of elements to copy.</param>
         </member>
         <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlock(System.Void*,System.Byte,System.UInt32)">
             <summary>

--- a/src/System.Runtime.CompilerServices.Unsafe/tests/UnsafeTests.cs
+++ b/src/System.Runtime.CompilerServices.Unsafe/tests/UnsafeTests.cs
@@ -314,6 +314,50 @@ namespace System.Runtime.CompilerServices
 
         [Theory]
         [MemberData(nameof(CopyBlockData))]
+        public static unsafe void CopyBlockRef(int numBytes)
+        {
+            byte* source = stackalloc byte[numBytes];
+            byte* destination = stackalloc byte[numBytes];
+
+            for (int i = 0; i < numBytes; i++)
+            {
+                byte value = (byte)(i % 255);
+                source[i] = value;
+            }
+
+            Unsafe.CopyBlock(ref destination[0], ref source[0], numBytes);
+
+            for (int i = 0; i < numBytes; i++)
+            {
+                byte value = (byte)(i % 255);
+                Assert.Equal(value, destination[i]);
+                Assert.Equal(source[i], destination[i]);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(CopyBlockData))]
+        public static unsafe void CopyBlockRefIntData(int numBytes)
+        {
+            var source = stackalloc int[numBytes];
+            var destination = stackalloc int[numBytes];
+
+            for (int i = 0; i < numBytes; i++)
+            {
+                source[i] = i;
+            }
+
+            Unsafe.CopyBlock(ref destination[0], ref source[0], numBytes);
+
+            for (int i = 0; i < numBytes; i++)
+            {
+                Assert.Equal(i, destination[i]);
+                Assert.Equal(source[i], destination[i]);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(CopyBlockData))]
         public static unsafe void CopyBlockUnaligned(int numBytes)
         {
             byte* source = stackalloc byte[numBytes + 1];
@@ -359,6 +403,54 @@ namespace System.Runtime.CompilerServices
             {
                 byte value = (byte)(i % 255);
                 Assert.Equal(value, destination[i]);
+                Assert.Equal(source[i], destination[i]);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(CopyBlockData))]
+        public static unsafe void CopyBlockUnalignedRef(int numBytes)
+        {
+            byte* source = stackalloc byte[numBytes + 1];
+            byte* destination = stackalloc byte[numBytes + 1];
+            source += 1;      // +1 = make unaligned
+            destination += 1; // +1 = make unaligned
+
+            for (int i = 0; i < numBytes; i++)
+            {
+                byte value = (byte)(i % 255);
+                source[i] = value;
+            }
+
+            Unsafe.CopyBlockUnaligned(ref destination[0], ref source[0], numBytes);
+
+            for (int i = 0; i < numBytes; i++)
+            {
+                byte value = (byte)(i % 255);
+                Assert.Equal(value, destination[i]);
+                Assert.Equal(source[i], destination[i]);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(CopyBlockData))]
+        public static unsafe void CopyBlockUnalignedRefIntData(int numBytes)
+        {
+            int* source = stackalloc int[numBytes + 1];
+            int* destination = stackalloc int[numBytes + 1];
+            source += 1;      // +1 = make unaligned (only on 64-bit)
+            destination += 1; // +1 = make unaligned (only on 64-bit)
+
+            for (int i = 0; i < numBytes; i++)
+            {
+                source[i] = i;
+            }
+
+            Unsafe.CopyBlockUnaligned(ref destination[0], ref source[0], numBytes);
+
+            for (int i = 0; i < numBytes; i++)
+            {
+                Assert.Equal(i, destination[i]);
                 Assert.Equal(source[i], destination[i]);
             }
         }

--- a/src/System.Runtime.CompilerServices.Unsafe/tests/UnsafeTests.cs
+++ b/src/System.Runtime.CompilerServices.Unsafe/tests/UnsafeTests.cs
@@ -181,31 +181,6 @@ namespace System.Runtime.CompilerServices
 
         [Theory]
         [MemberData(nameof(InitBlockData))]
-        public static unsafe void InitBlockUIntPtrStack(int numBytes, byte value)
-        {
-            byte* stackPtr = stackalloc byte[numBytes];
-            Unsafe.InitBlock(stackPtr, value, (UIntPtr)numBytes);
-            for (int i = 0; i < numBytes; i++)
-            {
-                Assert.Equal(stackPtr[i], value);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(InitBlockData))]
-        public static unsafe void InitBlockUIntPtrUnmanaged(int numBytes, byte value)
-        {
-            IntPtr allocatedMemory = Marshal.AllocCoTaskMem(numBytes);
-            byte* bytePtr = (byte*)allocatedMemory.ToPointer();
-            Unsafe.InitBlock(bytePtr, value, (UIntPtr)numBytes);
-            for (int i = 0; i < numBytes; i++)
-            {
-                Assert.Equal(bytePtr[i], value);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(InitBlockData))]
         public static unsafe void InitBlockRefStack(int numBytes, byte value)
         {
             byte* stackPtr = stackalloc byte[numBytes];
@@ -223,31 +198,6 @@ namespace System.Runtime.CompilerServices
             IntPtr allocatedMemory = Marshal.AllocCoTaskMem(numBytes);
             byte* bytePtr = (byte*)allocatedMemory.ToPointer();
             Unsafe.InitBlock(ref *bytePtr, value, (uint)numBytes);
-            for (int i = 0; i < numBytes; i++)
-            {
-                Assert.Equal(bytePtr[i], value);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(InitBlockData))]
-        public static unsafe void InitBlockRefUIntPtrStack(int numBytes, byte value)
-        {
-            byte* stackPtr = stackalloc byte[numBytes];
-            Unsafe.InitBlock(ref *stackPtr, value, (UIntPtr)numBytes);
-            for (int i = 0; i < numBytes; i++)
-            {
-                Assert.Equal(stackPtr[i], value);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(InitBlockData))]
-        public static unsafe void InitBlockRefUIntPtrUnmanaged(int numBytes, byte value)
-        {
-            IntPtr allocatedMemory = Marshal.AllocCoTaskMem(numBytes);
-            byte* bytePtr = (byte*)allocatedMemory.ToPointer();
-            Unsafe.InitBlock(ref *bytePtr, value, (UIntPtr)numBytes);
             for (int i = 0; i < numBytes; i++)
             {
                 Assert.Equal(bytePtr[i], value);
@@ -282,32 +232,6 @@ namespace System.Runtime.CompilerServices
 
         [Theory]
         [MemberData(nameof(InitBlockData))]
-        public static unsafe void InitBlockUnalignedUIntPtrStack(int numBytes, byte value)
-        {
-            byte* stackPtr = stackalloc byte[numBytes + 1];
-            stackPtr += 1; // +1 = make unaligned
-            Unsafe.InitBlockUnaligned(stackPtr, value, (UIntPtr)numBytes);
-            for (int i = 0; i < numBytes; i++)
-            {
-                Assert.Equal(stackPtr[i], value);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(InitBlockData))]
-        public static unsafe void InitBlockUnalignedUIntPtrUnmanaged(int numBytes, byte value)
-        {
-            IntPtr allocatedMemory = Marshal.AllocCoTaskMem(numBytes + 1);
-            byte* bytePtr = (byte*)allocatedMemory.ToPointer() + 1; // +1 = make unaligned
-            Unsafe.InitBlockUnaligned(bytePtr, value, (UIntPtr)numBytes);
-            for (int i = 0; i < numBytes; i++)
-            {
-                Assert.Equal(bytePtr[i], value);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(InitBlockData))]
         public static unsafe void InitBlockUnalignedRefStack(int numBytes, byte value)
         {
             byte* stackPtr = stackalloc byte[numBytes + 1];
@@ -332,31 +256,6 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        [Theory]
-        [MemberData(nameof(InitBlockData))]
-        public static unsafe void InitBlockUnalignedRefUIntPtrStack(int numBytes, byte value)
-        {
-            byte* stackPtr = stackalloc byte[numBytes + 1];
-            stackPtr += 1; // +1 = make unaligned
-            Unsafe.InitBlockUnaligned(ref *stackPtr, value, (UIntPtr)numBytes);
-            for (int i = 0; i < numBytes; i++)
-            {
-                Assert.Equal(stackPtr[i], value);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(InitBlockData))]
-        public static unsafe void InitBlockUnalignedRefUIntPtrUnmanaged(int numBytes, byte value)
-        {
-            IntPtr allocatedMemory = Marshal.AllocCoTaskMem(numBytes + 1);
-            byte* bytePtr = (byte*)allocatedMemory.ToPointer() + 1; // +1 = make unaligned
-            Unsafe.InitBlockUnaligned(ref *bytePtr, value, (UIntPtr)numBytes);
-            for (int i = 0; i < numBytes; i++)
-            {
-                Assert.Equal(bytePtr[i], value);
-            }
-        }
         public static IEnumerable<object[]> InitBlockData()
         {
             yield return new object[] { 0, 1 };
@@ -392,29 +291,6 @@ namespace System.Runtime.CompilerServices
 
         [Theory]
         [MemberData(nameof(CopyBlockData))]
-        public static unsafe void CopyBlockUIntPtr(int numBytes)
-        {
-            byte* source = stackalloc byte[numBytes];
-            byte* destination = stackalloc byte[numBytes];
-
-            for (int i = 0; i < numBytes; i++)
-            {
-                byte value = (byte)(i % 255);
-                source[i] = value;
-            }
-
-            Unsafe.CopyBlock(destination, source, (UIntPtr)numBytes);
-
-            for (int i = 0; i < numBytes; i++)
-            {
-                byte value = (byte)(i % 255);
-                Assert.Equal(value, destination[i]);
-                Assert.Equal(source[i], destination[i]);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(CopyBlockData))]
         public static unsafe void CopyBlockRef(int numBytes)
         {
             byte* source = stackalloc byte[numBytes];
@@ -427,29 +303,6 @@ namespace System.Runtime.CompilerServices
             }
 
             Unsafe.CopyBlock(ref destination[0], ref source[0], (uint)numBytes);
-
-            for (int i = 0; i < numBytes; i++)
-            {
-                byte value = (byte)(i % 255);
-                Assert.Equal(value, destination[i]);
-                Assert.Equal(source[i], destination[i]);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(CopyBlockData))]
-        public static unsafe void CopyBlockRefUIntPtr(int numBytes)
-        {
-            byte* source = stackalloc byte[numBytes];
-            byte* destination = stackalloc byte[numBytes];
-
-            for (int i = 0; i < numBytes; i++)
-            {
-                byte value = (byte)(i % 255);
-                source[i] = value;
-            }
-
-            Unsafe.CopyBlock(ref destination[0], ref source[0], (UIntPtr)numBytes);
 
             for (int i = 0; i < numBytes; i++)
             {
@@ -484,32 +337,6 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-
-        [Theory]
-        [MemberData(nameof(CopyBlockData))]
-        public static unsafe void CopyBlockUnalignedUIntPtr(int numBytes)
-        {
-            byte* source = stackalloc byte[numBytes + 1];
-            byte* destination = stackalloc byte[numBytes + 1];
-            source += 1;      // +1 = make unaligned
-            destination += 1; // +1 = make unaligned
-
-            for (int i = 0; i < numBytes; i++)
-            {
-                byte value = (byte)(i % 255);
-                source[i] = value;
-            }
-
-            Unsafe.CopyBlockUnaligned(destination, source, (UIntPtr)numBytes);
-
-            for (int i = 0; i < numBytes; i++)
-            {
-                byte value = (byte)(i % 255);
-                Assert.Equal(value, destination[i]);
-                Assert.Equal(source[i], destination[i]);
-            }
-        }
-
         [Theory]
         [MemberData(nameof(CopyBlockData))]
         public static unsafe void CopyBlockUnalignedRef(int numBytes)
@@ -526,31 +353,6 @@ namespace System.Runtime.CompilerServices
             }
 
             Unsafe.CopyBlockUnaligned(ref destination[0], ref source[0], (uint)numBytes);
-
-            for (int i = 0; i < numBytes; i++)
-            {
-                byte value = (byte)(i % 255);
-                Assert.Equal(value, destination[i]);
-                Assert.Equal(source[i], destination[i]);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(CopyBlockData))]
-        public static unsafe void CopyBlockUnalignedRefUIntPtr(int numBytes)
-        {
-            byte* source = stackalloc byte[numBytes + 1];
-            byte* destination = stackalloc byte[numBytes + 1];
-            source += 1;      // +1 = make unaligned
-            destination += 1; // +1 = make unaligned
-
-            for (int i = 0; i < numBytes; i++)
-            {
-                byte value = (byte)(i % 255);
-                source[i] = value;
-            }
-
-            Unsafe.CopyBlockUnaligned(ref destination[0], ref source[0], (UIntPtr)numBytes);
 
             for (int i = 0; i < numBytes; i++)
             {

--- a/src/System.Runtime.CompilerServices.Unsafe/tests/UnsafeTests.cs
+++ b/src/System.Runtime.CompilerServices.Unsafe/tests/UnsafeTests.cs
@@ -206,6 +206,56 @@ namespace System.Runtime.CompilerServices
 
         [Theory]
         [MemberData(nameof(InitBlockData))]
+        public static unsafe void InitBlockRefStack(int numBytes, byte value)
+        {
+            byte* stackPtr = stackalloc byte[numBytes];
+            Unsafe.InitBlock(ref *stackPtr, value, (uint)numBytes);
+            for (int i = 0; i < numBytes; i++)
+            {
+                Assert.Equal(stackPtr[i], value);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InitBlockData))]
+        public static unsafe void InitBlockRefUnmanaged(int numBytes, byte value)
+        {
+            IntPtr allocatedMemory = Marshal.AllocCoTaskMem(numBytes);
+            byte* bytePtr = (byte*)allocatedMemory.ToPointer();
+            Unsafe.InitBlock(ref *bytePtr, value, (uint)numBytes);
+            for (int i = 0; i < numBytes; i++)
+            {
+                Assert.Equal(bytePtr[i], value);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InitBlockData))]
+        public static unsafe void InitBlockRefUIntPtrStack(int numBytes, byte value)
+        {
+            byte* stackPtr = stackalloc byte[numBytes];
+            Unsafe.InitBlock(ref *stackPtr, value, (UIntPtr)numBytes);
+            for (int i = 0; i < numBytes; i++)
+            {
+                Assert.Equal(stackPtr[i], value);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InitBlockData))]
+        public static unsafe void InitBlockRefUIntPtrUnmanaged(int numBytes, byte value)
+        {
+            IntPtr allocatedMemory = Marshal.AllocCoTaskMem(numBytes);
+            byte* bytePtr = (byte*)allocatedMemory.ToPointer();
+            Unsafe.InitBlock(ref *bytePtr, value, (UIntPtr)numBytes);
+            for (int i = 0; i < numBytes; i++)
+            {
+                Assert.Equal(bytePtr[i], value);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InitBlockData))]
         public static unsafe void InitBlockUnalignedStack(int numBytes, byte value)
         {
             byte* stackPtr = stackalloc byte[numBytes + 1];
@@ -256,6 +306,57 @@ namespace System.Runtime.CompilerServices
             }
         }
 
+        [Theory]
+        [MemberData(nameof(InitBlockData))]
+        public static unsafe void InitBlockUnalignedRefStack(int numBytes, byte value)
+        {
+            byte* stackPtr = stackalloc byte[numBytes + 1];
+            stackPtr += 1; // +1 = make unaligned
+            Unsafe.InitBlockUnaligned(ref *stackPtr, value, (uint)numBytes);
+            for (int i = 0; i < numBytes; i++)
+            {
+                Assert.Equal(stackPtr[i], value);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InitBlockData))]
+        public static unsafe void InitBlockUnalignedRefUnmanaged(int numBytes, byte value)
+        {
+            IntPtr allocatedMemory = Marshal.AllocCoTaskMem(numBytes + 1);
+            byte* bytePtr = (byte*)allocatedMemory.ToPointer() + 1; // +1 = make unaligned
+            Unsafe.InitBlockUnaligned(ref *bytePtr, value, (uint)numBytes);
+            for (int i = 0; i < numBytes; i++)
+            {
+                Assert.Equal(bytePtr[i], value);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InitBlockData))]
+        public static unsafe void InitBlockUnalignedRefUIntPtrStack(int numBytes, byte value)
+        {
+            byte* stackPtr = stackalloc byte[numBytes + 1];
+            stackPtr += 1; // +1 = make unaligned
+            Unsafe.InitBlockUnaligned(ref *stackPtr, value, (UIntPtr)numBytes);
+            for (int i = 0; i < numBytes; i++)
+            {
+                Assert.Equal(stackPtr[i], value);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InitBlockData))]
+        public static unsafe void InitBlockUnalignedRefUIntPtrUnmanaged(int numBytes, byte value)
+        {
+            IntPtr allocatedMemory = Marshal.AllocCoTaskMem(numBytes + 1);
+            byte* bytePtr = (byte*)allocatedMemory.ToPointer() + 1; // +1 = make unaligned
+            Unsafe.InitBlockUnaligned(ref *bytePtr, value, (UIntPtr)numBytes);
+            for (int i = 0; i < numBytes; i++)
+            {
+                Assert.Equal(bytePtr[i], value);
+            }
+        }
         public static IEnumerable<object[]> InitBlockData()
         {
             yield return new object[] { 0, 1 };
@@ -325,7 +426,7 @@ namespace System.Runtime.CompilerServices
                 source[i] = value;
             }
 
-            Unsafe.CopyBlock(ref destination[0], ref source[0], numBytes);
+            Unsafe.CopyBlock(ref destination[0], ref source[0], (uint)numBytes);
 
             for (int i = 0; i < numBytes; i++)
             {
@@ -337,21 +438,22 @@ namespace System.Runtime.CompilerServices
 
         [Theory]
         [MemberData(nameof(CopyBlockData))]
-        public static unsafe void CopyBlockRefShortData(int numBytes)
+        public static unsafe void CopyBlockRefUIntPtr(int numBytes)
         {
-            short* source = stackalloc short[numBytes];
-            short* destination = stackalloc short[numBytes];
+            byte* source = stackalloc byte[numBytes];
+            byte* destination = stackalloc byte[numBytes];
 
             for (int i = 0; i < numBytes; i++)
             {
-                source[i] = (short)i;
+                byte value = (byte)(i % 255);
+                source[i] = value;
             }
 
-            Unsafe.CopyBlock(ref destination[0], ref source[0], numBytes);
+            Unsafe.CopyBlock(ref destination[0], ref source[0], (UIntPtr)numBytes);
 
             for (int i = 0; i < numBytes; i++)
             {
-                var value = (short)i;
+                byte value = (byte)(i % 255);
                 Assert.Equal(value, destination[i]);
                 Assert.Equal(source[i], destination[i]);
             }
@@ -423,7 +525,7 @@ namespace System.Runtime.CompilerServices
                 source[i] = value;
             }
 
-            Unsafe.CopyBlockUnaligned(ref destination[0], ref source[0], numBytes);
+            Unsafe.CopyBlockUnaligned(ref destination[0], ref source[0], (uint)numBytes);
 
             for (int i = 0; i < numBytes; i++)
             {
@@ -435,23 +537,24 @@ namespace System.Runtime.CompilerServices
 
         [Theory]
         [MemberData(nameof(CopyBlockData))]
-        public static unsafe void CopyBlockUnalignedRefShortData(int numBytes)
+        public static unsafe void CopyBlockUnalignedRefUIntPtr(int numBytes)
         {
-            short* source = stackalloc short[numBytes + 1];
-            short* destination = stackalloc short[numBytes + 1];
+            byte* source = stackalloc byte[numBytes + 1];
+            byte* destination = stackalloc byte[numBytes + 1];
             source += 1;      // +1 = make unaligned
             destination += 1; // +1 = make unaligned
 
             for (int i = 0; i < numBytes; i++)
             {
-                source[i] = (short)i;
+                byte value = (byte)(i % 255);
+                source[i] = value;
             }
 
-            Unsafe.CopyBlockUnaligned(ref destination[0], ref source[0], numBytes);
+            Unsafe.CopyBlockUnaligned(ref destination[0], ref source[0], (UIntPtr)numBytes);
 
             for (int i = 0; i < numBytes; i++)
             {
-                var value = (short)i;
+                byte value = (byte)(i % 255);
                 Assert.Equal(value, destination[i]);
                 Assert.Equal(source[i], destination[i]);
             }

--- a/src/System.Runtime.CompilerServices.Unsafe/tests/UnsafeTests.cs
+++ b/src/System.Runtime.CompilerServices.Unsafe/tests/UnsafeTests.cs
@@ -337,21 +337,22 @@ namespace System.Runtime.CompilerServices
 
         [Theory]
         [MemberData(nameof(CopyBlockData))]
-        public static unsafe void CopyBlockRefIntData(int numBytes)
+        public static unsafe void CopyBlockRefShortData(int numBytes)
         {
-            var source = stackalloc int[numBytes];
-            var destination = stackalloc int[numBytes];
+            short* source = stackalloc short[numBytes];
+            short* destination = stackalloc short[numBytes];
 
             for (int i = 0; i < numBytes; i++)
             {
-                source[i] = i;
+                source[i] = (short)i;
             }
 
             Unsafe.CopyBlock(ref destination[0], ref source[0], numBytes);
 
             for (int i = 0; i < numBytes; i++)
             {
-                Assert.Equal(i, destination[i]);
+                var value = (short)i;
+                Assert.Equal(value, destination[i]);
                 Assert.Equal(source[i], destination[i]);
             }
         }
@@ -434,23 +435,24 @@ namespace System.Runtime.CompilerServices
 
         [Theory]
         [MemberData(nameof(CopyBlockData))]
-        public static unsafe void CopyBlockUnalignedRefIntData(int numBytes)
+        public static unsafe void CopyBlockUnalignedRefShortData(int numBytes)
         {
-            int* source = stackalloc int[numBytes + 1];
-            int* destination = stackalloc int[numBytes + 1];
-            source += 1;      // +1 = make unaligned (only on 64-bit)
-            destination += 1; // +1 = make unaligned (only on 64-bit)
+            short* source = stackalloc short[numBytes + 1];
+            short* destination = stackalloc short[numBytes + 1];
+            source += 1;      // +1 = make unaligned
+            destination += 1; // +1 = make unaligned
 
             for (int i = 0; i < numBytes; i++)
             {
-                source[i] = i;
+                source[i] = (short)i;
             }
 
             Unsafe.CopyBlockUnaligned(ref destination[0], ref source[0], numBytes);
 
             for (int i = 0; i < numBytes; i++)
             {
-                Assert.Equal(i, destination[i]);
+                var value = (short)i;
+                Assert.Equal(value, destination[i]);
                 Assert.Equal(source[i], destination[i]);
             }
         }


### PR DESCRIPTION
Adds `CopyBlock`/`CopyBlockUnaligned` to `Unsafe` for `ref` parameters as discussed in https://github.com/dotnet/corefx/issues/13427

Implements the generic versions of this, if this is not wanted, it can be changed to e.g. `ref byte`. Caller must know NOT to call this with a `T` containing references.

@jkotas @AtsushiKan @benaadams @jamesqo @omariom 

**UPDATE**: For API review, basically the choice is whether to add any of the below or perhaps both. Or in any shape that FXDC finds suitable. The below has been chosen to fit existing API definitions. The functionality is needed for `Span<T>` and other `ref` based scenarios for e.g. optimal performance.
```csharp
void CopyBlock<T>(ref T destination, ref T source, int elementCount);
void CopyBlockUnaligned<T>(ref T destination, ref T source, int elementCount);
```
OR
```csharp
void CopyBlock(ref byte destination, ref byte source, uint byteCount);
void CopyBlock(ref byte destination, ref byte source, UIntPtr byteCount);
void CopyBlockUnaligned(ref byte destination, ref byte source, uint byteCount);
void CopyBlockUnaligned(ref byte destination, ref byte source, UIntPtr byteCount);
```
I will change the implementation once I get word of the result of the API review. If needed I can create a separate issue for API review, but since this change is rather small I am hoping to keep it here.

Personally, I think adding both would be great. Not the least since the generic version covers the most common use case for the work I do, and because it fits `Span<T>`.