### PR TITLE
fix param name

### DIFF
--- a/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -596,7 +596,7 @@ namespace System.Runtime.InteropServices
         public static void Prelink(System.Reflection.MethodInfo m) { }
         public static void PrelinkAll(Type c) { }
         public static string PtrToStringAuto(System.IntPtr ptr) { throw null; }
-        public static string PtrToStringAuto(System.IntPtr ptr, int length) { throw null; }        
+        public static string PtrToStringAuto(System.IntPtr ptr, int len) { throw null; }        
         public static string PtrToStringAnsi(System.IntPtr ptr) { throw null; }
         public static string PtrToStringAnsi(System.IntPtr ptr, int len) { throw null; }
         public static string PtrToStringBSTR(System.IntPtr ptr) { throw null; }


### PR DESCRIPTION
Parameter name changes are breaking. It should be `len`, not `length`, to match desktop.

@shrah 