### PR TITLE
Allow for half-lifted conversions in expressions.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -512,7 +512,9 @@ namespace System.Dynamic.Utils
             if (retryForLifted)
             {
                 return FindConversionOperator(eMethods, nnExprType, nnConvType, implicitOnly)
-                    ?? FindConversionOperator(cMethods, nnExprType, nnConvType, implicitOnly);
+                    ?? FindConversionOperator(cMethods, nnExprType, nnConvType, implicitOnly)
+                    ?? FindConversionOperator(eMethods, nnExprType, convertToType, implicitOnly)
+                    ?? FindConversionOperator(cMethods, nnExprType, convertToType, implicitOnly);
             }
 
             return null;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -455,7 +455,8 @@ namespace System.Linq.Expressions
             // check for lifted call
             if ((operand.Type.IsNullableType() || convertToType.IsNullableType()) &&
                 ParameterIsAssignable(pms[0], operand.Type.GetNonNullableType()) &&
-                TypeUtils.AreEquivalent(method.ReturnType, convertToType.GetNonNullableType()))
+                (TypeUtils.AreEquivalent(method.ReturnType, convertToType.GetNonNullableType()) ||
+                TypeUtils.AreEquivalent(method.ReturnType, convertToType)))
             {
                 return new UnaryExpression(unaryType, operand, convertToType, method);
             }


### PR DESCRIPTION
If a conversion existed from a value type to a nullable type then conversions would not be lifted for the nullable form of the source type.
Fix this. Fixes #11992.

Also select such lifted operations if the methodless form of the `Convert` factory is used to request automatic selection of convert methods.

As well as tests covering this case, include a test ensuring the lifted form is not picked by this change should a direct nullable-to-nullable conversion be available.