### PR TITLE
Enable distro agnostic build of System.Security.Cryptography.Native

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
@@ -43,6 +43,13 @@ set(NATIVECRYPTO_SOURCES
     pal_x509ext.cpp
 )
 
+if (FEATURE_DISTRO_AGNOSTIC_SSL)
+    list(APPEND NATIVECRYPTO_SOURCES
+        opensslshim.cpp
+    )
+    add_definitions(-DFEATURE_DISTRO_AGNOSTIC_SSL)
+endif()
+
 add_library(objlib OBJECT ${NATIVECRYPTO_SOURCES} ${VERSION_FILE_PATH})
 
 add_library(System.Security.Cryptography.Native
@@ -59,36 +66,46 @@ add_library(System.Security.Cryptography.Native.OpenSsl
 set_target_properties(System.Security.Cryptography.Native PROPERTIES PREFIX "")
 set_target_properties(System.Security.Cryptography.Native.OpenSsl PROPERTIES PREFIX "")
 
-target_link_libraries(System.Security.Cryptography.Native
-  ${OPENSSL_CRYPTO_LIBRARY}
-  ${OPENSSL_SSL_LIBRARY}
-)
+if (NOT FEATURE_DISTRO_AGNOSTIC_SSL)
+  target_link_libraries(System.Security.Cryptography.Native
+    ${OPENSSL_CRYPTO_LIBRARY}
+    ${OPENSSL_SSL_LIBRARY}
+  )
 
-target_link_libraries(System.Security.Cryptography.Native.OpenSsl
-  ${OPENSSL_CRYPTO_LIBRARY}
-  ${OPENSSL_SSL_LIBRARY}
-)
+  target_link_libraries(System.Security.Cryptography.Native.OpenSsl
+    ${OPENSSL_CRYPTO_LIBRARY}
+    ${OPENSSL_SSL_LIBRARY}
+  )
 
-# On OS X every library emits the manner in which it should be referenced.
-# All of our libraries are referenced via @rpath, which is similar to how Linux and Windows
-# libraries are loaded. The homebrew installation of OpenSSL (libcrypto, libssl) uses the
-# full path to the library installation. This means that this library is not flexible to
-# users installing newer libcrypto in the working directory, or to systems which do not
-# install to the same path as homebrew does.
-#
-# So, after compiling, rewrite the references to libcrypto to be more flexible.
-if (APPLE)
-    add_custom_command(TARGET System.Security.Cryptography.Native POST_BUILD
-        COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib @rpath/libcrypto.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native>
-        COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libssl.1.0.0.dylib @rpath/libssl.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native>
-        COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath @loader_path $<TARGET_FILE:System.Security.Cryptography.Native>
-        )
+  # On OS X every library emits the manner in which it should be referenced.
+  # All of our libraries are referenced via @rpath, which is similar to how Linux and Windows
+  # libraries are loaded. The homebrew installation of OpenSSL (libcrypto, libssl) uses the
+  # full path to the library installation. This means that this library is not flexible to
+  # users installing newer libcrypto in the working directory, or to systems which do not
+  # install to the same path as homebrew does.
+  #
+  # So, after compiling, rewrite the references to libcrypto to be more flexible.
+  if (APPLE)
+      add_custom_command(TARGET System.Security.Cryptography.Native POST_BUILD
+          COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib @rpath/libcrypto.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native>
+          COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libssl.1.0.0.dylib @rpath/libssl.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native>
+          COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath @loader_path $<TARGET_FILE:System.Security.Cryptography.Native>
+          )
+  
+      add_custom_command(TARGET System.Security.Cryptography.Native.OpenSsl POST_BUILD
+          COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib @rpath/libcrypto.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
+          COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libssl.1.0.0.dylib @rpath/libssl.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
+          COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath @loader_path $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
+          )
+  endif()
+elseif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL NetBSD)
+  target_link_libraries(System.Security.Cryptography.Native
+    dl
+  )
 
-    add_custom_command(TARGET System.Security.Cryptography.Native.OpenSsl POST_BUILD
-        COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib @rpath/libcrypto.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
-        COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libssl.1.0.0.dylib @rpath/libssl.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
-        COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath @loader_path $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
-        )
+  target_link_libraries(System.Security.Cryptography.Native.OpenSsl
+    dl
+  )
 endif()
 
 include(configure.cmake)

--- a/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
@@ -44,6 +44,10 @@ set(NATIVECRYPTO_SOURCES
 )
 
 if (FEATURE_DISTRO_AGNOSTIC_SSL)
+    if (NOT CMAKE_SYSTEM_NAME STREQUAL Linux)
+        message(FATAL_ERROR "FEATURE_DISTRO_AGNOSTIC_SSL can only be enabled for Linux")
+    endif()
+
     list(APPEND NATIVECRYPTO_SOURCES
         opensslshim.cpp
     )
@@ -66,46 +70,55 @@ add_library(System.Security.Cryptography.Native.OpenSsl
 set_target_properties(System.Security.Cryptography.Native PROPERTIES PREFIX "")
 set_target_properties(System.Security.Cryptography.Native.OpenSsl PROPERTIES PREFIX "")
 
-if (NOT FEATURE_DISTRO_AGNOSTIC_SSL)
-  target_link_libraries(System.Security.Cryptography.Native
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-  )
+if (FEATURE_DISTRO_AGNOSTIC_SSL)
+    add_custom_command(TARGET System.Security.Cryptography.Native.OpenSsl POST_BUILD
+        COMMENT "Verifying System.Security.Cryptography.Native.OpenSsl.so dependencies"
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../verify-so.sh 
+            $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl> 
+            "Verification failed. System.Security.Cryptography.Native.OpenSsl.so has undefined dependencies. These are likely OpenSSL APIs that need to be added to opensslshim.h"
+        VERBATIM
+    )
 
-  target_link_libraries(System.Security.Cryptography.Native.OpenSsl
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-  )
+    # Link with libdl.so to get the dlopen / dlsym / dlclose
+    target_link_libraries(System.Security.Cryptography.Native
+      dl
+    )
 
-  # On OS X every library emits the manner in which it should be referenced.
-  # All of our libraries are referenced via @rpath, which is similar to how Linux and Windows
-  # libraries are loaded. The homebrew installation of OpenSSL (libcrypto, libssl) uses the
-  # full path to the library installation. This means that this library is not flexible to
-  # users installing newer libcrypto in the working directory, or to systems which do not
-  # install to the same path as homebrew does.
-  #
-  # So, after compiling, rewrite the references to libcrypto to be more flexible.
-  if (APPLE)
-      add_custom_command(TARGET System.Security.Cryptography.Native POST_BUILD
-          COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib @rpath/libcrypto.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native>
-          COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libssl.1.0.0.dylib @rpath/libssl.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native>
-          COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath @loader_path $<TARGET_FILE:System.Security.Cryptography.Native>
-          )
+    target_link_libraries(System.Security.Cryptography.Native.OpenSsl
+      dl
+    )
+else()
+    target_link_libraries(System.Security.Cryptography.Native
+      ${OPENSSL_CRYPTO_LIBRARY}
+      ${OPENSSL_SSL_LIBRARY}
+    )
   
-      add_custom_command(TARGET System.Security.Cryptography.Native.OpenSsl POST_BUILD
-          COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib @rpath/libcrypto.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
-          COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libssl.1.0.0.dylib @rpath/libssl.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
-          COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath @loader_path $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
-          )
-  endif()
-elseif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL NetBSD)
-  target_link_libraries(System.Security.Cryptography.Native
-    dl
-  )
-
-  target_link_libraries(System.Security.Cryptography.Native.OpenSsl
-    dl
-  )
+    target_link_libraries(System.Security.Cryptography.Native.OpenSsl
+      ${OPENSSL_CRYPTO_LIBRARY}
+      ${OPENSSL_SSL_LIBRARY}
+    )
+  
+    # On OS X every library emits the manner in which it should be referenced.
+    # All of our libraries are referenced via @rpath, which is similar to how Linux and Windows
+    # libraries are loaded. The homebrew installation of OpenSSL (libcrypto, libssl) uses the
+    # full path to the library installation. This means that this library is not flexible to
+    # users installing newer libcrypto in the working directory, or to systems which do not
+    # install to the same path as homebrew does.
+    #
+    # So, after compiling, rewrite the references to libcrypto to be more flexible.
+    if (APPLE)
+        add_custom_command(TARGET System.Security.Cryptography.Native POST_BUILD
+            COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib @rpath/libcrypto.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native>
+            COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libssl.1.0.0.dylib @rpath/libssl.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native>
+            COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath @loader_path $<TARGET_FILE:System.Security.Cryptography.Native>
+            )
+    
+        add_custom_command(TARGET System.Security.Cryptography.Native.OpenSsl POST_BUILD
+            COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib @rpath/libcrypto.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
+            COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/openssl/lib/libssl.1.0.0.dylib @rpath/libssl.1.0.0.dylib $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
+            COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath @loader_path $<TARGET_FILE:System.Security.Cryptography.Native.OpenSsl>
+            )
+    endif()
 endif()
 
 include(configure.cmake)

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.cpp
@@ -5,6 +5,7 @@
 #include "pal_types.h"
 #include "pal_utilities.h"
 #include "pal_safecrt.h"
+#include "opensslshim.h"
 
 #include <assert.h>
 #include <limits.h>
@@ -13,13 +14,6 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-#include <openssl/asn1.h>
-#include <openssl/bio.h>
-#include <openssl/err.h>
-#include <openssl/evp.h>
-#include <openssl/rand.h>
-#include <openssl/x509.h>
-#include <openssl/x509v3.h>
 #include <memory>
 
 // See X509NameType.SimpleName
@@ -84,7 +78,11 @@ extern "C" int32_t CryptoNative_GetX509Thumbprint(X509* x509, uint8_t* pBuf, int
         return -SHA_DIGEST_LENGTH;
     }
 
-    memcpy_s(pBuf, UnsignedCast(cBuf), x509->sha1_hash, SHA_DIGEST_LENGTH);
+    if (!X509_digest(x509, EVP_sha1(), pBuf, NULL))
+    {
+        return 0;
+    }
+
     return 1;
 }
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.cpp
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+#include <dlfcn.h>
+#include <stdio.h>
+
+#include "opensslshim.h"
+
+// Define pointers to all the used ICU functions
+#define PER_FUNCTION_BLOCK(fn, isRequired) decltype(fn) fn##_ptr;
+FOR_ALL_OPENSSL_FUNCTIONS
+#undef PER_FUNCTION_BLOCK
+
+static void* libssl = nullptr;
+
+bool OpenLibrary()
+{
+    // First try the default versioned so naming as described in the OpenSSL doc
+    libssl = dlopen("libssl.so.1.0.0", RTLD_LAZY);
+    if (libssl == nullptr)
+    {
+        // Fedora derived distros use different naming for the version 1.0.0
+        libssl = dlopen("libssl.so.10", RTLD_LAZY);
+    }
+
+    return libssl != nullptr;
+}
+
+__attribute__((constructor))
+void InitializeOpenSSLShim()
+{
+    if (!OpenLibrary())
+    {
+        fprintf(stderr, "No usable version of the libssl was found\n");
+        abort();
+    }
+
+    // Get pointers to all the ICU functions that are needed
+#define PER_FUNCTION_BLOCK(fn, isRequired) \
+    fn##_ptr = reinterpret_cast<decltype(fn)>(dlsym(libssl, #fn)); \
+    if ((fn##_ptr) == NULL && isRequired) { fprintf(stderr, "Cannot get required symbol " #fn " from libssl\n"); abort(); }
+
+    FOR_ALL_OPENSSL_FUNCTIONS
+#undef PER_FUNCTION_BLOCK    
+}
+
+__attribute__((destructor))
+void ShutdownOpenSSLShim()
+{
+    if (libssl != nullptr)
+    {
+        dlclose(libssl);
+    }
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -32,6 +32,8 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
+#include "pal_crypto_config.h"
+
 #ifdef FEATURE_DISTRO_AGNOSTIC_SSL
 
 #define API_EXISTS(fn) (fn != nullptr)
@@ -39,7 +41,7 @@
 // List of all functions from the libssl that are used in the System.Security.Cryptography.Native.
 // Forgetting to add a function here results in build failure with message reporting the function
 // that needs to be added.
-#define FOR_ALL_OPENSSL_FUNCTIONS \
+#define FOR_ALL_UNCONDITIONAL_OPENSSL_FUNCTIONS \
     PER_FUNCTION_BLOCK(ASN1_BIT_STRING_free, true) \
     PER_FUNCTION_BLOCK(ASN1_INTEGER_get, true) \
     PER_FUNCTION_BLOCK(ASN1_OBJECT_free, true) \
@@ -92,7 +94,6 @@
     PER_FUNCTION_BLOCK(ECDSA_sign, true) \
     PER_FUNCTION_BLOCK(ECDSA_size, true) \
     PER_FUNCTION_BLOCK(ECDSA_verify, true) \
-    PER_FUNCTION_BLOCK(EC_GF2m_simple_method, false) \
     PER_FUNCTION_BLOCK(EC_GFp_mont_method, true) \
     PER_FUNCTION_BLOCK(EC_GFp_simple_method, true) \
     PER_FUNCTION_BLOCK(EC_GROUP_check, true) \
@@ -100,7 +101,6 @@
     PER_FUNCTION_BLOCK(EC_GROUP_get0_generator, true) \
     PER_FUNCTION_BLOCK(EC_GROUP_get0_seed, true) \
     PER_FUNCTION_BLOCK(EC_GROUP_get_cofactor, true) \
-    PER_FUNCTION_BLOCK(EC_GROUP_get_curve_GF2m, false) \
     PER_FUNCTION_BLOCK(EC_GROUP_get_curve_GFp, true) \
     PER_FUNCTION_BLOCK(EC_GROUP_get_curve_name, true) \
     PER_FUNCTION_BLOCK(EC_GROUP_get_degree, true) \
@@ -108,7 +108,6 @@
     PER_FUNCTION_BLOCK(EC_GROUP_get_seed_len, true) \
     PER_FUNCTION_BLOCK(EC_GROUP_method_of, true) \
     PER_FUNCTION_BLOCK(EC_GROUP_new, true) \
-    PER_FUNCTION_BLOCK(EC_GROUP_set_curve_GF2m, false) \
     PER_FUNCTION_BLOCK(EC_GROUP_set_curve_GFp, true) \
     PER_FUNCTION_BLOCK(EC_GROUP_set_generator, true) \
     PER_FUNCTION_BLOCK(EC_GROUP_set_seed, true) \
@@ -126,10 +125,8 @@
     PER_FUNCTION_BLOCK(EC_KEY_up_ref, true) \
     PER_FUNCTION_BLOCK(EC_METHOD_get_field_type, true) \
     PER_FUNCTION_BLOCK(EC_POINT_free, true) \
-    PER_FUNCTION_BLOCK(EC_POINT_get_affine_coordinates_GF2m, false) \
     PER_FUNCTION_BLOCK(EC_POINT_get_affine_coordinates_GFp, true) \
     PER_FUNCTION_BLOCK(EC_POINT_new, true) \
-    PER_FUNCTION_BLOCK(EC_POINT_set_affine_coordinates_GF2m, false) \
     PER_FUNCTION_BLOCK(EC_POINT_set_affine_coordinates_GFp, true) \
     PER_FUNCTION_BLOCK(ERR_clear_error, true) \
     PER_FUNCTION_BLOCK(ERR_error_string_n, true) \
@@ -317,6 +314,21 @@
     PER_FUNCTION_BLOCK(X509_verify_cert_error_string, true) \
     PER_FUNCTION_BLOCK(X509_VERIFY_PARAM_set_time, true) \
 
+#if HAVE_OPENSSL_EC2M
+#define FOR_ALL_OPENSSL_FUNCTIONS \
+    FOR_ALL_UNCONDITIONAL_OPENSSL_FUNCTIONS \
+    PER_FUNCTION_BLOCK(EC_GF2m_simple_method, false) \
+    PER_FUNCTION_BLOCK(EC_GROUP_get_curve_GF2m, false) \
+    PER_FUNCTION_BLOCK(EC_GROUP_set_curve_GF2m, false) \
+    PER_FUNCTION_BLOCK(EC_POINT_get_affine_coordinates_GF2m, false) \
+    PER_FUNCTION_BLOCK(EC_POINT_set_affine_coordinates_GF2m, false) \
+    
+#else // HAVE_OPENSSL_EC2M
+#define FOR_ALL_OPENSSL_FUNCTIONS \
+    FOR_ALL_UNCONDITIONAL_OPENSSL_FUNCTIONS
+
+#endif // HAVE_OPENSSL_EC2M
+
 // Declare pointers to all the used OpenSSL functions
 #define PER_FUNCTION_BLOCK(fn, isRequired) extern decltype(fn)* fn##_ptr;
 FOR_ALL_OPENSSL_FUNCTIONS
@@ -376,7 +388,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define ECDSA_sign ECDSA_sign_ptr
 #define ECDSA_size ECDSA_size_ptr
 #define ECDSA_verify ECDSA_verify_ptr
-#define EC_GF2m_simple_method EC_GF2m_simple_method_ptr
 #define EC_GFp_mont_method EC_GFp_mont_method_ptr
 #define EC_GFp_simple_method EC_GFp_simple_method_ptr
 #define EC_GROUP_check EC_GROUP_check_ptr
@@ -384,7 +395,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define EC_GROUP_get0_generator EC_GROUP_get0_generator_ptr
 #define EC_GROUP_get0_seed EC_GROUP_get0_seed_ptr
 #define EC_GROUP_get_cofactor EC_GROUP_get_cofactor_ptr
-#define EC_GROUP_get_curve_GF2m EC_GROUP_get_curve_GF2m_ptr
 #define EC_GROUP_get_curve_GFp EC_GROUP_get_curve_GFp_ptr
 #define EC_GROUP_get_curve_name EC_GROUP_get_curve_name_ptr
 #define EC_GROUP_get_degree EC_GROUP_get_degree_ptr
@@ -392,7 +402,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define EC_GROUP_get_seed_len EC_GROUP_get_seed_len_ptr
 #define EC_GROUP_method_of EC_GROUP_method_of_ptr
 #define EC_GROUP_new EC_GROUP_new_ptr
-#define EC_GROUP_set_curve_GF2m EC_GROUP_set_curve_GF2m_ptr
 #define EC_GROUP_set_curve_GFp EC_GROUP_set_curve_GFp_ptr
 #define EC_GROUP_set_generator EC_GROUP_set_generator_ptr
 #define EC_GROUP_set_seed EC_GROUP_set_seed_ptr
@@ -410,10 +419,8 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define EC_KEY_up_ref EC_KEY_up_ref_ptr
 #define EC_METHOD_get_field_type EC_METHOD_get_field_type_ptr
 #define EC_POINT_free EC_POINT_free_ptr
-#define EC_POINT_get_affine_coordinates_GF2m EC_POINT_get_affine_coordinates_GF2m_ptr
 #define EC_POINT_get_affine_coordinates_GFp EC_POINT_get_affine_coordinates_GFp_ptr
 #define EC_POINT_new EC_POINT_new_ptr
-#define EC_POINT_set_affine_coordinates_GF2m EC_POINT_set_affine_coordinates_GF2m_ptr
 #define EC_POINT_set_affine_coordinates_GFp EC_POINT_set_affine_coordinates_GFp_ptr
 #define ERR_clear_error ERR_clear_error_ptr
 #define ERR_error_string_n ERR_error_string_n_ptr
@@ -600,6 +607,14 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_verify_cert X509_verify_cert_ptr
 #define X509_verify_cert_error_string X509_verify_cert_error_string_ptr
 #define X509_VERIFY_PARAM_set_time X509_VERIFY_PARAM_set_time_ptr
+
+#if HAVE_OPENSSL_EC2M
+#define EC_GF2m_simple_method EC_GF2m_simple_method_ptr
+#define EC_GROUP_get_curve_GF2m EC_GROUP_get_curve_GF2m_ptr
+#define EC_GROUP_set_curve_GF2m EC_GROUP_set_curve_GF2m_ptr
+#define EC_POINT_get_affine_coordinates_GF2m EC_POINT_get_affine_coordinates_GF2m_ptr
+#define EC_POINT_set_affine_coordinates_GF2m EC_POINT_set_affine_coordinates_GF2m_ptr
+#endif // HAVE_OPENSSL_EC2M
 
 #else // FEATURE_DISTRO_AGNOSTIC_SSL
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -7,8 +7,7 @@
 // different versioned so files naming and different configuration options
 // on various Linux distributions.
 
-#ifndef __OPENSSLSHIM_H__
-#define __OPENSSLSHIM_H__
+#pragma once
 
 // All the openssl includes need to be here to ensure that the APIs we use
 // are overriden to be called through our function pointers.
@@ -565,7 +564,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_EXTENSION_get_data X509_EXTENSION_get_data_ptr
 #define X509_EXTENSION_get_object X509_EXTENSION_get_object_ptr
 #define X509_free X509_free_ptr
-#define X509_free X509_free_ptr
 #define X509_get_default_cert_dir X509_get_default_cert_dir_ptr
 #define X509_get_default_cert_dir_env X509_get_default_cert_dir_env_ptr
 #define X509_get_default_cert_file X509_get_default_cert_file_ptr
@@ -581,7 +579,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_NAME_entry_count X509_NAME_entry_count_ptr
 #define X509_NAME_ENTRY_get_data X509_NAME_ENTRY_get_data_ptr
 #define X509_NAME_ENTRY_get_object X509_NAME_ENTRY_get_object_ptr
-#define X509_NAME_free X509_NAME_free_ptr
 #define X509_NAME_free X509_NAME_free_ptr
 #define X509_NAME_get_entry X509_NAME_get_entry_ptr
 #define X509_NAME_get_index_by_NID X509_NAME_get_index_by_NID_ptr
@@ -609,5 +606,3 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define API_EXISTS(fn) true
 
 #endif // FEATURE_DISTRO_AGNOSTIC_SSL
-
-#endif // __OPENSSLSHIM_H__

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -1,0 +1,613 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+// Enable calling OpenSSL functions through shims to enable support for 
+// different versioned so files naming and different configuration options
+// on various Linux distributions.
+
+#ifndef __OPENSSLSHIM_H__
+#define __OPENSSLSHIM_H__
+
+// All the openssl includes need to be here to ensure that the APIs we use
+// are overriden to be called through our function pointers.
+#include <openssl/asn1.h>
+#include <openssl/bio.h>
+#include <openssl/bn.h>
+#include <openssl/dsa.h>
+#include <openssl/ecdsa.h>
+#include <openssl/ec.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/md5.h>
+#include <openssl/objects.h>
+#include <openssl/pem.h>
+#include <openssl/pkcs12.h>
+#include <openssl/pkcs7.h>
+#include <openssl/rand.h>
+#include <openssl/rsa.h>
+#include <openssl/sha.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+
+#ifdef FEATURE_DISTRO_AGNOSTIC_SSL
+
+#define API_EXISTS(fn) (fn != nullptr)
+
+// List of all functions from the libssl that are used in the System.Security.Cryptography.Native.
+// Forgetting to add a function here results in build failure with message reporting the function
+// that needs to be added.
+#define FOR_ALL_OPENSSL_FUNCTIONS \
+    PER_FUNCTION_BLOCK(ASN1_BIT_STRING_free, true) \
+    PER_FUNCTION_BLOCK(ASN1_INTEGER_get, true) \
+    PER_FUNCTION_BLOCK(ASN1_OBJECT_free, true) \
+    PER_FUNCTION_BLOCK(ASN1_OCTET_STRING_free, true) \
+    PER_FUNCTION_BLOCK(ASN1_OCTET_STRING_new, true) \
+    PER_FUNCTION_BLOCK(ASN1_OCTET_STRING_set, true) \
+    PER_FUNCTION_BLOCK(ASN1_STRING_free, true) \
+    PER_FUNCTION_BLOCK(ASN1_STRING_print_ex, true) \
+    PER_FUNCTION_BLOCK(BASIC_CONSTRAINTS_free, true) \
+    PER_FUNCTION_BLOCK(BIO_ctrl, true) \
+    PER_FUNCTION_BLOCK(BIO_ctrl_pending, true) \
+    PER_FUNCTION_BLOCK(BIO_free, true) \
+    PER_FUNCTION_BLOCK(BIO_gets, true) \
+    PER_FUNCTION_BLOCK(BIO_new, true) \
+    PER_FUNCTION_BLOCK(BIO_new_file, true) \
+    PER_FUNCTION_BLOCK(BIO_read, true) \
+    PER_FUNCTION_BLOCK(BIO_s_mem, true) \
+    PER_FUNCTION_BLOCK(BIO_write, true) \
+    PER_FUNCTION_BLOCK(BN_bin2bn, true) \
+    PER_FUNCTION_BLOCK(BN_bn2bin, true) \
+    PER_FUNCTION_BLOCK(BN_clear_free, true) \
+    PER_FUNCTION_BLOCK(BN_free, true) \
+    PER_FUNCTION_BLOCK(BN_new, true) \
+    PER_FUNCTION_BLOCK(BN_num_bits, true) \
+    PER_FUNCTION_BLOCK(CRYPTO_add_lock, true) \
+    PER_FUNCTION_BLOCK(CRYPTO_num_locks, true) \
+    PER_FUNCTION_BLOCK(CRYPTO_set_locking_callback, true) \
+    PER_FUNCTION_BLOCK(d2i_ASN1_BIT_STRING, true) \
+    PER_FUNCTION_BLOCK(d2i_ASN1_OCTET_STRING, true) \
+    PER_FUNCTION_BLOCK(d2i_ASN1_type_bytes, true) \
+    PER_FUNCTION_BLOCK(d2i_BASIC_CONSTRAINTS, true) \
+    PER_FUNCTION_BLOCK(d2i_EXTENDED_KEY_USAGE, true) \
+    PER_FUNCTION_BLOCK(d2i_PKCS12, true) \
+    PER_FUNCTION_BLOCK(d2i_PKCS12_bio, true) \
+    PER_FUNCTION_BLOCK(d2i_PKCS7, true) \
+    PER_FUNCTION_BLOCK(d2i_PKCS7_bio, true) \
+    PER_FUNCTION_BLOCK(d2i_RSAPublicKey, true) \
+    PER_FUNCTION_BLOCK(d2i_X509, true) \
+    PER_FUNCTION_BLOCK(d2i_X509_bio, true) \
+    PER_FUNCTION_BLOCK(d2i_X509_CRL, true) \
+    PER_FUNCTION_BLOCK(d2i_X509_NAME, true) \
+    PER_FUNCTION_BLOCK(DSA_free, true) \
+    PER_FUNCTION_BLOCK(DSA_generate_key, true) \
+    PER_FUNCTION_BLOCK(DSA_generate_parameters_ex, true) \
+    PER_FUNCTION_BLOCK(DSA_new, true) \
+    PER_FUNCTION_BLOCK(DSA_sign, true) \
+    PER_FUNCTION_BLOCK(DSA_size, true) \
+    PER_FUNCTION_BLOCK(DSA_up_ref, true) \
+    PER_FUNCTION_BLOCK(DSA_verify, true) \
+    PER_FUNCTION_BLOCK(ECDSA_sign, true) \
+    PER_FUNCTION_BLOCK(ECDSA_size, true) \
+    PER_FUNCTION_BLOCK(ECDSA_verify, true) \
+    PER_FUNCTION_BLOCK(EC_GF2m_simple_method, false) \
+    PER_FUNCTION_BLOCK(EC_GFp_mont_method, true) \
+    PER_FUNCTION_BLOCK(EC_GFp_simple_method, true) \
+    PER_FUNCTION_BLOCK(EC_GROUP_check, true) \
+    PER_FUNCTION_BLOCK(EC_GROUP_free, true) \
+    PER_FUNCTION_BLOCK(EC_GROUP_get0_generator, true) \
+    PER_FUNCTION_BLOCK(EC_GROUP_get0_seed, true) \
+    PER_FUNCTION_BLOCK(EC_GROUP_get_cofactor, true) \
+    PER_FUNCTION_BLOCK(EC_GROUP_get_curve_GF2m, false) \
+    PER_FUNCTION_BLOCK(EC_GROUP_get_curve_GFp, true) \
+    PER_FUNCTION_BLOCK(EC_GROUP_get_curve_name, true) \
+    PER_FUNCTION_BLOCK(EC_GROUP_get_degree, true) \
+    PER_FUNCTION_BLOCK(EC_GROUP_get_order, true) \
+    PER_FUNCTION_BLOCK(EC_GROUP_get_seed_len, true) \
+    PER_FUNCTION_BLOCK(EC_GROUP_method_of, true) \
+    PER_FUNCTION_BLOCK(EC_GROUP_new, true) \
+    PER_FUNCTION_BLOCK(EC_GROUP_set_curve_GF2m, false) \
+    PER_FUNCTION_BLOCK(EC_GROUP_set_curve_GFp, true) \
+    PER_FUNCTION_BLOCK(EC_GROUP_set_generator, true) \
+    PER_FUNCTION_BLOCK(EC_GROUP_set_seed, true) \
+    PER_FUNCTION_BLOCK(EC_KEY_check_key, true) \
+    PER_FUNCTION_BLOCK(EC_KEY_free, true) \
+    PER_FUNCTION_BLOCK(EC_KEY_generate_key, true) \
+    PER_FUNCTION_BLOCK(EC_KEY_get0_group, true) \
+    PER_FUNCTION_BLOCK(EC_KEY_get0_private_key, true) \
+    PER_FUNCTION_BLOCK(EC_KEY_get0_public_key, true) \
+    PER_FUNCTION_BLOCK(EC_KEY_new, true) \
+    PER_FUNCTION_BLOCK(EC_KEY_new_by_curve_name, true) \
+    PER_FUNCTION_BLOCK(EC_KEY_set_group, true) \
+    PER_FUNCTION_BLOCK(EC_KEY_set_private_key, true) \
+    PER_FUNCTION_BLOCK(EC_KEY_set_public_key_affine_coordinates, true) \
+    PER_FUNCTION_BLOCK(EC_KEY_up_ref, true) \
+    PER_FUNCTION_BLOCK(EC_METHOD_get_field_type, true) \
+    PER_FUNCTION_BLOCK(EC_POINT_free, true) \
+    PER_FUNCTION_BLOCK(EC_POINT_get_affine_coordinates_GF2m, false) \
+    PER_FUNCTION_BLOCK(EC_POINT_get_affine_coordinates_GFp, true) \
+    PER_FUNCTION_BLOCK(EC_POINT_new, true) \
+    PER_FUNCTION_BLOCK(EC_POINT_set_affine_coordinates_GF2m, false) \
+    PER_FUNCTION_BLOCK(EC_POINT_set_affine_coordinates_GFp, true) \
+    PER_FUNCTION_BLOCK(ERR_clear_error, true) \
+    PER_FUNCTION_BLOCK(ERR_error_string_n, true) \
+    PER_FUNCTION_BLOCK(ERR_get_error, true) \
+    PER_FUNCTION_BLOCK(ERR_load_crypto_strings, true) \
+    PER_FUNCTION_BLOCK(ERR_peek_error, true) \
+    PER_FUNCTION_BLOCK(ERR_peek_last_error, true) \
+    PER_FUNCTION_BLOCK(ERR_reason_error_string, true) \
+    PER_FUNCTION_BLOCK(EVP_aes_128_cbc, true) \
+    PER_FUNCTION_BLOCK(EVP_aes_128_ecb, true) \
+    PER_FUNCTION_BLOCK(EVP_aes_192_cbc, true) \
+    PER_FUNCTION_BLOCK(EVP_aes_192_ecb, true) \
+    PER_FUNCTION_BLOCK(EVP_aes_256_cbc, true) \
+    PER_FUNCTION_BLOCK(EVP_aes_256_ecb, true) \
+    PER_FUNCTION_BLOCK(EVP_CIPHER_CTX_cleanup, true) \
+    PER_FUNCTION_BLOCK(EVP_CIPHER_CTX_ctrl, true) \
+    PER_FUNCTION_BLOCK(EVP_CIPHER_CTX_init, true) \
+    PER_FUNCTION_BLOCK(EVP_CIPHER_CTX_set_key_length, true) \
+    PER_FUNCTION_BLOCK(EVP_CIPHER_CTX_set_padding, true) \
+    PER_FUNCTION_BLOCK(EVP_CipherFinal_ex, true) \
+    PER_FUNCTION_BLOCK(EVP_CipherInit_ex, true) \
+    PER_FUNCTION_BLOCK(EVP_CipherUpdate, true) \
+    PER_FUNCTION_BLOCK(EVP_des_cbc, true) \
+    PER_FUNCTION_BLOCK(EVP_des_ecb, true) \
+    PER_FUNCTION_BLOCK(EVP_des_ede3, true) \
+    PER_FUNCTION_BLOCK(EVP_des_ede3_cbc, true) \
+    PER_FUNCTION_BLOCK(EVP_DigestFinal_ex, true) \
+    PER_FUNCTION_BLOCK(EVP_DigestInit_ex, true) \
+    PER_FUNCTION_BLOCK(EVP_DigestUpdate, true) \
+    PER_FUNCTION_BLOCK(EVP_md5, true) \
+    PER_FUNCTION_BLOCK(EVP_MD_CTX_create, true) \
+    PER_FUNCTION_BLOCK(EVP_MD_CTX_destroy, true) \
+    PER_FUNCTION_BLOCK(EVP_MD_size, true) \
+    PER_FUNCTION_BLOCK(EVP_PKEY_free, true) \
+    PER_FUNCTION_BLOCK(EVP_PKEY_get1_DSA, true) \
+    PER_FUNCTION_BLOCK(EVP_PKEY_get1_EC_KEY, true) \
+    PER_FUNCTION_BLOCK(EVP_PKEY_get1_RSA, true) \
+    PER_FUNCTION_BLOCK(EVP_PKEY_new, true) \
+    PER_FUNCTION_BLOCK(EVP_PKEY_set1_DSA, true) \
+    PER_FUNCTION_BLOCK(EVP_PKEY_set1_EC_KEY, true) \
+    PER_FUNCTION_BLOCK(EVP_PKEY_set1_RSA, true) \
+    PER_FUNCTION_BLOCK(EVP_rc2_cbc, true) \
+    PER_FUNCTION_BLOCK(EVP_rc2_ecb, true) \
+    PER_FUNCTION_BLOCK(EVP_sha1, true) \
+    PER_FUNCTION_BLOCK(EVP_sha256, true) \
+    PER_FUNCTION_BLOCK(EVP_sha384, true) \
+    PER_FUNCTION_BLOCK(EVP_sha512, true) \
+    PER_FUNCTION_BLOCK(EXTENDED_KEY_USAGE_free, true) \
+    PER_FUNCTION_BLOCK(GENERAL_NAMES_free, true) \
+    PER_FUNCTION_BLOCK(HMAC_CTX_cleanup, true) \
+    PER_FUNCTION_BLOCK(HMAC_CTX_init, true) \
+    PER_FUNCTION_BLOCK(HMAC_Final, true) \
+    PER_FUNCTION_BLOCK(HMAC_Init_ex, true) \
+    PER_FUNCTION_BLOCK(HMAC_Update, true) \
+    PER_FUNCTION_BLOCK(i2d_ASN1_INTEGER, true) \
+    PER_FUNCTION_BLOCK(i2d_ASN1_TYPE, true) \
+    PER_FUNCTION_BLOCK(i2d_PKCS12, true) \
+    PER_FUNCTION_BLOCK(i2d_PKCS7, true) \
+    PER_FUNCTION_BLOCK(i2d_X509, true) \
+    PER_FUNCTION_BLOCK(i2d_X509_PUBKEY, true) \
+    PER_FUNCTION_BLOCK(OBJ_ln2nid, true) \
+    PER_FUNCTION_BLOCK(OBJ_nid2ln, true) \
+    PER_FUNCTION_BLOCK(OBJ_nid2obj, true) \
+    PER_FUNCTION_BLOCK(OBJ_obj2nid, true) \
+    PER_FUNCTION_BLOCK(OBJ_obj2txt, true) \
+    PER_FUNCTION_BLOCK(OBJ_sn2nid, true) \
+    PER_FUNCTION_BLOCK(OBJ_txt2nid, true) \
+    PER_FUNCTION_BLOCK(OBJ_txt2obj, true) \
+    PER_FUNCTION_BLOCK(OPENSSL_add_all_algorithms_conf, true) \
+    PER_FUNCTION_BLOCK(PEM_read_bio_PKCS7, true) \
+    PER_FUNCTION_BLOCK(PEM_read_bio_X509_AUX, true) \
+    PER_FUNCTION_BLOCK(PEM_read_bio_X509_CRL, true) \
+    PER_FUNCTION_BLOCK(PEM_write_bio_X509_CRL, true) \
+    PER_FUNCTION_BLOCK(PKCS12_create, true) \
+    PER_FUNCTION_BLOCK(PKCS12_free, true) \
+    PER_FUNCTION_BLOCK(PKCS12_parse, true) \
+    PER_FUNCTION_BLOCK(PKCS7_add_certificate, true) \
+    PER_FUNCTION_BLOCK(PKCS7_content_new, true) \
+    PER_FUNCTION_BLOCK(PKCS7_free, true) \
+    PER_FUNCTION_BLOCK(PKCS7_new, true) \
+    PER_FUNCTION_BLOCK(PKCS7_set_type, true) \
+    PER_FUNCTION_BLOCK(RAND_bytes, true) \
+    PER_FUNCTION_BLOCK(RAND_poll, true) \
+    PER_FUNCTION_BLOCK(RSA_free, true) \
+    PER_FUNCTION_BLOCK(RSA_generate_key_ex, true) \
+    PER_FUNCTION_BLOCK(RSA_new, true) \
+    PER_FUNCTION_BLOCK(RSA_private_decrypt, true) \
+    PER_FUNCTION_BLOCK(RSA_public_encrypt, true) \
+    PER_FUNCTION_BLOCK(RSA_sign, true) \
+    PER_FUNCTION_BLOCK(RSA_size, true) \
+    PER_FUNCTION_BLOCK(RSA_up_ref, true) \
+    PER_FUNCTION_BLOCK(RSA_verify, true) \
+    PER_FUNCTION_BLOCK(sk_free, true) \
+    PER_FUNCTION_BLOCK(sk_new_null, true) \
+    PER_FUNCTION_BLOCK(sk_num, true) \
+    PER_FUNCTION_BLOCK(sk_pop_free, true) \
+    PER_FUNCTION_BLOCK(sk_push, true) \
+    PER_FUNCTION_BLOCK(sk_value, true) \
+    PER_FUNCTION_BLOCK(SSL_CIPHER_description, true) \
+    PER_FUNCTION_BLOCK(SSL_ctrl, true) \
+    PER_FUNCTION_BLOCK(SSL_CTX_check_private_key, true) \
+    PER_FUNCTION_BLOCK(SSL_CTX_ctrl, true) \
+    PER_FUNCTION_BLOCK(SSL_CTX_free, true) \
+    PER_FUNCTION_BLOCK(SSL_CTX_new, true) \
+    PER_FUNCTION_BLOCK(SSL_CTX_set_cert_verify_callback, true) \
+    PER_FUNCTION_BLOCK(SSL_CTX_set_cipher_list, true) \
+    PER_FUNCTION_BLOCK(SSL_CTX_set_client_CA_list, true) \
+    PER_FUNCTION_BLOCK(SSL_CTX_set_client_cert_cb, true) \
+    PER_FUNCTION_BLOCK(SSL_CTX_set_quiet_shutdown, true) \
+    PER_FUNCTION_BLOCK(SSL_CTX_set_verify, true) \
+    PER_FUNCTION_BLOCK(SSL_CTX_use_certificate, true) \
+    PER_FUNCTION_BLOCK(SSL_CTX_use_PrivateKey, true) \
+    PER_FUNCTION_BLOCK(SSL_do_handshake, true) \
+    PER_FUNCTION_BLOCK(SSL_free, true) \
+    PER_FUNCTION_BLOCK(SSL_get_client_CA_list, true) \
+    PER_FUNCTION_BLOCK(SSL_get_current_cipher, true) \
+    PER_FUNCTION_BLOCK(SSL_get_error, true) \
+    PER_FUNCTION_BLOCK(SSL_get_finished, true) \
+    PER_FUNCTION_BLOCK(SSL_get_peer_cert_chain, true) \
+    PER_FUNCTION_BLOCK(SSL_get_peer_certificate, true) \
+    PER_FUNCTION_BLOCK(SSL_get_peer_finished, true) \
+    PER_FUNCTION_BLOCK(SSL_get_SSL_CTX, true) \
+    PER_FUNCTION_BLOCK(SSL_get_version, true) \
+    PER_FUNCTION_BLOCK(SSL_library_init, true) \
+    PER_FUNCTION_BLOCK(SSL_load_error_strings, true) \
+    PER_FUNCTION_BLOCK(SSL_new, true) \
+    PER_FUNCTION_BLOCK(SSL_read, true) \
+    PER_FUNCTION_BLOCK(SSL_renegotiate_pending, true) \
+    PER_FUNCTION_BLOCK(SSL_set_accept_state, true) \
+    PER_FUNCTION_BLOCK(SSL_set_bio, true) \
+    PER_FUNCTION_BLOCK(SSL_set_connect_state, true) \
+    PER_FUNCTION_BLOCK(SSL_shutdown, true) \
+    PER_FUNCTION_BLOCK(SSL_state, true) \
+    PER_FUNCTION_BLOCK(SSLv23_method, true) \
+    PER_FUNCTION_BLOCK(SSLv3_method, true) \
+    PER_FUNCTION_BLOCK(SSL_write, true) \
+    PER_FUNCTION_BLOCK(TLSv1_1_method, true) \
+    PER_FUNCTION_BLOCK(TLSv1_2_method, true) \
+    PER_FUNCTION_BLOCK(TLSv1_method, true) \
+    PER_FUNCTION_BLOCK(X509_check_issued, true) \
+    PER_FUNCTION_BLOCK(X509_check_purpose, true) \
+    PER_FUNCTION_BLOCK(X509_CRL_free, true) \
+    PER_FUNCTION_BLOCK(X509_digest, true) \
+    PER_FUNCTION_BLOCK(X509_dup, true) \
+    PER_FUNCTION_BLOCK(X509_EXTENSION_create_by_OBJ, true) \
+    PER_FUNCTION_BLOCK(X509_EXTENSION_free, true) \
+    PER_FUNCTION_BLOCK(X509_EXTENSION_get_critical, true) \
+    PER_FUNCTION_BLOCK(X509_EXTENSION_get_data, true) \
+    PER_FUNCTION_BLOCK(X509_EXTENSION_get_object, true) \
+    PER_FUNCTION_BLOCK(X509_free, true) \
+    PER_FUNCTION_BLOCK(X509_get_default_cert_dir, true) \
+    PER_FUNCTION_BLOCK(X509_get_default_cert_dir_env, true) \
+    PER_FUNCTION_BLOCK(X509_get_default_cert_file, true) \
+    PER_FUNCTION_BLOCK(X509_get_default_cert_file_env, true) \
+    PER_FUNCTION_BLOCK(X509_get_ext, true) \
+    PER_FUNCTION_BLOCK(X509_get_ext_count, true) \
+    PER_FUNCTION_BLOCK(X509_get_ext_d2i, true) \
+    PER_FUNCTION_BLOCK(X509_get_issuer_name, true) \
+    PER_FUNCTION_BLOCK(X509_get_serialNumber, true) \
+    PER_FUNCTION_BLOCK(X509_get_subject_name, true) \
+    PER_FUNCTION_BLOCK(X509_issuer_name_hash, true) \
+    PER_FUNCTION_BLOCK(X509_NAME_dup, true) \
+    PER_FUNCTION_BLOCK(X509_NAME_entry_count, true) \
+    PER_FUNCTION_BLOCK(X509_NAME_ENTRY_get_data, true) \
+    PER_FUNCTION_BLOCK(X509_NAME_ENTRY_get_object, true) \
+    PER_FUNCTION_BLOCK(X509_NAME_free, true) \
+    PER_FUNCTION_BLOCK(X509_NAME_get_entry, true) \
+    PER_FUNCTION_BLOCK(X509_NAME_get_index_by_NID, true) \
+    PER_FUNCTION_BLOCK(X509_PUBKEY_get, true) \
+    PER_FUNCTION_BLOCK(X509_STORE_add_cert, true) \
+    PER_FUNCTION_BLOCK(X509_STORE_add_crl, true) \
+    PER_FUNCTION_BLOCK(X509_STORE_CTX_free, true) \
+    PER_FUNCTION_BLOCK(X509_STORE_CTX_get0_param, true) \
+    PER_FUNCTION_BLOCK(X509_STORE_CTX_get1_chain, true) \
+    PER_FUNCTION_BLOCK(X509_STORE_CTX_get_error, true) \
+    PER_FUNCTION_BLOCK(X509_STORE_CTX_get_error_depth, true) \
+    PER_FUNCTION_BLOCK(X509_STORE_CTX_init, true) \
+    PER_FUNCTION_BLOCK(X509_STORE_CTX_new, true) \
+    PER_FUNCTION_BLOCK(X509_STORE_CTX_set_verify_cb, true) \
+    PER_FUNCTION_BLOCK(X509_STORE_free, true) \
+    PER_FUNCTION_BLOCK(X509_STORE_new, true) \
+    PER_FUNCTION_BLOCK(X509_STORE_set_flags, true) \
+    PER_FUNCTION_BLOCK(X509V3_EXT_print, true) \
+    PER_FUNCTION_BLOCK(X509_verify_cert, true) \
+    PER_FUNCTION_BLOCK(X509_verify_cert_error_string, true) \
+    PER_FUNCTION_BLOCK(X509_VERIFY_PARAM_set_time, true) \
+
+// Declare pointers to all the used OpenSSL functions
+#define PER_FUNCTION_BLOCK(fn, isRequired) extern decltype(fn)* fn##_ptr;
+FOR_ALL_OPENSSL_FUNCTIONS
+#undef PER_FUNCTION_BLOCK
+
+// Redefine all calls to OpenSSL functions as calls through pointers that are set
+// to the functions from the libssl.so selected by the shim.
+#define ASN1_BIT_STRING_free ASN1_BIT_STRING_free_ptr
+#define ASN1_INTEGER_get ASN1_INTEGER_get_ptr
+#define ASN1_OBJECT_free ASN1_OBJECT_free_ptr
+#define ASN1_OCTET_STRING_free ASN1_OCTET_STRING_free_ptr
+#define ASN1_OCTET_STRING_new ASN1_OCTET_STRING_new_ptr
+#define ASN1_OCTET_STRING_set ASN1_OCTET_STRING_set_ptr
+#define ASN1_STRING_free ASN1_STRING_free_ptr
+#define ASN1_STRING_print_ex ASN1_STRING_print_ex_ptr
+#define BASIC_CONSTRAINTS_free BASIC_CONSTRAINTS_free_ptr
+#define BIO_ctrl BIO_ctrl_ptr
+#define BIO_ctrl_pending BIO_ctrl_pending_ptr
+#define BIO_free BIO_free_ptr
+#define BIO_gets BIO_gets_ptr
+#define BIO_new BIO_new_ptr
+#define BIO_new_file BIO_new_file_ptr
+#define BIO_read BIO_read_ptr
+#define BIO_s_mem BIO_s_mem_ptr
+#define BIO_write BIO_write_ptr
+#define BN_bin2bn BN_bin2bn_ptr
+#define BN_bn2bin BN_bn2bin_ptr
+#define BN_clear_free BN_clear_free_ptr
+#define BN_free BN_free_ptr
+#define BN_new BN_new_ptr
+#define BN_num_bits BN_num_bits_ptr
+#define CRYPTO_add_lock CRYPTO_add_lock_ptr
+#define CRYPTO_num_locks CRYPTO_num_locks_ptr
+#define CRYPTO_set_locking_callback CRYPTO_set_locking_callback_ptr
+#define d2i_ASN1_BIT_STRING d2i_ASN1_BIT_STRING_ptr
+#define d2i_ASN1_OCTET_STRING d2i_ASN1_OCTET_STRING_ptr
+#define d2i_ASN1_type_bytes d2i_ASN1_type_bytes_ptr
+#define d2i_BASIC_CONSTRAINTS d2i_BASIC_CONSTRAINTS_ptr
+#define d2i_EXTENDED_KEY_USAGE d2i_EXTENDED_KEY_USAGE_ptr
+#define d2i_PKCS12 d2i_PKCS12_ptr
+#define d2i_PKCS12_bio d2i_PKCS12_bio_ptr
+#define d2i_PKCS7 d2i_PKCS7_ptr
+#define d2i_PKCS7_bio d2i_PKCS7_bio_ptr
+#define d2i_RSAPublicKey d2i_RSAPublicKey_ptr
+#define d2i_X509 d2i_X509_ptr
+#define d2i_X509_bio d2i_X509_bio_ptr
+#define d2i_X509_CRL d2i_X509_CRL_ptr
+#define d2i_X509_NAME d2i_X509_NAME_ptr
+#define DSA_free DSA_free_ptr
+#define DSA_generate_key DSA_generate_key_ptr
+#define DSA_generate_parameters_ex DSA_generate_parameters_ex_ptr
+#define DSA_new DSA_new_ptr
+#define DSA_sign DSA_sign_ptr
+#define DSA_size DSA_size_ptr
+#define DSA_up_ref DSA_up_ref_ptr
+#define DSA_verify DSA_verify_ptr
+#define ECDSA_sign ECDSA_sign_ptr
+#define ECDSA_size ECDSA_size_ptr
+#define ECDSA_verify ECDSA_verify_ptr
+#define EC_GF2m_simple_method EC_GF2m_simple_method_ptr
+#define EC_GFp_mont_method EC_GFp_mont_method_ptr
+#define EC_GFp_simple_method EC_GFp_simple_method_ptr
+#define EC_GROUP_check EC_GROUP_check_ptr
+#define EC_GROUP_free EC_GROUP_free_ptr
+#define EC_GROUP_get0_generator EC_GROUP_get0_generator_ptr
+#define EC_GROUP_get0_seed EC_GROUP_get0_seed_ptr
+#define EC_GROUP_get_cofactor EC_GROUP_get_cofactor_ptr
+#define EC_GROUP_get_curve_GF2m EC_GROUP_get_curve_GF2m_ptr
+#define EC_GROUP_get_curve_GFp EC_GROUP_get_curve_GFp_ptr
+#define EC_GROUP_get_curve_name EC_GROUP_get_curve_name_ptr
+#define EC_GROUP_get_degree EC_GROUP_get_degree_ptr
+#define EC_GROUP_get_order EC_GROUP_get_order_ptr
+#define EC_GROUP_get_seed_len EC_GROUP_get_seed_len_ptr
+#define EC_GROUP_method_of EC_GROUP_method_of_ptr
+#define EC_GROUP_new EC_GROUP_new_ptr
+#define EC_GROUP_set_curve_GF2m EC_GROUP_set_curve_GF2m_ptr
+#define EC_GROUP_set_curve_GFp EC_GROUP_set_curve_GFp_ptr
+#define EC_GROUP_set_generator EC_GROUP_set_generator_ptr
+#define EC_GROUP_set_seed EC_GROUP_set_seed_ptr
+#define EC_KEY_check_key EC_KEY_check_key_ptr
+#define EC_KEY_free EC_KEY_free_ptr
+#define EC_KEY_generate_key EC_KEY_generate_key_ptr
+#define EC_KEY_get0_group EC_KEY_get0_group_ptr
+#define EC_KEY_get0_private_key EC_KEY_get0_private_key_ptr
+#define EC_KEY_get0_public_key EC_KEY_get0_public_key_ptr
+#define EC_KEY_new EC_KEY_new_ptr
+#define EC_KEY_new_by_curve_name EC_KEY_new_by_curve_name_ptr
+#define EC_KEY_set_group EC_KEY_set_group_ptr
+#define EC_KEY_set_private_key EC_KEY_set_private_key_ptr
+#define EC_KEY_set_public_key_affine_coordinates EC_KEY_set_public_key_affine_coordinates_ptr
+#define EC_KEY_up_ref EC_KEY_up_ref_ptr
+#define EC_METHOD_get_field_type EC_METHOD_get_field_type_ptr
+#define EC_POINT_free EC_POINT_free_ptr
+#define EC_POINT_get_affine_coordinates_GF2m EC_POINT_get_affine_coordinates_GF2m_ptr
+#define EC_POINT_get_affine_coordinates_GFp EC_POINT_get_affine_coordinates_GFp_ptr
+#define EC_POINT_new EC_POINT_new_ptr
+#define EC_POINT_set_affine_coordinates_GF2m EC_POINT_set_affine_coordinates_GF2m_ptr
+#define EC_POINT_set_affine_coordinates_GFp EC_POINT_set_affine_coordinates_GFp_ptr
+#define ERR_clear_error ERR_clear_error_ptr
+#define ERR_error_string_n ERR_error_string_n_ptr
+#define ERR_get_error ERR_get_error_ptr
+#define ERR_load_crypto_strings ERR_load_crypto_strings_ptr
+#define ERR_peek_error ERR_peek_error_ptr
+#define ERR_peek_last_error ERR_peek_last_error_ptr
+#define ERR_reason_error_string ERR_reason_error_string_ptr
+#define EVP_aes_128_cbc EVP_aes_128_cbc_ptr
+#define EVP_aes_128_ecb EVP_aes_128_ecb_ptr
+#define EVP_aes_192_cbc EVP_aes_192_cbc_ptr
+#define EVP_aes_192_ecb EVP_aes_192_ecb_ptr
+#define EVP_aes_256_cbc EVP_aes_256_cbc_ptr
+#define EVP_aes_256_ecb EVP_aes_256_ecb_ptr
+#define EVP_CIPHER_CTX_cleanup EVP_CIPHER_CTX_cleanup_ptr
+#define EVP_CIPHER_CTX_ctrl EVP_CIPHER_CTX_ctrl_ptr
+#define EVP_CIPHER_CTX_init EVP_CIPHER_CTX_init_ptr
+#define EVP_CIPHER_CTX_set_key_length EVP_CIPHER_CTX_set_key_length_ptr
+#define EVP_CIPHER_CTX_set_padding EVP_CIPHER_CTX_set_padding_ptr
+#define EVP_CipherFinal_ex EVP_CipherFinal_ex_ptr
+#define EVP_CipherInit_ex EVP_CipherInit_ex_ptr
+#define EVP_CipherUpdate EVP_CipherUpdate_ptr
+#define EVP_des_cbc EVP_des_cbc_ptr
+#define EVP_des_ecb EVP_des_ecb_ptr
+#define EVP_des_ede3 EVP_des_ede3_ptr
+#define EVP_des_ede3_cbc EVP_des_ede3_cbc_ptr
+#define EVP_DigestFinal_ex EVP_DigestFinal_ex_ptr
+#define EVP_DigestInit_ex EVP_DigestInit_ex_ptr
+#define EVP_DigestUpdate EVP_DigestUpdate_ptr
+#define EVP_md5 EVP_md5_ptr
+#define EVP_MD_CTX_create EVP_MD_CTX_create_ptr
+#define EVP_MD_CTX_destroy EVP_MD_CTX_destroy_ptr
+#define EVP_MD_size EVP_MD_size_ptr
+#define EVP_PKEY_free EVP_PKEY_free_ptr
+#define EVP_PKEY_get1_DSA EVP_PKEY_get1_DSA_ptr
+#define EVP_PKEY_get1_EC_KEY EVP_PKEY_get1_EC_KEY_ptr
+#define EVP_PKEY_get1_RSA EVP_PKEY_get1_RSA_ptr
+#define EVP_PKEY_new EVP_PKEY_new_ptr
+#define EVP_PKEY_set1_DSA EVP_PKEY_set1_DSA_ptr
+#define EVP_PKEY_set1_EC_KEY EVP_PKEY_set1_EC_KEY_ptr
+#define EVP_PKEY_set1_RSA EVP_PKEY_set1_RSA_ptr
+#define EVP_rc2_cbc EVP_rc2_cbc_ptr
+#define EVP_rc2_ecb EVP_rc2_ecb_ptr
+#define EVP_sha1 EVP_sha1_ptr
+#define EVP_sha256 EVP_sha256_ptr
+#define EVP_sha384 EVP_sha384_ptr
+#define EVP_sha512 EVP_sha512_ptr
+#define EXTENDED_KEY_USAGE_free EXTENDED_KEY_USAGE_free_ptr
+#define GENERAL_NAMES_free GENERAL_NAMES_free_ptr
+#define HMAC_CTX_cleanup HMAC_CTX_cleanup_ptr
+#define HMAC_CTX_init HMAC_CTX_init_ptr
+#define HMAC_Final HMAC_Final_ptr
+#define HMAC_Init_ex HMAC_Init_ex_ptr
+#define HMAC_Update HMAC_Update_ptr
+#define i2d_ASN1_INTEGER i2d_ASN1_INTEGER_ptr
+#define i2d_ASN1_TYPE i2d_ASN1_TYPE_ptr
+#define i2d_PKCS12 i2d_PKCS12_ptr
+#define i2d_PKCS7 i2d_PKCS7_ptr
+#define i2d_X509 i2d_X509_ptr
+#define i2d_X509_PUBKEY i2d_X509_PUBKEY_ptr
+#define OBJ_ln2nid OBJ_ln2nid_ptr
+#define OBJ_nid2ln OBJ_nid2ln_ptr
+#define OBJ_nid2obj OBJ_nid2obj_ptr
+#define OBJ_obj2nid OBJ_obj2nid_ptr
+#define OBJ_obj2txt OBJ_obj2txt_ptr
+#define OBJ_sn2nid OBJ_sn2nid_ptr
+#define OBJ_txt2nid OBJ_txt2nid_ptr
+#define OBJ_txt2obj OBJ_txt2obj_ptr
+#define OPENSSL_add_all_algorithms_conf OPENSSL_add_all_algorithms_conf_ptr
+#define PEM_read_bio_PKCS7 PEM_read_bio_PKCS7_ptr
+#define PEM_read_bio_X509_AUX PEM_read_bio_X509_AUX_ptr
+#define PEM_read_bio_X509_CRL PEM_read_bio_X509_CRL_ptr
+#define PEM_write_bio_X509_CRL PEM_write_bio_X509_CRL_ptr
+#define PKCS12_create PKCS12_create_ptr
+#define PKCS12_free PKCS12_free_ptr
+#define PKCS12_parse PKCS12_parse_ptr
+#define PKCS7_add_certificate PKCS7_add_certificate_ptr
+#define PKCS7_content_new PKCS7_content_new_ptr
+#define PKCS7_free PKCS7_free_ptr
+#define PKCS7_new PKCS7_new_ptr
+#define PKCS7_set_type PKCS7_set_type_ptr
+#define RAND_bytes RAND_bytes_ptr
+#define RAND_poll RAND_poll_ptr
+#define RSA_free RSA_free_ptr
+#define RSA_generate_key_ex RSA_generate_key_ex_ptr
+#define RSA_new RSA_new_ptr
+#define RSA_private_decrypt RSA_private_decrypt_ptr
+#define RSA_public_encrypt RSA_public_encrypt_ptr
+#define RSA_sign RSA_sign_ptr
+#define RSA_size RSA_size_ptr
+#define RSA_up_ref RSA_up_ref_ptr
+#define RSA_verify RSA_verify_ptr
+#define sk_free sk_free_ptr
+#define sk_new_null sk_new_null_ptr
+#define sk_num sk_num_ptr
+#define sk_pop_free sk_pop_free_ptr
+#define sk_push sk_push_ptr
+#define sk_value sk_value_ptr
+#define SSL_CIPHER_description SSL_CIPHER_description_ptr
+#define SSL_ctrl SSL_ctrl_ptr
+#define SSL_CTX_check_private_key SSL_CTX_check_private_key_ptr
+#define SSL_CTX_ctrl SSL_CTX_ctrl_ptr
+#define SSL_CTX_free SSL_CTX_free_ptr
+#define SSL_CTX_new SSL_CTX_new_ptr
+#define SSL_CTX_set_cert_verify_callback SSL_CTX_set_cert_verify_callback_ptr
+#define SSL_CTX_set_cipher_list SSL_CTX_set_cipher_list_ptr
+#define SSL_CTX_set_client_CA_list SSL_CTX_set_client_CA_list_ptr
+#define SSL_CTX_set_client_cert_cb SSL_CTX_set_client_cert_cb_ptr
+#define SSL_CTX_set_quiet_shutdown SSL_CTX_set_quiet_shutdown_ptr
+#define SSL_CTX_set_verify SSL_CTX_set_verify_ptr
+#define SSL_CTX_use_certificate SSL_CTX_use_certificate_ptr
+#define SSL_CTX_use_PrivateKey SSL_CTX_use_PrivateKey_ptr
+#define SSL_do_handshake SSL_do_handshake_ptr
+#define SSL_free SSL_free_ptr
+#define SSL_get_client_CA_list SSL_get_client_CA_list_ptr
+#define SSL_get_current_cipher SSL_get_current_cipher_ptr
+#define SSL_get_error SSL_get_error_ptr
+#define SSL_get_finished SSL_get_finished_ptr
+#define SSL_get_peer_cert_chain SSL_get_peer_cert_chain_ptr
+#define SSL_get_peer_certificate SSL_get_peer_certificate_ptr
+#define SSL_get_peer_finished SSL_get_peer_finished_ptr
+#define SSL_get_SSL_CTX SSL_get_SSL_CTX_ptr
+#define SSL_get_version SSL_get_version_ptr
+#define SSL_library_init SSL_library_init_ptr
+#define SSL_load_error_strings SSL_load_error_strings_ptr
+#define SSL_new SSL_new_ptr
+#define SSL_read SSL_read_ptr
+#define SSL_renegotiate_pending SSL_renegotiate_pending_ptr
+#define SSL_set_accept_state SSL_set_accept_state_ptr
+#define SSL_set_bio SSL_set_bio_ptr
+#define SSL_set_connect_state SSL_set_connect_state_ptr
+#define SSL_shutdown SSL_shutdown_ptr
+#define SSL_state SSL_state_ptr
+#define SSLv23_method SSLv23_method_ptr
+#define SSLv3_method SSLv3_method_ptr
+#define SSL_write SSL_write_ptr
+#define TLSv1_1_method TLSv1_1_method_ptr
+#define TLSv1_2_method TLSv1_2_method_ptr
+#define TLSv1_method TLSv1_method_ptr
+#define X509_check_issued X509_check_issued_ptr
+#define X509_check_purpose X509_check_purpose_ptr
+#define X509_CRL_free X509_CRL_free_ptr
+#define X509_digest X509_digest_ptr
+#define X509_dup X509_dup_ptr
+#define X509_EXTENSION_create_by_OBJ X509_EXTENSION_create_by_OBJ_ptr
+#define X509_EXTENSION_free X509_EXTENSION_free_ptr
+#define X509_EXTENSION_get_critical X509_EXTENSION_get_critical_ptr
+#define X509_EXTENSION_get_data X509_EXTENSION_get_data_ptr
+#define X509_EXTENSION_get_object X509_EXTENSION_get_object_ptr
+#define X509_free X509_free_ptr
+#define X509_free X509_free_ptr
+#define X509_get_default_cert_dir X509_get_default_cert_dir_ptr
+#define X509_get_default_cert_dir_env X509_get_default_cert_dir_env_ptr
+#define X509_get_default_cert_file X509_get_default_cert_file_ptr
+#define X509_get_default_cert_file_env X509_get_default_cert_file_env_ptr
+#define X509_get_ext X509_get_ext_ptr
+#define X509_get_ext_count X509_get_ext_count_ptr
+#define X509_get_ext_d2i X509_get_ext_d2i_ptr
+#define X509_get_issuer_name X509_get_issuer_name_ptr
+#define X509_get_serialNumber X509_get_serialNumber_ptr
+#define X509_get_subject_name X509_get_subject_name_ptr
+#define X509_issuer_name_hash X509_issuer_name_hash_ptr
+#define X509_NAME_dup X509_NAME_dup_ptr
+#define X509_NAME_entry_count X509_NAME_entry_count_ptr
+#define X509_NAME_ENTRY_get_data X509_NAME_ENTRY_get_data_ptr
+#define X509_NAME_ENTRY_get_object X509_NAME_ENTRY_get_object_ptr
+#define X509_NAME_free X509_NAME_free_ptr
+#define X509_NAME_free X509_NAME_free_ptr
+#define X509_NAME_get_entry X509_NAME_get_entry_ptr
+#define X509_NAME_get_index_by_NID X509_NAME_get_index_by_NID_ptr
+#define X509_PUBKEY_get X509_PUBKEY_get_ptr
+#define X509_STORE_add_cert X509_STORE_add_cert_ptr
+#define X509_STORE_add_crl X509_STORE_add_crl_ptr
+#define X509_STORE_CTX_free X509_STORE_CTX_free_ptr
+#define X509_STORE_CTX_get0_param X509_STORE_CTX_get0_param_ptr
+#define X509_STORE_CTX_get1_chain X509_STORE_CTX_get1_chain_ptr
+#define X509_STORE_CTX_get_error X509_STORE_CTX_get_error_ptr
+#define X509_STORE_CTX_get_error_depth X509_STORE_CTX_get_error_depth_ptr
+#define X509_STORE_CTX_init X509_STORE_CTX_init_ptr
+#define X509_STORE_CTX_new X509_STORE_CTX_new_ptr
+#define X509_STORE_CTX_set_verify_cb X509_STORE_CTX_set_verify_cb_ptr
+#define X509_STORE_free X509_STORE_free_ptr
+#define X509_STORE_new X509_STORE_new_ptr
+#define X509_STORE_set_flags X509_STORE_set_flags_ptr
+#define X509V3_EXT_print X509V3_EXT_print_ptr
+#define X509_verify_cert X509_verify_cert_ptr
+#define X509_verify_cert_error_string X509_verify_cert_error_string_ptr
+#define X509_VERIFY_PARAM_set_time X509_VERIFY_PARAM_set_time_ptr
+
+#else // FEATURE_DISTRO_AGNOSTIC_SSL
+
+#define API_EXISTS(fn) true
+
+#endif // FEATURE_DISTRO_AGNOSTIC_SSL
+
+#endif // __OPENSSLSHIM_H__

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.cpp
@@ -4,8 +4,6 @@
 
 #include "pal_asn1.h"
 
-#include <openssl/objects.h>
-
 static_assert(PAL_NID_undef == NID_undef, "");
 static_assert(PAL_NID_X9_62_prime256v1 == NID_X9_62_prime256v1, "");
 static_assert(PAL_NID_secp224r1 == NID_secp224r1, "");

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.h
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_types.h"
-
-#include <openssl/asn1.h>
+#include "opensslshim.h"
 
 /*
 NID values that are used in managed code.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1_print.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1_print.h
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_types.h"
-
-#include <openssl/asn1.h>
+#include "opensslshim.h"
 
 /*
 Flags for the 'type' parameter of CryptoNative_DecodeAsn1TypeBytes.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_bignum.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_bignum.h
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_types.h"
-
-#include <openssl/bn.h>
+#include "opensslshim.h"
 
 /*
 Cleans up and deletes an BIGNUM instance.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_bio.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_bio.h
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_types.h"
-
-#include <openssl/bio.h>
+#include "opensslshim.h"
 
 /*
 Creates a new memory-backed BIO instance.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_crypto_types.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_crypto_types.h
@@ -4,8 +4,7 @@
 
 #pragma once
 #include "pal_types.h"
-
-#include <openssl/x509.h>
+#include "opensslshim.h"
 
 typedef STACK_OF(X509) X509Stack;
 typedef STACK_OF(X509_NAME) X509NameStack;

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_dsa.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_dsa.cpp
@@ -4,7 +4,6 @@
 
 #include "pal_dsa.h"
 #include "pal_utilities.h"
-#include <openssl/err.h>
 
 extern "C" int32_t CryptoNative_DsaUpRef(DSA* dsa)
 {

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_dsa.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_dsa.h
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_types.h"
-
-#include <openssl/dsa.h>
+#include "opensslshim.h"
 
 /*
 Shims the DSA_new method.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.cpp
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#include "pal_crypto_config.h"
 #include "pal_ecc_import_export.h"
 #include "pal_utilities.h"
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.cpp
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#include <openssl/ec.h>
-#include <openssl/objects.h>
 #include "pal_crypto_config.h"
 #include "pal_ecc_import_export.h"
 #include "pal_utilities.h"
@@ -33,7 +31,7 @@ const EC_METHOD* CurveTypeToMethod(ECCurveType curveType)
         return EC_GFp_mont_method();
 
 #if HAVE_OPENSSL_EC2M
-    if (curveType == ECCurveType::Characteristic2)
+    if (API_EXISTS(EC_GF2m_simple_method) && (curveType == ECCurveType::Characteristic2))
         return EC_GF2m_simple_method();
 #endif
 
@@ -93,7 +91,7 @@ extern "C" int32_t CryptoNative_GetECKeyParameters(
         goto error;
 
 #if HAVE_OPENSSL_EC2M
-    if (curveType == ECCurveType::Characteristic2)
+    if (API_EXISTS(EC_POINT_get_affine_coordinates_GF2m) && (curveType == ECCurveType::Characteristic2))
     {
         if (!EC_POINT_get_affine_coordinates_GF2m(group, Q, xBn, yBn, nullptr)) 
             goto error;
@@ -221,7 +219,7 @@ extern "C" int32_t CryptoNative_GetECCurveParameters(
 
     // Extract p, a, b
 #if HAVE_OPENSSL_EC2M
-    if (*curveType == ECCurveType::Characteristic2)
+    if (API_EXISTS(EC_GROUP_get_curve_GF2m) && (*curveType == ECCurveType::Characteristic2))
     {
         // pBn represents the binary polynomial
         if (!EC_GROUP_get_curve_GF2m(group, pBn, aBn, bBn, nullptr)) 
@@ -238,7 +236,7 @@ extern "C" int32_t CryptoNative_GetECCurveParameters(
     // Extract gx and gy
     G = const_cast<EC_POINT*>(EC_GROUP_get0_generator(group));
 #if HAVE_OPENSSL_EC2M
-    if (*curveType == ECCurveType::Characteristic2)
+    if (API_EXISTS(EC_POINT_get_affine_coordinates_GF2m) && (*curveType == ECCurveType::Characteristic2))
     {
         if (!EC_POINT_get_affine_coordinates_GF2m(group, G, xBn, yBn, NULL)) 
             goto error;
@@ -431,7 +429,7 @@ extern "C" EC_KEY* CryptoNative_EcKeyCreateByExplicitParameters(
     bBn = BN_bin2bn(b, bLength, nullptr);
 
 #if HAVE_OPENSSL_EC2M
-    if (curveType == ECCurveType::Characteristic2)
+    if (API_EXISTS(EC_GROUP_set_curve_GF2m) && (curveType == ECCurveType::Characteristic2))
     {
         if (!EC_GROUP_set_curve_GF2m(group, pBn, aBn, bBn, nullptr)) 
             goto error;
@@ -449,7 +447,7 @@ extern "C" EC_KEY* CryptoNative_EcKeyCreateByExplicitParameters(
     gyBn = BN_bin2bn(gy, gyLength, nullptr);
 
 #if HAVE_OPENSSL_EC2M
-    if (curveType == ECCurveType::Characteristic2)
+    if (API_EXISTS(EC_POINT_set_affine_coordinates_GF2m) && (curveType == ECCurveType::Characteristic2))
     {
         EC_POINT_set_affine_coordinates_GF2m(group, G, gxBn, gyBn, nullptr);
     }

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.h
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_types.h"
-
-#include <openssl/ecdsa.h>
-#include <openssl/ec.h>
+#include "opensslshim.h"
 
 typedef enum : int32_t {
     Unspecified = 0,

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ecdsa.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ecdsa.h
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_types.h"
-
-#include <openssl/ecdsa.h>
+#include "opensslshim.h"
 
 /*
 Shims the ECDSA_sign method.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_eckey.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_eckey.cpp
@@ -5,7 +5,6 @@
 #include "pal_eckey.h"
 
 #include <assert.h>
-#include <openssl/objects.h>
 
 extern "C" void CryptoNative_EcKeyDestroy(EC_KEY* r)
 {

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_eckey.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_eckey.h
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_types.h"
-
-#include <openssl/ec.h>
+#include "opensslshim.h"
 
 /*
 Cleans up and deletes an EC_KEY instance.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_err.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_err.cpp
@@ -5,8 +5,6 @@
 #include "pal_err.h"
 #include "pal_utilities.h"
 
-#include <openssl/err.h>
-
 extern "C" uint64_t CryptoNative_ErrGetError()
 {
     return ERR_get_error();

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_err.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_err.h
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include <stdint.h>
+#include "opensslshim.h"
 
 /*
 Shims the ERR_get_error method.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp.h
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include <stdint.h>
-#include <openssl/evp.h>
+#include "opensslshim.h"
 
 /*
 Creates and initializes an EVP_MD_CTX with the given args.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.h
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_types.h"
-#include <openssl/evp.h>
+#include "opensslshim.h"
 
 /*
 Creates and initializes an EVP_CIPHER_CTX with the given args.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_pkey.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_pkey.h
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_types.h"
-
-#include <openssl/evp.h>
+#include "opensslshim.h"
 
 /*
 Shims the EVP_PKEY_new method.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_pkey_dsa.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_pkey_dsa.h
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_types.h"
-
-#include <openssl/evp.h>
+#include "opensslshim.h"
 
 /*
 Shims the EVP_PKEY_get1_DSA method.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_pkey_eckey.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_pkey_eckey.h
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_types.h"
-
-#include <openssl/ec.h>
-#include <openssl/evp.h>
+#include "opensslshim.h"
 
 /*
 Shims the EVP_PKEY_get1_EC_KEY method.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_pkey_rsa.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_pkey_rsa.h
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_types.h"
-
-#include <openssl/evp.h>
+#include "opensslshim.h"
 
 /*
 Shims the EVP_PKEY_get1_RSA method.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_hmac.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_hmac.cpp
@@ -8,7 +8,6 @@
 
 #include <assert.h>
 #include <memory>
-#include <openssl/hmac.h>
 
 extern "C" HMAC_CTX* CryptoNative_HmacCreate(const uint8_t* key, int32_t keyLen, const EVP_MD* md)
 {

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_hmac.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_hmac.h
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_types.h"
+#include "opensslshim.h"
 
 // The shim API here is slightly less than 1:1 with underlying API so that:
 //   * P/Invokes are less chatty

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs12.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs12.cpp
@@ -4,8 +4,6 @@
 
 #include "pal_pkcs12.h"
 
-#include <openssl/err.h>
-
 extern "C" PKCS12* CryptoNative_DecodePkcs12(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs12.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs12.h
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_crypto_types.h"
-
-#include <openssl/pkcs12.h>
+#include "opensslshim.h"
 
 /*
 Shims the d2i_PKCS12 method and makes it easier to invoke from managed code.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs7.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs7.cpp
@@ -4,8 +4,6 @@
 
 #include "pal_pkcs7.h"
 
-#include <openssl/pem.h>
-
 extern "C" PKCS7* CryptoNative_PemReadBioPkcs7(BIO* bp)
 {
     return PEM_read_bio_PKCS7(bp, nullptr, nullptr, nullptr);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs7.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_pkcs7.h
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_crypto_types.h"
-
-#include <openssl/pkcs7.h>
+#include "opensslshim.h"
 
 /*
 Reads a PKCS7 instance in PEM format from a BIO.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_rsa.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_rsa.h
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_types.h"
-
-#include <openssl/rsa.h>
+#include "opensslshim.h"
 
 /*
 Padding options for RsaPublicEncrypt and RsaPrivateDecrypt.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_ssl.h"
-#include "pal_crypto_config.h"
 
 #include <assert.h>
 #include <string.h>

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -7,7 +7,6 @@
 
 #include <assert.h>
 #include <string.h>
-#include <openssl/err.h>
 
 static_assert(PAL_SSL_ERROR_NONE == SSL_ERROR_NONE, "");
 static_assert(PAL_SSL_ERROR_SSL == SSL_ERROR_SSL, "");

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
@@ -3,10 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_crypto_types.h"
-
-#include <openssl/ssl.h>
-#include <openssl/md5.h>
-#include <openssl/sha.h>
+#include "opensslshim.h"
 
 /*
 These values should be kept in sync with System.Security.Authentication.SslProtocols.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.cpp
@@ -5,8 +5,6 @@
 #include "pal_x509.h"
 
 #include <assert.h>
-#include <openssl/pem.h>
-#include <openssl/x509v3.h>
 
 static_assert(PAL_X509_V_OK == X509_V_OK, "");
 static_assert(PAL_X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT == X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT, "");

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_crypto_types.h"
-
-#include <openssl/x509.h>
+#include "opensslshim.h"
 
 /*
 These values should be kept in sync with System.Security.Cryptography.X509Certificates.X509RevocationFlag.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509_name.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509_name.h
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_crypto_types.h"
-
-#include <openssl/x509.h>
+#include "opensslshim.h"
 
 /*
 Function:

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509_root.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509_root.cpp
@@ -5,8 +5,6 @@
 #include "pal_x509_root.h"
 
 #include <assert.h>
-#include <openssl/pem.h>
-#include <openssl/x509v3.h>
 
 extern "C" const char* CryptoNative_GetX509RootStorePath()
 {

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509_root.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509_root.h
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#include "opensslshim.h"
+
 /*
 Look up the directory in which all certificate files therein are considered
 trusted (root or trusted intermediate).

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509ext.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509ext.h
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal_types.h"
-
-#include <openssl/x509v3.h>
+#include "opensslshim.h"
 
 /*
 Creates an X509_EXTENSION with the given args.

--- a/src/Native/Unix/verify-so.sh
+++ b/src/Native/Unix/verify-so.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# $1 contains full path to the .so to verify
+# $2 contains message to print when the verification fails
+ldd -r $1 | awk 'BEGIN {count=0} /undefined symbol:/ { if (count==0) {print "Undefined symbol(s) found:"} print " " $3; count++ } END {if (count>0) exit(1)}'
+if [ $? != 0 ]; then
+    echo "$2"
+    exit 1
+fi

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -90,16 +90,6 @@ build_native()
         echo "Failed to build corefx native components."
         exit 1
     fi
-    
-    if [ "$__BuildOS" != "OSX" ]; then
-        echo "Verifying System.Security.Cryptography.Native.OpenSsl.so dependencies"
-
-        ldd -r $__BinDir/System.Security.Cryptography.Native.OpenSsl.so | awk 'BEGIN {count=0} /undefined symbol:/ { if (count==0) {print "Undefined symbol(s) found:"} print " " $3; count++ } END {if (count>0) exit(1)}'
-        if [ $? != 0 ]; then
-            echo "Failed. System.Security.Cryptography.Native.OpenSsl.so has undefined dependencies. These are likely OpenSSL APIs that need to be added to opensslshim.h"
-            exit 1
-        fi    
-    fi
 }
 
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -90,6 +90,16 @@ build_native()
         echo "Failed to build corefx native components."
         exit 1
     fi
+    
+    if [ "$__BuildOS" != "OSX" ]; then
+        echo "Verifying System.Security.Cryptography.Native.OpenSsl.so dependencies"
+
+        ldd -r $__BinDir/System.Security.Cryptography.Native.OpenSsl.so | awk 'BEGIN {count=0} /undefined symbol:/ { if (count==0) {print "Undefined symbol(s) found:"} print " " $3; count++ } END {if (count>0) exit(1)}'
+        if [ $? != 0 ]; then
+            echo "Failed. System.Security.Cryptography.Native.OpenSsl.so has undefined dependencies. These are likely OpenSSL APIs that need to be added to opensslshim.h"
+            exit 1
+        fi    
+    fi
 }
 
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)


### PR DESCRIPTION
If the FEATURE_DISTRO_AGNOSTIC_SSL is enabled, the System.Security.Cryptography.Native
doesn't link to libssl / libcrypto at build time. It uses a shim that opens the
libssl shared library with versioned so name specific for the platform and gets all needed
API function pointers using dlsym and stores them in global variables.
The calls to those APIs are then redirected through these pointers.

I have verified that our code doesn't access any data members in structures with layout
that can vary based on compilation options of the OpenSSL and that can have variable
offset. The only direct access of this kind that we were using, the X509::sha1_hash,
was replaced by call to recompute the hash, based on @bartonjs suggestion.

There are couple of functions that we use and that don't have to exist in the libssl when
it is compiled with particular options. These were handled at the build time before, now
I have also added runtime handling of this case.

Finally, I have added verification of the System.Security.Cryptography.Native.OpenSsl.so
to make sure it doesn't have any undefined symbols. This could happen if someone adds
usage of a new OpenSSL API and doesn't add its name to the opensslshim.h. The build fails
in this case and lists all the undefined symbols.