### PR TITLE
Remove unused usings in System.Linq.Expressions tests

### DIFF
--- a/src/System.Linq.Expressions/tests/Array/ArrayAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayAccessTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Array/ArrayArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayArrayIndexTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Array/ArrayArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayArrayLengthTests.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Array/ArrayBoundsOneOffTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayBoundsOneOffTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Array/NullableArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NullableArrayIndexTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Array/NullableArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NullableArrayLengthTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Array/NullableNewArrayListTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NullableNewArrayListTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullablePowerTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullablePowerTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryPowerTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryPowerTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/OpAssign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/OpAssign.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Xunit;

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryAndTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryAndTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryExclusiveOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryExclusiveOrTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableAndTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableAndTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableExclusiveOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableExclusiveOrTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableOrTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryOrTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryNullableLogicalTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryNullableLogicalTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqual.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqual.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqualityTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqualityTests.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace System.Linq.Expressions.Tests
 {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceNotEqual.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceNotEqual.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Block/BlockFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockFactoryTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Block/BlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockTests.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using Xunit;

--- a/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using Xunit;

--- a/src/System.Linq.Expressions/tests/Block/SharedBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/SharedBlockTests.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using Xunit;
 
 namespace System.Linq.Expressions.Tests
 {

--- a/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Xunit;

--- a/src/System.Linq.Expressions/tests/Cast/AsNullable.cs
+++ b/src/System.Linq.Expressions/tests/Cast/AsNullable.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Cast/AsTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/AsTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Cast/CastNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastNullableTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Cast/CastTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Xunit;

--- a/src/System.Linq.Expressions/tests/Cast/IsNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/IsNullableTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Cast/IsTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/IsTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/CompilerTests.cs
+++ b/src/System.Linq.Expressions/tests/CompilerTests.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Constant/ConstantArrayTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantArrayTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Constant/ConstantNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/DebugViewTests.cs
+++ b/src/System.Linq.Expressions/tests/DebugViewTests.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Default/DefaultTests.cs
+++ b/src/System.Linq.Expressions/tests/Default/DefaultTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/DelegateType/ActionTypeTests.cs
+++ b/src/System.Linq.Expressions/tests/DelegateType/ActionTypeTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/DelegateType/FuncTypeTests.cs
+++ b/src/System.Linq.Expressions/tests/DelegateType/FuncTypeTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/DelegateType/GetDelegateTypeTests.cs
+++ b/src/System.Linq.Expressions/tests/DelegateType/GetDelegateTypeTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Reflection;
 using System.Text.RegularExpressions;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/ExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ExpressionTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/ExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ExpressionTests.cs
@@ -25,10 +25,7 @@ namespace System.Linq.Expressions.Tests
         {
             public class Visitor : ExpressionVisitor
             {
-                protected override Expression VisitExtension(Expression node)
-                {
-                    return MarkerExtension;
-                }
+                protected override Expression VisitExtension(Expression node) => MarkerExtension;
             }
 
             public IncompleteExpressionOverride()
@@ -36,68 +33,41 @@ namespace System.Linq.Expressions.Tests
             {
             }
 
-            public Expression VisitChildren()
-            {
-                return VisitChildren(new Visitor());
-            }
+            public Expression VisitChildren() => VisitChildren(new Visitor());
         }
 
         private class ClaimedReducibleOverride : IncompleteExpressionOverride
         {
-            public override bool CanReduce
-            {
-                get { return true; }
-            }
+            public override bool CanReduce => true;
         }
 
         private class ReducesToSame : ClaimedReducibleOverride
         {
-            public override Expression Reduce()
-            {
-                return this;
-            }
+            public override Expression Reduce() => this;
         }
 
         private class ReducesToNull : ClaimedReducibleOverride
         {
-            public override Expression Reduce()
-            {
-                return null;
-            }
+            public override Expression Reduce() => null;
         }
 
         private class ReducesToLongTyped : ClaimedReducibleOverride
         {
             private class ReducedToLongTyped : IncompleteExpressionOverride
             {
-                public override Type Type
-                {
-                    get { return typeof(long); }
-                }
+                public override Type Type => typeof(long);
             }
 
-            public override Type Type
-            {
-                get { return typeof(int); }
-            }
+            public override Type Type => typeof(int);
 
-            public override Expression Reduce()
-            {
-                return new ReducedToLongTyped();
-            }
+            public override Expression Reduce() => new ReducedToLongTyped();
         }
 
         private class Reduces : ClaimedReducibleOverride
         {
-            public override Type Type
-            {
-                get { return typeof(int); }
-            }
+            public override Type Type => typeof(int);
 
-            public override Expression Reduce()
-            {
-                return new Reduces();
-            }
+            public override Expression Reduce() => new Reduces();
         }
 
         private class ReducesFromStrangeNodeType : Expression
@@ -163,14 +133,8 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
-        public static IEnumerable<object[]> SomeTypes
-        {
-            get
-            {
-                return new[] { typeof(int), typeof(void), typeof(object), typeof(DateTime), typeof(string), typeof(ExpressionTests), typeof(ExpressionType) }
-                    .Select(type => new object[] { type });
-            }
-        }
+        public static IEnumerable<object[]> SomeTypes => new[] { typeof(int), typeof(void), typeof(object), typeof(DateTime), typeof(string), typeof(ExpressionTests), typeof(ExpressionType) }
+    .Select(type => new object[] { type });
 
         [Fact]
         public void NodeTypeMustBeOverridden()
@@ -306,10 +270,7 @@ namespace System.Linq.Expressions.Tests
             set { }
         }
 
-        private static int Unwritable
-        {
-            get { return 0; }
-        }
+        private static int Unwritable => 0;
 
         private class UnreadableIndexableClass
         {
@@ -321,10 +282,7 @@ namespace System.Linq.Expressions.Tests
 
         private class UnwritableIndexableClass
         {
-            public int this[int index]
-            {
-                get { return 0; }
-            }
+            public int this[int index] => 0;
         }
 
         [Fact]
@@ -353,13 +311,7 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
-        public static IEnumerable<object[]> UnreadableExpressionData
-        {
-            get
-            {
-                return UnreadableExpressions.Concat(new Expression[1]).Select(exp => new object[] { exp });
-            }
-        }
+        public static IEnumerable<object[]> UnreadableExpressionData => UnreadableExpressions.Concat(new Expression[1]).Select(exp => new object[] { exp });
 
         public static IEnumerable<Expression> WritableExpressions
         {
@@ -385,21 +337,9 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
-        public static IEnumerable<object[]> UnwritableExpressionData
-        {
-            get
-            {
-                return UnwritableExpressions.Select(exp => new object[] { exp });
-            }
-        }
+        public static IEnumerable<object[]> UnwritableExpressionData => UnwritableExpressions.Select(exp => new object[] { exp });
 
-        public static IEnumerable<object[]> WritableExpressionData
-        {
-            get
-            {
-                return WritableExpressions.Select(exp => new object[] { exp });
-            }
-        }
+        public static IEnumerable<object[]> WritableExpressionData => WritableExpressions.Select(exp => new object[] { exp });
 
         [Theory, MemberData(nameof(UnreadableExpressionData))]
         public void ConfirmCannotRead(Expression unreadableExpression)

--- a/src/System.Linq.Expressions/tests/Goto/GotoExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/Goto/GotoExpressionTests.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using Xunit;
 
 namespace System.Linq.Expressions.Tests
 {

--- a/src/System.Linq.Expressions/tests/ILReader/LocalsSignatureParser.cs
+++ b/src/System.Linq.Expressions/tests/ILReader/LocalsSignatureParser.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace System.Linq.Expressions.Tests
 {

--- a/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionVisitorTests.cs
+++ b/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionVisitorTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Invoke/InvokeFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvokeFactoryTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Label/LabelTargetTests.cs
+++ b/src/System.Linq.Expressions/tests/Label/LabelTargetTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Label/LabelTests.cs
+++ b/src/System.Linq.Expressions/tests/Label/LabelTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaAddNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaAddNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaAddTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaAddTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaDivideNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaDivideNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaDivideTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaIdentityNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaIdentityNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaIdentityTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaIdentityTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaModuloNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaModuloNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaModuloTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Reflection;
-using System.Threading;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedAddCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedAddCheckedNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedAddNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedAddNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseAndNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseAndNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseExclusiveOrNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseExclusiveOrNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseOrNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseOrNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonEqualNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonGreaterThanNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonGreaterThanNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonGreaterThanOrEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonGreaterThanOrEqualNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonLessThanNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonLessThanNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonLessThanOrEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonLessThanOrEqualNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonNotEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonNotEqualNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedDivideNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedDivideNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedModuloNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedModuloNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyCheckedNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractCheckedNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonEqualNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonGreaterThanNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonGreaterThanNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonGreaterThanOrEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonGreaterThanOrEqualNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonLessThanNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonLessThanNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonLessThanOrEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonLessThanOrEqualNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonNotEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonNotEqualNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/ListInit/ElementInitTests.cs
+++ b/src/System.Linq.Expressions/tests/ListInit/ElementInitTests.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;

--- a/src/System.Linq.Expressions/tests/Loop/LoopTests.cs
+++ b/src/System.Linq.Expressions/tests/Loop/LoopTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Reflection;
 using System.Text;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;

--- a/src/System.Linq.Expressions/tests/MemberInit/MemberInitTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/MemberInitTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/New/NewTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Xunit;

--- a/src/System.Linq.Expressions/tests/New/NewWithParameterTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewWithParameterTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/New/NewWithTwoParametersTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewWithTwoParametersTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/New/TypeExtensions.cs
+++ b/src/System.Linq.Expressions/tests/New/TypeExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Ternary/TernaryArrayNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Ternary/TernaryArrayNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Ternary/TernaryArrayTests.cs
+++ b/src/System.Linq.Expressions/tests/Ternary/TernaryArrayTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Ternary/TernaryNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Ternary/TernaryNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Ternary/TernaryTests.cs
+++ b/src/System.Linq.Expressions/tests/Ternary/TernaryTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/TestExtensions/InlinePerCompilationTypeAttribute.cs
+++ b/src/System.Linq.Expressions/tests/TestExtensions/InlinePerCompilationTypeAttribute.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
-using Xunit;
 using Xunit.Sdk;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/TestExtensions/TestOrderAttribute.cs
+++ b/src/System.Linq.Expressions/tests/TestExtensions/TestOrderAttribute.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 
 namespace System.Linq.Expressions.Tests
 {

--- a/src/System.Linq.Expressions/tests/TestExtensions/TestOrderer.cs
+++ b/src/System.Linq.Expressions/tests/TestExtensions/TestOrderer.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeBinaryTests.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeBinaryTests.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace System.Linq.Expressions.Tests
 {

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeIs.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeIs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/IncDecAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/IncDecAssignTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostDecrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostDecrementAssignTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostIncrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostIncrementAssignTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreDecrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreDecrementAssignTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreIncrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreIncrementAssignTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Reflection;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableOneOffTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableOneOffTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryDecrementNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryDecrementNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryDecrementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryDecrementTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIncrementNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIncrementNullableTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIncrementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIncrementTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseNullableTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueNullableTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementNullableTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryQuoteTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryQuoteTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Reflection;
 using Xunit;
 
 using static System.Linq.Expressions.Expression;

--- a/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusNullableTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnaryUnboxTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryUnboxTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Unary/UnboxTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnboxTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/System.Linq.Expressions/tests/Variables/ParameterExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/ParameterExpressionTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq.Expressions.Tests

--- a/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Xunit;

--- a/src/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Xunit;

--- a/src/System.Linq.Expressions/tests/Variables/VariableTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/VariableTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests


### PR DESCRIPTION
Some bulk removal of unused usings in test code as part of clean-up work. Also making one file consistent wrt C# 6.0 feature usage.