### PR TITLE
Fixing some typos in System.Linq.Expressions

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
@@ -25,7 +25,7 @@ namespace System.Dynamic.Utils
                 return res;
             }
 
-            // otherwise make sure only readonly collection every gets exposed
+            // otherwise make sure only read-only collection every gets exposed
             Interlocked.CompareExchange<IReadOnlyList<T>>(
                 ref collection,
                 value.ToReadOnly(),
@@ -48,14 +48,14 @@ namespace System.Dynamic.Utils
         ///
         /// This enables users to get the ReadOnlyCollection w/o it consuming more memory than if
         /// it was just an array.  Meanwhile The DLR internally avoids accessing  which would force
-        /// the readonly collection to be created resulting in a typical memory savings.
+        /// the read-only collection to be created resulting in a typical memory savings.
         /// </summary>
         public static ReadOnlyCollection<Expression> ReturnReadOnly(IArgumentProvider provider, ref object collection)
         {
             Expression tObj = collection as Expression;
             if (tObj != null)
             {
-                // otherwise make sure only one readonly collection ever gets exposed
+                // otherwise make sure only one read-only collection ever gets exposed
                 Interlocked.CompareExchange(
                     ref collection,
                     new ReadOnlyCollection<Expression>(new ListArgumentProvider(provider, tObj)),
@@ -63,7 +63,7 @@ namespace System.Dynamic.Utils
                 );
             }
 
-            // and return what is not guaranteed to be a readonly collection
+            // and return what is not guaranteed to be a read-only collection
             return (ReadOnlyCollection<Expression>)collection;
         }
 

--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -463,10 +463,10 @@
     <value>More than one property '{0}' on type '{1}' is compatible with the supplied arguments.</value>
   </data>
   <data name="IncorrectNumberOfTypeArgsForFunc" xml:space="preserve">
-    <value>An incorrect number of type args were specified for the declaration of a Func type.</value>
+    <value>An incorrect number of type arguments were specified for the declaration of a Func type.</value>
   </data>
   <data name="IncorrectNumberOfTypeArgsForAction" xml:space="preserve">
-    <value>An incorrect number of type args were specified for the declaration of an Action type.</value>
+    <value>An incorrect number of type arguments were specified for the declaration of an Action type.</value>
   </data>
   <data name="ArgumentCannotBeOfTypeVoid" xml:space="preserve">
     <value>Argument type cannot be System.Void.</value>

--- a/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
@@ -539,7 +539,7 @@ namespace System.Dynamic
                     );
 
                     Expression condition;
-                    // If the return type can not be assigned null then just check for type assignablity otherwise allow null.
+                    // If the return type can not be assigned null then just check for type assignability otherwise allow null.
                     if (binder.ReturnType.GetTypeInfo().IsValueType && Nullable.GetUnderlyingType(binder.ReturnType) == null)
                     {
                         condition = Expression.TypeIs(resultMO.Expression, binder.ReturnType);

--- a/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
@@ -35,7 +35,7 @@ namespace System.Dynamic
         private static readonly MethodInfo ExpandoCheckVersion =
             typeof(RuntimeOps).GetMethod(nameof(RuntimeOps.ExpandoCheckVersion));
 
-        internal readonly object LockObject;                          // the readonly field is used for locking the Expando object
+        internal readonly object LockObject;                          // the read-only field is used for locking the Expando object
         private ExpandoData _data;                                    // the data currently being held by the Expando object
         private int _count;                                           // the count of available members
 

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/ExpressionUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/ExpressionUtils.cs
@@ -18,7 +18,7 @@ namespace System.Dynamic.Utils
             ParameterExpression tObj = collection as ParameterExpression;
             if (tObj != null)
             {
-                // otherwise make sure only one readonly collection ever gets exposed
+                // otherwise make sure only one read-only collection ever gets exposed
                 Interlocked.CompareExchange(
                     ref collection,
                     new ReadOnlyCollection<ParameterExpression>(new ListParameterProvider(provider, tObj)),
@@ -26,7 +26,7 @@ namespace System.Dynamic.Utils
                 );
             }
 
-            // and return what is not guaranteed to be a readonly collection
+            // and return what is not guaranteed to be a read-only collection
             return (ReadOnlyCollection<ParameterExpression>)collection;
         }
     }

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -755,7 +755,8 @@ namespace System.Dynamic.Utils
         public static bool IsVector(this Type type)
         {
             // Unfortunately, the IsSzArray property of System.Type is inaccessible to us,
-            // so we use a little equality comparison trick instead:
+            // so we use a little equality comparison trick instead. This omission is being
+            // tracked at https://github.com/dotnet/coreclr/issues/1877.
             return type == type.GetElementType().MakeArrayType();
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -124,9 +124,9 @@ namespace System.Linq.Expressions
         /// supports nodes which hold onto 5 Expressions and puts all of the arguments into the
         /// ReadOnlyCollection.
         ///
-        /// Ultimately this means if we create the readonly collection we will be slightly more wasteful as we'll
-        /// have a readonly collection + some fields in the type.  The DLR internally avoids accessing anything
-        /// which would force the readonly collection to be created.
+        /// Ultimately this means if we create the read-only collection we will be slightly more wasteful as we'll
+        /// have a read-only collection + some fields in the type.  The DLR internally avoids accessing anything
+        /// which would force the read-only collection to be created.
         ///
         /// This is used by BlockExpression5 and MethodCallExpression5.
         /// </summary>
@@ -135,7 +135,7 @@ namespace System.Linq.Expressions
             Expression tObj = collection as Expression;
             if (tObj != null)
             {
-                // otherwise make sure only one readonly collection ever gets exposed
+                // otherwise make sure only one read-only collection ever gets exposed
                 Interlocked.CompareExchange(
                     ref collection,
                     new ReadOnlyCollection<Expression>(new BlockExpressionList(provider, tObj)),
@@ -143,7 +143,7 @@ namespace System.Linq.Expressions
                 );
             }
 
-            // and return what is not guaranteed to be a readonly collection
+            // and return what is not guaranteed to be a read-only collection
             return (ReadOnlyCollection<Expression>)collection;
         }
     }
@@ -152,7 +152,7 @@ namespace System.Linq.Expressions
 
     internal sealed class Block2 : BlockExpression
     {
-        private object _arg0;                   // storage for the 1st argument or a readonly collection.  See IArgumentProvider
+        private object _arg0;                   // storage for the 1st argument or a read-only collection.  See IArgumentProvider
         private readonly Expression _arg1;      // storage for the 2nd argument.
 
         internal Block2(Expression arg0, Expression arg1)
@@ -190,7 +190,7 @@ namespace System.Linq.Expressions
 
     internal sealed class Block3 : BlockExpression
     {
-        private object _arg0;                       // storage for the 1st argument or a readonly collection.  See IArgumentProvider
+        private object _arg0;                       // storage for the 1st argument or a read-only collection.  See IArgumentProvider
         private readonly Expression _arg1, _arg2;   // storage for the 2nd and 3rd arguments.
 
         internal Block3(Expression arg0, Expression arg1, Expression arg2)
@@ -230,8 +230,8 @@ namespace System.Linq.Expressions
 
     internal sealed class Block4 : BlockExpression
     {
-        private object _arg0;                               // storage for the 1st argument or a readonly collection.  See IArgumentProvider
-        private readonly Expression _arg1, _arg2, _arg3;    // storarg for the 2nd, 3rd, and 4th arguments.
+        private object _arg0;                               // storage for the 1st argument or a read-only collection.  See IArgumentProvider
+        private readonly Expression _arg1, _arg2, _arg3;    // storage for the 2nd, 3rd, and 4th arguments.
 
         internal Block4(Expression arg0, Expression arg1, Expression arg2, Expression arg3)
         {
@@ -272,7 +272,7 @@ namespace System.Linq.Expressions
 
     internal sealed class Block5 : BlockExpression
     {
-        private object _arg0;                                       // storage for the 1st argument or a readonly collection.  See IArgumentProvider
+        private object _arg0;                                       // storage for the 1st argument or a read-only collection.  See IArgumentProvider
         private readonly Expression _arg1, _arg2, _arg3, _arg4;     // storage for the 2nd - 5th args.
 
         internal Block5(Expression arg0, Expression arg1, Expression arg2, Expression arg3, Expression arg4)
@@ -350,7 +350,7 @@ namespace System.Linq.Expressions
 
     internal class ScopeExpression : BlockExpression
     {
-        private IReadOnlyList<ParameterExpression> _variables;      // list of variables or ReadOnlyCollection if the user has accessed the readonly collection
+        private IReadOnlyList<ParameterExpression> _variables;      // list of variables or ReadOnlyCollection if the user has accessed the read-only collection
 
         internal ScopeExpression(IReadOnlyList<ParameterExpression> variables)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.netstandard1.7.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.netstandard1.7.cs
@@ -13,7 +13,7 @@ namespace System.Linq.Expressions.Compiler
         /// <summary>
         /// Finds a delegate type for a CallSite using the types in the ReadOnlyCollection of Expression.
         ///
-        /// We take the readonly collection of Expression explicitly to avoid allocating memory (an array
+        /// We take the read-only collection of Expression explicitly to avoid allocating memory (an array
         /// of types) on lookup of delegate types.
         /// </summary>
         internal static Type MakeCallSiteDelegate(ReadOnlyCollection<Expression> types, Type returnType)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Generated.cs
@@ -14,7 +14,7 @@ namespace System.Linq.Expressions.Compiler
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1505:AvoidUnmaintainableCode"), System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         private void EmitExpression(Expression node, CompilationFlags flags)
         {
-            // When compling deep trees, we run the risk of triggering a terminating StackOverflowException,
+            // When compiling deep trees, we run the risk of triggering a terminating StackOverflowException,
             // so we use the StackGuard utility here to probe for sufficient stack and continue the work on
             // another thread when we run out of stack space.
             if (!_guard.TryEnterOnCurrentStack())

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Generated.cs
@@ -9,10 +9,9 @@ namespace System.Linq.Expressions.Compiler
         private readonly StackGuard _guard = new StackGuard();
 
         /// <summary>
-        /// Rewrite the expression
+        /// Rewrite the expression by performing stack spilling where necessary.
         /// </summary>
-        ///
-        /// <param name="node">Expression to rewrite</param>
+        /// <param name="node">Expression to rewrite.</param>
         /// <param name="stack">State of the stack before the expression is emitted.</param>
         /// <returns>Rewritten expression.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1505:AvoidUnmaintainableCode")]
@@ -24,7 +23,7 @@ namespace System.Linq.Expressions.Compiler
                 return new Result(RewriteAction.None, null);
             }
 
-            // When compling deep trees, we run the risk of triggering a terminating StackOverflowException,
+            // When compiling deep trees, we run the risk of triggering a terminating StackOverflowException,
             // so we use the StackGuard utility here to probe for sufficient stack and continue the work on
             // another thread when we run out of stack space.
             if (!_guard.TryEnterOnCurrentStack())

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
@@ -1105,7 +1105,7 @@ namespace System.Linq.Expressions.Compiler
 
         private static bool IsRefInstance(Expression instance)
         {
-            // Primitive value types are okay because they are all readonly,
+            // Primitive value types are okay because they are all read-only,
             // but we can't rely on this for non-primitive types. So we have
             // to either throw NotSupported or use ref locals.
             return instance != null && instance.Type.GetTypeInfo().IsValueType && instance.Type.GetTypeCode() == TypeCode.Object;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/VariableBinder.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/VariableBinder.cs
@@ -34,7 +34,7 @@ namespace System.Linq.Expressions.Compiler
 
         public override Expression Visit(Expression node)
         {
-            // When compling deep trees, we run the risk of triggering a terminating StackOverflowException,
+            // When compiling deep trees, we run the risk of triggering a terminating StackOverflowException,
             // so we use the StackGuard utility here to probe for sufficient stack and continue the work on
             // another thread when we run out of stack space.
             if (!_guard.TryEnterOnCurrentStack())

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
@@ -478,7 +478,7 @@ namespace System.Linq.Expressions
 
     internal class DynamicExpressionN : DynamicExpression, IArgumentProvider
     {
-        private IReadOnlyList<Expression> _arguments;       // storage for the original IList or readonly collection.  See IArgumentProvider for more info.
+        private IReadOnlyList<Expression> _arguments;       // storage for the original IList or read-only collection.  See IArgumentProvider for more info.
 
         internal DynamicExpressionN(Type delegateType, CallSiteBinder binder, IReadOnlyList<Expression> arguments)
             : base(delegateType, binder)
@@ -531,7 +531,7 @@ namespace System.Linq.Expressions
 
     internal class DynamicExpression1 : DynamicExpression, IArgumentProvider
     {
-        private object _arg0;               // storage for the 1st argument or a readonly collection.  See IArgumentProvider for more info.
+        private object _arg0;               // storage for the 1st argument or a read-only collection.  See IArgumentProvider for more info.
 
         internal DynamicExpression1(Type delegateType, CallSiteBinder binder, Expression arg0)
             : base(delegateType, binder)
@@ -587,7 +587,7 @@ namespace System.Linq.Expressions
 
     internal class DynamicExpression2 : DynamicExpression, IArgumentProvider
     {
-        private object _arg0;                   // storage for the 1st argument or a readonly collection.  See IArgumentProvider for more info.
+        private object _arg0;                   // storage for the 1st argument or a read-only collection.  See IArgumentProvider for more info.
         private readonly Expression _arg1;      // storage for the 2nd argument
 
         internal DynamicExpression2(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1)
@@ -646,7 +646,7 @@ namespace System.Linq.Expressions
 
     internal class DynamicExpression3 : DynamicExpression, IArgumentProvider
     {
-        private object _arg0;                       // storage for the 1st argument or a readonly collection.  See IArgumentProvider for more info.
+        private object _arg0;                       // storage for the 1st argument or a read-only collection.  See IArgumentProvider for more info.
         private readonly Expression _arg1, _arg2;   // storage for the 2nd & 3rd arguments
 
         internal DynamicExpression3(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1, Expression arg2)
@@ -707,7 +707,7 @@ namespace System.Linq.Expressions
 
     internal class DynamicExpression4 : DynamicExpression, IArgumentProvider
     {
-        private object _arg0;                               // storage for the 1st argument or a readonly collection.  See IArgumentProvider for more info.
+        private object _arg0;                               // storage for the 1st argument or a read-only collection.  See IArgumentProvider for more info.
         private readonly Expression _arg1, _arg2, _arg3;    // storage for the 2nd - 4th arguments
 
         internal DynamicExpression4(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1, Expression arg2, Expression arg3)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -1045,14 +1045,14 @@ namespace System.Linq.Expressions
             return new InvalidOperationException(Strings.PropertyWithMoreThanOneMatch(p0, p1));
         }
         /// <summary>
-        /// ArgumentException with message like "An incorrect number of type args were specified for the declaration of a Func type."
+        /// ArgumentException with message like "An incorrect number of type arguments were specified for the declaration of a Func type."
         /// </summary>
         internal static Exception IncorrectNumberOfTypeArgsForFunc(string paramName)
         {
             return new ArgumentException(Strings.IncorrectNumberOfTypeArgsForFunc, paramName);
         }
         /// <summary>
-        /// ArgumentException with message like "An incorrect number of type args were specified for the declaration of an Action type."
+        /// ArgumentException with message like "An incorrect number of type arguments were specified for the declaration of an Action type."
         /// </summary>
         internal static Exception IncorrectNumberOfTypeArgsForAction(string paramName)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
@@ -233,9 +233,9 @@ comparand: null
         /// Helper used for ensuring we only return 1 instance of a ReadOnlyCollection of T.
         ///
         /// This is called from various methods where we internally hold onto an IList of T
-        /// or a readonly collection of T.  We check to see if we've already returned a
-        /// readonly collection of T and if so simply return the other one.  Otherwise we do
-        /// a thread-safe replacement of the list w/ a readonly collection which wraps it.
+        /// or a read-only collection of T.  We check to see if we've already returned a
+        /// read-only collection of T and if so simply return the other one.  Otherwise we do
+        /// a thread-safe replacement of the list w/ a read-only collection which wraps it.
         ///
         /// Ultimately this saves us from having to allocate a ReadOnlyCollection for our
         /// data types because the compiler is capable of going directly to the IList of T.
@@ -257,7 +257,7 @@ comparand: null
         ///
         /// This enables users to get the ReadOnlyCollection w/o it consuming more memory than if
         /// it was just an array.  Meanwhile The DLR internally avoids accessing  which would force
-        /// the readonly collection to be created resulting in a typical memory savings.
+        /// the read-only collection to be created resulting in a typical memory savings.
         /// </summary>
         internal static ReadOnlyCollection<Expression> ReturnReadOnly(IArgumentProvider provider, ref object collection)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2964,7 +2964,7 @@ namespace System.Linq.Expressions.Interpreter
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         private void CompileNoLabelPush(Expression expr)
         {
-            // When compling deep trees, we run the risk of triggering a terminating StackOverflowException,
+            // When compiling deep trees, we run the risk of triggering a terminating StackOverflowException,
             // so we use the StackGuard utility here to probe for sufficient stack and continue the work on
             // another thread when we run out of stack space.
             if (!_guard.TryEnterOnCurrentStack())

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
@@ -178,7 +178,7 @@ namespace System.Linq.Expressions
 
     internal sealed class InvocationExpression1 : InvocationExpression
     {
-        private object _arg0;       // storage for the 1st argument or a readonly collection.  See IArgumentProvider
+        private object _arg0;       // storage for the 1st argument or a read-only collection.  See IArgumentProvider
 
         public InvocationExpression1(Expression lambda, Type returnType, Expression arg0)
             : base(lambda, returnType)
@@ -217,8 +217,8 @@ namespace System.Linq.Expressions
 
     internal sealed class InvocationExpression2 : InvocationExpression
     {
-        private object _arg0;               // storage for the 1st argument or a readonly collection.  See IArgumentProvider
-        private readonly Expression _arg1;  // storage for the 2nd arg
+        private object _arg0;               // storage for the 1st argument or a read-only collection.  See IArgumentProvider
+        private readonly Expression _arg1;  // storage for the 2nd argument
 
         public InvocationExpression2(Expression lambda, Type returnType, Expression arg0, Expression arg1)
             : base(lambda, returnType)
@@ -259,9 +259,9 @@ namespace System.Linq.Expressions
 
     internal sealed class InvocationExpression3 : InvocationExpression
     {
-        private object _arg0;               // storage for the 1st argument or a readonly collection.  See IArgumentProvider
-        private readonly Expression _arg1;  // storage for the 2nd arg
-        private readonly Expression _arg2;  // storage for the 3rd arg
+        private object _arg0;               // storage for the 1st argument or a read-only collection.  See IArgumentProvider
+        private readonly Expression _arg1;  // storage for the 2nd argument
+        private readonly Expression _arg2;  // storage for the 3rd argument
 
         public InvocationExpression3(Expression lambda, Type returnType, Expression arg0, Expression arg1, Expression arg2)
             : base(lambda, returnType)
@@ -304,10 +304,10 @@ namespace System.Linq.Expressions
 
     internal sealed class InvocationExpression4 : InvocationExpression
     {
-        private object _arg0;               // storage for the 1st argument or a readonly collection.  See IArgumentProvider
-        private readonly Expression _arg1;  // storage for the 2nd arg
-        private readonly Expression _arg2;  // storage for the 3rd arg
-        private readonly Expression _arg3;  // storage for the 4th arg
+        private object _arg0;               // storage for the 1st argument or a read-only collection.  See IArgumentProvider
+        private readonly Expression _arg1;  // storage for the 2nd argument
+        private readonly Expression _arg2;  // storage for the 3rd argument
+        private readonly Expression _arg3;  // storage for the 4th argument
 
         public InvocationExpression4(Expression lambda, Type returnType, Expression arg0, Expression arg1, Expression arg2, Expression arg3)
             : base(lambda, returnType)
@@ -352,11 +352,11 @@ namespace System.Linq.Expressions
 
     internal sealed class InvocationExpression5 : InvocationExpression
     {
-        private object _arg0;               // storage for the 1st argument or a readonly collection.  See IArgumentProvider
-        private readonly Expression _arg1;  // storage for the 2nd arg
-        private readonly Expression _arg2;  // storage for the 3rd arg
-        private readonly Expression _arg3;  // storage for the 4th arg
-        private readonly Expression _arg4;  // storage for the 5th arg
+        private object _arg0;               // storage for the 1st argument or a read-only collection.  See IArgumentProvider
+        private readonly Expression _arg1;  // storage for the 2nd argument
+        private readonly Expression _arg2;  // storage for the 3rd argument
+        private readonly Expression _arg3;  // storage for the 4th argument
+        private readonly Expression _arg4;  // storage for the 5th argument
 
         public InvocationExpression5(Expression lambda, Type returnType, Expression arg0, Expression arg1, Expression arg2, Expression arg3, Expression arg4)
             : base(lambda, returnType)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
@@ -225,7 +225,7 @@ namespace System.Linq.Expressions
 
     internal sealed class MethodCallExpression1 : MethodCallExpression, IArgumentProvider
     {
-        private object _arg0;       // storage for the 1st argument or a readonly collection.  See IArgumentProvider
+        private object _arg0;       // storage for the 1st argument or a read-only collection.  See IArgumentProvider
 
         public MethodCallExpression1(MethodInfo method, Expression arg0)
             : base(method)
@@ -265,7 +265,7 @@ namespace System.Linq.Expressions
 
     internal sealed class MethodCallExpression2 : MethodCallExpression, IArgumentProvider
     {
-        private object _arg0;               // storage for the 1st argument or a readonly collection.  See IArgumentProvider
+        private object _arg0;               // storage for the 1st argument or a read-only collection.  See IArgumentProvider
         private readonly Expression _arg1;  // storage for the 2nd arg
 
         public MethodCallExpression2(MethodInfo method, Expression arg0, Expression arg1)
@@ -307,7 +307,7 @@ namespace System.Linq.Expressions
 
     internal sealed class MethodCallExpression3 : MethodCallExpression, IArgumentProvider
     {
-        private object _arg0;           // storage for the 1st argument or a readonly collection.  See IArgumentProvider
+        private object _arg0;           // storage for the 1st argument or a read-only collection.  See IArgumentProvider
         private readonly Expression _arg1, _arg2; // storage for the 2nd - 3rd args.
 
         public MethodCallExpression3(MethodInfo method, Expression arg0, Expression arg1, Expression arg2)
@@ -351,7 +351,7 @@ namespace System.Linq.Expressions
 
     internal sealed class MethodCallExpression4 : MethodCallExpression, IArgumentProvider
     {
-        private object _arg0;               // storage for the 1st argument or a readonly collection.  See IArgumentProvider
+        private object _arg0;               // storage for the 1st argument or a read-only collection.  See IArgumentProvider
         private readonly Expression _arg1, _arg2, _arg3;  // storage for the 2nd - 4th args.
 
         public MethodCallExpression4(MethodInfo method, Expression arg0, Expression arg1, Expression arg2, Expression arg3)
@@ -397,7 +397,7 @@ namespace System.Linq.Expressions
 
     internal sealed class MethodCallExpression5 : MethodCallExpression, IArgumentProvider
     {
-        private object _arg0;           // storage for the 1st argument or a readonly collection.  See IArgumentProvider
+        private object _arg0;           // storage for the 1st argument or a read-only collection.  See IArgumentProvider
         private readonly Expression _arg1, _arg2, _arg3, _arg4;   // storage for the 2nd - 5th args.
 
         public MethodCallExpression5(MethodInfo method, Expression arg0, Expression arg1, Expression arg2, Expression arg3, Expression arg4)
@@ -474,7 +474,7 @@ namespace System.Linq.Expressions
 
     internal sealed class InstanceMethodCallExpression1 : InstanceMethodCallExpression, IArgumentProvider
     {
-        private object _arg0;                // storage for the 1st argument or a readonly collection.  See IArgumentProvider
+        private object _arg0;                // storage for the 1st argument or a read-only collection.  See IArgumentProvider
 
         public InstanceMethodCallExpression1(MethodInfo method, Expression instance, Expression arg0)
             : base(method, instance)
@@ -513,7 +513,7 @@ namespace System.Linq.Expressions
 
     internal sealed class InstanceMethodCallExpression2 : InstanceMethodCallExpression, IArgumentProvider
     {
-        private object _arg0;                // storage for the 1st argument or a readonly collection.  See IArgumentProvider
+        private object _arg0;                // storage for the 1st argument or a read-only collection.  See IArgumentProvider
         private readonly Expression _arg1;   // storage for the 2nd argument
 
         public InstanceMethodCallExpression2(MethodInfo method, Expression instance, Expression arg0, Expression arg1)
@@ -555,7 +555,7 @@ namespace System.Linq.Expressions
 
     internal sealed class InstanceMethodCallExpression3 : InstanceMethodCallExpression, IArgumentProvider
     {
-        private object _arg0;                       // storage for the 1st argument or a readonly collection.  See IArgumentProvider
+        private object _arg0;                       // storage for the 1st argument or a read-only collection.  See IArgumentProvider
         private readonly Expression _arg1, _arg2;   // storage for the 2nd - 3rd argument
 
         public InstanceMethodCallExpression3(MethodInfo method, Expression instance, Expression arg0, Expression arg1, Expression arg2)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -832,12 +832,12 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// A string like "An incorrect number of type args were specified for the declaration of a Func type."
+        /// A string like "An incorrect number of type arguments were specified for the declaration of a Func type."
         /// </summary>
         internal static string IncorrectNumberOfTypeArgsForFunc => SR.IncorrectNumberOfTypeArgsForFunc;
 
         /// <summary>
-        /// A string like "An incorrect number of type args were specified for the declaration of an Action type."
+        /// A string like "An incorrect number of type arguments were specified for the declaration of an Action type."
         /// </summary>
         internal static string IncorrectNumberOfTypeArgsForAction => SR.IncorrectNumberOfTypeArgsForAction;
 

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/DebugInfoGenerator.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/DebugInfoGenerator.cs
@@ -20,7 +20,7 @@ namespace System.Runtime.CompilerServices
         /// <returns>PDB symbol generator.</returns>
         public static DebugInfoGenerator CreatePdbGenerator()
         {
-            // Creating PDBs is not suported in .NET Core
+            // Creating PDBs is not supported in .NET Core
             throw new PlatformNotSupportedException();
         }
 
@@ -29,7 +29,7 @@ namespace System.Runtime.CompilerServices
         /// </summary>
         /// <param name="method">The lambda being generated.</param>
         /// <param name="ilOffset">IL offset where to mark the sequence point.</param>
-        /// <param name="sequencePoint">Debug informaton corresponding to the sequence point.</param>
+        /// <param name="sequencePoint">Debug information corresponding to the sequence point.</param>
         public abstract void MarkSequencePoint(LambdaExpression method, int ilOffset, DebugInfoExpression sequencePoint);
 
         internal virtual void MarkSequencePoint(LambdaExpression method, MethodBase methodBase, ILGenerator ilg, DebugInfoExpression sequencePoint)


### PR DESCRIPTION
Noticed a few typos while browsing the code; searched for more using some tools.