### PR TITLE
Removing an unused contract method and adding documentation

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/ContractUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/ContractUtils.cs
@@ -9,6 +9,9 @@ namespace System.Dynamic.Utils
 {
     internal static partial class ContractUtils
     {
+        /// <summary>
+        /// Returns an exception object to be thrown when code is supposed to be unreachable.
+        /// </summary>
         public static Exception Unreachable
         {
             get
@@ -18,6 +21,18 @@ namespace System.Dynamic.Utils
             }
         }
 
+        /// <summary>
+        /// Requires the <paramref name="precondition"/> to be <c>true</c>.
+        /// </summary>
+        /// <param name="precondition">
+        /// The precondition to check for being <c>true</c>.
+        /// </param>
+        /// <param name="paramName">
+        /// The parameter name to use in the <see cref="ArgumentException.ParamName"/> property when an exception is thrown.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="precondition"/> is <c>false</c>.
+        /// </exception>
         public static void Requires(bool precondition, string paramName)
         {
             Debug.Assert(!string.IsNullOrEmpty(paramName));
@@ -28,6 +43,18 @@ namespace System.Dynamic.Utils
             }
         }
 
+        /// <summary>
+        /// Requires the <paramref name="value"/> to be non-<c>null</c>.
+        /// </summary>
+        /// <param name="value">
+        /// The value to check for being non-<c>null</c>.
+        /// </param>
+        /// <param name="paramName">
+        /// The parameter name to use in the <see cref="ArgumentException.ParamName"/> property when an exception is thrown.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="value"/> is <c>null</c>.
+        /// </exception>
         public static void RequiresNotNull(object value, string paramName)
         {
             Debug.Assert(!string.IsNullOrEmpty(paramName));
@@ -38,6 +65,22 @@ namespace System.Dynamic.Utils
             }
         }
 
+        /// <summary>
+        /// Requires the <paramref name="value"/> to be non-<c>null</c>.
+        /// </summary>
+        /// <param name="value">
+        /// The value to check for being non-<c>null</c>.
+        /// </param>
+        /// <param name="paramName">
+        /// The parameter name to use in the <see cref="ArgumentException.ParamName"/> property when an exception is thrown.
+        /// </param>
+        /// <param name="index">
+        /// The index of the argument being checked for <c>null</c>.
+        /// If an exception is thrown, this value is used in <see cref="ArgumentException.ParamName"/> if it's greater than or equal to 0.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="value"/> is <c>null</c>.
+        /// </exception>
         public static void RequiresNotNull(object value, string paramName, int index)
         {
             Debug.Assert(!string.IsNullOrEmpty(paramName));
@@ -48,6 +91,18 @@ namespace System.Dynamic.Utils
             }
         }
 
+        /// <summary>
+        /// Requires the <paramref name="collection"/> to be non-empty.
+        /// </summary>
+        /// <param name="collection">
+        /// The collection to check for being non-empty.
+        /// </param>
+        /// <param name="paramName">
+        /// The parameter name to use in the <see cref="ArgumentException.ParamName"/> property when an exception is thrown.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        /// Thrown if the <paramref name="collection"/> is empty.
+        /// </exception>
         public static void RequiresNotEmpty<T>(ICollection<T> collection, string paramName)
         {
             RequiresNotNull(collection, paramName);
@@ -57,21 +112,21 @@ namespace System.Dynamic.Utils
             }
         }
 
-        public static void RequiresNotEmptyList<T>(IReadOnlyList<T> collection, string paramName)
-        {
-            RequiresNotNull(collection, paramName);
-            if (collection.Count == 0)
-            {
-                throw new ArgumentException(Strings.NonEmptyCollectionRequired, paramName);
-            }
-        }
-
         /// <summary>
-        /// Requires the array and all its items to be non-null.
+        /// Requires the <paramref name="array"/> and all its items to be non-<c>null</c>.
         /// </summary>
+        /// <param name="array">
+        /// The array to check for being non-<c>null</c> and containing non-<c>null</c> items.
+        /// </param>
+        /// <param name="arrayName">
+        /// The parameter name to use in the <see cref="ArgumentException.ParamName"/> property when an exception is thrown.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if the <paramref name="array"/> or any of its items is <c>null</c>.
+        /// </exception>
         public static void RequiresNotNullItems<T>(IList<T> array, string arrayName)
         {
-            Debug.Assert(arrayName != null);
+            Debug.Assert(!string.IsNullOrEmpty(arrayName));
             RequiresNotNull(array, arrayName);
 
             for (int i = 0, n = array.Count; i < n; i++)


### PR DESCRIPTION
Noticed an unused `ContractUtils` method, thus removing it. While at it, also adding and improving documentation on the remaining methods.