### PR TITLE
Bring SpanExtensions/ReadOnlySpanExtensions up to CoreClr parity.

### DIFF
--- a/src/System.Memory/pkg/System.Memory.pkgproj
+++ b/src/System.Memory/pkg/System.Memory.pkgproj
@@ -2,6 +2,9 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <ProjectReference Include="..\ref\System.Memory.csproj">
+      <SupportedFramework>net45;netcore45;wp8;wpa81;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
+    </ProjectReference>
     <ProjectReference Include="..\src\System.Memory.csproj">
       <SupportedFramework>net45;netcore45;wp8;wpa81;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -31,6 +31,13 @@ namespace System
         public bool TryCopyTo(System.Span<T> destination) { throw null; }
     }
 
+    public static class ReadOnlySpanExtensions
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public static ReadOnlySpan<char> Slice(this string text) { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public static ReadOnlySpan<char> Slice(this string text, int start) { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public static ReadOnlySpan<char> Slice(this string text, int start, int length) { throw null; }
+    }
+
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Span<T>
     {
@@ -61,6 +68,14 @@ namespace System
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public System.Span<T> Slice(int start, int length) { throw null; }
         public T[] ToArray() { throw null; }
         public bool TryCopyTo(System.Span<T> destination) { throw null; }
+    }
+
+    public static class SpanExtensions
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] public static System.Span<byte> AsBytes<T>(this Span<T> source) where T : struct { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] public static System.ReadOnlySpan<byte> AsBytes<T>(this ReadOnlySpan<T> source) where T : struct { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] public static System.Span<TTo> NonPortableCast<TFrom, TTo>(this System.Span<TFrom> source) where TFrom : struct where TTo : struct { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] public static System.ReadOnlySpan<TTo> NonPortableCast<TFrom, TTo>(this System.ReadOnlySpan<TFrom> source) where TFrom : struct where TTo : struct { throw null; }
     }
 }
 

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -16,7 +16,9 @@
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\Pinnable.cs" />
     <Compile Include="System\ReadOnlySpan.cs" />
+    <Compile Include="System\ReadOnlySpanExtensions.cs" />
     <Compile Include="System\Span.cs" />
+    <Compile Include="System\SpanExtensions.cs" />
     <Compile Include="System\SpanHelpers.cs" />
     <Compile Include="System\ThrowHelper.cs" />
   </ItemGroup>

--- a/src/System.Memory/src/System/ReadOnlySpan.cs
+++ b/src/System.Memory/src/System/ReadOnlySpan.cs
@@ -373,6 +373,10 @@ namespace System
                 return ref Unsafe.AddByteOffset<T>(ref _pinnable.Data, _byteOffset);
         }
 
+        // These expose the internal representation for Span-related apis use only.
+        internal Pinnable<T> Pinnable => _pinnable;
+        internal IntPtr ByteOffset => _byteOffset;
+
         //
         // If the Span was constructed from an object,
         //

--- a/src/System.Memory/src/System/ReadOnlySpanExtensions.cs
+++ b/src/System.Memory/src/System/ReadOnlySpanExtensions.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    /// <summary>
+    /// Extension methods for ReadOnlySpan&lt;T&gt;.
+    /// </summary>
+    public static class ReadOnlySpanExtensions
+    {
+        /// <summary>
+        /// Creates a new readonly span over the portion of the target string.
+        /// </summary>
+        /// <param name="text">The target string.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="text"/> is null.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlySpan<char> Slice(this string text)
+        {
+            if (text == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.text);
+
+            return new ReadOnlySpan<char>(Unsafe.As<Pinnable<char>>(text), StringAdjustment, text.Length);
+        }
+
+        /// <summary>
+        /// Creates a new readonly span over the portion of the target string, beginning at 'start'.
+        /// </summary>
+        /// <param name="text">The target string.</param>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="text"/> is null.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="start"/> index is not in range (&lt;0 or &gt;Length).
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlySpan<char> Slice(this string text, int start)
+        {
+            if (text == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.text);
+            int textLength = text.Length;
+            if ((uint)start > (uint)textLength)
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            unsafe
+            {
+                byte* byteOffset = ((byte*)StringAdjustment) + (uint)(start * sizeof(char));
+                return new ReadOnlySpan<char>(Unsafe.As<Pinnable<char>>(text), (IntPtr)byteOffset, textLength - start);
+            }
+        }
+
+        /// <summary>
+        /// Creates a new readonly span over the portion of the target string, beginning at <paramref name="start"/>, of given <paramref name="length"/>.
+        /// </summary>
+        /// <param name="text">The target string.</param>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <param name="length">The number of items in the span.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="text"/> is null.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="start"/> or end index is not in range (&lt;0 or &gt;=Length).
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlySpan<char> Slice(this string text, int start, int length)
+        {
+            if (text == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.text);
+            int textLength = text.Length;
+            if ((uint)start > (uint)textLength || (uint)length > (uint)(textLength - start))
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            unsafe
+            {
+                byte* byteOffset = ((byte*)StringAdjustment) + (uint)(start * sizeof(char));
+                return new ReadOnlySpan<char>(Unsafe.As<Pinnable<char>>(text), (IntPtr)byteOffset, length);
+            }
+        }
+
+        private static readonly IntPtr StringAdjustment = MeasureStringAdjustment();
+
+        private static IntPtr MeasureStringAdjustment()
+        {
+            string sampleString = "a";
+            unsafe
+            {
+                fixed (char* pSampleString = sampleString)
+                {
+                    return Unsafe.ByteOffset<char>(ref Unsafe.As<Pinnable<char>>(sampleString).Data, ref Unsafe.AsRef<char>(pSampleString));
+                }
+            }
+        }
+    }
+}

--- a/src/System.Memory/src/System/Span.cs
+++ b/src/System.Memory/src/System/Span.cs
@@ -150,7 +150,7 @@ namespace System
 
         // Constructor for internal use only.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private Span(Pinnable<T> pinnable, IntPtr byteOffset, int length)
+        internal Span(Pinnable<T> pinnable, IntPtr byteOffset, int length)
         {
             Debug.Assert(length >= 0);
 
@@ -206,7 +206,7 @@ namespace System
                 else
                     Unsafe.Add<T>(ref Unsafe.AddByteOffset<T>(ref _pinnable.Data, _byteOffset), index) = value;
             }
-    }
+        }
 
         /// <summary>
         /// Returns a reference to specified element of the Span.
@@ -417,6 +417,10 @@ namespace System
             else
                 return ref Unsafe.AddByteOffset<T>(ref _pinnable.Data, _byteOffset);
         }
+
+        // These expose the internal representation for Span-related apis use only.
+        internal Pinnable<T> Pinnable => _pinnable;
+        internal IntPtr ByteOffset => _byteOffset;
 
         //
         // If the Span was constructed from an object,

--- a/src/System.Memory/src/System/SpanExtensions.cs
+++ b/src/System.Memory/src/System/SpanExtensions.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    /// <summary>
+    /// Extension methods for Span&lt;T&gt;.
+    /// </summary>
+    public static class SpanExtensions
+    {
+        /// <summary>
+        /// Casts a Span of one primitive type <typeparamref name="T"/> to Span of bytes.
+        /// That type may not contain pointers or references. This is checked at runtime in order to preserve type safety.
+        /// </summary>
+        /// <param name="source">The source slice, of type <typeparamref name="T"/>.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when <typeparamref name="T"/> contains pointers.
+        /// </exception>
+        /// <exception cref="System.OverflowException">
+        /// Thrown if the Length property of the new Span would exceed Int32.MaxValue.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<byte> AsBytes<T>(this Span<T> source)
+            where T : struct
+        {
+            if (!SpanHelpers.IsReferenceFree<T>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
+
+            int newLength = checked(source.Length * Unsafe.SizeOf<T>());
+            return new Span<byte>(Unsafe.As<Pinnable<byte>>(source.Pinnable), source.ByteOffset, newLength);
+        }
+
+        /// <summary>
+        /// Casts a ReadOnlySpan of one primitive type <typeparamref name="T"/> to ReadOnlySpan of bytes.
+        /// That type may not contain pointers or references. This is checked at runtime in order to preserve type safety.
+        /// </summary>
+        /// <param name="source">The source slice, of type <typeparamref name="T"/>.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when <typeparamref name="T"/> contains pointers.
+        /// </exception>
+        /// <exception cref="System.OverflowException">
+        /// Thrown if the Length property of the new Span would exceed Int32.MaxValue.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlySpan<byte> AsBytes<T>(this ReadOnlySpan<T> source)
+            where T : struct
+        {
+            if (!SpanHelpers.IsReferenceFree<T>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
+
+            int newLength = checked(source.Length * Unsafe.SizeOf<T>());
+            return new ReadOnlySpan<byte>(Unsafe.As<Pinnable<byte>>(source.Pinnable), source.ByteOffset, newLength);
+        }
+
+        /// <summary>
+        /// Casts a Span of one primitive type <typeparamref name="TFrom"/> to another primitive type <typeparamref name="TTo"/>.
+        /// These types may not contain pointers or references. This is checked at runtime in order to preserve type safety.
+        /// </summary>
+        /// <remarks>
+        /// Supported only for platforms that support misaligned memory access.
+        /// </remarks>
+        /// <param name="source">The source slice, of type <typeparamref name="TFrom"/>.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
+        /// </exception>
+        /// <exception cref="System.OverflowException">
+        /// Thrown if the Length property of the new Span would exceed Int32.MaxValue.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<TTo> NonPortableCast<TFrom, TTo>(this Span<TFrom> source)
+            where TFrom : struct
+            where TTo : struct
+        {
+            if (!SpanHelpers.IsReferenceFree<TFrom>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TFrom));
+
+            if (!SpanHelpers.IsReferenceFree<TTo>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TTo));
+
+            int newLength = checked((int)((long)source.Length * Unsafe.SizeOf<TFrom>() / Unsafe.SizeOf<TTo>()));
+            return new Span<TTo>(Unsafe.As<Pinnable<TTo>>(source.Pinnable), source.ByteOffset, newLength);
+        }
+
+        /// <summary>
+        /// Casts a ReadOnlySpan of one primitive type <typeparamref name="TFrom"/> to another primitive type <typeparamref name="TTo"/>.
+        /// These types may not contain pointers or references. This is checked at runtime in order to preserve type safety.
+        /// </summary>
+        /// <remarks>
+        /// Supported only for platforms that support misaligned memory access.
+        /// </remarks>
+        /// <param name="source">The source slice, of type <typeparamref name="TFrom"/>.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
+        /// </exception>
+        /// <exception cref="System.OverflowException">
+        /// Thrown if the Length property of the new Span would exceed Int32.MaxValue.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlySpan<TTo> NonPortableCast<TFrom, TTo>(this ReadOnlySpan<TFrom> source)
+            where TFrom : struct
+            where TTo : struct
+        {
+            if (!SpanHelpers.IsReferenceFree<TFrom>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TFrom));
+
+            if (!SpanHelpers.IsReferenceFree<TTo>())
+                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TTo));
+
+            int newLength = checked((int)((long)source.Length * Unsafe.SizeOf<TFrom>() / Unsafe.SizeOf<TTo>()));
+            return new ReadOnlySpan<TTo>(Unsafe.As<Pinnable<TTo>>(source.Pinnable), source.ByteOffset, newLength);
+        }
+    }
+}

--- a/src/System.Memory/src/System/ThrowHelper.cs
+++ b/src/System.Memory/src/System/ThrowHelper.cs
@@ -53,6 +53,7 @@ namespace System
         array,
         length,
         start,
+        text,
         obj,
     }
 }

--- a/src/System.Memory/tests/ReadOnlySpan/AsBytes.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/AsBytes.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System.Runtime.CompilerServices;
+
+namespace System.SpanTests
+{
+    public static partial class ReadOnlySpanTests
+    {
+        [Fact]
+        public static void AsBytesUIntToByte()
+        {
+            uint[] a = { 0x44332211, 0x88776655 };
+            ReadOnlySpan<uint> span = new ReadOnlySpan<uint>(a);
+            ReadOnlySpan<byte> asBytes = span.AsBytes<uint>();
+
+            Assert.True(Unsafe.AreSame<byte>(ref Unsafe.As<uint, byte>(ref span.DangerousGetPinnableReference()), ref asBytes.DangerousGetPinnableReference()));
+            asBytes.Validate<byte>(0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88);
+        }
+
+        [Fact]
+        public static void AsBytesContainsReferences()
+        {
+            ReadOnlySpan<StructWithReferences> span = new ReadOnlySpan<StructWithReferences>(Array.Empty<StructWithReferences>());
+            AssertThrows<ArgumentException, StructWithReferences>(span, (_span) => _span.AsBytes<StructWithReferences>().DontBox());
+        }
+    }
+}

--- a/src/System.Memory/tests/ReadOnlySpan/NonPortableCast.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/NonPortableCast.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System.Runtime.CompilerServices;
+
+namespace System.SpanTests
+{
+    public static partial class ReadOnlySpanTests
+    {
+        [Fact]
+        public static void PortableCastUIntToUShort()
+        {
+            uint[] a = { 0x44332211, 0x88776655 };
+            ReadOnlySpan<uint> span = new ReadOnlySpan<uint>(a);
+            ReadOnlySpan<ushort> asUShort = span.NonPortableCast<uint, ushort>();
+
+            Assert.True(Unsafe.AreSame<ushort>(ref Unsafe.As<uint, ushort>(ref span.DangerousGetPinnableReference()), ref asUShort.DangerousGetPinnableReference()));
+            asUShort.Validate<ushort>(0x2211, 0x4433, 0x6655, 0x8877);
+        }
+
+        [Fact]
+        public static void PortableCastToTypeContainsReferences()
+        {
+            ReadOnlySpan<uint> span = new ReadOnlySpan<uint>(Array.Empty<uint>());
+            AssertThrows<ArgumentException, uint>(span, (_span) => _span.NonPortableCast<uint, StructWithReferences>().DontBox());
+        }
+
+        [Fact]
+        public static void PortableCastFromTypeContainsReferences()
+        {
+            ReadOnlySpan<StructWithReferences> span = new ReadOnlySpan<StructWithReferences>(Array.Empty<StructWithReferences>());
+            AssertThrows<ArgumentException, StructWithReferences>(span, (_span) => _span.NonPortableCast<StructWithReferences, uint>().DontBox());
+        }
+    }
+}

--- a/src/System.Memory/tests/ReadOnlySpan/StringSlice.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/StringSlice.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System.Runtime.CompilerServices;
+
+namespace System.SpanTests
+{
+    public static partial class ReadOnlySpanTests
+    {
+        [Fact]
+        public static void StringSliceNullary()
+        {
+            string s = "Hello";
+            ReadOnlySpan<char> span = s.Slice();
+            char[] expected = s.ToCharArray();
+            span.Validate(expected);
+        }
+
+        [Fact]
+        public static void StringSliceInt()
+        {
+            string s = "Goodbye";
+            ReadOnlySpan<char> span = s.Slice(2);
+            char[] expected = s.Substring(2).ToCharArray();
+            span.Validate(expected);
+        }
+
+        [Fact]
+        public static void StringSliceIntPastEnd()
+        {
+            string s = "Hello";
+            ReadOnlySpan<char> span = s.Slice(s.Length);
+            Assert.Equal(0, span.Length);
+        }
+
+        [Fact]
+        public static void StringSliceIntInt()
+        {
+            string s = "Goodbye";
+            ReadOnlySpan<char> span = s.Slice(2, 4);
+            char[] expected = s.Substring(2, 4).ToCharArray();
+            span.Validate(expected);
+        }
+
+        [Fact]
+        public static void StringSliceIntIntUpToEnd()
+        {
+            string s = "Goodbye";
+            ReadOnlySpan<char> span = s.Slice(2, s.Length - 2);
+            char[] expected = s.Substring(2).ToCharArray();
+            span.Validate(expected);
+        }
+
+        [Fact]
+        public static void StringSliceIntIntPastEnd()
+        {
+            string s = "Hello";
+            ReadOnlySpan<char> span = s.Slice(s.Length, 0);
+            Assert.Equal(0, span.Length);
+        }
+
+        [Fact]
+        public static void StringSliceNullChecked()
+        {
+            string s = null;
+            Assert.Throws<ArgumentNullException>(() => s.Slice().DontBox());
+            Assert.Throws<ArgumentNullException>(() => s.Slice(0).DontBox());
+            Assert.Throws<ArgumentNullException>(() => s.Slice(0, 0).DontBox());
+        }
+
+        [Fact]
+        public static void StringSliceIntRangeChecked()
+        {
+            string s = "Hello";
+            Assert.Throws<ArgumentOutOfRangeException>(() => s.Slice(-1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => s.Slice(s.Length + 1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => s.Slice(-1, 0).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => s.Slice(0, s.Length + 1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => s.Slice(2, s.Length + 1 - 2).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => s.Slice(s.Length + 1, 0).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => s.Slice(s.Length, 1).DontBox());
+        }
+    }
+}

--- a/src/System.Memory/tests/Span/AsBytes.cs
+++ b/src/System.Memory/tests/Span/AsBytes.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System.Runtime.CompilerServices;
+
+namespace System.SpanTests
+{
+    public static partial class SpanTests
+    {
+        [Fact]
+        public static void AsBytesUIntToByte()
+        {
+            uint[] a = { 0x44332211, 0x88776655 };
+            Span<uint> span = new Span<uint>(a);
+            Span<byte> asBytes = span.AsBytes<uint>();
+
+            Assert.True(Unsafe.AreSame<byte>(ref Unsafe.As<uint, byte>(ref span.DangerousGetPinnableReference()), ref asBytes.DangerousGetPinnableReference()));
+            asBytes.Validate<byte>(0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88);
+        }
+
+        [Fact]
+        public static void AsBytesContainsReferences()
+        {
+            Span<StructWithReferences> span = new Span<StructWithReferences>(Array.Empty<StructWithReferences>());
+            AssertThrows<ArgumentException, StructWithReferences>(span, (_span) => _span.AsBytes<StructWithReferences>().DontBox());
+        }
+    }
+}

--- a/src/System.Memory/tests/Span/NonPortableCast.cs
+++ b/src/System.Memory/tests/Span/NonPortableCast.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System.Runtime.CompilerServices;
+
+namespace System.SpanTests
+{
+    public static partial class SpanTests
+    {
+        [Fact]
+        public static void PortableCastUIntToUShort()
+        {
+            uint[] a = { 0x44332211, 0x88776655 };
+            Span<uint> span = new Span<uint>(a);
+            Span<ushort> asUShort = span.NonPortableCast<uint, ushort>();
+
+            Assert.True(Unsafe.AreSame<ushort>(ref Unsafe.As<uint, ushort>(ref span.DangerousGetPinnableReference()), ref asUShort.DangerousGetPinnableReference()));
+            asUShort.Validate<ushort>(0x2211, 0x4433, 0x6655, 0x8877);
+        }
+
+        [Fact]
+        public static void PortableCastToTypeContainsReferences()
+        {
+            Span<uint> span = new Span<uint>(Array.Empty<uint>());
+            AssertThrows<ArgumentException, uint>(span, (_span) => _span.NonPortableCast<uint, StructWithReferences>().DontBox());
+        }
+
+        [Fact]
+        public static void PortableCastFromTypeContainsReferences()
+        {
+            Span<StructWithReferences> span = new Span<StructWithReferences>(Array.Empty<StructWithReferences>());
+            AssertThrows<ArgumentException, StructWithReferences>(span, (_span) => _span.NonPortableCast<StructWithReferences, uint>().DontBox());
+        }
+    }
+}

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -8,6 +8,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
+    <Compile Include="Span\AsBytes.cs" />
     <Compile Include="Span\CopyTo.cs" />
     <Compile Include="Span\CtorArray.cs" />
     <Compile Include="Span\CtorArrayInt.cs" />
@@ -17,12 +18,14 @@
     <Compile Include="Span\DangerousGetPinnableReference.cs" />
     <Compile Include="Span\Empty.cs" />
     <Compile Include="Span\Equality.cs" />
+    <Compile Include="Span\NonPortableCast.cs" />
     <Compile Include="Span\Overflow.cs" />
     <Compile Include="Span\Slice.cs" />
     <Compile Include="Span\TestHelpers.cs" />
     <Compile Include="Span\ToArray.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ReadOnlySpan\AsBytes.cs" />
     <Compile Include="ReadOnlySpan\CopyTo.cs" />
     <Compile Include="ReadOnlySpan\CtorArray.cs" />
     <Compile Include="ReadOnlySpan\CtorArrayInt.cs" />
@@ -32,8 +35,10 @@
     <Compile Include="ReadOnlySpan\DangerousGetPinnableReference.cs" />
     <Compile Include="ReadOnlySpan\Empty.cs" />
     <Compile Include="ReadOnlySpan\Equality.cs" />
+    <Compile Include="ReadOnlySpan\NonPortableCast.cs" />
     <Compile Include="ReadOnlySpan\Overflow.cs" />
     <Compile Include="ReadOnlySpan\Slice.cs" />
+    <Compile Include="ReadOnlySpan\StringSlice.cs" />
     <Compile Include="ReadOnlySpan\TestHelpers.cs" />
     <Compile Include="ReadOnlySpan\ToArray.cs" />
   </ItemGroup>


### PR DESCRIPTION
This is a necessary step to removing Span from corefxlab.
corefxlab cannot implement these from outside the surface area.