### PR TITLE
Changing signature of Map to use arrays

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/CollectionExtensions.Map.cs
+++ b/src/Common/src/System/Dynamic/Utils/CollectionExtensions.Map.cs
@@ -2,22 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-
 namespace System.Dynamic.Utils
 {
     internal static partial class CollectionExtensions
     {
         // Name needs to be different so it doesn't conflict with Enumerable.Select
-        public static U[] Map<T, U>(this ICollection<T> collection, Func<T, U> select)
+        public static U[] Map<T, U>(this T[] array, Func<T, U> select)
         {
-            int count = collection.Count;
+            int count = array.Length;
+
             U[] result = new U[count];
-            count = 0;
-            foreach (T t in collection)
+            
+            for (int i = 0; i < count; i++)
             {
-                result[count++] = select(t);
+                result[i] = select(array[i]);
             }
+
             return result;
         }
     }


### PR DESCRIPTION
With some uses of `Map` eliminated in the code base, this extension method can now be narrowed down to operate on arrays instead, thus avoiding enumerator allocations.