### PR TITLE
Fix body of SecurityElement.ToString in contracts

### DIFF
--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -1577,7 +1577,7 @@ namespace System.Security
         public static bool IsValidText(string text) { throw null; }
         public System.Security.SecurityElement SearchForChildByTag(string tag) { throw null; }
         public string SearchForTextOfTag(string tag) { throw null; }
-        public override string ToString() => base.ToString();
+        public override string ToString() { throw null; }
     }
 }
 namespace System.Security.Permissions


### PR DESCRIPTION
I noticed this while doing a Ctrl+F for => in the file. It looks like it should be `throw null;` instead.