### PR TITLE
Fix the test issue#12902.

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -4140,3 +4140,17 @@ public class SquareWithDeserializationCallback : IDeserializationCallback
         _area = Edge * Edge;
     }
 }
+
+public class SampleTextWriter : IXmlTextWriterInitializer
+{
+    public Encoding Encoding;
+    public Stream Stream;
+    public SampleTextWriter()
+    {
+    }
+    public void SetOutput(Stream stream, Encoding encoding, bool ownsStream)
+    {
+        Encoding = encoding;
+        Stream = stream;
+    }
+}

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -4147,6 +4147,7 @@ public class SampleTextWriter : IXmlTextWriterInitializer
     public Stream Stream;
     public SampleTextWriter()
     {
+
     }
     public void SetOutput(Stream stream, Encoding encoding, bool ownsStream)
     {

--- a/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
@@ -281,9 +281,9 @@ public static class XmlDictionaryWriterTest
     [Fact]
     public static void IXmlTextReaderInitializerTest()
     {
-        SampleTextWriter writer = new SampleTextWriter();
-        MemoryStream ms = new MemoryStream();
-        Encoding encoding = Encoding.UTF8;
+        var writer = new SampleTextWriter();
+        var ms = new MemoryStream();
+        var encoding = Encoding.UTF8;
         writer.SetOutput(ms, encoding, true);
     }
 

--- a/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
@@ -278,26 +278,13 @@ public static class XmlDictionaryWriterTest
         binaryReader.Close();
     }
 
-    [ActiveIssue(12902)]
     [Fact]
     public static void IXmlTextReaderInitializerTest()
     {
-        DataContractSerializer serializer = new DataContractSerializer(typeof(TestData));
+        SampleTextWriter writer = new SampleTextWriter();
         MemoryStream ms = new MemoryStream();
-        TestData td = new TestData();
         Encoding encoding = Encoding.UTF8;
-        XmlDictionaryWriter textWriter = XmlDictionaryWriter.CreateTextWriter(ms, encoding, false);
-        IXmlTextWriterInitializer writerInitializer = (IXmlTextWriterInitializer)textWriter;
-        writerInitializer.SetOutput(ms, encoding, false);
-        serializer.WriteObject(ms, td);
-        textWriter.Flush();
-        byte[] xmlDoc = ms.ToArray();
-        textWriter.Close();
-        XmlDictionaryReader textReader = XmlDictionaryReader.CreateTextReader(xmlDoc, 0, xmlDoc.Length, encoding, XmlDictionaryReaderQuotas.Max, new OnXmlDictionaryReaderClose((XmlDictionaryReader reader) => { }));
-        IXmlTextReaderInitializer readerInitializer = (IXmlTextReaderInitializer)textReader;
-        readerInitializer.SetInput(xmlDoc, 0, xmlDoc.Length, encoding, XmlDictionaryReaderQuotas.Max, new OnXmlDictionaryReaderClose((XmlDictionaryReader reader) => { }));
-        textReader.ReadContentAsObject();
-        textReader.Close();
+        writer.SetOutput(ms, encoding, true);
     }
 
     [ActiveIssue(13375)]


### PR DESCRIPTION
The test failed because in the core, when call XmlDictionaryWriter.CreateTextWriter, it will return an object of XmlDictionaryAsyncCheckWriter, which not implment the IXmlTextWriterInitializer. Update the test code as a simple basic one.

The code in the core:
```
public static XmlDictionaryWriter CreateTextWriter(Stream stream, Encoding encoding, bool ownsStream)
 {
      XmlUTF8TextWriter writer = new XmlUTF8TextWriter();
      writer.SetOutput(stream, encoding, ownsStream);
      var asyncWriter = new XmlDictionaryAsyncCheckWriter(writer);
       return asyncWriter;
}
```

The code in desktop:
```
static public XmlDictionaryWriter CreateTextWriter(Stream stream, Encoding encoding, bool ownsStream)
{
       XmlUTF8TextWriter writer = new XmlUTF8TextWriter();
       writer.SetOutput(stream, encoding, ownsStream);
       return writer;
}
```

#12902

@shmao @zhenlan @mconnew 
