### PR TITLE
[WIP] Add P2P reference to Microsoft.CSharp to System.Linq.Expressions.Tests

### DIFF
--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -247,6 +247,10 @@
       <Project>{aef718e9-d4fc-418f-a7ae-ed6b2c7b3787}</Project>
       <Name>System.Linq.Expressions</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Microsoft.CSharp\src\Microsoft.CSharp.csproj">
+      <Project>{96AA2060-C846-4E56-9509-E8CB9C114C8F}</Project>
+      <Name>Microsoft.CSharp</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Include the tests in the code coverage analysis of CSharp.

As discussed at https://github.com/dotnet/corefx/pull/14014#discussion_r89675755

Before merge a coverage test should be done after #14016 has removed the duplication of tests.