### PR TITLE
Updating System.Net.* refs based on netstandard.

### DIFF
--- a/src/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/System.Net.Http/ref/System.Net.Http.cs
@@ -80,28 +80,20 @@ namespace System.Net.Http
         public HttpClientHandler() { }
         public bool AllowAutoRedirect { get { throw null; } set { } }
         public System.Net.DecompressionMethods AutomaticDecompression { get { throw null; } set { } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public bool CheckCertificateRevocationList { get { throw null; } set { } }
         public System.Net.Http.ClientCertificateOption ClientCertificateOptions { get { throw null; } set { } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.Security.Cryptography.X509Certificates.X509CertificateCollection ClientCertificates { get; }
         public System.Net.CookieContainer CookieContainer { get { throw null; } set { } }
         public System.Net.ICredentials Credentials { get { throw null; } set { } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.Net.ICredentials DefaultProxyCredentials { get { throw null; } set { } }
         public int MaxAutomaticRedirections { get { throw null; } set { } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public int MaxConnectionsPerServer { get { throw null; } set { } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public int MaxResponseHeadersLength { get { throw null; } set { } }
         public long MaxRequestContentBufferSize { get { throw null; } set { } }
         public bool PreAuthenticate { get { throw null; } set { } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.Collections.Generic.IDictionary<string, object> Properties { get { throw null; } }
         public System.Net.IWebProxy Proxy { get { throw null; } set { } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, System.Net.Security.SslPolicyErrors, bool> ServerCertificateCustomValidationCallback { get { throw null; } set { } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.Security.Authentication.SslProtocols SslProtocols { get { throw null; } set { } }
         public virtual bool SupportsAutomaticDecompression { get { throw null; } }
         public virtual bool SupportsProxy { get { throw null; } }

--- a/src/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/System.Net.Http/ref/System.Net.Http.cs
@@ -14,7 +14,7 @@ namespace System.Net.Http
         public ByteArrayContent(byte[] content, int offset, int count) { }
         protected override System.Threading.Tasks.Task<System.IO.Stream> CreateContentReadStreamAsync() { throw null; }
         protected override System.Threading.Tasks.Task SerializeToStreamAsync(System.IO.Stream stream, System.Net.TransportContext context) { throw null; }
-        protected internal override bool TryComputeLength(out long length) { throw null; }
+        protected internal override bool TryComputeLength(out long length) { length = default(long); throw null; }
     }
     public enum ClientCertificateOption
     {
@@ -31,13 +31,13 @@ namespace System.Net.Http
     }
     public partial class FormUrlEncodedContent : System.Net.Http.ByteArrayContent
     {
-        public FormUrlEncodedContent(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> nameValueCollection) : base(default(byte[])) { }
+        public FormUrlEncodedContent(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> nameValueCollection) : base (default(byte[])) { }
     }
     public partial class HttpClient : System.Net.Http.HttpMessageInvoker
     {
-        public HttpClient() : base(default(System.Net.Http.HttpMessageHandler)) { }
-        public HttpClient(System.Net.Http.HttpMessageHandler handler) : base(default(System.Net.Http.HttpMessageHandler)) { }
-        public HttpClient(System.Net.Http.HttpMessageHandler handler, bool disposeHandler) : base(default(System.Net.Http.HttpMessageHandler)) { }
+        public HttpClient() : base (default(System.Net.Http.HttpMessageHandler)) { }
+        public HttpClient(System.Net.Http.HttpMessageHandler handler) : base (default(System.Net.Http.HttpMessageHandler)) { }
+        public HttpClient(System.Net.Http.HttpMessageHandler handler, bool disposeHandler) : base (default(System.Net.Http.HttpMessageHandler)) { }
         public System.Uri BaseAddress { get { throw null; } set { } }
         public System.Net.Http.Headers.HttpRequestHeaders DefaultRequestHeaders { get { throw null; } }
         public long MaxResponseContentBufferSize { get { throw null; } set { } }
@@ -80,20 +80,28 @@ namespace System.Net.Http
         public HttpClientHandler() { }
         public bool AllowAutoRedirect { get { throw null; } set { } }
         public System.Net.DecompressionMethods AutomaticDecompression { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public bool CheckCertificateRevocationList { get { throw null; } set { } }
         public System.Net.Http.ClientCertificateOption ClientCertificateOptions { get { throw null; } set { } }
-        public System.Security.Cryptography.X509Certificates.X509CertificateCollection ClientCertificates { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public System.Security.Cryptography.X509Certificates.X509CertificateCollection ClientCertificates { get; }
         public System.Net.CookieContainer CookieContainer { get { throw null; } set { } }
         public System.Net.ICredentials Credentials { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.Net.ICredentials DefaultProxyCredentials { get { throw null; } set { } }
         public int MaxAutomaticRedirections { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public int MaxConnectionsPerServer { get { throw null; } set { } }
-        public long MaxRequestContentBufferSize { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public int MaxResponseHeadersLength { get { throw null; } set { } }
+        public long MaxRequestContentBufferSize { get { throw null; } set { } }
         public bool PreAuthenticate { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.Collections.Generic.IDictionary<string, object> Properties { get { throw null; } }
         public System.Net.IWebProxy Proxy { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, System.Net.Security.SslPolicyErrors, bool> ServerCertificateCustomValidationCallback { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.Security.Authentication.SslProtocols SslProtocols { get { throw null; } set { } }
         public virtual bool SupportsAutomaticDecompression { get { throw null; } }
         public virtual bool SupportsProxy { get { throw null; } }
@@ -214,7 +222,7 @@ namespace System.Net.Http
         public System.Collections.Generic.IEnumerator<System.Net.Http.HttpContent> GetEnumerator() { throw null; }
         protected override System.Threading.Tasks.Task SerializeToStreamAsync(System.IO.Stream stream, System.Net.TransportContext context) { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        protected internal override bool TryComputeLength(out long length) { throw null; }
+        protected internal override bool TryComputeLength(out long length) { length = default(long); throw null; }
     }
     public partial class MultipartFormDataContent : System.Net.Http.MultipartContent
     {
@@ -231,13 +239,13 @@ namespace System.Net.Http
         protected override System.Threading.Tasks.Task<System.IO.Stream> CreateContentReadStreamAsync() { throw null; }
         protected override void Dispose(bool disposing) { }
         protected override System.Threading.Tasks.Task SerializeToStreamAsync(System.IO.Stream stream, System.Net.TransportContext context) { throw null; }
-        protected internal override bool TryComputeLength(out long length) { throw null; }
+        protected internal override bool TryComputeLength(out long length) { length = default(long); throw null; }
     }
     public partial class StringContent : System.Net.Http.ByteArrayContent
     {
-        public StringContent(string content) : base(default(byte[])) { }
-        public StringContent(string content, System.Text.Encoding encoding) : base(default(byte[])) { }
-        public StringContent(string content, System.Text.Encoding encoding, string mediaType) : base(default(byte[])) { }
+        public StringContent(string content) : base (default(byte[])) { }
+        public StringContent(string content, System.Text.Encoding encoding) : base (default(byte[])) { }
+        public StringContent(string content, System.Text.Encoding encoding, string mediaType) : base (default(byte[])) { }
     }
 }
 namespace System.Net.Http.Headers
@@ -249,11 +257,11 @@ namespace System.Net.Http.Headers
         public string Parameter { get { throw null; } }
         public string Scheme { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
-        object System.ICloneable.Clone() { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Net.Http.Headers.AuthenticationHeaderValue Parse(string input) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.AuthenticationHeaderValue parsedValue) { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.AuthenticationHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.AuthenticationHeaderValue); throw null; }
     }
     public partial class CacheControlHeaderValue : System.ICloneable
     {
@@ -274,12 +282,12 @@ namespace System.Net.Http.Headers
         public bool ProxyRevalidate { get { throw null; } set { } }
         public bool Public { get { throw null; } set { } }
         public System.Nullable<System.TimeSpan> SharedMaxAge { get { throw null; } set { } }
-        object System.ICloneable.Clone() { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Net.Http.Headers.CacheControlHeaderValue Parse(string input) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.CacheControlHeaderValue parsedValue) { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.CacheControlHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.CacheControlHeaderValue); throw null; }
     }
     public partial class ContentDispositionHeaderValue : System.ICloneable
     {
@@ -294,12 +302,12 @@ namespace System.Net.Http.Headers
         public System.Collections.Generic.ICollection<System.Net.Http.Headers.NameValueHeaderValue> Parameters { get { throw null; } }
         public System.Nullable<System.DateTimeOffset> ReadDate { get { throw null; } set { } }
         public System.Nullable<long> Size { get { throw null; } set { } }
-        object System.ICloneable.Clone() { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Net.Http.Headers.ContentDispositionHeaderValue Parse(string input) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.ContentDispositionHeaderValue parsedValue) { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.ContentDispositionHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.ContentDispositionHeaderValue); throw null; }
     }
     public partial class ContentRangeHeaderValue : System.ICloneable
     {
@@ -312,12 +320,12 @@ namespace System.Net.Http.Headers
         public System.Nullable<long> Length { get { throw null; } }
         public System.Nullable<long> To { get { throw null; } }
         public string Unit { get { throw null; } set { } }
-        object System.ICloneable.Clone() { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Net.Http.Headers.ContentRangeHeaderValue Parse(string input) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.ContentRangeHeaderValue parsedValue) { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.ContentRangeHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.ContentRangeHeaderValue); throw null; }
     }
     public partial class EntityTagHeaderValue : System.ICloneable
     {
@@ -326,12 +334,12 @@ namespace System.Net.Http.Headers
         public static System.Net.Http.Headers.EntityTagHeaderValue Any { get { throw null; } }
         public bool IsWeak { get { throw null; } }
         public string Tag { get { throw null; } }
-        object System.ICloneable.Clone() { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Net.Http.Headers.EntityTagHeaderValue Parse(string input) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.EntityTagHeaderValue parsedValue) { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.EntityTagHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.EntityTagHeaderValue); throw null; }
     }
     public sealed partial class HttpContentHeaders : System.Net.Http.Headers.HttpHeaders
     {
@@ -362,7 +370,7 @@ namespace System.Net.Http.Headers
         public override string ToString() { throw null; }
         public bool TryAddWithoutValidation(string name, System.Collections.Generic.IEnumerable<string> values) { throw null; }
         public bool TryAddWithoutValidation(string name, string value) { throw null; }
-        public bool TryGetValues(string name, out System.Collections.Generic.IEnumerable<string> values) { throw null; }
+        public bool TryGetValues(string name, out System.Collections.Generic.IEnumerable<string> values) { values = default(System.Collections.Generic.IEnumerable<string>); throw null; }
     }
     public sealed partial class HttpHeaderValueCollection<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable where T : class
     {
@@ -446,21 +454,21 @@ namespace System.Net.Http.Headers
         public string CharSet { get { throw null; } set { } }
         public string MediaType { get { throw null; } set { } }
         public System.Collections.Generic.ICollection<System.Net.Http.Headers.NameValueHeaderValue> Parameters { get { throw null; } }
-        object System.ICloneable.Clone() { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Net.Http.Headers.MediaTypeHeaderValue Parse(string input) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.MediaTypeHeaderValue parsedValue) { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.MediaTypeHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.MediaTypeHeaderValue); throw null; }
     }
     public sealed partial class MediaTypeWithQualityHeaderValue : System.Net.Http.Headers.MediaTypeHeaderValue, System.ICloneable
     {
-        public MediaTypeWithQualityHeaderValue(string mediaType) : base(default(System.Net.Http.Headers.MediaTypeHeaderValue)) { }
-        public MediaTypeWithQualityHeaderValue(string mediaType, double quality) : base(default(System.Net.Http.Headers.MediaTypeHeaderValue)) { }
+        public MediaTypeWithQualityHeaderValue(string mediaType) : base (default(System.Net.Http.Headers.MediaTypeHeaderValue)) { }
+        public MediaTypeWithQualityHeaderValue(string mediaType, double quality) : base (default(System.Net.Http.Headers.MediaTypeHeaderValue)) { }
         public System.Nullable<double> Quality { get { throw null; } set { } }
-        object System.ICloneable.Clone() { throw null; }
         public static new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue Parse(string input) { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.MediaTypeWithQualityHeaderValue parsedValue) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.MediaTypeWithQualityHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue); throw null; }
     }
     public partial class NameValueHeaderValue : System.ICloneable
     {
@@ -469,25 +477,25 @@ namespace System.Net.Http.Headers
         public NameValueHeaderValue(string name, string value) { }
         public string Name { get { throw null; } }
         public string Value { get { throw null; } set { } }
-        object System.ICloneable.Clone() { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Net.Http.Headers.NameValueHeaderValue Parse(string input) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.NameValueHeaderValue parsedValue) { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.NameValueHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.NameValueHeaderValue); throw null; }
     }
     public partial class NameValueWithParametersHeaderValue : System.Net.Http.Headers.NameValueHeaderValue, System.ICloneable
     {
-        protected NameValueWithParametersHeaderValue(System.Net.Http.Headers.NameValueWithParametersHeaderValue source) : base(default(string)) { }
-        public NameValueWithParametersHeaderValue(string name) : base(default(string)) { }
-        public NameValueWithParametersHeaderValue(string name, string value) : base(default(string)) { }
+        protected NameValueWithParametersHeaderValue(System.Net.Http.Headers.NameValueWithParametersHeaderValue source) : base (default(string)) { }
+        public NameValueWithParametersHeaderValue(string name) : base (default(string)) { }
+        public NameValueWithParametersHeaderValue(string name, string value) : base (default(string)) { }
         public System.Collections.Generic.ICollection<System.Net.Http.Headers.NameValueHeaderValue> Parameters { get { throw null; } }
-        object System.ICloneable.Clone() { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static new System.Net.Http.Headers.NameValueWithParametersHeaderValue Parse(string input) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.NameValueWithParametersHeaderValue parsedValue) { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.NameValueWithParametersHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.NameValueWithParametersHeaderValue); throw null; }
     }
     public partial class ProductHeaderValue : System.ICloneable
     {
@@ -495,12 +503,12 @@ namespace System.Net.Http.Headers
         public ProductHeaderValue(string name, string version) { }
         public string Name { get { throw null; } }
         public string Version { get { throw null; } }
-        object System.ICloneable.Clone() { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Net.Http.Headers.ProductHeaderValue Parse(string input) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.ProductHeaderValue parsedValue) { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.ProductHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.ProductHeaderValue); throw null; }
     }
     public partial class ProductInfoHeaderValue : System.ICloneable
     {
@@ -509,12 +517,12 @@ namespace System.Net.Http.Headers
         public ProductInfoHeaderValue(string productName, string productVersion) { }
         public string Comment { get { throw null; } }
         public System.Net.Http.Headers.ProductHeaderValue Product { get { throw null; } }
-        object System.ICloneable.Clone() { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Net.Http.Headers.ProductInfoHeaderValue Parse(string input) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.ProductInfoHeaderValue parsedValue) { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.ProductInfoHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.ProductInfoHeaderValue); throw null; }
     }
     public partial class RangeConditionHeaderValue : System.ICloneable
     {
@@ -523,12 +531,12 @@ namespace System.Net.Http.Headers
         public RangeConditionHeaderValue(string entityTag) { }
         public System.Nullable<System.DateTimeOffset> Date { get { throw null; } }
         public System.Net.Http.Headers.EntityTagHeaderValue EntityTag { get { throw null; } }
-        object System.ICloneable.Clone() { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Net.Http.Headers.RangeConditionHeaderValue Parse(string input) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.RangeConditionHeaderValue parsedValue) { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.RangeConditionHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.RangeConditionHeaderValue); throw null; }
     }
     public partial class RangeHeaderValue : System.ICloneable
     {
@@ -536,21 +544,21 @@ namespace System.Net.Http.Headers
         public RangeHeaderValue(System.Nullable<long> from, System.Nullable<long> to) { }
         public System.Collections.Generic.ICollection<System.Net.Http.Headers.RangeItemHeaderValue> Ranges { get { throw null; } }
         public string Unit { get { throw null; } set { } }
-        object System.ICloneable.Clone() { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Net.Http.Headers.RangeHeaderValue Parse(string input) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.RangeHeaderValue parsedValue) { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.RangeHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.RangeHeaderValue); throw null; }
     }
     public partial class RangeItemHeaderValue : System.ICloneable
     {
         public RangeItemHeaderValue(System.Nullable<long> from, System.Nullable<long> to) { }
         public System.Nullable<long> From { get { throw null; } }
         public System.Nullable<long> To { get { throw null; } }
-        object System.ICloneable.Clone() { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
     }
     public partial class RetryConditionHeaderValue : System.ICloneable
@@ -559,12 +567,12 @@ namespace System.Net.Http.Headers
         public RetryConditionHeaderValue(System.TimeSpan delta) { }
         public System.Nullable<System.DateTimeOffset> Date { get { throw null; } }
         public System.Nullable<System.TimeSpan> Delta { get { throw null; } }
-        object System.ICloneable.Clone() { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Net.Http.Headers.RetryConditionHeaderValue Parse(string input) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.RetryConditionHeaderValue parsedValue) { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.RetryConditionHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.RetryConditionHeaderValue); throw null; }
     }
     public partial class StringWithQualityHeaderValue : System.ICloneable
     {
@@ -572,12 +580,12 @@ namespace System.Net.Http.Headers
         public StringWithQualityHeaderValue(string value, double quality) { }
         public System.Nullable<double> Quality { get { throw null; } }
         public string Value { get { throw null; } }
-        object System.ICloneable.Clone() { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Net.Http.Headers.StringWithQualityHeaderValue Parse(string input) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.StringWithQualityHeaderValue parsedValue) { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.StringWithQualityHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.StringWithQualityHeaderValue); throw null; }
     }
     public partial class TransferCodingHeaderValue : System.ICloneable
     {
@@ -585,21 +593,21 @@ namespace System.Net.Http.Headers
         public TransferCodingHeaderValue(string value) { }
         public System.Collections.Generic.ICollection<System.Net.Http.Headers.NameValueHeaderValue> Parameters { get { throw null; } }
         public string Value { get { throw null; } }
-        object System.ICloneable.Clone() { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Net.Http.Headers.TransferCodingHeaderValue Parse(string input) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.TransferCodingHeaderValue parsedValue) { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.TransferCodingHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.TransferCodingHeaderValue); throw null; }
     }
     public sealed partial class TransferCodingWithQualityHeaderValue : System.Net.Http.Headers.TransferCodingHeaderValue, System.ICloneable
     {
-        public TransferCodingWithQualityHeaderValue(string value) : base(default(System.Net.Http.Headers.TransferCodingHeaderValue)) { }
-        public TransferCodingWithQualityHeaderValue(string value, double quality) : base(default(System.Net.Http.Headers.TransferCodingHeaderValue)) { }
+        public TransferCodingWithQualityHeaderValue(string value) : base (default(System.Net.Http.Headers.TransferCodingHeaderValue)) { }
+        public TransferCodingWithQualityHeaderValue(string value, double quality) : base (default(System.Net.Http.Headers.TransferCodingHeaderValue)) { }
         public System.Nullable<double> Quality { get { throw null; } set { } }
-        object System.ICloneable.Clone() { throw null; }
         public static new System.Net.Http.Headers.TransferCodingWithQualityHeaderValue Parse(string input) { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.TransferCodingWithQualityHeaderValue parsedValue) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.TransferCodingWithQualityHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.TransferCodingWithQualityHeaderValue); throw null; }
     }
     public partial class ViaHeaderValue : System.ICloneable
     {
@@ -610,12 +618,12 @@ namespace System.Net.Http.Headers
         public string ProtocolName { get { throw null; } }
         public string ProtocolVersion { get { throw null; } }
         public string ReceivedBy { get { throw null; } }
-        object System.ICloneable.Clone() { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Net.Http.Headers.ViaHeaderValue Parse(string input) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.ViaHeaderValue parsedValue) { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.ViaHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.ViaHeaderValue); throw null; }
     }
     public partial class WarningHeaderValue : System.ICloneable
     {
@@ -625,11 +633,11 @@ namespace System.Net.Http.Headers
         public int Code { get { throw null; } }
         public System.Nullable<System.DateTimeOffset> Date { get { throw null; } }
         public string Text { get { throw null; } }
-        object System.ICloneable.Clone() { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Net.Http.Headers.WarningHeaderValue Parse(string input) { throw null; }
+        object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string input, out System.Net.Http.Headers.WarningHeaderValue parsedValue) { throw null; }
+        public static bool TryParse(string input, out System.Net.Http.Headers.WarningHeaderValue parsedValue) { parsedValue = default(System.Net.Http.Headers.WarningHeaderValue); throw null; }
     }
 }

--- a/src/System.Net.HttpListener/ref/System.Net.HttpListener.cs
+++ b/src/System.Net.HttpListener/ref/System.Net.HttpListener.cs
@@ -13,11 +13,15 @@ namespace System.Net
         public HttpListener() { }
         public System.Net.AuthenticationSchemes AuthenticationSchemes { get { throw null; } set { } }
         public System.Net.AuthenticationSchemeSelector AuthenticationSchemeSelectorDelegate { get { throw null; } set { } }
+        public System.Security.Authentication.ExtendedProtection.ServiceNameCollection DefaultServiceNames { get { throw null; } }
+        public System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy ExtendedProtectionPolicy { get { throw null; } set { } }
+        public System.Net.HttpListener.ExtendedProtectionSelector ExtendedProtectionSelectorDelegate { get { throw null; } set { } }
         public bool IgnoreWriteExceptions { get { throw null; } set { } }
         public bool IsListening { get { throw null; } }
         public static bool IsSupported { get { throw null; } }
         public System.Net.HttpListenerPrefixCollection Prefixes { get { throw null; } }
         public string Realm { get { throw null; } set { } }
+        public System.Net.HttpListenerTimeoutManager TimeoutManager { get { throw null; } }
         public bool UnsafeConnectionNtlmAuthentication { get { throw null; } set { } }
         public void Abort() { }
         public System.IAsyncResult BeginGetContext(System.AsyncCallback callback, object state) { throw null; }
@@ -28,10 +32,11 @@ namespace System.Net
         public void Start() { }
         public void Stop() { }
         void System.IDisposable.Dispose() { }
+        public delegate System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy ExtendedProtectionSelector(System.Net.HttpListenerRequest request);
     }
     public partial class HttpListenerBasicIdentity : System.Security.Principal.GenericIdentity
     {
-        public HttpListenerBasicIdentity(string username, string password) : base(default(string)) { }
+        public HttpListenerBasicIdentity(string username, string password) : base (default(string)) { }
         public virtual string Password { get { throw null; } }
     }
     public sealed partial class HttpListenerContext
@@ -42,13 +47,17 @@ namespace System.Net
         public System.Security.Principal.IPrincipal User { get { throw null; } }
         public System.Threading.Tasks.Task<System.Net.WebSockets.HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol) { throw null; }
         public System.Threading.Tasks.Task<System.Net.WebSockets.HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol, int receiveBufferSize, System.TimeSpan keepAliveInterval) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         public System.Threading.Tasks.Task<System.Net.WebSockets.HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol, int receiveBufferSize, System.TimeSpan keepAliveInterval, System.ArraySegment<byte> internalBuffer) { throw null; }
+        public System.Threading.Tasks.Task<System.Net.WebSockets.HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol, System.TimeSpan keepAliveInterval) { throw null; }
     }
     public partial class HttpListenerException : System.ComponentModel.Win32Exception
     {
         public HttpListenerException() { }
         public HttpListenerException(int errorCode) { }
         public HttpListenerException(int errorCode, string message) { }
+        protected HttpListenerException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public override int ErrorCode { get { throw null; } }
     }
     public partial class HttpListenerPrefixCollection : System.Collections.Generic.ICollection<string>, System.Collections.Generic.IEnumerable<string>, System.Collections.IEnumerable
     {
@@ -128,12 +137,22 @@ namespace System.Net
         public void SetCookie(System.Net.Cookie cookie) { }
         void System.IDisposable.Dispose() { }
     }
+    public partial class HttpListenerTimeoutManager
+    {
+        internal HttpListenerTimeoutManager() { }
+        public System.TimeSpan DrainEntityBody { get { throw null; } set { } }
+        public System.TimeSpan EntityBody { get { throw null; } set { } }
+        public System.TimeSpan HeaderWait { get { throw null; } set { } }
+        public System.TimeSpan IdleConnection { get { throw null; } set { } }
+        public long MinSendBytesPerSecond { get { throw null; } set { } }
+        public System.TimeSpan RequestQueue { get { throw null; } set { } }
+    }
 }
 namespace System.Net.WebSockets
 {
     public partial class HttpListenerWebSocketContext : System.Net.WebSockets.WebSocketContext
     {
-        private HttpListenerWebSocketContext() { }
+        internal HttpListenerWebSocketContext() { }
         public override System.Net.CookieCollection CookieCollection { get { throw null; } }
         public override System.Collections.Specialized.NameValueCollection Headers { get { throw null; } }
         public override bool IsAuthenticated { get { throw null; } }

--- a/src/System.Net.HttpListener/ref/project.json
+++ b/src/System.Net.HttpListener/ref/project.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-<<<<<<< HEAD
     "System.Collections.Specialized": "4.4.0-beta-24721-02",
     "System.Runtime": "4.4.0-beta-24721-02",
     "System.Net.Primitives": "4.4.0-beta-24721-02",

--- a/src/System.Net.HttpListener/ref/project.json
+++ b/src/System.Net.HttpListener/ref/project.json
@@ -1,8 +1,10 @@
 {
   "dependencies": {
+<<<<<<< HEAD
     "System.Collections.Specialized": "4.4.0-beta-24721-02",
     "System.Runtime": "4.4.0-beta-24721-02",
     "System.Net.Primitives": "4.4.0-beta-24721-02",
+    "System.Net.Security": "4.4.0-beta-24721-02",
     "System.Net.WebHeaderCollection": "4.4.0-beta-24721-02",
     "System.Net.WebSockets": "4.4.0-beta-24721-02",
     "System.Security.Claims": "4.4.0-beta-24721-02",

--- a/src/System.Net.Mail/ref/System.Net.Mail.cs
+++ b/src/System.Net.Mail/ref/System.Net.Mail.cs
@@ -177,6 +177,7 @@ namespace System.Net.Mail
         public string Host { get { throw null; } set { } }
         public string PickupDirectoryLocation { get { throw null; } set { } }
         public int Port { get { throw null; } set { } }
+        public System.Net.ServicePoint ServicePoint { get { throw null; } }
         public string TargetName { get { throw null; } set { } }
         public int Timeout { get { throw null; } set { } }
         public bool UseDefaultCredentials { get { throw null; } set { } }
@@ -189,7 +190,6 @@ namespace System.Net.Mail
         public void SendAsync(System.Net.Mail.MailMessage message, object userToken) { }
         public void SendAsync(string from, string recipients, string subject, string body, object userToken) { }
         public void SendAsyncCancel() { }
-        public System.Net.ServicePoint ServicePoint { get { throw null; } }
         public System.Threading.Tasks.Task SendMailAsync(System.Net.Mail.MailMessage message) { throw null; }
         public System.Threading.Tasks.Task SendMailAsync(string from, string recipients, string subject, string body) { throw null; }
     }

--- a/src/System.Net.Mail/ref/System.Net.Mime.cs
+++ b/src/System.Net.Mail/ref/System.Net.Mime.cs
@@ -7,23 +7,23 @@
 
 namespace System.Net.Mime
 {
-    public class ContentDisposition
+    public partial class ContentDisposition
     {
         public ContentDisposition() { }
         public ContentDisposition(string disposition) { }
+        public System.DateTime CreationDate { get { throw null; } set { } }
         public string DispositionType { get { throw null; } set { } }
-        public System.Collections.Specialized.StringDictionary Parameters { get { throw null; } }
         public string FileName { get { throw null; } set { } }
-        public DateTime CreationDate { get { throw null; } set { } }
-        public DateTime ModificationDate { get { throw null; } set { } }
         public bool Inline { get { throw null; } set { } }
-        public DateTime ReadDate { get { throw null; } set { } }
+        public System.DateTime ModificationDate { get { throw null; } set { } }
+        public System.Collections.Specialized.StringDictionary Parameters { get { throw null; } }
+        public System.DateTime ReadDate { get { throw null; } set { } }
         public long Size { get { throw null; } set { } }
-        public override string ToString() { throw null; }
         public override bool Equals(object rparam) { throw null; }
         public override int GetHashCode() { throw null; }
+        public override string ToString() { throw null; }
     }
-    public class ContentType
+    public partial class ContentType
     {
         public ContentType() { }
         public ContentType(string contentType) { }
@@ -32,47 +32,45 @@ namespace System.Net.Mime
         public string MediaType { get { throw null; } set { } }
         public string Name { get { throw null; } set { } }
         public System.Collections.Specialized.StringDictionary Parameters { get { throw null; } }
-        public override string ToString() { throw null; }
         public override bool Equals(object rparam) { throw null; }
         public override int GetHashCode() { throw null; }
+        public override string ToString() { throw null; }
     }
-    public static class DispositionTypeNames
+    public static partial class DispositionTypeNames
     {
-        public const string Inline = "inline";
         public const string Attachment = "attachment";
+        public const string Inline = "inline";
     }
-    public static class MediaTypeNames
+    public static partial class MediaTypeNames
     {
-        public static class Text
+        public static partial class Application
         {
-            public const string Plain = "text/plain";
-            public const string Html = "text/html";
-            public const string Xml = "text/xml";
-            public const string RichText = "text/richtext";
-        }
-
-        public static class Application
-        {
-            public const string Soap = "application/soap+xml";
             public const string Octet = "application/octet-stream";
-            public const string Rtf = "application/rtf";
             public const string Pdf = "application/pdf";
+            public const string Rtf = "application/rtf";
+            public const string Soap = "application/soap+xml";
             public const string Zip = "application/zip";
         }
-
-        public static class Image
+        public static partial class Image
         {
             public const string Gif = "image/gif";
-            public const string Tiff = "image/tiff";
             public const string Jpeg = "image/jpeg";
+            public const string Tiff = "image/tiff";
+        }
+        public static partial class Text
+        {
+            public const string Html = "text/html";
+            public const string Plain = "text/plain";
+            public const string RichText = "text/richtext";
+            public const string Xml = "text/xml";
         }
     }
     public enum TransferEncoding
     {
-        Unknown = -1,
-        QuotedPrintable = 0,
         Base64 = 1,
-        SevenBit = 2,
         EightBit = 3,
+        QuotedPrintable = 0,
+        SevenBit = 2,
+        Unknown = -1,
     }
 }

--- a/src/System.Net.NameResolution/ref/System.Net.NameResolution.cs
+++ b/src/System.Net.NameResolution/ref/System.Net.NameResolution.cs
@@ -10,34 +10,34 @@ namespace System.Net
 {
     public static partial class Dns
     {
-        public static IAsyncResult BeginGetHostAddresses(string hostNameOrAddress, AsyncCallback requestCallback, object state) { throw null; }
-        [Obsolete("BeginGetHostByName is obsoleted for this type, please use BeginGetHostEntry instead. http://go.microsoft.com/fwlink/?linkid=14202")]
-        public static IAsyncResult BeginGetHostByName(string hostName, AsyncCallback requestCallback, object stateObject) { throw null; }
-        public static IAsyncResult BeginGetHostEntry(string hostNameOrAddress, AsyncCallback requestCallback, object stateObject) { throw null; }
-        public static IAsyncResult BeginGetHostEntry(IPAddress address, AsyncCallback requestCallback, object stateObject) { throw null; }
-        [Obsolete("BeginResolve is obsoleted for this type, please use BeginGetHostEntry instead. http://go.microsoft.com/fwlink/?linkid=14202")]
-        public static IAsyncResult BeginResolve(string hostName, AsyncCallback requestCallback, object stateObject) { throw null; }
-        public static IPAddress[] EndGetHostAddresses(IAsyncResult asyncResult) { throw null; }
-        [Obsolete("EndGetHostByName is obsoleted for this type, please use EndGetHostEntry instead. http://go.microsoft.com/fwlink/?linkid=14202")]
-        public static IPHostEntry EndGetHostByName(IAsyncResult asyncResult) { throw null; }
-        public static IPHostEntry EndGetHostEntry(IAsyncResult asyncResult) { throw null; }
-        [Obsolete("EndResolve is obsoleted for this type, please use EndGetHostEntry instead. http://go.microsoft.com/fwlink/?linkid=14202")]
-        public static IPHostEntry EndResolve(IAsyncResult asyncResult) { throw null; }
-        public static IPAddress[] GetHostAddresses(string hostNameOrAddress) { throw null; }
-        [Obsolete("GetHostByAddress is obsoleted for this type, please use GetHostEntry instead. http://go.microsoft.com/fwlink/?linkid=14202")]
-        public static IPHostEntry GetHostByAddress(IPAddress address) { throw null; }
-        [Obsolete("GetHostByAddress is obsoleted for this type, please use GetHostEntry instead. http://go.microsoft.com/fwlink/?linkid=14202")]
-        public static IPHostEntry GetHostByAddress(string address) { throw null; }
-        [Obsolete("GetHostByName is obsoleted for this type, please use GetHostEntry instead. http://go.microsoft.com/fwlink/?linkid=14202")]
-        public static IPHostEntry GetHostByName(string hostName) { throw null; }
+        public static System.IAsyncResult BeginGetHostAddresses(string hostNameOrAddress, System.AsyncCallback requestCallback, object state) { throw null; }
+        [System.ObsoleteAttribute("BeginGetHostByName is obsoleted for this type, please use BeginGetHostEntry instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public static System.IAsyncResult BeginGetHostByName(string hostName, System.AsyncCallback requestCallback, object stateObject) { throw null; }
+        public static System.IAsyncResult BeginGetHostEntry(System.Net.IPAddress address, System.AsyncCallback requestCallback, object stateObject) { throw null; }
+        public static System.IAsyncResult BeginGetHostEntry(string hostNameOrAddress, System.AsyncCallback requestCallback, object stateObject) { throw null; }
+        [System.ObsoleteAttribute("BeginResolve is obsoleted for this type, please use BeginGetHostEntry instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public static System.IAsyncResult BeginResolve(string hostName, System.AsyncCallback requestCallback, object stateObject) { throw null; }
+        public static System.Net.IPAddress[] EndGetHostAddresses(System.IAsyncResult asyncResult) { throw null; }
+        [System.ObsoleteAttribute("EndGetHostByName is obsoleted for this type, please use EndGetHostEntry instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public static System.Net.IPHostEntry EndGetHostByName(System.IAsyncResult asyncResult) { throw null; }
+        public static System.Net.IPHostEntry EndGetHostEntry(System.IAsyncResult asyncResult) { throw null; }
+        [System.ObsoleteAttribute("EndResolve is obsoleted for this type, please use EndGetHostEntry instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public static System.Net.IPHostEntry EndResolve(System.IAsyncResult asyncResult) { throw null; }
+        public static System.Net.IPAddress[] GetHostAddresses(string hostNameOrAddress) { throw null; }
         public static System.Threading.Tasks.Task<System.Net.IPAddress[]> GetHostAddressesAsync(string hostNameOrAddress) { throw null; }
-        public static IPHostEntry GetHostEntry(string hostNameOrAddress) { throw null; }
-        public static IPHostEntry GetHostEntry(IPAddress address) { throw null; }
+        [System.ObsoleteAttribute("GetHostByAddress is obsoleted for this type, please use GetHostEntry instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public static System.Net.IPHostEntry GetHostByAddress(System.Net.IPAddress address) { throw null; }
+        [System.ObsoleteAttribute("GetHostByAddress is obsoleted for this type, please use GetHostEntry instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public static System.Net.IPHostEntry GetHostByAddress(string address) { throw null; }
+        [System.ObsoleteAttribute("GetHostByName is obsoleted for this type, please use GetHostEntry instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public static System.Net.IPHostEntry GetHostByName(string hostName) { throw null; }
+        public static System.Net.IPHostEntry GetHostEntry(System.Net.IPAddress address) { throw null; }
+        public static System.Net.IPHostEntry GetHostEntry(string hostNameOrAddress) { throw null; }
         public static System.Threading.Tasks.Task<System.Net.IPHostEntry> GetHostEntryAsync(System.Net.IPAddress address) { throw null; }
         public static System.Threading.Tasks.Task<System.Net.IPHostEntry> GetHostEntryAsync(string hostNameOrAddress) { throw null; }
         public static string GetHostName() { throw null; }
-        [Obsolete("Resolve is obsoleted for this type, please use GetHostEntry instead. http://go.microsoft.com/fwlink/?linkid=14202")]
-        public static IPHostEntry Resolve(string hostName) { throw null; }
+        [System.ObsoleteAttribute("Resolve is obsoleted for this type, please use GetHostEntry instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public static System.Net.IPHostEntry Resolve(string hostName) { throw null; }
     }
     public partial class IPHostEntry
     {

--- a/src/System.Net.NetworkInformation/ref/System.Net.NetworkInformation.cs
+++ b/src/System.Net.NetworkInformation/ref/System.Net.NetworkInformation.cs
@@ -205,6 +205,17 @@ namespace System.Net.NetworkInformation
         public abstract long UnicastPacketsReceived { get; }
         public abstract long UnicastPacketsSent { get; }
     }
+    public abstract partial class IPv4InterfaceProperties
+    {
+        protected IPv4InterfaceProperties() { }
+        public abstract int Index { get; }
+        public abstract bool IsAutomaticPrivateAddressingActive { get; }
+        public abstract bool IsAutomaticPrivateAddressingEnabled { get; }
+        public abstract bool IsDhcpEnabled { get; }
+        public abstract bool IsForwardingEnabled { get; }
+        public abstract int Mtu { get; }
+        public abstract bool UsesWins { get; }
+    }
     public abstract partial class IPv4InterfaceStatistics
     {
         protected IPv4InterfaceStatistics() { }
@@ -220,17 +231,6 @@ namespace System.Net.NetworkInformation
         public abstract long OutputQueueLength { get; }
         public abstract long UnicastPacketsReceived { get; }
         public abstract long UnicastPacketsSent { get; }
-    }
-    public abstract partial class IPv4InterfaceProperties
-    {
-        protected IPv4InterfaceProperties() { }
-        public abstract int Index { get; }
-        public abstract bool IsAutomaticPrivateAddressingActive { get; }
-        public abstract bool IsAutomaticPrivateAddressingEnabled { get; }
-        public abstract bool IsDhcpEnabled { get; }
-        public abstract bool IsForwardingEnabled { get; }
-        public abstract int Mtu { get; }
-        public abstract bool UsesWins { get; }
     }
     public abstract partial class IPv6InterfaceProperties
     {
@@ -278,16 +278,10 @@ namespace System.Net.NetworkInformation
         internal NetworkAvailabilityEventArgs() { }
         public bool IsAvailable { get { throw null; } }
     }
-    public partial class NetworkChange
+    public static partial class NetworkChange
     {
-        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
-        [System.ObsoleteAttribute("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
-        public NetworkChange() { }
         public static event System.Net.NetworkInformation.NetworkAddressChangedEventHandler NetworkAddressChanged { add { } remove { } }
         public static event System.Net.NetworkInformation.NetworkAvailabilityChangedEventHandler NetworkAvailabilityChanged { add { } remove { } }
-        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
-        [System.ObsoleteAttribute("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
-        public static void RegisterNetworkChange(System.Net.NetworkInformation.NetworkChange nc) { }
     }
     public partial class NetworkInformationException : System.ComponentModel.Win32Exception
     {

--- a/src/System.Net.Ping/ref/System.Net.Ping.cs
+++ b/src/System.Net.Ping/ref/System.Net.Ping.cs
@@ -41,22 +41,22 @@ namespace System.Net.NetworkInformation
         public event System.Net.NetworkInformation.PingCompletedEventHandler PingCompleted { add { } remove { } }
         protected override void Dispose(bool disposing) { }
         protected void OnPingCompleted(System.Net.NetworkInformation.PingCompletedEventArgs e) { }
-        public PingReply Send(string hostNameOrAddress) { throw null; }
-        public PingReply Send(string hostNameOrAddress, int timeout) { throw null; }
-        public PingReply Send(System.Net.IPAddress address) { throw null; }
-        public PingReply Send(System.Net.IPAddress address, int timeout) { throw null; }
-        public PingReply Send(string hostNameOrAddress, int timeout, byte[] buffer) { throw null; }
-        public PingReply Send(System.Net.IPAddress address, int timeout, byte[] buffer) { throw null; }
-        public PingReply Send(string hostNameOrAddress, int timeout, byte[] buffer, System.Net.NetworkInformation.PingOptions options) { throw null; }
-        public PingReply Send(System.Net.IPAddress address, int timeout, byte[] buffer, System.Net.NetworkInformation.PingOptions options) { throw null; }
-        public void SendAsync(string hostNameOrAddress, object userToken) { }
-        public void SendAsync(string hostNameOrAddress, int timeout, object userToken) { }
-        public void SendAsync(System.Net.IPAddress address, object userToken) { }
-        public void SendAsync(System.Net.IPAddress address, int timeout, object userToken) { }
-        public void SendAsync(string hostNameOrAddress, int timeout, byte[] buffer, object userToken) { }
-        public void SendAsync(System.Net.IPAddress address, int timeout, byte[] buffer, object userToken) { }
-        public void SendAsync(string hostNameOrAddress, int timeout, byte[] buffer, System.Net.NetworkInformation.PingOptions options, object userToken) { }
+        public System.Net.NetworkInformation.PingReply Send(System.Net.IPAddress address) { throw null; }
+        public System.Net.NetworkInformation.PingReply Send(System.Net.IPAddress address, int timeout) { throw null; }
+        public System.Net.NetworkInformation.PingReply Send(System.Net.IPAddress address, int timeout, byte[] buffer) { throw null; }
+        public System.Net.NetworkInformation.PingReply Send(System.Net.IPAddress address, int timeout, byte[] buffer, System.Net.NetworkInformation.PingOptions options) { throw null; }
+        public System.Net.NetworkInformation.PingReply Send(string hostNameOrAddress) { throw null; }
+        public System.Net.NetworkInformation.PingReply Send(string hostNameOrAddress, int timeout) { throw null; }
+        public System.Net.NetworkInformation.PingReply Send(string hostNameOrAddress, int timeout, byte[] buffer) { throw null; }
+        public System.Net.NetworkInformation.PingReply Send(string hostNameOrAddress, int timeout, byte[] buffer, System.Net.NetworkInformation.PingOptions options) { throw null; }
         public void SendAsync(System.Net.IPAddress address, int timeout, byte[] buffer, System.Net.NetworkInformation.PingOptions options, object userToken) { }
+        public void SendAsync(System.Net.IPAddress address, int timeout, byte[] buffer, object userToken) { }
+        public void SendAsync(System.Net.IPAddress address, int timeout, object userToken) { }
+        public void SendAsync(System.Net.IPAddress address, object userToken) { }
+        public void SendAsync(string hostNameOrAddress, int timeout, byte[] buffer, System.Net.NetworkInformation.PingOptions options, object userToken) { }
+        public void SendAsync(string hostNameOrAddress, int timeout, byte[] buffer, object userToken) { }
+        public void SendAsync(string hostNameOrAddress, int timeout, object userToken) { }
+        public void SendAsync(string hostNameOrAddress, object userToken) { }
         public void SendAsyncCancel() { }
         public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(System.Net.IPAddress address) { throw null; }
         public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(System.Net.IPAddress address, int timeout) { throw null; }
@@ -67,17 +67,17 @@ namespace System.Net.NetworkInformation
         public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(string hostNameOrAddress, int timeout, byte[] buffer) { throw null; }
         public System.Threading.Tasks.Task<System.Net.NetworkInformation.PingReply> SendPingAsync(string hostNameOrAddress, int timeout, byte[] buffer, System.Net.NetworkInformation.PingOptions options) { throw null; }
     }
-    public delegate void PingCompletedEventHandler(object sender, PingCompletedEventArgs e);
-    public class PingCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    public partial class PingCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
     {
         internal PingCompletedEventArgs() : base(null, false, null) { }
-        public PingReply Reply { get; }
+        public System.Net.NetworkInformation.PingReply Reply { get { throw null; } }
     }
+    public delegate void PingCompletedEventHandler(object sender, System.Net.NetworkInformation.PingCompletedEventArgs e);
     public partial class PingException : System.InvalidOperationException
     {
+        protected PingException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public PingException(string message) { }
         public PingException(string message, System.Exception innerException) { }
-        protected PingException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
     public partial class PingOptions
     {

--- a/src/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -5,7 +5,6 @@
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-
 namespace System.Net
 {
     [System.FlagsAttribute]
@@ -47,16 +46,16 @@ namespace System.Net
     {
         public CookieCollection() { }
         public int Count { get { throw null; } }
-        public System.Net.Cookie this[string name] { get { throw null; } }
-        public System.Net.Cookie this[int index] { get { throw null; } }
+        public bool IsReadOnly { get { throw null; } }
         public bool IsSynchronized { get { throw null; } }
+        public System.Net.Cookie this[int index] { get { throw null; } }
+        public System.Net.Cookie this[string name] { get { throw null; } }
         public object SyncRoot { get { throw null; } }
         public void Add(System.Net.Cookie cookie) { }
         public void Add(System.Net.CookieCollection cookies) { }
-        public System.Collections.IEnumerator GetEnumerator() { throw null; }
         public void CopyTo(System.Array array, int index) { }
-        public void CopyTo(Cookie[] array, int index) { }
-        public bool IsReadOnly { get { throw null; } }
+        public void CopyTo(System.Net.Cookie[] array, int index) { }
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
     }
     public partial class CookieContainer
     {
@@ -64,19 +63,19 @@ namespace System.Net
         public const int DefaultCookieLimit = 300;
         public const int DefaultPerDomainCookieLimit = 20;
         public CookieContainer() { }
+        public CookieContainer(int capacity) { }
+        public CookieContainer(int capacity, int perDomainCapacity, int maxCookieSize) { }
         public int Capacity { get { throw null; } set { } }
         public int Count { get { throw null; } }
         public int MaxCookieSize { get { throw null; } set { } }
         public int PerDomainCapacity { get { throw null; } set { } }
+        public void Add(System.Net.Cookie cookie) { }
+        public void Add(System.Net.CookieCollection cookies) { }
         public void Add(System.Uri uri, System.Net.Cookie cookie) { }
         public void Add(System.Uri uri, System.Net.CookieCollection cookies) { }
         public string GetCookieHeader(System.Uri uri) { throw null; }
         public System.Net.CookieCollection GetCookies(System.Uri uri) { throw null; }
         public void SetCookies(System.Uri uri, string cookieHeader) { }
-        public CookieContainer(int capacity) { }
-        public CookieContainer(int capacity, int perDomainCapacity, int maxCookieSize) { }
-        public void Add(CookieCollection cookies) { }
-        public void Add(Cookie cookie) { }
     }
     public partial class CookieException : System.FormatException, System.Runtime.Serialization.ISerializable
     {
@@ -173,6 +172,17 @@ namespace System.Net
         UpgradeRequired = 426,
         UseProxy = 305,
     }
+    public static partial class HttpVersion
+    {
+#if netcoreapp11
+        public static readonly Version Unknown;
+#endif
+        public static readonly System.Version Version10;
+        public static readonly System.Version Version11;
+#if netcoreapp11
+        public static readonly Version Version20;
+#endif
+    }
     public partial interface ICredentials
     {
         System.Net.NetworkCredential GetCredential(System.Uri uri, string authType);
@@ -193,6 +203,8 @@ namespace System.Net
         public IPAddress(byte[] address) { }
         public IPAddress(byte[] address, long scopeid) { }
         public IPAddress(long newAddress) { }
+        [System.ObsoleteAttribute("This property has been deprecated. It is address family dependent. Please use IPAddress.Equals method to perform comparisons. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public long Address { get { throw null; } set { } }
         public System.Net.Sockets.AddressFamily AddressFamily { get { throw null; } }
         public bool IsIPv4MappedToIPv6 { get { throw null; } }
         public bool IsIPv6LinkLocal { get { throw null; } }
@@ -214,9 +226,7 @@ namespace System.Net
         public static long NetworkToHostOrder(long network) { throw null; }
         public static System.Net.IPAddress Parse(string ipString) { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string ipString, out System.Net.IPAddress address) { throw null; }
-        [Obsolete("This property has been deprecated. It is address family dependent. Please use IPAddress.Equals method to perform comparisons. http://go.microsoft.com/fwlink/?linkid=14202")]
-        public long Address { get { throw null; } set { } }
+        public static bool TryParse(string ipString, out System.Net.IPAddress address) { address = default(System.Net.IPAddress); throw null; }
     }
     public partial class IPEndPoint : System.Net.EndPoint
     {
@@ -242,10 +252,16 @@ namespace System.Net
     public partial class NetworkCredential : System.Net.ICredentials, System.Net.ICredentialsByHost
     {
         public NetworkCredential() { }
+        [System.CLSCompliantAttribute(false)]
+        public NetworkCredential(string userName, System.Security.SecureString password) { }
+        [System.CLSCompliantAttribute(false)]
+        public NetworkCredential(string userName, System.Security.SecureString password, string domain) { }
         public NetworkCredential(string userName, string password) { }
         public NetworkCredential(string userName, string password, string domain) { }
         public string Domain { get { throw null; } set { } }
         public string Password { get { throw null; } set { } }
+        [System.CLSCompliantAttribute(false)]
+        public System.Security.SecureString SecurePassword { get { throw null; } set { } }
         public string UserName { get { throw null; } set { } }
         public System.Net.NetworkCredential GetCredential(string host, int port, string authenticationType) { throw null; }
         public System.Net.NetworkCredential GetCredential(System.Uri uri, string authType) { throw null; }
@@ -266,32 +282,20 @@ namespace System.Net
         protected TransportContext() { }
         public abstract System.Security.Authentication.ExtendedProtection.ChannelBinding GetChannelBinding(System.Security.Authentication.ExtendedProtection.ChannelBindingKind kind);
     }
-
-    public static class HttpVersion
-    {
-#if netcoreapp11
-        public static readonly Version Unknown = new Version(0, 0);
-#endif
-        public static readonly Version Version10 = new Version(1, 0);
-        public static readonly Version Version11 = new Version(1, 1);
-#if netcoreapp11
-        public static readonly Version Version20 = new Version(2, 0);
-#endif
-    }
 }
 namespace System.Net.Cache
 {
     public enum RequestCacheLevel
     {
-        Default = 0,
         BypassCache = 1,
-        CacheOnly = 2,
         CacheIfAvailable = 3,
-        Revalidate = 4,
+        CacheOnly = 2,
+        Default = 0,
+        NoCacheNoStore = 6,
         Reload = 5,
-        NoCacheNoStore = 6
+        Revalidate = 4,
     }
-    public class RequestCachePolicy
+    public partial class RequestCachePolicy
     {
         public RequestCachePolicy() { }
         public RequestCachePolicy(System.Net.Cache.RequestCacheLevel level) { }
@@ -357,6 +361,7 @@ namespace System.Net.Sockets
         Irda = 26,
         Iso = 7,
         Lat = 14,
+        Max = 29,
         NetBios = 17,
         NetworkDesigners = 28,
         NS = 6,
@@ -464,6 +469,8 @@ namespace System.Security.Authentication
     [System.FlagsAttribute]
     public enum SslProtocols
     {
+        [Obsolete("This value has been deprecated.  It is no longer supported. http://go.microsoft.com/fwlink/?linkid=14202")]
+        Default = 240,
         None = 0,
         [Obsolete("This value has been deprecated.  It is no longer supported. http://go.microsoft.com/fwlink/?linkid=14202")]
         Ssl2 = 12,
@@ -472,16 +479,14 @@ namespace System.Security.Authentication
         Tls = 192,
         Tls11 = 768,
         Tls12 = 3072,
-        [Obsolete("This value has been deprecated.  It is no longer supported. http://go.microsoft.com/fwlink/?linkid=14202")]
-        Default = Ssl3 | Tls
     }
 }
 namespace System.Security.Authentication.ExtendedProtection
 {
     public abstract partial class ChannelBinding : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
-        protected ChannelBinding() : base(default(bool)) { }
-        protected ChannelBinding(bool ownsHandle) : base(default(bool)) { }
+        protected ChannelBinding() : base (default(bool)) { }
+        protected ChannelBinding(bool ownsHandle) : base (default(bool)) { }
         public abstract int Size { get; }
     }
     public enum ChannelBindingKind

--- a/src/System.Net.Primitives/ref/project.json
+++ b/src/System.Net.Primitives/ref/project.json
@@ -2,7 +2,8 @@
   "dependencies": {
     "Microsoft.Win32.Primitives": "4.4.0-beta-24721-02",
     "System.Runtime": "4.4.0-beta-24721-02",
-    "System.Runtime.Handles": "4.4.0-beta-24721-02"
+    "System.Runtime.Handles": "4.4.0-beta-24721-02",
+    "System.Runtime.InteropServices": "4.4.0-beta-24721-02"
   },
   "frameworks": {
     "netstandard1.7": {},

--- a/src/System.Net.Primitives/src/System/Net/NetworkCredential.cs
+++ b/src/System.Net.Primitives/src/System/Net/NetworkCredential.cs
@@ -52,6 +52,20 @@ namespace System.Net
             Domain = domain;
         }
 
+        [System.CLSCompliantAttribute(false)]
+        public NetworkCredential(string userName, SecureString password) 
+        { 
+            // TODO: #12134
+            throw new PlatformNotSupportedException();
+        }
+
+        [System.CLSCompliantAttribute(false)]
+        public NetworkCredential(string userName, SecureString password, string domain) 
+        { 
+            // TODO: #12134
+            throw new PlatformNotSupportedException();
+        }
+
         /// <devdoc>
         ///    <para>
         ///       The user name associated with this credential.
@@ -104,6 +118,20 @@ namespace System.Net
             }
         }
 
+        [System.CLSCompliantAttribute(false)]
+        public System.Security.SecureString SecurePassword 
+        { 
+            get 
+            { 
+                // TODO: #12134
+                throw new PlatformNotSupportedException();
+            } 
+            set 
+            { 
+                // TODO: #12134
+                throw new PlatformNotSupportedException();
+            } 
+        }
         internal string InternalGetUserName()
         {
             return _userName;

--- a/src/System.Net.Requests/ref/System.Net.Requests.cs
+++ b/src/System.Net.Requests/ref/System.Net.Requests.cs
@@ -8,36 +8,33 @@
 
 namespace System.Net
 {
-    public delegate void HttpContinueDelegate(int StatusCode, WebHeaderCollection httpHeaders);
-    public class AuthenticationManager
+    public partial class AuthenticationManager
     {
-        private AuthenticationManager() { }
+        internal AuthenticationManager() { }
         public static System.Net.ICredentialPolicy CredentialPolicy { get { throw null; } set { } }
         public static System.Collections.Specialized.StringDictionary CustomTargetNameDictionary { get { throw null; } }
-        public static Authorization Authenticate(string challenge, System.Net.WebRequest request, ICredentials credentials) { throw null; }
-        public static Authorization PreAuthenticate(System.Net.WebRequest request, ICredentials credentials) { throw null; }
-        public static void Register(IAuthenticationModule authenticationModule) { }
-        public static void Unregister(IAuthenticationModule authenticationModule) { }
-        public static void Unregister(string authenticationScheme) { }
         public static System.Collections.IEnumerator RegisteredModules { get { throw null; } }
+        public static System.Net.Authorization Authenticate(string challenge, System.Net.WebRequest request, System.Net.ICredentials credentials) { throw null; }
+        public static System.Net.Authorization PreAuthenticate(System.Net.WebRequest request, System.Net.ICredentials credentials) { throw null; }
+        public static void Register(System.Net.IAuthenticationModule authenticationModule) { }
+        public static void Unregister(System.Net.IAuthenticationModule authenticationModule) { }
+        public static void Unregister(string authenticationScheme) { }
     }
-    public class Authorization
+    public partial class Authorization
     {
         public Authorization(string token) { }
         public Authorization(string token, bool finished) { }
         public Authorization(string token, bool finished, string connectionGroupId) { }
-
-        public string Message { get { throw null; } }
-        public string ConnectionGroupId { get { throw null; } }
         public bool Complete { get { throw null; } }
-        public string[] ProtectionRealm { get { throw null; } set { } }
+        public string ConnectionGroupId { get { throw null; } }
+        public string Message { get { throw null; } }
         public bool MutuallyAuthenticated { get { throw null; } set { } }
+        public string[] ProtectionRealm { get { throw null; } set { } }
     }
-    public class FileWebRequest : WebRequest, System.Runtime.Serialization.ISerializable
+    public partial class FileWebRequest : System.Net.WebRequest, System.Runtime.Serialization.ISerializable
     {
-        internal FileWebRequest() { }
-        [Obsolete("Serialization is obsoleted for this type. http://go.microsoft.com/fwlink/?linkid=14202")]
-        protected FileWebRequest(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) : base(serializationInfo, streamingContext) { }
+        [System.ObsoleteAttribute("Serialization is obsoleted for this type. http://go.microsoft.com/fwlink/?linkid=14202")]
+        protected FileWebRequest(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public override string ConnectionGroupName { get { throw null; } set { } }
         public override long ContentLength { get { throw null; } set { } }
         public override string ContentType { get { throw null; } set { } }
@@ -46,35 +43,74 @@ namespace System.Net
         public override string Method { get { throw null; } set { } }
         public override bool PreAuthenticate { get { throw null; } set { } }
         public override System.Net.IWebProxy Proxy { get { throw null; } set { } }
-        public override int Timeout { get { throw null; } set { } }
         public override System.Uri RequestUri { get { throw null; } }
+        public override int Timeout { get { throw null; } set { } }
         public override bool UseDefaultCredentials { get { throw null; } set { } }
-        public override void Abort() { throw null; }
+        public override void Abort() { }
         public override System.IAsyncResult BeginGetRequestStream(System.AsyncCallback callback, object state) { throw null; }
         public override System.IAsyncResult BeginGetResponse(System.AsyncCallback callback, object state) { throw null; }
         public override System.IO.Stream EndGetRequestStream(System.IAsyncResult asyncResult) { throw null; }
         public override System.Net.WebResponse EndGetResponse(System.IAsyncResult asyncResult) { throw null; }
+        protected override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public override System.IO.Stream GetRequestStream() { throw null; }
         public override System.Net.WebResponse GetResponse() { throw null; }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
-        protected override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
-    public class FileWebResponse : WebResponse, System.Runtime.Serialization.ISerializable
+    public partial class FileWebResponse : System.Net.WebResponse, System.Runtime.Serialization.ISerializable
     {
-        internal FileWebResponse() { }
-        [Obsolete("Serialization is obsoleted for this type. http://go.microsoft.com/fwlink/?linkid=14202")]
-        protected FileWebResponse(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) : base(serializationInfo, streamingContext) { }
+        [System.ObsoleteAttribute("Serialization is obsoleted for this type. http://go.microsoft.com/fwlink/?linkid=14202")]
+        protected FileWebResponse(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public override long ContentLength { get { throw null; } }
         public override string ContentType { get { throw null; } }
-        public override WebHeaderCollection Headers { get { throw null; } }
+        public override System.Net.WebHeaderCollection Headers { get { throw null; } }
+        public override System.Uri ResponseUri { get { throw null; } }
         public override bool SupportsHeaders { get { throw null; } }
-        public override Uri ResponseUri { get { throw null; } }
-        public override void Close() { throw null; }
-        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public override void Close() { }
         protected override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public override System.IO.Stream GetResponseStream() { throw null; }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
-    public sealed class FtpWebRequest : WebRequest
+    public enum FtpStatusCode
+    {
+        AccountNeeded = 532,
+        ActionAbortedLocalProcessingError = 451,
+        ActionAbortedUnknownPageType = 551,
+        ActionNotTakenFilenameNotAllowed = 553,
+        ActionNotTakenFileUnavailable = 550,
+        ActionNotTakenFileUnavailableOrBusy = 450,
+        ActionNotTakenInsufficientSpace = 452,
+        ArgumentSyntaxError = 501,
+        BadCommandSequence = 503,
+        CantOpenData = 425,
+        ClosingControl = 221,
+        ClosingData = 226,
+        CommandExtraneous = 202,
+        CommandNotImplemented = 502,
+        CommandOK = 200,
+        CommandSyntaxError = 500,
+        ConnectionClosed = 426,
+        DataAlreadyOpen = 125,
+        DirectoryStatus = 212,
+        EnteringPassive = 227,
+        FileActionAborted = 552,
+        FileActionOK = 250,
+        FileCommandPending = 350,
+        FileStatus = 213,
+        LoggedInProceed = 230,
+        NeedLoginAccount = 332,
+        NotLoggedIn = 530,
+        OpeningData = 150,
+        PathnameCreated = 257,
+        RestartMarker = 110,
+        SendPasswordCommand = 331,
+        SendUserCommand = 220,
+        ServerWantsSecureSession = 234,
+        ServiceNotAvailable = 421,
+        ServiceTemporarilyNotAvailable = 120,
+        SystemType = 215,
+        Undefined = 0,
+    }
+    public sealed partial class FtpWebRequest : System.Net.WebRequest
     {
         internal FtpWebRequest() { }
         public System.Security.Cryptography.X509Certificates.X509CertificateCollection ClientCertificates { get { throw null; } set { } }
@@ -83,137 +119,156 @@ namespace System.Net
         public long ContentOffset { get { throw null; } set { } }
         public override string ContentType { get { throw null; } set { } }
         public override System.Net.ICredentials Credentials { get { throw null; } set { } }
+        public static new System.Net.Cache.RequestCachePolicy DefaultCachePolicy { get { throw null; } set { } }
+        public bool EnableSsl { get { throw null; } set { } }
         public override System.Net.WebHeaderCollection Headers { get { throw null; } set { } }
+        public bool KeepAlive { get { throw null; } set { } }
         public override string Method { get { throw null; } set { } }
         public override bool PreAuthenticate { get { throw null; } set { } }
         public override System.Net.IWebProxy Proxy { get { throw null; } set { } }
-        public string RenameTo { get { throw null; } set { } }
-        public override int Timeout { get { throw null; } set { } }
-        public bool EnableSsl { get { throw null; } set { } }
-        public bool UsePassive { get { throw null; } set { } }
-        public bool UseBinary { get { throw null; } set { } }
-        public bool KeepAlive { get { throw null; } set { } }
         public int ReadWriteTimeout { get { throw null; } set { } }
+        public string RenameTo { get { throw null; } set { } }
+        public override System.Uri RequestUri { get { throw null; } }
         public System.Net.ServicePoint ServicePoint { get { throw null; } }
-        public static new System.Net.Cache.RequestCachePolicy DefaultCachePolicy { get { throw null; } set { } }
-        public override System.Uri RequestUri { get { throw null; } }
+        public override int Timeout { get { throw null; } set { } }
+        public bool UseBinary { get { throw null; } set { } }
         public override bool UseDefaultCredentials { get { throw null; } set { } }
-        public override void Abort() { throw null; }
-        public override System.IAsyncResult BeginGetRequestStream(System.AsyncCallback callback, object state) { throw null; }
-        public override System.IAsyncResult BeginGetResponse(System.AsyncCallback callback, object state) { throw null; }
-        public override System.IO.Stream EndGetRequestStream(System.IAsyncResult asyncResult) { throw null; }
-        public override System.Net.WebResponse EndGetResponse(System.IAsyncResult asyncResult) { throw null; }
-        public override System.IO.Stream GetRequestStream() { throw null; }
-        public override System.Net.WebResponse GetResponse() { throw null; }
-    }
-    public class FtpWebResponse : WebResponse
-    {
-        internal FtpWebResponse() { }
-        public override long ContentLength { get { throw null; } }
-        public override string ContentType { get { throw null; } }
-        public override WebHeaderCollection Headers { get { throw null; } }
-        public override bool SupportsHeaders { get { throw null; } }
-        public override Uri ResponseUri { get { throw null; } }
-        public override void Close() { throw null; }
-        public override System.IO.Stream GetResponseStream() { throw null; }
-        public string BannerMessage { get { throw null; } }
-        public string ExitMessage { get { throw null; } }
-        public string WelcomeMessage { get { throw null; } }
-        public FtpStatusCode StatusCode { get { throw null; } } 
-        public string StatusDescription { get { throw null; } }
-        public DateTime LastModified { get { throw null; } }
-    }
-    public partial class HttpWebRequest : System.Net.WebRequest
-    {
-        internal HttpWebRequest() { }
-        public string Accept { get { throw null; } set { } }
-        public virtual bool AllowReadStreamBuffering { get { throw null; } set { } }
-        public override string ContentType { get { throw null; } set { } }
-        public int ContinueTimeout { get { throw null; } set { } }
-        public virtual System.Net.CookieContainer CookieContainer { get { throw null; } set { } }
-        public override System.Net.ICredentials Credentials { get { throw null; } set { } }
-        public virtual bool HaveResponse { get { throw null; } }
-        public override System.Net.WebHeaderCollection Headers { get { throw null; } set { } }
-        public override string Method { get { throw null; } set { } }
-        public override System.Uri RequestUri { get { throw null; } }
-        public virtual bool SupportsCookieContainer { get { throw null; } }
-        public override bool UseDefaultCredentials { get { throw null; } set { } }
+        public bool UsePassive { get { throw null; } set { } }
         public override void Abort() { }
         public override System.IAsyncResult BeginGetRequestStream(System.AsyncCallback callback, object state) { throw null; }
         public override System.IAsyncResult BeginGetResponse(System.AsyncCallback callback, object state) { throw null; }
         public override System.IO.Stream EndGetRequestStream(System.IAsyncResult asyncResult) { throw null; }
-        public System.IO.Stream EndGetRequestStream(System.IAsyncResult asyncResult, out System.Net.TransportContext context) { throw null; }
         public override System.Net.WebResponse EndGetResponse(System.IAsyncResult asyncResult) { throw null; }
+        public override System.IO.Stream GetRequestStream() { throw null; }
         public override System.Net.WebResponse GetResponse() { throw null; }
-        public virtual bool AllowWriteStreamBuffering { get { throw null; } set { } }        
+    }
+    public partial class FtpWebResponse : System.Net.WebResponse, System.IDisposable
+    {
+        internal FtpWebResponse() { }
+        public string BannerMessage { get { throw null; } }
+        public override long ContentLength { get { throw null; } }
+        public string ExitMessage { get { throw null; } }
+        public override System.Net.WebHeaderCollection Headers { get { throw null; } }
+        public System.DateTime LastModified { get { throw null; } }
+        public override System.Uri ResponseUri { get { throw null; } }
+        public System.Net.FtpStatusCode StatusCode { get { throw null; } }
+        public string StatusDescription { get { throw null; } }
+        public override bool SupportsHeaders { get { throw null; } }
+        public string WelcomeMessage { get { throw null; } }
+        public override void Close() { }
+        public override System.IO.Stream GetResponseStream() { throw null; }
+    }
+    [System.ObsoleteAttribute("This class has been deprecated. Please use WebRequest.DefaultWebProxy instead to access and set the global default proxy. Use 'null' instead of GetEmptyWebProxy. http://go.microsoft.com/fwlink/?linkid=14202")]
+    public partial class GlobalProxySelection
+    {
+        public GlobalProxySelection() { }
+        public static System.Net.IWebProxy Select { get { throw null; } set { } }
+        public static System.Net.IWebProxy GetEmptyWebProxy() { throw null; }
+    }
+    public delegate void HttpContinueDelegate(int StatusCode, System.Net.WebHeaderCollection httpHeaders);
+    public partial class HttpWebRequest : System.Net.WebRequest, System.Runtime.Serialization.ISerializable
+    {
+        [System.ObsoleteAttribute("Serialization is obsoleted for this type.  http://go.microsoft.com/fwlink/?linkid=14202")]
+        protected HttpWebRequest(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public string Accept { get { throw null; } set { } }
+        public System.Uri Address { get { throw null; } }
         public virtual bool AllowAutoRedirect { get { throw null; } set { } }
-        public Uri Address { get { throw null; } }
-        public DecompressionMethods AutomaticDecompression { get { throw null; } set { } }
-        public DateTime Date { get { throw null; } set { } }
-        public static int DefaultMaximumResponseHeadersLength { get { throw null; } set { } }
+        public virtual bool AllowReadStreamBuffering { get { throw null; } set { } }
+        public virtual bool AllowWriteStreamBuffering { get { throw null; } set { } }
+        public System.Net.DecompressionMethods AutomaticDecompression { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509CertificateCollection ClientCertificates { get { throw null; } set { } }
+        public string Connection { get { throw null; } set { } }
+        public override string ConnectionGroupName { get { throw null; } set { } }
+        public override long ContentLength { get { throw null; } set { } }
+        public override string ContentType { get { throw null; } set { } }
+        public System.Net.HttpContinueDelegate ContinueDelegate { get { throw null; } set { } }
+        public int ContinueTimeout { get { throw null; } set { } }
+        public virtual System.Net.CookieContainer CookieContainer { get { throw null; } set { } }
+        public override System.Net.ICredentials Credentials { get { throw null; } set { } }
+        public System.DateTime Date { get { throw null; } set { } }
+        public static new System.Net.Cache.RequestCachePolicy DefaultCachePolicy { get { throw null; } set { } }
         public static int DefaultMaximumErrorResponseLength { get { throw null; } set { } }
-        public System.Security.Cryptography.X509Certificates.X509CertificateCollection ClientCertificates {
-            get { throw null; } set { } }
+        public static int DefaultMaximumResponseHeadersLength { get { throw null; } set { } }
         public string Expect { get { throw null; } set { } }
-        public DateTime IfModifiedSince { get { throw null; } set { } }
+        public virtual bool HaveResponse { get { throw null; } }
+        public override System.Net.WebHeaderCollection Headers { get { throw null; } set { } }
+        public string Host { get { throw null; } set { } }
+        public System.DateTime IfModifiedSince { get { throw null; } set { } }
         public bool KeepAlive { get { throw null; } set { } }
         public int MaximumAutomaticRedirections { get { throw null; } set { } }
         public int MaximumResponseHeadersLength { get { throw null; } set { } }
-        public string MediaType { get { throw null; } set { } }        
-        public System.IO.Stream GetRequestStream(out TransportContext context) { throw null; }
+        public string MediaType { get { throw null; } set { } }
+        public override string Method { get { throw null; } set { } }
         public bool Pipelined { get { throw null; } set { } }
-        public Version ProtocolVersion { get { throw null; } set { } }
+        public override bool PreAuthenticate { get { throw null; } set { } }
+        public System.Version ProtocolVersion { get { throw null; } set { } }
+        public override System.Net.IWebProxy Proxy { get { throw null; } set { } }
         public int ReadWriteTimeout { get { throw null; } set { } }
         public string Referer { get { throw null; } set { } }
+        public override System.Uri RequestUri { get { throw null; } }
         public bool SendChunked { get { throw null; } set { } }
-        public ServicePoint ServicePoint { get { throw null; } }
+        public System.Net.Security.RemoteCertificateValidationCallback ServerCertificateValidationCallback { get { throw null; } set { } }
+        public System.Net.ServicePoint ServicePoint { get { throw null; } }
+        public virtual bool SupportsCookieContainer { get { throw null; } }
+        public override int Timeout { get { throw null; } set { } }
         public string TransferEncoding { get { throw null; } set { } }
-        public string UserAgent { get { throw null; } set { } }
         public bool UnsafeAuthenticatedConnectionSharing { get { throw null; } set { } }
-        public override System.IO.Stream GetRequestStream() { throw null; }
+        public override bool UseDefaultCredentials { get { throw null; } set { } }
+        public string UserAgent { get { throw null; } set { } }
+        public override void Abort() { }
         public void AddRange(int range) { }
-        public void AddRange(int from,int to) { }
+        public void AddRange(int from, int to) { }
         public void AddRange(long range) { }
-        public void AddRange(long from,long to) { }
+        public void AddRange(long from, long to) { }
         public void AddRange(string rangeSpecifier, int range) { }
-        public void AddRange(string rangeSpecifier, int from,int to) { }
+        public void AddRange(string rangeSpecifier, int from, int to) { }
         public void AddRange(string rangeSpecifier, long range) { }
-        public void AddRange(string rangeSpecifier, long from,long to) { }
-        public string Host { get { throw null; } set { } }
-        public override string ConnectionGroupName { get { throw null; } set { } }
-        public System.Net.Security.RemoteCertificateValidationCallback ServerCertificateValidationCallback { get; set; }
-        public HttpContinueDelegate ContinueDelegate { get { throw null; } set { } }
+        public void AddRange(string rangeSpecifier, long from, long to) { }
+        public override System.IAsyncResult BeginGetRequestStream(System.AsyncCallback callback, object state) { throw null; }
+        public override System.IAsyncResult BeginGetResponse(System.AsyncCallback callback, object state) { throw null; }
+        public override System.IO.Stream EndGetRequestStream(System.IAsyncResult asyncResult) { throw null; }
+        public System.IO.Stream EndGetRequestStream(System.IAsyncResult asyncResult, out System.Net.TransportContext context) { context = default(System.Net.TransportContext); throw null; }
+        public override System.Net.WebResponse EndGetResponse(System.IAsyncResult asyncResult) { throw null; }
+        protected override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public override System.IO.Stream GetRequestStream() { throw null; }
+        public System.IO.Stream GetRequestStream(out System.Net.TransportContext context) { context = default(System.Net.TransportContext); throw null; }
+        public override System.Net.WebResponse GetResponse() { throw null; }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
-    public partial class HttpWebResponse : System.Net.WebResponse
+    public partial class HttpWebResponse : System.Net.WebResponse, System.Runtime.Serialization.ISerializable
     {
-        public HttpWebResponse() { }
+        [System.ObsoleteAttribute("Serialization is obsoleted for this type.  http://go.microsoft.com/fwlink/?linkid=14202")]
+        protected HttpWebResponse(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public string CharacterSet { get { throw null; } }
+        public string ContentEncoding { get { throw null; } }
         public override long ContentLength { get { throw null; } }
         public override string ContentType { get { throw null; } }
         public virtual System.Net.CookieCollection Cookies { get { throw null; } set { } }
         public override System.Net.WebHeaderCollection Headers { get { throw null; } }
+        public override bool IsMutuallyAuthenticated { get { throw null; } }
+        public System.DateTime LastModified { get { throw null; } }
         public virtual string Method { get { throw null; } }
+        public System.Version ProtocolVersion { get { throw null; } }
         public override System.Uri ResponseUri { get { throw null; } }
+        public string Server { get { throw null; } }
         public virtual System.Net.HttpStatusCode StatusCode { get { throw null; } }
         public virtual string StatusDescription { get { throw null; } }
         public override bool SupportsHeaders { get { throw null; } }
+        public override void Close() { }
         protected override void Dispose(bool disposing) { }
+        protected override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public string GetResponseHeader(string headerName) { throw null; }
         public override System.IO.Stream GetResponseStream() { throw null; }
-        public string GetResponseHeader(string headerName) { throw null; }        
-        public Version ProtocolVersion { get { throw null; } }        
-        public DateTime LastModified { get { throw null; } }        
-        public String ContentEncoding { get { throw null; } }
-        public string CharacterSet { get { throw null; } }
-        public string Server { get { throw null; } }
-        public override void Close() { throw null; }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
-    public interface IAuthenticationModule
+    public partial interface IAuthenticationModule
     {
+        string AuthenticationType { get; }
+        bool CanPreAuthenticate { get; }
         System.Net.Authorization Authenticate(string challenge, System.Net.WebRequest request, System.Net.ICredentials credentials);
         System.Net.Authorization PreAuthenticate(System.Net.WebRequest request, System.Net.ICredentials credentials);
-        bool CanPreAuthenticate { get; }
-        string AuthenticationType { get; }
     }
-    public interface ICredentialPolicy
+    public partial interface ICredentialPolicy
     {
         bool ShouldSendCredential(System.Uri challengeUri, System.Net.WebRequest request, System.Net.NetworkCredential credential, System.Net.IAuthenticationModule authenticationModule);
     }
@@ -224,26 +279,23 @@ namespace System.Net
     public partial class ProtocolViolationException : System.InvalidOperationException, System.Runtime.Serialization.ISerializable
     {
         public ProtocolViolationException() { }
-        public ProtocolViolationException(string message) { }
         protected ProtocolViolationException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
-        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public ProtocolViolationException(string message) { }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
-    public partial class WebException : System.InvalidOperationException , System.Runtime.Serialization.ISerializable
+    public partial class WebException : System.InvalidOperationException, System.Runtime.Serialization.ISerializable
     {
         public WebException() { }
+        protected WebException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public WebException(string message) { }
         public WebException(string message, System.Exception innerException) { }
         public WebException(string message, System.Exception innerException, System.Net.WebExceptionStatus status, System.Net.WebResponse response) { }
         public WebException(string message, System.Net.WebExceptionStatus status) { }
         public System.Net.WebResponse Response { get { throw null; } }
         public System.Net.WebExceptionStatus Status { get { throw null; } }
-        protected WebException(System.Runtime.Serialization.SerializationInfo serializationInfo, 
-            System.Runtime.Serialization.StreamingContext streamingContext) { }
-        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, 
-            System.Runtime.Serialization.StreamingContext streamingContext) { }
-        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo,
-            System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
     public enum WebExceptionStatus
     {
@@ -267,17 +319,17 @@ namespace System.Net
         Success = 0,
         Timeout = 14,
         TrustFailure = 9,
-        UnknownError = 16
+        UnknownError = 16,
     }
     public abstract partial class WebRequest : System.MarshalByRefObject, System.Runtime.Serialization.ISerializable
     {
         protected WebRequest() { }
         protected WebRequest(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public System.Net.Security.AuthenticationLevel AuthenticationLevel { get { throw null; } set { } }
-        public virtual long ContentLength { get { throw null; } set { } }
-        public virtual string ContentType { get { throw null; } set { } }
         public virtual System.Net.Cache.RequestCachePolicy CachePolicy { get { throw null; } set { } }
         public virtual string ConnectionGroupName { get { throw null; } set { } }
+        public virtual long ContentLength { get { throw null; } set { } }
+        public virtual string ContentType { get { throw null; } set { } }
         public virtual System.Net.ICredentials Credentials { get { throw null; } set { } }
         public static System.Net.Cache.RequestCachePolicy DefaultCachePolicy { get { throw null; } set { } }
         public static System.Net.IWebProxy DefaultWebProxy { get { throw null; } set { } }
@@ -289,59 +341,59 @@ namespace System.Net
         public virtual System.Uri RequestUri { get { throw null; } }
         public virtual int Timeout { get { throw null; } set { } }
         public virtual bool UseDefaultCredentials { get { throw null; } set { } }
-        public virtual void Abort() { throw null; }
+        public virtual void Abort() { }
         public virtual System.IAsyncResult BeginGetRequestStream(System.AsyncCallback callback, object state) { throw null; }
         public virtual System.IAsyncResult BeginGetResponse(System.AsyncCallback callback, object state) { throw null; }
         public static System.Net.WebRequest Create(string requestUriString) { throw null; }
         public static System.Net.WebRequest Create(System.Uri requestUri) { throw null; }
-        public static System.Net.WebRequest CreateDefault(Uri requestUri) { throw null; }
+        public static System.Net.WebRequest CreateDefault(System.Uri requestUri) { throw null; }
         public static System.Net.HttpWebRequest CreateHttp(string requestUriString) { throw null; }
         public static System.Net.HttpWebRequest CreateHttp(System.Uri requestUri) { throw null; }
         public virtual System.IO.Stream EndGetRequestStream(System.IAsyncResult asyncResult) { throw null; }
         public virtual System.Net.WebResponse EndGetResponse(System.IAsyncResult asyncResult) { throw null; }
-        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { throw null; }
-        protected virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { throw null; }
+        protected virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public virtual System.IO.Stream GetRequestStream() { throw null; }
         public virtual System.Threading.Tasks.Task<System.IO.Stream> GetRequestStreamAsync() { throw null; }
         public virtual System.Net.WebResponse GetResponse() { throw null; }
-        public virtual System.Threading.Tasks.Task<System.Net.WebResponse> GetResponseAsync() { throw null; }        
+        public virtual System.Threading.Tasks.Task<System.Net.WebResponse> GetResponseAsync() { throw null; }
         public static System.Net.IWebProxy GetSystemWebProxy() { throw null; }
         public static bool RegisterPrefix(string prefix, System.Net.IWebRequestCreate creator) { throw null; }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
-    public static class WebRequestMethods
+    public static partial class WebRequestMethods
     {
-        public static class Ftp
-        {
-            public const string DownloadFile = "RETR";
-            public const string ListDirectory = "NLST";
-            public const string UploadFile = "STOR";
-            public const string DeleteFile = "DELE";
-            public const string AppendFile = "APPE";
-            public const string GetFileSize = "SIZE";
-            public const string UploadFileWithUniqueName = "STOU";
-            public const string MakeDirectory = "MKD";
-            public const string RemoveDirectory = "RMD";
-            public const string ListDirectoryDetails = "LIST";
-            public const string GetDateTimestamp = "MDTM";
-            public const string PrintWorkingDirectory = "PWD";
-            public const string Rename = "RENAME";
-        }
-        public static class Http
-        {
-            public const string Get = "GET";
-            public const string Connect = "CONNECT";
-            public const string Head = "HEAD";
-            public const string Put = "PUT";
-            public const string Post = "POST";
-            public const string MkCol = "MKCOL";
-        }
-        public static class File
+        public static partial class File
         {
             public const string DownloadFile = "GET";
             public const string UploadFile = "PUT";
         }
+        public static partial class Ftp
+        {
+            public const string AppendFile = "APPE";
+            public const string DeleteFile = "DELE";
+            public const string DownloadFile = "RETR";
+            public const string GetDateTimestamp = "MDTM";
+            public const string GetFileSize = "SIZE";
+            public const string ListDirectory = "NLST";
+            public const string ListDirectoryDetails = "LIST";
+            public const string MakeDirectory = "MKD";
+            public const string PrintWorkingDirectory = "PWD";
+            public const string RemoveDirectory = "RMD";
+            public const string Rename = "RENAME";
+            public const string UploadFile = "STOR";
+            public const string UploadFileWithUniqueName = "STOU";
+        }
+        public static partial class Http
+        {
+            public const string Connect = "CONNECT";
+            public const string Get = "GET";
+            public const string Head = "HEAD";
+            public const string MkCol = "MKCOL";
+            public const string Post = "POST";
+            public const string Put = "PUT";
+        }
     }
-    public abstract partial class WebResponse : System.MarshalByRefObject, System.Runtime.Serialization.ISerializable, System.IDisposable
+    public abstract partial class WebResponse : System.MarshalByRefObject, System.IDisposable, System.Runtime.Serialization.ISerializable
     {
         protected WebResponse() { }
         protected WebResponse(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
@@ -355,93 +407,47 @@ namespace System.Net
         public virtual void Close() { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        public virtual System.IO.Stream GetResponseStream() { throw null; }
         protected virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public virtual System.IO.Stream GetResponseStream() { throw null; }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
-    }
-    [ObsoleteAttribute("This class has been deprecated. Please use WebRequest.DefaultWebProxy instead to access and set the global default proxy. Use 'null' instead of GetEmptyWebProxy. http://go.microsoft.com/fwlink/?linkid=14202")]
-    public class GlobalProxySelection
-    {
-        public static IWebProxy Select { get { throw null; } set { } }
-        public static IWebProxy GetEmptyWebProxy() { throw null; }
-    }
-    public enum FtpStatusCode
-    {
-        Undefined = 0,
-        RestartMarker = 110,
-        ServiceTemporarilyNotAvailable = 120,
-        DataAlreadyOpen = 125,
-        OpeningData = 150,
-        CommandOK = 200,
-        CommandExtraneous = 202,
-        DirectoryStatus = 212,
-        FileStatus = 213,
-        SystemType = 215,
-        SendUserCommand = 220,
-        ClosingControl = 221,
-        ClosingData = 226,
-        EnteringPassive = 227,
-        LoggedInProceed = 230,
-        ServerWantsSecureSession = 234,
-        FileActionOK = 250,
-        PathnameCreated = 257,
-        SendPasswordCommand = 331,
-        NeedLoginAccount = 332,
-        FileCommandPending = 350,
-        ServiceNotAvailable = 421,
-        CantOpenData = 425,
-        ConnectionClosed = 426,
-        ActionNotTakenFileUnavailableOrBusy = 450,
-        ActionAbortedLocalProcessingError = 451,
-        ActionNotTakenInsufficientSpace = 452,
-        CommandSyntaxError = 500,
-        ArgumentSyntaxError = 501,
-        CommandNotImplemented = 502,
-        BadCommandSequence = 503,
-        NotLoggedIn = 530,
-        AccountNeeded = 532,
-        ActionNotTakenFileUnavailable = 550,
-        ActionAbortedUnknownPageType = 551,
-        FileActionAborted = 552,
-        ActionNotTakenFilenameNotAllowed = 553
     }
 }
 namespace System.Net.Cache
 {
     public enum HttpCacheAgeControl
     {
-        None = 0x0,
-        MinFresh = 0x1,
-        MaxAge = 0x2,
-        MaxStale = 0x4,
-        MaxAgeAndMinFresh = 0x3,
-        MaxAgeAndMaxStale = 0x6
+        MaxAge = 2,
+        MaxAgeAndMaxStale = 6,
+        MaxAgeAndMinFresh = 3,
+        MaxStale = 4,
+        MinFresh = 1,
+        None = 0,
     }
     public enum HttpRequestCacheLevel
     {
-        Default = 0,
         BypassCache = 1,
-        CacheOnly = 2,
         CacheIfAvailable = 3,
-        Revalidate = 4,
-        Reload = 5,
-        NoCacheNoStore = 6,
+        CacheOnly = 2,
         CacheOrNextCacheOnly = 7,
-        Refresh = 8
+        Default = 0,
+        NoCacheNoStore = 6,
+        Refresh = 8,
+        Reload = 5,
+        Revalidate = 4,
     }
-    public class HttpRequestCachePolicy : RequestCachePolicy
+    public partial class HttpRequestCachePolicy : System.Net.Cache.RequestCachePolicy
     {
         public HttpRequestCachePolicy() { }
         public HttpRequestCachePolicy(System.DateTime cacheSyncDate) { }
-        public HttpRequestCachePolicy(System.Net.Cache.HttpRequestCacheLevel level) { }
         public HttpRequestCachePolicy(System.Net.Cache.HttpCacheAgeControl cacheAgeControl, System.TimeSpan ageOrFreshOrStale) { }
         public HttpRequestCachePolicy(System.Net.Cache.HttpCacheAgeControl cacheAgeControl, System.TimeSpan maxAge, System.TimeSpan freshOrStale) { }
         public HttpRequestCachePolicy(System.Net.Cache.HttpCacheAgeControl cacheAgeControl, System.TimeSpan maxAge, System.TimeSpan freshOrStale, System.DateTime cacheSyncDate) { }
-        public new System.Net.Cache.HttpRequestCacheLevel Level { get { throw null; } }
+        public HttpRequestCachePolicy(System.Net.Cache.HttpRequestCacheLevel level) { }
         public System.DateTime CacheSyncDate { get { throw null; } }
+        public new System.Net.Cache.HttpRequestCacheLevel Level { get { throw null; } }
         public System.TimeSpan MaxAge { get { throw null; } }
-        public System.TimeSpan MinFresh { get { throw null; } }
         public System.TimeSpan MaxStale { get { throw null; } }
+        public System.TimeSpan MinFresh { get { throw null; } }
         public override string ToString() { throw null; }
     }
 }

--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -8,16 +8,16 @@
 
 namespace System.Net.Security
 {
-    public abstract class AuthenticatedStream : System.IO.Stream
+    public abstract partial class AuthenticatedStream : System.IO.Stream
     {
         protected AuthenticatedStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen) { }
+        protected System.IO.Stream InnerStream { get { throw null; } }
         public abstract bool IsAuthenticated { get; }
         public abstract bool IsEncrypted { get; }
         public abstract bool IsMutuallyAuthenticated { get; }
         public abstract bool IsServer { get; }
         public abstract bool IsSigned { get; }
         public bool LeaveInnerStreamOpen { get { throw null; } }
-        protected System.IO.Stream InnerStream { get { throw null; } }
         protected override void Dispose(bool disposing) { }
     }
     public enum EncryptionPolicy
@@ -27,10 +27,10 @@ namespace System.Net.Security
         RequireEncryption = 0,
     }
     public delegate System.Security.Cryptography.X509Certificates.X509Certificate LocalCertificateSelectionCallback(object sender, string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection localCertificates, System.Security.Cryptography.X509Certificates.X509Certificate remoteCertificate, string[] acceptableIssuers);
-    public partial class NegotiateStream : AuthenticatedStream
+    public partial class NegotiateStream : System.Net.Security.AuthenticatedStream
     {
-        public NegotiateStream(System.IO.Stream innerStream) : base(innerStream, false) { }
-        public NegotiateStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen) : base(innerStream, leaveInnerStreamOpen) { }
+        public NegotiateStream(System.IO.Stream innerStream) : base (default(System.IO.Stream), default(bool)) { }
+        public NegotiateStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen) : base (default(System.IO.Stream), default(bool)) { }
         public override bool CanRead { get { throw null; } }
         public override bool CanSeek { get { throw null; } }
         public override bool CanTimeout { get { throw null; } }
@@ -47,38 +47,39 @@ namespace System.Net.Security
         public virtual System.Security.Principal.IIdentity RemoteIdentity { get { throw null; } }
         public override int WriteTimeout { get { throw null; } set { } }
         public virtual void AuthenticateAsClient() { }
-        public virtual void AuthenticateAsClient(System.Net.NetworkCredential credential, string targetName) { }
         public virtual void AuthenticateAsClient(System.Net.NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ChannelBinding binding, string targetName) { }
-        public virtual void AuthenticateAsClient(System.Net.NetworkCredential credential, string targetName, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel) { }
         public virtual void AuthenticateAsClient(System.Net.NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ChannelBinding binding, string targetName, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel) { }
-        public virtual void AuthenticateAsServer() { }
-        public virtual void AuthenticateAsServer(System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy) { }
-        public virtual void AuthenticateAsServer(NetworkCredential credential, ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel) { }
-        public virtual void AuthenticateAsServer(NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy, ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel) { }
+        public virtual void AuthenticateAsClient(System.Net.NetworkCredential credential, string targetName) { }
+        public virtual void AuthenticateAsClient(System.Net.NetworkCredential credential, string targetName, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel) { }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync() { throw null; }
-        public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(NetworkCredential credential, string targetName) { throw null; }
-        public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ChannelBinding binding, string targetName) { throw null; }
-        public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(NetworkCredential credential, string targetName, ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel) { throw null; }
-        public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ChannelBinding binding, string targetName, ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel) { throw null; }
+        public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(System.Net.NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ChannelBinding binding, string targetName) { throw null; }
+        public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(System.Net.NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ChannelBinding binding, string targetName, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel) { throw null; }
+        public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(System.Net.NetworkCredential credential, string targetName) { throw null; }
+        public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(System.Net.NetworkCredential credential, string targetName, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel) { throw null; }
+        public virtual void AuthenticateAsServer() { }
+        public virtual void AuthenticateAsServer(System.Net.NetworkCredential credential, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel) { }
+        public virtual void AuthenticateAsServer(System.Net.NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel) { }
+        public virtual void AuthenticateAsServer(System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy) { }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync() { throw null; }
+        public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Net.NetworkCredential credential, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel) { throw null; }
+        public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Net.NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel) { throw null; }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy) { throw null; }
-        public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(NetworkCredential credential, ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel) { throw null; }
-        public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy, ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel) { throw null; }
         public virtual System.IAsyncResult BeginAuthenticateAsClient(System.AsyncCallback asyncCallback, object asyncState) { throw null; }
-        public virtual System.IAsyncResult BeginAuthenticateAsClient(System.Net.NetworkCredential credential, string targetName, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
         public virtual System.IAsyncResult BeginAuthenticateAsClient(System.Net.NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ChannelBinding binding, string targetName, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
-        public virtual System.IAsyncResult BeginAuthenticateAsClient(System.Net.NetworkCredential credential, string targetName, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
         public virtual System.IAsyncResult BeginAuthenticateAsClient(System.Net.NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ChannelBinding binding, string targetName, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
-        public virtual System.IAsyncResult BeginAuthenticateAsServer(AsyncCallback asyncCallback, object asyncState) { throw null; }
+        public virtual System.IAsyncResult BeginAuthenticateAsClient(System.Net.NetworkCredential credential, string targetName, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
+        public virtual System.IAsyncResult BeginAuthenticateAsClient(System.Net.NetworkCredential credential, string targetName, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
+        public virtual System.IAsyncResult BeginAuthenticateAsServer(System.AsyncCallback asyncCallback, object asyncState) { throw null; }
+        public virtual System.IAsyncResult BeginAuthenticateAsServer(System.Net.NetworkCredential credential, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
+        public virtual System.IAsyncResult BeginAuthenticateAsServer(System.Net.NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
         public virtual System.IAsyncResult BeginAuthenticateAsServer(System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
-        public virtual IAsyncResult BeginAuthenticateAsServer(System.Net.NetworkCredential credential, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
-        public virtual IAsyncResult BeginAuthenticateAsServer(System.Net.NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
-        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState) { throw null; }
-        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState) { throw null; }
+        public override System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
+        public override System.IAsyncResult BeginWrite(byte[] buffer, int offset, int count, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
+        protected override void Dispose(bool disposing) { }
         public virtual void EndAuthenticateAsClient(System.IAsyncResult asyncResult) { }
         public virtual void EndAuthenticateAsServer(System.IAsyncResult asyncResult) { }
-        public override int EndRead(IAsyncResult asyncResult) { throw null; }
-        public override void EndWrite(IAsyncResult asyncResult) { }
+        public override int EndRead(System.IAsyncResult asyncResult) { throw null; }
+        public override void EndWrite(System.IAsyncResult asyncResult) { }
         public override void Flush() { }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
@@ -87,18 +88,18 @@ namespace System.Net.Security
     }
     public enum ProtectionLevel
     {
+        EncryptAndSign = 2,
         None = 0,
         Sign = 1,
-        EncryptAndSign = 2
     }
     public delegate bool RemoteCertificateValidationCallback(object sender, System.Security.Cryptography.X509Certificates.X509Certificate certificate, System.Security.Cryptography.X509Certificates.X509Chain chain, System.Net.Security.SslPolicyErrors sslPolicyErrors);
-    public partial class SslStream : AuthenticatedStream
+    public partial class SslStream : System.Net.Security.AuthenticatedStream
     {
-        public SslStream(System.IO.Stream innerStream) : base(innerStream, false) { }
-        public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen) : base(innerStream, leaveInnerStreamOpen) { }
-        public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen, System.Net.Security.RemoteCertificateValidationCallback userCertificateValidationCallback) : base(innerStream, leaveInnerStreamOpen) { }
-        public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen, System.Net.Security.RemoteCertificateValidationCallback userCertificateValidationCallback, System.Net.Security.LocalCertificateSelectionCallback userCertificateSelectionCallback) : base(innerStream, leaveInnerStreamOpen) { }
-        public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen, System.Net.Security.RemoteCertificateValidationCallback userCertificateValidationCallback, System.Net.Security.LocalCertificateSelectionCallback userCertificateSelectionCallback, System.Net.Security.EncryptionPolicy encryptionPolicy) : base(innerStream, leaveInnerStreamOpen) { }
+        public SslStream(System.IO.Stream innerStream) : base (default(System.IO.Stream), default(bool)) { }
+        public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen) : base (default(System.IO.Stream), default(bool)) { }
+        public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen, System.Net.Security.RemoteCertificateValidationCallback userCertificateValidationCallback) : base (default(System.IO.Stream), default(bool)) { }
+        public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen, System.Net.Security.RemoteCertificateValidationCallback userCertificateValidationCallback, System.Net.Security.LocalCertificateSelectionCallback userCertificateSelectionCallback) : base (default(System.IO.Stream), default(bool)) { }
+        public SslStream(System.IO.Stream innerStream, bool leaveInnerStreamOpen, System.Net.Security.RemoteCertificateValidationCallback userCertificateValidationCallback, System.Net.Security.LocalCertificateSelectionCallback userCertificateSelectionCallback, System.Net.Security.EncryptionPolicy encryptionPolicy) : base (default(System.IO.Stream), default(bool)) { }
         public override bool CanRead { get { throw null; } }
         public override bool CanSeek { get { throw null; } }
         public override bool CanTimeout { get { throw null; } }
@@ -128,15 +129,15 @@ namespace System.Net.Security
 #if netcoreapp11
         public virtual void AuthenticateAsClient(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates, bool checkCertificateRevocation) { }
 #endif
-        public virtual void AuthenticateAsServer(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate) { }
-        public virtual void AuthenticateAsServer(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { }
-#if netcoreapp11
-        public virtual void AuthenticateAsServer(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, bool checkCertificateRevocation) { }
-#endif
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(string targetHost) { throw null; }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { throw null; }
 #if netcoreapp11
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates, bool checkCertificateRevocation) { throw null; }
+#endif
+        public virtual void AuthenticateAsServer(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate) { }
+        public virtual void AuthenticateAsServer(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { }	
+#if netcoreapp11
+        public virtual void AuthenticateAsServer(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, bool checkCertificateRevocation) { }
 #endif
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate) { throw null; }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { throw null; }
@@ -153,12 +154,13 @@ namespace System.Net.Security
 #if netcoreapp11
         public virtual System.IAsyncResult BeginAuthenticateAsServer(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, bool checkCertificateRevocation, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
 #endif
-        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState) { throw null; }
-        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState) { throw null; }
-        public virtual void EndAuthenticateAsClient(IAsyncResult asyncResult) { }
-        public virtual void EndAuthenticateAsServer(IAsyncResult asyncResult) { }
-        public override int EndRead(IAsyncResult asyncResult) { throw null; }
-        public override void EndWrite(IAsyncResult asyncResult) { }
+        public override System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
+        public override System.IAsyncResult BeginWrite(byte[] buffer, int offset, int count, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
+        protected override void Dispose(bool disposing) { }
+        public virtual void EndAuthenticateAsClient(System.IAsyncResult asyncResult) { }
+        public virtual void EndAuthenticateAsServer(System.IAsyncResult asyncResult) { }
+        public override int EndRead(System.IAsyncResult asyncResult) { throw null; }
+        public override void EndWrite(System.IAsyncResult asyncResult) { }
         public override void Flush() { }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
@@ -175,27 +177,27 @@ namespace System.Security.Authentication
     public partial class AuthenticationException : System.SystemException
     {
         public AuthenticationException() { }
+        protected AuthenticationException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public AuthenticationException(string message) { }
         public AuthenticationException(string message, System.Exception innerException) { }
-        protected AuthenticationException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
     public partial class InvalidCredentialException : System.Security.Authentication.AuthenticationException
     {
         public InvalidCredentialException() { }
+        protected InvalidCredentialException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public InvalidCredentialException(string message) { }
         public InvalidCredentialException(string message, System.Exception innerException) { }
-        protected InvalidCredentialException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
 }
 namespace System.Security.Authentication.ExtendedProtection
 {
     public partial class ExtendedProtectionPolicy : System.Runtime.Serialization.ISerializable
     {
+        protected ExtendedProtectionPolicy(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ExtendedProtectionPolicy(System.Security.Authentication.ExtendedProtection.PolicyEnforcement policyEnforcement) { }
         public ExtendedProtectionPolicy(System.Security.Authentication.ExtendedProtection.PolicyEnforcement policyEnforcement, System.Security.Authentication.ExtendedProtection.ChannelBinding customChannelBinding) { }
         public ExtendedProtectionPolicy(System.Security.Authentication.ExtendedProtection.PolicyEnforcement policyEnforcement, System.Security.Authentication.ExtendedProtection.ProtectionScenario protectionScenario, System.Collections.ICollection customServiceNames) { }
         public ExtendedProtectionPolicy(System.Security.Authentication.ExtendedProtection.PolicyEnforcement policyEnforcement, System.Security.Authentication.ExtendedProtection.ProtectionScenario protectionScenario, System.Security.Authentication.ExtendedProtection.ServiceNameCollection customServiceNames) { }
-        protected ExtendedProtectionPolicy(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public System.Security.Authentication.ExtendedProtection.ChannelBinding CustomChannelBinding { get { throw null; } }
         public System.Security.Authentication.ExtendedProtection.ServiceNameCollection CustomServiceNames { get { throw null; } }
         public static bool OSSupportsExtendedProtection { get { throw null; } }

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
@@ -34,13 +34,13 @@ namespace System.Net.Security.Tests
                 // Anonymous (with domain name).
                 yield return new object[] { new NetworkCredential(
                     Configuration.Security.ActiveDirectoryUserName,
-                    null,
+                    (string)null,
                     Configuration.Security.ActiveDirectoryName) };
                 
                 // Anonymous (without domain).
                 yield return new object[] { new NetworkCredential(
                     Configuration.Security.ActiveDirectoryUserName,
-                    null,
+                    (string)null,
                     null) };
             }
         }
@@ -49,11 +49,11 @@ namespace System.Net.Security.Tests
         {
             get
             {
-                yield return new object[] { new NetworkCredential(null, null, Configuration.Security.ActiveDirectoryName) };
-                yield return new object[] { new NetworkCredential(null, null, null) };
+                yield return new object[] { new NetworkCredential(null, (string)null, Configuration.Security.ActiveDirectoryName) };
+                yield return new object[] { new NetworkCredential(null, (string)null, null) };
                 yield return new object[] { new NetworkCredential(
                     "baduser", 
-                    null, 
+                    (string)null, 
                     Configuration.Security.ActiveDirectoryName) };
                 yield return new object[] { new NetworkCredential(
                     "baduser", 

--- a/src/System.Net.ServicePoint/ref/System.Net.ServicePoint.cs
+++ b/src/System.Net.ServicePoint/ref/System.Net.ServicePoint.cs
@@ -8,60 +8,61 @@
 namespace System.Net
 {
     public delegate System.Net.IPEndPoint BindIPEndPoint(System.Net.ServicePoint servicePoint, System.Net.IPEndPoint remoteEndPoint, int retryCount);
-    public class ServicePoint
-    {
-        internal ServicePoint() { }
-        public System.Net.BindIPEndPoint BindIPEndPointDelegate { get { throw null; } set { } }
-        public int ConnectionLeaseTimeout { get { throw null; } set { } }
-        public System.Uri Address { get { throw null; } }
-        public int MaxIdleTime { get { throw null; } set { } }
-        public bool UseNagleAlgorithm { get { throw null; } set { } }
-        public int ReceiveBufferSize { get { throw null; } set { } }
-        public bool Expect100Continue { get { throw null; } set { } }
-        public System.DateTime IdleSince { get { throw null; } }
-        public virtual System.Version ProtocolVersion { get { throw null; } }
-        public string ConnectionName { get { throw null; } }
-        public bool CloseConnectionGroup(string connectionGroupName) { throw null; }
-        public int ConnectionLimit { get { throw null; } set { } }
-        public int CurrentConnections { get { throw null; } }
-        public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get { throw null; } }
-        public System.Security.Cryptography.X509Certificates.X509Certificate ClientCertificate { get { throw null; } }
-        public bool SupportsPipelining { get { throw null; } }
-        public void SetTcpKeepAlive(bool enabled, int keepAliveTime, int keepAliveInterval) { throw null; }
-    }
-    public class ServicePointManager
-    {
-        public const int DefaultNonPersistentConnectionLimit = 4;
-        public const int DefaultPersistentConnectionLimit = 2;
-        private ServicePointManager() { }
-        public static System.Net.SecurityProtocolType SecurityProtocol { get { throw null; } set { } }
-        public static int MaxServicePoints { get { throw null; } set { } }
-        public static int DefaultConnectionLimit { get { throw null; } set { } }
-        public static int MaxServicePointIdleTime { get { throw null; } set { } }
-        public static bool UseNagleAlgorithm { get { throw null; } set { } }
-        public static bool Expect100Continue { get { throw null; } set { } }
-        public static bool EnableDnsRoundRobin { get { throw null; } set { } }
-        public static int DnsRefreshTimeout { get { throw null; } set { } }
-        public static System.Net.Security.RemoteCertificateValidationCallback ServerCertificateValidationCallback { get { throw null; } set { } }
-        public static bool ReusePort { get { throw null; } set { } }
-        public static bool CheckCertificateRevocationList { get { throw null; } set { } }
-        public static System.Net.Security.EncryptionPolicy EncryptionPolicy { get { throw null; } }
-        public static System.Net.ServicePoint FindServicePoint(System.Uri address) { throw null; }
-        public static System.Net.ServicePoint FindServicePoint(string uriString, System.Net.IWebProxy proxy) { throw null; }
-        public static System.Net.ServicePoint FindServicePoint(System.Uri address, System.Net.IWebProxy proxy) { throw null; }
-        public static void SetTcpKeepAlive(bool enabled, int keepAliveTime, int keepAliveInterval) { throw null; }
-    }
-    [Flags]
+   [Flags]
     public enum SecurityProtocolType
     {
 #if netcoreapp11
         SystemDefault = 0,
 #endif
 #pragma warning disable CS0618
-        Ssl3 = System.Security.Authentication.SslProtocols.Ssl3,
+        [Obsolete("This value has been deprecated.  It is no longer supported. http://go.microsoft.com/fwlink/?linkid=14202")]
+        Ssl3 = 48,
 #pragma warning restore CS0618
-        Tls = System.Security.Authentication.SslProtocols.Tls,
-        Tls11 = System.Security.Authentication.SslProtocols.Tls11,
-        Tls12 = System.Security.Authentication.SslProtocols.Tls12,
+        Tls = 192,
+        Tls11 = 768,
+        Tls12 = 3072,
+    }
+    public partial class ServicePoint
+    {
+        internal ServicePoint() { }
+        public System.Uri Address { get { throw null; } }
+        public System.Net.BindIPEndPoint BindIPEndPointDelegate { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate Certificate { get { throw null; } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate ClientCertificate { get { throw null; } }
+        public int ConnectionLeaseTimeout { get { throw null; } set { } }
+        public int ConnectionLimit { get { throw null; } set { } }
+        public string ConnectionName { get { throw null; } }
+        public int CurrentConnections { get { throw null; } }
+        public bool Expect100Continue { get { throw null; } set { } }
+        public System.DateTime IdleSince { get { throw null; } }
+        public int MaxIdleTime { get { throw null; } set { } }
+        public virtual System.Version ProtocolVersion { get { throw null; } }
+        public int ReceiveBufferSize { get { throw null; } set { } }
+        public bool SupportsPipelining { get { throw null; } }
+        public bool UseNagleAlgorithm { get { throw null; } set { } }
+        public bool CloseConnectionGroup(string connectionGroupName) { throw null; }
+        public void SetTcpKeepAlive(bool enabled, int keepAliveTime, int keepAliveInterval) { }
+    }
+    public partial class ServicePointManager
+    {
+        internal ServicePointManager() { }
+        public const int DefaultNonPersistentConnectionLimit = 4;
+        public const int DefaultPersistentConnectionLimit = 2;
+        public static bool CheckCertificateRevocationList { get { throw null; } set { } }
+        public static int DefaultConnectionLimit { get { throw null; } set { } }
+        public static int DnsRefreshTimeout { get { throw null; } set { } }
+        public static bool EnableDnsRoundRobin { get { throw null; } set { } }
+        public static System.Net.Security.EncryptionPolicy EncryptionPolicy { get { throw null; } }
+        public static bool Expect100Continue { get { throw null; } set { } }
+        public static int MaxServicePointIdleTime { get { throw null; } set { } }
+        public static int MaxServicePoints { get { throw null; } set { } }
+        public static bool ReusePort { get { throw null; } set { } }
+        public static System.Net.SecurityProtocolType SecurityProtocol { get { throw null; } set { } }
+        public static System.Net.Security.RemoteCertificateValidationCallback ServerCertificateValidationCallback { get { throw null; } set { } }
+        public static bool UseNagleAlgorithm { get { throw null; } set { } }
+        public static System.Net.ServicePoint FindServicePoint(string uriString, System.Net.IWebProxy proxy) { throw null; }
+        public static System.Net.ServicePoint FindServicePoint(System.Uri address) { throw null; }
+        public static System.Net.ServicePoint FindServicePoint(System.Uri address, System.Net.IWebProxy proxy) { throw null; }
+        public static void SetTcpKeepAlive(bool enabled, int keepAliveTime, int keepAliveInterval) { }
     }
 }

--- a/src/System.Net.ServicePoint/tests/ServicePointManagerTest.cs
+++ b/src/System.Net.ServicePoint/tests/ServicePointManagerTest.cs
@@ -157,8 +157,10 @@ namespace System.Net.Tests
             const int ssl2Server = 0x00000004;
 
             SecurityProtocolType ssl2 = (SecurityProtocolType)(ssl2Client | ssl2Server);
+#pragma warning disable CS0618 // Ssl3 is obsolete.
             Assert.Throws<NotSupportedException>(() => ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3);
             Assert.Throws<NotSupportedException>(() => ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 | ssl2);
+#pragma warning restore CS0618
             Assert.Throws<NotSupportedException>(() => ServicePointManager.SecurityProtocol = ssl2);
             Assert.Throws<ArgumentNullException>("uriString", () => ServicePointManager.FindServicePoint((string)null, null));
             Assert.Throws<ArgumentOutOfRangeException>("value", () => ServicePointManager.MaxServicePoints = -1);

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -99,24 +99,22 @@ namespace System.Net.Sockets
         public override long Position { get { throw null; } set { } }
         protected bool Readable { get { throw null; } set { } }
         public override int ReadTimeout { get { throw null; } set { } }
-        protected Socket Socket { get { throw null; } }
+        protected System.Net.Sockets.Socket Socket { get { throw null; } }
         protected bool Writeable { get { throw null; } set { } }
         public override int WriteTimeout { get { throw null; } set { } }
-        public override IAsyncResult BeginRead(byte[] buffer, int offset, int size, AsyncCallback callback, Object state) { throw null; }
-        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int size, AsyncCallback callback, Object state) { throw null; }
+        public override System.IAsyncResult BeginRead(byte[] buffer, int offset, int size, System.AsyncCallback callback, object state) { throw null; }
+        public override System.IAsyncResult BeginWrite(byte[] buffer, int offset, int size, System.AsyncCallback callback, object state) { throw null; }
         public void Close(int timeout) { }
         protected override void Dispose(bool disposing) { }
+        public override int EndRead(System.IAsyncResult asyncResult) { throw null; }
+        public override void EndWrite(System.IAsyncResult asyncResult) { }
         ~NetworkStream() { }
-        public override int EndRead(IAsyncResult asyncResult) { throw null; }
-        public override void EndWrite(IAsyncResult asyncResult) { }
         public override void Flush() { }
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
-        public override int Read(byte[] buffer, int offset, int size) { throw null; }
-        public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int size, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public override int Read(byte[] buffer, int offset, int size) { buffer = default(byte[]); throw null; }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
         public override void SetLength(long value) { }
         public override void Write(byte[] buffer, int offset, int size) { }
-        public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int size, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
     public enum ProtocolFamily
     {
@@ -203,8 +201,8 @@ namespace System.Net.Sockets
     public partial class Socket : System.IDisposable
     {
         public Socket(System.Net.Sockets.AddressFamily addressFamily, System.Net.Sockets.SocketType socketType, System.Net.Sockets.ProtocolType protocolType) { }
+        public Socket(System.Net.Sockets.SocketInformation socketInformation) { }
         public Socket(System.Net.Sockets.SocketType socketType, System.Net.Sockets.ProtocolType protocolType) { }
-        public Socket(SocketInformation socketInformation) { }
         public System.Net.Sockets.AddressFamily AddressFamily { get { throw null; } }
         public int Available { get { throw null; } }
         public bool Blocking { get { throw null; } set { } }
@@ -213,7 +211,7 @@ namespace System.Net.Sockets
         public bool DualMode { get { throw null; } set { } }
         public bool EnableBroadcast { get { throw null; } set { } }
         public bool ExclusiveAddressUse { get { throw null; } set { } }
-        public IntPtr Handle { get { throw null; } }
+        public System.IntPtr Handle { get { throw null; } }
         public bool IsBound { get { throw null; } }
         public System.Net.Sockets.LingerOption LingerState { get { throw null; } set { } }
         public System.Net.EndPoint LocalEndPoint { get { throw null; } }
@@ -228,33 +226,35 @@ namespace System.Net.Sockets
         public int SendBufferSize { get { throw null; } set { } }
         public int SendTimeout { get { throw null; } set { } }
         public System.Net.Sockets.SocketType SocketType { get { throw null; } }
-        [Obsolete("SupportsIPv4 is obsoleted for this type, please use OSSupportsIPv4 instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("SupportsIPv4 is obsoleted for this type, please use OSSupportsIPv4 instead. http://go.microsoft.com/fwlink/?linkid=14202")]
         public static bool SupportsIPv4 { get { throw null; } }
-        [Obsolete("SupportsIPv6 is obsoleted for this type, please use OSSupportsIPv6 instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("SupportsIPv6 is obsoleted for this type, please use OSSupportsIPv6 instead. http://go.microsoft.com/fwlink/?linkid=14202")]
         public static bool SupportsIPv6 { get { throw null; } }
         public short Ttl { get { throw null; } set { } }
         public bool UseOnlyOverlappedIO { get { throw null; } set { } }
         public System.Net.Sockets.Socket Accept() { throw null; }
         public bool AcceptAsync(System.Net.Sockets.SocketAsyncEventArgs e) { throw null; }
-        public IAsyncResult BeginAccept(AsyncCallback callback, object state) { throw null; }
-        public IAsyncResult BeginAccept(int receiveSize, AsyncCallback callback, object state) { throw null; }
-        public IAsyncResult BeginAccept(Socket acceptSocket, int receiveSize, AsyncCallback callback, object state) { throw null; }
-        public IAsyncResult BeginConnect(string host, int port, AsyncCallback requestCallback, object state) { throw null; }
-        public IAsyncResult BeginConnect(IPAddress address, int port, AsyncCallback requestCallback, object state) { throw null; }
-        public IAsyncResult BeginConnect(IPAddress[] addresses, int port, AsyncCallback requestCallback, object state) { throw null; }
-        public IAsyncResult BeginConnect(EndPoint remoteEP, AsyncCallback callback, object state) { throw null; }
-        public IAsyncResult BeginDisconnect(bool reuseSocket, AsyncCallback callback, object state) { throw null; }
-        public IAsyncResult BeginReceive(byte[] buffer, int offset, int size, SocketFlags socketFlags, AsyncCallback callback, object state) { throw null; }
-        public IAsyncResult BeginReceive(byte[] buffer, int offset, int size, SocketFlags socketFlags, out SocketError errorCode, AsyncCallback callback, object state) { throw null; }
-        public IAsyncResult BeginReceive(Collections.Generic.IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, AsyncCallback callback, object state) { throw null; }
-        public IAsyncResult BeginReceive(Collections.Generic.IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, out SocketError errorCode, AsyncCallback callback, object state) { throw null; }
-        public IAsyncResult BeginReceiveFrom(byte[] buffer, int offset, int size, SocketFlags socketFlags, ref EndPoint remoteEP, AsyncCallback callback, object state) { throw null; }
-        public IAsyncResult BeginReceiveMessageFrom(byte[] buffer, int offset, int size, SocketFlags socketFlags, ref EndPoint remoteEP, AsyncCallback callback, object state) { throw null; }
-        public IAsyncResult BeginSend(byte[] buffer, int offset, int size, SocketFlags socketFlags, AsyncCallback callback, object state) { throw null; }
-        public IAsyncResult BeginSend(byte[] buffer, int offset, int size, SocketFlags socketFlags, out SocketError errorCode, AsyncCallback callback, object state) { throw null; }
-        public IAsyncResult BeginSend(Collections.Generic.IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, AsyncCallback callback, object state) { throw null; }
-        public IAsyncResult BeginSend(Collections.Generic.IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, out SocketError errorCode, AsyncCallback callback, object state) { throw null; }
-        public IAsyncResult BeginSendTo(byte[] buffer, int offset, int size, SocketFlags socketFlags, EndPoint remoteEP, AsyncCallback callback, object state) { throw null; }
+        public System.IAsyncResult BeginAccept(System.AsyncCallback callback, object state) { throw null; }
+        public System.IAsyncResult BeginAccept(int receiveSize, System.AsyncCallback callback, object state) { throw null; }
+        public System.IAsyncResult BeginAccept(System.Net.Sockets.Socket acceptSocket, int receiveSize, System.AsyncCallback callback, object state) { throw null; }
+        public System.IAsyncResult BeginConnect(System.Net.EndPoint remoteEP, System.AsyncCallback callback, object state) { throw null; }
+        public System.IAsyncResult BeginConnect(System.Net.IPAddress address, int port, System.AsyncCallback requestCallback, object state) { throw null; }
+        public System.IAsyncResult BeginConnect(System.Net.IPAddress[] addresses, int port, System.AsyncCallback requestCallback, object state) { throw null; }
+        public System.IAsyncResult BeginConnect(string host, int port, System.AsyncCallback requestCallback, object state) { throw null; }
+        public System.IAsyncResult BeginDisconnect(bool reuseSocket, System.AsyncCallback callback, object state) { throw null; }
+        public System.IAsyncResult BeginReceive(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, System.AsyncCallback callback, object state) { throw null; }
+        public System.IAsyncResult BeginReceive(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode, System.AsyncCallback callback, object state) { errorCode = default(System.Net.Sockets.SocketError); throw null; }
+        public System.IAsyncResult BeginReceive(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, System.AsyncCallback callback, object state) { throw null; }
+        public System.IAsyncResult BeginReceive(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode, System.AsyncCallback callback, object state) { errorCode = default(System.Net.Sockets.SocketError); throw null; }
+        public System.IAsyncResult BeginReceiveFrom(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP, System.AsyncCallback callback, object state) { throw null; }
+        public System.IAsyncResult BeginReceiveMessageFrom(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP, System.AsyncCallback callback, object state) { throw null; }
+        public System.IAsyncResult BeginSend(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, System.AsyncCallback callback, object state) { throw null; }
+        public System.IAsyncResult BeginSend(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode, System.AsyncCallback callback, object state) { errorCode = default(System.Net.Sockets.SocketError); throw null; }
+        public System.IAsyncResult BeginSend(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, System.AsyncCallback callback, object state) { throw null; }
+        public System.IAsyncResult BeginSend(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode, System.AsyncCallback callback, object state) { errorCode = default(System.Net.Sockets.SocketError); throw null; }
+        public System.IAsyncResult BeginSendFile(string fileName, System.AsyncCallback callback, object state) { throw null; }
+        public System.IAsyncResult BeginSendFile(string fileName, byte[] preBuffer, byte[] postBuffer, System.Net.Sockets.TransmitFileOptions flags, System.AsyncCallback callback, object state) { throw null; }
+        public System.IAsyncResult BeginSendTo(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP, System.AsyncCallback callback, object state) { throw null; }
         public void Bind(System.Net.EndPoint localEP) { }
         public static void CancelConnectAsync(System.Net.Sockets.SocketAsyncEventArgs e) { }
         public void Close() { }
@@ -265,22 +265,25 @@ namespace System.Net.Sockets
         public void Connect(string host, int port) { }
         public bool ConnectAsync(System.Net.Sockets.SocketAsyncEventArgs e) { throw null; }
         public static bool ConnectAsync(System.Net.Sockets.SocketType socketType, System.Net.Sockets.ProtocolType protocolType, System.Net.Sockets.SocketAsyncEventArgs e) { throw null; }
+        public void Disconnect(bool reuseSocket) { }
+        public bool DisconnectAsync(System.Net.Sockets.SocketAsyncEventArgs e) { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
+        public System.Net.Sockets.SocketInformation DuplicateAndClose(int targetProcessId) { throw null; }
+        public System.Net.Sockets.Socket EndAccept(out byte[] buffer, System.IAsyncResult asyncResult) { buffer = default(byte[]); throw null; }
+        public System.Net.Sockets.Socket EndAccept(out byte[] buffer, out int bytesTransferred, System.IAsyncResult asyncResult) { buffer = default(byte[]); bytesTransferred = default(int); throw null; }
+        public System.Net.Sockets.Socket EndAccept(System.IAsyncResult asyncResult) { throw null; }
+        public void EndConnect(System.IAsyncResult asyncResult) { }
+        public void EndDisconnect(System.IAsyncResult asyncResult) { }
+        public int EndReceive(System.IAsyncResult asyncResult) { throw null; }
+        public int EndReceive(System.IAsyncResult asyncResult, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); throw null; }
+        public int EndReceiveFrom(System.IAsyncResult asyncResult, ref System.Net.EndPoint endPoint) { throw null; }
+        public int EndReceiveMessageFrom(System.IAsyncResult asyncResult, ref System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint endPoint, out System.Net.Sockets.IPPacketInformation ipPacketInformation) { ipPacketInformation = default(System.Net.Sockets.IPPacketInformation); throw null; }
+        public int EndSend(System.IAsyncResult asyncResult) { throw null; }
+        public int EndSend(System.IAsyncResult asyncResult, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); throw null; }
+        public void EndSendFile(System.IAsyncResult asyncResult) { }
+        public int EndSendTo(System.IAsyncResult asyncResult) { throw null; }
         ~Socket() { }
-        public void Disconnect(bool reuseSocket) { }
-        public bool DisconnectAsync(SocketAsyncEventArgs e) { throw null; }
-        public SocketInformation DuplicateAndClose(int targetProcessId) { throw null; }
-        public Socket EndAccept(IAsyncResult asyncResult) { throw null; }
-        public void EndConnect(IAsyncResult asyncResult) { }
-        public void EndDisconnect(IAsyncResult asyncResult) { }
-        public int EndReceive(IAsyncResult asyncResult) { throw null; }
-        public int EndReceive(IAsyncResult asyncResult, out SocketError errorCode) { throw null; }
-        public int EndReceiveFrom(IAsyncResult asyncResult, ref EndPoint endPoint) { throw null; }
-        public int EndReceiveMessageFrom(IAsyncResult asyncResult, ref SocketFlags socketFlags, ref EndPoint endPoint, out IPPacketInformation ipPacketInformation) { throw null; }
-        public int EndSend(IAsyncResult asyncResult) { throw null; }
-        public int EndSend(IAsyncResult asyncResult, out SocketError errorCode) { throw null; }
-        public int EndSendTo(IAsyncResult asyncResult) { throw null; }
         public object GetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName) { throw null; }
         public void GetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, byte[] optionValue) { }
         public byte[] GetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, int optionLength) { throw null; }
@@ -290,37 +293,39 @@ namespace System.Net.Sockets
         public bool Poll(int microSeconds, System.Net.Sockets.SelectMode mode) { throw null; }
         public int Receive(byte[] buffer) { throw null; }
         public int Receive(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags) { throw null; }
-        public int Receive(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { throw null; }
+        public int Receive(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); throw null; }
         public int Receive(byte[] buffer, int size, System.Net.Sockets.SocketFlags socketFlags) { throw null; }
         public int Receive(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags) { throw null; }
         public int Receive(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers) { throw null; }
         public int Receive(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { throw null; }
-        public int Receive(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { throw null; }
+        public int Receive(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); throw null; }
         public bool ReceiveAsync(System.Net.Sockets.SocketAsyncEventArgs e) { throw null; }
         public int ReceiveFrom(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { throw null; }
         public int ReceiveFrom(byte[] buffer, int size, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { throw null; }
         public int ReceiveFrom(byte[] buffer, ref System.Net.EndPoint remoteEP) { throw null; }
         public int ReceiveFrom(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { throw null; }
         public bool ReceiveFromAsync(System.Net.Sockets.SocketAsyncEventArgs e) { throw null; }
-        public int ReceiveMessageFrom(byte[] buffer, int offset, int size, ref System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP, out System.Net.Sockets.IPPacketInformation ipPacketInformation) { throw null; }
+        public int ReceiveMessageFrom(byte[] buffer, int offset, int size, ref System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP, out System.Net.Sockets.IPPacketInformation ipPacketInformation) { ipPacketInformation = default(System.Net.Sockets.IPPacketInformation); throw null; }
         public bool ReceiveMessageFromAsync(System.Net.Sockets.SocketAsyncEventArgs e) { throw null; }
         public static void Select(System.Collections.IList checkRead, System.Collections.IList checkWrite, System.Collections.IList checkError, int microSeconds) { }
         public int Send(byte[] buffer) { throw null; }
         public int Send(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags) { throw null; }
-        public int Send(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { throw null; }
+        public int Send(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); throw null; }
         public int Send(byte[] buffer, int size, System.Net.Sockets.SocketFlags socketFlags) { throw null; }
         public int Send(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags) { throw null; }
         public int Send(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers) { throw null; }
         public int Send(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { throw null; }
-        public int Send(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { throw null; }
+        public int Send(System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { errorCode = default(System.Net.Sockets.SocketError); throw null; }
         public bool SendAsync(System.Net.Sockets.SocketAsyncEventArgs e) { throw null; }
+        public void SendFile(string fileName) { }
+        public void SendFile(string fileName, byte[] preBuffer, byte[] postBuffer, System.Net.Sockets.TransmitFileOptions flags) { }
         public bool SendPacketsAsync(System.Net.Sockets.SocketAsyncEventArgs e) { throw null; }
         public int SendTo(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { throw null; }
         public int SendTo(byte[] buffer, int size, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { throw null; }
         public int SendTo(byte[] buffer, System.Net.EndPoint remoteEP) { throw null; }
         public int SendTo(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { throw null; }
         public bool SendToAsync(System.Net.Sockets.SocketAsyncEventArgs e) { throw null; }
-        public void SetIPProtectionLevel(System.Net.Sockets.IPProtectionLevel level) { throw null; }
+        public void SetIPProtectionLevel(System.Net.Sockets.IPProtectionLevel level) { }
         public void SetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, bool optionValue) { }
         public void SetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, byte[] optionValue) { }
         public void SetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, int optionValue) { }
@@ -343,6 +348,7 @@ namespace System.Net.Sockets
         public System.Net.Sockets.IPPacketInformation ReceiveMessageFromPacketInfo { get { throw null; } }
         public System.Net.EndPoint RemoteEndPoint { get { throw null; } set { } }
         public System.Net.Sockets.SendPacketsElement[] SendPacketsElements { get { throw null; } set { } }
+        public System.Net.Sockets.TransmitFileOptions SendPacketsFlags { get { throw null; } set { } }
         public int SendPacketsSendSize { get { throw null; } set { } }
         public System.Net.Sockets.SocketError SocketError { get { throw null; } set { } }
         public System.Net.Sockets.SocketFlags SocketFlags { get { throw null; } set { } }
@@ -373,6 +379,8 @@ namespace System.Net.Sockets
         Broadcast = 1024,
         ControlDataTruncated = 512,
         DontRoute = 4,
+// Enum value isn't used but keeping commented out so we don't reuse the slot in the future
+//        MaxIOVectorLength = 16,
         Multicast = 2048,
         None = 0,
         OutOfBand = 1,
@@ -380,17 +388,18 @@ namespace System.Net.Sockets
         Peek = 2,
         Truncated = 256,
     }
-    public struct SocketInformation
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct SocketInformation
     {
-        public SocketInformationOptions Options { get { throw null; } set { } }
+        public System.Net.Sockets.SocketInformationOptions Options { get { throw null; } set { } }
         public byte[] ProtocolInformation { get { throw null; } set { } }
     }
-    [Flags]
+    [System.FlagsAttribute]
     public enum SocketInformationOptions
     {
-        NonBlocking = 1,
         Connected = 2,
         Listening = 4,
+        NonBlocking = 1,
         UseOnlyOverlappedIO = 8,
     }
     public enum SocketOptionLevel
@@ -439,7 +448,7 @@ namespace System.Net.Sockets
         ReceiveLowWater = 4100,
         ReceiveTimeout = 4102,
         ReuseAddress = 4,
-        ReuseUnicastPort = 12295, 
+        ReuseUnicastPort = 12295,
         SendBuffer = 4097,
         SendLowWater = 4099,
         SendTimeout = 4101,
@@ -450,37 +459,19 @@ namespace System.Net.Sockets
         UpdateConnectContext = 28688,
         UseLoopback = 64,
     }
-    // Review note: RemoteEndPoint definition includes the Address and Port.
-    // PacketInformation includes Address and Interface (physical interface number).
-    // The redundancy could be removed by replacing RemoteEndPoint with Port.
-    
-    // Alternative:
-    //    public struct SocketReceiveFromResult
-    //    {
-    //        public int ReceivedBytes;
-    //        public IPAddress Address;
-    //        public int Port;
-    //    }
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public struct SocketReceiveFromResult
     {
         public int ReceivedBytes;
         public EndPoint RemoteEndPoint;
     }
-    // Alternative:
-    //    public struct SocketReceiveMessageFromResult
-    //    {
-    //        public int ReceivedBytes;
-    //        public SocketFlags SocketFlags;
-    //        public IPAddress Address;
-    //        public int Port;
-    //        public int Interface;
-    //    }
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public struct SocketReceiveMessageFromResult
     {
         public int ReceivedBytes;
-        public SocketFlags SocketFlags;
         public EndPoint RemoteEndPoint;
         public IPPacketInformation PacketInformation;
+        public SocketFlags SocketFlags;
     }
     public enum SocketShutdown
     {
@@ -488,7 +479,6 @@ namespace System.Net.Sockets
         Receive = 0,
         Send = 1,
     }
-
     public static partial class SocketTaskExtensions
     {
         public static System.Threading.Tasks.Task<Socket> AcceptAsync(this System.Net.Sockets.Socket socket) { throw null; }
@@ -499,9 +489,9 @@ namespace System.Net.Sockets
         public static System.Threading.Tasks.Task ConnectAsync(this System.Net.Sockets.Socket socket, string host, int port) { throw null; }
         public static System.Threading.Tasks.Task<int> ReceiveAsync(this System.Net.Sockets.Socket socket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags) { throw null; }
         public static System.Threading.Tasks.Task<int> ReceiveAsync(this System.Net.Sockets.Socket socket, System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { throw null; }
-        public static System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveFromResult> ReceiveFromAsync(this System.Net.Sockets.Socket socket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { throw null; }
-        public static System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveMessageFromResult> ReceiveMessageFromAsync(this System.Net.Sockets.Socket socket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { throw null; }
-        public static System.Threading.Tasks.Task<int> SendAsync(this System.Net.Sockets.Socket socket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags) { throw null; }
+        public static System.Threading.Tasks.Task<SocketReceiveFromResult> ReceiveFromAsync(this System.Net.Sockets.Socket socket, ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { throw null; }
+        public static System.Threading.Tasks.Task<SocketReceiveMessageFromResult> ReceiveMessageFromAsync(this System.Net.Sockets.Socket socket, ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { throw null; }
+        public static System.Threading.Tasks.Task<int> SendAsync(this System.Net.Sockets.Socket socket, ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags) { throw null; }
         public static System.Threading.Tasks.Task<int> SendAsync(this System.Net.Sockets.Socket socket, System.Collections.Generic.IList<System.ArraySegment<byte>> buffers, System.Net.Sockets.SocketFlags socketFlags) { throw null; }
         public static System.Threading.Tasks.Task<int> SendToAsync(this System.Net.Sockets.Socket socket, System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { throw null; }
     }
@@ -517,8 +507,8 @@ namespace System.Net.Sockets
     public partial class TcpClient : System.IDisposable
     {
         public TcpClient() { }
-        public TcpClient(System.Net.Sockets.AddressFamily family) { }
         public TcpClient(System.Net.IPEndPoint localEP) { }
+        public TcpClient(System.Net.Sockets.AddressFamily family) { }
         public TcpClient(string hostname, int port) { }
         protected bool Active { get { throw null; } set { } }
         public int Available { get { throw null; } }
@@ -531,9 +521,9 @@ namespace System.Net.Sockets
         public int ReceiveTimeout { get { throw null; } set { } }
         public int SendBufferSize { get { throw null; } set { } }
         public int SendTimeout { get { throw null; } set { } }
-        public IAsyncResult BeginConnect(IPAddress address, int port, AsyncCallback requestCallback, object state) { throw null; }
-        public IAsyncResult BeginConnect(IPAddress[] addresses, int port, AsyncCallback requestCallback, object state) { throw null; }
-        public IAsyncResult BeginConnect(string host, int port, AsyncCallback requestCallback, object state) { throw null; }
+        public System.IAsyncResult BeginConnect(System.Net.IPAddress address, int port, System.AsyncCallback requestCallback, object state) { throw null; }
+        public System.IAsyncResult BeginConnect(System.Net.IPAddress[] addresses, int port, System.AsyncCallback requestCallback, object state) { throw null; }
+        public System.IAsyncResult BeginConnect(string host, int port, System.AsyncCallback requestCallback, object state) { throw null; }
         public void Close() { }
         public void Connect(System.Net.IPAddress address, int port) { }
         public void Connect(System.Net.IPAddress[] ipAddresses, int port) { }
@@ -544,8 +534,8 @@ namespace System.Net.Sockets
         public System.Threading.Tasks.Task ConnectAsync(string host, int port) { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
+        public void EndConnect(System.IAsyncResult asyncResult) { }
         ~TcpClient() { }
-        public void EndConnect(IAsyncResult asyncResult) { }
         public System.Net.Sockets.NetworkStream GetStream() { throw null; }
     }
     public partial class TcpListener
@@ -562,18 +552,17 @@ namespace System.Net.Sockets
         public System.Threading.Tasks.Task<System.Net.Sockets.Socket> AcceptSocketAsync() { throw null; }
         public System.Net.Sockets.TcpClient AcceptTcpClient() { throw null; }
         public System.Threading.Tasks.Task<System.Net.Sockets.TcpClient> AcceptTcpClientAsync() { throw null; }
+        public void AllowNatTraversal(bool allowed) { }
         public System.IAsyncResult BeginAcceptSocket(System.AsyncCallback callback, object state) { throw null; }
         public System.IAsyncResult BeginAcceptTcpClient(System.AsyncCallback callback, object state) { throw null; }
+        public static System.Net.Sockets.TcpListener Create(int port) { throw null; }
         public System.Net.Sockets.Socket EndAcceptSocket(System.IAsyncResult asyncResult) { throw null; }
         public System.Net.Sockets.TcpClient EndAcceptTcpClient(System.IAsyncResult asyncResult) { throw null; }
         public bool Pending() { throw null; }
         public void Start() { }
         public void Start(int backlog) { }
         public void Stop() { }
-        public void AllowNatTraversal(bool allowed) { throw null; }
-        public static TcpListener Create(int port) { throw null; }
     }
-
     [System.FlagsAttribute]
     public enum TransmitFileOptions
     {
@@ -600,25 +589,26 @@ namespace System.Net.Sockets
         public bool ExclusiveAddressUse { get { throw null; } set { } }
         public bool MulticastLoopback { get { throw null; } set { } }
         public short Ttl { get { throw null; } set { } }
-        public IAsyncResult BeginReceive(AsyncCallback requestCallback, object state) { throw null; }
-        public IAsyncResult BeginSend(byte[] datagram, int bytes, AsyncCallback requestCallback, object state) { throw null; }
-        public IAsyncResult BeginSend(byte[] datagram, int bytes, IPEndPoint endPoint, AsyncCallback requestCallback, object state) { throw null; }
-        public IAsyncResult BeginSend(byte[] datagram, int bytes, string hostname, int port, AsyncCallback requestCallback, object state) { throw null; }
+        public void AllowNatTraversal(bool allowed) { }
+        public System.IAsyncResult BeginReceive(System.AsyncCallback requestCallback, object state) { throw null; }
+        public System.IAsyncResult BeginSend(byte[] datagram, int bytes, System.AsyncCallback requestCallback, object state) { throw null; }
+        public System.IAsyncResult BeginSend(byte[] datagram, int bytes, System.Net.IPEndPoint endPoint, System.AsyncCallback requestCallback, object state) { throw null; }
+        public System.IAsyncResult BeginSend(byte[] datagram, int bytes, string hostname, int port, System.AsyncCallback requestCallback, object state) { throw null; }
         public void Close() { }
-        public void Connect(IPAddress addr, int port) { }
-        public void Connect(IPEndPoint endPoint) { }
+        public void Connect(System.Net.IPAddress addr, int port) { }
+        public void Connect(System.Net.IPEndPoint endPoint) { }
         public void Connect(string hostname, int port) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public void DropMulticastGroup(System.Net.IPAddress multicastAddr) { }
         public void DropMulticastGroup(System.Net.IPAddress multicastAddr, int ifindex) { }
-        public byte[] EndReceive(IAsyncResult asyncResult, ref IPEndPoint remoteEP) { throw null; }
-        public int EndSend(IAsyncResult asyncResult) { throw null; }
+        public byte[] EndReceive(System.IAsyncResult asyncResult, ref System.Net.IPEndPoint remoteEP) { throw null; }
+        public int EndSend(System.IAsyncResult asyncResult) { throw null; }
         public void JoinMulticastGroup(int ifindex, System.Net.IPAddress multicastAddr) { }
         public void JoinMulticastGroup(System.Net.IPAddress multicastAddr) { }
         public void JoinMulticastGroup(System.Net.IPAddress multicastAddr, int timeToLive) { }
         public void JoinMulticastGroup(System.Net.IPAddress multicastAddr, System.Net.IPAddress localAddress) { }
-        public byte[] Receive(ref IPEndPoint remoteEP) { throw null; }
+        public byte[] Receive(ref System.Net.IPEndPoint remoteEP) { throw null; }
         public System.Threading.Tasks.Task<System.Net.Sockets.UdpReceiveResult> ReceiveAsync() { throw null; }
         public int Send(byte[] dgram, int bytes) { throw null; }
         public int Send(byte[] dgram, int bytes, System.Net.IPEndPoint endPoint) { throw null; }
@@ -626,12 +616,11 @@ namespace System.Net.Sockets
         public System.Threading.Tasks.Task<int> SendAsync(byte[] datagram, int bytes) { throw null; }
         public System.Threading.Tasks.Task<int> SendAsync(byte[] datagram, int bytes, System.Net.IPEndPoint endPoint) { throw null; }
         public System.Threading.Tasks.Task<int> SendAsync(byte[] datagram, int bytes, string hostname, int port) { throw null; }
-        public void AllowNatTraversal(bool allowed) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct UdpReceiveResult : System.IEquatable<System.Net.Sockets.UdpReceiveResult>
     {
-        public UdpReceiveResult(byte[] buffer, System.Net.IPEndPoint remoteEndPoint) { throw null; }
+        public UdpReceiveResult(byte[] buffer, System.Net.IPEndPoint remoteEndPoint) { throw null;}
         public byte[] Buffer { get { throw null; } }
         public System.Net.IPEndPoint RemoteEndPoint { get { throw null; } }
         public bool Equals(System.Net.Sockets.UdpReceiveResult other) { throw null; }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -2852,6 +2852,36 @@ namespace System.Net.Sockets
             return bytesTransferred;
         }
 
+        public void SendFile(string fileName) 
+        {
+            // TODO: #12460
+            throw new PlatformNotSupportedException();
+        }
+
+        public void SendFile(string fileName, byte[] preBuffer, byte[] postBuffer, TransmitFileOptions flags) 
+        { 
+            // TODO: #12460
+            throw new PlatformNotSupportedException();
+        }
+
+        public IAsyncResult BeginSendFile(string fileName, AsyncCallback callback, object state) 
+        { 
+            // TODO: #12460
+            throw new PlatformNotSupportedException();
+        }
+
+        public IAsyncResult BeginSendFile(string fileName, byte[] preBuffer, byte[] postBuffer, TransmitFileOptions flags, AsyncCallback callback, object state) 
+        { 
+            // TODO: #12460
+            throw new PlatformNotSupportedException();
+        }
+
+        public void EndSendFile(IAsyncResult asyncResult) 
+        { 
+            // TODO: #12460
+            throw new PlatformNotSupportedException();
+        }
+
         // Routine Description:
         // 
         //    BeginSendTo - Async implementation of SendTo,
@@ -3915,7 +3945,7 @@ namespace System.Net.Sockets
             return EndAccept(out buffer, out bytesTransferred, asyncResult);
         }
 
-        internal Socket EndAccept(out byte[] buffer, IAsyncResult asyncResult)
+        public Socket EndAccept(out byte[] buffer, IAsyncResult asyncResult)
         {
             int bytesTransferred;
             byte[] innerBuffer;
@@ -3926,7 +3956,7 @@ namespace System.Net.Sockets
             return socket;
         }
 
-        internal Socket EndAccept(out byte[] buffer, out int bytesTransferred, IAsyncResult asyncResult)
+        public Socket EndAccept(out byte[] buffer, out int bytesTransferred, IAsyncResult asyncResult)
         {
             if (NetEventSource.IsEnabled) NetEventSource.Enter(this, asyncResult);
             if (CleanedUp)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -210,6 +210,21 @@ namespace System.Net.Sockets
             }
         }
 
+        public System.Net.Sockets.TransmitFileOptions SendPacketsFlags 
+        { 
+            get 
+            { 
+                // TODO: #12460
+                throw new PlatformNotSupportedException();
+            } 
+
+            set 
+            { 
+                // TODO: #12460
+                throw new PlatformNotSupportedException();
+            } 
+        }
+        
         public int SendPacketsSendSize
         {
             get { return _sendPacketsSendSize; }

--- a/src/System.Net.WebClient/ref/System.Net.WebClient.cs
+++ b/src/System.Net.WebClient/ref/System.Net.WebClient.cs
@@ -7,79 +7,73 @@
 
 namespace System.Net
 {
-    public class DownloadDataCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    public partial class DownloadDataCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
     {
-        internal DownloadDataCompletedEventArgs(byte[] result, System.Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken) { }
+        internal DownloadDataCompletedEventArgs() : base(null, false, null) { }
         public byte[] Result { get { throw null; } }
     }
     public delegate void DownloadDataCompletedEventHandler(object sender, System.Net.DownloadDataCompletedEventArgs e);
-    public class DownloadProgressChangedEventArgs : System.ComponentModel.ProgressChangedEventArgs
+    public partial class DownloadProgressChangedEventArgs : System.ComponentModel.ProgressChangedEventArgs
     {
-        internal DownloadProgressChangedEventArgs(int progressPercentage, object userToken, long bytesReceived, long totalBytesToReceive) : base(progressPercentage, userToken) { }
+        internal DownloadProgressChangedEventArgs() : base (default(int), default(object)) { }
         public long BytesReceived { get { throw null; } }
         public long TotalBytesToReceive { get { throw null; } }
     }
     public delegate void DownloadProgressChangedEventHandler(object sender, System.Net.DownloadProgressChangedEventArgs e);
-    public class DownloadStringCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    public partial class DownloadStringCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
     {
-        internal DownloadStringCompletedEventArgs(string result, System.Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken) { }
+        internal DownloadStringCompletedEventArgs() : base(null, false, null) { }
         public string Result { get { throw null; } }
     }
     public delegate void DownloadStringCompletedEventHandler(object sender, System.Net.DownloadStringCompletedEventArgs e);
-    public delegate void OpenReadCompletedEventHandler(object sender, System.Net.OpenReadCompletedEventArgs e);
-    public class OpenReadCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    public partial class OpenReadCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
     {
-        internal OpenReadCompletedEventArgs(System.IO.Stream result, System.Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken) { }
+        internal OpenReadCompletedEventArgs() : base(null, false, null) { }
+        public System.IO.Stream Result { get { throw null; } }
+    }
+    public delegate void OpenReadCompletedEventHandler(object sender, System.Net.OpenReadCompletedEventArgs e);
+    public partial class OpenWriteCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    {
+        internal OpenWriteCompletedEventArgs() : base(null, false, null) { }
         public System.IO.Stream Result { get { throw null; } }
     }
     public delegate void OpenWriteCompletedEventHandler(object sender, System.Net.OpenWriteCompletedEventArgs e);
-    public class OpenWriteCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    public partial class UploadDataCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
     {
-        internal OpenWriteCompletedEventArgs(System.IO.Stream result, System.Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken) { }
-        public System.IO.Stream Result { get { throw null; } }
-    }
-    public class UploadDataCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
-    {
-        internal UploadDataCompletedEventArgs(byte[] result, System.Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken) { }
+        internal UploadDataCompletedEventArgs() : base(null, false, null) { }
         public byte[] Result { get { throw null; } }
     }
     public delegate void UploadDataCompletedEventHandler(object sender, System.Net.UploadDataCompletedEventArgs e);
-    public class UploadFileCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    public partial class UploadFileCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
     {
-        internal UploadFileCompletedEventArgs(byte[] result, System.Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken) { }
+        internal UploadFileCompletedEventArgs() : base(null, false, null) { }
         public byte[] Result { get { throw null; } }
     }
     public delegate void UploadFileCompletedEventHandler(object sender, System.Net.UploadFileCompletedEventArgs e);
-    public class UploadProgressChangedEventArgs : System.ComponentModel.ProgressChangedEventArgs
+    public partial class UploadProgressChangedEventArgs : System.ComponentModel.ProgressChangedEventArgs
     {
-        internal UploadProgressChangedEventArgs(int progressPercentage, object userToken, long bytesSent, long totalBytesToSend, long bytesReceived, long totalBytesToReceive) : base(progressPercentage, userToken) { }
+        internal UploadProgressChangedEventArgs() : base (default(int), default(object)) { }
         public long BytesReceived { get { throw null; } }
-        public long TotalBytesToReceive { get { throw null; } }
         public long BytesSent { get { throw null; } }
+        public long TotalBytesToReceive { get { throw null; } }
         public long TotalBytesToSend { get { throw null; } }
     }
     public delegate void UploadProgressChangedEventHandler(object sender, System.Net.UploadProgressChangedEventArgs e);
-    public class UploadStringCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    public partial class UploadStringCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
     {
-        internal UploadStringCompletedEventArgs(string result, System.Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken) { }
+        internal UploadStringCompletedEventArgs() : base(null, false, null) { }
         public string Result { get { throw null; } }
     }
     public delegate void UploadStringCompletedEventHandler(object sender, System.Net.UploadStringCompletedEventArgs e);
-    public class UploadValuesCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    public partial class UploadValuesCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
     {
-        internal UploadValuesCompletedEventArgs(byte[] result, System.Exception exception, bool cancelled, object userToken) : base(exception, cancelled, userToken) { }
+        internal UploadValuesCompletedEventArgs() : base(null, false, null) { }
         public byte[] Result { get { throw null; } }
     }
     public delegate void UploadValuesCompletedEventHandler(object sender, System.Net.UploadValuesCompletedEventArgs e);
-    public class WebClient : System.ComponentModel.Component
+    public partial class WebClient : System.ComponentModel.Component
     {
         public WebClient() { }
-        [System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public bool AllowReadStreamBuffering { get { throw null; } set { } }
-        [System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public bool AllowWriteStreamBuffering { get { throw null; } set { } }
         public string BaseAddress { get { throw null; } set { } }
         public System.Net.Cache.RequestCachePolicy CachePolicy { get { throw null; } set { } }
         public System.Net.ICredentials Credentials { get { throw null; } set { } }
@@ -101,9 +95,6 @@ namespace System.Net
         public event System.Net.UploadProgressChangedEventHandler UploadProgressChanged { add { } remove { } }
         public event System.Net.UploadStringCompletedEventHandler UploadStringCompleted { add { } remove { } }
         public event System.Net.UploadValuesCompletedEventHandler UploadValuesCompleted { add { } remove { } }
-        [System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public event System.Net.WriteStreamClosedEventHandler WriteStreamClosed { add { } remove { } }
         public void CancelAsync() { }
         public byte[] DownloadData(string address) { throw null; }
         public byte[] DownloadData(System.Uri address) { throw null; }
@@ -137,9 +128,6 @@ namespace System.Net
         protected virtual void OnUploadProgressChanged(System.Net.UploadProgressChangedEventArgs e) { }
         protected virtual void OnUploadStringCompleted(System.Net.UploadStringCompletedEventArgs e) { }
         protected virtual void OnUploadValuesCompleted(System.Net.UploadValuesCompletedEventArgs e) { }
-        [System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        protected virtual void OnWriteStreamClosed(System.Net.WriteStreamClosedEventArgs e) { }
         public System.IO.Stream OpenRead(string address) { throw null; }
         public System.IO.Stream OpenRead(System.Uri address) { throw null; }
         public void OpenReadAsync(System.Uri address) { }
@@ -147,52 +135,52 @@ namespace System.Net
         public System.Threading.Tasks.Task<System.IO.Stream> OpenReadTaskAsync(string address) { throw null; }
         public System.Threading.Tasks.Task<System.IO.Stream> OpenReadTaskAsync(System.Uri address) { throw null; }
         public System.IO.Stream OpenWrite(string address) { throw null; }
-        public System.IO.Stream OpenWrite(System.Uri address) { throw null; }
         public System.IO.Stream OpenWrite(string address, string method) { throw null; }
+        public System.IO.Stream OpenWrite(System.Uri address) { throw null; }
         public System.IO.Stream OpenWrite(System.Uri address, string method) { throw null; }
         public void OpenWriteAsync(System.Uri address) { }
         public void OpenWriteAsync(System.Uri address, string method) { }
         public void OpenWriteAsync(System.Uri address, string method, object userToken) { }
         public System.Threading.Tasks.Task<System.IO.Stream> OpenWriteTaskAsync(string address) { throw null; }
-        public System.Threading.Tasks.Task<System.IO.Stream> OpenWriteTaskAsync(System.Uri address) { throw null; }
         public System.Threading.Tasks.Task<System.IO.Stream> OpenWriteTaskAsync(string address, string method) { throw null; }
+        public System.Threading.Tasks.Task<System.IO.Stream> OpenWriteTaskAsync(System.Uri address) { throw null; }
         public System.Threading.Tasks.Task<System.IO.Stream> OpenWriteTaskAsync(System.Uri address, string method) { throw null; }
         public byte[] UploadData(string address, byte[] data) { throw null; }
-        public byte[] UploadData(System.Uri address, byte[] data) { throw null; }
         public byte[] UploadData(string address, string method, byte[] data) { throw null; }
+        public byte[] UploadData(System.Uri address, byte[] data) { throw null; }
         public byte[] UploadData(System.Uri address, string method, byte[] data) { throw null; }
         public void UploadDataAsync(System.Uri address, byte[] data) { }
         public void UploadDataAsync(System.Uri address, string method, byte[] data) { }
         public void UploadDataAsync(System.Uri address, string method, byte[] data, object userToken) { }
         public System.Threading.Tasks.Task<byte[]> UploadDataTaskAsync(string address, byte[] data) { throw null; }
-        public System.Threading.Tasks.Task<byte[]> UploadDataTaskAsync(System.Uri address, byte[] data) { throw null; }
         public System.Threading.Tasks.Task<byte[]> UploadDataTaskAsync(string address, string method, byte[] data) { throw null; }
+        public System.Threading.Tasks.Task<byte[]> UploadDataTaskAsync(System.Uri address, byte[] data) { throw null; }
         public System.Threading.Tasks.Task<byte[]> UploadDataTaskAsync(System.Uri address, string method, byte[] data) { throw null; }
         public byte[] UploadFile(string address, string fileName) { throw null; }
-        public byte[] UploadFile(System.Uri address, string fileName) { throw null; }
         public byte[] UploadFile(string address, string method, string fileName) { throw null; }
+        public byte[] UploadFile(System.Uri address, string fileName) { throw null; }
         public byte[] UploadFile(System.Uri address, string method, string fileName) { throw null; }
-        public System.Threading.Tasks.Task<byte[]> UploadFileTaskAsync(string address, string fileName) { throw null; }
-        public System.Threading.Tasks.Task<byte[]> UploadFileTaskAsync(System.Uri address, string fileName) { throw null; }
-        public System.Threading.Tasks.Task<byte[]> UploadFileTaskAsync(string address, string method, string fileName) { throw null; }
-        public System.Threading.Tasks.Task<byte[]> UploadFileTaskAsync(System.Uri address, string method, string fileName) { throw null; }
         public void UploadFileAsync(System.Uri address, string fileName) { }
         public void UploadFileAsync(System.Uri address, string method, string fileName) { }
         public void UploadFileAsync(System.Uri address, string method, string fileName, object userToken) { }
+        public System.Threading.Tasks.Task<byte[]> UploadFileTaskAsync(string address, string fileName) { throw null; }
+        public System.Threading.Tasks.Task<byte[]> UploadFileTaskAsync(string address, string method, string fileName) { throw null; }
+        public System.Threading.Tasks.Task<byte[]> UploadFileTaskAsync(System.Uri address, string fileName) { throw null; }
+        public System.Threading.Tasks.Task<byte[]> UploadFileTaskAsync(System.Uri address, string method, string fileName) { throw null; }
         public string UploadString(string address, string data) { throw null; }
-        public string UploadString(System.Uri address, string data) { throw null; }
         public string UploadString(string address, string method, string data) { throw null; }
+        public string UploadString(System.Uri address, string data) { throw null; }
         public string UploadString(System.Uri address, string method, string data) { throw null; }
         public void UploadStringAsync(System.Uri address, string data) { }
         public void UploadStringAsync(System.Uri address, string method, string data) { }
         public void UploadStringAsync(System.Uri address, string method, string data, object userToken) { }
         public System.Threading.Tasks.Task<string> UploadStringTaskAsync(string address, string data) { throw null; }
-        public System.Threading.Tasks.Task<string> UploadStringTaskAsync(System.Uri address, string data) { throw null; }
         public System.Threading.Tasks.Task<string> UploadStringTaskAsync(string address, string method, string data) { throw null; }
+        public System.Threading.Tasks.Task<string> UploadStringTaskAsync(System.Uri address, string data) { throw null; }
         public System.Threading.Tasks.Task<string> UploadStringTaskAsync(System.Uri address, string method, string data) { throw null; }
         public byte[] UploadValues(string address, System.Collections.Specialized.NameValueCollection data) { throw null; }
-        public byte[] UploadValues(System.Uri address, System.Collections.Specialized.NameValueCollection data) { throw null; }
         public byte[] UploadValues(string address, string method, System.Collections.Specialized.NameValueCollection data) { throw null; }
+        public byte[] UploadValues(System.Uri address, System.Collections.Specialized.NameValueCollection data) { throw null; }
         public byte[] UploadValues(System.Uri address, string method, System.Collections.Specialized.NameValueCollection data) { throw null; }
         public void UploadValuesAsync(System.Uri address, System.Collections.Specialized.NameValueCollection data) { }
         public void UploadValuesAsync(System.Uri address, string method, System.Collections.Specialized.NameValueCollection data) { }
@@ -202,16 +190,4 @@ namespace System.Net
         public System.Threading.Tasks.Task<byte[]> UploadValuesTaskAsync(System.Uri address, System.Collections.Specialized.NameValueCollection data) { throw null; }
         public System.Threading.Tasks.Task<byte[]> UploadValuesTaskAsync(System.Uri address, string method, System.Collections.Specialized.NameValueCollection data) { throw null; }
     }
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    public class WriteStreamClosedEventArgs : System.EventArgs
-    {
-        [System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public WriteStreamClosedEventArgs() { }
-        [System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public System.Exception Error { get { throw null; } }
-    }
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    public delegate void WriteStreamClosedEventHandler(object sender, System.Net.WriteStreamClosedEventArgs e);
 }

--- a/src/System.Net.WebHeaderCollection/ref/System.Net.WebHeaderCollection.cs
+++ b/src/System.Net.WebHeaderCollection/ref/System.Net.WebHeaderCollection.cs
@@ -85,39 +85,39 @@ namespace System.Net
         Warning = 9,
         WwwAuthenticate = 29,
     }
-
-    public partial class WebHeaderCollection : System.Collections.Specialized.NameValueCollection,
-                                               System.Collections.IEnumerable, System.Runtime.Serialization.ISerializable
+    public partial class WebHeaderCollection : System.Collections.Specialized.NameValueCollection, System.Runtime.Serialization.ISerializable
     {
         public WebHeaderCollection() { }
+        protected WebHeaderCollection(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public override string[] AllKeys { get { throw null; } }
         public override int Count { get { throw null; } }
         public string this[System.Net.HttpRequestHeader header] { get { throw null; } set { } }
         public string this[System.Net.HttpResponseHeader header] { get { throw null; } set { } }
-        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
-        public override string ToString() { throw null; }
-        protected WebHeaderCollection(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
-        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
-        public new string this[string name] { get { throw null; } set { } }
-        public override System.Collections.IEnumerator GetEnumerator() { throw null; }
-        public override void Remove(string name) { }
-        public byte[] ToByteArray() { throw null; }
-        public static bool IsRestricted(string headerName, bool response) { throw null; }
-        public static bool IsRestricted(string headerName) { throw null; }
-        public override void OnDeserialization(object sender) { }
-        public void Remove(HttpResponseHeader header) { }
-        public void Remove(HttpRequestHeader header) { }
-        public override string[] GetValues(int index) { throw null; }
-        public override string[] GetValues(string header) { throw null; }
-        public override string GetKey(int index) { throw null; }
-        public override void Clear() { }
-        public override string Get(int index) { throw null; }
-        public override string Get(string name) { throw null; }
-        public void Add(HttpRequestHeader header, string value) { }
-        public void Add(HttpResponseHeader header, string value) { }
+        public override System.Collections.Specialized.NameObjectCollectionBase.KeysCollection Keys { get { throw null; } }
+        public void Add(System.Net.HttpRequestHeader header, string value) { }
+        public void Add(System.Net.HttpResponseHeader header, string value) { }
         public void Add(string header) { }
         public override void Add(string name, string value) { }
         protected void AddWithoutValidate(string headerName, string headerValue) { }
-        public override System.Collections.Specialized.NameObjectCollectionBase.KeysCollection Keys { get { throw null; } }
+        public override void Clear() { }
+        public override string Get(int index) { throw null; }
+        public override string Get(string name) { throw null; }
+        public override System.Collections.IEnumerator GetEnumerator() { throw null; }
+        public override string GetKey(int index) { throw null; }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public override string[] GetValues(int index) { throw null; }
+        public override string[] GetValues(string header) { throw null; }
+        public static bool IsRestricted(string headerName) { throw null; }
+        public static bool IsRestricted(string headerName, bool response) { throw null; }
+        public override void OnDeserialization(object sender) { }
+        public void Remove(System.Net.HttpRequestHeader header) { }
+        public void Remove(System.Net.HttpResponseHeader header) { }
+        public override void Remove(string name) { }
+        public void Set(System.Net.HttpRequestHeader header, string value) { }
+        public void Set(System.Net.HttpResponseHeader header, string value) { }
+        public override void Set(string name, string value) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public byte[] ToByteArray() { throw null; }
+        public override string ToString() { throw null; }
     }
 }

--- a/src/System.Net.WebProxy/ref/System.Net.WebProxy.cs
+++ b/src/System.Net.WebProxy/ref/System.Net.WebProxy.cs
@@ -7,36 +7,36 @@
 
 namespace System.Net
 {
-    public interface IWebProxyScript
+    public partial interface IWebProxyScript
     {
         void Close();
         bool Load(System.Uri scriptLocation, string script, System.Type helperType);
         string Run(string url, string host);
     }
-    public class WebProxy : System.Net.IWebProxy, System.Runtime.Serialization.ISerializable
+    public partial class WebProxy : System.Net.IWebProxy, System.Runtime.Serialization.ISerializable
     {
         public WebProxy() { }
-        public WebProxy(System.Uri Address) { }
-        public WebProxy(System.Uri Address, bool BypassOnLocal) { }
-        public WebProxy(System.Uri Address, bool BypassOnLocal, string[] BypassList) { }
-        public WebProxy(System.Uri Address, bool BypassOnLocal, string[] BypassList, System.Net.ICredentials Credentials) { }
-        public WebProxy(string Host, int Port) { }
+        protected WebProxy(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public WebProxy(string Address) { }
         public WebProxy(string Address, bool BypassOnLocal) { }
         public WebProxy(string Address, bool BypassOnLocal, string[] BypassList) { }
         public WebProxy(string Address, bool BypassOnLocal, string[] BypassList, System.Net.ICredentials Credentials) { }
-        public Uri Address { get { throw null; } set { } }
-        public bool BypassProxyOnLocal { get { throw null; } set { } }
-        public string[] BypassList { get { throw null; } set { } }
+        public WebProxy(string Host, int Port) { }
+        public WebProxy(System.Uri Address) { }
+        public WebProxy(System.Uri Address, bool BypassOnLocal) { }
+        public WebProxy(System.Uri Address, bool BypassOnLocal, string[] BypassList) { }
+        public WebProxy(System.Uri Address, bool BypassOnLocal, string[] BypassList, System.Net.ICredentials Credentials) { }
+        public System.Uri Address { get { throw null; } set { } }
         public System.Collections.ArrayList BypassArrayList { get { throw null; } }
+        public string[] BypassList { get { throw null; } set { } }
+        public bool BypassProxyOnLocal { get { throw null; } set { } }
         public System.Net.ICredentials Credentials { get { throw null; } set { } }
         public bool UseDefaultCredentials { get { throw null; } set { } }
-        public Uri GetProxy(Uri destination) { throw null; }
-        public bool IsBypassed(Uri host) { throw null; }
-        protected WebProxy(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
-        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        [System.ObsoleteAttribute("This method has been deprecated. Please use the proxy selected for you by default. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public static System.Net.WebProxy GetDefaultProxy() { throw null; }
         protected virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
-        [Obsolete("This method has been deprecated. Please use the proxy selected for you by default. http://go.microsoft.com/fwlink/?linkid=14202")]
-        public static WebProxy GetDefaultProxy() { throw null; }
+        public System.Uri GetProxy(System.Uri destination) { throw null; }
+        public bool IsBypassed(System.Uri host) { throw null; }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
 }

--- a/src/System.Net.WebSockets/ref/System.Net.WebSockets.cs
+++ b/src/System.Net.WebSockets/ref/System.Net.WebSockets.cs
@@ -11,25 +11,25 @@ namespace System.Net.WebSockets
     public abstract partial class WebSocket : System.IDisposable
     {
         protected WebSocket() { }
-        public static System.TimeSpan DefaultKeepAliveInterval { get { throw null; } }
         public abstract System.Nullable<System.Net.WebSockets.WebSocketCloseStatus> CloseStatus { get; }
         public abstract string CloseStatusDescription { get; }
+        public static System.TimeSpan DefaultKeepAliveInterval { get { throw null; } }
         public abstract System.Net.WebSockets.WebSocketState State { get; }
         public abstract string SubProtocol { get; }
         public abstract void Abort();
         public abstract System.Threading.Tasks.Task CloseAsync(System.Net.WebSockets.WebSocketCloseStatus closeStatus, string statusDescription, System.Threading.CancellationToken cancellationToken);
         public abstract System.Threading.Tasks.Task CloseOutputAsync(System.Net.WebSockets.WebSocketCloseStatus closeStatus, string statusDescription, System.Threading.CancellationToken cancellationToken);
         public static System.ArraySegment<byte> CreateClientBuffer(int receiveBufferSize, int sendBufferSize) { throw null; }
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         public static System.Net.WebSockets.WebSocket CreateClientWebSocket(System.IO.Stream innerStream, string subProtocol, int receiveBufferSize, int sendBufferSize, System.TimeSpan keepAliveInterval, bool useZeroMaskingKey, System.ArraySegment<byte> internalBuffer) { throw null; }
         public static System.ArraySegment<byte> CreateServerBuffer(int receiveBufferSize) { throw null; }
         public abstract void Dispose();
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.")]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.ObsoleteAttribute("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.")]
         public static bool IsApplicationTargeting45() { throw null; }
         protected static bool IsStateTerminal(System.Net.WebSockets.WebSocketState state) { throw null; }
         public abstract System.Threading.Tasks.Task<System.Net.WebSockets.WebSocketReceiveResult> ReceiveAsync(System.ArraySegment<byte> buffer, System.Threading.CancellationToken cancellationToken);
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         public static void RegisterPrefixes() { }
         public abstract System.Threading.Tasks.Task SendAsync(System.ArraySegment<byte> buffer, System.Net.WebSockets.WebSocketMessageType messageType, bool endOfMessage, System.Threading.CancellationToken cancellationToken);
         protected static void ThrowOnInvalidState(System.Net.WebSockets.WebSocketState state, params System.Net.WebSockets.WebSocketState[] validStates) { }
@@ -47,19 +47,20 @@ namespace System.Net.WebSockets
         PolicyViolation = 1008,
         ProtocolError = 1002,
     }
-    public abstract class WebSocketContext
+    public abstract partial class WebSocketContext
     {
-        public abstract System.Uri RequestUri { get; }
-        public abstract System.Collections.Specialized.NameValueCollection Headers { get; }
-        public abstract string Origin { get; }
-        public abstract System.Collections.Generic.IEnumerable<string> SecWebSocketProtocols { get; }
-        public abstract string SecWebSocketVersion { get; }
-        public abstract string SecWebSocketKey { get; }
+        protected WebSocketContext() { }
         public abstract System.Net.CookieCollection CookieCollection { get; }
-        public abstract System.Security.Principal.IPrincipal User { get; }
+        public abstract System.Collections.Specialized.NameValueCollection Headers { get; }
         public abstract bool IsAuthenticated { get; }
         public abstract bool IsLocal { get; }
         public abstract bool IsSecureConnection { get; }
+        public abstract string Origin { get; }
+        public abstract System.Uri RequestUri { get; }
+        public abstract string SecWebSocketKey { get; }
+        public abstract System.Collections.Generic.IEnumerable<string> SecWebSocketProtocols { get; }
+        public abstract string SecWebSocketVersion { get; }
+        public abstract System.Security.Principal.IPrincipal User { get; }
         public abstract System.Net.WebSockets.WebSocket WebSocket { get; }
     }
     public enum WebSocketError
@@ -91,9 +92,9 @@ namespace System.Net.WebSockets
         public WebSocketException(System.Net.WebSockets.WebSocketError error, string message, System.Exception innerException) { }
         public WebSocketException(string message) { }
         public WebSocketException(string message, System.Exception innerException) { }
-        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public System.Net.WebSockets.WebSocketError WebSocketErrorCode { get { throw null; } }
         public override int ErrorCode { get { throw null; } }
+        public System.Net.WebSockets.WebSocketError WebSocketErrorCode { get { throw null; } }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public enum WebSocketMessageType
     {


### PR DESCRIPTION
Fixes #13372.

Diffing all System.Net.* contracts with standard/ref and making corresponding changes, including ordering which simplifies future comparisons.
Remaining API implementations are tracked by: #12134 #12460

@davidsh, @karelz, @danmosemsft PTAL.
/cc: @safern @geoffkizer
