### PR TITLE
Remove unnecessary First helper in System.Dynamic.Utils

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/CollectionExtensions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/CollectionExtensions.cs
@@ -15,22 +15,5 @@ namespace System.Dynamic.Utils
             res[list.Count] = item;
             return res;
         }
-
-        public static T First<T>(this IEnumerable<T> source)
-        {
-            var list = source as IList<T>;
-            if (list != null)
-            {
-                return list[0];
-            }
-            using (var e = source.GetEnumerator())
-            {
-                if (e.MoveNext())
-                {
-                    return e.Current;
-                }
-            }
-            throw new InvalidOperationException();
-        }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
@@ -667,7 +667,7 @@ namespace System.Runtime.CompilerServices
                 Expression.Block(
                     Expression.Call(
                         typeof(CallSiteOps).GetMethod(nameof(CallSiteOps.SetNotMatched)),
-                        @params.First()
+                        @params[0]
                     ),
                     Expression.Default(invoke.GetReturnType())
                 ),

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteBinder.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteBinder.cs
@@ -186,7 +186,7 @@ namespace System.Runtime.CompilerServices
                     Expression.Condition(
                         Expression.Call(
                             CallSiteOps_SetNotMatched,
-                            @params.First()
+                            site
                         ),
                         Expression.Default(signature.ReturnLabel.Type),
                         Expression.Invoke(


### PR DESCRIPTION
This helper is pretty much the same as `Enumerable.First` and its two uses either already know the first element or can simply index into a collection to get it. It seems we can do away with it.