### PR TITLE
Bring back DBNull support in the interpreter

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -144,8 +144,8 @@ namespace System.Linq.Expressions.Interpreter
                     return default(float);
                 case TypeCode.Double:
                     return default(double);
-                //case TypeCode.DBNull:
-                //    return default(DBNull);
+                case TypeCode.DBNull:
+                    return default(DBNull);
                 case TypeCode.DateTime:
                     return default(DateTime);
                 case TypeCode.Decimal:

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -144,13 +144,12 @@ namespace System.Linq.Expressions.Interpreter
                     return default(float);
                 case TypeCode.Double:
                     return default(double);
-                case TypeCode.DBNull:
-                    return default(DBNull);
                 case TypeCode.DateTime:
                     return default(DateTime);
                 case TypeCode.Decimal:
                     return default(decimal);
                 default:
+                    // Also covers DBNull which is a class.
                     return null;
             }
 


### PR DESCRIPTION
Now that `netstandard1.6` has been removed from the `.builds` file, the lines to support `DBNull` can be uncommented.