### PR TITLE
Removing some dead code in System.Linq.Expressions

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/TypeExtensions.cs
+++ b/src/Common/src/System/Dynamic/Utils/TypeExtensions.cs
@@ -29,12 +29,6 @@ namespace System.Dynamic.Utils
             return pis;
         }
 
-
-        public static bool IsSubclassOf(this Type source, Type other)
-        {
-            return source.GetTypeInfo().IsSubclassOf(other);
-        }
-
 #if FEATURE_COMPILE
         // Expression trees/compiler just use IsByRef, why do we need this?
         // (see LambdaCompiler.EmitArguments for usage in the compiler)

--- a/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
@@ -13,11 +13,6 @@ namespace System.Dynamic.Utils
             return t1.IsEquivalentTo(t2);
         }
 
-        public static bool IsEquivalentTo(this Type t1, Type t2)
-        {
-            return t1 == t2;
-        }
-
         public static bool AreReferenceAssignable(Type dest, Type src)
         {
             // This actually implements "Is this identity assignable and/or reference assignable?"


### PR DESCRIPTION
Two extension methods that were introduced to work around reduced API surface prior to the upgrade of the target framework we build against.