### PR TITLE
MSFT.CSharp: Replace empty ; with more blatant {}

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorHandling.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorHandling.cs
@@ -159,7 +159,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             {
                 // Copy the strings over to another buffer.
                 string[] prgpszNew = new string[cpsz];
-                Array.Copy(prgpsz, 0, prgpszNew, 0, cpsz); ;
+                Array.Copy(prgpsz, 0, prgpszNew, 0, cpsz);
 
                 for (int i = 0; i < cpsz; i++)
                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ConstValFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ConstValFactory.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public static CONSTVAL GetInt(int value)
         {
-            CONSTVAL result = new CONSTVAL(); ;
+            CONSTVAL result = new CONSTVAL();
             result.iVal = value;
             return result;
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
@@ -376,7 +376,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(fieldType != null);
             EXPRFIELDINFO rval = new EXPRFIELDINFO();
             rval.kind = ExpressionKind.EK_FIELDINFO;
-            rval.type = GetTypes().GetOptPredefAgg(PredefinedType.PT_FIELDINFO).getThisType(); ;
+            rval.type = GetTypes().GetOptPredefAgg(PredefinedType.PT_FIELDINFO).getThisType();
             rval.flags = 0;
             rval.Init(field, fieldType);
             return rval;


### PR DESCRIPTION
Also Remove excessive semicolons