### PR TITLE
Fix typos suport → support

### DIFF
--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSource.cs
@@ -3934,7 +3934,7 @@ namespace System.Diagnostics.Tracing
                             goto default;
                         break;
                     default:
-                        /* Contract.Assert(false, "Warning: User validation code sub-optimial: Unsuported opcode " + instrs[idx] +
+                        /* Contract.Assert(false, "Warning: User validation code sub-optimial: Unsupported opcode " + instrs[idx] +
                             " at " + idx + " in method " + method.Name); */
                         return -1;
                 }

--- a/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -79,7 +79,7 @@ namespace System.Net.Security.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Fact]
-        public async Task ClientAsyncAuthenticate_UnsuportedAllClient_Fail()
+        public async Task ClientAsyncAuthenticate_UnsupportedAllClient_Fail()
         {
             await Assert.ThrowsAsync<NotSupportedException>(() =>
             {

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -79,7 +79,7 @@ namespace System.Net.Security.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Fact]
-        public async Task ServerAsyncAuthenticate_UnsuportedAllServer_Fail()
+        public async Task ServerAsyncAuthenticate_UnsupportedAllServer_Fail()
         {
             await Assert.ThrowsAsync<NotSupportedException>(() =>
             {

--- a/src/System.Net.Security/tests/UnitTests/SslStreamAllowedProtocolsTest.cs
+++ b/src/System.Net.Security/tests/UnitTests/SslStreamAllowedProtocolsTest.cs
@@ -57,7 +57,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        public void SslStream_AuthenticateAsClientAsync_AllUnsuported_Fails()
+        public void SslStream_AuthenticateAsClientAsync_AllUnsupported_Fails()
         {
             SslStream stream = new SslStream(new NotImplementedStream());
             Assert.Throws<NotSupportedException>(() => AuthenticateAsClient(stream, false, "host", null, SslProtocolSupport.UnsupportedSslProtocols, false));

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -4233,7 +4233,7 @@ namespace System.Net.Sockets
                 {
                     // Disable CS0162 and CS0429: Unreachable code detected
                     //
-                    // SuportsMultipleConnectAttempts is a constant; when false, the following lines will trigger CS0162 or CS0429.
+                    // SupportsMultipleConnectAttempts is a constant; when false, the following lines will trigger CS0162 or CS0429.
                     //
                     // This is the only *Connect* API that actually supports multiple endpoint attempts, as it's responsible 
                     // for creating each Socket instance and can create one per attempt (with the instance methods, once a 
@@ -5486,7 +5486,7 @@ namespace System.Net.Sockets
 
         // Disable CS0162: Unreachable code detected
         //
-        // SuportsMultipleConnectAttempts is a constant; when false, the following lines will trigger CS0162.
+        // SupportsMultipleConnectAttempts is a constant; when false, the following lines will trigger CS0162.
 #pragma warning disable 162, 429
         private static object PostOneBeginConnect(MultipleAddressConnectAsyncResult context)
         {

--- a/src/System.Private.Xml/src/System/Xml/Serialization/Types.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/Types.cs
@@ -549,7 +549,7 @@ namespace System.Xml.Serialization
 
             // Unsuppoted types that we map to string, if in the future we decide 
             // to add support for them we would need to create custom formatters for them
-            // normalizedString is the only one unsuported type that suppose to preserve whitesapce
+            // normalizedString is the only one unsupported type that suppose to preserve whitesapce
             AddPrimitive(typeof(string), "normalizedString", "String", TypeFlags.AmbiguousDataType | TypeFlags.CanBeAttributeValue | TypeFlags.CanBeElementValue | TypeFlags.CanBeTextValue | TypeFlags.Reference | TypeFlags.HasDefaultConstructor);
             for (int i = 0; i < s_unsupportedTypes.Length; i++)
             {

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSchemaExporter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSchemaExporter.cs
@@ -597,7 +597,7 @@ namespace System.Xml.Serialization
             }
             else
             {
-                throw new InvalidOperationException(SR.Format(SR.XmlInternalErrorDetails, "Unsuported anonymous mapping type: " + mapping.ToString()));
+                throw new InvalidOperationException(SR.Format(SR.XmlInternalErrorDetails, "Unsupported anonymous mapping type: " + mapping.ToString()));
             }
         }
 

--- a/src/System.Reflection.Emit.Lightweight/pkg/System.Reflection.Emit.Lightweight.pkgproj
+++ b/src/System.Reflection.Emit.Lightweight/pkg/System.Reflection.Emit.Lightweight.pkgproj
@@ -12,7 +12,7 @@
     <!-- MonoTouch, Xamarin.iOS, Xamarin.TVOS, and Xamarain.WatchOS don't actually support this, 
          but do support a PCL profile that contained it so we must treat as inbox -->
     <InboxOnTargetFramework Include="$(AllXamarinFrameworks)" />
-    <!-- This dependency is not suported on AOT, but that is OK since this package is
+    <!-- This dependency is not supported on AOT, but that is OK since this package is
          restricted from AOT via runtime.json -->
     <SuppressDependencyError Include="System.Reflection.Emit.ILGeneration">
       <Version>4.0.0.0</Version>

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/NetFxToWinRtStreamAdapter.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/NetFxToWinRtStreamAdapter.cs
@@ -441,7 +441,7 @@ namespace System.IO
         // Cloning can be added in future, however, it would be quite complex
         // to support it correctly for generic streams.
 
-        private static void ThrowCloningNotSuported(String methodName)
+        private static void ThrowCloningNotSupported(String methodName)
         {
             NotSupportedException nse = new NotSupportedException(SR.Format(SR.NotSupported_CloningNotSupported, methodName));
             nse.SetErrorCode(HResults.E_NOTIMPL);
@@ -451,21 +451,21 @@ namespace System.IO
 
         public IRandomAccessStream CloneStream()
         {
-            ThrowCloningNotSuported("CloneStream");
+            ThrowCloningNotSupported("CloneStream");
             return null;
         }
 
 
         public IInputStream GetInputStreamAt(UInt64 position)
         {
-            ThrowCloningNotSuported("GetInputStreamAt");
+            ThrowCloningNotSupported("GetInputStreamAt");
             return null;
         }
 
 
         public IOutputStream GetOutputStreamAt(UInt64 position)
         {
-            ThrowCloningNotSuported("GetOutputStreamAt");
+            ThrowCloningNotSupported("GetOutputStreamAt");
             return null;
         }
         #endregion IRandomAccessStream public interface: Cloning related


### PR DESCRIPTION
Mostly comments, private members and test names where they have no effect, but one is in an exception message.