### PR TITLE
Cleaning up Error class in System.Linq.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -447,9 +447,6 @@
   <data name="LogicalOperatorMustHaveBooleanOperators" xml:space="preserve">
     <value>The user-defined operator method '{1}' for operator '{0}' must have associated boolean True and False operators.</value>
   </data>
-  <data name="MethodDoesNotExistOnType" xml:space="preserve">
-    <value>No method '{0}' exists on type '{1}'.</value>
-  </data>
   <data name="MethodWithArgsDoesNotExistOnType" xml:space="preserve">
     <value>No method '{0}' on type '{1}' is compatible with the supplied arguments.</value>
   </data>
@@ -650,8 +647,5 @@
   </data>
   <data name="SameKeyExistsInExpando" xml:space="preserve">
     <value>An element with the same key '{0}' already exists in the ExpandoObject.</value>
-  </data>
-  <data name="InterpreterCannotThrowNonExceptions" xml:space="preserve">
-    <value>Interpreted expressions cannot throw an object of a type that is not derived from System.Exception.</value>
   </data>
 </root>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -611,13 +611,6 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "Expression of type '{0}' cannot be used for constructor parameter of type '{1}'"
         /// </summary>
-        internal static Exception ExpressionTypeDoesNotMatchConstructorParameter(object p0, object p1, string paramName)
-        {
-            return Dynamic.Utils.Error.ExpressionTypeDoesNotMatchConstructorParameter(p0, p1, paramName);
-        }
-        /// <summary>
-        /// ArgumentException with message like "Expression of type '{0}' cannot be used for constructor parameter of type '{1}'"
-        /// </summary>
         internal static Exception ExpressionTypeDoesNotMatchConstructorParameter(object p0, object p1, string paramName, int index)
         {
             return Dynamic.Utils.Error.ExpressionTypeDoesNotMatchConstructorParameter(p0, p1, paramName, index);
@@ -1010,13 +1003,6 @@ namespace System.Linq.Expressions
             return new ArgumentException(Strings.LogicalOperatorMustHaveBooleanOperators(p0, p1));
         }
         /// <summary>
-        /// InvalidOperationException with message like "No method '{0}' exists on type '{1}'."
-        /// </summary>
-        internal static Exception MethodDoesNotExistOnType(object p0, object p1)
-        {
-            return new InvalidOperationException(Strings.MethodDoesNotExistOnType(p0, p1));
-        }
-        /// <summary>
         /// InvalidOperationException with message like "No method '{0}' on type '{1}' is compatible with the supplied arguments."
         /// </summary>
         internal static Exception MethodWithArgsDoesNotExistOnType(object p0, object p1)
@@ -1317,14 +1303,12 @@ namespace System.Linq.Expressions
             return new InvalidOperationException(Strings.NonAbstractConstructorRequired);
         }
 
+        /// <summary>
+        /// InvalidProgramException with default message.
+        /// </summary>
         internal static Exception InvalidProgram()
         {
             return new InvalidProgramException();
-        }
-
-        internal static InvalidOperationException InterpreterCannotThrowNonExceptions()
-        {
-            return new InvalidOperationException(Strings.InterpreterCannotThrowNonExceptions);
         }
 
         private static string GetParamName(string paramName, int index)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -630,11 +630,6 @@ namespace System.Linq.Expressions
         internal static string LogicalOperatorMustHaveBooleanOperators(object p0, object p1) => SR.Format(SR.LogicalOperatorMustHaveBooleanOperators, p0, p1);
 
         /// <summary>
-        /// A string like "No method '{0}' exists on type '{1}'."
-        /// </summary>
-        internal static string MethodDoesNotExistOnType(object p0, object p1) => SR.Format(SR.MethodDoesNotExistOnType, p0, p1);
-
-        /// <summary>
         /// A string like "No method '{0}' on type '{1}' is compatible with the supplied arguments."
         /// </summary>
         internal static string MethodWithArgsDoesNotExistOnType(object p0, object p1) => SR.Format(SR.MethodWithArgsDoesNotExistOnType, p0, p1);
@@ -834,10 +829,5 @@ namespace System.Linq.Expressions
         /// A string like "The constructor should not be declared on an abstract class"
         /// </summary>
         internal static string NonAbstractConstructorRequired => SR.NonAbstractConstructorRequired;
-
-        /// <summary>
-        /// A string like "Interpreted expressions cannot throw an object of a type that is not derived from System.Exception.".
-        /// </summary>
-        internal static string InterpreterCannotThrowNonExceptions => SR.InterpreterCannotThrowNonExceptions;
     }
 }


### PR DESCRIPTION
Removing some `Error` and `String` members that are no longer used.