### PR TITLE
Improving ToString for field instructions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/FieldOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/FieldOperations.cs
@@ -7,14 +7,25 @@ using System.Reflection;
 
 namespace System.Linq.Expressions.Interpreter
 {
-    internal sealed class LoadStaticFieldInstruction : Instruction
+    internal abstract class FieldInstruction : Instruction
     {
-        private readonly FieldInfo _field;
+        protected readonly FieldInfo _field;
 
+        public FieldInstruction(FieldInfo field)
+        {
+            Assert.NotNull(field);
+            _field = field;
+        }
+
+        public override string ToString() => InstructionName + "(" + _field + ")";
+    }
+
+    internal sealed class LoadStaticFieldInstruction : FieldInstruction
+    {
         public LoadStaticFieldInstruction(FieldInfo field)
+            : base(field)
         {
             Debug.Assert(field.IsStatic);
-            _field = field;
         }
 
         public override string InstructionName => "LoadStaticField";
@@ -27,14 +38,11 @@ namespace System.Linq.Expressions.Interpreter
         }
     }
 
-    internal sealed class LoadFieldInstruction : Instruction
+    internal sealed class LoadFieldInstruction : FieldInstruction
     {
-        private readonly FieldInfo _field;
-
         public LoadFieldInstruction(FieldInfo field)
+            : base(field)
         {
-            Assert.NotNull(field);
-            _field = field;
         }
 
         public override string InstructionName => "LoadField";
@@ -51,14 +59,12 @@ namespace System.Linq.Expressions.Interpreter
         }
     }
 
-    internal sealed class StoreFieldInstruction : Instruction
+    internal sealed class StoreFieldInstruction : FieldInstruction
     {
-        private readonly FieldInfo _field;
-
         public StoreFieldInstruction(FieldInfo field)
+            : base(field)
         {
             Assert.NotNull(field);
-            _field = field;
         }
 
         public override string InstructionName => "StoreField";
@@ -76,14 +82,12 @@ namespace System.Linq.Expressions.Interpreter
         }
     }
 
-    internal sealed class StoreStaticFieldInstruction : Instruction
+    internal sealed class StoreStaticFieldInstruction : FieldInstruction
     {
-        private readonly FieldInfo _field;
-
         public StoreStaticFieldInstruction(FieldInfo field)
+            : base(field)
         {
-            Assert.NotNull(field);
-            _field = field;
+            Debug.Assert(field.IsStatic);
         }
 
         public override string InstructionName => "StoreStaticField";

--- a/src/System.Linq.Expressions/tests/StackSpillerTests.cs
+++ b/src/System.Linq.Expressions/tests/StackSpillerTests.cs
@@ -1377,7 +1377,7 @@ namespace System.Linq.Expressions.Tests
                         IP_0006: EnterFinally[0] -> 6
                         IP_0007: LeaveFinally()
                       }
-                      IP_0008: StoreField()
+                      IP_0008: StoreField(Int32 Baz)
                       IP_0009: StoreLocal(0)
                       IP_0010: LoadLocal(0)
                       IP_0011: ValueTypeCopy()
@@ -1575,7 +1575,7 @@ namespace System.Linq.Expressions.Tests
                         IP_0009: EnterFinally[0] -> 9
                         IP_0010: LeaveFinally()
                       }
-                      IP_0011: StoreField()
+                      IP_0011: StoreField(Int32 Foo)
                       IP_0012: Pop()
                       IP_0013: StoreLocal(0)
                       IP_0014: LoadLocal(0)


### PR DESCRIPTION
Discovered this during the work on stack spilling. Refactoring the field instructions using a common `FieldInstruction` base class and providing a custom `ToString` override to include the field information in the string representation.

We should likely do a separate pass to improve all reflection printing to include more information such as the declaring type.