### PR TITLE
Revisiting use of var in System.Linq.Expressions test code

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -40,7 +40,7 @@ namespace System
                 const string versionFile = "/proc/version";
                 if (File.Exists(versionFile))
                 {
-                    var s = File.ReadAllText(versionFile);
+                    string s = File.ReadAllText(versionFile);
 
                     if (s.Contains("Microsoft") || s.Contains("WSL"))
                     {

--- a/src/System.Linq.Expressions/tests/Array/ArrayAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayAccessTests.cs
@@ -13,17 +13,17 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void ArrayAccess_MultiDimensionalOf1(bool useInterpreter)
         {
-            var arrayType = typeof(int).MakeArrayType(1);
-            var arrayCtor = arrayType.GetTypeInfo().DeclaredConstructors.Single(ctor => ctor.GetParameters().Length == 2);
+            Type arrayType = typeof(int).MakeArrayType(1);
+            ConstructorInfo arrayCtor = arrayType.GetTypeInfo().DeclaredConstructors.Single(ctor => ctor.GetParameters().Length == 2);
             var arr = (System.Array)arrayCtor.Invoke(new object[] { 1, 1 });
-            var c = Expression.Constant(arr);
-            var e = Expression.ArrayAccess(c, Expression.Constant(1));
+            ConstantExpression c = Expression.Constant(arr);
+            IndexExpression e = Expression.ArrayAccess(c, Expression.Constant(1));
 
-            var set = Expression.Lambda<Action>(Expression.Assign(e, Expression.Constant(42))).Compile(useInterpreter);
+            Action set = Expression.Lambda<Action>(Expression.Assign(e, Expression.Constant(42))).Compile(useInterpreter);
             set();
             Assert.Equal(42, arr.GetValue(1));
 
-            var get = Expression.Lambda<Func<int>>(e).Compile(useInterpreter);
+            Func<int> get = Expression.Lambda<Func<int>>(e).Compile(useInterpreter);
             Assert.Equal(42, get());
         }
 
@@ -31,14 +31,14 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void ArrayIndex_MultiDimensionalOf1(bool useInterpreter)
         {
-            var arrayType = typeof(int).MakeArrayType(1);
-            var arrayCtor = arrayType.GetTypeInfo().DeclaredConstructors.Single(ctor => ctor.GetParameters().Length == 2);
+            Type arrayType = typeof(int).MakeArrayType(1);
+            ConstructorInfo arrayCtor = arrayType.GetTypeInfo().DeclaredConstructors.Single(ctor => ctor.GetParameters().Length == 2);
             var arr = (System.Array)arrayCtor.Invoke(new object[] { 1, 1 });
             arr.SetValue(42, 1);
-            var c = Expression.Constant(arr);
-            var e = Expression.ArrayIndex(c, Expression.Constant(1));
+            ConstantExpression c = Expression.Constant(arr);
+            BinaryExpression e = Expression.ArrayIndex(c, Expression.Constant(1));
 
-            var get = Expression.Lambda<Func<int>>(e).Compile(useInterpreter);
+            Func<int> get = Expression.Lambda<Func<int>>(e).Compile(useInterpreter);
             Assert.Equal(42, get());
         }
     }

--- a/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
@@ -2715,7 +2715,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.ArrayIndex(Expression.Parameter(typeof(int[]), "xs"), Expression.Parameter(typeof(int), "i"));
+            BinaryExpression e = Expression.ArrayIndex(Expression.Parameter(typeof(int[]), "xs"), Expression.Parameter(typeof(int), "i"));
             Assert.Equal("xs[i]", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
@@ -1561,7 +1561,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.ArrayLength(Expression.Parameter(typeof(int[]), "xs"));
+            UnaryExpression e = Expression.ArrayLength(Expression.Parameter(typeof(int[]), "xs"));
             Assert.Equal("ArrayLength(xs)", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
@@ -863,13 +863,13 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e1 = Expression.NewArrayInit(typeof(int));
+            NewArrayExpression e1 = Expression.NewArrayInit(typeof(int));
             Assert.Equal("new [] {}", e1.ToString());
 
-            var e2 = Expression.NewArrayInit(typeof(int), Expression.Parameter(typeof(int), "x"));
+            NewArrayExpression e2 = Expression.NewArrayInit(typeof(int), Expression.Parameter(typeof(int), "x"));
             Assert.Equal("new [] {x}", e2.ToString());
 
-            var e3 = Expression.NewArrayInit(typeof(int), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
+            NewArrayExpression e3 = Expression.NewArrayInit(typeof(int), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
             Assert.Equal("new [] {x, y}", e3.ToString());
         }
 
@@ -1697,13 +1697,13 @@ namespace System.Linq.Expressions.Tests
         public static void AutoQuote(bool useInterpreter)
         {
             Expression<Func<int, int>> doubleIt = x => x * 2;
-            var quoted = Expression.Lambda<Func<Expression<Func<int, int>>[]>>(
+            Expression<Func<Expression<Func<int, int>>[]>> quoted = Expression.Lambda<Func<Expression<Func<int, int>>[]>>(
                 Expression.NewArrayInit(
                     typeof(Expression<Func<int, int>>),
                     doubleIt
                     )
                 );
-            var del = quoted.Compile(useInterpreter);
+            Func<Expression<Func<int, int>>[]> del = quoted.Compile(useInterpreter);
             Assert.Equal(new [] {doubleIt}, del());
 
             quoted = Expression.Lambda<Func<Expression<Func<int, int>>[]>>(
@@ -1722,14 +1722,14 @@ namespace System.Linq.Expressions.Tests
         public static void NestedCompile(bool useInterpreter)
         {
             Expression<Func<int, int>> doubleIt = x => x * 2;
-            var unquoted = Expression.Lambda<Func<Func<int, int>[]>>(
+            Expression<Func<Func<int, int>[]>> unquoted = Expression.Lambda<Func<Func<int, int>[]>>(
                 Expression.NewArrayInit(
                     typeof(Func<int, int>),
                     doubleIt
                     )
                 );
-            var del = unquoted.Compile(useInterpreter);
-            var arr = del();
+            Func<Func<int, int>[]> del = unquoted.Compile(useInterpreter);
+            Func<int, int>[] arr = del();
             Assert.Equal(1, arr.Length);
             Assert.Equal(26, arr[0](13));
         }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
@@ -562,10 +562,10 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e1 = Expression.Add(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e1 = Expression.Add(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a + b)", e1.ToString());
 
-            var e2 = Expression.AddChecked(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e2 = Expression.AddChecked(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a + b)", e2.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
@@ -387,7 +387,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.Divide(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e = Expression.Divide(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a / b)", e.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
@@ -387,7 +387,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.Modulo(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e = Expression.Modulo(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a % b)", e.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
@@ -570,10 +570,10 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e1 = Expression.Multiply(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e1 = Expression.Multiply(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a * b)", e1.ToString());
 
-            var e2 = Expression.MultiplyChecked(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e2 = Expression.MultiplyChecked(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a * b)", e2.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryPowerTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryPowerTests.cs
@@ -353,7 +353,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.Power(Expression.Parameter(typeof(double), "a"), Expression.Parameter(typeof(double), "b"));
+            BinaryExpression e = Expression.Power(Expression.Parameter(typeof(double), "a"), Expression.Parameter(typeof(double), "b"));
             Assert.Equal("(a ** b)", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
@@ -1083,18 +1083,18 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e1 = Expression.LeftShift(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e1 = Expression.LeftShift(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a << b)", e1.ToString());
 
-            var e2 = Expression.RightShift(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e2 = Expression.RightShift(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a >> b)", e2.ToString());
         }
 
         [Theory, InlineData(typeof(E)), InlineData(typeof(El)), InlineData(typeof(string))]
         public static void IncorrectLHSTypes(Type type)
         {
-            var lhs = Expression.Default(type);
-            var rhs = Expression.Constant(0);
+            DefaultExpression lhs = Expression.Default(type);
+            ConstantExpression rhs = Expression.Constant(0);
             Assert.Throws<InvalidOperationException>(() => Expression.LeftShift(lhs, rhs));
             Assert.Throws<InvalidOperationException>(() => Expression.RightShift(lhs, rhs));
         }
@@ -1103,8 +1103,8 @@ namespace System.Linq.Expressions.Tests
          InlineData(typeof(short)), InlineData(typeof(uint))]
         public static void IncorrectRHSTypes(Type type)
         {
-            var lhs = Expression.Constant(0);
-            var rhs = Expression.Default(type);
+            ConstantExpression lhs = Expression.Constant(0);
+            DefaultExpression rhs = Expression.Default(type);
             Assert.Throws<InvalidOperationException>(() => Expression.LeftShift(lhs, rhs));
             Assert.Throws<InvalidOperationException>(() => Expression.RightShift(lhs, rhs));
         }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
@@ -591,10 +591,10 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e1 = Expression.Subtract(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e1 = Expression.Subtract(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a - b)", e1.ToString());
 
-            var e2 = Expression.SubtractChecked(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e2 = Expression.SubtractChecked(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a - b)", e2.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
@@ -151,8 +151,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void BasicAssignmentExpressionTest()
         {
-            var left = Expression.Parameter(typeof(int));
-            var right = Expression.Parameter(typeof(int));
+            ParameterExpression left = Expression.Parameter(typeof(int));
+            ParameterExpression right = Expression.Parameter(typeof(int));
 
             BinaryExpression actual = Expression.Assign(left, right);
 
@@ -343,7 +343,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.Assign(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e = Expression.Assign(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a = b)", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/OpAssign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/OpAssign.cs
@@ -111,7 +111,7 @@ namespace System.Linq.Expressions.Tests
                     ConstantExpression yExp = Expression.Constant(y);
                     Expression woAssign = withoutAssignment(xExp, yExp);
                     Type boxType = typeof(Box<>).MakeGenericType(type);
-                    var prop = boxType.GetProperty("StaticValue");
+                    PropertyInfo prop = boxType.GetProperty("StaticValue");
                     prop.SetValue(null, x);
                     Expression property = Expression.Property(null, prop);
                     Expression assignment = withAssignment(property, yExp);
@@ -312,7 +312,7 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(ToStringData))]
         public static void ToStringTest(ExpressionType kind, string symbol, Type type)
         {
-            var e = Expression.MakeBinary(kind, Expression.Parameter(type, "a"), Expression.Parameter(type, "b"));
+            BinaryExpression e = Expression.MakeBinary(kind, Expression.Parameter(type, "a"), Expression.Parameter(type, "b"));
             Assert.Equal($"(a {symbol} b)", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryAndTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryAndTests.cs
@@ -270,13 +270,13 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e1 = Expression.And(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e1 = Expression.And(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a & b)", e1.ToString());
 
-            var e2 = Expression.And(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(bool), "b"));
+            BinaryExpression e2 = Expression.And(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(bool), "b"));
             Assert.Equal("(a And b)", e2.ToString());
 
-            var e3 = Expression.And(Expression.Parameter(typeof(bool?), "a"), Expression.Parameter(typeof(bool?), "b"));
+            BinaryExpression e3 = Expression.And(Expression.Parameter(typeof(bool?), "a"), Expression.Parameter(typeof(bool?), "b"));
             Assert.Equal("(a And b)", e3.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryExclusiveOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryExclusiveOrTests.cs
@@ -270,7 +270,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.ExclusiveOr(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e = Expression.ExclusiveOr(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a ^ b)", e.ToString());
 
             // NB: Unlike And and Or, there's no special case for bool and bool? here.

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryOrTests.cs
@@ -270,13 +270,13 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e1 = Expression.Or(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e1 = Expression.Or(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a | b)", e1.ToString());
 
-            var e2 = Expression.Or(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(bool), "b"));
+            BinaryExpression e2 = Expression.Or(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(bool), "b"));
             Assert.Equal("(a Or b)", e2.ToString());
 
-            var e3 = Expression.Or(Expression.Parameter(typeof(bool?), "a"), Expression.Parameter(typeof(bool?), "b"));
+            BinaryExpression e3 = Expression.Or(Expression.Parameter(typeof(bool?), "a"), Expression.Parameter(typeof(bool?), "b"));
             Assert.Equal("(a Or b)", e3.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
@@ -94,7 +94,7 @@ namespace System.Linq.Expressions.Tests
             Type type2 = array2.GetType().GetElementType();
             for (int i = 0; i < array1.Length; i++)
             {
-                var value1 = array1.GetValue(i);
+                object value1 = array1.GetValue(i);
                 for (int j = 0; j < array2.Length; j++)
                 {
                     VerifyCoalesce(value1, type1, array2.GetValue(j), type2, useInterpreter);
@@ -109,13 +109,13 @@ namespace System.Linq.Expressions.Tests
             Type type1 = array1.GetType().GetElementType();
             for (int i = 0; i < array1.Length; i++)
             {
-                var value1 = array1.GetValue(i);
+                object value1 = array1.GetValue(i);
                 for (int j = 0; j < array2.Length; j++)
                 {
-                    var value2 = array2.GetValue(j);
-                    var type2 = value2.GetType();
+                    object value2 = array2.GetValue(j);
+                    Type type2 = value2.GetType();
 
-                    var result = value1 != null ? value1 : value2;
+                    object result = value1 != null ? value1 : value2;
                     if (result.GetType() == typeof(char))
                     {
                         // ChangeType does not support conversion of char to float, double, or decimal,
@@ -125,7 +125,7 @@ namespace System.Linq.Expressions.Tests
                         result = Convert.ChangeType(result, typeof(int));
                     }
 
-                    var expected = Convert.ChangeType(result, type2);
+                    object expected = Convert.ChangeType(result, type2);
 
                     VerifyCoalesce(value1, type1, value2, type2, useInterpreter, expected);
                 }
@@ -296,8 +296,8 @@ namespace System.Linq.Expressions.Tests
         {
             int? i = 0;
             double? d = 0;
-            var left = Expression.Constant(d, typeof(double?));
-            var right = Expression.Constant(i, typeof(int?));
+            ConstantExpression left = Expression.Constant(d, typeof(double?));
+            ConstantExpression right = Expression.Constant(i, typeof(int?));
             Expression<Func<double?, int?>> conversion = x => 1 + (int?)x;
 
             BinaryExpression actual = Expression.Coalesce(left, right, conversion);
@@ -437,7 +437,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.Coalesce(Expression.Parameter(typeof(string), "a"), Expression.Parameter(typeof(string), "b"));
+            BinaryExpression e = Expression.Coalesce(Expression.Parameter(typeof(string), "a"), Expression.Parameter(typeof(string), "b"));
             Assert.Equal("(a ?? b)", e.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/CompareTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/CompareTests.cs
@@ -194,28 +194,28 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void GreaterThanOrEqual_ToString()
         {
-            var e = Expression.GreaterThanOrEqual(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e = Expression.GreaterThanOrEqual(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a >= b)", e.ToString());
         }
 
         [Fact]
         public static void GreaterThan_ToString()
         {
-            var e = Expression.GreaterThan(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e = Expression.GreaterThan(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a > b)", e.ToString());
         }
 
         [Fact]
         public static void LessThanOrEqual_ToString()
         {
-            var e = Expression.LessThanOrEqual(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e = Expression.LessThanOrEqual(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a <= b)", e.ToString());
         }
 
         [Fact]
         public static void LessThan_ToString()
         {
-            var e = Expression.LessThan(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e = Expression.LessThan(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a < b)", e.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/EqualNotEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/EqualNotEqualTests.cs
@@ -194,14 +194,14 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Equal_ToString()
         {
-            var e = Expression.Equal(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e = Expression.Equal(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a == b)", e.ToString());
         }
 
         [Fact]
         public static void NotEqual_ToString()
         {
-            var e = Expression.NotEqual(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
+            BinaryExpression e = Expression.NotEqual(Expression.Parameter(typeof(int), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("(a != b)", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
@@ -768,10 +768,10 @@ namespace System.Linq.Expressions.Tests
         {
             // NB: These were && and || in .NET 3.5 but shipped as AndAlso and OrElse in .NET 4.0; we kept the latter.
 
-            var e1 = Expression.AndAlso(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(bool), "b"));
+            BinaryExpression e1 = Expression.AndAlso(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(bool), "b"));
             Assert.Equal("(a AndAlso b)", e1.ToString());
 
-            var e2 = Expression.OrElse(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(bool), "b"));
+            BinaryExpression e2 = Expression.OrElse(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(bool), "b"));
             Assert.Equal("(a OrElse b)", e2.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqual.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqual.cs
@@ -180,18 +180,18 @@ namespace System.Linq.Expressions.Tests
             Expression e2 = Expression.Constant("foo");
             Expression e3 = Expression.Constant("qux");
 
-            var eq = Expression.ReferenceEqual(e1, e2);
+            BinaryExpression eq = Expression.ReferenceEqual(e1, e2);
 
             Assert.Same(eq, eq.Update(e1, null, e2));
 
-            var eq1 = eq.Update(e1, null, e3);
+            BinaryExpression eq1 = eq.Update(e1, null, e3);
             Assert.Equal(ExpressionType.Equal, eq1.NodeType);
             Assert.Same(e1, eq1.Left);
             Assert.Same(e3, eq1.Right);
             Assert.Null(eq1.Conversion);
             Assert.Null(eq1.Method);
 
-            var eq2 = eq.Update(e3, null, e2);
+            BinaryExpression eq2 = eq.Update(e3, null, e2);
             Assert.Equal(ExpressionType.Equal, eq2.NodeType);
             Assert.Same(e3, eq2.Left);
             Assert.Same(e2, eq2.Right);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceNotEqual.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceNotEqual.cs
@@ -180,18 +180,18 @@ namespace System.Linq.Expressions.Tests
             Expression e2 = Expression.Constant("foo");
             Expression e3 = Expression.Constant("qux");
 
-            var ne = Expression.ReferenceNotEqual(e1, e2);
+            BinaryExpression ne = Expression.ReferenceNotEqual(e1, e2);
 
             Assert.Same(ne, ne.Update(e1, null, e2));
 
-            var ne1 = ne.Update(e1, null, e3);
+            BinaryExpression ne1 = ne.Update(e1, null, e3);
             Assert.Equal(ExpressionType.NotEqual, ne1.NodeType);
             Assert.Same(e1, ne1.Left);
             Assert.Same(e3, ne1.Right);
             Assert.Null(ne1.Conversion);
             Assert.Null(ne1.Method);
 
-            var ne2 = ne.Update(e3, null, e2);
+            BinaryExpression ne2 = ne.Update(e3, null, e2);
             Assert.Equal(ExpressionType.NotEqual, ne2.NodeType);
             Assert.Same(e3, ne2.Left);
             Assert.Same(e2, ne2.Right);

--- a/src/System.Linq.Expressions/tests/Block/BlockFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockFactoryTests.cs
@@ -37,32 +37,32 @@ namespace System.Linq.Expressions.Tests
         {
             // (Expression[]) overload
             {
-                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
-                var expr = Expression.Block(args);
+                ConstantExpression[] args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
+                BlockExpression expr = Expression.Block(args);
 
                 AssertBlockIsOptimized(expr, args);
             }
 
             // (IEnumerable<Expression>) overload
             {
-                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
-                var expr = Expression.Block(args);
+                List<ConstantExpression> args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
+                BlockExpression expr = Expression.Block(args);
 
                 AssertBlockIsOptimized(expr, args);
             }
 
             // (Type, Expression[]) overload
             {
-                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
-                var expr = Expression.Block(args.Last().Type, args);
+                ConstantExpression[] args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
+                BlockExpression expr = Expression.Block(args.Last().Type, args);
 
                 AssertBlockIsOptimized(expr, args);
             }
 
             // (Type, IEnumerable<Expression>) overload
             {
-                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
-                var expr = Expression.Block(args.Last().Type, args);
+                List<ConstantExpression> args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
+                BlockExpression expr = Expression.Block(args.Last().Type, args);
 
                 AssertBlockIsOptimized(expr, args);
             }
@@ -70,8 +70,8 @@ namespace System.Linq.Expressions.Tests
             // (IEnumerable<ParameterExpression>, Expression[]) overload
             {
                 var vars = new ParameterExpression[0];
-                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
-                var expr = Expression.Block(vars, args);
+                ConstantExpression[] args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
+                BlockExpression expr = Expression.Block(vars, args);
 
                 AssertBlockIsOptimized(expr, args);
             }
@@ -79,8 +79,8 @@ namespace System.Linq.Expressions.Tests
             // (IEnumerable<ParameterExpression>, IEnumerable<Expression>) overload
             {
                 var vars = new ParameterExpression[0];
-                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
-                var expr = Expression.Block(vars, args);
+                List<ConstantExpression> args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
+                BlockExpression expr = Expression.Block(vars, args);
 
                 AssertBlockIsOptimized(expr, args);
             }
@@ -88,8 +88,8 @@ namespace System.Linq.Expressions.Tests
             // (Type, IEnumerable<ParameterExpression>, Expression[]) overload
             {
                 var vars = new ParameterExpression[0];
-                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
-                var expr = Expression.Block(args.Last().Type, vars, args);
+                ConstantExpression[] args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
+                BlockExpression expr = Expression.Block(args.Last().Type, vars, args);
 
                 AssertBlockIsOptimized(expr, args);
             }
@@ -97,8 +97,8 @@ namespace System.Linq.Expressions.Tests
             // (Type, IEnumerable<ParameterExpression>, IEnumerable<Expression>) overload
             {
                 var vars = new ParameterExpression[0];
-                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
-                var expr = Expression.Block(args.Last().Type, vars, args);
+                List<ConstantExpression> args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
+                BlockExpression expr = Expression.Block(args.Last().Type, vars, args);
 
                 AssertBlockIsOptimized(expr, args);
             }
@@ -106,10 +106,10 @@ namespace System.Linq.Expressions.Tests
 
         private static void AssertBlockIsOptimized(BlockExpression expr, IReadOnlyList<Expression> args)
         {
-            var n = args.Count;
+            int n = args.Count;
 
-            var updated = Update(expr);
-            var visited = Visit(expr);
+            BlockExpression updated = Update(expr);
+            BlockExpression visited = Visit(expr);
 
             foreach (var node in new[] { expr, updated, visited })
             {
@@ -141,7 +141,7 @@ namespace System.Linq.Expressions.Tests
         {
             // Tests the call of Update to Expression.Block factories.
 
-            var res = node.Update(node.Variables, node.Expressions.ToArray());
+            BlockExpression res = node.Update(node.Variables, node.Expressions.ToArray());
 
             Assert.NotSame(node, res);
 

--- a/src/System.Linq.Expressions/tests/Block/BlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockTests.cs
@@ -23,77 +23,77 @@ namespace System.Linq.Expressions.Tests
         private static IEnumerable<KeyValuePair<Expression, object>> BlockClosureVariableInitialization()
         {
             {
-                var p = Expression.Parameter(typeof(int));
-                var q = Expression.Parameter(typeof(Func<int>));
-                var l = Expression.Lambda<Func<int>>(p);
+                ParameterExpression p = Expression.Parameter(typeof(int));
+                ParameterExpression q = Expression.Parameter(typeof(Func<int>));
+                Expression<Func<int>> l = Expression.Lambda<Func<int>>(p);
                 yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(int));
             }
 
             {
-                var p = Expression.Parameter(typeof(int));
-                var q = Expression.Parameter(typeof(Action<int>));
-                var x = Expression.Parameter(typeof(int));
-                var l = Expression.Lambda<Action<int>>(Expression.Assign(p, x), x);
+                ParameterExpression p = Expression.Parameter(typeof(int));
+                ParameterExpression q = Expression.Parameter(typeof(Action<int>));
+                ParameterExpression x = Expression.Parameter(typeof(int));
+                Expression<Action<int>> l = Expression.Lambda<Action<int>>(Expression.Assign(p, x), x);
                 yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(int));
             }
 
             {
-                var p = Expression.Parameter(typeof(TimeSpan));
-                var q = Expression.Parameter(typeof(Func<TimeSpan>));
-                var l = Expression.Lambda<Func<TimeSpan>>(p);
+                ParameterExpression p = Expression.Parameter(typeof(TimeSpan));
+                ParameterExpression q = Expression.Parameter(typeof(Func<TimeSpan>));
+                Expression<Func<TimeSpan>> l = Expression.Lambda<Func<TimeSpan>>(p);
                 yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(TimeSpan));
             }
 
             {
-                var p = Expression.Parameter(typeof(TimeSpan));
-                var q = Expression.Parameter(typeof(Action<TimeSpan>));
-                var x = Expression.Parameter(typeof(TimeSpan));
-                var l = Expression.Lambda<Action<TimeSpan>>(Expression.Assign(p, x), x);
+                ParameterExpression p = Expression.Parameter(typeof(TimeSpan));
+                ParameterExpression q = Expression.Parameter(typeof(Action<TimeSpan>));
+                ParameterExpression x = Expression.Parameter(typeof(TimeSpan));
+                Expression<Action<TimeSpan>> l = Expression.Lambda<Action<TimeSpan>>(Expression.Assign(p, x), x);
                 yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(TimeSpan));
             }
 
             {
-                var p = Expression.Parameter(typeof(string));
-                var q = Expression.Parameter(typeof(Func<string>));
-                var l = Expression.Lambda<Func<string>>(p);
+                ParameterExpression p = Expression.Parameter(typeof(string));
+                ParameterExpression q = Expression.Parameter(typeof(Func<string>));
+                Expression<Func<string>> l = Expression.Lambda<Func<string>>(p);
                 yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(string));
             }
 
             {
-                var p = Expression.Parameter(typeof(string));
-                var q = Expression.Parameter(typeof(Action<string>));
-                var x = Expression.Parameter(typeof(string));
-                var l = Expression.Lambda<Action<string>>(Expression.Assign(p, x), x);
+                ParameterExpression p = Expression.Parameter(typeof(string));
+                ParameterExpression q = Expression.Parameter(typeof(Action<string>));
+                ParameterExpression x = Expression.Parameter(typeof(string));
+                Expression<Action<string>> l = Expression.Lambda<Action<string>>(Expression.Assign(p, x), x);
                 yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(string));
             }
 
             {
-                var p = Expression.Parameter(typeof(int?));
-                var q = Expression.Parameter(typeof(Func<int?>));
-                var l = Expression.Lambda<Func<int?>>(p);
+                ParameterExpression p = Expression.Parameter(typeof(int?));
+                ParameterExpression q = Expression.Parameter(typeof(Func<int?>));
+                Expression<Func<int?>> l = Expression.Lambda<Func<int?>>(p);
                 yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(int?));
             }
 
             {
-                var p = Expression.Parameter(typeof(int?));
-                var q = Expression.Parameter(typeof(Action<int?>));
-                var x = Expression.Parameter(typeof(int?));
-                var l = Expression.Lambda<Action<int?>>(Expression.Assign(p, x), x);
+                ParameterExpression p = Expression.Parameter(typeof(int?));
+                ParameterExpression q = Expression.Parameter(typeof(Action<int?>));
+                ParameterExpression x = Expression.Parameter(typeof(int?));
+                Expression<Action<int?>> l = Expression.Lambda<Action<int?>>(Expression.Assign(p, x), x);
                 yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(int?));
             }
 
             {
-                var p = Expression.Parameter(typeof(TimeSpan?));
-                var q = Expression.Parameter(typeof(Func<TimeSpan?>));
-                var l = Expression.Lambda<Func<TimeSpan?>>(p);
+                ParameterExpression p = Expression.Parameter(typeof(TimeSpan?));
+                ParameterExpression q = Expression.Parameter(typeof(Func<TimeSpan?>));
+                Expression<Func<TimeSpan?>> l = Expression.Lambda<Func<TimeSpan?>>(p);
                 yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(TimeSpan?));
             }
 
             {
-                var p = Expression.Parameter(typeof(TimeSpan?));
-                var q = Expression.Parameter(typeof(Action<TimeSpan?>));
-                var x = Expression.Parameter(typeof(TimeSpan?));
-                var l = Expression.Lambda<Action<TimeSpan?>>(Expression.Assign(p, x), x);
+                ParameterExpression p = Expression.Parameter(typeof(TimeSpan?));
+                ParameterExpression q = Expression.Parameter(typeof(Action<TimeSpan?>));
+                ParameterExpression x = Expression.Parameter(typeof(TimeSpan?));
+                Expression<Action<TimeSpan?>> l = Expression.Lambda<Action<TimeSpan?>>(Expression.Assign(p, x), x);
                 yield return new KeyValuePair<Expression, object>(Expression.Block(new[] { p, q }, Expression.Assign(q, l), p), default(TimeSpan?));
             }
         }
@@ -125,7 +125,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void VisitChangingOnlyParmeters()
         {
-            var block = Expression.Block(
+            BlockExpression block = Expression.Block(
                 new[] { Expression.Parameter(typeof(int)), Expression.Parameter(typeof(string)) },
                 Expression.Empty()
                 );
@@ -135,7 +135,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void VisitChangingOnlyParmetersMultiStatementBody()
         {
-            var block = Expression.Block(
+            BlockExpression block = Expression.Block(
                 new[] { Expression.Parameter(typeof(int)), Expression.Parameter(typeof(string)) },
                 Expression.Empty(),
                 Expression.Empty()
@@ -146,7 +146,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void VisitChangingOnlyParmetersTyped()
         {
-            var block = Expression.Block(
+            BlockExpression block = Expression.Block(
                 typeof(object),
                 new[] { Expression.Parameter(typeof(int)), Expression.Parameter(typeof(string)) },
                 Expression.Constant("")
@@ -158,7 +158,7 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void EmptyBlock(bool useInterpreter)
         {
-            var block = Expression.Block();
+            BlockExpression block = Expression.Block();
             Assert.Equal(typeof(void), block.Type);
             Assert.Throws<ArgumentOutOfRangeException>("index", () => block.Result);
             Action nop = Expression.Lambda<Action>(block).Compile(useInterpreter);
@@ -169,7 +169,7 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void EmptyBlockExplicitType(bool useInterpreter)
         {
-            var block = Expression.Block(typeof(void));
+            BlockExpression block = Expression.Block(typeof(void));
             Assert.Equal(typeof(void), block.Type);
             Assert.Throws<ArgumentOutOfRangeException>("index", () => block.Result);
             Action nop = Expression.Lambda<Action>(block).Compile(useInterpreter);
@@ -186,7 +186,7 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void EmptyScope(bool useInterpreter)
         {
-            var scope = Expression.Block(new[] { Expression.Parameter(typeof(int), "x") }, new Expression[0]);
+            BlockExpression scope = Expression.Block(new[] { Expression.Parameter(typeof(int), "x") }, new Expression[0]);
             Assert.Equal(typeof(void), scope.Type);
             Assert.Throws<ArgumentOutOfRangeException>("index", () => scope.Result);
             Action nop = Expression.Lambda<Action>(scope).Compile(useInterpreter);
@@ -197,7 +197,7 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void EmptyScopeExplicitType(bool useInterpreter)
         {
-            var scope = Expression.Block(typeof(void), new[] { Expression.Parameter(typeof(int), "x") }, new Expression[0]);
+            BlockExpression scope = Expression.Block(typeof(void), new[] { Expression.Parameter(typeof(int), "x") }, new Expression[0]);
             Assert.Equal(typeof(void), scope.Type);
             Assert.Throws<ArgumentOutOfRangeException>("index", () => scope.Result);
             Action nop = Expression.Lambda<Action>(scope).Compile(useInterpreter);
@@ -216,13 +216,13 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e1 = Expression.Block(Expression.Empty());
+            BlockExpression e1 = Expression.Block(Expression.Empty());
             Assert.Equal("{ ... }", e1.ToString());
 
-            var e2 = Expression.Block(new[] { Expression.Parameter(typeof(int), "x") }, Expression.Empty());
+            BlockExpression e2 = Expression.Block(new[] { Expression.Parameter(typeof(int), "x") }, Expression.Empty());
             Assert.Equal("{var x; ... }", e2.ToString());
 
-            var e3 = Expression.Block(new[] { Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y") }, Expression.Empty());
+            BlockExpression e3 = Expression.Block(new[] { Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y") }, Expression.Empty());
             Assert.Equal("{var x;var y; ... }", e3.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
@@ -19,7 +19,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckCallFactoryOptimizationInstance2()
         {
-            var expr = Expression.Call(Expression.Parameter(typeof(MS)), typeof(MS).GetMethod("I2"), Expression.Constant(0), Expression.Constant(1));
+            MethodCallExpression expr = Expression.Call(Expression.Parameter(typeof(MS)), typeof(MS).GetMethod("I2"), Expression.Constant(0), Expression.Constant(1));
 
             AssertInstanceMethodCall(2, expr);
 
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckCallFactoryOptimizationInstance3()
         {
-            var expr = Expression.Call(Expression.Parameter(typeof(MS)), typeof(MS).GetMethod("I3"), Expression.Constant(0), Expression.Constant(1), Expression.Constant(2));
+            MethodCallExpression expr = Expression.Call(Expression.Parameter(typeof(MS)), typeof(MS).GetMethod("I3"), Expression.Constant(0), Expression.Constant(1), Expression.Constant(2));
 
             AssertInstanceMethodCall(3, expr);
 
@@ -39,7 +39,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckCallFactoryOptimizationStatic1()
         {
-            var expr = Expression.Call(typeof(MS).GetMethod("S1"), Expression.Constant(0));
+            MethodCallExpression expr = Expression.Call(typeof(MS).GetMethod("S1"), Expression.Constant(0));
 
             AssertStaticMethodCall(1, expr);
 
@@ -49,8 +49,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckCallFactoryOptimizationStatic2()
         {
-            var expr1 = Expression.Call(typeof(MS).GetMethod("S2"), Expression.Constant(0), Expression.Constant(1));
-            var expr2 = Expression.Call(null, typeof(MS).GetMethod("S2"), Expression.Constant(0), Expression.Constant(1));
+            MethodCallExpression expr1 = Expression.Call(typeof(MS).GetMethod("S2"), Expression.Constant(0), Expression.Constant(1));
+            MethodCallExpression expr2 = Expression.Call(null, typeof(MS).GetMethod("S2"), Expression.Constant(0), Expression.Constant(1));
 
             AssertStaticMethodCall(2, expr1);
             AssertStaticMethodCall(2, expr2);
@@ -61,8 +61,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckCallFactoryOptimizationStatic3()
         {
-            var expr1 = Expression.Call(typeof(MS).GetMethod("S3"), Expression.Constant(0), Expression.Constant(1), Expression.Constant(2));
-            var expr2 = Expression.Call(null, typeof(MS).GetMethod("S3"), Expression.Constant(0), Expression.Constant(1), Expression.Constant(2));
+            MethodCallExpression expr1 = Expression.Call(typeof(MS).GetMethod("S3"), Expression.Constant(0), Expression.Constant(1), Expression.Constant(2));
+            MethodCallExpression expr2 = Expression.Call(null, typeof(MS).GetMethod("S3"), Expression.Constant(0), Expression.Constant(1), Expression.Constant(2));
 
             AssertStaticMethodCall(3, expr1);
             AssertStaticMethodCall(3, expr2);
@@ -73,7 +73,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckCallFactoryOptimizationStatic4()
         {
-            var expr = Expression.Call(typeof(MS).GetMethod("S4"), Expression.Constant(0), Expression.Constant(1), Expression.Constant(2), Expression.Constant(3));
+            MethodCallExpression expr = Expression.Call(typeof(MS).GetMethod("S4"), Expression.Constant(0), Expression.Constant(1), Expression.Constant(2), Expression.Constant(3));
 
             AssertStaticMethodCall(4, expr);
 
@@ -83,7 +83,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckCallFactoryOptimizationStatic5()
         {
-            var expr = Expression.Call(typeof(MS).GetMethod("S5"), Expression.Constant(0), Expression.Constant(1), Expression.Constant(2), Expression.Constant(3), Expression.Constant(4));
+            MethodCallExpression expr = Expression.Call(typeof(MS).GetMethod("S5"), Expression.Constant(0), Expression.Constant(1), Expression.Constant(2), Expression.Constant(3), Expression.Constant(4));
 
             AssertStaticMethodCall(5, expr);
 
@@ -93,10 +93,10 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckArrayIndexOptimization1()
         {
-            var instance = Expression.Parameter(typeof(int[]));
-            var args = new[] { Expression.Constant(0) };
-            var expr = Expression.ArrayIndex(instance, args);
-            var method = typeof(int[]).GetMethod("Get", BindingFlags.Public | BindingFlags.Instance);
+            ParameterExpression instance = Expression.Parameter(typeof(int[]));
+            ConstantExpression[] args = new[] { Expression.Constant(0) };
+            MethodCallExpression expr = Expression.ArrayIndex(instance, args);
+            MethodInfo method = typeof(int[]).GetMethod("Get", BindingFlags.Public | BindingFlags.Instance);
 
             AssertCallIsOptimized(expr, instance, method, args);
         }
@@ -104,46 +104,46 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckArrayIndexOptimization2()
         {
-            var instance = Expression.Parameter(typeof(int[,]));
-            var args = new[] { Expression.Constant(0), Expression.Constant(0) };
-            var expr = Expression.ArrayIndex(instance, args);
-            var method = typeof(int[,]).GetMethod("Get", BindingFlags.Public | BindingFlags.Instance);
+            ParameterExpression instance = Expression.Parameter(typeof(int[,]));
+            ConstantExpression[] args = new[] { Expression.Constant(0), Expression.Constant(0) };
+            MethodCallExpression expr = Expression.ArrayIndex(instance, args);
+            MethodInfo method = typeof(int[,]).GetMethod("Get", BindingFlags.Public | BindingFlags.Instance);
 
             AssertCallIsOptimized(expr, instance, method, args);
         }
 
         private static void AssertCallIsOptimizedInstance(int n)
         {
-            var method = typeof(MS).GetMethod("I" + n);
+            MethodInfo method = typeof(MS).GetMethod("I" + n);
 
             AssertCallIsOptimized(method);
         }
 
         private static void AssertCallIsOptimizedStatic(int n)
         {
-            var method = typeof(MS).GetMethod("S" + n);
+            MethodInfo method = typeof(MS).GetMethod("S" + n);
 
             AssertCallIsOptimized(method);
         }
 
         private static void AssertCallIsOptimized(MethodInfo method)
         {
-            var instance = method.IsStatic ? null : Expression.Parameter(method.DeclaringType);
+            ParameterExpression instance = method.IsStatic ? null : Expression.Parameter(method.DeclaringType);
 
-            var n = method.GetParameters().Length;
+            int n = method.GetParameters().Length;
 
             // Expression[] overload
             {
-                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
-                var expr = Expression.Call(instance, method, args);
+                ConstantExpression[] args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
+                MethodCallExpression expr = Expression.Call(instance, method, args);
 
                 AssertCallIsOptimized(expr, instance, method, args);
             }
 
             // IEnumerable<Expression> overload
             {
-                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
-                var expr = Expression.Call(instance, method, args);
+                List<ConstantExpression> args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
+                MethodCallExpression expr = Expression.Call(instance, method, args);
 
                 AssertCallIsOptimized(expr, instance, method, args);
             }
@@ -151,10 +151,10 @@ namespace System.Linq.Expressions.Tests
 
         private static void AssertCallIsOptimized(MethodCallExpression expr, Expression instance, MethodInfo method, IReadOnlyList<Expression> args)
         {
-            var n = method.GetParameters().Length;
+            int n = method.GetParameters().Length;
 
-            var updated = Update(expr);
-            var visited = Visit(expr);
+            MethodCallExpression updated = Update(expr);
+            MethodCallExpression visited = Visit(expr);
 
             foreach (var node in new[] { expr, updated, visited })
             {
@@ -205,7 +205,7 @@ namespace System.Linq.Expressions.Tests
         {
             // Tests the call of Update to Expression.Call factories.
 
-            var res = node.Update(node.Object, node.Arguments.ToArray());
+            MethodCallExpression res = node.Update(node.Object, node.Arguments.ToArray());
 
             Assert.NotSame(node, res);
 

--- a/src/System.Linq.Expressions/tests/Call/CallTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallTests.cs
@@ -55,10 +55,10 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void UnboxReturnsReference(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(object));
-            var unbox = Expression.Unbox(p, typeof(Mutable));
-            var call = Expression.Call(unbox, typeof(Mutable).GetMethod("Foo"));
-            var lambda = Expression.Lambda<Func<object, int>>(call, p).Compile(useInterpreter);
+            ParameterExpression p = Expression.Parameter(typeof(object));
+            UnaryExpression unbox = Expression.Unbox(p, typeof(Mutable));
+            MethodCallExpression call = Expression.Call(unbox, typeof(Mutable).GetMethod("Foo"));
+            Func<object, int> lambda = Expression.Lambda<Func<object, int>>(call, p).Compile(useInterpreter);
 
             object boxed = new Mutable();
             Assert.Equal(0, lambda(boxed));
@@ -71,10 +71,10 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void ArrayWriteBack(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(Mutable[]));
-            var indexed = Expression.ArrayIndex(p, Expression.Constant(0));
-            var call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
-            var lambda = Expression.Lambda<Func<Mutable[], int>>(call, p).Compile(useInterpreter);
+            ParameterExpression p = Expression.Parameter(typeof(Mutable[]));
+            BinaryExpression indexed = Expression.ArrayIndex(p, Expression.Constant(0));
+            MethodCallExpression call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
+            Func<Mutable[], int> lambda = Expression.Lambda<Func<Mutable[], int>>(call, p).Compile(useInterpreter);
 
             var array = new Mutable[1];
             Assert.Equal(0, lambda(array));
@@ -86,10 +86,10 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void MultiRankArrayWriteBack(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(Mutable[,]));
-            var indexed = Expression.ArrayIndex(p, Expression.Constant(0), Expression.Constant(0));
-            var call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
-            var lambda = Expression.Lambda<Func<Mutable[,], int>>(call, p).Compile(useInterpreter);
+            ParameterExpression p = Expression.Parameter(typeof(Mutable[,]));
+            MethodCallExpression indexed = Expression.ArrayIndex(p, Expression.Constant(0), Expression.Constant(0));
+            MethodCallExpression call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
+            Func<Mutable[,], int> lambda = Expression.Lambda<Func<Mutable[,], int>>(call, p).Compile(useInterpreter);
 
             var array = new Mutable[1, 1];
             Assert.Equal(0, lambda(array));
@@ -101,10 +101,10 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void ArrayAccessWriteBack(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(Mutable[]));
-            var indexed = Expression.ArrayAccess(p, Expression.Constant(0));
-            var call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
-            var lambda = Expression.Lambda<Func<Mutable[], int>>(call, p).Compile(useInterpreter);
+            ParameterExpression p = Expression.Parameter(typeof(Mutable[]));
+            IndexExpression indexed = Expression.ArrayAccess(p, Expression.Constant(0));
+            MethodCallExpression call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
+            Func<Mutable[], int> lambda = Expression.Lambda<Func<Mutable[], int>>(call, p).Compile(useInterpreter);
 
             var array = new Mutable[1];
             Assert.Equal(0, lambda(array));
@@ -116,10 +116,10 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void MultiRankArrayAccessWriteBack(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(Mutable[,]));
-            var indexed = Expression.ArrayAccess(p, Expression.Constant(0), Expression.Constant(0));
-            var call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
-            var lambda = Expression.Lambda<Func<Mutable[,], int>>(call, p).Compile(useInterpreter);
+            ParameterExpression p = Expression.Parameter(typeof(Mutable[,]));
+            IndexExpression indexed = Expression.ArrayAccess(p, Expression.Constant(0), Expression.Constant(0));
+            MethodCallExpression call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
+            Func<Mutable[,], int> lambda = Expression.Lambda<Func<Mutable[,], int>>(call, p).Compile(useInterpreter);
 
             var array = new Mutable[1, 1];
             Assert.Equal(0, lambda(array));
@@ -131,10 +131,10 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void IndexedPropertyAccessNoWriteBack(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(List<Mutable>));
-            var indexed = Expression.Property(p, typeof(List<Mutable>).GetProperty("Item"), Expression.Constant(0));
-            var call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
-            var lambda = Expression.Lambda<Func<List<Mutable>, int>>(call, p).Compile(useInterpreter);
+            ParameterExpression p = Expression.Parameter(typeof(List<Mutable>));
+            IndexExpression indexed = Expression.Property(p, typeof(List<Mutable>).GetProperty("Item"), Expression.Constant(0));
+            MethodCallExpression call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
+            Func<List<Mutable>, int> lambda = Expression.Lambda<Func<List<Mutable>, int>>(call, p).Compile(useInterpreter);
 
             var list = new List<Mutable> { new Mutable() };
             Assert.Equal(0, lambda(list));
@@ -145,10 +145,10 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void FieldAccessWriteBack(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(Wrapper<Mutable>));
-            var member = Expression.Field(p, typeof(Wrapper<Mutable>).GetField("Field"));
-            var call = Expression.Call(member, typeof(Mutable).GetMethod("Foo"));
-            var lambda = Expression.Lambda<Func<Wrapper<Mutable>, int>>(call, p).Compile(useInterpreter);
+            ParameterExpression p = Expression.Parameter(typeof(Wrapper<Mutable>));
+            MemberExpression member = Expression.Field(p, typeof(Wrapper<Mutable>).GetField("Field"));
+            MethodCallExpression call = Expression.Call(member, typeof(Mutable).GetMethod("Foo"));
+            Func<Wrapper<Mutable>, int> lambda = Expression.Lambda<Func<Wrapper<Mutable>, int>>(call, p).Compile(useInterpreter);
 
             var wrapper = new Wrapper<Mutable>();
             Assert.Equal(0, lambda(wrapper));
@@ -160,10 +160,10 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void PropertyAccessNoWriteBack(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(Wrapper<Mutable>));
-            var member = Expression.Property(p, typeof(Wrapper<Mutable>).GetProperty("Property"));
-            var call = Expression.Call(member, typeof(Mutable).GetMethod("Foo"));
-            var lambda = Expression.Lambda<Func<Wrapper<Mutable>, int>>(call, p).Compile(useInterpreter);
+            ParameterExpression p = Expression.Parameter(typeof(Wrapper<Mutable>));
+            MemberExpression member = Expression.Property(p, typeof(Wrapper<Mutable>).GetProperty("Property"));
+            MethodCallExpression call = Expression.Call(member, typeof(Mutable).GetMethod("Foo"));
+            Func<Wrapper<Mutable>, int> lambda = Expression.Lambda<Func<Wrapper<Mutable>, int>>(call, p).Compile(useInterpreter);
 
             var wrapper = new Wrapper<Mutable>();
             Assert.Equal(0, lambda(wrapper));
@@ -174,10 +174,10 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void ReadonlyFieldAccessWriteBack(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(Wrapper<Mutable>));
-            var member = Expression.Field(p, typeof(Wrapper<Mutable>).GetField("ReadOnlyField"));
-            var call = Expression.Call(member, typeof(Mutable).GetMethod("Foo"));
-            var lambda = Expression.Lambda<Func<Wrapper<Mutable>, int>>(call, p).Compile(useInterpreter);
+            ParameterExpression p = Expression.Parameter(typeof(Wrapper<Mutable>));
+            MemberExpression member = Expression.Field(p, typeof(Wrapper<Mutable>).GetField("ReadOnlyField"));
+            MethodCallExpression call = Expression.Call(member, typeof(Mutable).GetMethod("Foo"));
+            Func<Wrapper<Mutable>, int> lambda = Expression.Lambda<Func<Wrapper<Mutable>, int>>(call, p).Compile(useInterpreter);
 
             var wrapper = new Wrapper<Mutable>();
             Assert.Equal(0, lambda(wrapper));
@@ -189,9 +189,9 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void ConstFieldAccessWriteBack(bool useInterpreter)
         {
-            var member = Expression.Field(null, typeof(Wrapper<Mutable>).GetField("Zero"));
-            var call = Expression.Call(member, typeof(int).GetMethod("GetType"));
-            var lambda = Expression.Lambda<Func<Type>>(call).Compile(useInterpreter);
+            MemberExpression member = Expression.Field(null, typeof(Wrapper<Mutable>).GetField("Zero"));
+            MethodCallExpression call = Expression.Call(member, typeof(int).GetMethod("GetType"));
+            Func<Type> lambda = Expression.Lambda<Func<Type>>(call).Compile(useInterpreter);
 
             var wrapper = new Wrapper<Mutable>();
             Assert.Equal(typeof(int), lambda());
@@ -201,11 +201,11 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void CallByRefMutableStructPropertyWriteBack(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(Mutable));
-            var x = Expression.Property(p, "X");
-            var call = Expression.Call(typeof(Methods).GetMethod("ByRef"), x);
-            var body = Expression.Block(call, x);
-            var lambda = Expression.Lambda<Func<Mutable, int>>(body, p).Compile(useInterpreter);
+            ParameterExpression p = Expression.Parameter(typeof(Mutable));
+            MemberExpression x = Expression.Property(p, "X");
+            MethodCallExpression call = Expression.Call(typeof(Methods).GetMethod("ByRef"), x);
+            BlockExpression body = Expression.Block(call, x);
+            Func<Mutable, int> lambda = Expression.Lambda<Func<Mutable, int>>(body, p).Compile(useInterpreter);
 
             var m = new Mutable() { X = 41 };
             Assert.Equal(42, lambda(m));
@@ -215,11 +215,11 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void CallByRefMutableStructIndexWriteBack(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(Mutable));
-            var x = Expression.MakeIndex(p, typeof(Mutable).GetProperty("Item"), new[] { Expression.Constant(0) });
-            var call = Expression.Call(typeof(Methods).GetMethod("ByRef"), x);
-            var body = Expression.Block(call, x);
-            var lambda = Expression.Lambda<Func<Mutable, int>>(body, p).Compile(useInterpreter);
+            ParameterExpression p = Expression.Parameter(typeof(Mutable));
+            IndexExpression x = Expression.MakeIndex(p, typeof(Mutable).GetProperty("Item"), new[] { Expression.Constant(0) });
+            MethodCallExpression call = Expression.Call(typeof(Methods).GetMethod("ByRef"), x);
+            BlockExpression body = Expression.Block(call, x);
+            Func<Mutable, int> lambda = Expression.Lambda<Func<Mutable, int>>(body, p).Compile(useInterpreter);
 
             var m = new Mutable() { X = 41 };
             Assert.Equal(42, lambda(m));
@@ -554,31 +554,31 @@ namespace System.Linq.Expressions.Tests
         {
             // NB: Static methods are inconsistent compared to static members; the declaring type is not included
 
-            var e1 = Expression.Call(null, typeof(SomeMethods).GetMethod(nameof(SomeMethods.S0), BindingFlags.Static | BindingFlags.Public));
+            MethodCallExpression e1 = Expression.Call(null, typeof(SomeMethods).GetMethod(nameof(SomeMethods.S0), BindingFlags.Static | BindingFlags.Public));
             Assert.Equal("S0()", e1.ToString());
 
-            var e2 = Expression.Call(null, typeof(SomeMethods).GetMethod(nameof(SomeMethods.S1), BindingFlags.Static | BindingFlags.Public), Expression.Parameter(typeof(int), "x"));
+            MethodCallExpression e2 = Expression.Call(null, typeof(SomeMethods).GetMethod(nameof(SomeMethods.S1), BindingFlags.Static | BindingFlags.Public), Expression.Parameter(typeof(int), "x"));
             Assert.Equal("S1(x)", e2.ToString());
 
-            var e3 = Expression.Call(null, typeof(SomeMethods).GetMethod(nameof(SomeMethods.S2), BindingFlags.Static | BindingFlags.Public), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
+            MethodCallExpression e3 = Expression.Call(null, typeof(SomeMethods).GetMethod(nameof(SomeMethods.S2), BindingFlags.Static | BindingFlags.Public), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
             Assert.Equal("S2(x, y)", e3.ToString());
 
-            var e4 = Expression.Call(Expression.Parameter(typeof(SomeMethods), "o"), typeof(SomeMethods).GetMethod(nameof(SomeMethods.I0), BindingFlags.Instance | BindingFlags.Public));
+            MethodCallExpression e4 = Expression.Call(Expression.Parameter(typeof(SomeMethods), "o"), typeof(SomeMethods).GetMethod(nameof(SomeMethods.I0), BindingFlags.Instance | BindingFlags.Public));
             Assert.Equal("o.I0()", e4.ToString());
 
-            var e5 = Expression.Call(Expression.Parameter(typeof(SomeMethods), "o"), typeof(SomeMethods).GetMethod(nameof(SomeMethods.I1), BindingFlags.Instance | BindingFlags.Public), Expression.Parameter(typeof(int), "x"));
+            MethodCallExpression e5 = Expression.Call(Expression.Parameter(typeof(SomeMethods), "o"), typeof(SomeMethods).GetMethod(nameof(SomeMethods.I1), BindingFlags.Instance | BindingFlags.Public), Expression.Parameter(typeof(int), "x"));
             Assert.Equal("o.I1(x)", e5.ToString());
 
-            var e6 = Expression.Call(Expression.Parameter(typeof(SomeMethods), "o"), typeof(SomeMethods).GetMethod(nameof(SomeMethods.I2), BindingFlags.Instance | BindingFlags.Public), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
+            MethodCallExpression e6 = Expression.Call(Expression.Parameter(typeof(SomeMethods), "o"), typeof(SomeMethods).GetMethod(nameof(SomeMethods.I2), BindingFlags.Instance | BindingFlags.Public), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
             Assert.Equal("o.I2(x, y)", e6.ToString());
 
-            var e7 = Expression.Call(null, typeof(ExtensionMethods).GetMethod(nameof(ExtensionMethods.E0), BindingFlags.Static | BindingFlags.Public), Expression.Parameter(typeof(int), "x"));
+            MethodCallExpression e7 = Expression.Call(null, typeof(ExtensionMethods).GetMethod(nameof(ExtensionMethods.E0), BindingFlags.Static | BindingFlags.Public), Expression.Parameter(typeof(int), "x"));
             Assert.Equal("x.E0()", e7.ToString());
 
-            var e8 = Expression.Call(null, typeof(ExtensionMethods).GetMethod(nameof(ExtensionMethods.E1), BindingFlags.Static | BindingFlags.Public), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
+            MethodCallExpression e8 = Expression.Call(null, typeof(ExtensionMethods).GetMethod(nameof(ExtensionMethods.E1), BindingFlags.Static | BindingFlags.Public), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
             Assert.Equal("x.E1(y)", e8.ToString());
 
-            var e9 = Expression.Call(null, typeof(ExtensionMethods).GetMethod(nameof(ExtensionMethods.E2), BindingFlags.Static | BindingFlags.Public), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"), Expression.Parameter(typeof(int), "z"));
+            MethodCallExpression e9 = Expression.Call(null, typeof(ExtensionMethods).GetMethod(nameof(ExtensionMethods.E2), BindingFlags.Static | BindingFlags.Public), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"), Expression.Parameter(typeof(int), "z"));
             Assert.Equal("x.E2(y, z)", e9.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/Cast/AsTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/AsTests.cs
@@ -842,7 +842,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.TypeAs(Expression.Parameter(typeof(object), "o"), typeof(string));
+            UnaryExpression e = Expression.TypeAs(Expression.Parameter(typeof(object), "o"), typeof(string));
             Assert.Equal("(o As String)", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/Cast/CastTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastTests.cs
@@ -2395,22 +2395,22 @@ namespace System.Linq.Expressions.Tests
         public static void CanCastReferenceToUnderlyingTypeToEnumType(Type type, bool useInterpreter)
         {
             object value = Activator.CreateInstance(type);
-            var exp = Expression.Lambda<Func<bool>>(
+            Expression<Func<bool>> exp = Expression.Lambda<Func<bool>>(
                 Expression.Equal(
                     Expression.Default(type),
                     Expression.Convert(Expression.Constant(value, typeof(object)), type)));
-            var func = exp.Compile(useInterpreter);
+            Func<bool> func = exp.Compile(useInterpreter);
             Assert.True(func());
         }
 
         [Theory, PerCompilationType(nameof(EnumerableTypesAndIncompatibleObjects))]
         public static void CannotCastReferenceToWrongUnderlyingTypeEnum(Type type, object value, bool useInterpreter)
         {
-            var exp = Expression.Lambda<Action>(
+            Expression<Action> exp = Expression.Lambda<Action>(
                 Expression.Block(
                     Expression.Convert(Expression.Constant(value, typeof(object)), type),
                     Expression.Empty()));
-            var act = exp.Compile(useInterpreter);
+            Action act = exp.Compile(useInterpreter);
             Assert.Throws<InvalidCastException>(act);
         }
 
@@ -2419,22 +2419,22 @@ namespace System.Linq.Expressions.Tests
         {
             Type underlying = Enum.GetUnderlyingType(type);
             object value = Activator.CreateInstance(underlying);
-            var exp = Expression.Lambda<Func<bool>>(
+            Expression<Func<bool>> exp = Expression.Lambda<Func<bool>>(
                 Expression.Equal(
                     Expression.Default(type),
                     Expression.Convert(Expression.Constant(value, underlying), type)));
-            var func = exp.Compile(useInterpreter);
+            Func<bool> func = exp.Compile(useInterpreter);
             Assert.True(func());
         }
 
         [Theory, PerCompilationType(nameof(EnumerableTypesAndIncompatibleUnderlyingObjects))]
         public static void CannotCastWrongUnderlyingTypeEnum(Type type, object value, bool useInterpreter)
         {
-            var exp = Expression.Lambda<Action>(
+            Expression<Action> exp = Expression.Lambda<Action>(
                 Expression.Block(
                     Expression.Convert(Expression.Constant(value, typeof(object)), type),
                     Expression.Empty()));
-            var act = exp.Compile(useInterpreter);
+            Action act = exp.Compile(useInterpreter);
             Assert.Throws<InvalidCastException>(act);
         }
     }

--- a/src/System.Linq.Expressions/tests/CompilerTests.cs
+++ b/src/System.Linq.Expressions/tests/CompilerTests.cs
@@ -16,12 +16,12 @@ namespace System.Linq.Expressions.Tests
         {
             var e = (Expression)Expression.Constant(0);
 
-            var n = 10000;
+            int n = 10000;
 
             for (var i = 0; i < n; i++)
                 e = Expression.Add(e, Expression.Constant(1));
 
-            var f = Expression.Lambda<Func<int>>(e).Compile(useInterpreter);
+            Func<int> f = Expression.Lambda<Func<int>>(e).Compile(useInterpreter);
 
             Assert.Equal(n, f());
         }
@@ -369,17 +369,17 @@ namespace System.Linq.Expressions.Tests
 
         public static void VerifyIL(this LambdaExpression expression, string expected, bool appendInnerLambdas = false)
         {
-            var actual = expression.GetIL(appendInnerLambdas);
+            string actual = expression.GetIL(appendInnerLambdas);
 
-            var nExpected = Normalize(expected);
-            var nActual = Normalize(actual);
+            string nExpected = Normalize(expected);
+            string nActual = Normalize(actual);
 
             Assert.Equal(nExpected, nActual);
         }
 
         private static string Normalize(string s)
         {
-            var lines =
+            Collections.Generic.IEnumerable<string> lines =
                 s
                 .Replace("\r\n", "\n")
                 .Split(new[] { '\n' })
@@ -401,19 +401,19 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyEmitConstantsToIL(Expression e, int expectedCount, object expectedValue)
         {
-            var f = Expression.Lambda(e).Compile();
+            Delegate f = Expression.Lambda(e).Compile();
 
             var c = f.Target as Closure;
             Assert.NotNull(c);
             Assert.Equal(expectedCount, c.Constants.Length);
 
-            var o = f.DynamicInvoke();
+            object o = f.DynamicInvoke();
             Assert.Equal(expectedValue, o);
         }
 
         private static void Verify_VariableBinder_CatchBlock_Filter(CatchBlock @catch)
         {
-            var e =
+            Expression<Action> e =
                 Expression.Lambda<Action>(
                     Expression.TryCatch(
                         Expression.Empty(),

--- a/src/System.Linq.Expressions/tests/Conditional/ConditionalTests.cs
+++ b/src/System.Linq.Expressions/tests/Conditional/ConditionalTests.cs
@@ -12,11 +12,11 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void VisitIfThenDoesNotCloneTree()
         {
-            var ifTrue = ((Expression<Action>)(() => Nop())).Body;
+            Expression ifTrue = ((Expression<Action>)(() => Nop())).Body;
 
-            var e = Expression.IfThen(Expression.Constant(true), ifTrue);
+            ConditionalExpression e = Expression.IfThen(Expression.Constant(true), ifTrue);
 
-            var r = new Visitor().Visit(e);
+            Expression r = new Visitor().Visit(e);
 
             Assert.Same(e, r);
         }
@@ -26,7 +26,7 @@ namespace System.Linq.Expressions.Tests
         public void Conditional(bool useInterpreter)
         {
             Expression<Func<int, int, int>> f = (x, y) => x > 5 ? x : y;
-            var d = f.Compile(useInterpreter);
+            Func<int, int, int> d = f.Compile(useInterpreter);
             Assert.Equal(7, d(7, 4));
             Assert.Equal(6, d(3, 6));
         }
@@ -232,10 +232,10 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e1 = Expression.Condition(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(int), "b"), Expression.Parameter(typeof(int), "c"));
+            ConditionalExpression e1 = Expression.Condition(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(int), "b"), Expression.Parameter(typeof(int), "c"));
             Assert.Equal("IIF(a, b, c)", e1.ToString());
 
-            var e2 = Expression.IfThen(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(int), "b"));
+            ConditionalExpression e2 = Expression.IfThen(Expression.Parameter(typeof(bool), "a"), Expression.Parameter(typeof(int), "b"));
             Assert.Equal("IIF(a, b, default(Void))", e2.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
@@ -386,9 +386,9 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void BoundConstantCaching1(bool useInterpreter)
         {
-            var c = Expression.Constant(new Bar());
+            ConstantExpression c = Expression.Constant(new Bar());
 
-            var e =
+            BinaryExpression e =
                 Expression.Add(
                     Expression.Field(c, "Foo"),
                     Expression.Subtract(
@@ -404,11 +404,11 @@ namespace System.Linq.Expressions.Tests
         public static void BoundConstantCaching2(bool useInterpreter)
         {
             var b = new Bar();
-            var c1 = Expression.Constant(b);
-            var c2 = Expression.Constant(b);
-            var c3 = Expression.Constant(b);
+            ConstantExpression c1 = Expression.Constant(b);
+            ConstantExpression c2 = Expression.Constant(b);
+            ConstantExpression c3 = Expression.Constant(b);
 
-            var e =
+            BinaryExpression e =
                 Expression.Add(
                     Expression.Field(c1, "Foo"),
                     Expression.Subtract(
@@ -441,7 +441,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void BoundConstantCaching4(bool useInterpreter)
         {
-            var bs = new[]
+            Bar[] bs = new[]
             {
                 new Bar() { Foo = 1 },
                 new Bar() { Foo = 1 },
@@ -935,21 +935,21 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e1 = Expression.Constant(1);
+            ConstantExpression e1 = Expression.Constant(1);
             Assert.Equal("1", e1.ToString());
 
-            var e2 = Expression.Constant("bar");
+            ConstantExpression e2 = Expression.Constant("bar");
             Assert.Equal("\"bar\"", e2.ToString());
 
-            var e3 = Expression.Constant(null, typeof(object));
+            ConstantExpression e3 = Expression.Constant(null, typeof(object));
             Assert.Equal("null", e3.ToString());
 
             var b = new Bar();
-            var e4 = Expression.Constant(b);
+            ConstantExpression e4 = Expression.Constant(b);
             Assert.Equal($"value({b.ToString()})", e4.ToString());
 
             var f = new Foo();
-            var e5 = Expression.Constant(f);
+            ConstantExpression e5 = Expression.Constant(f);
             Assert.Equal(f.ToString(), e5.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/Convert/ConvertCheckedTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertCheckedTests.cs
@@ -7476,7 +7476,7 @@ namespace System.Linq.Expressions.Tests
 
             if (value.HasValue)
             {
-                var unboxed = value.GetValueOrDefault();
+                byte unboxed = value.GetValueOrDefault();
                 if (unboxed > sbyte.MaxValue)
                     Assert.Throws<OverflowException>(() => f());
                 else
@@ -8170,7 +8170,7 @@ namespace System.Linq.Expressions.Tests
 
             if (value.HasValue)
             {
-                var unboxed = value.GetValueOrDefault();
+                char unboxed = value.GetValueOrDefault();
                 if (unboxed > sbyte.MaxValue)
                     Assert.Throws<OverflowException>(() => f());
                 else
@@ -11088,7 +11088,7 @@ namespace System.Linq.Expressions.Tests
 
             if (value.HasValue)
             {
-                var unboxed = value.GetValueOrDefault();
+                E unboxed = value.GetValueOrDefault();
                 if ((int)unboxed < sbyte.MinValue | (int)unboxed > sbyte.MaxValue)
                     Assert.Throws<OverflowException>(() => f());
                 else
@@ -11821,7 +11821,7 @@ namespace System.Linq.Expressions.Tests
 
             if (value.HasValue)
             {
-                var unboxed = value.GetValueOrDefault();
+                El unboxed = value.GetValueOrDefault();
                 if ((long)unboxed < sbyte.MinValue | (long)unboxed > sbyte.MaxValue)
                     Assert.Throws<OverflowException>(() => f());
                 else
@@ -13792,7 +13792,7 @@ namespace System.Linq.Expressions.Tests
 
             if (value.HasValue)
             {
-                var unboxed = value.GetValueOrDefault();
+                int unboxed = value.GetValueOrDefault();
                 if (unboxed < sbyte.MinValue | unboxed > sbyte.MaxValue)
                     Assert.Throws<OverflowException>(() => f());
                 else
@@ -14569,7 +14569,7 @@ namespace System.Linq.Expressions.Tests
 
             if (value.HasValue)
             {
-                var unboxed = value.GetValueOrDefault();
+                long unboxed = value.GetValueOrDefault();
                 if (unboxed < sbyte.MinValue | unboxed > sbyte.MaxValue)
                     Assert.Throws<OverflowException>(() => f());
                 else
@@ -16024,7 +16024,7 @@ namespace System.Linq.Expressions.Tests
 
             if (value.HasValue)
             {
-                var unboxed = value.GetValueOrDefault();
+                short unboxed = value.GetValueOrDefault();
                 if (unboxed < sbyte.MinValue | unboxed > sbyte.MaxValue)
                     Assert.Throws<OverflowException>(() => f());
                 else
@@ -16775,7 +16775,7 @@ namespace System.Linq.Expressions.Tests
 
             if (value.HasValue)
             {
-                var unboxed = value.GetValueOrDefault();
+                uint unboxed = value.GetValueOrDefault();
                 if (unboxed > sbyte.MaxValue)
                     Assert.Throws<OverflowException>(() => f());
                 else
@@ -17555,7 +17555,7 @@ namespace System.Linq.Expressions.Tests
 
             if (value.HasValue)
             {
-                var unboxed = value.GetValueOrDefault();
+                ulong unboxed = value.GetValueOrDefault();
                 if (unboxed > (ulong)sbyte.MaxValue)
                     Assert.Throws<OverflowException>(() => f());
                 else
@@ -18266,7 +18266,7 @@ namespace System.Linq.Expressions.Tests
 
             if (value.HasValue)
             {
-                var unboxed = value.GetValueOrDefault();
+                ushort unboxed = value.GetValueOrDefault();
                 if (unboxed > sbyte.MaxValue)
                     Assert.Throws<OverflowException>(() => f());
                 else

--- a/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
@@ -16522,7 +16522,7 @@ namespace System.Linq.Expressions.Tests
         public static void ImplicitHalfLiftedConversionFromCSCompiler(bool useInterpreter)
         {
             Expression<Func<ImplicitHalfLiftedFrom?, HalfLiftedTo?>> e = x => x;
-            var f = e.Compile(useInterpreter);
+            Func<ImplicitHalfLiftedFrom?, HalfLiftedTo?> f = e.Compile(useInterpreter);
             Assert.NotNull(f(new ImplicitHalfLiftedFrom()));
             Assert.Null(f(new ImplicitHalfLiftedFrom { NullEquiv = true }));
             Assert.Null(f(null));
@@ -16532,7 +16532,7 @@ namespace System.Linq.Expressions.Tests
         public static void ExplicitHalfLiftedConversionFromCSCompiler(bool useInterpreter)
         {
             Expression<Func<ExplicitHalfLiftedFrom?, HalfLiftedTo?>> e = x => (HalfLiftedTo?)x;
-            var f = e.Compile(useInterpreter);
+            Func<ExplicitHalfLiftedFrom?, HalfLiftedTo?> f = e.Compile(useInterpreter);
             Assert.NotNull(f(new ExplicitHalfLiftedFrom()));
             Assert.Null(f(new ExplicitHalfLiftedFrom { NullEquiv = true }));
             Assert.Null(f(null));
@@ -16542,7 +16542,7 @@ namespace System.Linq.Expressions.Tests
         public static void ImplicitHalfLiftedOverloadedConversionFromCSCompiler(bool useInterpreter)
         {
             Expression<Func<ImplicitHalfLiftedOverloaded?, HalfLiftedTo?>> e = x => x;
-            var f = e.Compile(useInterpreter);
+            Func<ImplicitHalfLiftedOverloaded?, HalfLiftedTo?> f = e.Compile(useInterpreter);
             Assert.NotNull(f(new ImplicitHalfLiftedOverloaded()));
             Assert.NotNull(f(null));
         }
@@ -16555,7 +16555,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Lambda<Func<ImplicitHalfLiftedFrom?, HalfLiftedTo?>>(
                     Expression.Convert(x, typeof(HalfLiftedTo?)),
                     x);
-            var f = e.Compile(useInterpreter);
+            Func<ImplicitHalfLiftedFrom?, HalfLiftedTo?> f = e.Compile(useInterpreter);
             Assert.NotNull(f(new ImplicitHalfLiftedFrom()));
             Assert.Null(f(new ImplicitHalfLiftedFrom { NullEquiv = true }));
             Assert.Null(f(null));
@@ -16569,7 +16569,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Lambda<Func<ExplicitHalfLiftedFrom?, HalfLiftedTo?>>(
                     Expression.Convert(x, typeof(HalfLiftedTo?)),
                     x);
-            var f = e.Compile(useInterpreter);
+            Func<ExplicitHalfLiftedFrom?, HalfLiftedTo?> f = e.Compile(useInterpreter);
             Assert.NotNull(f(new ExplicitHalfLiftedFrom()));
             Assert.Null(f(new ExplicitHalfLiftedFrom { NullEquiv = true }));
             Assert.Null(f(null));
@@ -16583,7 +16583,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Lambda<Func<ImplicitHalfLiftedOverloaded?, HalfLiftedTo?>>(
                     Expression.Convert(x, typeof(HalfLiftedTo?)),
                     x);
-            var f = e.Compile(useInterpreter);
+            Func<ImplicitHalfLiftedOverloaded?, HalfLiftedTo?> f = e.Compile(useInterpreter);
             Assert.NotNull(f(new ImplicitHalfLiftedOverloaded()));
             Assert.NotNull(f(null));
         }
@@ -16596,7 +16596,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Lambda<Func<ImplicitHalfLiftedFrom?, HalfLiftedTo?>>(
                     Expression.Convert(x, typeof(HalfLiftedTo?), typeof(ImplicitHalfLiftedFrom).GetMethod("op_Implicit")),
                     x);
-            var f = e.Compile(useInterpreter);
+            Func<ImplicitHalfLiftedFrom?, HalfLiftedTo?> f = e.Compile(useInterpreter);
             Assert.NotNull(f(new ImplicitHalfLiftedFrom()));
             Assert.Null(f(new ImplicitHalfLiftedFrom { NullEquiv = true }));
             Assert.Null(f(null));
@@ -16610,7 +16610,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Lambda<Func<ExplicitHalfLiftedFrom?, HalfLiftedTo?>>(
                     Expression.Convert(x, typeof(HalfLiftedTo?), typeof(ExplicitHalfLiftedFrom).GetMethod("op_Explicit")),
                     x);
-            var f = e.Compile(useInterpreter);
+            Func<ExplicitHalfLiftedFrom?, HalfLiftedTo?> f = e.Compile(useInterpreter);
             Assert.NotNull(f(new ExplicitHalfLiftedFrom()));
             Assert.Null(f(new ExplicitHalfLiftedFrom { NullEquiv = true }));
             Assert.Null(f(null));
@@ -16619,7 +16619,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void ImplicitHalfLiftedOverloadedConversionExplicitlySetMethod(bool useInterpreter)
         {
-            var opMethods =
+            List<MethodInfo> opMethods =
                 typeof(ImplicitHalfLiftedOverloaded).GetMethods().Where(m => m.Name == "op_Implicit").ToList();
             MethodInfo direct =
                 opMethods.First(m => m.GetParameters()[0].ParameterType == typeof(ImplicitHalfLiftedOverloaded?));
@@ -16630,7 +16630,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Lambda<Func<ImplicitHalfLiftedOverloaded?, HalfLiftedTo?>>(
                     Expression.Convert(x, typeof(HalfLiftedTo?), direct),
                     x);
-            var f = e.Compile(useInterpreter);
+            Func<ImplicitHalfLiftedOverloaded?, HalfLiftedTo?> f = e.Compile(useInterpreter);
             Assert.NotNull(f(new ImplicitHalfLiftedOverloaded()));
             Assert.NotNull(f(null));
             e = Expression.Lambda<Func<ImplicitHalfLiftedOverloaded?, HalfLiftedTo?>>(
@@ -16660,7 +16660,7 @@ namespace System.Linq.Expressions.Tests
         public static void ImplicitHalfLiftedConversionOpOnTargetFromCSCompiler(bool useInterpreter)
         {
             Expression<Func<HalfLiftedFromTargetOperator?, HalfLiftedToTargetOperator?>> e = x => x;
-            var f = e.Compile(useInterpreter);
+            Func<HalfLiftedFromTargetOperator?, HalfLiftedToTargetOperator?> f = e.Compile(useInterpreter);
             Assert.NotNull(f(new HalfLiftedFromTargetOperator()));
             Assert.Null(f(new HalfLiftedFromTargetOperator { NullEquiv = true }));
             Assert.Null(f(null));
@@ -16674,7 +16674,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Lambda<Func<HalfLiftedFromTargetOperator?, HalfLiftedToTargetOperator?>>(
                     Expression.Convert(x, typeof(HalfLiftedToTargetOperator?)),
                     x);
-            var f = e.Compile(useInterpreter);
+            Func<HalfLiftedFromTargetOperator?, HalfLiftedToTargetOperator?> f = e.Compile(useInterpreter);
             Assert.NotNull(f(new HalfLiftedFromTargetOperator()));
             Assert.Null(f(new HalfLiftedFromTargetOperator { NullEquiv = true }));
             Assert.Null(f(null));

--- a/src/System.Linq.Expressions/tests/DebugInfo/DebugInfoExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/DebugInfo/DebugInfoExpressionTests.cs
@@ -48,7 +48,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.DebugInfo(Expression.SymbolDocument("foo.cs"), 12, 23, 34, 45);
+            DebugInfoExpression e = Expression.DebugInfo(Expression.SymbolDocument("foo.cs"), 12, 23, 34, 45);
             Assert.Equal("<DebugInfo(foo.cs: 12, 23, 34, 45)>", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/DebugViewTests.cs
+++ b/src/System.Linq.Expressions/tests/DebugViewTests.cs
@@ -88,11 +88,11 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Binary_Arithmetic()
         {
-            var a = Expression.Parameter(typeof(int), "a");
-            var b = Expression.Parameter(typeof(int), "b");
+            ParameterExpression a = Expression.Parameter(typeof(int), "a");
+            ParameterExpression b = Expression.Parameter(typeof(int), "b");
 
-            var x = Expression.Parameter(typeof(double), "x");
-            var y = Expression.Parameter(typeof(double), "y");
+            ParameterExpression x = Expression.Parameter(typeof(double), "x");
+            ParameterExpression y = Expression.Parameter(typeof(double), "y");
 
             Check("$a + $b", Expression.Add(a, b));
             Check("$a #+ $b", Expression.AddChecked(a, b));
@@ -110,8 +110,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Binary_Logical()
         {
-            var a = Expression.Parameter(typeof(int), "a");
-            var b = Expression.Parameter(typeof(int), "b");
+            ParameterExpression a = Expression.Parameter(typeof(int), "a");
+            ParameterExpression b = Expression.Parameter(typeof(int), "b");
 
             Check("$a & $b", Expression.And(a, b));
             Check("$a | $b", Expression.Or(a, b));
@@ -121,8 +121,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Binary_Comparison()
         {
-            var a = Expression.Parameter(typeof(int), "a");
-            var b = Expression.Parameter(typeof(int), "b");
+            ParameterExpression a = Expression.Parameter(typeof(int), "a");
+            ParameterExpression b = Expression.Parameter(typeof(int), "b");
 
             Check("$a < $b", Expression.LessThan(a, b));
             Check("$a <= $b", Expression.LessThanOrEqual(a, b));
@@ -135,8 +135,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Binary_Coalesce()
         {
-            var n = Expression.Parameter(typeof(int?), "n");
-            var b = Expression.Parameter(typeof(int), "b");
+            ParameterExpression n = Expression.Parameter(typeof(int?), "n");
+            ParameterExpression b = Expression.Parameter(typeof(int), "b");
 
             Check("$n ?? $b", Expression.Coalesce(n, b));
         }
@@ -144,8 +144,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Binary_Shortcircuiting()
         {
-            var a = Expression.Parameter(typeof(bool), "a");
-            var b = Expression.Parameter(typeof(bool), "b");
+            ParameterExpression a = Expression.Parameter(typeof(bool), "a");
+            ParameterExpression b = Expression.Parameter(typeof(bool), "b");
 
             Check("$a && $b", Expression.AndAlso(a, b));
             Check("$a || $b", Expression.OrElse(a, b));
@@ -154,11 +154,11 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Binary_Assign()
         {
-            var a = Expression.Parameter(typeof(int), "a");
-            var b = Expression.Parameter(typeof(int), "b");
+            ParameterExpression a = Expression.Parameter(typeof(int), "a");
+            ParameterExpression b = Expression.Parameter(typeof(int), "b");
 
-            var x = Expression.Parameter(typeof(double), "x");
-            var y = Expression.Parameter(typeof(double), "y");
+            ParameterExpression x = Expression.Parameter(typeof(double), "x");
+            ParameterExpression y = Expression.Parameter(typeof(double), "y");
 
             Check("$a = $b",   Expression.Assign(a, b));
             Check("$a += $b",  Expression.AddAssign(a, b));
@@ -181,8 +181,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Binary_ArrayIndex()
         {
-            var xs = Expression.Parameter(typeof(int[]), "xs");
-            var a = Expression.Parameter(typeof(int), "a");
+            ParameterExpression xs = Expression.Parameter(typeof(int[]), "xs");
+            ParameterExpression a = Expression.Parameter(typeof(int), "a");
 
             Check("$xs[$a]", Expression.ArrayIndex(xs, a));
         }
@@ -190,7 +190,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Unary_Arithmetic()
         {
-            var a = Expression.Parameter(typeof(int), "a");
+            ParameterExpression a = Expression.Parameter(typeof(int), "a");
 
             Check("+$a", Expression.UnaryPlus(a));
             Check("-$a", Expression.Negate(a));
@@ -204,7 +204,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Unary_Boolean()
         {
-            var b = Expression.Parameter(typeof(bool), "b");
+            ParameterExpression b = Expression.Parameter(typeof(bool), "b");
 
             Check("!$b", Expression.Not(b));
             Check(".IsTrue($b)", Expression.IsTrue(b));
@@ -214,7 +214,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Unary_Assign()
         {
-            var a = Expression.Parameter(typeof(int), "a");
+            ParameterExpression a = Expression.Parameter(typeof(int), "a");
 
             Check("++$a", Expression.PreIncrementAssign(a));
             Check("$a++", Expression.PostIncrementAssign(a));
@@ -225,8 +225,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Unary_Convert()
         {
-            var o = Expression.Parameter(typeof(object), "o");
-            var x = Expression.Parameter(typeof(long), "x");
+            ParameterExpression o = Expression.Parameter(typeof(object), "o");
+            ParameterExpression x = Expression.Parameter(typeof(long), "x");
 
             Check("(System.Int32)$o", Expression.Convert(o, typeof(int)));
             Check("(System.Int32)$o", Expression.ConvertChecked(o, typeof(int)));
@@ -238,8 +238,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Unary_Exceptions()
         {
-            var e = Expression.Parameter(typeof(Exception), "e");
-            var xs = Expression.Parameter(typeof(int[]), "xs");
+            ParameterExpression e = Expression.Parameter(typeof(Exception), "e");
+            ParameterExpression xs = Expression.Parameter(typeof(int[]), "xs");
 
             Check(".Rethrow", Expression.Rethrow());
             Check(".Throw $e", Expression.Throw(e));
@@ -248,7 +248,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Unary_ArrayLength()
         {
-            var xs = Expression.Parameter(typeof(int[]), "xs");
+            ParameterExpression xs = Expression.Parameter(typeof(int[]), "xs");
 
             Check("$xs.Length", Expression.ArrayLength(xs));
         }
@@ -256,7 +256,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Unary_Quote()
         {
-            var expr = Expression.Lambda<Action>(Expression.Empty());
+            Expression<Action> expr = Expression.Lambda<Action>(Expression.Empty());
 
             Check("'(.Lambda #Lambda1<System.Action>)\\r\\n\\r\\n.Lambda #Lambda1<System.Action>() {\\r\\n    .Default(System.Void)\\r\\n}", Expression.Quote(expr));
         }
@@ -264,9 +264,9 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Conditional()
         {
-            var a = Expression.Parameter(typeof(bool), "a");
-            var s1 = Expression.Parameter(typeof(bool), "ifTrue");
-            var s2 = Expression.Parameter(typeof(bool), "ifFalse");
+            ParameterExpression a = Expression.Parameter(typeof(bool), "a");
+            ParameterExpression s1 = Expression.Parameter(typeof(bool), "ifTrue");
+            ParameterExpression s2 = Expression.Parameter(typeof(bool), "ifFalse");
 
             Check(".If (\\r\\n    $a\\r\\n) {\\r\\n    $ifTrue\\r\\n} .Else {\\r\\n    .Default(System.Void)\\r\\n}", Expression.IfThen(a, s1));
             Check(".If (\\r\\n    $a\\r\\n) {\\r\\n    $ifTrue\\r\\n} .Else {\\r\\n    $ifFalse\\r\\n}", Expression.IfThenElse(a, s1, s2));
@@ -275,8 +275,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void RuntimeVariables()
         {
-            var a = Expression.Parameter(typeof(bool), "a");
-            var b = Expression.Parameter(typeof(bool), "b");
+            ParameterExpression a = Expression.Parameter(typeof(bool), "a");
+            ParameterExpression b = Expression.Parameter(typeof(bool), "b");
 
             Check(".RuntimeVariables()", Expression.RuntimeVariables());
             Check(".RuntimeVariables($a)", Expression.RuntimeVariables(a));
@@ -286,7 +286,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Member()
         {
-            var s = Expression.Parameter(typeof(string), "s");
+            ParameterExpression s = Expression.Parameter(typeof(string), "s");
 
             Check("$s.Length", Expression.Property(s, "Length"));
             Check("System.DateTime.Now", Expression.Property(null, typeof(DateTime).GetProperty("Now")));
@@ -295,11 +295,11 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Invoke()
         {
-            var f0 = Expression.Parameter(typeof(Func<int>), "f");
-            var f1 = Expression.Parameter(typeof(Func<int, int>), "f");
-            var f2 = Expression.Parameter(typeof(Func<int, int, int>), "f");
-            var x = Expression.Parameter(typeof(int), "x");
-            var y = Expression.Parameter(typeof(int), "y");
+            ParameterExpression f0 = Expression.Parameter(typeof(Func<int>), "f");
+            ParameterExpression f1 = Expression.Parameter(typeof(Func<int, int>), "f");
+            ParameterExpression f2 = Expression.Parameter(typeof(Func<int, int, int>), "f");
+            ParameterExpression x = Expression.Parameter(typeof(int), "x");
+            ParameterExpression y = Expression.Parameter(typeof(int), "y");
 
             Check(".Invoke $f()", Expression.Invoke(f0));
             Check(".Invoke $f($x)", Expression.Invoke(f1, x));
@@ -309,10 +309,10 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Call()
         {
-            var x = Expression.Parameter(typeof(int), "x");
-            var y = Expression.Parameter(typeof(int), "y");
-            var d = Expression.Parameter(typeof(double), "d");
-            var s = Expression.Parameter(typeof(string), "s");
+            ParameterExpression x = Expression.Parameter(typeof(int), "x");
+            ParameterExpression y = Expression.Parameter(typeof(int), "y");
+            ParameterExpression d = Expression.Parameter(typeof(double), "d");
+            ParameterExpression s = Expression.Parameter(typeof(string), "s");
 
             Check(".Call $x.ToString()", Expression.Call(x, typeof(int).GetMethod("ToString", Type.EmptyTypes)));
             Check(".Call $s.Substring($x)", Expression.Call(s, typeof(string).GetMethod("Substring", new[] { typeof(int) }), x));
@@ -323,8 +323,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void NewArray()
         {
-            var x = Expression.Parameter(typeof(int), "x");
-            var y = Expression.Parameter(typeof(int), "y");
+            ParameterExpression x = Expression.Parameter(typeof(int), "x");
+            ParameterExpression y = Expression.Parameter(typeof(int), "y");
 
             Check(".NewArray System.Int32[$x]", Expression.NewArrayBounds(typeof(int), x));
             Check(".NewArray System.Int32[\\r\\n    $x,\\r\\n    $y]", Expression.NewArrayBounds(typeof(int), x, y));
@@ -336,7 +336,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void TypeBinary()
         {
-            var o = Expression.Parameter(typeof(object), "o");
+            ParameterExpression o = Expression.Parameter(typeof(object), "o");
 
             Check("$o .Is System.Int32", Expression.TypeIs(o, typeof(int)));
             Check("$o .TypeEqual System.Int32", Expression.TypeEqual(o, typeof(int)));
@@ -345,10 +345,10 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void New()
         {
-            var l = Expression.Parameter(typeof(long), "l");
-            var x = Expression.Parameter(typeof(int), "x");
-            var y = Expression.Parameter(typeof(int), "y");
-            var z = Expression.Parameter(typeof(int), "z");
+            ParameterExpression l = Expression.Parameter(typeof(long), "l");
+            ParameterExpression x = Expression.Parameter(typeof(int), "x");
+            ParameterExpression y = Expression.Parameter(typeof(int), "y");
+            ParameterExpression z = Expression.Parameter(typeof(int), "z");
 
             Check(".New System.TimeSpan($l)", Expression.New(typeof(TimeSpan).GetConstructor(new[] { typeof(long) }), l));
             Check(".New System.TimeSpan(\\r\\n    $x,\\r\\n    $y,\\r\\n    $z)", Expression.New(typeof(TimeSpan).GetConstructor(new[] { typeof(int), typeof(int), typeof(int) }), x, y, z));
@@ -357,8 +357,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Block()
         {
-            var x = Expression.Parameter(typeof(int), "x");
-            var y = Expression.Parameter(typeof(int), "y");
+            ParameterExpression x = Expression.Parameter(typeof(int), "x");
+            ParameterExpression y = Expression.Parameter(typeof(int), "y");
 
             Check(".Block() {\\r\\n    $x\\r\\n}", Expression.Block(x));
             Check(".Block() {\\r\\n    $x;\\r\\n    $y\\r\\n}", Expression.Block(x, y));
@@ -371,10 +371,10 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Label()
         {
-            var t1 = Expression.Label(typeof(void), "l1");
-            var t2 = Expression.Label(typeof(int), "l2");
+            LabelTarget t1 = Expression.Label(typeof(void), "l1");
+            LabelTarget t2 = Expression.Label(typeof(int), "l2");
 
-            var x = Expression.Parameter(typeof(int), "x");
+            ParameterExpression x = Expression.Parameter(typeof(int), "x");
 
             Check(".Label\\r\\n.LabelTarget l1:", Expression.Label(t1));
             Check(".Label\\r\\n    $x\\r\\n.LabelTarget l2:", Expression.Label(t2, x));
@@ -383,10 +383,10 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Goto()
         {
-            var t1 = Expression.Label(typeof(void), "l1");
-            var t2 = Expression.Label(typeof(int), "l2");
+            LabelTarget t1 = Expression.Label(typeof(void), "l1");
+            LabelTarget t2 = Expression.Label(typeof(int), "l2");
 
-            var x = Expression.Parameter(typeof(int), "x");
+            ParameterExpression x = Expression.Parameter(typeof(int), "x");
 
             Check(".Break l1 { }", Expression.Break(t1));
             Check(".Break l2 { $x }", Expression.Break(t2, x));
@@ -398,8 +398,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Loop()
         {
-            var t1 = Expression.Label(typeof(void), "l1");
-            var t2 = Expression.Label(typeof(int), "l2");
+            LabelTarget t1 = Expression.Label(typeof(void), "l1");
+            LabelTarget t2 = Expression.Label(typeof(int), "l2");
 
             Check(".Loop  {\\r\\n    .Default(System.Void)\\r\\n}", Expression.Loop(Expression.Empty()));
             Check(".Loop  {\\r\\n    .Default(System.Void)\\r\\n}\\r\\n.LabelTarget l2:", Expression.Loop(Expression.Empty(), t2));
@@ -409,12 +409,12 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Switch()
         {
-            var x = Expression.Parameter(typeof(int), "x");
-            var y = Expression.Parameter(typeof(int), "y");
-            var z = Expression.Parameter(typeof(int), "z");
+            ParameterExpression x = Expression.Parameter(typeof(int), "x");
+            ParameterExpression y = Expression.Parameter(typeof(int), "y");
+            ParameterExpression z = Expression.Parameter(typeof(int), "z");
 
-            var a = Expression.Parameter(typeof(int), "a");
-            var b = Expression.Parameter(typeof(int), "b");
+            ParameterExpression a = Expression.Parameter(typeof(int), "a");
+            ParameterExpression b = Expression.Parameter(typeof(int), "b");
 
             Check(".Switch ($x) {\\r\\n.Case ($y):\\r\\n        .Default(System.Void)\\r\\n}", Expression.Switch(x, Expression.SwitchCase(Expression.Empty(), y)));
             Check(".Switch ($x) {\\r\\n.Case ($y):\\r\\n.Case ($z):\\r\\n        .Default(System.Void)\\r\\n}", Expression.Switch(x, Expression.SwitchCase(Expression.Empty(), y, z)));
@@ -426,14 +426,14 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Try()
         {
-            var a = Expression.Parameter(typeof(int), "a");
-            var b = Expression.Parameter(typeof(int), "b");
-            var c = Expression.Parameter(typeof(int), "c");
+            ParameterExpression a = Expression.Parameter(typeof(int), "a");
+            ParameterExpression b = Expression.Parameter(typeof(int), "b");
+            ParameterExpression c = Expression.Parameter(typeof(int), "c");
 
-            var e = Expression.Parameter(typeof(Exception), "e");
-            var i = Expression.Parameter(typeof(InvalidOperationException), "i");
+            ParameterExpression e = Expression.Parameter(typeof(Exception), "e");
+            ParameterExpression i = Expression.Parameter(typeof(InvalidOperationException), "i");
 
-            var f = Expression.Parameter(typeof(bool), "f");
+            ParameterExpression f = Expression.Parameter(typeof(bool), "f");
 
             Check(".Try {\\r\\n    $a\\r\\n} .Finally {\\r\\n    .Default(System.Void)\\r\\n}", Expression.TryFinally(a, Expression.Empty()));
             Check(".Try {\\r\\n    $a\\r\\n} .Fault {\\r\\n    .Default(System.Void)\\r\\n}", Expression.TryFault(a, Expression.Empty()));
@@ -446,9 +446,9 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Index()
         {
-            var xs = Expression.Parameter(typeof(int[]), "xs");
-            var a = Expression.Parameter(typeof(int), "a");
-            var d = Expression.Parameter(typeof(Dictionary<int, int>), "d");
+            ParameterExpression xs = Expression.Parameter(typeof(int[]), "xs");
+            ParameterExpression a = Expression.Parameter(typeof(int), "a");
+            ParameterExpression d = Expression.Parameter(typeof(Dictionary<int, int>), "d");
 
             Check("$xs[$a]", Expression.ArrayAccess(xs, a));
             Check("$d.Item[$a]", Expression.MakeIndex(d, typeof(Dictionary<int, int>).GetProperty("Item"), new[] { a }));
@@ -457,8 +457,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ListInit()
         {
-            var a = Expression.Parameter(typeof(int), "a");
-            var b = Expression.Parameter(typeof(int), "b");
+            ParameterExpression a = Expression.Parameter(typeof(int), "a");
+            ParameterExpression b = Expression.Parameter(typeof(int), "b");
 
             Check(".New System.Collections.Generic.List`1[System.Int32](){\\r\\n    $a\\r\\n}", Expression.ListInit(Expression.New(typeof(List<int>)), a));
             Check(".New System.Collections.Generic.List`1[System.Int32](){\\r\\n    $a,\\r\\n    $b\\r\\n}", Expression.ListInit(Expression.New(typeof(List<int>)), a, b));
@@ -468,9 +468,9 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void MemberInit()
         {
-            var a = Expression.Parameter(typeof(int), "a");
-            var b = Expression.Parameter(typeof(int), "b");
-            var c = Expression.Parameter(typeof(int), "c");
+            ParameterExpression a = Expression.Parameter(typeof(int), "a");
+            ParameterExpression b = Expression.Parameter(typeof(int), "b");
+            ParameterExpression c = Expression.Parameter(typeof(int), "c");
 
             Check(".New System.Linq.Expressions.Tests.Bar(){\\r\\n    Foo = $a,\\r\\n    Qux = {\\r\\n        Baz = $b,\\r\\n        XS = {\\r\\n            $c\\r\\n        }\\r\\n    }\\r\\n}", Expression.MemberInit(Expression.New(typeof(Bar)), Expression.Bind(typeof(Bar).GetProperty("Foo"), a), Expression.MemberBind(typeof(Bar).GetProperty("Qux"), Expression.Bind(typeof(Qux).GetProperty("Baz"), b), Expression.ListBind(typeof(Qux).GetProperty("XS"), Expression.ElementInit(typeof(List<int>).GetMethod("Add"), c)))));
         }

--- a/src/System.Linq.Expressions/tests/Default/DefaultTests.cs
+++ b/src/System.Linq.Expressions/tests/Default/DefaultTests.cs
@@ -26,9 +26,9 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public void DefaultEnumRef(bool useInterpreter)
         {
-            var x = Expression.Variable(typeof(MyEnum), "x");
+            ParameterExpression x = Expression.Variable(typeof(MyEnum), "x");
 
-            var expression = Expression.Lambda<Action>(
+            Expression<Action> expression = Expression.Lambda<Action>(
                             Expression.Block(
                             new[] { x },
                             Expression.Assign(x, Expression.Default(typeof(MyEnum))),

--- a/src/System.Linq.Expressions/tests/DelegateType/GetDelegateTypeTests.cs
+++ b/src/System.Linq.Expressions/tests/DelegateType/GetDelegateTypeTests.cs
@@ -61,7 +61,7 @@ namespace System.Linq.Expressions.Tests
             Assert.True(typeof(MulticastDelegate).IsAssignableFrom(delType));
             Assert.DoesNotMatch(new Regex(@"System\.Action"), delType.FullName);
             Assert.DoesNotMatch(new Regex(@"System\.Func"), delType.FullName);
-            var method = delType.GetMethod("Invoke");
+            Reflection.MethodInfo method = delType.GetMethod("Invoke");
             Assert.Equal(typeArgs.Last(), method.ReturnType);
             Assert.Equal(typeArgs.Take(typeArgs.Length - 1), method.GetParameters().Select(p => p.ParameterType));
         }
@@ -78,7 +78,7 @@ namespace System.Linq.Expressions.Tests
             Assert.True(typeof(MulticastDelegate).IsAssignableFrom(delType));
             Assert.DoesNotMatch(new Regex(@"System\.Action"), delType.FullName);
             Assert.DoesNotMatch(new Regex(@"System\.Func"), delType.FullName);
-            var method = delType.GetMethod("Invoke");
+            Reflection.MethodInfo method = delType.GetMethod("Invoke");
             Assert.Equal(typeof(void), method.ReturnType);
             Assert.Equal(typeArgs, method.GetParameters().Select(p => p.ParameterType));
         }

--- a/src/System.Linq.Expressions/tests/Dynamic/BindingRestrictionsProxyTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/BindingRestrictionsProxyTests.cs
@@ -53,7 +53,7 @@ namespace System.Dynamic.Tests
             var att =
                 (DebuggerTypeProxyAttribute)
                     type.GetCustomAttributes().Single(at => at.TypeId.Equals(typeof(DebuggerTypeProxyAttribute)));
-            var proxyName = att.ProxyTypeName;
+            string proxyName = att.ProxyTypeName;
             proxyName = proxyName.Substring(0, proxyName.IndexOf(','));
             return type.GetTypeInfo().Assembly.GetType(proxyName);
         }
@@ -64,10 +64,10 @@ namespace System.Dynamic.Tests
         [Fact]
         public void EmptyRestiction()
         {
-            var empty = BindingRestrictions.Empty;
-            var view = GetDebugViewObject(empty);
+            BindingRestrictions empty = BindingRestrictions.Empty;
+            BindingRestrictionsProxyProxy view = GetDebugViewObject(empty);
             Assert.True(view.IsEmpty);
-            var restrictions = view.Restrictions;
+            BindingRestrictions[] restrictions = view.Restrictions;
             Assert.Equal(1, restrictions.Length);
             Assert.Same(empty, restrictions[0]);
             Assert.Same(empty.ToExpression(), view.Test);
@@ -77,11 +77,11 @@ namespace System.Dynamic.Tests
         [Fact]
         public void CustomRestriction()
         {
-            var exp = Expression.Constant(false);
-            var custom = BindingRestrictions.GetExpressionRestriction(exp);
-            var view = GetDebugViewObject(custom);
+            ConstantExpression exp = Expression.Constant(false);
+            BindingRestrictions custom = BindingRestrictions.GetExpressionRestriction(exp);
+            BindingRestrictionsProxyProxy view = GetDebugViewObject(custom);
             Assert.False(view.IsEmpty);
-            var restrictions = view.Restrictions;
+            BindingRestrictions[] restrictions = view.Restrictions;
             Assert.Equal(1, restrictions.Length);
             Assert.Same(custom, restrictions[0]);
             Assert.NotSame(BindingRestrictions.Empty.ToExpression(), view.Test);
@@ -98,21 +98,21 @@ namespace System.Dynamic.Tests
                 Expression.Equal(Expression.Constant(2), Expression.Constant(3))
             };
 
-            var br = BindingRestrictions.Empty;
+            BindingRestrictions br = BindingRestrictions.Empty;
             var restrictions = new List<BindingRestrictions>();
             foreach (var exp in exps)
             {
-                var res = BindingRestrictions.GetExpressionRestriction(exp);
+                BindingRestrictions res = BindingRestrictions.GetExpressionRestriction(exp);
                 restrictions.Add(res);
                 br = br.Merge(res);
             }
 
-            var view = GetDebugViewObject(br);
+            BindingRestrictionsProxyProxy view = GetDebugViewObject(br);
             Assert.False(view.IsEmpty);
 
             Assert.Equal(br.ToExpression().ToString(), view.ToString());
 
-            var viewedRestrictions = view.Restrictions;
+            BindingRestrictions[] viewedRestrictions = view.Restrictions;
 
             // Check equal to source restrictions, but not insisting on order.
             Assert.Equal(3, viewedRestrictions.Length);
@@ -128,13 +128,13 @@ namespace System.Dynamic.Tests
                 Expression.Equal(Expression.Constant(2), Expression.Constant(3))
             };
 
-            var br = BindingRestrictions.Empty;
+            BindingRestrictions br = BindingRestrictions.Empty;
             foreach (var exp in exps)
             {
                 br = br.Merge(BindingRestrictions.GetExpressionRestriction(exp));
             }
 
-            var view = GetDebugViewObject(br);
+            BindingRestrictionsProxyProxy view = GetDebugViewObject(br);
 
             // The expression in the view will be a tree of AndAlso nodes.
             // If we examine the expression of the restriction a new AndAlso
@@ -142,7 +142,7 @@ namespace System.Dynamic.Tests
             // with the initial set.
 
             var notAndAlso = new List<Expression>();
-            var vExp = view.Test;
+            Expression vExp = view.Test;
             Assert.Equal(ExpressionType.AndAlso, vExp.NodeType);
 
             Stack<Expression> toSplit = new Stack<Expression>();
@@ -174,7 +174,7 @@ namespace System.Dynamic.Tests
         [Fact]
         public void ThrowOnNullToCtor()
         {
-            var tie = Assert.Throws<TargetInvocationException>(() => BindingRestrictionsProxyCtor.Invoke(new object[] {null}));
+            TargetInvocationException tie = Assert.Throws<TargetInvocationException>(() => BindingRestrictionsProxyCtor.Invoke(new object[] {null}));
             ArgumentNullException ane = (ArgumentNullException)tie.InnerException;
             Assert.Equal("node", ane.ParamName);
         }

--- a/src/System.Linq.Expressions/tests/Dynamic/CallInfoTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/CallInfoTests.cs
@@ -58,7 +58,7 @@ namespace System.Dynamic.Tests
         [Fact]
         public void EqualityBasedOnNamesAndCount()
         {
-            var names = new[] {"foo", "bar", "baz", "quux", "quuux"};
+            string[] names = new[] {"foo", "bar", "baz", "quux", "quuux"};
             for (int i = 0; i <= names.Length; ++i)
             {
                 for (int j = 0; j != 3; ++j)
@@ -79,7 +79,7 @@ namespace System.Dynamic.Tests
         [Fact]
         public void HashCodeBasedOnEquality()
         {
-            var names = new[] {"foo", "bar", "baz", "quux", "quuux"};
+            string[] names = new[] {"foo", "bar", "baz", "quux", "quuux"};
             for (int i = 0; i <= names.Length; ++i)
             {
                 for (int j = 0; j != 3; ++j)
@@ -120,7 +120,7 @@ namespace System.Dynamic.Tests
         public void FreshCopyOfNamesMadeEnumerable()
         {
             List<string> nameList = new List<string> {"foo", "bar"};
-            var nameReadOnly = nameList.AsReadOnly();
+            ReadOnlyCollection<string> nameReadOnly = nameList.AsReadOnly();
             var info = new CallInfo(2, nameReadOnly);
             nameList[0] = "baz";
             nameList[1] = "qux";

--- a/src/System.Linq.Expressions/tests/Dynamic/ExpandoObjectProxyTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/ExpandoObjectProxyTests.cs
@@ -17,7 +17,7 @@ namespace System.Dynamic.Tests
             var att =
                 (DebuggerTypeProxyAttribute)
                     type.GetCustomAttributes().Single(at => at.TypeId.Equals(typeof(DebuggerTypeProxyAttribute)));
-            var proxyName = att.ProxyTypeName;
+            string proxyName = att.ProxyTypeName;
             proxyName = proxyName.Substring(0, proxyName.IndexOf(','));
             return type.GetTypeInfo().Assembly.GetType(proxyName);
         }
@@ -81,7 +81,7 @@ namespace System.Dynamic.Tests
         [MemberData(nameof(ValueCollections))]
         public void ItemsAreRootHidden(object eo)
         {
-            var itemsProp = GetDebugViewObject(eo).GetType().GetProperty("Items");
+            PropertyInfo itemsProp = GetDebugViewObject(eo).GetType().GetProperty("Items");
             var browsable = (DebuggerBrowsableAttribute)itemsProp.GetCustomAttribute(typeof(DebuggerBrowsableAttribute));
             Assert.Equal(DebuggerBrowsableState.RootHidden, browsable.State);
         }
@@ -90,7 +90,7 @@ namespace System.Dynamic.Tests
         public void KeyCollectionCorrectlyViewed(ICollection<string> keys)
         {
             object view = GetDebugViewObject(keys);
-            var itemsProp = view.GetType().GetProperty("Items");
+            PropertyInfo itemsProp = view.GetType().GetProperty("Items");
             string[] items = (string[])itemsProp.GetValue(view);
             AssertSameCollectionIgnoreOrder(keys, items);
         }
@@ -99,7 +99,7 @@ namespace System.Dynamic.Tests
         public void ValueCollectionCorrectlyViewed(ICollection<object> keys)
         {
             object view = GetDebugViewObject(keys);
-            var itemsProp = view.GetType().GetProperty("Items");
+            PropertyInfo itemsProp = view.GetType().GetProperty("Items");
             object[] items = (object[])itemsProp.GetValue(view);
             AssertSameCollectionIgnoreOrder(keys, items);
         }
@@ -109,7 +109,7 @@ namespace System.Dynamic.Tests
         {
             Type debugViewType = GetDebugViewType(collection.GetType());
             ConstructorInfo constructor = debugViewType.GetConstructors().Single();
-            var tie = Assert.Throws<TargetInvocationException>(() => constructor.Invoke(new object[] {null}));
+            TargetInvocationException tie = Assert.Throws<TargetInvocationException>(() => constructor.Invoke(new object[] {null}));
             var ane = (ArgumentNullException)tie.InnerException;
             Assert.Equal("collection", ane.ParamName);
         }

--- a/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -403,7 +403,7 @@ namespace System.Linq.Expressions.Tests
         public void NonExceptionDerivedExceptionWrapped(bool useInterpreter)
         {
             Action throwWrapped = Expression.Lambda<Action>(Expression.Throw(Expression.Constant("Hello"))).Compile(useInterpreter);
-            var rwe = Assert.Throws<RuntimeWrappedException>(throwWrapped);
+            RuntimeWrappedException rwe = Assert.Throws<RuntimeWrappedException>(throwWrapped);
             Assert.Equal("Hello", rwe.WrappedException);
         }
 
@@ -1035,7 +1035,7 @@ namespace System.Linq.Expressions.Tests
         public void JumpOutOfExceptionFilter(bool useInterpreter)
         {
             LabelTarget target = Expression.Label();
-            var tryExp = Expression.Lambda<Func<int>>(
+            Expression<Func<int>> tryExp = Expression.Lambda<Func<int>>(
                 Expression.TryCatch(
                     Expression.Throw(Expression.Constant(new TestException()), typeof(int)),
                     Expression.Catch(
@@ -1323,27 +1323,27 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void ToStringTest()
         {
-            var e1 = Expression.Throw(Expression.Parameter(typeof(Exception), "ex"));
+            UnaryExpression e1 = Expression.Throw(Expression.Parameter(typeof(Exception), "ex"));
             Assert.Equal("throw(ex)", e1.ToString());
 
-            var e2 = Expression.TryFinally(Expression.Empty(), Expression.Empty());
+            TryExpression e2 = Expression.TryFinally(Expression.Empty(), Expression.Empty());
             Assert.Equal("try { ... }", e2.ToString());
 
-            var e3 = Expression.TryFault(Expression.Empty(), Expression.Empty());
+            TryExpression e3 = Expression.TryFault(Expression.Empty(), Expression.Empty());
             Assert.Equal("try { ... }", e3.ToString());
 
-            var e4 = Expression.TryCatch(Expression.Empty(), Expression.Catch(typeof(Exception), Expression.Empty()));
+            TryExpression e4 = Expression.TryCatch(Expression.Empty(), Expression.Catch(typeof(Exception), Expression.Empty()));
             Assert.Equal("try { ... }", e4.ToString());
 
-            var e5 = Expression.Catch(typeof(Exception), Expression.Empty());
+            CatchBlock e5 = Expression.Catch(typeof(Exception), Expression.Empty());
             Assert.Equal("catch (Exception) { ... }", e5.ToString());
 
-            var e6 = Expression.Catch(Expression.Parameter(typeof(Exception), "ex"), Expression.Empty());
+            CatchBlock e6 = Expression.Catch(Expression.Parameter(typeof(Exception), "ex"), Expression.Empty());
             Assert.Equal("catch (Exception ex) { ... }", e6.ToString());
 
             // NB: No ToString form for filters
 
-            var e7 = Expression.Catch(Expression.Parameter(typeof(Exception), "ex"), Expression.Empty(), Expression.Constant(true));
+            CatchBlock e7 = Expression.Catch(Expression.Parameter(typeof(Exception), "ex"), Expression.Empty(), Expression.Constant(true));
             Assert.Equal("catch (Exception ex) { ... }", e7.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/ExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ExpressionTests.cs
@@ -374,21 +374,21 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void CompileIrreduciebleExtension(bool useInterpreter)
         {
-            var exp = Expression.Lambda<Action>(new IrreducibleWithTypeAndNodeType());
+            Expression<Action> exp = Expression.Lambda<Action>(new IrreducibleWithTypeAndNodeType());
             Assert.Throws<ArgumentException>(null, () => exp.Compile(useInterpreter));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public void CompileIrreduciebleStrangeNodeTypeExtension(bool useInterpreter)
         {
-            var exp = Expression.Lambda<Action>(new IrreduceibleWithTypeAndStrangeNodeType());
+            Expression<Action> exp = Expression.Lambda<Action>(new IrreduceibleWithTypeAndStrangeNodeType());
             Assert.Throws<ArgumentException>(null, () => exp.Compile(useInterpreter));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public void CompileReducibleStrangeNodeTypeExtension(bool useInterpreter)
         {
-            var exp = Expression.Lambda<Func<int>>(new ReducesFromStrangeNodeType());
+            Expression<Func<int>> exp = Expression.Lambda<Func<int>>(new ReducesFromStrangeNodeType());
             Assert.Equal(3, exp.Compile(useInterpreter)());
         }
 
@@ -398,7 +398,7 @@ namespace System.Linq.Expressions.Tests
             var e1 = new ExtensionNoToString();
             Assert.Equal($"[{typeof(ExtensionNoToString).FullName}]", e1.ToString());
 
-            var e2 = Expression.Add(Expression.Constant(1), new ExtensionToString());
+            BinaryExpression e2 = Expression.Add(Expression.Constant(1), new ExtensionToString());
             Assert.Equal($"(1 + bar)", e2.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/ILReader/DynamicScopeTokenResolver.cs
+++ b/src/System.Linq.Expressions/tests/ILReader/DynamicScopeTokenResolver.cs
@@ -26,8 +26,8 @@ namespace System.Linq.Expressions.Tests
 
         static DynamicScopeTokenResolver()
         {
-            var dynamicScope = Type.GetType("System.Reflection.Emit.DynamicScope", throwOnError: true);
-            var dynamicILGenerator = Type.GetType("System.Reflection.Emit.DynamicILGenerator", throwOnError: true);
+            Type dynamicScope = Type.GetType("System.Reflection.Emit.DynamicScope", throwOnError: true);
+            Type dynamicILGenerator = Type.GetType("System.Reflection.Emit.DynamicILGenerator", throwOnError: true);
 
             s_indexer = dynamicScope.GetPropertyAssert("Item");
             s_scopeFi = dynamicILGenerator.GetFieldAssert("m_scope");
@@ -65,7 +65,7 @@ namespace System.Linq.Expressions.Tests
 
         public FieldInfo AsField(int token)
         {
-            var item = this[token];
+            object item = this[token];
 
             if (item is RuntimeFieldHandle)
                 return FieldInfo.GetFieldFromHandle((RuntimeFieldHandle)item);
@@ -85,7 +85,7 @@ namespace System.Linq.Expressions.Tests
 
         public MethodBase AsMethod(int token)
         {
-            var item = this[token];
+            object item = this[token];
 
             if (item is DynamicMethod)
                 return item as DynamicMethod;

--- a/src/System.Linq.Expressions/tests/ILReader/ILPrinter.cs
+++ b/src/System.Linq.Expressions/tests/ILReader/ILPrinter.cs
@@ -28,7 +28,7 @@ namespace System.Linq.Expressions.Tests
             MethodInfo method = d.GetMethodInfo();
             ITypeFactory typeFactory = GetTypeFactory(expression);
 
-            var oldCulture = CultureInfo.CurrentCulture;
+            CultureInfo oldCulture = CultureInfo.CurrentCulture;
             CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
             try
             {
@@ -65,15 +65,15 @@ namespace System.Linq.Expressions.Tests
 
         private static void AppendIL(MethodInfo method, StringWriter sw, ITypeFactory typeFactory)
         {
-            var reader = ILReaderFactory.Create(method);
-            var exceptions = reader.ILProvider.GetExceptionInfos();
+            ILReader reader = ILReaderFactory.Create(method);
+            ExceptionInfo[] exceptions = reader.ILProvider.GetExceptionInfos();
             var writer = new RichILStringToTextWriter(sw, exceptions);
 
             sw.WriteLine(".method " + method.ToIL());
             sw.WriteLine("{");
             sw.WriteLine("  .maxstack " + reader.ILProvider.MaxStackSize);
 
-            var sig = reader.ILProvider.GetLocalSignature();
+            byte[] sig = reader.ILProvider.GetLocalSignature();
             var lsp = new LocalsSignatureParser(reader.Resolver, typeFactory);
             var locals = default(Type[]);
             if (lsp.Parse(sig, out locals) && locals.Length > 0)
@@ -174,7 +174,7 @@ namespace System.Linq.Expressions.Tests
 
             private void Visit(Type type)
             {
-                var ti = type.GetTypeInfo();
+                TypeInfo ti = type.GetTypeInfo();
 
                 if (ti.IsArray || ti.IsPointer || ti.IsByRef)
                 {

--- a/src/System.Linq.Expressions/tests/ILReader/ILProvider.cs
+++ b/src/System.Linq.Expressions/tests/ILReader/ILProvider.cs
@@ -44,13 +44,13 @@ namespace System.Linq.Expressions.Tests
             StartAddress = GetStartAddress();
             EndAddress = GetEndAddress();
 
-            var n = GetNumberOfCatches();
+            int n = GetNumberOfCatches();
             if (n > 0)
             {
-                var handlerStart = GetCatchAddresses();
-                var handlerEnd = GetCatchEndAddresses();
-                var catchType = GetCatchClass();
-                var types = GetExceptionTypes();
+                int[] handlerStart = GetCatchAddresses();
+                int[] handlerEnd = GetCatchEndAddresses();
+                Type[] catchType = GetCatchClass();
+                int[] types = GetExceptionTypes();
 
                 Handlers = new HandlerInfo[n];
 

--- a/src/System.Linq.Expressions/tests/ILReader/LocalsSignatureParser.cs
+++ b/src/System.Linq.Expressions/tests/ILReader/LocalsSignatureParser.cs
@@ -130,7 +130,7 @@ namespace System.Linq.Expressions.Tests
 
             internal void TypeDefOrRef(int token, byte indexType, int index)
             {
-                var type = _parent._tokenResolver.AsType(token);
+                Type type = _parent._tokenResolver.AsType(token);
                 ((TypeInner)_inner).Resolve(type);
             }
 

--- a/src/System.Linq.Expressions/tests/ILReader/PrivateReflectionHelpers.cs
+++ b/src/System.Linq.Expressions/tests/ILReader/PrivateReflectionHelpers.cs
@@ -11,21 +11,21 @@ namespace System.Linq.Expressions.Tests
     {
         public static FieldInfo GetFieldAssert(this Type type, string name)
         {
-            var field = type.GetField(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
+            FieldInfo field = type.GetField(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
             Debug.Assert(field != null, $"Expected field '{name}' on type '{type.Name}'.");
             return field;
         }
 
         public static MethodInfo GetMethodAssert(this Type type, string name)
         {
-            var method = type.GetMethod(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
+            MethodInfo method = type.GetMethod(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
             Debug.Assert(method != null, $"Expected method '{name}' on type '{type.Name}'.");
             return method;
         }
 
         public static PropertyInfo GetPropertyAssert(this Type type, string name)
         {
-            var property = type.GetProperty(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
+            PropertyInfo property = type.GetProperty(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
             Debug.Assert(property != null, $"Expected property '{name}' on type '{type.Name}'.");
             return property;
         }

--- a/src/System.Linq.Expressions/tests/ILReader/ReadableILStringVisitor.cs
+++ b/src/System.Linq.Expressions/tests/ILReader/ReadableILStringVisitor.cs
@@ -64,7 +64,7 @@ namespace System.Linq.Expressions.Tests
         {
             foreach (var e in exceptions)
             {
-                var startCount = 0;
+                int startCount = 0;
                 if (!_startCounts.TryGetValue(e.StartAddress, out startCount))
                 {
                     _startCounts.Add(e.StartAddress, startCount);
@@ -91,7 +91,7 @@ namespace System.Linq.Expressions.Tests
                         _startCatch.Add(c.StartAddress, c.Type);
                     }
 
-                    var endCount = 0;
+                    int endCount = 0;
 
                     if (!_endCounts.TryGetValue(c.EndAddress, out endCount))
                     {
@@ -105,7 +105,7 @@ namespace System.Linq.Expressions.Tests
 
         public override void Process(ILInstruction instruction, string operandString)
         {
-            var endCount = 0;
+            int endCount = 0;
             if (_endCounts.TryGetValue(instruction.Offset, out endCount))
             {
                 for (var i = 0; i < endCount; i++)
@@ -115,7 +115,7 @@ namespace System.Linq.Expressions.Tests
                 }
             }
 
-            var startCount = 0;
+            int startCount = 0;
             if (_startCounts.TryGetValue(instruction.Offset, out startCount))
             {
                 for (var i = 0; i < startCount; i++)
@@ -291,8 +291,8 @@ namespace System.Linq.Expressions.Tests
             string member;
             try
             {
-                var prefix = "";
-                var token = "";
+                string prefix = "";
+                string token = "";
                 switch (inlineTokInstruction.Member.MemberType)
                 {
                     case MemberTypes.Method:
@@ -445,14 +445,14 @@ namespace System.Linq.Expressions.Tests
                 }
                 else
                 {
-                    var bounds = string.Join(",", Enumerable.Repeat("...", type.GetArrayRank()));
+                    string bounds = string.Join(",", Enumerable.Repeat("...", type.GetArrayRank()));
                     return ToIL(type.GetElementType()) + "[" + bounds + "]";
                 }
             }
             else if (type.IsGenericType && !type.IsGenericTypeDefinition && !type.IsGenericParameter /* TODO */)
             {
-                var args = string.Join(",", type.GetGenericArguments().Select(ToIL));
-                var def = ToIL(type.GetGenericTypeDefinition());
+                string args = string.Join(",", type.GetGenericArguments().Select(ToIL));
+                string def = ToIL(type.GetGenericTypeDefinition());
                 return def + "<" + args + ">";
             }
             else if (type.IsByRef)
@@ -491,7 +491,7 @@ namespace System.Linq.Expressions.Tests
                 return "";
             }
 
-            var res = "";
+            string res = "";
 
             if (!method.IsStatic)
             {
@@ -499,7 +499,7 @@ namespace System.Linq.Expressions.Tests
             }
 
             var mtd = method as MethodInfo;
-            var ret = mtd?.ReturnType ?? typeof(void);
+            Type ret = mtd?.ReturnType ?? typeof(void);
 
             res += ret.ToIL() + " ";
             res += method.DeclaringType.ToIL();

--- a/src/System.Linq.Expressions/tests/ILReader/TokenResolver.cs
+++ b/src/System.Linq.Expressions/tests/ILReader/TokenResolver.cs
@@ -59,7 +59,7 @@ namespace System.Linq.Expressions.Tests
 
         private static MethodInfo GetMethodInfo(string name)
         {
-            var parameterTypes = typeof(ModuleExtensions).GetMethod(name).GetParameters().Skip(1).Select(p => p.ParameterType).ToArray();
+            Type[] parameterTypes = typeof(ModuleExtensions).GetMethod(name).GetParameters().Skip(1).Select(p => p.ParameterType).ToArray();
             return typeof(Module).GetMethod(name, parameterTypes);
         }
 

--- a/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionHelpers.cs
+++ b/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionHelpers.cs
@@ -17,7 +17,7 @@ namespace System.Linq.Expressions.Tests
 
         internal static void AssertInvokeCorrect<T>(T expected, IndexExpression expression)
         {
-            var lambda = Expression.Lambda<Func<T>>(expression);
+            Expression<Func<T>> lambda = Expression.Lambda<Func<T>>(expression);
 
             // Compile and evaluate with interpretation flag and without
             // in case there are bugs in the compiler/interpreter.

--- a/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionTests.cs
@@ -54,13 +54,13 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e1 = Expression.MakeIndex(Expression.Parameter(typeof(Vector1), "v"), typeof(Vector1).GetProperty("Item"), new[] { Expression.Parameter(typeof(int), "i") });
+            IndexExpression e1 = Expression.MakeIndex(Expression.Parameter(typeof(Vector1), "v"), typeof(Vector1).GetProperty("Item"), new[] { Expression.Parameter(typeof(int), "i") });
             Assert.Equal("v.Item[i]", e1.ToString());
 
-            var e2 = Expression.MakeIndex(Expression.Parameter(typeof(Vector2), "v"), typeof(Vector2).GetProperty("Item"), new[] { Expression.Parameter(typeof(int), "i"), Expression.Parameter(typeof(int), "j") });
+            IndexExpression e2 = Expression.MakeIndex(Expression.Parameter(typeof(Vector2), "v"), typeof(Vector2).GetProperty("Item"), new[] { Expression.Parameter(typeof(int), "i"), Expression.Parameter(typeof(int), "j") });
             Assert.Equal("v.Item[i, j]", e2.ToString());
 
-            var e3 = Expression.ArrayAccess(Expression.Parameter(typeof(int[,]), "xs"), Expression.Parameter(typeof(int), "i"), Expression.Parameter(typeof(int), "j"));
+            IndexExpression e3 = Expression.ArrayAccess(Expression.Parameter(typeof(int[,]), "xs"), Expression.Parameter(typeof(int), "i"), Expression.Parameter(typeof(int), "j"));
             Assert.Equal("xs[i, j]", e3.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/InterpreterTests.cs
+++ b/src/System.Linq.Expressions/tests/InterpreterTests.cs
@@ -101,17 +101,17 @@ namespace System.Linq.Expressions.Tests
 
         public static void VerifyInstructions(this LambdaExpression expression, string expected)
         {
-            var actual = expression.GetInstructions();
+            string actual = expression.GetInstructions();
 
-            var nExpected = Normalize(expected);
-            var nActual = Normalize(actual);
+            string nExpected = Normalize(expected);
+            string nActual = Normalize(actual);
 
             Assert.Equal(nExpected, nActual);
         }
 
         private static string Normalize(string s)
         {
-            var lines =
+            Collections.Generic.IEnumerable<string> lines =
                 s
                 .Replace("\r\n", "\n")
                 .Split(new[] { '\n' })

--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -16,12 +16,12 @@ namespace System.Linq.Expressions.Tests
         {
             // Expression<X> f = x => {};
             Expression<X> f = Expression.Lambda<X>(Expression.Empty(), Expression.Parameter(typeof(X)));
-            var a = Expression.Lambda(Expression.Invoke(f, f));
+            LambdaExpression a = Expression.Lambda(Expression.Invoke(f, f));
 
             a.Compile(useInterpreter).DynamicInvoke();
 
-            var it = Expression.Parameter(f.Type);
-            var b = Expression.Lambda(Expression.Invoke(Expression.Lambda(Expression.Invoke(it, it), it), f));
+            ParameterExpression it = Expression.Parameter(f.Type);
+            LambdaExpression b = Expression.Lambda(Expression.Invoke(Expression.Lambda(Expression.Invoke(it, it), it), f));
 
             b.Compile(useInterpreter).DynamicInvoke();
         }
@@ -50,15 +50,15 @@ namespace System.Linq.Expressions.Tests
 
             public Action Compile()
             {
-                var ind0 = Expression.Constant(this);
-                var fld = Expression.PropertyOrField(ind0, "DoItA");
-                var block = Expression.Block(typeof(void), Expression.Invoke(fld, ind0));
+                ConstantExpression ind0 = Expression.Constant(this);
+                MemberExpression fld = Expression.PropertyOrField(ind0, "DoItA");
+                BlockExpression block = Expression.Block(typeof(void), Expression.Invoke(fld, ind0));
                 return Expression.Lambda<Action>(block).Compile(_preferInterpretation);
             }
 
             public void DoTest()
             {
-                var act = Compile();
+                Action act = Compile();
                 act();
                 Assert.Equal(1, DoItA(this));
             }
@@ -83,8 +83,8 @@ namespace System.Linq.Expressions.Tests
         public static void InvocationDoesNotChangeFunctionInvoked(bool useInterpreter)
         {
             FuncHolder holder = new FuncHolder();
-            var fld = Expression.Field(Expression.Constant(holder), "Function");
-            var inv = Expression.Invoke(fld);
+            MemberExpression fld = Expression.Field(Expression.Constant(holder), "Function");
+            InvocationExpression inv = Expression.Invoke(fld);
             Func<int> act = (Func<int>)Expression.Lambda(inv).Compile(useInterpreter);
             act();
             Assert.Equal(1, holder.Function());
@@ -93,10 +93,10 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e1 = Expression.Invoke(Expression.Parameter(typeof(Action), "f"));
+            InvocationExpression e1 = Expression.Invoke(Expression.Parameter(typeof(Action), "f"));
             Assert.Equal("Invoke(f)", e1.ToString());
 
-            var e2 = Expression.Invoke(Expression.Parameter(typeof(Action<int>), "f"), Expression.Parameter(typeof(int), "x"));
+            InvocationExpression e2 = Expression.Invoke(Expression.Parameter(typeof(Action<int>), "f"), Expression.Parameter(typeof(int), "x"));
             Assert.Equal("Invoke(f, x)", e2.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/Invoke/InvokeFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvokeFactoryTests.cs
@@ -47,23 +47,23 @@ namespace System.Linq.Expressions.Tests
 
         private static void AssertInvokeIsOptimized(int n)
         {
-            var genArgs = Enumerable.Repeat(typeof(int), n + 1).ToArray();
-            var delegateType = Expression.GetFuncType(genArgs);
+            Type[] genArgs = Enumerable.Repeat(typeof(int), n + 1).ToArray();
+            Type delegateType = Expression.GetFuncType(genArgs);
 
-            var instance = Expression.Parameter(delegateType);
+            ParameterExpression instance = Expression.Parameter(delegateType);
 
             // Expression[] overload
             {
-                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
-                var expr = Expression.Invoke(instance, args);
+                ConstantExpression[] args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToArray();
+                InvocationExpression expr = Expression.Invoke(instance, args);
 
                 AssertInvokeIsOptimized(expr, instance, args);
             }
 
             // IEnumerable<Expression> overload
             {
-                var args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
-                var expr = Expression.Invoke(instance, args);
+                List<ConstantExpression> args = Enumerable.Range(0, n).Select(i => Expression.Constant(i)).ToList();
+                InvocationExpression expr = Expression.Invoke(instance, args);
 
                 AssertInvokeIsOptimized(expr, instance, args);
             }
@@ -71,10 +71,10 @@ namespace System.Linq.Expressions.Tests
 
         private static void AssertInvokeIsOptimized(InvocationExpression expr, Expression expression, IReadOnlyList<Expression> args)
         {
-            var n = args.Count;
+            int n = args.Count;
 
-            var updated = Update(expr);
-            var visited = Visit(expr);
+            InvocationExpression updated = Update(expr);
+            InvocationExpression visited = Visit(expr);
 
             foreach (var node in new[] { expr, updated, visited })
             {
@@ -112,7 +112,7 @@ namespace System.Linq.Expressions.Tests
         {
             // Tests the call of Update to Expression.Invoke factories.
 
-            var res = node.Update(node.Expression, node.Arguments.ToArray());
+            InvocationExpression res = node.Update(node.Expression, node.Arguments.ToArray());
 
             Assert.NotSame(node, res);
 

--- a/src/System.Linq.Expressions/tests/Label/LabelTargetTests.cs
+++ b/src/System.Linq.Expressions/tests/Label/LabelTargetTests.cs
@@ -119,7 +119,7 @@ namespace System.Linq.Expressions.Tests
         public void LableNameNeedNotBeValidCSharpLabelWithValue(bool useInterpreter)
         {
             LabelTarget target = Expression.Label(typeof(int), "1, 2, 3, 4. This is not a valid C♯ label!\"'<>.\uffff");
-            var func = Expression.Lambda<Func<int>>(
+            Func<int> func = Expression.Lambda<Func<int>>(
                 Expression.Block(
                     Expression.Return(target, Expression.Constant(42)),
                     Expression.Throw(Expression.Constant(new CustomException())),

--- a/src/System.Linq.Expressions/tests/Label/LabelTests.cs
+++ b/src/System.Linq.Expressions/tests/Label/LabelTests.cs
@@ -63,8 +63,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void AssignableDefaultByQuotingAllowed()
         {
-            var lambda = Expression.Lambda<Func<int>>(Expression.Constant(0));
-            var label = Expression.Label(Expression.Label(typeof(Expression<Func<int>>)), lambda);
+            Expression<Func<int>> lambda = Expression.Lambda<Func<int>>(Expression.Constant(0));
+            LabelExpression label = Expression.Label(Expression.Label(typeof(Expression<Func<int>>)), lambda);
             Assert.Equal(typeof(Expression<Func<int>>), label.Type);
             Assert.Equal(ExpressionType.Quote, label.DefaultValue.NodeType);
             Assert.Same(lambda, ((UnaryExpression)label.DefaultValue).Operand);

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -36,10 +36,10 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void Lambda(bool useInterpreter)
         {
-            var paramI = Expression.Parameter(typeof(int), "i");
-            var paramJ = Expression.Parameter(typeof(double), "j");
-            var paramK = Expression.Parameter(typeof(decimal), "k");
-            var paramL = Expression.Parameter(typeof(short), "l");
+            ParameterExpression paramI = Expression.Parameter(typeof(int), "i");
+            ParameterExpression paramJ = Expression.Parameter(typeof(double), "j");
+            ParameterExpression paramK = Expression.Parameter(typeof(decimal), "k");
+            ParameterExpression paramL = Expression.Parameter(typeof(short), "l");
 
             Expression lambda = (Expression<Func<int, double, decimal, int>>)((i, j, k) => i);
 
@@ -80,8 +80,8 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void HighArityDelegate(bool useInterpreter)
         {
-            var paramList = Enumerable.Range(0, 20).Select(_ => Expression.Variable(typeof(int))).ToArray();
-            var exp = Expression.Lambda<IcosanaryInt32Func>(
+            ParameterExpression[] paramList = Enumerable.Range(0, 20).Select(_ => Expression.Variable(typeof(int))).ToArray();
+            Expression<IcosanaryInt32Func> exp = Expression.Lambda<IcosanaryInt32Func>(
                 Expression.Add(
                     paramList[0],
                     Expression.Add(
@@ -222,7 +222,7 @@ namespace System.Linq.Expressions.Tests
         [Fact, TestOrder(1)]
         public void ImplicitlyTyped()
         {
-            var exp = Expression.Lambda(
+            LambdaExpression exp = Expression.Lambda(
                 Expression.Empty()
                 );
             Assert.IsAssignableFrom<Expression<Action>>(exp);
@@ -266,7 +266,7 @@ namespace System.Linq.Expressions.Tests
                 double, double, double, double,
                 bool>), exp.Type);
 
-            var paramList = Enumerable.Range(0, 20).Select(_ => Expression.Variable(typeof(int))).ToArray();
+            ParameterExpression[] paramList = Enumerable.Range(0, 20).Select(_ => Expression.Variable(typeof(int))).ToArray();
             exp = Expression.Lambda(
                 Expression.Constant(0),
                 paramList
@@ -305,14 +305,14 @@ namespace System.Linq.Expressions.Tests
             // The two compilation options are given plenty of exercise between here and elsewhere
             // Make sure the no-preference approach keeps working.
 
-            var param = Expression.Parameter(typeof(int));
-            var typedExp = Expression.Lambda<Func<int, int>>(
+            ParameterExpression param = Expression.Parameter(typeof(int));
+            Expression<Func<int, int>> typedExp = Expression.Lambda<Func<int, int>>(
                 Expression.Add(param, Expression.Constant(2)),
                 param
                 );
             Assert.Equal(5, typedExp.Compile()(3));
 
-            var exp = Expression.Lambda(
+            LambdaExpression exp = Expression.Lambda(
                 Expression.Add(param, Expression.Constant(7)),
                 param
                 );
@@ -322,7 +322,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void DuplicateParameters()
         {
-            var param = Expression.Parameter(typeof(int));
+            ParameterExpression param = Expression.Parameter(typeof(int));
             Assert.Throws<ArgumentException>("parameters[1]", () => Expression.Lambda(Expression.Empty(), false, param, param));
             Assert.Throws<ArgumentException>("parameters[1]",
                 () => Expression.Lambda<Func<int, int, int>>(Expression.Constant(0), false, param, param));
@@ -392,38 +392,38 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void AutoQuote(bool useInterpreter)
         {
-            var param = Expression.Parameter(typeof(int));
-            var inner = Expression.Lambda<Func<int, int>>(
+            ParameterExpression param = Expression.Parameter(typeof(int));
+            Expression<Func<int, int>> inner = Expression.Lambda<Func<int, int>>(
                 Expression.Multiply(param, Expression.Constant(2)),
                 param
                 );
-            var outer = Expression.Lambda<Func<Expression<Func<int, int>>>>(inner);
+            Expression<Func<Expression<Func<int, int>>>> outer = Expression.Lambda<Func<Expression<Func<int, int>>>>(inner);
             Assert.IsType<UnaryExpression>(outer.Body);
             Assert.Equal(ExpressionType.Quote, outer.Body.NodeType);
-            var outerDel = outer.Compile(useInterpreter);
-            var innerDel = outerDel().Compile(useInterpreter);
+            Func<Expression<Func<int, int>>> outerDel = outer.Compile(useInterpreter);
+            Func<int, int> innerDel = outerDel().Compile(useInterpreter);
             Assert.Equal(16, innerDel(8));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public void NestedCompile(bool useInterpreter)
         {
-            var param = Expression.Parameter(typeof(int));
-            var inner = Expression.Lambda<Func<int, int>>(
+            ParameterExpression param = Expression.Parameter(typeof(int));
+            Expression<Func<int, int>> inner = Expression.Lambda<Func<int, int>>(
                 Expression.Multiply(param, Expression.Constant(2)),
                 param
                 );
-            var outer = Expression.Lambda<Func<Func<int, int>>>(inner);
+            Expression<Func<Func<int, int>>> outer = Expression.Lambda<Func<Func<int, int>>>(inner);
             Assert.Same(inner, outer.Body);
-            var outerDel = outer.Compile(useInterpreter);
-            var innerDel = outerDel();
+            Func<Func<int, int>> outerDel = outer.Compile(useInterpreter);
+            Func<int, int> innerDel = outerDel();
             Assert.Equal(16, innerDel(8));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public void AnyTypeCanBeReturnedVoid(bool useInterpreter)
         {
-            var act = Expression.Lambda<Action>(Expression.Constant("foo")).Compile(useInterpreter);
+            Action act = Expression.Lambda<Action>(Expression.Constant("foo")).Compile(useInterpreter);
             act();
         }
 
@@ -447,25 +447,25 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void UpdateSameReturnsSame()
         {
-            var param = Expression.Parameter(typeof(int));
-            var identExp = Expression.Lambda<Func<int, int>>(param, param);
+            ParameterExpression param = Expression.Parameter(typeof(int));
+            Expression<Func<int, int>> identExp = Expression.Lambda<Func<int, int>>(param, param);
             Assert.Same(identExp, identExp.Update(param, identExp.Parameters));
         }
 
         [Fact]
         public void UpdateDifferentBodyReturnsDifferent()
         {
-            var param = Expression.Parameter(typeof(int));
-            var identExp = Expression.Lambda<Func<int, int>>(param, param);
+            ParameterExpression param = Expression.Parameter(typeof(int));
+            Expression<Func<int, int>> identExp = Expression.Lambda<Func<int, int>>(param, param);
             Assert.NotSame(identExp, identExp.Update(Expression.UnaryPlus(param), identExp.Parameters));
         }
 
         [Fact]
         public void UpdateDifferentParamsReturnsDifferent()
         {
-            var param0 = Expression.Parameter(typeof(int));
-            var param1 = Expression.Parameter(typeof(int));
-            var add = Expression.Lambda<Func<int, int, int>>(
+            ParameterExpression param0 = Expression.Parameter(typeof(int));
+            ParameterExpression param1 = Expression.Parameter(typeof(int));
+            Expression<Func<int, int, int>> add = Expression.Lambda<Func<int, int, int>>(
                 Expression.Add(param0, param1),
                 param0,
                 param1
@@ -489,24 +489,24 @@ namespace System.Linq.Expressions.Tests
         public void CurriedFunctions(bool useInterpreter)
         {
             Expression<Func<int, Func<int>>> f1 = x => () => x;
-            var d1 = f1.Compile(useInterpreter);
-            var c1 = d1(42);
+            Func<int, Func<int>> d1 = f1.Compile(useInterpreter);
+            Func<int> c1 = d1(42);
             Assert.Equal(42, c1());
             Assert.Equal(42, c1());
 
             Expression<Func<int, Func<int, int>>> f2 = x => y => x - y;
-            var d2 = f2.Compile(useInterpreter);
-            var c2 = d2(42);
+            Func<int, Func<int, int>> d2 = f2.Compile(useInterpreter);
+            Func<int, int> c2 = d2(42);
             Assert.Equal(41, c2(1));
             Assert.Equal(40, c2(2));
 
             Expression<Func<int, Func<int, Func<int, int>>>> f3 = x => y => z => x * y - z;
-            var d3 = f3.Compile(useInterpreter);
-            var c3 = d3(2);
-            var c31 = c3(21);
+            Func<int, Func<int, Func<int, int>>> d3 = f3.Compile(useInterpreter);
+            Func<int, Func<int, int>> c3 = d3(2);
+            Func<int, int> c31 = c3(21);
             Assert.Equal(41, c31(1));
             Assert.Equal(40, c31(2));
-            var c32 = c3(22);
+            Func<int, int> c32 = c3(22);
             Assert.Equal(41, c32(3));
             Assert.Equal(40, c32(4));
         }
@@ -534,8 +534,8 @@ namespace System.Linq.Expressions.Tests
             //
             for (var i = 0; i < 10; i++)
             {
-                var val = Expression.Parameter(typeof(int));
-                var sum = Expression.Parameter(typeof(int));
+                ParameterExpression val = Expression.Parameter(typeof(int));
+                ParameterExpression sum = Expression.Parameter(typeof(int));
 
                 var addExprs = new List<Expression>();
 
@@ -545,11 +545,11 @@ namespace System.Linq.Expressions.Tests
                     addExprs.Add(Expression.AddAssign(sum, val));
                 }
 
-                var adds = Expression.Block(addExprs);
-                var body = Expression.Block(new[] { sum }, Expression.Assign(sum, Expression.Constant(0)), adds, sum);
+                BlockExpression adds = Expression.Block(addExprs);
+                BlockExpression body = Expression.Block(new[] { sum }, Expression.Assign(sum, Expression.Constant(0)), adds, sum);
 
-                var e = Expression.Lambda<Func<int, Func<int>>>(Expression.Lambda<Func<int>>(body), val);
-                var f = e.Compile(useInterpreter);
+                Expression<Func<int, Func<int>>> e = Expression.Lambda<Func<int, Func<int>>>(Expression.Lambda<Func<int>>(body), val);
+                Func<int, Func<int>> f = e.Compile(useInterpreter);
 
                 Assert.Equal(i * (i + 1) / 2, f(i)());
             }
@@ -559,15 +559,15 @@ namespace System.Linq.Expressions.Tests
         public void CurriedFunctionsUsingRef(bool useInterpreter)
         {
             Expression<Func<int, Func<int>>> f1 = x => () => x * Add(ref x, 1);
-            var d1 = f1.Compile(useInterpreter);
+            Func<int, Func<int>> d1 = f1.Compile(useInterpreter);
             Assert.Equal(3 * 4, d1(3)());
 
             Expression<Func<int, Func<int>>> f2 = x => () => x * Add(ref x, 1) * Add(ref x, 2);
-            var d2 = f2.Compile(useInterpreter);
+            Func<int, Func<int>> d2 = f2.Compile(useInterpreter);
             Assert.Equal(3 * 4 * 6, d2(3)());
 
             Expression<Func<int, Func<int>>> f3 = x => () => x * Add(ref x, 1) * Add(ref x, 2) * x;
-            var d3 = f3.Compile(useInterpreter);
+            Func<int, Func<int>> d3 = f3.Compile(useInterpreter);
             Assert.Equal(3 * 4 * 6 * 6, d3(3)());
         }
 
@@ -593,12 +593,12 @@ namespace System.Linq.Expressions.Tests
             // to optimizations for closure storage access.
             //
 
-            var add = typeof(LambdaTests).GetMethod(nameof(LambdaTests.Add), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            MethodInfo add = typeof(LambdaTests).GetMethod(nameof(LambdaTests.Add), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
 
             for (var i = 0; i < 10; i++)
             {
-                var val = Expression.Parameter(typeof(int));
-                var sum = Expression.Parameter(typeof(int));
+                ParameterExpression val = Expression.Parameter(typeof(int));
+                ParameterExpression sum = Expression.Parameter(typeof(int));
 
                 var addExprs = new List<Expression>();
 
@@ -608,11 +608,11 @@ namespace System.Linq.Expressions.Tests
                     addExprs.Add(Expression.Call(add, sum, val));
                 }
 
-                var adds = Expression.Block(addExprs);
-                var body = Expression.Block(new[] { sum }, Expression.Assign(sum, Expression.Constant(0)), adds, sum);
+                BlockExpression adds = Expression.Block(addExprs);
+                BlockExpression body = Expression.Block(new[] { sum }, Expression.Assign(sum, Expression.Constant(0)), adds, sum);
 
-                var e = Expression.Lambda<Func<int, Func<int>>>(Expression.Lambda<Func<int>>(body), val);
-                var f = e.Compile(useInterpreter);
+                Expression<Func<int, Func<int>>> e = Expression.Lambda<Func<int, Func<int>>>(Expression.Lambda<Func<int>>(body), val);
+                Func<int, Func<int>> f = e.Compile(useInterpreter);
 
                 Assert.Equal(i * (i + 1) / 2, f(i)());
             }
@@ -621,10 +621,10 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void CurriedFunctionsVariableCaptureSemantics(bool useInterpreter)
         {
-            var x = Expression.Parameter(typeof(int));
-            var f = Expression.Parameter(typeof(Func<int>));
+            ParameterExpression x = Expression.Parameter(typeof(int));
+            ParameterExpression f = Expression.Parameter(typeof(Func<int>));
 
-            var e =
+            Expression<Func<Func<int>>> e =
                 Expression.Lambda<Func<Func<int>>>(
                     Expression.Block(
                         new[] { f, x },
@@ -641,9 +641,9 @@ namespace System.Linq.Expressions.Tests
                     )
                 );
 
-            var d = e.Compile(useInterpreter);
+            Func<Func<int>> d = e.Compile(useInterpreter);
 
-            var i = d();
+            Func<int> i = d();
 
             Assert.Equal(42, i());
             Assert.Equal(84, i());

--- a/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
@@ -38,18 +38,18 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void NullNewMethod()
         {
-            var validExpression = Expression.Constant(1);
+            ConstantExpression validExpression = Expression.Constant(1);
             Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, validExpression));
             Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, Enumerable.Repeat(validExpression, 1)));
 
-            var validMethod = typeof(List<int>).GetMethod("Add");
+            MethodInfo validMethod = typeof(List<int>).GetMethod("Add");
             Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, validMethod, validExpression));
             Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, validMethod, Enumerable.Repeat(validExpression, 1)));
 
             Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, default(MethodInfo), validExpression));
             Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, null, Enumerable.Repeat(validExpression, 1)));
 
-            var validElementInit = Expression.ElementInit(validMethod, validExpression);
+            ElementInit validElementInit = Expression.ElementInit(validMethod, validExpression);
             Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, validElementInit));
             Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, Enumerable.Repeat(validElementInit, 1)));
         }
@@ -57,13 +57,13 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void NullInitializers()
         {
-            var validNew = Expression.New(typeof(List<int>));
+            NewExpression validNew = Expression.New(typeof(List<int>));
             Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, default(Expression[])));
             Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, default(IEnumerable<Expression>)));
             Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, default(ElementInit[])));
             Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, default(IEnumerable<ElementInit>)));
 
-            var validMethod = typeof(List<int>).GetMethod("Add");
+            MethodInfo validMethod = typeof(List<int>).GetMethod("Add");
             Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, validMethod, default(Expression[])));
             Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, validMethod, default(IEnumerable<Expression>)));
 
@@ -73,13 +73,13 @@ namespace System.Linq.Expressions.Tests
 
         private static IEnumerable<object[]> ZeroInitializerInits()
         {
-            var validNew = Expression.New(typeof(List<int>));
+            NewExpression validNew = Expression.New(typeof(List<int>));
             yield return new object[] {Expression.ListInit(validNew, new Expression[0])};
             yield return new object[] {Expression.ListInit(validNew, Enumerable.Empty<Expression>())};
             yield return new object[] {Expression.ListInit(validNew, new ElementInit[0])};
             yield return new object[] {Expression.ListInit(validNew, Enumerable.Empty<ElementInit>())};
 
-            var validMethod = typeof(List<int>).GetMethod("Add");
+            MethodInfo validMethod = typeof(List<int>).GetMethod("Add");
             yield return new object[] {Expression.ListInit(validNew, validMethod)};
             yield return new object[] {Expression.ListInit(validNew, validMethod, Enumerable.Empty<Expression>())};
 
@@ -90,15 +90,15 @@ namespace System.Linq.Expressions.Tests
         [Theory, PerCompilationType(nameof(ZeroInitializerInits))]
         public void ZeroInitializers(Expression init, bool useInterpreter)
         {
-            var exp = Expression.Lambda<Func<List<int>>>(init);
-            var func = exp.Compile(useInterpreter);
+            Expression<Func<List<int>>> exp = Expression.Lambda<Func<List<int>>>(init);
+            Func<List<int>> func = exp.Compile(useInterpreter);
             Assert.Empty(func());
         }
 
         [Fact]
         public void TypeWithoutAdd()
         {
-            var newExp = Expression.New(typeof(string).GetConstructor(new[] { typeof(char[]) }), Expression.Constant("aaaa".ToCharArray()));
+            NewExpression newExp = Expression.New(typeof(string).GetConstructor(new[] { typeof(char[]) }), Expression.Constant("aaaa".ToCharArray()));
             Assert.Throws<InvalidOperationException>(() => Expression.ListInit(newExp, Expression.Constant('a')));
             Assert.Throws<InvalidOperationException>(() => Expression.ListInit(newExp, Enumerable.Repeat(Expression.Constant('a'), 1)));
             Assert.Throws<InvalidOperationException>(() => Expression.ListInit(newExp, default(MethodInfo), Expression.Constant('a')));
@@ -116,8 +116,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void StaticAddMethodOnType()
         {
-            var newExp = Expression.New(typeof(EnumerableStaticAdd));
-            var adder = typeof(EnumerableStaticAdd).GetMethod(nameof(EnumerableStaticAdd.Add));
+            NewExpression newExp = Expression.New(typeof(EnumerableStaticAdd));
+            MethodInfo adder = typeof(EnumerableStaticAdd).GetMethod(nameof(EnumerableStaticAdd.Add));
 
             // this exception behavior (rather than ArgumentException) is compatible with the .NET Framework
             Assert.Throws<InvalidOperationException>(() => Expression.ListInit(newExp, Expression.Constant("")));
@@ -130,16 +130,16 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void InitializersWrappedExactly()
         {
-            var newExp = Expression.New(typeof(List<int>));
-            var expressions = new[] { Expression.Constant(1), Expression.Constant(2), Expression.Constant(int.MaxValue) };
-            var listInit = Expression.ListInit(newExp, expressions);
+            NewExpression newExp = Expression.New(typeof(List<int>));
+            ConstantExpression[] expressions = new[] { Expression.Constant(1), Expression.Constant(2), Expression.Constant(int.MaxValue) };
+            ListInitExpression listInit = Expression.ListInit(newExp, expressions);
             Assert.Equal(expressions, listInit.Initializers.Select(i => i.GetArgument(0)));
         }
 
         [Fact]
         public void CanReduce()
         {
-            var listInit = Expression.ListInit(
+            ListInitExpression listInit = Expression.ListInit(
                 Expression.New(typeof(List<int>)),
                 Expression.Constant(0)
                 );
@@ -184,7 +184,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void UpdateSameReturnsSame()
         {
-            var init = Expression.ListInit(
+            ListInitExpression init = Expression.ListInit(
                 Expression.New(typeof(List<int>)),
                 Expression.Constant(1),
                 Expression.Constant(2),
@@ -195,7 +195,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void UpdateDifferentNewReturnsDifferent()
         {
-            var init = Expression.ListInit(
+            ListInitExpression init = Expression.ListInit(
                 Expression.New(typeof(List<int>)),
                 Expression.Constant(1),
                 Expression.Constant(2),
@@ -206,24 +206,24 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void UpdateDifferentInitializersReturnsDifferent()
         {
-            var meth = typeof(List<int>).GetMethod("Add");
-            var inits = new[]
+            MethodInfo meth = typeof(List<int>).GetMethod("Add");
+            ElementInit[] inits = new[]
             {
                 Expression.ElementInit(meth, Expression.Constant(1)),
                 Expression.ElementInit(meth, Expression.Constant(2)),
                 Expression.ElementInit(meth, Expression.Constant(3))
             };
-            var init = Expression.ListInit(Expression.New(typeof(List<int>)), inits);
+            ListInitExpression init = Expression.ListInit(Expression.New(typeof(List<int>)), inits);
             Assert.NotSame(init, init.Update(Expression.New(typeof(List<int>)), inits));
         }
 
         [Fact]
         public static void ToStringTest()
         {
-            var e1 = Expression.ListInit(Expression.New(typeof(List<int>)), Expression.Parameter(typeof(int), "x"));
+            ListInitExpression e1 = Expression.ListInit(Expression.New(typeof(List<int>)), Expression.Parameter(typeof(int), "x"));
             Assert.Equal("new List`1() {Void Add(Int32)(x)}", e1.ToString());
 
-            var e2 = Expression.ListInit(Expression.New(typeof(List<int>)), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
+            ListInitExpression e2 = Expression.ListInit(Expression.New(typeof(List<int>)), Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
             Assert.Equal("new List`1() {Void Add(Int32)(x), Void Add(Int32)(y)}", e2.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/Loop/LoopTests.cs
+++ b/src/System.Linq.Expressions/tests/Loop/LoopTests.cs
@@ -190,10 +190,10 @@ namespace System.Linq.Expressions.Tests
         public void ExplicitContinue(bool useInterpreter)
         {
             var builder = new StringBuilder();
-            var value = Expression.Variable(typeof(int));
-            var @break = Expression.Label();
-            var @continue = Expression.Label();
-            var append = typeof(StringBuilder).GetMethod(nameof(StringBuilder.Append), new[] {typeof(int)});
+            ParameterExpression value = Expression.Variable(typeof(int));
+            LabelTarget @break = Expression.Label();
+            LabelTarget @continue = Expression.Label();
+            Reflection.MethodInfo append = typeof(StringBuilder).GetMethod(nameof(StringBuilder.Append), new[] {typeof(int)});
             Action act = Expression.Lambda<Action>(
                 Expression.Block(
                     new[] {value},
@@ -251,7 +251,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void CannotReduce()
         {
-            var loop = Expression.Loop(Expression.Empty(), Expression.Label(), Expression.Label());
+            LoopExpression loop = Expression.Loop(Expression.Empty(), Expression.Label(), Expression.Label());
             Assert.False(loop.CanReduce);
             Assert.Same(loop, loop.Reduce());
             Assert.Throws<ArgumentException>(null, () => loop.ReduceAndCheck());
@@ -260,35 +260,35 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void UpdateSameIsSame()
         {
-            var loop = Expression.Loop(Expression.Empty(), Expression.Label(), Expression.Label());
+            LoopExpression loop = Expression.Loop(Expression.Empty(), Expression.Label(), Expression.Label());
             Assert.Same(loop, loop.Update(loop.BreakLabel, loop.ContinueLabel, loop.Body));
         }
 
         [Fact]
         public void UpdateDifferentBodyIsDifferent()
         {
-            var loop = Expression.Loop(Expression.Empty(), Expression.Label(), Expression.Label());
+            LoopExpression loop = Expression.Loop(Expression.Empty(), Expression.Label(), Expression.Label());
             Assert.NotSame(loop, loop.Update(loop.BreakLabel, loop.ContinueLabel, Expression.Empty()));
         }
 
         [Fact]
         public void UpdateDifferentBreakIsDifferent()
         {
-            var loop = Expression.Loop(Expression.Empty(), Expression.Label(), Expression.Label());
+            LoopExpression loop = Expression.Loop(Expression.Empty(), Expression.Label(), Expression.Label());
             Assert.NotSame(loop, loop.Update(Expression.Label(), loop.ContinueLabel, loop.Body));
         }
 
         [Fact]
         public void UpdateDifferentContinueIsDifferent()
         {
-            var loop = Expression.Loop(Expression.Empty(), Expression.Label(), Expression.Label());
+            LoopExpression loop = Expression.Loop(Expression.Empty(), Expression.Label(), Expression.Label());
             Assert.NotSame(loop, loop.Update(loop.BreakLabel, Expression.Label(), loop.Body));
         }
 
         [Fact]
         public void ToStringTest()
         {
-            var e = Expression.Loop(Expression.Empty());
+            LoopExpression e = Expression.Loop(Expression.Empty());
             Assert.Equal("loop { ... }", e.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -539,10 +539,10 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e1 = Expression.Property(null, typeof(DateTime).GetProperty(nameof(DateTime.Now)));
+            MemberExpression e1 = Expression.Property(null, typeof(DateTime).GetProperty(nameof(DateTime.Now)));
             Assert.Equal("DateTime.Now", e1.ToString());
 
-            var e2 = Expression.Property(Expression.Parameter(typeof(DateTime), "d"), typeof(DateTime).GetProperty(nameof(DateTime.Year)));
+            MemberExpression e2 = Expression.Property(Expression.Parameter(typeof(DateTime), "d"), typeof(DateTime).GetProperty(nameof(DateTime.Year)));
             Assert.Equal("d.Year", e2.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
@@ -100,8 +100,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void MustBeMemberOfType()
         {
-            var newExp = Expression.New(typeof(UriBuilder));
-            var bind = Expression.Bind(
+            NewExpression newExp = Expression.New(typeof(UriBuilder));
+            MemberAssignment bind = Expression.Bind(
                 typeof(PropertyAndFields).GetProperty(nameof(PropertyAndFields.StringProperty)),
                 Expression.Constant("value")
                 );
@@ -149,7 +149,7 @@ namespace System.Linq.Expressions.Tests
         public void ConstantField(bool useInterpreter)
         {
             MemberInfo member = typeof(PropertyAndFields).GetMember(nameof(PropertyAndFields.ConstantString))[0];
-            var attemptAssignToConstant = Expression.Lambda<Func<PropertyAndFields>>(
+            Expression<Func<PropertyAndFields>> attemptAssignToConstant = Expression.Lambda<Func<PropertyAndFields>>(
                 Expression.MemberInit(
                     Expression.New(typeof(PropertyAndFields)),
                     Expression.Bind(member, Expression.Constant(""))
@@ -163,13 +163,13 @@ namespace System.Linq.Expressions.Tests
         public void ReadonlyField(bool useInterpreter)
         {
             MemberInfo member = typeof(PropertyAndFields).GetMember(nameof(PropertyAndFields.ReadonlyStringField))[0];
-            var assignToReadonly = Expression.Lambda<Func<PropertyAndFields>>(
+            Expression<Func<PropertyAndFields>> assignToReadonly = Expression.Lambda<Func<PropertyAndFields>>(
                 Expression.MemberInit(
                     Expression.New(typeof(PropertyAndFields)),
                     Expression.Bind(member, Expression.Constant("ABC"))
                     )
                 );
-            var func = assignToReadonly.Compile(useInterpreter);
+            Func<PropertyAndFields> func = assignToReadonly.Compile(useInterpreter);
             Assert.Equal("ABC", func().ReadonlyStringField);
         }
 
@@ -195,13 +195,13 @@ namespace System.Linq.Expressions.Tests
         public void StaticField(bool useInterpreter)
         {
             MemberInfo member = typeof(PropertyAndFields).GetMember(nameof(PropertyAndFields.StaticStringField))[0];
-            var assignToReadonly = Expression.Lambda<Func<PropertyAndFields>>(
+            Expression<Func<PropertyAndFields>> assignToReadonly = Expression.Lambda<Func<PropertyAndFields>>(
                 Expression.MemberInit(
                     Expression.New(typeof(PropertyAndFields)),
                     Expression.Bind(member, Expression.Constant("ABC"))
                     )
                 );
-            var func = assignToReadonly.Compile(useInterpreter);
+            Func<PropertyAndFields> func = assignToReadonly.Compile(useInterpreter);
             PropertyAndFields.StaticStringField = "123";
             func();
             Assert.Equal("ABC", PropertyAndFields.StaticStringField);
@@ -211,13 +211,13 @@ namespace System.Linq.Expressions.Tests
         public void StaticReadonlyField(bool useInterpreter)
         {
             MemberInfo member = typeof(PropertyAndFields).GetMember(nameof(PropertyAndFields.StaticReadonlyStringField))[0];
-            var assignToReadonly = Expression.Lambda<Func<PropertyAndFields>>(
+            Expression<Func<PropertyAndFields>> assignToReadonly = Expression.Lambda<Func<PropertyAndFields>>(
                 Expression.MemberInit(
                     Expression.New(typeof(PropertyAndFields)),
                     Expression.Bind(member, Expression.Constant("ABC" + useInterpreter))
                     )
                 );
-            var func = assignToReadonly.Compile(useInterpreter);
+            Func<PropertyAndFields> func = assignToReadonly.Compile(useInterpreter);
             func();
             Assert.Equal("ABC" + useInterpreter, PropertyAndFields.StaticReadonlyStringField);
         }
@@ -226,7 +226,7 @@ namespace System.Linq.Expressions.Tests
         public void StaticProperty(bool useInterpreter)
         {
             MemberInfo member = typeof(PropertyAndFields).GetMember(nameof(PropertyAndFields.StaticStringProperty))[0];
-            var assignToStaticProperty = Expression.Lambda<Func<PropertyAndFields>>(
+            Expression<Func<PropertyAndFields>> assignToStaticProperty = Expression.Lambda<Func<PropertyAndFields>>(
                 Expression.MemberInit(
                     Expression.New(typeof(PropertyAndFields)),
                     Expression.Bind(member, Expression.Constant("ABC"))
@@ -238,21 +238,21 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void UpdateDifferentReturnsDifferent()
         {
-            var bind = Expression.Bind(typeof(PropertyAndFields).GetProperty("StringProperty"), Expression.Constant("Hello Property"));
+            MemberAssignment bind = Expression.Bind(typeof(PropertyAndFields).GetProperty("StringProperty"), Expression.Constant("Hello Property"));
             Assert.NotSame(bind, Expression.Default(typeof(string)));
         }
 
         [Fact]
         public void UpdateSameReturnsSame()
         {
-            var bind = Expression.Bind(typeof(PropertyAndFields).GetProperty("StringProperty"), Expression.Constant("Hello Property"));
+            MemberAssignment bind = Expression.Bind(typeof(PropertyAndFields).GetProperty("StringProperty"), Expression.Constant("Hello Property"));
             Assert.Same(bind, bind.Update(bind.Expression));
         }
 
         [Fact]
         public void MemberBindingTypeAssignment()
         {
-            var bind = Expression.Bind(typeof(PropertyAndFields).GetProperty("StringProperty"), Expression.Constant("Hello Property"));
+            MemberAssignment bind = Expression.Bind(typeof(PropertyAndFields).GetProperty("StringProperty"), Expression.Constant("Hello Property"));
             Assert.Equal(MemberBindingType.Assignment, bind.BindingType);
         }
     }

--- a/src/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
@@ -175,7 +175,7 @@ namespace System.Linq.Expressions.Tests
         public void StaticListProperty(bool useInterpreter)
         {
             PropertyInfo property = typeof(ListWrapper<int>).GetProperty(nameof(ListWrapper<int>.StaticListProperty));
-            var exp = Expression.Lambda<Func<ListWrapper<int>>>(
+            Expression<Func<ListWrapper<int>>> exp = Expression.Lambda<Func<ListWrapper<int>>>(
                 Expression.MemberInit(
                     Expression.New(typeof(ListWrapper<int>)),
                     Expression.ListBind(
@@ -195,7 +195,7 @@ namespace System.Linq.Expressions.Tests
         public void StaticListField(bool useInterpreter)
         {
             FieldInfo field = typeof(ListWrapper<int>).GetField(nameof(ListWrapper<int>.StaticListField));
-            var exp = Expression.Lambda<Func<ListWrapper<int>>>(
+            Expression<Func<ListWrapper<int>>> exp = Expression.Lambda<Func<ListWrapper<int>>>(
                 Expression.MemberInit(
                     Expression.New(typeof(ListWrapper<int>)),
                     Expression.ListBind(

--- a/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
@@ -54,8 +54,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void NullBindings()
         {
-            var mem = typeof(PropertyAndFields).GetProperty(nameof(PropertyAndFields.StringProperty));
-            var meth = mem.GetGetMethod();
+            PropertyInfo mem = typeof(PropertyAndFields).GetProperty(nameof(PropertyAndFields.StringProperty));
+            MethodInfo meth = mem.GetGetMethod();
             Assert.Throws<ArgumentNullException>("bindings", () => Expression.MemberBind(mem, default(MemberBinding[])));
             Assert.Throws<ArgumentNullException>("bindings", () => Expression.MemberBind(mem, default(IEnumerable<MemberBinding>)));
             Assert.Throws<ArgumentNullException>("bindings", () => Expression.MemberBind(meth, default(MemberBinding[])));
@@ -65,8 +65,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void NullBindingInBindings()
         {
-            var mem = typeof(PropertyAndFields).GetProperty(nameof(PropertyAndFields.StringProperty));
-            var meth = mem.GetGetMethod();
+            PropertyInfo mem = typeof(PropertyAndFields).GetProperty(nameof(PropertyAndFields.StringProperty));
+            MethodInfo meth = mem.GetGetMethod();
             Assert.Throws<ArgumentNullException>("bindings", () => Expression.MemberBind(mem, default(MemberBinding)));
             Assert.Throws<ArgumentNullException>("bindings", () => Expression.MemberBind(mem, Enumerable.Repeat<MemberBinding>(null, 1)));
             Assert.Throws<ArgumentNullException>("bindings", () => Expression.MemberBind(meth, default(MemberBinding)));
@@ -87,18 +87,18 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void MemberBindingMustBeMemberOfType()
         {
-            var bind = Expression.MemberBind(
+            MemberMemberBinding bind = Expression.MemberBind(
                 typeof(Outer).GetProperty(nameof(Outer.InnerProperty)),
                 Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(3))
                 );
-            var newExp = Expression.New(typeof(PropertyAndFields));
+            NewExpression newExp = Expression.New(typeof(PropertyAndFields));
             Assert.Throws<ArgumentException>(() => Expression.MemberInit(newExp, bind));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public void InnerProperty(bool useInterpreter)
         {
-            var exp = Expression.Lambda<Func<Outer>>(
+            Expression<Func<Outer>> exp = Expression.Lambda<Func<Outer>>(
                 Expression.MemberInit(
                     Expression.New(typeof(Outer)),
                     Expression.MemberBind(
@@ -107,14 +107,14 @@ namespace System.Linq.Expressions.Tests
                         )
                     )
                 );
-            var func = exp.Compile(useInterpreter);
+            Func<Outer> func = exp.Compile(useInterpreter);
             Assert.Equal(3, func().InnerProperty.Value);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public void InnerField(bool useInterpreter)
         {
-            var exp = Expression.Lambda<Func<Outer>>(
+            Expression<Func<Outer>> exp = Expression.Lambda<Func<Outer>>(
                 Expression.MemberInit(
                     Expression.New(typeof(Outer)),
                     Expression.MemberBind(
@@ -123,14 +123,14 @@ namespace System.Linq.Expressions.Tests
                         )
                     )
                 );
-            var func = exp.Compile(useInterpreter);
+            Func<Outer> func = exp.Compile(useInterpreter);
             Assert.Equal(4, func().InnerField.Value);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public void StaticInnerProperty(bool useInterpreter)
         {
-            var exp = Expression.Lambda<Func<Outer>>(
+            Expression<Func<Outer>> exp = Expression.Lambda<Func<Outer>>(
                 Expression.MemberInit(
                     Expression.New(typeof(Outer)),
                     Expression.MemberBind(
@@ -145,7 +145,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void StaticInnerField(bool useInterpreter)
         {
-            var exp = Expression.Lambda<Func<Outer>>(
+            Expression<Func<Outer>> exp = Expression.Lambda<Func<Outer>>(
                 Expression.MemberInit(
                     Expression.New(typeof(Outer)),
                     Expression.MemberBind(
@@ -160,7 +160,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void ReadonlyInnerProperty(bool useInterpreter)
         {
-            var exp = Expression.Lambda<Func<Outer>>(
+            Expression<Func<Outer>> exp = Expression.Lambda<Func<Outer>>(
                 Expression.MemberInit(
                     Expression.New(typeof(Outer)),
                     Expression.MemberBind(
@@ -169,14 +169,14 @@ namespace System.Linq.Expressions.Tests
                         )
                     )
                 );
-            var func = exp.Compile(useInterpreter);
+            Func<Outer> func = exp.Compile(useInterpreter);
             Assert.Equal(7, func().ReadonlyInnerProperty.Value);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public void ReadonlyInnerField(bool useInterpreter)
         {
-            var exp = Expression.Lambda<Func<Outer>>(
+            Expression<Func<Outer>> exp = Expression.Lambda<Func<Outer>>(
                 Expression.MemberInit(
                     Expression.New(typeof(Outer)),
                     Expression.MemberBind(
@@ -185,14 +185,14 @@ namespace System.Linq.Expressions.Tests
                         )
                     )
                 );
-            var func = exp.Compile(useInterpreter);
+            Func<Outer> func = exp.Compile(useInterpreter);
             Assert.Equal(8, func().ReadonlyInnerField.Value);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public void StaticReadonlyInnerProperty(bool useInterpreter)
         {
-            var exp = Expression.Lambda<Func<Outer>>(
+            Expression<Func<Outer>> exp = Expression.Lambda<Func<Outer>>(
                 Expression.MemberInit(
                     Expression.New(typeof(Outer)),
                     Expression.MemberBind(
@@ -207,7 +207,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void StaticReadonlyInnerField(bool useInterpreter)
         {
-            var exp = Expression.Lambda<Func<Outer>>(
+            Expression<Func<Outer>> exp = Expression.Lambda<Func<Outer>>(
                 Expression.MemberInit(
                     Expression.New(typeof(Outer)),
                     Expression.MemberBind(
@@ -221,15 +221,15 @@ namespace System.Linq.Expressions.Tests
 
         public void WriteOnlyInnerProperty()
         {
-            var bind = Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(0));
-            var property = typeof(Outer).GetProperty(nameof(Outer.WriteonlyInnerProperty));
+            MemberAssignment bind = Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(0));
+            PropertyInfo property = typeof(Outer).GetProperty(nameof(Outer.WriteonlyInnerProperty));
             Assert.Throws<ArgumentException>(() => Expression.MemberBind(property, bind));
         }
 
         public void StaticWriteOnlyInnerProperty()
         {
-            var bind = Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(0));
-            var property = typeof(Outer).GetProperty(nameof(Outer.StaticWriteonlyInnerProperty));
+            MemberAssignment bind = Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(0));
+            PropertyInfo property = typeof(Outer).GetProperty(nameof(Outer.StaticWriteonlyInnerProperty));
             Assert.Throws<ArgumentException>(() => Expression.MemberBind(property, bind));
         }
     }

--- a/src/System.Linq.Expressions/tests/MemberInit/MemberInitTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/MemberInitTests.cs
@@ -20,24 +20,24 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e1 = Expression.MemberInit(Expression.New(typeof(Y)), Expression.Bind(typeof(Y).GetProperty(nameof(Y.Z)), Expression.Parameter(typeof(int), "z")));
+            MemberInitExpression e1 = Expression.MemberInit(Expression.New(typeof(Y)), Expression.Bind(typeof(Y).GetProperty(nameof(Y.Z)), Expression.Parameter(typeof(int), "z")));
             Assert.Equal("new Y() {Z = z}", e1.ToString());
 
-            var e2 = Expression.MemberInit(Expression.New(typeof(Y)), Expression.Bind(typeof(Y).GetProperty(nameof(Y.Z)), Expression.Parameter(typeof(int), "z")), Expression.Bind(typeof(Y).GetProperty(nameof(Y.A)), Expression.Parameter(typeof(int), "a")));
+            MemberInitExpression e2 = Expression.MemberInit(Expression.New(typeof(Y)), Expression.Bind(typeof(Y).GetProperty(nameof(Y.Z)), Expression.Parameter(typeof(int), "z")), Expression.Bind(typeof(Y).GetProperty(nameof(Y.A)), Expression.Parameter(typeof(int), "a")));
             Assert.Equal("new Y() {Z = z, A = a}", e2.ToString());
 
-            var e3 = Expression.MemberInit(Expression.New(typeof(X)), Expression.MemberBind(typeof(X).GetProperty(nameof(X.Y)), Expression.Bind(typeof(Y).GetProperty(nameof(Y.Z)), Expression.Parameter(typeof(int), "z"))));
+            MemberInitExpression e3 = Expression.MemberInit(Expression.New(typeof(X)), Expression.MemberBind(typeof(X).GetProperty(nameof(X.Y)), Expression.Bind(typeof(Y).GetProperty(nameof(Y.Z)), Expression.Parameter(typeof(int), "z"))));
             Assert.Equal("new X() {Y = {Z = z}}", e3.ToString());
 
-            var e4 = Expression.MemberInit(Expression.New(typeof(X)), Expression.MemberBind(typeof(X).GetProperty(nameof(X.Y)), Expression.Bind(typeof(Y).GetProperty(nameof(Y.Z)), Expression.Parameter(typeof(int), "z")), Expression.Bind(typeof(Y).GetProperty(nameof(Y.A)), Expression.Parameter(typeof(int), "a"))));
+            MemberInitExpression e4 = Expression.MemberInit(Expression.New(typeof(X)), Expression.MemberBind(typeof(X).GetProperty(nameof(X.Y)), Expression.Bind(typeof(Y).GetProperty(nameof(Y.Z)), Expression.Parameter(typeof(int), "z")), Expression.Bind(typeof(Y).GetProperty(nameof(Y.A)), Expression.Parameter(typeof(int), "a"))));
             Assert.Equal("new X() {Y = {Z = z, A = a}}", e4.ToString());
 
-            var add = typeof(List<int>).GetMethod(nameof(List<int>.Add));
+            Reflection.MethodInfo add = typeof(List<int>).GetMethod(nameof(List<int>.Add));
 
-            var e5 = Expression.MemberInit(Expression.New(typeof(X)), Expression.ListBind(typeof(X).GetProperty(nameof(X.XS)), Expression.ElementInit(add, Expression.Parameter(typeof(int), "a"))));
+            MemberInitExpression e5 = Expression.MemberInit(Expression.New(typeof(X)), Expression.ListBind(typeof(X).GetProperty(nameof(X.XS)), Expression.ElementInit(add, Expression.Parameter(typeof(int), "a"))));
             Assert.Equal("new X() {XS = {Void Add(Int32)(a)}}", e5.ToString());
 
-            var e6 = Expression.MemberInit(Expression.New(typeof(X)), Expression.ListBind(typeof(X).GetProperty(nameof(X.XS)), Expression.ElementInit(add, Expression.Parameter(typeof(int), "a")), Expression.ElementInit(add, Expression.Parameter(typeof(int), "b"))));
+            MemberInitExpression e6 = Expression.MemberInit(Expression.New(typeof(X)), Expression.ListBind(typeof(X).GetProperty(nameof(X.XS)), Expression.ElementInit(add, Expression.Parameter(typeof(int), "a")), Expression.ElementInit(add, Expression.Parameter(typeof(int), "b"))));
             Assert.Equal("new X() {XS = {Void Add(Int32)(a), Void Add(Int32)(b)}}", e6.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/New/NewTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewTests.cs
@@ -251,7 +251,7 @@ namespace System.Linq.Expressions.Tests
 
             public static Func<TestPrivateDefaultConstructor> GetInstanceFunc(bool useInterpreter)
             {
-                var lambda = Expression.Lambda<Func<TestPrivateDefaultConstructor>>(Expression.New(typeof(TestPrivateDefaultConstructor)), new ParameterExpression[] { });
+                Expression<Func<TestPrivateDefaultConstructor>> lambda = Expression.Lambda<Func<TestPrivateDefaultConstructor>>(Expression.New(typeof(TestPrivateDefaultConstructor)), new ParameterExpression[] { });
                 return lambda.Compile(useInterpreter);
             }
 
@@ -272,7 +272,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void StaticConstructor_ThrowsArgumentException()
         {
-            var cctor = typeof(StaticCtor).GetTypeInfo().DeclaredConstructors.Single(c => c.IsStatic);
+            ConstructorInfo cctor = typeof(StaticCtor).GetTypeInfo().DeclaredConstructors.Single(c => c.IsStatic);
 
             Assert.Throws<ArgumentException>("constructor", () => Expression.New(cctor));
             Assert.Throws<ArgumentException>("constructor", () => Expression.New(cctor, new Expression[0]));
@@ -286,8 +286,8 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void Compile_AbstractCtor_ThrowsInvalidOperationExeption(bool useInterpretation)
         {
-            var ctor = typeof(AbstractCtor).GetTypeInfo().DeclaredConstructors.Single();
-            var f = Expression.Lambda<Func<AbstractCtor>>(Expression.New(ctor));
+            ConstructorInfo ctor = typeof(AbstractCtor).GetTypeInfo().DeclaredConstructors.Single();
+            Expression<Func<AbstractCtor>> f = Expression.Lambda<Func<AbstractCtor>>(Expression.New(ctor));
 
             Assert.Throws<InvalidOperationException>(() => f.Compile(useInterpretation));
         }
@@ -447,16 +447,16 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e1 = Expression.New(typeof(Bar).GetConstructor(Type.EmptyTypes));
+            NewExpression e1 = Expression.New(typeof(Bar).GetConstructor(Type.EmptyTypes));
             Assert.Equal("new Bar()", e1.ToString());
 
-            var e2 = Expression.New(typeof(Bar).GetConstructor(new[] { typeof(int) }), Expression.Parameter(typeof(int), "foo"));
+            NewExpression e2 = Expression.New(typeof(Bar).GetConstructor(new[] { typeof(int) }), Expression.Parameter(typeof(int), "foo"));
             Assert.Equal("new Bar(foo)", e2.ToString());
 
-            var e3 = Expression.New(typeof(Bar).GetConstructor(new[] { typeof(int), typeof(int) }), Expression.Parameter(typeof(int), "foo"), Expression.Parameter(typeof(int), "qux"));
+            NewExpression e3 = Expression.New(typeof(Bar).GetConstructor(new[] { typeof(int), typeof(int) }), Expression.Parameter(typeof(int), "foo"), Expression.Parameter(typeof(int), "qux"));
             Assert.Equal("new Bar(foo, qux)", e3.ToString());
 
-            var e4 = Expression.New(typeof(Bar).GetConstructor(new[] { typeof(int), typeof(int) }), new[] { Expression.Parameter(typeof(int), "foo"), Expression.Parameter(typeof(int), "qux") }, new[] { typeof(Bar).GetProperty(nameof(Bar.Foo)), typeof(Bar).GetProperty(nameof(Bar.Qux)) });
+            NewExpression e4 = Expression.New(typeof(Bar).GetConstructor(new[] { typeof(int), typeof(int) }), new[] { Expression.Parameter(typeof(int), "foo"), Expression.Parameter(typeof(int), "qux") }, new[] { typeof(Bar).GetProperty(nameof(Bar.Foo)), typeof(Bar).GetProperty(nameof(Bar.Qux)) });
             Assert.Equal("new Bar(Foo = foo, Qux = qux)", e4.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/New/NewWithByRefParameterTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewWithByRefParameterTests.cs
@@ -41,9 +41,9 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void CreateByRef(bool useInterpreter)
         {
-            var pX = Expression.Parameter(typeof(int).MakeByRefType());
-            var pY = Expression.Parameter(typeof(int).MakeByRefType());
-            var del =
+            ParameterExpression pX = Expression.Parameter(typeof(int).MakeByRefType());
+            ParameterExpression pY = Expression.Parameter(typeof(int).MakeByRefType());
+            ByRefNewFactory2 del =
                 Expression.Lambda<ByRefNewFactory2>(
                     Expression.New(typeof(ByRefNewType).GetConstructors()[0], pX, pY), pX, pY).Compile(useInterpreter);
             int x = 3;
@@ -56,9 +56,9 @@ namespace System.Linq.Expressions.Tests
         [Theory, InlineData(false)]
         public void CreateByRefAliasing(bool useInterpreter)
         {
-            var pX = Expression.Parameter(typeof(int).MakeByRefType());
-            var pY = Expression.Parameter(typeof(int).MakeByRefType());
-            var del =
+            ParameterExpression pX = Expression.Parameter(typeof(int).MakeByRefType());
+            ParameterExpression pY = Expression.Parameter(typeof(int).MakeByRefType());
+            ByRefNewFactory2 del =
                 Expression.Lambda<ByRefNewFactory2>(
                     Expression.New(typeof(ByRefNewType).GetConstructors()[0], pX, pY), pX, pY).Compile(useInterpreter);
             int x = 3;
@@ -75,8 +75,8 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void CreateByRefReferencingReadonly(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(int).MakeByRefType());
-            var del =
+            ParameterExpression p = Expression.Parameter(typeof(int).MakeByRefType());
+            ByRefNewFactory1 del =
                 Expression.Lambda<ByRefNewFactory1>(
                     Expression.New(
                         typeof(ByRefNewType).GetConstructors()[0],
@@ -90,7 +90,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void CreateByRefReferencingOnlyReadonly(bool useInterpreter)
         {
-            var del =
+            Func<ByRefNewType> del =
                 Expression.Lambda<Func<ByRefNewType>>(
                     Expression.New(
                         typeof(ByRefNewType).GetConstructors()[0],
@@ -103,9 +103,9 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void CreateByRefThrowing(bool useInterpreter)
         {
-            var pX = Expression.Parameter(typeof(int).MakeByRefType());
-            var pY = Expression.Parameter(typeof(int).MakeByRefType());
-            var del =
+            ParameterExpression pX = Expression.Parameter(typeof(int).MakeByRefType());
+            ParameterExpression pY = Expression.Parameter(typeof(int).MakeByRefType());
+            ByRefNewFactory2 del =
                 Expression.Lambda<ByRefNewFactory2>(
                     Expression.New(typeof(ByRefNewType).GetConstructors()[0], pX, pY), pX, pY).Compile(useInterpreter);
             int x = -9;
@@ -116,8 +116,8 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void CreateOut(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(int).MakeByRefType());
-            var del =
+            ParameterExpression p = Expression.Parameter(typeof(int).MakeByRefType());
+            OutNewTypeFactory del =
                 Expression.Lambda<OutNewTypeFactory>(Expression.New(typeof(OutNewType).GetConstructors()[0], p), p)
                     .Compile(useInterpreter);
             int x;

--- a/src/System.Linq.Expressions/tests/New/TypeExtensions.cs
+++ b/src/System.Linq.Expressions/tests/New/TypeExtensions.cs
@@ -92,7 +92,7 @@ namespace System.Linq.Expressions.Tests
             {
                 return false;
             }
-            var ps = mi.GetParameters();
+            ParameterInfo[] ps = mi.GetParameters();
 
             if (ps.Length != argTypes.Length)
             {

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -17,10 +17,10 @@ namespace System.Linq.Expressions.Tests
         {
             int? i = 10;
             double? j = 23.89;
-            var left = Expression.Constant(i, typeof(Nullable<int>));
-            var right = Expression.Constant(j, typeof(Nullable<double>));
+            ConstantExpression left = Expression.Constant(i, typeof(Nullable<int>));
+            ConstantExpression right = Expression.Constant(j, typeof(Nullable<double>));
             Expression<Func<int, double?>> conversion = (int k) => (double?)i;
-            var v = Expression.MakeBinary(ExpressionType.Coalesce, left, right, false, null, conversion);
+            BinaryExpression v = Expression.MakeBinary(ExpressionType.Coalesce, left, right, false, null, conversion);
             Assert.NotNull(v);
         }
 
@@ -556,7 +556,7 @@ namespace System.Linq.Expressions.Tests
             CheckMethod("Min", Expression.Call(typeof(Queryable), "Min", taCust, query));
             CheckMethod("Min", Expression.Call(typeof(Queryable), "Min", taCustString, query, selName));
             CheckMethod("OfType", Expression.Call(typeof(Queryable), "OfType", new Type[] { typeof(object) }, query));
-            var ordered = Expression.Call(typeof(Queryable), "OrderBy", taCustString, query, selName);
+            MethodCallExpression ordered = Expression.Call(typeof(Queryable), "OrderBy", taCustString, query, selName);
             CheckMethod("OrderBy", ordered);
             ordered = Expression.Call(typeof(Queryable), "OrderByDescending", taCustString, query, selName);
             CheckMethod("OrderByDescending", ordered);
@@ -594,8 +594,8 @@ namespace System.Linq.Expressions.Tests
 
         private static void ConstructAggregates<T>(T value)
         {
-            var values = Expression.Constant(new T[] { }.AsQueryable());
-            var custs = Expression.Constant(new NWindProxy.Customer[] { }.AsQueryable());
+            ConstantExpression values = Expression.Constant(new T[] { }.AsQueryable());
+            ConstantExpression custs = Expression.Constant(new NWindProxy.Customer[] { }.AsQueryable());
             Expression<Func<NWindProxy.Customer, T>> cvalue = c => value;
             Type[] taCust = new Type[] { typeof(NWindProxy.Customer) };
             CheckMethod("Sum", Expression.Call(typeof(Queryable), "Sum", null, values));
@@ -678,9 +678,9 @@ namespace System.Linq.Expressions.Tests
         public static void ObjectCallOnValueType(bool useInterpreter)
         {
             object st_local = new TC1();
-            var mi = typeof(object).GetMethod("ToString");
-            var lam = Expression.Lambda<Func<string>>(Expression.Call(Expression.Constant(st_local), mi, null), null);
-            var f = lam.Compile(useInterpreter);
+            MethodInfo mi = typeof(object).GetMethod("ToString");
+            Expression<Func<string>> lam = Expression.Lambda<Func<string>>(Expression.Call(Expression.Constant(st_local), mi, null), null);
+            Func<string> f = lam.Compile(useInterpreter);
         }
 
         [Theory]
@@ -717,7 +717,7 @@ namespace System.Linq.Expressions.Tests
             Assert.NotNull(f2());
             Assert.Equal(f2().Value.Name, "lhs");
 
-            var constant = Expression.Constant(1.0, typeof(double));
+            ConstantExpression constant = Expression.Constant(1.0, typeof(double));
             Assert.Throws<ArgumentException>(null, () => Expression.Lambda<Func<double?>>(constant, null));
         }
 
@@ -802,17 +802,17 @@ namespace System.Linq.Expressions.Tests
         public static void Writeback(bool useInterpreter)
         {
             CustomerWriteBack a = new CustomerWriteBack();
-            var t = typeof(CustomerWriteBack);
-            var mi = t.GetMethod("Func0");
-            var pi = t.GetMethod("get_X");
-            var piCust = t.GetMethod("get_Cust");
-            var miCust = t.GetMethod("ComputeCust");
+            Type t = typeof(CustomerWriteBack);
+            MethodInfo mi = t.GetMethod("Func0");
+            MethodInfo pi = t.GetMethod("get_X");
+            MethodInfo piCust = t.GetMethod("get_Cust");
+            MethodInfo miCust = t.GetMethod("ComputeCust");
 
             Expression<Func<int>> e1 =
                     Expression.Lambda<Func<int>>(
                         Expression.Call(typeof(CustomerWriteBack).GetMethod("Funct1"), new[] { Expression.Property(null, typeof(CustomerWriteBack).GetProperty("Prop")) }),
                         null);
-            var f1 = e1.Compile(useInterpreter);
+            Func<int> f1 = e1.Compile(useInterpreter);
             int result = f1();
             Assert.Equal(5, result);
 
@@ -823,8 +823,8 @@ namespace System.Linq.Expressions.Tests
                      new Expression[] { Expression.Property(Expression.Constant(a, typeof(CustomerWriteBack)), pi) }
                      ),
                  null);
-            var f = e.Compile(useInterpreter);
-            var r = f();
+            Func<string> f = e.Compile(useInterpreter);
+            string r = f();
             Assert.Equal(a.m_x, "Changed");
 
             Expression<Func<Customer>> e2 = Expression.Lambda<Func<Customer>>(
@@ -834,8 +834,8 @@ namespace System.Linq.Expressions.Tests
                      new Expression[] { Expression.Property(Expression.Constant(a, typeof(CustomerWriteBack)), piCust) }
                      ),
                  null);
-            var f2 = e2.Compile(useInterpreter);
-            var r2 = f2();
+            Func<Customer> f2 = e2.Compile(useInterpreter);
+            Customer r2 = f2();
             Assert.True(a.Cust.zip == 90008 && a.Cust.name == "SreeCho");
         }
 
@@ -869,7 +869,7 @@ namespace System.Linq.Expressions.Tests
 
             Expression<Func<Complex, Complex>> testExpr = (x) => +x;
             Assert.Equal(testExpr.ToString(), "x => +x");
-            var v = testExpr.Compile(useInterpreter);
+            Func<Complex, Complex> v = testExpr.Compile(useInterpreter);
         }
 
         private struct S
@@ -887,8 +887,8 @@ namespace System.Linq.Expressions.Tests
 
             Expression<Func<int?, int?, bool?>> e = Expression.Lambda<Func<int?, int?, bool?>>(
                 Expression.GreaterThan(p1, p2, true, null), new ParameterExpression[] { p1, p2 });
-            var f = e.Compile(useInterpreter);
-            var r = f(x, y);
+            Func<int?, int?, bool?> f = e.Compile(useInterpreter);
+            bool? r = f(x, y);
             Assert.True(r.Value);
 
             Expression<Func<int?, int?, bool?>> e1 = Expression.Lambda<Func<int?, int?, bool?>>(
@@ -929,7 +929,7 @@ namespace System.Linq.Expressions.Tests
                     true,
                     null),
                 null);
-            var f6 = e6.Compile(useInterpreter);
+            Func<bool?> f6 = e6.Compile(useInterpreter);
             Assert.Null(f6());
         }
 
@@ -970,7 +970,7 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void NewExpressionwithMemberAssignInit(bool useInterpreter)
         {
-            var s = "Bad Mojo";
+            string s = "Bad Mojo";
             int val = 10;
 
             ConstructorInfo constructor = typeof(TestClass).GetConstructor(new Type[] { typeof(string), typeof(int) });
@@ -1500,7 +1500,7 @@ namespace System.Linq.Expressions.Tests
         public static void ShiftWithMismatchedNulls(bool useInterpreter)
         {
             Expression<Func<byte?, int, int?>> e = (byte? b, int i) => (byte?)(b << i);
-            var f = e.Compile(useInterpreter);
+            Func<byte?, int, int?> f = e.Compile(useInterpreter);
             Assert.Equal(20, f(5, 2));
         }
 
@@ -1538,8 +1538,8 @@ namespace System.Linq.Expressions.Tests
         public static void MixedTypeNullableOps(bool useInterpreter)
         {
             Expression<Func<decimal, int?, decimal?>> e = (d, i) => d + i;
-            var f = e.Compile(useInterpreter);
-            var result = f(1.0m, 4);
+            Func<decimal, int?, decimal?> f = e.Compile(useInterpreter);
+            decimal? result = f(1.0m, 4);
             Debug.WriteLine(result);
         }
 
@@ -1548,7 +1548,7 @@ namespace System.Linq.Expressions.Tests
         public static void NullGuidConstant(bool useInterpreter)
         {
             Expression<Func<Guid?, bool>> f2 = g2 => g2 != null;
-            var d2 = f2.Compile(useInterpreter);
+            Func<Guid?, bool> d2 = f2.Compile(useInterpreter);
             Assert.True(d2(Guid.NewGuid()));
             Assert.False(d2(null));
         }
@@ -1563,7 +1563,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Constant(1, typeof(int?))
                     ));
 
-            var result = f.Compile(useInterpreter)();
+            int? result = f.Compile(useInterpreter)();
             Assert.False(result.HasValue);
         }
 
@@ -1737,7 +1737,7 @@ namespace System.Linq.Expressions.Tests
         public static void CallCompiledLambda(bool useInterpreter)
         {
             Expression<Func<int, int>> f = x => x + 1;
-            var compiled = f.Compile(useInterpreter);
+            Func<int, int> compiled = f.Compile(useInterpreter);
             Expression<Func<int>> lambda = () => compiled(5);
             Func<int> d = lambda.Compile(useInterpreter);
             Assert.Equal(6, d());
@@ -1748,7 +1748,7 @@ namespace System.Linq.Expressions.Tests
         public static void CallCompiledLambdaWithTypeMissing(bool useInterpreter)
         {
             Expression<Func<object, bool>> f = x => x == Type.Missing;
-            var compiled = f.Compile(useInterpreter);
+            Func<object, bool> compiled = f.Compile(useInterpreter);
             Expression<Func<object, bool>> lambda = x => compiled(x);
             Func<object, bool> d = lambda.Compile(useInterpreter);
             Assert.Equal(true, d(Type.Missing));
@@ -1829,7 +1829,7 @@ namespace System.Linq.Expressions.Tests
         public static void StaticMethodCall(bool useInterpreter)
         {
             Expression<Func<int, int, int>> f = (a, b) => Math.Max(a, b);
-            var d = f.Compile(useInterpreter);
+            Func<int, int, int> d = f.Compile(useInterpreter);
             Assert.Equal(4, d(3, 4));
         }
 
@@ -1839,7 +1839,7 @@ namespace System.Linq.Expressions.Tests
         {
             Foo foo = new Foo();
             Expression<Func<int, int>> f = (a) => foo.Zip(a);
-            var d = f.Compile(useInterpreter);
+            Func<int, int> d = f.Compile(useInterpreter);
             Assert.Equal(225, d(15));
         }
 
@@ -1849,7 +1849,7 @@ namespace System.Linq.Expressions.Tests
         {
             Foo bar = new Bar();
             Expression<Func<Foo, string>> f = foo => foo.Virt();
-            var d = f.Compile(useInterpreter);
+            Func<Foo, string> d = f.Compile(useInterpreter);
             Assert.Equal("Bar", d(bar));
         }
 
@@ -1858,7 +1858,7 @@ namespace System.Linq.Expressions.Tests
         public static void NestedLambda(bool useInterpreter)
         {
             Expression<Func<int, int>> f = (a) => M1(a, (b) => b * b);
-            var d = f.Compile(useInterpreter);
+            Func<int, int> d = f.Compile(useInterpreter);
             Assert.Equal(100, d(10));
         }
 
@@ -1867,7 +1867,7 @@ namespace System.Linq.Expressions.Tests
         public static void NestedLambdaWithOuterArg(bool useInterpreter)
         {
             Expression<Func<int, int>> f = (a) => M1(a + a, (b) => b * a);
-            var d = f.Compile(useInterpreter);
+            Func<int, int> d = f.Compile(useInterpreter);
             Assert.Equal(200, d(10));
         }
 
@@ -1876,7 +1876,7 @@ namespace System.Linq.Expressions.Tests
         public static void NestedExpressionLambda(bool useInterpreter)
         {
             Expression<Func<int, int>> f = (a) => M2(a, (b) => b * b);
-            var d = f.Compile(useInterpreter);
+            Func<int, int> d = f.Compile(useInterpreter);
             Assert.Equal(10, d(10));
         }
 
@@ -1885,7 +1885,7 @@ namespace System.Linq.Expressions.Tests
         public static void NestedExpressionLambdaWithOuterArg(bool useInterpreter)
         {
             Expression<Func<int, int>> f = (a) => M2(a, (b) => b * a);
-            var d = f.Compile(useInterpreter);
+            Func<int, int> d = f.Compile(useInterpreter);
             Assert.Equal(99, d(99));
         }
 
@@ -1894,7 +1894,7 @@ namespace System.Linq.Expressions.Tests
         public static void ArrayInitializedWithLiterals(bool useInterpreter)
         {
             Expression<Func<int[]>> f = () => new int[] { 1, 2, 3, 4, 5 };
-            var d = f.Compile(useInterpreter);
+            Func<int[]> d = f.Compile(useInterpreter);
             int[] v = d();
             Assert.Equal(5, v.Length);
         }
@@ -1905,7 +1905,7 @@ namespace System.Linq.Expressions.Tests
         {
             Foo foo = new Foo();
             Expression<Func<Foo[]>> f = () => new Foo[] { foo };
-            var d = f.Compile(useInterpreter);
+            Func<Foo[]> d = f.Compile(useInterpreter);
             Foo[] v = d();
             Assert.Equal(1, v.Length);
             Assert.Equal(foo, v[0]);
@@ -1916,7 +1916,7 @@ namespace System.Linq.Expressions.Tests
         public static void NullableAddition(bool useInterpreter)
         {
             Expression<Func<double?, double?>> f = (v) => v + v;
-            var d = f.Compile(useInterpreter);
+            Func<double?, double?> d = f.Compile(useInterpreter);
             Assert.Equal(20.0, d(10.0));
         }
 
@@ -1925,7 +1925,7 @@ namespace System.Linq.Expressions.Tests
         public static void NullableComparedToLiteral(bool useInterpreter)
         {
             Expression<Func<int?, bool>> f = (v) => v > 10;
-            var d = f.Compile(useInterpreter);
+            Func<int?, bool> d = f.Compile(useInterpreter);
             Assert.True(d(12));
             Assert.False(d(5));
             Assert.True(d(int.MaxValue));
@@ -1938,7 +1938,7 @@ namespace System.Linq.Expressions.Tests
         public static void NullableModuloLiteral(bool useInterpreter)
         {
             Expression<Func<double?, double?>> f = (v) => v % 10;
-            var d = f.Compile(useInterpreter);
+            Func<double?, double?> d = f.Compile(useInterpreter);
             Assert.Equal(5.0, d(15.0));
         }
 
@@ -1947,7 +1947,7 @@ namespace System.Linq.Expressions.Tests
         public static void ArrayIndexer(bool useInterpreter)
         {
             Expression<Func<int[], int, int>> f = (v, i) => v[i];
-            var d = f.Compile(useInterpreter);
+            Func<int[], int, int> d = f.Compile(useInterpreter);
             int[] ints = new[] { 1, 2, 3 };
             Assert.Equal(3, d(ints, 2));
         }
@@ -1957,7 +1957,7 @@ namespace System.Linq.Expressions.Tests
         public static void ConvertToNullableDouble(bool useInterpreter)
         {
             Expression<Func<int?, double?>> f = (v) => (double?)v;
-            var d = f.Compile(useInterpreter);
+            Func<int?, double?> d = f.Compile(useInterpreter);
             Assert.Equal(10.0, d(10));
         }
 
@@ -1966,7 +1966,7 @@ namespace System.Linq.Expressions.Tests
         public static void UnboxToInt(bool useInterpreter)
         {
             Expression<Func<object, int>> f = (a) => (int)a;
-            var d = f.Compile(useInterpreter);
+            Func<object, int> d = f.Compile(useInterpreter);
             Assert.Equal(5, d(5));
         }
 
@@ -1975,7 +1975,7 @@ namespace System.Linq.Expressions.Tests
         public static void TypeIs(bool useInterpreter)
         {
             Expression<Func<Foo, bool>> f = x => x is Foo;
-            var d = f.Compile(useInterpreter);
+            Func<Foo, bool> d = f.Compile(useInterpreter);
             Assert.True(d(new Foo()));
         }
 
@@ -1984,7 +1984,7 @@ namespace System.Linq.Expressions.Tests
         public static void TypeAs(bool useInterpreter)
         {
             Expression<Func<Foo, Bar>> f = x => x as Bar;
-            var d = f.Compile(useInterpreter);
+            Func<Foo, Bar> d = f.Compile(useInterpreter);
             Assert.Null(d(new Foo()));
             Assert.NotNull(d(new Bar()));
         }
@@ -1994,7 +1994,7 @@ namespace System.Linq.Expressions.Tests
         public static void Coalesce(bool useInterpreter)
         {
             Expression<Func<int?, int>> f = x => x ?? 5;
-            var d = f.Compile(useInterpreter);
+            Func<int?, int> d = f.Compile(useInterpreter);
             Assert.Equal(5, d(null));
             Assert.Equal(2, d(2));
         }
@@ -2004,7 +2004,7 @@ namespace System.Linq.Expressions.Tests
         public static void CoalesceRefTypes(bool useInterpreter)
         {
             Expression<Func<string, string>> f = x => x ?? "nil";
-            var d = f.Compile(useInterpreter);
+            Func<string, string> d = f.Compile(useInterpreter);
             Assert.Equal("nil", d(null));
             Assert.Equal("Not Nil", d("Not Nil"));
         }
@@ -2014,7 +2014,7 @@ namespace System.Linq.Expressions.Tests
         public static void MultiDimensionalArrayAccess(bool useInterpreter)
         {
             Expression<Func<int, int, int[,], int>> f = (x, y, a) => a[x, y];
-            var d = f.Compile(useInterpreter);
+            Func<int, int, int[,], int> d = f.Compile(useInterpreter);
             int[,] array = new int[2, 2] { { 0, 1 }, { 2, 3 } };
             Assert.Equal(3, d(1, 1, array));
         }
@@ -2024,7 +2024,7 @@ namespace System.Linq.Expressions.Tests
         public static void NewClassWithMemberIntializer(bool useInterpreter)
         {
             Expression<Func<int, ClassX>> f = v => new ClassX { A = v };
-            var d = f.Compile(useInterpreter);
+            Func<int, ClassX> d = f.Compile(useInterpreter);
             Assert.Equal(5, d(5).A);
         }
 
@@ -2033,7 +2033,7 @@ namespace System.Linq.Expressions.Tests
         public static void NewStructWithArgs(bool useInterpreter)
         {
             Expression<Func<int, StructZ>> f = v => new StructZ(v);
-            var d = f.Compile(useInterpreter);
+            Func<int, StructZ> d = f.Compile(useInterpreter);
             Assert.Equal(5, d(5).A);
         }
 
@@ -2042,7 +2042,7 @@ namespace System.Linq.Expressions.Tests
         public static void NewStructWithArgsAndMemberInitializer(bool useInterpreter)
         {
             Expression<Func<int, StructZ>> f = v => new StructZ(v) { A = v + 1 };
-            var d = f.Compile(useInterpreter);
+            Func<int, StructZ> d = f.Compile(useInterpreter);
             Assert.Equal(6, d(5).A);
         }
 
@@ -2051,7 +2051,7 @@ namespace System.Linq.Expressions.Tests
         public static void NewClassWithMemberIntializers(bool useInterpreter)
         {
             Expression<Func<int, ClassX>> f = v => new ClassX { A = v, B = v };
-            var d = f.Compile(useInterpreter);
+            Func<int, ClassX> d = f.Compile(useInterpreter);
             Assert.Equal(5, d(5).A);
             Assert.Equal(7, d(7).B);
         }
@@ -2061,7 +2061,7 @@ namespace System.Linq.Expressions.Tests
         public static void NewStructWithMemberIntializer(bool useInterpreter)
         {
             Expression<Func<int, StructX>> f = v => new StructX { A = v };
-            var d = f.Compile(useInterpreter);
+            Func<int, StructX> d = f.Compile(useInterpreter);
             Assert.Equal(5, d(5).A);
         }
 
@@ -2070,7 +2070,7 @@ namespace System.Linq.Expressions.Tests
         public static void NewStructWithMemberIntializers(bool useInterpreter)
         {
             Expression<Func<int, StructX>> f = v => new StructX { A = v, B = v };
-            var d = f.Compile(useInterpreter);
+            Func<int, StructX> d = f.Compile(useInterpreter);
             Assert.Equal(5, d(5).A);
             Assert.Equal(7, d(7).B);
         }
@@ -2080,7 +2080,7 @@ namespace System.Linq.Expressions.Tests
         public static void ListInitializer(bool useInterpreter)
         {
             Expression<Func<int, List<ClassY>>> f = x => new List<ClassY> { new ClassY { B = x } };
-            var d = f.Compile(useInterpreter);
+            Func<int, List<ClassY>> d = f.Compile(useInterpreter);
             List<ClassY> list = d(5);
             Assert.Equal(1, list.Count);
             Assert.Equal(5, list[0].B);
@@ -2091,7 +2091,7 @@ namespace System.Linq.Expressions.Tests
         public static void ListInitializerLong(bool useInterpreter)
         {
             Expression<Func<int, List<ClassY>>> f = x => new List<ClassY> { new ClassY { B = x }, new ClassY { B = x + 1 }, new ClassY { B = x + 2 } };
-            var d = f.Compile(useInterpreter);
+            Func<int, List<ClassY>> d = f.Compile(useInterpreter);
             List<ClassY> list = d(5);
             Assert.Equal(3, list.Count);
             Assert.Equal(5, list[0].B);
@@ -2104,7 +2104,7 @@ namespace System.Linq.Expressions.Tests
         public static void ListInitializerInferred(bool useInterpreter)
         {
             Expression<Func<int, List<ClassY>>> f = x => new List<ClassY> { new ClassY { B = x }, new ClassY { B = x + 1 }, new ClassY { B = x + 2 } };
-            var d = f.Compile(useInterpreter);
+            Func<int, List<ClassY>> d = f.Compile(useInterpreter);
             List<ClassY> list = d(5);
             Assert.Equal(3, list.Count);
             Assert.Equal(5, list[0].B);
@@ -2118,7 +2118,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression<Func<int, ClassX>> f =
                 v => new ClassX { A = v, B = v + 1, Ys = { new ClassY { B = v + 2 } } };
-            var d = f.Compile(useInterpreter);
+            Func<int, ClassX> d = f.Compile(useInterpreter);
             ClassX x = d(5);
             Assert.Equal(5, x.A);
             Assert.Equal(6, x.B);
@@ -2132,7 +2132,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression<Func<int, ClassX>> f =
                 v => new ClassX { A = v, B = v + 1, SYs = { new StructY { B = v + 2 } } };
-            var d = f.Compile(useInterpreter);
+            Func<int, ClassX> d = f.Compile(useInterpreter);
             ClassX x = d(5);
             Assert.Equal(5, x.A);
             Assert.Equal(6, x.B);
@@ -2146,7 +2146,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression<Func<int, ClassX>> f =
                 v => new ClassX { A = v, B = v + 1, Y = { B = v + 2 } };
-            var d = f.Compile(useInterpreter);
+            Func<int, ClassX> d = f.Compile(useInterpreter);
             ClassX x = d(5);
             Assert.Equal(5, x.A);
             Assert.Equal(6, x.B);
@@ -2159,7 +2159,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression<Func<int, StructX>> f =
                 v => new StructX { A = v, B = v + 1, Ys = { new ClassY { B = v + 2 } } };
-            var d = f.Compile(useInterpreter);
+            Func<int, StructX> d = f.Compile(useInterpreter);
             StructX x = d(5);
             Assert.Equal(5, x.A);
             Assert.Equal(6, x.B);
@@ -2173,7 +2173,7 @@ namespace System.Linq.Expressions.Tests
         {
             Expression<Func<int, StructX>> f =
                 v => new StructX { A = v, B = v + 1, SY = new StructY { B = v + 2 } };
-            var d = f.Compile(useInterpreter);
+            Func<int, StructX> d = f.Compile(useInterpreter);
             StructX x = d(5);
             Assert.Equal(5, x.A);
             Assert.Equal(6, x.B);
@@ -2200,7 +2200,7 @@ namespace System.Linq.Expressions.Tests
         {
             // Generate the expression:
             //   v => new T { A = v, B = v + 1, SYP = { B = v + 2 } };
-            var parameterV = Expression.Parameter(typeof(int), "v");
+            ParameterExpression parameterV = Expression.Parameter(typeof(int), "v");
             return
                 Expression.Lambda<Func<int, T>>(
                     // new T { A = v, B= v + 1, SYP = { B = v + 2 } }
@@ -2243,11 +2243,11 @@ namespace System.Linq.Expressions.Tests
         {
             int[] values = new[] { 1, 2, 3, 4, 5 };
 
-            var q = from v in values.AsQueryable()
+            IQueryable<int> q = from v in values.AsQueryable()
                     where v == 100 && BadJuju(v) == 10
                     select v;
 
-            var list = q.ToList();
+            List<int> list = q.ToList();
             Assert.Equal(0, list.Count);
         }
 
@@ -2256,11 +2256,11 @@ namespace System.Linq.Expressions.Tests
         {
             int[] values = new[] { 1, 2, 3, 4, 5 };
 
-            var q = from v in values.AsQueryable()
+            IQueryable<int> q = from v in values.AsQueryable()
                     where v != 100 || BadJuju(v) == 10
                     select v;
 
-            var list = q.ToList();
+            List<int> list = q.ToList();
             Assert.Equal(values.Length, list.Count);
         }
 
@@ -2431,9 +2431,9 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void UninitializedEnumOut(bool useInterpreter)
         {
-            var x = Expression.Variable(typeof(MyEnum), "x");
+            ParameterExpression x = Expression.Variable(typeof(MyEnum), "x");
 
-            var expression = Expression.Lambda<Action>(
+            Expression<Action> expression = Expression.Lambda<Action>(
                             Expression.Block(
                             new[] { x },
                             Expression.Call(null, typeof(EnumOutLambdaClass).GetMethod("Bar"), x)));

--- a/src/System.Linq.Expressions/tests/StackSpillerTests.cs
+++ b/src/System.Linq.Expressions/tests/StackSpillerTests.cs
@@ -20,11 +20,11 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_Binary_IndexAssign()
         {
-            var item = typeof(Dictionary<int, int>).GetProperty("Item");
+            Reflection.PropertyInfo item = typeof(Dictionary<int, int>).GetProperty("Item");
 
             Test((d, i, v) =>
             {
-                var index = Expression.Property(d, item, i);
+                IndexExpression index = Expression.Property(d, item, i);
 
                 return
                     Expression.Block(
@@ -37,11 +37,11 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_Binary_MemberAssign()
         {
-            var baz = typeof(Bar).GetProperty(nameof(Bar.Baz));
+            Reflection.PropertyInfo baz = typeof(Bar).GetProperty(nameof(Bar.Baz));
 
             Test((l, r) =>
             {
-                var prop = Expression.Property(l, baz);
+                MemberExpression prop = Expression.Property(l, baz);
 
                 return
                     Expression.Block(
@@ -71,7 +71,7 @@ namespace System.Linq.Expressions.Tests
         {
             Test((a, b) =>
             {
-                var @break = Expression.Label(typeof(int));
+                LabelTarget @break = Expression.Label(typeof(int));
                 return Expression.Add(a, Expression.Loop(Expression.Break(@break, b), @break));
             }, Expression.Constant(1), Expression.Constant(2));
         }
@@ -108,7 +108,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_Index()
         {
-            var item = typeof(Dictionary<int, int>).GetProperty("Item");
+            Reflection.PropertyInfo item = typeof(Dictionary<int, int>).GetProperty("Item");
 
             Test((d, i) => Expression.MakeIndex(d, item, new[] { i }), Expression.Constant(new Dictionary<int, int> { { 1, 2 } }), Expression.Constant(1));
         }
@@ -116,7 +116,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_Call_Static()
         {
-            var max = typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(int), typeof(int) });
+            Reflection.MethodInfo max = typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(int), typeof(int) });
 
             Test((x, y) => Expression.Call(max, x, y), Expression.Constant(1), Expression.Constant(2));
         }
@@ -124,7 +124,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_Call_Instance()
         {
-            var substring = typeof(string).GetMethod(nameof(string.Substring), new[] { typeof(int), typeof(int) });
+            Reflection.MethodInfo substring = typeof(string).GetMethod(nameof(string.Substring), new[] { typeof(int), typeof(int) });
 
             Test((s, i, j) => Expression.Call(s, substring, i, j), Expression.Constant("foobar"), Expression.Constant(1), Expression.Constant(2));
         }
@@ -138,8 +138,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_Invocation_Inline()
         {
-            var x = Expression.Parameter(typeof(int));
-            var y = Expression.Parameter(typeof(int));
+            ParameterExpression x = Expression.Parameter(typeof(int));
+            ParameterExpression y = Expression.Parameter(typeof(int));
 
             Test((a, b) => Expression.Invoke(Expression.Lambda(Expression.Subtract(x, y), x, y), a, b), Expression.Constant(1), Expression.Constant(2));
         }
@@ -147,7 +147,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_New()
         {
-            var ctor = typeof(TimeSpan).GetConstructor(new[] { typeof(int), typeof(int), typeof(int) });
+            Reflection.ConstructorInfo ctor = typeof(TimeSpan).GetConstructor(new[] { typeof(int), typeof(int), typeof(int) });
 
             Test((h, m, s) => Expression.New(ctor, h, m, s), Expression.Constant(1), Expression.Constant(2), Expression.Constant(3));
         }
@@ -157,7 +157,7 @@ namespace System.Linq.Expressions.Tests
         {
             Test((a, b, c) =>
             {
-                var p = Expression.Parameter(typeof(int[]));
+                ParameterExpression p = Expression.Parameter(typeof(int[]));
 
                 return
                     Expression.Block(
@@ -180,11 +180,11 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_NewArrayBounds()
         {
-            var getUpperBound = typeof(Array).GetMethod(nameof(Array.GetUpperBound));
+            Reflection.MethodInfo getUpperBound = typeof(Array).GetMethod(nameof(Array.GetUpperBound));
 
             Test((a, b, c) =>
             {
-                var p = Expression.Parameter(typeof(int[,,]));
+                ParameterExpression p = Expression.Parameter(typeof(int[,,]));
 
                 return
                     Expression.Block(
@@ -207,11 +207,11 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_ListInit()
         {
-            var item = typeof(List<int>).GetProperty("Item");
+            Reflection.PropertyInfo item = typeof(List<int>).GetProperty("Item");
 
             Test((a, b, c) =>
             {
-                var p = Expression.Parameter(typeof(List<int>));
+                ParameterExpression p = Expression.Parameter(typeof(List<int>));
 
                 return
                     Expression.Block(
@@ -234,13 +234,13 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_MemberInit_Bind()
         {
-            var baz = typeof(Bar).GetProperty(nameof(Bar.Baz));
-            var foo = typeof(Bar).GetProperty(nameof(Bar.Foo));
-            var qux = typeof(Bar).GetProperty(nameof(Bar.Qux));
+            Reflection.PropertyInfo baz = typeof(Bar).GetProperty(nameof(Bar.Baz));
+            Reflection.PropertyInfo foo = typeof(Bar).GetProperty(nameof(Bar.Foo));
+            Reflection.PropertyInfo qux = typeof(Bar).GetProperty(nameof(Bar.Qux));
 
             Test((a, b, c) =>
             {
-                var p = Expression.Parameter(typeof(Bar));
+                ParameterExpression p = Expression.Parameter(typeof(Bar));
 
                 return
                     Expression.Block(
@@ -268,14 +268,14 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_MemberInit_MemberBind()
         {
-            var bar = typeof(BarHolder).GetProperty(nameof(BarHolder.Bar));
-            var baz = typeof(Bar).GetProperty(nameof(Bar.Baz));
-            var foo = typeof(Bar).GetProperty(nameof(Bar.Foo));
-            var qux = typeof(Bar).GetProperty(nameof(Bar.Qux));
+            Reflection.PropertyInfo bar = typeof(BarHolder).GetProperty(nameof(BarHolder.Bar));
+            Reflection.PropertyInfo baz = typeof(Bar).GetProperty(nameof(Bar.Baz));
+            Reflection.PropertyInfo foo = typeof(Bar).GetProperty(nameof(Bar.Foo));
+            Reflection.PropertyInfo qux = typeof(Bar).GetProperty(nameof(Bar.Qux));
 
             Test((a, b, c) =>
             {
-                var p = Expression.Parameter(typeof(BarHolder));
+                ParameterExpression p = Expression.Parameter(typeof(BarHolder));
 
                 return
                     Expression.Block(
@@ -306,13 +306,13 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_MemberInit_ListBind()
         {
-            var xs = typeof(ListHolder).GetProperty(nameof(ListHolder.Xs));
-            var add = typeof(List<int>).GetMethod(nameof(List<int>.Add));
-            var item = typeof(List<int>).GetProperty("Item");
+            Reflection.PropertyInfo xs = typeof(ListHolder).GetProperty(nameof(ListHolder.Xs));
+            Reflection.MethodInfo add = typeof(List<int>).GetMethod(nameof(List<int>.Add));
+            Reflection.PropertyInfo item = typeof(List<int>).GetProperty("Item");
 
             Test((a, b, c) =>
             {
-                var p = Expression.Parameter(typeof(ListHolder));
+                ParameterExpression p = Expression.Parameter(typeof(ListHolder));
 
                 return
                     Expression.Block(
@@ -362,7 +362,7 @@ namespace System.Linq.Expressions.Tests
             {
                 Test((c, a, b) =>
                 {
-                    var lbl = Expression.Label(typeof(int));
+                    LabelTarget lbl = Expression.Label(typeof(int));
 
                     return
                         Expression.Block(
@@ -375,13 +375,13 @@ namespace System.Linq.Expressions.Tests
 
         private static Expression<Func<int>> Spill_RefInstance_IndexAssignment()
         {
-            var v = Expression.Parameter(typeof(ValueVector));
-            var item = typeof(ValueVector).GetProperty("Item");
-            var i = Expression.Constant(0);
-            var p = Expression.Property(v, item, i);
-            var x = Expression.Constant(42);
+            ParameterExpression v = Expression.Parameter(typeof(ValueVector));
+            Reflection.PropertyInfo item = typeof(ValueVector).GetProperty("Item");
+            ConstantExpression i = Expression.Constant(0);
+            IndexExpression p = Expression.Property(v, item, i);
+            ConstantExpression x = Expression.Constant(42);
 
-            var e =
+            Expression<Func<int>> e =
                 Expression.Lambda<Func<int>>(
                     Expression.Block(
                         new[] { v },
@@ -397,9 +397,9 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void Spill_RefInstance_IndexAssignment_Eval(bool useInterpreter)
         {
-            var e = Spill_RefInstance_IndexAssignment();
+            Expression<Func<int>> e = Spill_RefInstance_IndexAssignment();
 
-            var f = e.Compile(useInterpreter);
+            Func<int> f = e.Compile(useInterpreter);
 
             Assert.Equal(42, f());
         }
@@ -407,7 +407,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_RefInstance_IndexAssignment_CodeGen()
         {
-            var e = Spill_RefInstance_IndexAssignment();
+            Expression<Func<int>> e = Spill_RefInstance_IndexAssignment();
 
             e.Verify(
                 il: @"
@@ -481,11 +481,11 @@ namespace System.Linq.Expressions.Tests
 
         private static Expression<Func<int>> Spill_RefInstance_Index()
         {
-            var v = Expression.Parameter(typeof(ValueBar));
-            var item = typeof(ValueBar).GetProperty("Item");
-            var x = Expression.Constant(42);
+            ParameterExpression v = Expression.Parameter(typeof(ValueBar));
+            Reflection.PropertyInfo item = typeof(ValueBar).GetProperty("Item");
+            ConstantExpression x = Expression.Constant(42);
 
-            var e =
+            Expression<Func<int>> e =
                 Expression.Lambda<Func<int>>(
                     Expression.Block(
                         new[] { v },
@@ -500,9 +500,9 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void Spill_RefInstance_Index_Eval(bool useInterpreter)
         {
-            var e = Spill_RefInstance_Index();
+            Expression<Func<int>> e = Spill_RefInstance_Index();
 
-            var f = e.Compile(useInterpreter);
+            Func<int> f = e.Compile(useInterpreter);
 
             Assert.Equal(42, f());
         }
@@ -510,7 +510,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_RefInstance_Index_CodeGen()
         {
-            var e = Spill_RefInstance_Index();
+            Expression<Func<int>> e = Spill_RefInstance_Index();
 
             e.Verify(
                 il: @"
@@ -574,12 +574,12 @@ namespace System.Linq.Expressions.Tests
 
         private static Expression<Func<int>> Spill_RefInstance_MemberAssignment()
         {
-            var v = Expression.Parameter(typeof(ValueBar));
-            var foo = typeof(ValueBar).GetProperty(nameof(ValueBar.Foo));
-            var x = Expression.Constant(42);
-            var p = Expression.Property(v, foo);
+            ParameterExpression v = Expression.Parameter(typeof(ValueBar));
+            Reflection.PropertyInfo foo = typeof(ValueBar).GetProperty(nameof(ValueBar.Foo));
+            ConstantExpression x = Expression.Constant(42);
+            MemberExpression p = Expression.Property(v, foo);
 
-            var e =
+            Expression<Func<int>> e =
                 Expression.Lambda<Func<int>>(
                     Expression.Block(
                         new[] { v },
@@ -595,9 +595,9 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void Spill_RefInstance_MemberAssignment_Eval(bool useInterpreter)
         {
-            var e = Spill_RefInstance_MemberAssignment();
+            Expression<Func<int>> e = Spill_RefInstance_MemberAssignment();
 
-            var f = e.Compile(useInterpreter);
+            Func<int> f = e.Compile(useInterpreter);
 
             Assert.Equal(42, f());
         }
@@ -605,7 +605,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_RefInstance_MemberAssignment_CodeGen()
         {
-            var e = Spill_RefInstance_MemberAssignment();
+            Expression<Func<int>> e = Spill_RefInstance_MemberAssignment();
 
             e.Verify(
                 il: @"
@@ -675,9 +675,9 @@ namespace System.Linq.Expressions.Tests
 
         private static Expression<Func<int>> Spill_RefInstance_Call()
         {
-            var v = Expression.Parameter(typeof(ValueBar));
+            ParameterExpression v = Expression.Parameter(typeof(ValueBar));
 
-            var e =
+            Expression<Func<int>> e =
                 Expression.Lambda<Func<int>>(
                     Expression.Block(
                         new[] { v },
@@ -700,9 +700,9 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void Spill_RefInstance_Call_Eval(bool useInterpreter)
         {
-            var e = Spill_RefInstance_Call();
+            Expression<Func<int>> e = Spill_RefInstance_Call();
 
-            var f = e.Compile(useInterpreter);
+            Func<int> f = e.Compile(useInterpreter);
 
             Assert.Equal(42, f());
         }
@@ -710,7 +710,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_RefInstance_Call_CodeGen()
         {
-            var e = Spill_RefInstance_Call();
+            Expression<Func<int>> e = Spill_RefInstance_Call();
 
             e.Verify(
                 il: @"
@@ -780,12 +780,12 @@ namespace System.Linq.Expressions.Tests
 
         private static Expression<Func<int>> Spill_RefArgs_Call()
         {
-            var assign = typeof(ByRefs).GetMethod(nameof(ByRefs.Assign));
-            var x = Expression.Parameter(typeof(int));
-            var v = Expression.Constant(42);
-            var b = Expression.Block(new[] { x }, Expression.Call(assign, x, Spill(v)), x);
+            Reflection.MethodInfo assign = typeof(ByRefs).GetMethod(nameof(ByRefs.Assign));
+            ParameterExpression x = Expression.Parameter(typeof(int));
+            ConstantExpression v = Expression.Constant(42);
+            BlockExpression b = Expression.Block(new[] { x }, Expression.Call(assign, x, Spill(v)), x);
 
-            var e = Expression.Lambda<Func<int>>(b);
+            Expression<Func<int>> e = Expression.Lambda<Func<int>>(b);
 
             return e;
         }
@@ -794,9 +794,9 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void Spill_RefArgs_Call_Eval(bool useInterpreter)
         {
-            var e = Spill_RefArgs_Call();
+            Expression<Func<int>> e = Spill_RefArgs_Call();
 
-            var f = e.Compile(useInterpreter);
+            Func<int> f = e.Compile(useInterpreter);
 
             Assert.Equal(42, f());
         }
@@ -804,7 +804,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_RefArgs_Call_CodeGen()
         {
-            var e = Spill_RefArgs_Call();
+            Expression<Func<int>> e = Spill_RefArgs_Call();
 
             e.Verify(
                 il: @"
@@ -872,12 +872,12 @@ namespace System.Linq.Expressions.Tests
 
         private static Expression<Func<int>> Spill_RefArgs_New()
         {
-            var ctor = typeof(ByRefs).GetConstructors()[0];
-            var x = Expression.Parameter(typeof(int));
-            var v = Expression.Constant(42);
-            var b = Expression.Block(new[] { x }, Expression.New(ctor, x, Spill(v)), x);
+            Reflection.ConstructorInfo ctor = typeof(ByRefs).GetConstructors()[0];
+            ParameterExpression x = Expression.Parameter(typeof(int));
+            ConstantExpression v = Expression.Constant(42);
+            BlockExpression b = Expression.Block(new[] { x }, Expression.New(ctor, x, Spill(v)), x);
 
-            var e = Expression.Lambda<Func<int>>(b);
+            Expression<Func<int>> e = Expression.Lambda<Func<int>>(b);
 
             return e;
         }
@@ -886,9 +886,9 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void Spill_RefArgs_New_Eval(bool useInterpreter)
         {
-            var e = Spill_RefArgs_New();
+            Expression<Func<int>> e = Spill_RefArgs_New();
 
-            var f = e.Compile(useInterpreter);
+            Func<int> f = e.Compile(useInterpreter);
 
             Assert.Equal(42, f());
         }
@@ -896,7 +896,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_RefArgs_New_CodeGen()
         {
-            var e = Spill_RefArgs_New();
+            Expression<Func<int>> e = Spill_RefArgs_New();
 
             e.Verify(
                 il: @"
@@ -966,12 +966,12 @@ namespace System.Linq.Expressions.Tests
 
         private static Expression<Func<int>> Spill_RefArgs_Invoke()
         {
-            var assign = Expression.Constant(new Assign((ref int l, int r) => { l = r; }));
-            var x = Expression.Parameter(typeof(int));
-            var v = Expression.Constant(42);
-            var b = Expression.Block(new[] { x }, Expression.Invoke(assign, x, Spill(v)), x);
+            ConstantExpression assign = Expression.Constant(new Assign((ref int l, int r) => { l = r; }));
+            ParameterExpression x = Expression.Parameter(typeof(int));
+            ConstantExpression v = Expression.Constant(42);
+            BlockExpression b = Expression.Block(new[] { x }, Expression.Invoke(assign, x, Spill(v)), x);
 
-            var e = Expression.Lambda<Func<int>>(b);
+            Expression<Func<int>> e = Expression.Lambda<Func<int>>(b);
 
             return e;
         }
@@ -979,7 +979,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_RefArgs_Invoke_CodeGen()
         {
-            var e = Spill_RefArgs_Invoke();
+            Expression<Func<int>> e = Spill_RefArgs_Invoke();
 
             e.Verify(
                 il: @"
@@ -1055,23 +1055,23 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void Spill_RefArgs_Invoke_Eval(bool useInterpreter)
         {
-            var e = Spill_RefArgs_Invoke();
+            Expression<Func<int>> e = Spill_RefArgs_Invoke();
 
-            var f = e.Compile(useInterpreter);
+            Func<int> f = e.Compile(useInterpreter);
 
             Assert.Equal(42, f());
         }
 
         private static Expression<Func<int>> Spill_RefArgs_Invoke_Inline()
         {
-            var l = Expression.Parameter(typeof(int).MakeByRefType());
-            var r = Expression.Parameter(typeof(int));
-            var assign = Expression.Lambda<Assign>(Expression.Assign(l, r), l, r);
-            var x = Expression.Parameter(typeof(int));
-            var v = Expression.Constant(42);
-            var b = Expression.Block(new[] { x }, Expression.Invoke(assign, x, Spill(v)), x);
+            ParameterExpression l = Expression.Parameter(typeof(int).MakeByRefType());
+            ParameterExpression r = Expression.Parameter(typeof(int));
+            Expression<Assign> assign = Expression.Lambda<Assign>(Expression.Assign(l, r), l, r);
+            ParameterExpression x = Expression.Parameter(typeof(int));
+            ConstantExpression v = Expression.Constant(42);
+            BlockExpression b = Expression.Block(new[] { x }, Expression.Invoke(assign, x, Spill(v)), x);
 
-            var e = Expression.Lambda<Func<int>>(b);
+            Expression<Func<int>> e = Expression.Lambda<Func<int>>(b);
 
             return e;
         }
@@ -1080,9 +1080,9 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void Spill_RefArgs_Invoke_Inline_Eval(bool useInterpreter)
         {
-            var e = Spill_RefArgs_Invoke_Inline();
+            Expression<Func<int>> e = Spill_RefArgs_Invoke_Inline();
 
-            var f = e.Compile(useInterpreter);
+            Func<int> f = e.Compile(useInterpreter);
 
             Assert.Equal(42, f());
         }
@@ -1090,7 +1090,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_RefArgs_Invoke_Inline_CodeGen()
         {
-            var e = Spill_RefArgs_Invoke_Inline();
+            Expression<Func<int>> e = Spill_RefArgs_Invoke_Inline();
 
             e.Verify(
                 il: @"
@@ -1173,11 +1173,11 @@ namespace System.Linq.Expressions.Tests
 
         private static Expression<Func<ValueList>> Spill_RefInstance_ListInit()
         {
-            var l = Expression.Parameter(typeof(ValueList));
-            var i = Expression.ListInit(Expression.New(typeof(ValueList)), Spill(Expression.Constant(42)));
-            var b = Expression.Block(new[] { l }, Expression.Assign(l, i), l);
+            ParameterExpression l = Expression.Parameter(typeof(ValueList));
+            ListInitExpression i = Expression.ListInit(Expression.New(typeof(ValueList)), Spill(Expression.Constant(42)));
+            BlockExpression b = Expression.Block(new[] { l }, Expression.Assign(l, i), l);
 
-            var e = Expression.Lambda<Func<ValueList>>(b);
+            Expression<Func<ValueList>> e = Expression.Lambda<Func<ValueList>>(b);
 
             return e;
         }
@@ -1186,9 +1186,9 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void Spill_RefInstance_ListInit_Eval(bool useInterpreter)
         {
-            var e = Spill_RefInstance_ListInit();
+            Expression<Func<ValueList>> e = Spill_RefInstance_ListInit();
 
-            var f = e.Compile(useInterpreter);
+            Func<ValueList> f = e.Compile(useInterpreter);
 
             Assert.Equal(42, f()[0]);
         }
@@ -1196,7 +1196,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_RefInstance_ListInit_CodeGen()
         {
-            var e = Spill_RefInstance_ListInit();
+            Expression<Func<ValueList>> e = Spill_RefInstance_ListInit();
 
             e.Verify(
                 il: @"
@@ -1279,12 +1279,12 @@ namespace System.Linq.Expressions.Tests
 
         private static Expression<Func<ValueBar>> Spill_RefInstance_MemberInit_Assign_Field()
         {
-            var baz = typeof(ValueBar).GetField(nameof(ValueBar.Baz));
-            var l = Expression.Parameter(typeof(ValueBar));
-            var i = Expression.MemberInit(Expression.New(typeof(ValueBar)), Expression.Bind(baz, Spill(Expression.Constant(42))));
-            var b = Expression.Block(new[] { l }, Expression.Assign(l, i), l);
+            Reflection.FieldInfo baz = typeof(ValueBar).GetField(nameof(ValueBar.Baz));
+            ParameterExpression l = Expression.Parameter(typeof(ValueBar));
+            MemberInitExpression i = Expression.MemberInit(Expression.New(typeof(ValueBar)), Expression.Bind(baz, Spill(Expression.Constant(42))));
+            BlockExpression b = Expression.Block(new[] { l }, Expression.Assign(l, i), l);
 
-            var e = Expression.Lambda<Func<ValueBar>>(b);
+            Expression<Func<ValueBar>> e = Expression.Lambda<Func<ValueBar>>(b);
 
             return e;
         }
@@ -1293,9 +1293,9 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void Spill_RefInstance_MemberInit_Assign_Field_Eval(bool useInterpreter)
         {
-            var e = Spill_RefInstance_MemberInit_Assign_Field();
+            Expression<Func<ValueBar>> e = Spill_RefInstance_MemberInit_Assign_Field();
 
-            var f = e.Compile(useInterpreter);
+            Func<ValueBar> f = e.Compile(useInterpreter);
 
             Assert.Equal(42, f().Baz);
         }
@@ -1303,7 +1303,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_RefInstance_MemberInit_Assign_Field_CodeGen()
         {
-            var e = Spill_RefInstance_MemberInit_Assign_Field();
+            Expression<Func<ValueBar>> e = Spill_RefInstance_MemberInit_Assign_Field();
 
             e.Verify(
                 il: @"
@@ -1386,12 +1386,12 @@ namespace System.Linq.Expressions.Tests
 
         private static Expression<Func<ValueBar>> Spill_RefInstance_MemberInit_Assign_Property()
         {
-            var foo = typeof(ValueBar).GetProperty(nameof(ValueBar.Foo));
-            var l = Expression.Parameter(typeof(ValueBar));
-            var i = Expression.MemberInit(Expression.New(typeof(ValueBar)), Expression.Bind(foo, Spill(Expression.Constant(42))));
-            var b = Expression.Block(new[] { l }, Expression.Assign(l, i), l);
+            Reflection.PropertyInfo foo = typeof(ValueBar).GetProperty(nameof(ValueBar.Foo));
+            ParameterExpression l = Expression.Parameter(typeof(ValueBar));
+            MemberInitExpression i = Expression.MemberInit(Expression.New(typeof(ValueBar)), Expression.Bind(foo, Spill(Expression.Constant(42))));
+            BlockExpression b = Expression.Block(new[] { l }, Expression.Assign(l, i), l);
 
-            var e = Expression.Lambda<Func<ValueBar>>(b);
+            Expression<Func<ValueBar>> e = Expression.Lambda<Func<ValueBar>>(b);
 
             return e;
         }
@@ -1400,9 +1400,9 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void Spill_RefInstance_MemberInit_Assign_Property_Eval(bool useInterpreter)
         {
-            var e = Spill_RefInstance_MemberInit_Assign_Property();
+            Expression<Func<ValueBar>> e = Spill_RefInstance_MemberInit_Assign_Property();
 
-            var f = e.Compile(useInterpreter);
+            Func<ValueBar> f = e.Compile(useInterpreter);
 
             Assert.Equal(42, f().Foo);
         }
@@ -1410,7 +1410,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_RefInstance_MemberInit_Assign_Property_CodeGen()
         {
-            var e = Spill_RefInstance_MemberInit_Assign_Property();
+            Expression<Func<ValueBar>> e = Spill_RefInstance_MemberInit_Assign_Property();
 
             e.Verify(
                 il: @"
@@ -1493,13 +1493,13 @@ namespace System.Linq.Expressions.Tests
 
         private static Expression<Func<ValueBar>> Spill_RefInstance_MemberInit_MemberBind()
         {
-            var baz2 = typeof(ValueBar).GetProperty(nameof(ValueBar.Baz2));
-            var foo = typeof(Baz).GetField(nameof(Baz.Foo));
-            var l = Expression.Parameter(typeof(ValueBar));
-            var i = Expression.MemberInit(Expression.New(typeof(ValueBar).GetConstructor(new[] { typeof(Baz) }), Expression.New(typeof(Baz))), Expression.MemberBind(baz2, Expression.Bind(foo, Spill(Expression.Constant(42)))));
-            var b = Expression.Block(new[] { l }, Expression.Assign(l, i), l);
+            Reflection.PropertyInfo baz2 = typeof(ValueBar).GetProperty(nameof(ValueBar.Baz2));
+            Reflection.FieldInfo foo = typeof(Baz).GetField(nameof(Baz.Foo));
+            ParameterExpression l = Expression.Parameter(typeof(ValueBar));
+            MemberInitExpression i = Expression.MemberInit(Expression.New(typeof(ValueBar).GetConstructor(new[] { typeof(Baz) }), Expression.New(typeof(Baz))), Expression.MemberBind(baz2, Expression.Bind(foo, Spill(Expression.Constant(42)))));
+            BlockExpression b = Expression.Block(new[] { l }, Expression.Assign(l, i), l);
 
-            var e = Expression.Lambda<Func<ValueBar>>(b);
+            Expression<Func<ValueBar>> e = Expression.Lambda<Func<ValueBar>>(b);
 
             return e;
         }
@@ -1507,7 +1507,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_RefInstance_MemberInit_MemberBind_CodeGen()
         {
-            var e = Spill_RefInstance_MemberInit_MemberBind();
+            Expression<Func<ValueBar>> e = Spill_RefInstance_MemberInit_MemberBind();
 
             e.Verify(
                 il: @"
@@ -1585,13 +1585,13 @@ namespace System.Linq.Expressions.Tests
 
         private static Expression<Func<ValueBar>> Spill_RefInstance_MemberInit_ListBind()
         {
-            var xs = typeof(ValueBar).GetProperty(nameof(ValueBar.Xs));
-            var add = typeof(List<int>).GetMethod(nameof(List<int>.Add));
-            var l = Expression.Parameter(typeof(ValueBar));
-            var i = Expression.MemberInit(Expression.New(typeof(ValueBar)), Expression.ListBind(xs, Expression.ElementInit(add, Spill(Expression.Constant(42)))));
-            var b = Expression.Block(new[] { l }, Expression.Assign(l, i), l);
+            Reflection.PropertyInfo xs = typeof(ValueBar).GetProperty(nameof(ValueBar.Xs));
+            Reflection.MethodInfo add = typeof(List<int>).GetMethod(nameof(List<int>.Add));
+            ParameterExpression l = Expression.Parameter(typeof(ValueBar));
+            MemberInitExpression i = Expression.MemberInit(Expression.New(typeof(ValueBar)), Expression.ListBind(xs, Expression.ElementInit(add, Spill(Expression.Constant(42)))));
+            BlockExpression b = Expression.Block(new[] { l }, Expression.Assign(l, i), l);
 
-            var e = Expression.Lambda<Func<ValueBar>>(b);
+            Expression<Func<ValueBar>> e = Expression.Lambda<Func<ValueBar>>(b);
 
             return e;
         }
@@ -1599,7 +1599,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_RefInstance_MemberInit_ListBind_CodeGen()
         {
-            var e = Spill_RefInstance_MemberInit_ListBind();
+            Expression<Func<ValueBar>> e = Spill_RefInstance_MemberInit_ListBind();
 
             e.Verify(
                 il: @"
@@ -1681,11 +1681,11 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_Optimizations_Constant()
         {
-            var xs = Expression.Parameter(typeof(int[]));
-            var i = Expression.Constant(0);
-            var v = Spill(Expression.Constant(1));
+            ParameterExpression xs = Expression.Parameter(typeof(int[]));
+            ConstantExpression i = Expression.Constant(0);
+            Expression v = Spill(Expression.Constant(1));
 
-            var e =
+            Expression<Action<int[]>> e =
                 Expression.Lambda<Action<int[]>>(
                     Expression.Assign(Expression.ArrayAccess(xs, i), v),
                     xs
@@ -1739,11 +1739,11 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_Optimizations_Default()
         {
-            var xs = Expression.Parameter(typeof(int[]));
-            var i = Expression.Default(typeof(int));
-            var v = Spill(Expression.Constant(1));
+            ParameterExpression xs = Expression.Parameter(typeof(int[]));
+            DefaultExpression i = Expression.Default(typeof(int));
+            Expression v = Spill(Expression.Constant(1));
 
-            var e =
+            Expression<Action<int[]>> e =
                 Expression.Lambda<Action<int[]>>(
                     Expression.Assign(Expression.ArrayAccess(xs, i), v),
                     xs
@@ -1797,7 +1797,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_Optimizations_LiteralField()
         {
-            var e =
+            Expression<Func<double>> e =
                 Expression.Lambda<Func<double>>(
                     Expression.Add(
                         Expression.Field(null, typeof(Math).GetField(nameof(Math.PI))),
@@ -1845,7 +1845,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_Optimizations_StaticReadOnlyField()
         {
-            var e =
+            Expression<Func<string>> e =
                 Expression.Lambda<Func<string>>(
                     Expression.Call(
                         typeof(string).GetMethod(nameof(string.Concat), new[] { typeof(string), typeof(string) }),
@@ -1894,8 +1894,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_Optimizations_RuntimeVariables1()
         {
-            var f = Expression.Parameter(typeof(Action<IRuntimeVariables, int>));
-            var e =
+            ParameterExpression f = Expression.Parameter(typeof(Action<IRuntimeVariables, int>));
+            Expression<Action<Action<IRuntimeVariables, int>>> e =
                 Expression.Lambda<Action<Action<IRuntimeVariables, int>>>(
                     Expression.Invoke(
                         f,
@@ -1953,9 +1953,9 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_Optimizations_RuntimeVariables2()
         {
-            var f = Expression.Parameter(typeof(Action<IRuntimeVariables, int>));
-            var x = Expression.Parameter(typeof(int));
-            var e =
+            ParameterExpression f = Expression.Parameter(typeof(Action<IRuntimeVariables, int>));
+            ParameterExpression x = Expression.Parameter(typeof(int));
+            Expression<Action<Action<IRuntimeVariables, int>, int>> e =
                 Expression.Lambda<Action<Action<IRuntimeVariables, int>, int>>(
                     Expression.Invoke(
                         f,
@@ -2031,12 +2031,12 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_Optimizations_NoSpillBeyondSpillSite1()
         {
-            var f = Expression.Parameter(typeof(Func<int, int, int, int>));
-            var x = Expression.Parameter(typeof(int));
-            var y = Expression.Parameter(typeof(int));
-            var z = Expression.Parameter(typeof(int));
+            ParameterExpression f = Expression.Parameter(typeof(Func<int, int, int, int>));
+            ParameterExpression x = Expression.Parameter(typeof(int));
+            ParameterExpression y = Expression.Parameter(typeof(int));
+            ParameterExpression z = Expression.Parameter(typeof(int));
 
-            var e =
+            Expression<Func<Func<int, int, int, int>, int, int, int, int>> e =
                 Expression.Lambda<Func<Func<int, int, int, int>, int, int, int, int>>(
                     Expression.Invoke(
                         f,
@@ -2053,7 +2053,7 @@ namespace System.Linq.Expressions.Tests
                     z
                 );
 
-            var d = e.Compile();
+            Func<Func<int, int, int, int>, int, int, int, int> d = e.Compile();
             Assert.Equal(7, d((a, b, c) => a + b * c, 1, 2, 3));
 
             e.VerifyIL(@"
@@ -2104,13 +2104,13 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Spill_Optimizations_NoSpillBeyondSpillSite2()
         {
-            var f = Expression.Parameter(typeof(Func<int, int, int, int>));
-            var x1 = Expression.Parameter(typeof(int));
-            var x2 = Expression.Parameter(typeof(int));
-            var x3 = Expression.Parameter(typeof(int));
-            var x4 = Expression.Parameter(typeof(int));
+            ParameterExpression f = Expression.Parameter(typeof(Func<int, int, int, int>));
+            ParameterExpression x1 = Expression.Parameter(typeof(int));
+            ParameterExpression x2 = Expression.Parameter(typeof(int));
+            ParameterExpression x3 = Expression.Parameter(typeof(int));
+            ParameterExpression x4 = Expression.Parameter(typeof(int));
 
-            var e =
+            Expression<Func<int, int, int, int, int>> e =
                 Expression.Lambda<Func<int, int, int, int, int>>(
                     Expression.Add(
                         Expression.Add(
@@ -2131,7 +2131,7 @@ namespace System.Linq.Expressions.Tests
                     x4
                 );
 
-            var d = e.Compile();
+            Func<int, int, int, int, int> d = e.Compile();
             Assert.Equal(10, d(1, 2, 3, 4));
 
             e.VerifyIL(@"
@@ -2209,17 +2209,17 @@ namespace System.Linq.Expressions.Tests
 
         private static void Test(Func<Expression[], Expression> factory, Expression[] args, bool useInterpreter)
         {
-            var expected = Eval(factory(args), useInterpreter);
+            object expected = Eval(factory(args), useInterpreter);
 
             for (var i = 0; i < args.Length; i++)
             {
-                var newArgs = args.Select((arg, j) => j == i ? Spill(arg) : arg).ToArray();
+                Expression[] newArgs = args.Select((arg, j) => j == i ? Spill(arg) : arg).ToArray();
                 Assert.Equal(expected, Eval(factory(newArgs), useInterpreter));
             }
 
             for (var i = 0; i < args.Length; i++)
             {
-                var newArgs = args.Select((arg, j) => j == i ? new Extension(arg) : arg).ToArray();
+                Expression[] newArgs = args.Select((arg, j) => j == i ? new Extension(arg) : arg).ToArray();
                 Assert.Equal(expected, Eval(factory(newArgs), useInterpreter));
             }
         }

--- a/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
+++ b/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
@@ -14,15 +14,15 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public void IntSwitch1(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(int));
-            var p1 = Expression.Parameter(typeof(string));
-            var s = Expression.Switch(p,
+            ParameterExpression p = Expression.Parameter(typeof(int));
+            ParameterExpression p1 = Expression.Parameter(typeof(string));
+            SwitchExpression s = Expression.Switch(p,
                 Expression.Assign(p1, Expression.Constant("default")),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("hello")), Expression.Constant(1)),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("two")), Expression.Constant(2)),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("lala")), Expression.Constant(1)));
 
-            var block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
+            BlockExpression block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
 
             Func<int, string> f = Expression.Lambda<Func<int, string>>(block, p).Compile(useInterpreter);
 
@@ -35,15 +35,15 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public void NullableIntSwitch1(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(int?));
-            var p1 = Expression.Parameter(typeof(string));
-            var s = Expression.Switch(p,
+            ParameterExpression p = Expression.Parameter(typeof(int?));
+            ParameterExpression p1 = Expression.Parameter(typeof(string));
+            SwitchExpression s = Expression.Switch(p,
                 Expression.Assign(p1, Expression.Constant("default")),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("hello")), Expression.Constant((int?)1, typeof(int?))),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("two")), Expression.Constant((int?)2, typeof(int?))),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("lala")), Expression.Constant((int?)1, typeof(int?))));
 
-            var block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
+            BlockExpression block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
 
             Func<int?, string> f = Expression.Lambda<Func<int?, string>>(block, p).Compile(useInterpreter);
 
@@ -57,16 +57,16 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public void NullableIntSwitch2(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(int?));
-            var p1 = Expression.Parameter(typeof(string));
-            var s = Expression.Switch(p,
+            ParameterExpression p = Expression.Parameter(typeof(int?));
+            ParameterExpression p1 = Expression.Parameter(typeof(string));
+            SwitchExpression s = Expression.Switch(p,
                 Expression.Assign(p1, Expression.Constant("default")),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("hello")), Expression.Constant((int?)1, typeof(int?))),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("two")), Expression.Constant((int?)2, typeof(int?))),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("null")), Expression.Constant((int?)null, typeof(int?))),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("lala")), Expression.Constant((int?)1, typeof(int?))));
 
-            var block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
+            BlockExpression block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
 
             Func<int?, string> f = Expression.Lambda<Func<int?, string>>(block, p).Compile(useInterpreter);
 
@@ -80,15 +80,15 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public void IntSwitch2(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(byte));
-            var p1 = Expression.Parameter(typeof(string));
-            var s = Expression.Switch(p,
+            ParameterExpression p = Expression.Parameter(typeof(byte));
+            ParameterExpression p1 = Expression.Parameter(typeof(string));
+            SwitchExpression s = Expression.Switch(p,
                 Expression.Assign(p1, Expression.Constant("default")),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("hello")), Expression.Constant((byte)1)),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("two")), Expression.Constant((byte)2)),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("lala")), Expression.Constant((byte)1)));
 
-            var block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
+            BlockExpression block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
 
             Func<byte, string> f = Expression.Lambda<Func<byte, string>>(block, p).Compile(useInterpreter);
 
@@ -101,16 +101,16 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public void IntSwitch3(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(uint));
-            var p1 = Expression.Parameter(typeof(string));
-            var s = Expression.Switch(p,
+            ParameterExpression p = Expression.Parameter(typeof(uint));
+            ParameterExpression p1 = Expression.Parameter(typeof(string));
+            SwitchExpression s = Expression.Switch(p,
                 Expression.Assign(p1, Expression.Constant("default")),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("hello")), Expression.Constant((uint)1)),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("two")), Expression.Constant((uint)2)),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("lala")), Expression.Constant((uint)1)),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("wow")), Expression.Constant(uint.MaxValue)));
 
-            var block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
+            BlockExpression block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
 
             Func<uint, string> f = Expression.Lambda<Func<uint, string>>(block, p).Compile(useInterpreter);
 
@@ -124,8 +124,8 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public void StringSwitch(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(string));
-            var s = Expression.Switch(p,
+            ParameterExpression p = Expression.Parameter(typeof(string));
+            SwitchExpression s = Expression.Switch(p,
                 Expression.Constant("default"),
                 Expression.SwitchCase(Expression.Constant("hello"), Expression.Constant("hi")),
                 Expression.SwitchCase(Expression.Constant("lala"), Expression.Constant("bye")));
@@ -142,15 +142,15 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public void StringSwitch1(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(string));
-            var p1 = Expression.Parameter(typeof(string));
-            var s = Expression.Switch(p,
+            ParameterExpression p = Expression.Parameter(typeof(string));
+            ParameterExpression p1 = Expression.Parameter(typeof(string));
+            SwitchExpression s = Expression.Switch(p,
                 Expression.Assign(p1, Expression.Constant("default")),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("hello")), Expression.Constant("hi")),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("null")), Expression.Constant(null, typeof(string))),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("lala")), Expression.Constant("bye")));
 
-            var block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
+            BlockExpression block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
 
             Func<string, string> f = Expression.Lambda<Func<string, string>>(block, p).Compile(useInterpreter);
 
@@ -167,8 +167,8 @@ namespace System.Linq.Expressions.Tests
             Expression<Func<string>> expr1 = () => new string('a', 5);
             Expression<Func<string>> expr2 = () => new string('q', 5);
 
-            var p = Expression.Parameter(typeof(string));
-            var s = Expression.Switch(p,
+            ParameterExpression p = Expression.Parameter(typeof(string));
+            SwitchExpression s = Expression.Switch(p,
                 Expression.Constant("default"),
                 Expression.SwitchCase(Expression.Invoke(expr1), Expression.Invoke(expr2)),
                 Expression.SwitchCase(Expression.Constant("lala"), Expression.Constant("bye")));
@@ -185,16 +185,16 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public void ObjectSwitch1(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(object));
-            var p1 = Expression.Parameter(typeof(string));
-            var s = Expression.Switch(p,
+            ParameterExpression p = Expression.Parameter(typeof(object));
+            ParameterExpression p1 = Expression.Parameter(typeof(string));
+            SwitchExpression s = Expression.Switch(p,
                 Expression.Assign(p1, Expression.Constant("default")),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("hello")), Expression.Constant("hi")),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("null")), Expression.Constant(null, typeof(string))),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("lala")), Expression.Constant("bye")),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("lalala")), Expression.Constant("hi")));
 
-            var block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
+            BlockExpression block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
 
             Func<object, string> f = Expression.Lambda<Func<object, string>>(block, p).Compile(useInterpreter);
 
@@ -209,10 +209,10 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public void DefaultOnlySwitch(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(int));
-            var s = Expression.Switch(p, Expression.Constant(42));
+            ParameterExpression p = Expression.Parameter(typeof(int));
+            SwitchExpression s = Expression.Switch(p, Expression.Constant(42));
 
-            var fInt32Int32 = Expression.Lambda<Func<int, int>>(s, p).Compile(useInterpreter);
+            Func<int, int> fInt32Int32 = Expression.Lambda<Func<int, int>>(s, p).Compile(useInterpreter);
 
             Assert.Equal(42, fInt32Int32(0));
             Assert.Equal(42, fInt32Int32(1));
@@ -220,7 +220,7 @@ namespace System.Linq.Expressions.Tests
 
             s = Expression.Switch(typeof(object), p, Expression.Constant("A test string"), null);
 
-            var fInt32Object = Expression.Lambda<Func<int, object>>(s, p).Compile(useInterpreter);
+            Func<int, object> fInt32Object = Expression.Lambda<Func<int, object>>(s, p).Compile(useInterpreter);
 
             Assert.Equal("A test string", fInt32Object(0));
             Assert.Equal("A test string", fInt32Object(1));
@@ -229,7 +229,7 @@ namespace System.Linq.Expressions.Tests
             p = Expression.Parameter(typeof(string));
             s = Expression.Switch(p, Expression.Constant("foo"));
 
-            var fStringString = Expression.Lambda<Func<string, string>>(s, p).Compile(useInterpreter);
+            Func<string, string> fStringString = Expression.Lambda<Func<string, string>>(s, p).Compile(useInterpreter);
 
             Assert.Equal("foo", fStringString("bar"));
             Assert.Equal("foo", fStringString(null));
@@ -240,10 +240,10 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public void NoDefaultOrCasesSwitch(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(int));
-            var s = Expression.Switch(p);
+            ParameterExpression p = Expression.Parameter(typeof(int));
+            SwitchExpression s = Expression.Switch(p);
 
-            var f = Expression.Lambda<Action<int>>(s, p).Compile(useInterpreter);
+            Action<int> f = Expression.Lambda<Action<int>>(s, p).Compile(useInterpreter);
 
             f(0);
 
@@ -253,7 +253,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void TypedNoDefaultOrCasesSwitch()
         {
-            var p = Expression.Parameter(typeof(int));
+            ParameterExpression p = Expression.Parameter(typeof(int));
             // A SwitchExpression with neither a defaultBody nor any cases can not be any type except void.
             Assert.Throws<ArgumentException>("defaultBody", () => Expression.Switch(typeof(int), p, null, null));
         }
@@ -273,11 +273,11 @@ namespace System.Linq.Expressions.Tests
         public void DefaultOnlySwitchWithSideEffect(bool useInterpreter)
         {
             bool changed = false;
-            var pOut = Expression.Parameter(typeof(bool).MakeByRefType(), "changed");
-            var switchValue = Expression.Call(typeof(SwitchTests).GetMethod(nameof(QuestionMeaning)), pOut);
-            var s = Expression.Switch(switchValue, Expression.Constant(42));
+            ParameterExpression pOut = Expression.Parameter(typeof(bool).MakeByRefType(), "changed");
+            MethodCallExpression switchValue = Expression.Call(typeof(SwitchTests).GetMethod(nameof(QuestionMeaning)), pOut);
+            SwitchExpression s = Expression.Switch(switchValue, Expression.Constant(42));
 
-            var fInt32Int32 = Expression.Lambda<RefSettingDelegate>(s, pOut).Compile(useInterpreter);
+            RefSettingDelegate fInt32Int32 = Expression.Lambda<RefSettingDelegate>(s, pOut).Compile(useInterpreter);
 
             Assert.False(changed);
             Assert.Equal(42, fInt32Int32(ref changed));
@@ -292,11 +292,11 @@ namespace System.Linq.Expressions.Tests
         public void NoDefaultOrCasesSwitchWithSideEffect(bool useInterpreter)
         {
             bool changed = false;
-            var pOut = Expression.Parameter(typeof(bool).MakeByRefType(), "changed");
-            var switchValue = Expression.Call(typeof(SwitchTests).GetMethod(nameof(QuestionMeaning)), pOut);
-            var s = Expression.Switch(switchValue, (Expression)null);
+            ParameterExpression pOut = Expression.Parameter(typeof(bool).MakeByRefType(), "changed");
+            MethodCallExpression switchValue = Expression.Call(typeof(SwitchTests).GetMethod(nameof(QuestionMeaning)), pOut);
+            SwitchExpression s = Expression.Switch(switchValue, (Expression)null);
 
-            var f = Expression.Lambda<JustRefSettingDelegate>(s, pOut).Compile(useInterpreter);
+            JustRefSettingDelegate f = Expression.Lambda<JustRefSettingDelegate>(s, pOut).Compile(useInterpreter);
 
             Assert.False(changed);
             f(ref changed);
@@ -315,9 +315,9 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public void SwitchWithComparison(bool useInterpreter)
         {
-            var p = Expression.Parameter(typeof(string));
-            var p1 = Expression.Parameter(typeof(string));
-            var s = Expression.Switch(p,
+            ParameterExpression p = Expression.Parameter(typeof(string));
+            ParameterExpression p1 = Expression.Parameter(typeof(string));
+            SwitchExpression s = Expression.Switch(p,
                 Expression.Assign(p1, Expression.Constant("default")),
                 typeof(TestComparers).GetMethod(nameof(TestComparers.CaseInsensitiveStringCompare)),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("hello")), Expression.Constant("hi")),
@@ -325,7 +325,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("lala")), Expression.Constant("bye")),
                 Expression.SwitchCase(Expression.Assign(p1, Expression.Constant("lalala")), Expression.Constant("hi")));
 
-            var block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
+            BlockExpression block = Expression.Block(new ParameterExpression[] { p1 }, s, p1);
 
             Func<string, string> f = Expression.Lambda<Func<string, string>>(block, p).Compile(useInterpreter);
 
@@ -406,7 +406,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void LiftedCall(bool useInterpreter)
         {
-            var f = Expression.Lambda<Func<int>>(
+            Func<int> f = Expression.Lambda<Func<int>>(
                 Expression.Switch(
                     Expression.Constant(30, typeof(int?)),
                     Expression.Constant(0),
@@ -594,7 +594,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.SwitchCase(Expression.Constant(2), Expression.Constant(2))
                 );
 
-            var newCases = new[]
+            SwitchCase[] newCases = new[]
             {
                 Expression.SwitchCase(Expression.Constant(1), Expression.Constant(1)),
                 Expression.SwitchCase(Expression.Constant(2), Expression.Constant(2))
@@ -624,12 +624,12 @@ namespace System.Linq.Expressions.Tests
 
             for (var i = 1; i <= values.Length; i++)
             {
-                var cases = values.Take(i).Select((s, j) => Expression.SwitchCase(Expression.Constant(j), Expression.Constant(values[j]))).ToArray();
-                var value = Expression.Parameter(typeof(string));
-                var e = Expression.Lambda<Func<string, int>>(Expression.Switch(value, Expression.Constant(-1), cases), value);
-                var f = e.Compile(useInterpreter);
+                SwitchCase[] cases = values.Take(i).Select((s, j) => Expression.SwitchCase(Expression.Constant(j), Expression.Constant(values[j]))).ToArray();
+                ParameterExpression value = Expression.Parameter(typeof(string));
+                Expression<Func<string, int>> e = Expression.Lambda<Func<string, int>>(Expression.Switch(value, Expression.Constant(-1), cases), value);
+                Func<string, int> f = e.Compile(useInterpreter);
 
-                var k = 0;
+                int k = 0;
                 foreach (var str in values.Take(i))
                 {
                     Assert.Equal(k, f(str));
@@ -647,13 +647,13 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void ToStringTest()
         {
-            var e1 = Expression.Switch(Expression.Parameter(typeof(int), "x"), Expression.SwitchCase(Expression.Empty(), Expression.Constant(1)));
+            SwitchExpression e1 = Expression.Switch(Expression.Parameter(typeof(int), "x"), Expression.SwitchCase(Expression.Empty(), Expression.Constant(1)));
             Assert.Equal("switch (x) { ... }", e1.ToString());
 
-            var e2 = Expression.SwitchCase(Expression.Parameter(typeof(int), "x"), Expression.Constant(1));
+            SwitchCase e2 = Expression.SwitchCase(Expression.Parameter(typeof(int), "x"), Expression.Constant(1));
             Assert.Equal("case (1): ...", e2.ToString());
 
-            var e3 = Expression.SwitchCase(Expression.Parameter(typeof(int), "x"), Expression.Constant(1), Expression.Constant(2));
+            SwitchCase e3 = Expression.SwitchCase(Expression.Parameter(typeof(int), "x"), Expression.Constant(1), Expression.Constant(2));
             Assert.Equal("case (1, 2): ...", e3.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/TestExtensions/TestOrderer.cs
+++ b/src/System.Linq.Expressions/tests/TestExtensions/TestOrderer.cs
@@ -16,7 +16,7 @@ namespace System.Linq.Expressions.Tests
             Dictionary<int, List<TTestCase>> queue = new Dictionary<int, List<TTestCase>>();
             foreach (TTestCase testCase in testCases)
             {
-                var orderAttribute = testCase.TestMethod.Method.GetCustomAttributes(typeof(TestOrderAttribute)).FirstOrDefault();
+                Xunit.Abstractions.IAttributeInfo orderAttribute = testCase.TestMethod.Method.GetCustomAttributes(typeof(TestOrderAttribute)).FirstOrDefault();
                 int order;
                 if (orderAttribute == null || (order = orderAttribute.GetConstructorArguments().Cast<int>().First()) == 0)
                 {

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
@@ -112,7 +112,7 @@ namespace System.Linq.Expressions.Tests
                 expected = value != null && value.GetType() == nonNullable;
             }
 
-            var param = Expression.Parameter(expression.Type);
+            ParameterExpression param = Expression.Parameter(expression.Type);
 
             Func<bool> func = Expression.Lambda<Func<bool>>(
                 Expression.Block(
@@ -159,7 +159,7 @@ namespace System.Linq.Expressions.Tests
             Action<string> a = x => { };
             Action<string> b = ao;
 
-            var param = Expression.Parameter(typeof(Action<string>));
+            ParameterExpression param = Expression.Parameter(typeof(Action<string>));
 
             Func<Action<string>, bool> isActStr = Expression.Lambda<Func<Action<string>, bool>>(
                 Expression.TypeEqual(param, typeof(Action<string>)),
@@ -189,7 +189,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void ToStringTest()
         {
-            var e = Expression.TypeEqual(Expression.Parameter(typeof(string), "s"), typeof(string));
+            TypeBinaryExpression e = Expression.TypeEqual(Expression.Parameter(typeof(string), "s"), typeof(string));
             Assert.Equal("(s TypeEqual String)", e.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeIs.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeIs.cs
@@ -95,7 +95,7 @@ namespace System.Linq.Expressions.Tests
                 ? type == typeof(void)
                 : type.IsInstanceOfType(Expression.Lambda<Func<object>>(Expression.Convert(expression, typeof(object))).Compile()());
 
-            var param = Expression.Parameter(expression.Type);
+            ParameterExpression param = Expression.Parameter(expression.Type);
 
             Func<bool> func = Expression.Lambda<Func<bool>>(
                 Expression.Block(
@@ -137,7 +137,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void ToStringTest()
         {
-            var e = Expression.TypeIs(Expression.Parameter(typeof(object), "o"), typeof(string));
+            TypeBinaryExpression e = Expression.TypeIs(Expression.Parameter(typeof(object), "o"), typeof(string));
             Assert.Equal("(o Is String)", e.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostDecrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostDecrementAssignTests.cs
@@ -289,7 +289,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void ToStringTest()
         {
-            var e = Expression.PostDecrementAssign(Expression.Parameter(typeof(int), "x"));
+            UnaryExpression e = Expression.PostDecrementAssign(Expression.Parameter(typeof(int), "x"));
             Assert.Equal("x--", e.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostIncrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostIncrementAssignTests.cs
@@ -289,7 +289,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void ToStringTest()
         {
-            var e = Expression.PostIncrementAssign(Expression.Parameter(typeof(int), "x"));
+            UnaryExpression e = Expression.PostIncrementAssign(Expression.Parameter(typeof(int), "x"));
             Assert.Equal("x++", e.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreDecrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreDecrementAssignTests.cs
@@ -289,7 +289,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void ToStringTest()
         {
-            var e = Expression.PreDecrementAssign(Expression.Parameter(typeof(int), "x"));
+            UnaryExpression e = Expression.PreDecrementAssign(Expression.Parameter(typeof(int), "x"));
             Assert.Equal("--x", e.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreIncrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreIncrementAssignTests.cs
@@ -289,7 +289,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void ToStringTest()
         {
-            var e = Expression.PreIncrementAssign(Expression.Parameter(typeof(int), "x"));
+            UnaryExpression e = Expression.PreIncrementAssign(Expression.Parameter(typeof(int), "x"));
             Assert.Equal("++x", e.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
@@ -103,7 +103,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.NegateChecked(Expression.Parameter(typeof(int), "x"));
+            UnaryExpression e = Expression.NegateChecked(Expression.Parameter(typeof(int), "x"));
             Assert.Equal("-x", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableOneOffTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableOneOffTests.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void UnaryArithmeticNegateNullableStackBalance(bool useInterpreter)
         {
-            var e = Expression.Lambda<Func<decimal?>>(
+            Expression<Func<decimal?>> e = Expression.Lambda<Func<decimal?>>(
                 Expression.Negate(
                     Expression.Negate(
                         Expression.Constant(1.0m, typeof(decimal?))
@@ -19,7 +19,7 @@ namespace System.Linq.Expressions.Tests
                 )
             );
 
-            var f = e.Compile(useInterpreter);
+            Func<decimal?> f = e.Compile(useInterpreter);
 
             Assert.True(f() == 1.0m);
         }

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
@@ -103,7 +103,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.Negate(Expression.Parameter(typeof(int), "x"));
+            UnaryExpression e = Expression.Negate(Expression.Parameter(typeof(int), "x"));
             Assert.Equal("-x", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotTests.cs
@@ -103,7 +103,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.Not(Expression.Parameter(typeof(bool), "x"));
+            UnaryExpression e = Expression.Not(Expression.Parameter(typeof(bool), "x"));
             Assert.Equal("Not(x)", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryConvertTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryConvertTests.cs
@@ -78,7 +78,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void ConvertUnderlyingTypeToEnumTypeTest(bool useInterpreter)
         {
-            var enumValue = DayOfWeek.Monday;
+            DayOfWeek enumValue = DayOfWeek.Monday;
             var value = (int)enumValue;
 
             foreach (var o in new[] { Expression.Constant(value, typeof(int)), Expression.Constant(value, typeof(ValueType)), Expression.Constant(value, typeof(object)) })
@@ -90,13 +90,13 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void ConvertUnderlyingTypeToNullableEnumTypeTest(bool useInterpreter)
         {
-            var enumValue = DayOfWeek.Monday;
+            DayOfWeek enumValue = DayOfWeek.Monday;
             var value = (int)enumValue;
 
-            var cInt = Expression.Constant(value, typeof(int));
+            ConstantExpression cInt = Expression.Constant(value, typeof(int));
             VerifyUnaryConvert(Expression.Convert(cInt, typeof(DayOfWeek?)), enumValue, useInterpreter);
 
-            var cObj = Expression.Constant(value, typeof(object));
+            ConstantExpression cObj = Expression.Constant(value, typeof(object));
             VerifyUnaryConvertThrows<InvalidCastException>(Expression.Convert(cObj, typeof(DayOfWeek?)), useInterpreter);
         }
 
@@ -116,17 +116,17 @@ namespace System.Linq.Expressions.Tests
         {
             // NB: Unlike TypeAs, the output does not include the type we're converting to
 
-            var e1 = Expression.Convert(Expression.Parameter(typeof(object), "o"), typeof(int));
+            UnaryExpression e1 = Expression.Convert(Expression.Parameter(typeof(object), "o"), typeof(int));
             Assert.Equal("Convert(o, Int32)", e1.ToString());
 
-            var e2 = Expression.ConvertChecked(Expression.Parameter(typeof(long), "x"), typeof(int));
+            UnaryExpression e2 = Expression.ConvertChecked(Expression.Parameter(typeof(long), "x"), typeof(int));
             Assert.Equal("ConvertChecked(x, Int32)", e2.ToString());
         }
 
         private static IEnumerable<KeyValuePair<Expression, object>> ConvertBooleanToNumeric()
         {
-            var boolF = Expression.Constant(false);
-            var boolT = Expression.Constant(true);
+            ConstantExpression boolF = Expression.Constant(false);
+            ConstantExpression boolT = Expression.Constant(true);
 
             var factories = new Func<Expression, Type, Expression>[] { Expression.Convert, Expression.ConvertChecked };
 
@@ -151,7 +151,7 @@ namespace System.Linq.Expressions.Tests
 
         private static IEnumerable<Expression> ConvertNullToNonNullableValue()
         {
-            var nullC = Expression.Constant(null);
+            ConstantExpression nullC = Expression.Constant(null);
 
             var factories = new Func<Expression, Type, Expression>[] { Expression.Convert, Expression.ConvertChecked };
 
@@ -178,7 +178,7 @@ namespace System.Linq.Expressions.Tests
 
         private static IEnumerable<Expression> ConvertNullToNullableValue()
         {
-            var nullC = Expression.Constant(null);
+            ConstantExpression nullC = Expression.Constant(null);
 
             var factories = new Func<Expression, Type, Expression>[] { Expression.Convert, Expression.ConvertChecked };
 
@@ -232,8 +232,8 @@ namespace System.Linq.Expressions.Tests
                 // >>> From any non-nullable-value-type to any interface-type implemented by the value-type.
                 foreach (var o in new object[] { 1, DayOfWeek.Monday, new TimeSpan(3, 14, 15) })
                 {
-                    var t = o.GetType();
-                    var c = Expression.Constant(o, t);
+                    Type t = o.GetType();
+                    ConstantExpression c = Expression.Constant(o, t);
 
                     foreach (var i in t.GetTypeInfo().ImplementedInterfaces)
                     {
@@ -244,8 +244,8 @@ namespace System.Linq.Expressions.Tests
                 // >>> From any nullable-type to any interface-type implemented by the underlying type of the nullable-type.
                 foreach (var o in new object[] { (int?)1, (DayOfWeek?)DayOfWeek.Monday, (TimeSpan?)new TimeSpan(3, 14, 15) })
                 {
-                    var t = o.GetType();
-                    var n = typeof(Nullable<>).MakeGenericType(t);
+                    Type t = o.GetType();
+                    Type n = typeof(Nullable<>).MakeGenericType(t);
 
                     foreach (var c in new[] { Expression.Constant(o, n), Expression.Constant(null, n) })
                     {
@@ -282,8 +282,8 @@ namespace System.Linq.Expressions.Tests
                 // >>> From the type System.ValueType to any value-type.
                 foreach (var o in new object[] { 1, DayOfWeek.Monday, new TimeSpan(3, 14, 15) })
                 {
-                    var t = o.GetType();
-                    var n = typeof(Nullable<>).MakeGenericType(t);
+                    Type t = o.GetType();
+                    Type n = typeof(Nullable<>).MakeGenericType(t);
 
                     foreach (var f in new[] { typeof(object), typeof(ValueType) })
                     {
@@ -295,7 +295,7 @@ namespace System.Linq.Expressions.Tests
                 // >>> From any interface-type to any non-nullable-value-type that implements the interface-type.
                 foreach (var o in new object[] { 1, DayOfWeek.Monday, new TimeSpan(3, 14, 15) })
                 {
-                    var t = o.GetType();
+                    Type t = o.GetType();
 
                     foreach (var i in t.GetTypeInfo().ImplementedInterfaces)
                     {
@@ -306,8 +306,8 @@ namespace System.Linq.Expressions.Tests
                 // >>> From any interface-type to any nullable-type whose underlying type implements the interface-type.
                 foreach (var o in new object[] { 1, DayOfWeek.Monday, new TimeSpan(3, 14, 15) })
                 {
-                    var t = o.GetType();
-                    var n = typeof(Nullable<>).MakeGenericType(t);
+                    Type t = o.GetType();
+                    Type n = typeof(Nullable<>).MakeGenericType(t);
 
                     foreach (var i in t.GetTypeInfo().ImplementedInterfaces)
                     {
@@ -355,11 +355,11 @@ namespace System.Linq.Expressions.Tests
         private static IEnumerable<Expression> ConvertUnboxingInvalidCast()
         {
             var objs = new object[] { 1, 1L, 1.0f, 1.0, true, TimeSpan.FromSeconds(1), "bar" };
-            var types = objs.Select(o => o.GetType()).ToArray();
+            Type[] types = objs.Select(o => o.GetType()).ToArray();
 
             foreach (var o in objs)
             {
-                var c = Expression.Constant(o, typeof(object));
+                ConstantExpression c = Expression.Constant(o, typeof(object));
 
                 foreach (var t in types)
                 {
@@ -369,7 +369,7 @@ namespace System.Linq.Expressions.Tests
 
                         if (t.GetTypeInfo().IsValueType)
                         {
-                            var n = typeof(Nullable<>).MakeGenericType(t);
+                            Type n = typeof(Nullable<>).MakeGenericType(t);
                             yield return Expression.Convert(c, n);
                         }
                     }

--- a/src/System.Linq.Expressions/tests/Unary/UnaryDecrementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryDecrementTests.cs
@@ -93,7 +93,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.Decrement(Expression.Parameter(typeof(int), "x"));
+            UnaryExpression e = Expression.Decrement(Expression.Parameter(typeof(int), "x"));
             Assert.Equal("Decrement(x)", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIncrementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIncrementTests.cs
@@ -93,7 +93,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.Increment(Expression.Parameter(typeof(int), "x"));
+            UnaryExpression e = Expression.Increment(Expression.Parameter(typeof(int), "x"));
             Assert.Equal("Increment(x)", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseTests.cs
@@ -23,7 +23,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.IsFalse(Expression.Parameter(typeof(bool), "x"));
+            UnaryExpression e = Expression.IsFalse(Expression.Parameter(typeof(bool), "x"));
             Assert.Equal("IsFalse(x)", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueTests.cs
@@ -23,7 +23,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.IsTrue(Expression.Parameter(typeof(bool), "x"));
+            UnaryExpression e = Expression.IsTrue(Expression.Parameter(typeof(bool), "x"));
             Assert.Equal("IsTrue(x)", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementTests.cs
@@ -93,7 +93,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.OnesComplement(Expression.Parameter(typeof(int), "x"));
+            UnaryExpression e = Expression.OnesComplement(Expression.Parameter(typeof(int), "x"));
             Assert.Equal("~(x)", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryQuoteTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryQuoteTests.cs
@@ -13,9 +13,9 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void QuotePreservesTypingOfBlock(bool useInterpreter)
         {
-            var x = Parameter(typeof(int));
+            ParameterExpression x = Parameter(typeof(int));
 
-            var f1 =
+            Expression<Func<int, Type>> f1 =
                 Lambda<Func<int, Type>>(
                     Call(
                         typeof(UnaryQuoteTests).GetMethod(nameof(Quote1)),
@@ -28,9 +28,9 @@ namespace System.Linq.Expressions.Tests
 
             Assert.Equal(typeof(void), f1.Compile(useInterpreter)(42));
 
-            var s = Parameter(typeof(string));
+            ParameterExpression s = Parameter(typeof(string));
 
-            var f2 =
+            Expression<Func<string, Type>> f2 =
                 Lambda<Func<string, Type>>(
                     Call(
                         typeof(UnaryQuoteTests).GetMethod(nameof(Quote2)),

--- a/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusTests.cs
@@ -103,7 +103,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.UnaryPlus(Expression.Parameter(typeof(int), "x"));
+            UnaryExpression e = Expression.UnaryPlus(Expression.Parameter(typeof(int), "x"));
             Assert.Equal("+x", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/Unary/UnaryUnboxTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryUnboxTests.cs
@@ -22,7 +22,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void ToStringTest()
         {
-            var e = Expression.Unbox(Expression.Parameter(typeof(object), "x"), typeof(int));
+            UnaryExpression e = Expression.Unbox(Expression.Parameter(typeof(object), "x"), typeof(int));
             Assert.Equal("Unbox(x)", e.ToString());
         }
 

--- a/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
@@ -132,8 +132,8 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public void CanUseAsLambdaByRefParameter_String(bool useInterpreter)
         {
-            var param = Expression.Parameter(typeof(string).MakeByRefType());
-            var f = Expression.Lambda<ByRefFunc<string>>(
+            ParameterExpression param = Expression.Parameter(typeof(string).MakeByRefType());
+            ByRefFunc<string> f = Expression.Lambda<ByRefFunc<string>>(
                 Expression.Assign(param, Expression.Call(param, typeof(string).GetMethod(nameof(string.ToUpper), Type.EmptyTypes))),
                 param
                 ).Compile(useInterpreter);
@@ -146,8 +146,8 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public void CanUseAsLambdaByRefParameter_Char(bool useInterpreter)
         {
-            var param = Expression.Parameter(typeof(char).MakeByRefType());
-            var f = Expression.Lambda<ByRefFunc<char>>(
+            ParameterExpression param = Expression.Parameter(typeof(char).MakeByRefType());
+            ByRefFunc<char> f = Expression.Lambda<ByRefFunc<char>>(
                 Expression.Assign(param, Expression.Call(typeof(char).GetMethod(nameof(char.ToUpper), new[] { typeof(char) }), param)),
                 param
                 ).Compile(useInterpreter);
@@ -160,8 +160,8 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public void CanUseAsLambdaByRefParameter_Bool(bool useInterpreter)
         {
-            var param = Expression.Parameter(typeof(bool).MakeByRefType());
-            var f = Expression.Lambda<ByRefFunc<bool>>(
+            ParameterExpression param = Expression.Parameter(typeof(bool).MakeByRefType());
+            ByRefFunc<bool> f = Expression.Lambda<ByRefFunc<bool>>(
                 Expression.ExclusiveOrAssign(param, Expression.Constant(true)),
                 param
                 ).Compile(useInterpreter);
@@ -313,17 +313,17 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(ReadAndWriteRefCases))]
         public void ReadAndWriteRefParameters(bool useInterpreter, object value, object increment, object result)
         {
-            var type = value.GetType();
+            Type type = value.GetType();
 
-            var method = typeof(ParameterTests).GetMethod(nameof(AssertReadAndWriteRefParameters), BindingFlags.NonPublic | BindingFlags.Static);
+            MethodInfo method = typeof(ParameterTests).GetMethod(nameof(AssertReadAndWriteRefParameters), BindingFlags.NonPublic | BindingFlags.Static);
 
             method.MakeGenericMethod(type).Invoke(null, new object[] { useInterpreter, value, increment, result });
         }
 
         private static void AssertReadAndWriteRefParameters<T>(bool useInterpreter, T value, T increment, T result)
         {
-            var param = Expression.Parameter(typeof(T).MakeByRefType());
-            var addOneInPlace = Expression.Lambda<ByRefFunc<T>>(
+            ParameterExpression param = Expression.Parameter(typeof(T).MakeByRefType());
+            ByRefFunc<T> addOneInPlace = Expression.Lambda<ByRefFunc<T>>(
                 Expression.AddAssign(param, Expression.Constant(increment, typeof(T))),
                 param
                 ).Compile(useInterpreter);

--- a/src/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
@@ -177,13 +177,13 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void ToStringTest()
         {
-            var e1 = Expression.RuntimeVariables();
+            RuntimeVariablesExpression e1 = Expression.RuntimeVariables();
             Assert.Equal("()", e1.ToString());
 
-            var e2 = Expression.RuntimeVariables(Expression.Parameter(typeof(int), "x"));
+            RuntimeVariablesExpression e2 = Expression.RuntimeVariables(Expression.Parameter(typeof(int), "x"));
             Assert.Equal("(x)", e2.ToString());
 
-            var e3 = Expression.RuntimeVariables(Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
+            RuntimeVariablesExpression e3 = Expression.RuntimeVariables(Expression.Parameter(typeof(int), "x"), Expression.Parameter(typeof(int), "y"));
             Assert.Equal("(x, y)", e3.ToString());
         }
     }

--- a/src/System.Linq.Expressions/tests/Visitor/VisitorTests.cs
+++ b/src/System.Linq.Expressions/tests/Visitor/VisitorTests.cs
@@ -85,9 +85,9 @@ namespace System.Linq.Expressions.Tests
 
             public override Expression Reduce()
             {
-                var enType = typeof(IEnumerator<>).MakeGenericType(ItemVariable.Type);
-                var enumerator = Variable(enType);
-                var breakLabel = Label();
+                Type enType = typeof(IEnumerator<>).MakeGenericType(ItemVariable.Type);
+                ParameterExpression enumerator = Variable(enType);
+                LabelTarget breakLabel = Label();
                 return Block(
                     new[] {ItemVariable, enumerator},
                     Assign(enumerator, Call(Enumerable, typeof(IEnumerable<>).MakeGenericType(ItemVariable.Type).GetMethod(nameof(IEnumerable.GetEnumerator)))),
@@ -197,7 +197,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void VisitCollectionReturnSameIfChildrenUnchanged()
         {
-            var collection = new List<Expression> { Expression.Constant(0), Expression.Constant(2), Expression.DebugInfo(Expression.SymbolDocument("fileName"), 1, 1, 1, 1) }.AsReadOnly();
+            ReadOnlyCollection<Expression> collection = new List<Expression> { Expression.Constant(0), Expression.Constant(2), Expression.DebugInfo(Expression.SymbolDocument("fileName"), 1, 1, 1, 1) }.AsReadOnly();
             Assert.Same(collection, new DefaultVisitor().Visit(collection));
         }
 
@@ -205,8 +205,8 @@ namespace System.Linq.Expressions.Tests
         public void VisitCollectionDifferOnFirst()
         {
             string value = new string(new[] { 'a', 'b', 'c' });
-            var collection = new List<Expression> { Expression.Constant(value) }.AsReadOnly();
-            var visited = new ConstantRefreshingVisitor().Visit(collection);
+            ReadOnlyCollection<Expression> collection = new List<Expression> { Expression.Constant(value) }.AsReadOnly();
+            ReadOnlyCollection<Expression> visited = new ConstantRefreshingVisitor().Visit(collection);
             Assert.NotSame(collection, visited);
             Assert.NotSame(collection[0], visited[0]);
             Assert.Same(value, ((ConstantExpression)visited[0]).Value);
@@ -216,8 +216,8 @@ namespace System.Linq.Expressions.Tests
         public void VisitCollectionDifferOnLater()
         {
             string value = new string(new[] { 'a', 'b', 'c' });
-            var collection = new List<Expression> { Expression.Empty(), Expression.Constant(value) }.AsReadOnly();
-            var visited = new ConstantRefreshingVisitor().Visit(collection);
+            ReadOnlyCollection<Expression> collection = new List<Expression> { Expression.Empty(), Expression.Constant(value) }.AsReadOnly();
+            ReadOnlyCollection<Expression> visited = new ConstantRefreshingVisitor().Visit(collection);
             Assert.NotSame(collection, visited);
             Assert.Same(collection[0], visited[0]);
             Assert.NotSame(collection[1], visited[1]);
@@ -227,22 +227,22 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void VisitCollectionNullNodes()
         {
-            var collection = new List<Expression> { null, null, null }.AsReadOnly();
+            ReadOnlyCollection<Expression> collection = new List<Expression> { null, null, null }.AsReadOnly();
             Assert.Same(collection, new DefaultVisitor().Visit(collection));
         }
 
         [Fact]
         public void VisitCollectionWithElementVisitorReturnSameIfChildrenUnchanged()
         {
-            var collection = new List<string> { "ABC", "DEF" }.AsReadOnly();
+            ReadOnlyCollection<string> collection = new List<string> { "ABC", "DEF" }.AsReadOnly();
             Assert.Same(collection, ExpressionVisitor.Visit(collection, UpperCaseIfNotAlready));
         }
 
         [Fact]
         public void VisitCollectionWithElementVisitorDifferOnFirst()
         {
-            var collection = new List<string> { "abc" }.AsReadOnly();
-            var visited = ExpressionVisitor.Visit(collection, UpperCaseIfNotAlready);
+            ReadOnlyCollection<string> collection = new List<string> { "abc" }.AsReadOnly();
+            ReadOnlyCollection<string> visited = ExpressionVisitor.Visit(collection, UpperCaseIfNotAlready);
             Assert.NotSame(collection, visited);
             Assert.NotSame(collection[0], visited[0]);
         }
@@ -250,8 +250,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void VisitCollectionWithElementVisitorDifferOnLater()
         {
-            var collection = new List<string> { "ABC", "def", "GHI", "jkl" }.AsReadOnly();
-            var visited = ExpressionVisitor.Visit(collection, UpperCaseIfNotAlready);
+            ReadOnlyCollection<string> collection = new List<string> { "ABC", "def", "GHI", "jkl" }.AsReadOnly();
+            ReadOnlyCollection<string> visited = ExpressionVisitor.Visit(collection, UpperCaseIfNotAlready);
             Assert.NotSame(collection, visited);
             Assert.Same(collection[0], visited[0]);
             Assert.NotSame(collection[1], visited[1]);
@@ -262,14 +262,14 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void VisitCollectionWithElementVisitorNullNodes()
         {
-            var collection = new List<string> { null, null, null }.AsReadOnly();
+            ReadOnlyCollection<string> collection = new List<string> { null, null, null }.AsReadOnly();
             Assert.Same(collection, ExpressionVisitor.Visit(collection, UpperCaseIfNotAlready));
         }
 
         [Fact]
         public void VisitAndConvertReturnsSameIfVisitDoes()
         {
-            var constant = Expression.Constant(0);
+            ConstantExpression constant = Expression.Constant(0);
             Assert.Same(constant, new DefaultVisitor().Visit(constant));
             Assert.Same(constant, new DefaultVisitor().VisitAndConvert(constant, "foo"));
         }
@@ -306,8 +306,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void VisitAndConvertSameResultAsVisit()
         {
-            var constant = Expression.Constant(0);
-            var visited = new ConstantRefreshingVisitor().VisitAndConvert(constant, "");
+            ConstantExpression constant = Expression.Constant(0);
+            ConstantExpression visited = new ConstantRefreshingVisitor().VisitAndConvert(constant, "");
             Assert.NotSame(constant, visited);
             Assert.Equal(0, visited.Value);
         }
@@ -315,7 +315,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void ReduceChildrenCascades()
         {
-            var intVar = Expression.Variable(typeof(int));
+            ParameterExpression intVar = Expression.Variable(typeof(int));
             List<int> list = new List<int>();
             var foreachExp = new ForEachExpression(
                 intVar,
@@ -330,7 +330,7 @@ namespace System.Linq.Expressions.Tests
 
             // Check that not only has the visitor reduced the foreach into a block
             // but the using within that block into a try…finally.
-            var reduced = new DefaultVisitor().Visit(foreachExp);
+            Expression reduced = new DefaultVisitor().Visit(foreachExp);
             var block = (BlockExpression)reduced;
             var tryExp = (TryExpression)block.Expressions[1];
             var loop = (LoopExpression)tryExp.Body;


### PR DESCRIPTION
Using explicit types where the type is not immediately obvious. Automated code rewrite using a Roslyn code fix provider.