### PR TITLE
Introduce a string constant to replace copies of "CallSite.Target" in System.Linq.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
@@ -43,7 +43,14 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     public class CallSite
     {
-        // Cache of CallSite constructors for a given delegate type
+        /// <summary>
+        /// String used for generated CallSite methods.
+        /// </summary>
+        internal const string CallSiteTargetMethodName = "CallSite.Target";
+
+        /// <summary>
+        /// Cache of CallSite constructors for a given delegate type.
+        /// </summary>
         private static volatile CacheDict<Type, Func<CallSiteBinder, CallSite>> s_siteCtors;
 
         /// <summary>
@@ -60,7 +67,7 @@ namespace System.Runtime.CompilerServices
         }
 
         /// <summary>
-        /// used by Matchmaker sites to indicate rule match.
+        /// Used by Matchmaker sites to indicate rule match.
         /// </summary>
         internal bool _match;
 
@@ -649,7 +656,7 @@ namespace System.Runtime.CompilerServices
                         body.ToReadOnly()
                     )
                 ),
-                "CallSite.Target",
+                CallSiteTargetMethodName,
                 true, // always compile the rules with tail call optimization
                 new TrueReadOnlyCollection<ParameterExpression>(@params)
             );

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteBinder.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteBinder.cs
@@ -202,7 +202,7 @@ namespace System.Runtime.CompilerServices
 
             return Expression.Lambda<T>(
                 Expression.Block(body),
-                "CallSite.Target",
+                CallSite.CallSiteTargetMethodName,
                 true, // always compile the rules with tail call optimization
                 new TrueReadOnlyCollection<ParameterExpression>(@params)
             );

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteHelpers.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteHelpers.cs
@@ -31,7 +31,7 @@ namespace System.Runtime.CompilerServices
             // non-static method. If it does, it is a dynamic method.
             // This could be improved if the CLR provides a way to attach some information
             // to the dynamic method we create, like CustomAttributes.
-            if (mb.Name == "CallSite.Target" && mb.GetType() != s_knownNonDynamicMethodType)
+            if (mb.Name == CallSite.CallSiteTargetMethodName && mb.GetType() != s_knownNonDynamicMethodType)
             {
                 return true;
             }


### PR DESCRIPTION
This string is used by `IsInternalFrame` and should not be changed. This PR eliminates copies of the string literal in various places by introducing a `const`.