### PR TITLE
Avoiding unneccesary calls to Count in stack spiller

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Bindings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Bindings.cs
@@ -65,8 +65,11 @@ namespace System.Linq.Expressions.Compiler
                 base(binding, spiller)
             {
                 _bindings = binding.Bindings;
-                _bindingRewriters = new BindingRewriter[_bindings.Count];
-                for (int i = 0; i < _bindings.Count; i++)
+
+                int count = _bindings.Count;
+                _bindingRewriters = new BindingRewriter[count];
+
+                for (int i = 0; i < count; i++)
                 {
                     BindingRewriter br = BindingRewriter.Create(_bindings[i], spiller, stack);
                     _action |= br.Action;
@@ -81,8 +84,9 @@ namespace System.Linq.Expressions.Compiler
                     case RewriteAction.None:
                         return _binding;
                     case RewriteAction.Copy:
-                        MemberBinding[] newBindings = new MemberBinding[_bindings.Count];
-                        for (int i = 0; i < _bindings.Count; i++)
+                        int count = _bindings.Count;
+                        MemberBinding[] newBindings = new MemberBinding[count];
+                        for (int i = 0; i < count; i++)
                         {
                             newBindings[i] = _bindingRewriters[i].AsBinding();
                         }
@@ -99,10 +103,11 @@ namespace System.Linq.Expressions.Compiler
                 Expression member = MemberExpression.Make(target, _binding.Member);
                 Expression memberTemp = _spiller.MakeTemp(member.Type);
 
-                Expression[] block = new Expression[_bindings.Count + 2];
+                int count = _bindings.Count;
+                Expression[] block = new Expression[count + 2];
                 block[0] = new AssignBinaryExpression(memberTemp, member);
 
-                for (int i = 0; i < _bindings.Count; i++)
+                for (int i = 0; i < count; i++)
                 {
                     BindingRewriter br = _bindingRewriters[i];
                     block[i + 1] = br.AsExpression(memberTemp);
@@ -111,15 +116,16 @@ namespace System.Linq.Expressions.Compiler
                 // We need to copy back value types.
                 if (memberTemp.Type.GetTypeInfo().IsValueType)
                 {
-                    block[_bindings.Count + 1] = Expression.Block(
+                    block[count + 1] = Expression.Block(
                         typeof(void),
                         new AssignBinaryExpression(MemberExpression.Make(target, _binding.Member), memberTemp)
                     );
                 }
                 else
                 {
-                    block[_bindings.Count + 1] = Utils.Empty;
+                    block[count + 1] = Utils.Empty;
                 }
+
                 return MakeBlock(block);
             }
         }
@@ -134,8 +140,10 @@ namespace System.Linq.Expressions.Compiler
             {
                 _inits = binding.Initializers;
 
-                _childRewriters = new ChildRewriter[_inits.Count];
-                for (int i = 0; i < _inits.Count; i++)
+                int count = _inits.Count;
+                _childRewriters = new ChildRewriter[count];
+
+                for (int i = 0; i < count; i++)
                 {
                     ElementInit init = _inits[i];
 
@@ -154,8 +162,9 @@ namespace System.Linq.Expressions.Compiler
                     case RewriteAction.None:
                         return _binding;
                     case RewriteAction.Copy:
-                        ElementInit[] newInits = new ElementInit[_inits.Count];
-                        for (int i = 0; i < _inits.Count; i++)
+                        int count = _inits.Count;
+                        ElementInit[] newInits = new ElementInit[count];
+                        for (int i = 0; i < count; i++)
                         {
                             ChildRewriter cr = _childRewriters[i];
                             if (cr.Action == RewriteAction.None)
@@ -180,10 +189,11 @@ namespace System.Linq.Expressions.Compiler
                 Expression member = MemberExpression.Make(target, _binding.Member);
                 Expression memberTemp = _spiller.MakeTemp(member.Type);
 
-                Expression[] block = new Expression[_inits.Count + 2];
+                int count = _inits.Count;
+                Expression[] block = new Expression[count + 2];
                 block[0] = new AssignBinaryExpression(memberTemp, member);
 
-                for (int i = 0; i < _inits.Count; i++)
+                for (int i = 0; i < count; i++)
                 {
                     ChildRewriter cr = _childRewriters[i];
                     Result add = cr.Finish(new InstanceMethodCallExpressionN(_inits[i].AddMethod, memberTemp, cr[0, -1]));
@@ -193,15 +203,16 @@ namespace System.Linq.Expressions.Compiler
                 // We need to copy back value types
                 if (memberTemp.Type.GetTypeInfo().IsValueType)
                 {
-                    block[_inits.Count + 1] = Expression.Block(
+                    block[count + 1] = Expression.Block(
                         typeof(void),
                         new AssignBinaryExpression(MemberExpression.Make(target, _binding.Member), memberTemp)
                     );
                 }
                 else
                 {
-                    block[_inits.Count + 1] = Utils.Empty;
+                    block[count + 1] = Utils.Empty;
                 }
+
                 return MakeBlock(block);
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.SpilledExpressionBlock.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.SpilledExpressionBlock.cs
@@ -16,9 +16,19 @@ namespace System.Linq.Expressions.Compiler
         /// This should not be used for rewriting BlockExpression itself, or
         /// anything else that supports jumping.
         /// </summary>
+        private static Expression MakeBlock(ArrayBuilder<Expression> expressions)
+        {
+            return new SpilledExpressionBlock(expressions.ToArray());
+        }
+
+        /// <summary>
+        /// Creates a special block that is marked as not allowing jumps in.
+        /// This should not be used for rewriting BlockExpression itself, or
+        /// anything else that supports jumping.
+        /// </summary>
         private static Expression MakeBlock(params Expression[] expressions)
         {
-            return MakeBlock((IReadOnlyList<Expression>)expressions);
+            return new SpilledExpressionBlock(expressions);
         }
 
         /// <summary>


### PR DESCRIPTION
Addressing a few minor things in StackSpiller that caught my eye while reviewing #13126 and shouldn't get mixed up in the same PR:

* Reading `Count` repeatedly; in other places, we already did some work to evaluate this only once.
* Using `ArrayBuilder<T>` where array index counting is a bit more complex (and even more so in #13126).
* Unwarranted use of `var`.

CC @stephentoub