### PR TITLE
[WIP] [no merge] Support limiting the buffer size in LargeArrayBuilder.

### DIFF
--- a/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
@@ -224,11 +224,15 @@ namespace System.Collections.Generic
                     // doing min(256 * 2, 500) - 256. This represents the total we've allocated after
                     // this operation, minus the amount we've already allocated.
 
-                    Debug.Assert(_count >= ResizeLimit * 2);
+                    // Note: In case _count overflows (last buffer is 0x40000000) or _count * 2
+                    // overflows (last buffer is 0x20000000), we must cast to uint for correctness
+                    // during comparisons.
+
+                    Debug.Assert((uint)_count >= (uint)ResizeLimit * 2);
                     Debug.Assert(_count == _current.Length * 2);
 
                     _buffers.Add(_current);
-                    nextCapacity = Math.Min(_count * 2, limit) - _count;
+                    nextCapacity = (int)Math.Min((uint)_count * 2, (uint)limit) - _count;
                 }
 
                 _current = new T[nextCapacity];

--- a/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
@@ -52,6 +52,15 @@ namespace System.Collections.Generic
         /// </remarks>
         public void Add(T item) => Add(item, limit: int.MaxValue);
 
+        /// <summary>
+        /// Adds an item to this builder with the specified limit.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        /// <param name="limit">The maximum capacity to allocate.</param>
+        /// <remarks>
+        /// Use <see cref="Add"/> if adding to the builder is a bottleneck for your use case.
+        /// Otherwise, use <see cref="SlowAdd"/>.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Add(T item, int limit)
         {
@@ -142,6 +151,15 @@ namespace System.Collections.Generic
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void SlowAdd(T item) => Add(item);
 
+        /// <summary>
+        /// Adds an item to this builder with the specified limit.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        /// <param name="limit">The maximum capacity to allocate.</param>
+        /// <remarks>
+        /// Use <see cref="Add"/> if adding to the builder is a bottleneck for your use case.
+        /// Otherwise, use <see cref="SlowAdd"/>.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void SlowAdd(T item, int limit) => Add(item, limit);
 

--- a/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
@@ -57,10 +57,6 @@ namespace System.Collections.Generic
         /// </summary>
         /// <param name="item">The item to add.</param>
         /// <param name="limit">The maximum capacity to allocate.</param>
-        /// <remarks>
-        /// Use <see cref="Add"/> if adding to the builder is a bottleneck for your use case.
-        /// Otherwise, use <see cref="SlowAdd"/>.
-        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Add(T item, int limit)
         {
@@ -150,18 +146,6 @@ namespace System.Collections.Generic
         /// </remarks>
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void SlowAdd(T item) => Add(item);
-
-        /// <summary>
-        /// Adds an item to this builder with the specified limit.
-        /// </summary>
-        /// <param name="item">The item to add.</param>
-        /// <param name="limit">The maximum capacity to allocate.</param>
-        /// <remarks>
-        /// Use <see cref="Add"/> if adding to the builder is a bottleneck for your use case.
-        /// Otherwise, use <see cref="SlowAdd"/>.
-        /// </remarks>
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public void SlowAdd(T item, int limit) => Add(item, limit);
 
         /// <summary>
         /// Returns an array representation of this builder.

--- a/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
@@ -60,7 +60,7 @@ namespace System.Collections.Generic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Add(T item, int limit)
         {
-            Debug.Assert(limit > _count);
+            Debug.Assert((uint)limit > (uint)_count);
 
             if (_index == _current.Length)
             {
@@ -174,7 +174,7 @@ namespace System.Collections.Generic
             //   above step, except with _current.Length * 2.
             // - Make sure we never pass the provided limit in all of the above steps.
 
-            Debug.Assert(limit > _count);
+            Debug.Assert((uint)limit > (uint)_count);
             Debug.Assert(_index == _current.Length, $"{nameof(AllocateBuffer)} was called, but there's more space.");
 
             // If _count is int.MinValue, we want to go down the other path which will raise an exception.

--- a/src/Common/tests/Tests/System/Collections/Generic/LargeArrayBuilderTests.cs
+++ b/src/Common/tests/Tests/System/Collections/Generic/LargeArrayBuilderTests.cs
@@ -48,22 +48,15 @@ namespace System.Collections.Generic.Tests
         [MemberData(nameof(EnumerableWithLimitData))]
         public void AddWithLimit(IEnumerable<T> seed, int limit)
         {
-            var builder1 = new LargeArrayBuilder<T>(initialize: true);
-            var builder2 = new LargeArrayBuilder<T>(initialize: true);
+            var builder = new LargeArrayBuilder<T>(initialize: true);
 
             for (int i = 0; i < limit; i++)
             {
+                builder.Add(seed.ElementAt(i), limit);
+
                 int count = i + 1;
-                T item = seed.ElementAt(i);
-
-                builder1.Add(item, limit);
-                builder2.SlowAdd(item, limit);
-
-                Assert.Equal(count, builder1.Count);
-                Assert.Equal(count, builder2.Count);
-
-                Assert.Equal(seed.Take(count), builder1.ToArray());
-                Assert.Equal(seed.Take(count), builder2.ToArray());
+                Assert.Equal(count, builder.Count);
+                Assert.Equal(seed.Take(count), builder.ToArray());
             }
         }
 


### PR DESCRIPTION
There are certain Linq methods, such as `Where` and `Take`, where we cannot pinpoint the exact number of elements the iterator will contain, but we can establish an upper bound on how many elements there are. For example, `list.Where(p)` can have at most `list.Count` elements, and `e.Take(5)` can have at most 5 elements.

Currently, when we call `ToArray` on any of these iterators, the resizing pattern will be to allocate 4, then 8, then 16, etc. size buffers. This can be wasteful because e.g. if the source enumerable in `Where` contains 100 elements, we allocate space for 128 elements even though those last 28 slots will never be used.

This PR adds support to `LargeArrayBuilder<T>` to limit how many elements we allocate, so there is no extra space wasted. It should help drive down allocations in `Where`, `Where.Select`, & `Take` when the maximum count is far from the next power of 2.

Waiting on: #12703, #13628