### PR TITLE
Throw PNSE for Xls Uppercase-first sort issue on Linux

### DIFF
--- a/src/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/System.Private.Xml/src/Resources/Strings.resx
@@ -3725,6 +3725,6 @@
     <value>Type '{0}' cannot be serialized by XmlSerializer, serialization code for the type is missing. Consult the SDK documentation for adding it as a root serialization type. http://go.microsoft.com/fwlink/?LinkId=613136</value>
   </data>
   <data name="Xslt_UpperCaseFirstNotSupported" xml:space="preserve">
-    <value>Uppercase-First sorting option is not supported</value>
+    <value>Uppercase-First sorting option is not supported.</value>
   </data>
 </root>

--- a/src/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/System.Private.Xml/src/Resources/Strings.resx
@@ -3724,4 +3724,7 @@
   <data name="Xml_MissingSerializationCodeException" xml:space="preserve">
     <value>Type '{0}' cannot be serialized by XmlSerializer, serialization code for the type is missing. Consult the SDK documentation for adding it as a root serialization type. http://go.microsoft.com/fwlink/?LinkId=613136</value>
   </data>
+  <data name="Xslt_UpperCaseFirstNotSupported" xml:space="preserve">
+    <value>Uppercase-First sorting option is not supported</value>
+  </data>
 </root>

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlCollation.Unix.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlCollation.Unix.cs
@@ -18,7 +18,7 @@ namespace System.Xml.Xsl.Runtime
 
             if (UpperFirst)
             {
-                // TODO: Support uppder case first on Linux
+                // TODO: Support upper case first on Linux
                 // Issues #13926, #13236
                 throw new PlatformNotSupportedException(SR.Xslt_UpperCaseFirstNotSupported);
             }

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlCollation.Unix.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlCollation.Unix.cs
@@ -16,6 +16,13 @@ namespace System.Xml.Xsl.Runtime
             SortKey sortKey;
             byte[] bytesKey;
 
+            if (UpperFirst)
+            {
+                // TODO: Support uppder case first on Linux
+                // Issues #13926, #13236
+                throw new PlatformNotSupportedException(SR.Xslt_UpperCaseFirstNotSupported);
+            }
+
             sortKey = Culture.CompareInfo.GetSortKey(s, _compops);
 
             // Create an XmlStringSortKey using the SortKey if possible
@@ -30,8 +37,6 @@ namespace System.Xml.Xsl.Runtime
 
             // Get byte buffer from SortKey and modify it
             bytesKey = sortKey.KeyData;
-
-            // TODO: Add Linux implementation for modifying SortKey; issue #13236
 
             return new XmlStringSortKey(bytesKey, DescendingOrder);
         }


### PR DESCRIPTION
We should plan to support Uppercase-first in general as one of the options on CompareOptions.