### PR TITLE
Don't try to test both compiler and interpreter if only one available.

### DIFF
--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -246,19 +246,17 @@ namespace System.Linq.Expressions.Tests
 
     internal class CompilationTypes : IEnumerable<object[]>
     {
-        private static readonly object[] False = new object[] { false };
-        private static readonly object[] True = new object[] { true };
-
-        public IEnumerator<object[]> GetEnumerator()
+        private static readonly IEnumerable<object[]> Booleans = new[]
         {
-            yield return False;
-            yield return True;
-        }
+            new object[] {false},
+#if FEATURE_COMPILE && FEATURE_INTERPRET
+            new object[] {true}
+#endif
+        };
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+        public IEnumerator<object[]> GetEnumerator() => Booleans.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     internal class NoOpVisitor : ExpressionVisitor

--- a/src/System.Linq.Expressions/tests/TestExtensions/InlinePerCompilationTypeAttribute.cs
+++ b/src/System.Linq.Expressions/tests/TestExtensions/InlinePerCompilationTypeAttribute.cs
@@ -12,7 +12,13 @@ namespace System.Linq.Expressions.Tests
 {
     internal class InlinePerCompilationTypeAttribute : DataAttribute
     {
-        private static readonly object[] s_boxedBooleans = {false, true};
+        private static readonly object[] s_boxedBooleans =
+        {
+            false,
+#if FEATURE_COMPILE && FEATURE_INTERPRET
+            true
+#endif
+        };
 
         private readonly object[] _data;
 

--- a/src/System.Linq.Expressions/tests/TestExtensions/PerCompilationTypeAttribute.cs
+++ b/src/System.Linq.Expressions/tests/TestExtensions/PerCompilationTypeAttribute.cs
@@ -34,10 +34,14 @@ namespace System.Linq.Expressions.Tests
             foreach (object[] received in delegatedTo.GetData(testMethod))
             {
                 object[] withFalse = new object[received.Length + 1];
+#if FEATURE_COMPILE && FEATURE_INTERPRET
                 object[] withTrue = new object[received.Length + 1];
+#endif
 
                 withFalse[received.Length] = s_boxedFalse;
+#if FEATURE_COMPILE && FEATURE_INTERPRET
                 withTrue[received.Length] = s_boxedTrue;
+#endif
 
                 for (int i = 0; i != received.Length; ++i)
                 {
@@ -47,7 +51,9 @@ namespace System.Linq.Expressions.Tests
                 }
 
                 yield return withFalse;
+#if FEATURE_COMPILE && FEATURE_INTERPRET
                 yield return withTrue;
+#endif
             }
         }
     }


### PR DESCRIPTION
Unless both `FEATURE_COMPILE` and `FEATURE_INTERPRET` are defined, then the boolean argument to `Compile()` has no real effect, except to nearly double wall time the tests take to run. Therefore only pass one such value in other cases.