### PR TITLE
Simplifiy some Type-related methods in Linq.Expressions

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
@@ -13,11 +13,6 @@ namespace System.Dynamic.Utils
             return t1.IsEquivalentTo(t2);
         }
 
-        public static bool IsEquivalentTo(this Type t1, Type t2)
-        {
-            return t1 == t2;
-        }
-
         public static bool AreReferenceAssignable(Type dest, Type src)
         {
             // This actually implements "Is this identity assignable and/or reference assignable?"

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
@@ -16,9 +16,9 @@ namespace System.Dynamic.Utils
         /// </summary>
         public static MethodInfo GetAnyStaticMethodValidated(this Type type, string name, Type[] types)
         {
-            foreach (MethodInfo method in type.GetTypeInfo().DeclaredMethods)
+            foreach (MethodInfo method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly))
             {
-                if (method.IsStatic && method.Name == name && method.MatchesArgumentTypes(types))
+                if (method.Name == name && method.MatchesArgumentTypes(types))
                 {
                     return method;
                 }

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
@@ -102,16 +102,5 @@ namespace System.Dynamic.Utils
             else
                 return TypeCode.Object;
         }
-
-        public static IEnumerable<MethodInfo> GetStaticMethods(this Type type)
-        {
-            foreach (MethodInfo method in type.GetRuntimeMethods())
-            {
-                if (method.IsStatic)
-                {
-                    yield return method;
-                }
-            }
-        }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -476,11 +476,8 @@ namespace System.Dynamic.Utils
 
         public static MethodInfo GetUserDefinedCoercionMethod(Type convertFrom, Type convertToType)
         {
-            // check for implicit coercions first
             Type nnExprType = GetNonNullableType(convertFrom);
             Type nnConvType = GetNonNullableType(convertToType);
-
-            bool retryForLifted = !AreEquivalent(nnExprType, convertFrom) || !AreEquivalent(nnConvType, convertToType);
 
             // try exact match on types
             MethodInfo[] eMethods = nnExprType.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
@@ -499,16 +496,16 @@ namespace System.Dynamic.Utils
                 return method;
             }
 
-            // try lifted conversion
-            if (retryForLifted)
+            if (AreEquivalent(nnExprType, convertFrom) && AreEquivalent(nnConvType, convertToType))
             {
-                return FindConversionOperator(eMethods, nnExprType, nnConvType)
-                    ?? FindConversionOperator(cMethods, nnExprType, nnConvType)
-                    ?? FindConversionOperator(eMethods, nnExprType, convertToType)
-                    ?? FindConversionOperator(cMethods, nnExprType, convertToType);
+                return null;
             }
 
-            return null;
+            // try lifted conversion
+            return FindConversionOperator(eMethods, nnExprType, nnConvType)
+                   ?? FindConversionOperator(cMethods, nnExprType, nnConvType)
+                   ?? FindConversionOperator(eMethods, nnExprType, convertToType)
+                   ?? FindConversionOperator(cMethods, nnExprType, convertToType);
         }
 
         private static MethodInfo FindConversionOperator(MethodInfo[] methods, Type typeFrom, Type typeTo)

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -483,12 +483,7 @@ namespace System.Dynamic.Utils
             bool retryForLifted = !AreEquivalent(nnExprType, convertFrom) || !AreEquivalent(nnConvType, convertToType);
 
             // try exact match on types
-            IEnumerable<MethodInfo> eMethods = nnExprType.GetStaticMethods();
-            if (retryForLifted)
-            {
-                // If this may be scanned again for a lifted match, store it in a list.
-                eMethods = new List<MethodInfo>(eMethods);
-            }
+            MethodInfo[] eMethods = nnExprType.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
 
             MethodInfo method = FindConversionOperator(eMethods, convertFrom, convertToType, implicitOnly);
             if (method != null)
@@ -496,11 +491,7 @@ namespace System.Dynamic.Utils
                 return method;
             }
 
-            IEnumerable<MethodInfo> cMethods = nnConvType.GetStaticMethods();
-            if (retryForLifted)
-            {
-                cMethods = new List<MethodInfo>(cMethods);
-            }
+            MethodInfo[] cMethods = nnConvType.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
 
             method = FindConversionOperator(cMethods, convertFrom, convertToType, implicitOnly);
             if (method != null)
@@ -520,7 +511,7 @@ namespace System.Dynamic.Utils
             return null;
         }
 
-        private static MethodInfo FindConversionOperator(IEnumerable<MethodInfo> methods, Type typeFrom, Type typeTo, bool implicitOnly)
+        private static MethodInfo FindConversionOperator(MethodInfo[] methods, Type typeFrom, Type typeTo, bool implicitOnly)
         {
             foreach (MethodInfo mi in methods)
             {

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -474,7 +474,7 @@ namespace System.Dynamic.Utils
                 IsImplicitNullableConversion(source, destination);
         }
 
-        public static MethodInfo GetUserDefinedCoercionMethod(Type convertFrom, Type convertToType, bool implicitOnly)
+        public static MethodInfo GetUserDefinedCoercionMethod(Type convertFrom, Type convertToType)
         {
             // check for implicit coercions first
             Type nnExprType = GetNonNullableType(convertFrom);
@@ -485,7 +485,7 @@ namespace System.Dynamic.Utils
             // try exact match on types
             MethodInfo[] eMethods = nnExprType.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
 
-            MethodInfo method = FindConversionOperator(eMethods, convertFrom, convertToType, implicitOnly);
+            MethodInfo method = FindConversionOperator(eMethods, convertFrom, convertToType);
             if (method != null)
             {
                 return method;
@@ -493,7 +493,7 @@ namespace System.Dynamic.Utils
 
             MethodInfo[] cMethods = nnConvType.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
 
-            method = FindConversionOperator(cMethods, convertFrom, convertToType, implicitOnly);
+            method = FindConversionOperator(cMethods, convertFrom, convertToType);
             if (method != null)
             {
                 return method;
@@ -502,21 +502,21 @@ namespace System.Dynamic.Utils
             // try lifted conversion
             if (retryForLifted)
             {
-                return FindConversionOperator(eMethods, nnExprType, nnConvType, implicitOnly)
-                    ?? FindConversionOperator(cMethods, nnExprType, nnConvType, implicitOnly)
-                    ?? FindConversionOperator(eMethods, nnExprType, convertToType, implicitOnly)
-                    ?? FindConversionOperator(cMethods, nnExprType, convertToType, implicitOnly);
+                return FindConversionOperator(eMethods, nnExprType, nnConvType)
+                    ?? FindConversionOperator(cMethods, nnExprType, nnConvType)
+                    ?? FindConversionOperator(eMethods, nnExprType, convertToType)
+                    ?? FindConversionOperator(cMethods, nnExprType, convertToType);
             }
 
             return null;
         }
 
-        private static MethodInfo FindConversionOperator(MethodInfo[] methods, Type typeFrom, Type typeTo, bool implicitOnly)
+        private static MethodInfo FindConversionOperator(MethodInfo[] methods, Type typeFrom, Type typeTo)
         {
             foreach (MethodInfo mi in methods)
             {
                 if (
-                    (mi.Name == "op_Implicit" || (!implicitOnly && mi.Name == "op_Explicit"))
+                    (mi.Name == "op_Implicit" || mi.Name == "op_Explicit")
                     && AreEquivalent(mi.ReturnType, typeTo)
                     )
                 {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -428,7 +428,7 @@ namespace System.Linq.Expressions
 
         private static UnaryExpression GetUserDefinedCoercion(ExpressionType coercionType, Expression expression, Type convertToType)
         {
-            MethodInfo method = TypeUtils.GetUserDefinedCoercionMethod(expression.Type, convertToType, implicitOnly: false);
+            MethodInfo method = TypeUtils.GetUserDefinedCoercionMethod(expression.Type, convertToType);
             if (method != null)
             {
                 return new UnaryExpression(coercionType, expression, convertToType, method);


### PR DESCRIPTION
Remove `GetStaticMethods` helper, replacing with call to `GetMethods`, now that the form with `BindingFlag` overloads is available to use.

Contributes to #8576.

Remove conditional call to ToList as this makes it no longer useful.

Update signature called into to allow array iteration in the `foreach`.

Remove `implicitOnly` parameter to `GetUserDefinedCoercion`: It's only ever false. Remove the check for it, and remove it being called up the stack.

Remove obsolete `IsEquivalentTo` extension method, now available as instance method.

Replace filtered call to `DeclaredMethods` with `GetMethods` with appropriate flags. Also contributes to #8576.

Move retryForLifted test down to the branch that depends on it, now that it no longer needs to cache a collection