### PR TITLE
Addressing gap in IL printer

### DIFF
--- a/src/System.Linq.Expressions/tests/ILReader/ILPrinter.cs
+++ b/src/System.Linq.Expressions/tests/ILReader/ILPrinter.cs
@@ -157,6 +157,21 @@ namespace System.Linq.Expressions.Tests
                 return base.Visit(node);
             }
 
+            protected override MemberBinding VisitMemberBinding(MemberBinding node)
+            {
+                var property = node.Member as PropertyInfo;
+                if (property != null)
+                {
+                    Visit(property.PropertyType);
+                }
+                else
+                {
+                    Visit(((FieldInfo)node.Member).FieldType);
+                }
+
+                return base.VisitMemberBinding(node);
+            }
+
             private void Visit(Type type)
             {
                 var ti = type.GetTypeInfo();


### PR DESCRIPTION
Addressing a small gap in the IL printer found when writing more tests for stack spilling.

CC @stephentoub 