### PR TITLE
Port CryptoStream.FlushAsync

### DIFF
--- a/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
+++ b/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
@@ -59,6 +59,7 @@ namespace System.Security.Cryptography
         public override long Position { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }
         public override void Flush() { }
+        public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public void FlushFinalBlock() { }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
@@ -149,6 +149,20 @@ namespace System.Security.Cryptography
             return;
         }
 
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            // If we have been inherited into a subclass, the following implementation could be incorrect
+            // since it does not call through to Flush() which a subclass might have overriden.  To be safe 
+            // we will only use this implementation in cases where we know it is safe to do so,
+            // and delegate to our base class (which will call into Flush) when we are not sure.
+            if (GetType() != typeof(CryptoStream))
+                return base.FlushAsync(cancellationToken);
+
+            return cancellationToken.IsCancellationRequested ?
+                Task.FromCanceled(cancellationToken) :
+                Task.CompletedTask;
+        }
+
         public override long Seek(long offset, SeekOrigin origin)
         {
             throw new NotSupportedException(SR.NotSupported_UnseekableStream);

--- a/src/System.Security.Cryptography.Primitives/tests/CryptoStream.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/CryptoStream.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
@@ -158,7 +159,7 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
             }
         }
 
-#if netstandard17 
+#if netstandard17
         [Fact]
         public static void Clear()
         {
@@ -168,6 +169,38 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
             {
                 encryptStream.Clear();
                 Assert.Throws<NotSupportedException>(() => encryptStream.Write(new byte[] { 1, 2, 3, 4, 5 }, 0, 5));
+            }
+        }
+
+        [Fact]
+        public static void FlushAsync()
+        {
+            ICryptoTransform encryptor = new IdentityTransform(1, 1, true);
+            using (MemoryStream output = new MemoryStream())
+            using (CryptoStream encryptStream = new CryptoStream(output, encryptor, CryptoStreamMode.Write))
+            {
+                encryptStream.WriteAsync(new byte[] { 1, 2, 3, 4, 5 }, 0, 5);
+                Task waitable = encryptStream.FlushAsync(new Threading.CancellationToken(false));
+                Assert.False(waitable.IsCanceled);
+
+                encryptStream.WriteAsync(new byte[] { 1, 2, 3, 4, 5 }, 0, 5);
+                waitable = encryptStream.FlushAsync(new Threading.CancellationToken(true));
+                Assert.True(waitable.IsCanceled);
+            }
+        }
+
+        [Fact]
+        public static void FlushCalledOnFlushAsync_DeriveClass()
+        {
+            ICryptoTransform encryptor = new IdentityTransform(1, 1, true);
+            using (MemoryStream output = new MemoryStream())
+            using (MinimalCryptoStream encryptStream = new MinimalCryptoStream(output, encryptor, CryptoStreamMode.Write))
+            {
+                encryptStream.WriteAsync(new byte[] { 1, 2, 3, 4, 5 }, 0, 5);
+                Task waitable = encryptStream.FlushAsync(new Threading.CancellationToken(false));
+                Assert.False(waitable.IsCanceled);
+                waitable.Wait();
+                Assert.True(encryptStream.FlushCalled);
             }
         }
 #endif
@@ -273,6 +306,19 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
                 _writePos = 0;
                 _readPos = 0;
                 return outputBuffer;
+            }
+        }
+
+        public class MinimalCryptoStream : CryptoStream
+        {
+            public bool FlushCalled;
+
+            public MinimalCryptoStream(Stream stream, ICryptoTransform transform, CryptoStreamMode mode) : base(stream, transform, mode) { }
+
+            public override void Flush()
+            {
+                FlushCalled = true;
+                base.Flush();
             }
         }
 


### PR DESCRIPTION
Port the FlushAsync method from netfx; several other classes have the same logic and comments.

https://github.com/dotnet/corefx/issues/13872 Add missing CryptoStream::FlushAsync
