### PR TITLE
Have interpreter completely match compiler for thrown non-exceptions.

### DIFF
--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.builds
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.builds
@@ -4,9 +4,6 @@
   <ItemGroup>
     <Project Include="System.Linq.Expressions.csproj" />
     <Project Include="System.Linq.Expressions.csproj">
-      <TargetGroup>netstandard1.6</TargetGroup>
-    </Project>
-    <Project Include="System.Linq.Expressions.csproj">
       <TargetGroup>net463</TargetGroup>
     </Project>
     <!-- NETCore50 must redistribute binaries due to shared library

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 namespace System.Linq.Expressions.Interpreter
@@ -343,6 +344,7 @@ namespace System.Linq.Expressions.Interpreter
             // Start to run the try/catch/finally blocks
             Instruction[] instructions = frame.Interpreter.Instructions.Instructions;
             ExceptionHandler exHandler;
+            object unwrappedException;
             try
             {
                 // run the try block
@@ -361,10 +363,10 @@ namespace System.Linq.Expressions.Interpreter
                     frame.InstructionIndex += instructions[index].Run(frame);
                 }
             }
-            catch (Exception exception) when (_tryHandler.HasHandler(frame, ref exception, out exHandler))
+            catch (Exception exception) when (_tryHandler.HasHandler(frame, exception, out exHandler, out unwrappedException))
             {
-                Debug.Assert(!(exception is RethrowException));
-                frame.InstructionIndex += frame.Goto(exHandler.LabelIndex, exception, gotoExceptionHandler: true);
+                Debug.Assert(!(unwrappedException is RethrowException));
+                frame.InstructionIndex += frame.Goto(exHandler.LabelIndex, unwrappedException, gotoExceptionHandler: true);
 
 #if FEATURE_THREAD_ABORT
                 // stay in the current catch so that ThreadAbortException is not rethrown by CLR:
@@ -752,6 +754,7 @@ namespace System.Linq.Expressions.Interpreter
         internal static readonly ThrowInstruction VoidThrow = new ThrowInstruction(false, false);
         internal static readonly ThrowInstruction Rethrow = new ThrowInstruction(true, true);
         internal static readonly ThrowInstruction VoidRethrow = new ThrowInstruction(false, true);
+        private static ConstructorInfo _runtimeWrappedExceptionCtor;
 
         private readonly bool _hasResult, _rethrow;
 
@@ -767,14 +770,25 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int Run(InterpretedFrame frame)
         {
-            object ex = frame.Pop();
+            Exception ex = WrapThrownObject(frame.Pop());
             if (_rethrow)
             {
                 throw new RethrowException();
             }
 
-            // If ex is null then throwing it will result in an appropriate NullReferenceException.
-            throw ex == null ? null : ex as Exception ?? Error.InterpreterCannotThrowNonExceptions();
+            throw ex;
+        }
+
+        private static Exception WrapThrownObject(object thrown) =>
+            thrown == null ? null : (thrown as Exception ?? RuntimeWrap(thrown));
+
+        private static RuntimeWrappedException RuntimeWrap(object thrown)
+        {
+            ConstructorInfo ctor = _runtimeWrappedExceptionCtor
+                ?? (_runtimeWrappedExceptionCtor = typeof(RuntimeWrappedException)
+                .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+                .First(c => c.GetParameters().Length == 1));
+            return (RuntimeWrappedException)ctor.Invoke(new [] {thrown});
         }
     }
 


### PR DESCRIPTION
Interpreter can throw and catch reference types not derived from Exception.

If the exception escapes the expression it will be a `RuntimeWrappedException`.

Provides a better fix to #5898 than #13408.

At the beginning of the discussion of #5898 the idea that "Possibly something could be done by manipulating `RuntimeWrappedException`" was suggested, but not much came from that idea as that type wasn't available within corefx. Having the interpreter throw `InvalidOperationException` for non-exceptions and just accepting its inability to catch them was the best that could be done, so #13408 did that.

However, in the meantime #11930 had made `RuntimeWrapperException` available to use. And with it the interpreter can be made to match the compiler entirely. The compiler also seems to unwrap any RWE so there isn't a need to track whether an RWE had been created internally or not (someone would have to be very foolish to only realise that after writing code to do such tracking and then having to delete it again…).

So, with this PR both interpreter and compiler are akin in:

1. Being able to throw any reference type.
2. Being able to catch any reference type.
3. Being able to catch a non-exception reference type from a call into another assembly, whatever that assembly's `RuntimeCompatibilityAttribute` settings.
4. If a `RuntimeWrapperException` originating from outside the expression is thrown within it, they can catch the wrapped object.
5. If a non-exception is thrown by the expression, it can be caught in the invoking code as a `RuntimeWrapperException`.

cc @VSadov @bartdesmet @svick 

(The only remaining difference in exception handling between the two is now that the compiler can't do fault and filter blocks).