### PR TITLE
Implement IntPtr/UIntPtr enum casts in Linq expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -403,7 +403,7 @@ namespace System.Dynamic.Utils
                 case TypeCode.Char:
                     return true;
                 default:
-                    return false;
+                    return type == typeof(IntPtr) || type == typeof(UIntPtr);
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -867,6 +867,21 @@ namespace System.Linq.Expressions.Compiler
                                 il.Emit(OpCodes.Conv_Ovf_U8_Un);
                                 break;
                             default:
+                                if (typeTo.IsEnum)
+                                {
+                                    Type underlyingType = Enum.GetUnderlyingType(typeTo);
+                                    if (underlyingType == typeof(IntPtr))
+                                    {
+                                        il.Emit(OpCodes.Conv_Ovf_I_Un);
+                                        break;
+                                    }
+                                    else
+                                    {
+                                        Debug.Assert(underlyingType == typeof(UIntPtr));
+                                        il.Emit(OpCodes.Conv_Ovf_U_Un);
+                                        break;
+                                    }
+                                }
                                 throw Error.UnhandledConvert(typeTo);
                         }
                     }
@@ -900,6 +915,21 @@ namespace System.Linq.Expressions.Compiler
                                 il.Emit(OpCodes.Conv_Ovf_U8);
                                 break;
                             default:
+                                if (typeTo.IsEnum)
+                                {
+                                    Type underlyingType = Enum.GetUnderlyingType(typeTo);
+                                    if (underlyingType == typeof(IntPtr))
+                                    {
+                                        il.Emit(OpCodes.Conv_Ovf_I);
+                                        break;
+                                    }
+                                    else
+                                    {
+                                        Debug.Assert(underlyingType == typeof(UIntPtr));
+                                        il.Emit(OpCodes.Conv_Ovf_U);
+                                        break;
+                                    }
+                                }
                                 throw Error.UnhandledConvert(typeTo);
                         }
                     }
@@ -952,6 +982,21 @@ namespace System.Linq.Expressions.Compiler
                             il.Emit(OpCodes.Cgt_Un);
                             break;
                         default:
+                            if (typeTo.IsEnum)
+                            {
+                                Type underlyingType = Enum.GetUnderlyingType(typeTo);
+                                if (underlyingType == typeof(IntPtr))
+                                {
+                                    il.Emit(OpCodes.Conv_I);
+                                    break;
+                                }
+                                else
+                                {
+                                    Debug.Assert(underlyingType == typeof(UIntPtr));
+                                    il.Emit(OpCodes.Conv_U);
+                                    break;
+                                }
+                            }
                             throw Error.UnhandledConvert(typeTo);
                     }
                 }
@@ -1195,9 +1240,23 @@ namespace System.Linq.Expressions.Compiler
                 case TypeCode.DateTime:
                     if (type.GetTypeInfo().IsValueType)
                     {
-                        // Type.GetTypeCode on an enum returns the underlying
-                        // integer TypeCode, so we won't get here.
-                        Debug.Assert(!type.GetTypeInfo().IsEnum);
+                        if (type.GetTypeInfo().IsEnum)
+                        {
+                            Type underlyingType = Enum.GetUnderlyingType(type);
+                            if (underlyingType == typeof(IntPtr))
+                            {
+                                il.Emit(OpCodes.Ldc_I4_0);
+                                il.Emit(OpCodes.Conv_I);
+                                break;
+                            }
+                            else
+                            {
+                                Debug.Assert(underlyingType == typeof(UIntPtr));
+                                il.Emit(OpCodes.Ldc_I4_0);
+                                il.Emit(OpCodes.Conv_U);
+                                break;
+                            }
+                        }
 
                         // This is the IL for default(T) if T is a generic type
                         // parameter, so it should work for any type. It's also

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -493,12 +493,22 @@ namespace System.Linq.Expressions.Interpreter
                 // Disallowed in C#, but allowed in CIL
                 frame.Push(Enum.ToObject(_t, (char)from));
             }
+            else if (underlying == typeof(bool))
+            {
+                // Disallowed in C#, but allowed in CIL
+                frame.Push(Enum.ToObject(_t, (bool)from));
+            }
+            else if (underlying == typeof(IntPtr))
+            {
+                // Disallowed in C#, but allowed in CIL
+                frame.Push(Enum.ToObject(_t, ((IntPtr)from).ToInt64()));
+            }
             else
             {
                 // Only remaining possible type.
                 // Disallowed in C#, but allowed in CIL
-                Debug.Assert(underlying == typeof(bool));
-                frame.Push(Enum.ToObject(_t, (bool)from));
+                Debug.Assert(underlying == typeof(UIntPtr));
+                frame.Push(Enum.ToObject(_t, ((UIntPtr)from).ToUInt64()));
             }
 
             return 1;

--- a/src/System.Linq.Expressions/tests/Cast/CastTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastTests.cs
@@ -2376,6 +2376,8 @@ namespace System.Linq.Expressions.Tests
             yield return typeof(UInt64Enum);
             yield return NonCSharpTypes.CharEnumType;
             yield return NonCSharpTypes.BoolEnumType;
+            yield return NonCSharpTypes.IntPtrEnumType;
+            yield return NonCSharpTypes.UIntPtrEnumType;
         }
 
         public static IEnumerable<object[]> EnumerableTypeArgs() => EnumerableTypes().Select(t => new object[] {t});

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -351,8 +351,6 @@ namespace System.Linq.Expressions.Tests
     {
         private static Type _charEnumType;
         private static Type _boolEnumType;
-        private static Type _floatEnumType;
-        private static Type _doubleEnumType;
         private static Type _intPtrEnumType;
         private static Type _uintPtrEnumType;
 
@@ -396,40 +394,6 @@ namespace System.Linq.Expressions.Tests
             }
         }
         
-        public static Type FloatEnumType
-        {
-            get
-            {
-                if (_floatEnumType == null)
-                {
-                    EnumBuilder eb = GetModuleBuilder().DefineEnum("FloatEnumType", TypeAttributes.Public, typeof(float));
-                    eb.DefineLiteral("A", 1.0f);
-                    eb.DefineLiteral("B", 2.0f);
-                    eb.DefineLiteral("C", 3.0f);
-                    _floatEnumType = eb.CreateTypeInfo().AsType();
-                }
-
-                return _floatEnumType;
-            }
-        }
-
-        public static Type DoubleEnumType
-        {
-            get
-            {
-                if (_doubleEnumType == null)
-                {
-                    EnumBuilder eb = GetModuleBuilder().DefineEnum("DoubleEnumType", TypeAttributes.Public, typeof(double));
-                    eb.DefineLiteral("A", 1.0);
-                    eb.DefineLiteral("B", 2.0);
-                    eb.DefineLiteral("C", 3.0);
-                    _doubleEnumType = eb.CreateTypeInfo().AsType();
-                }
-
-                return _doubleEnumType;
-            }
-        }
-
         public static Type IntPtrEnumType
         {
             get

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -338,19 +338,23 @@ namespace System.Linq.Expressions.Tests
         }
     }
 
-    public enum ByteEnum : byte { A = Byte.MaxValue }
-    public enum SByteEnum : sbyte { A = SByte.MaxValue }
-    public enum Int16Enum : short { A = Int16.MaxValue }
-    public enum UInt16Enum : ushort { A = UInt16.MaxValue }
-    public enum Int32Enum : int { A = Int32.MaxValue }
-    public enum UInt32Enum : uint { A = UInt32.MaxValue }
-    public enum Int64Enum : long { A = Int64.MaxValue }
-    public enum UInt64Enum : ulong { A = UInt64.MaxValue }
+    public enum ByteEnum : byte { A = byte.MaxValue }
+    public enum SByteEnum : sbyte { A = sbyte.MaxValue }
+    public enum Int16Enum : short { A = short.MaxValue }
+    public enum UInt16Enum : ushort { A = ushort.MaxValue }
+    public enum Int32Enum : int { A = int.MaxValue }
+    public enum UInt32Enum : uint { A = uint.MaxValue }
+    public enum Int64Enum : long { A = long.MaxValue }
+    public enum UInt64Enum : ulong { A = ulong.MaxValue }
 
     public static class NonCSharpTypes
     {
         private static Type _charEnumType;
         private static Type _boolEnumType;
+        private static Type _floatEnumType;
+        private static Type _doubleEnumType;
+        private static Type _intPtrEnumType;
+        private static Type _uintPtrEnumType;
 
         private static ModuleBuilder GetModuleBuilder()
         {
@@ -389,6 +393,68 @@ namespace System.Linq.Expressions.Tests
                 }
 
                 return _boolEnumType;
+            }
+        }
+        
+        public static Type FloatEnumType
+        {
+            get
+            {
+                if (_floatEnumType == null)
+                {
+                    EnumBuilder eb = GetModuleBuilder().DefineEnum("FloatEnumType", TypeAttributes.Public, typeof(float));
+                    eb.DefineLiteral("A", 1.0f);
+                    eb.DefineLiteral("B", 2.0f);
+                    eb.DefineLiteral("C", 3.0f);
+                    _floatEnumType = eb.CreateTypeInfo().AsType();
+                }
+
+                return _floatEnumType;
+            }
+        }
+
+        public static Type DoubleEnumType
+        {
+            get
+            {
+                if (_doubleEnumType == null)
+                {
+                    EnumBuilder eb = GetModuleBuilder().DefineEnum("DoubleEnumType", TypeAttributes.Public, typeof(double));
+                    eb.DefineLiteral("A", 1.0);
+                    eb.DefineLiteral("B", 2.0);
+                    eb.DefineLiteral("C", 3.0);
+                    _doubleEnumType = eb.CreateTypeInfo().AsType();
+                }
+
+                return _doubleEnumType;
+            }
+        }
+
+        public static Type IntPtrEnumType
+        {
+            get
+            {
+                if (_intPtrEnumType == null)
+                {
+                    EnumBuilder eb = GetModuleBuilder().DefineEnum("IntPtrEnumType", TypeAttributes.Public, typeof(IntPtr));
+                    _intPtrEnumType = eb.CreateTypeInfo().AsType();
+                }
+
+                return _intPtrEnumType;
+            }
+        }
+
+        public static Type UIntPtrEnumType
+        {
+            get
+            {
+                if (_uintPtrEnumType == null)
+                {
+                    EnumBuilder eb = GetModuleBuilder().DefineEnum("UIntPtrEnumType", TypeAttributes.Public, typeof(UIntPtr));
+                    _uintPtrEnumType = eb.CreateTypeInfo().AsType();
+                }
+
+                return _uintPtrEnumType;
             }
         }
     }


### PR DESCRIPTION
@JonHanna @stephentoub @bartdesmet @vsadov

The strange creatures that are IntPtr and UIntPtr enums are explicitly supported in the CLI specification. Whether anyone has ever used one and if supporting them was accidental is a different story.

The previous behaviour was debug assertions in both compiler and interpreter on compilation and occasionally on creation of the trees