### PR TITLE
Reuse _state in some iterators.

### DIFF
--- a/src/System.Linq/src/System/Linq/Partition.cs
+++ b/src/System.Linq/src/System/Linq/Partition.cs
@@ -253,7 +253,10 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                int index = _state - 1; // Represents the zero-based index we're at.
+                // _state - 1 represents the zero-based index into the list.
+                // Having a separate field for the index would be more readable. However, we save it
+                // into _state with a bias to minimize field size of the iterator.
+                int index = _state - 1;
                 if ((uint)index <= (uint)(_maxIndexInclusive - _minIndexInclusive) && index < _source.Count - _minIndexInclusive)
                 {
                     _current = _source[_minIndexInclusive + index];

--- a/src/System.Linq/src/System/Linq/Partition.cs
+++ b/src/System.Linq/src/System/Linq/Partition.cs
@@ -235,7 +235,6 @@ namespace System.Linq
             private readonly IList<TSource> _source;
             private readonly int _minIndexInclusive;
             private readonly int _maxIndexInclusive;
-            private int _index;
 
             public ListPartition(IList<TSource> source, int minIndexInclusive, int maxIndexInclusive)
             {
@@ -245,7 +244,6 @@ namespace System.Linq
                 _source = source;
                 _minIndexInclusive = minIndexInclusive;
                 _maxIndexInclusive = maxIndexInclusive;
-                _index = minIndexInclusive;
             }
 
             public override Iterator<TSource> Clone()
@@ -255,10 +253,11 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                if ((_state == 1 & _index <= _maxIndexInclusive) && _index < _source.Count)
+                int index = _state - 1; // Represents the zero-based index we're at.
+                if ((uint)index <= (uint)(_maxIndexInclusive - _minIndexInclusive) && index < _source.Count - _minIndexInclusive)
                 {
-                    _current = _source[_index];
-                    ++_index;
+                    _current = _source[_minIndexInclusive + index];
+                    ++_state;
                     return true;
                 }
 

--- a/src/System.Linq/src/System/Linq/Repeat.cs
+++ b/src/System.Linq/src/System/Linq/Repeat.cs
@@ -46,14 +46,20 @@ namespace System.Linq
 
             public override void Dispose()
             {
-                // Don't let base Dispose wipe current.
+                // Don't let base.Dispose wipe Current.
                 _state = -1;
             }
 
             public override bool MoveNext()
             {
+                // Having a separate field for the number of sent items would be more readable.
+                // However, we save it into _state with a bias to minimize field size of the iterator.
                 int sent = _state - 1;
-                if (sent > -1 && sent != _count)
+
+                // We can't have sent a negative number of items, obviously. However, if this iterator
+                // was illegally casted to IEnumerator without GetEnumerator being called, or if we've
+                // already been disposed, then `sent` will be negative.
+                if (sent >= 0 && sent != _count)
                 {
                     ++_state;
                     return true;

--- a/src/System.Linq/src/System/Linq/Repeat.cs
+++ b/src/System.Linq/src/System/Linq/Repeat.cs
@@ -31,7 +31,6 @@ namespace System.Linq
         private sealed class RepeatIterator<TResult> : Iterator<TResult>, IPartition<TResult>
         {
             private readonly int _count;
-            private int _sent;
 
             public RepeatIterator(TResult element, int count)
             {
@@ -53,13 +52,14 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                if (_state == 1 & _sent != _count)
+                int sent = _state - 1;
+                if (sent > -1 && sent != _count)
                 {
-                    ++_sent;
+                    ++_state;
                     return true;
                 }
 
-                _state = -1;
+                Dispose();
                 return false;
             }
 

--- a/src/System.Linq/src/System/Linq/Reverse.cs
+++ b/src/System.Linq/src/System/Linq/Reverse.cs
@@ -42,7 +42,7 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                if (_state - 3 <= -3)
+                if (_state - 2 <= -2)
                 {
                     Dispose();
                     return false;

--- a/src/System.Linq/src/System/Linq/Reverse.cs
+++ b/src/System.Linq/src/System/Linq/Reverse.cs
@@ -44,6 +44,11 @@ namespace System.Linq
             {
                 if (_state - 2 <= -2)
                 {
+                    // Either someone called a method and cast us to IEnumerable without calling GetEnumerator,
+                    // or we were already disposed. In either case, iteration has ended, so return false.
+                    // A comparison is made against -2 instead of _state <= 0 because we want to handle cases where
+                    // the source is really large and adding the bias causes _state to overflow.
+                    Debug.Assert(_state == -1 || _state == 0);
                     Dispose();
                     return false;
                 }
@@ -51,11 +56,17 @@ namespace System.Linq
                 switch (_state)
                 {
                     case 1:
+                        // Iteration has just started. Capture the source into an array and set _state to 2 + the count.
+                        // Having an extra field for the count would be more readable, but we save it into _state with a
+                        // bias instead to minimize field size of the iterator.
                         Buffer<TSource> buffer = new Buffer<TSource>(_source);
                         _buffer = buffer._items;
                         _state = buffer._count + 2;
                         goto default;
                     default:
+                        // At this stage, _state starts from 2 + the count. _state - 3 represents the current index into the
+                        // buffer. It is continuously decremented until it hits 2, which means that we've run out of items to
+                        // yield and should return false.
                         int index = _state - 3;
                         if (index != -1)
                         {

--- a/src/System.Linq/src/System/Linq/Reverse.cs
+++ b/src/System.Linq/src/System/Linq/Reverse.cs
@@ -28,7 +28,6 @@ namespace System.Linq
         {
             private readonly IEnumerable<TSource> _source;
             private TSource[] _buffer;
-            private int _index;
 
             public ReverseIterator(IEnumerable<TSource> source)
             {
@@ -43,19 +42,25 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
+                if (_state - 3 <= -3)
+                {
+                    Dispose();
+                    return false;
+                }
+
                 switch (_state)
                 {
                     case 1:
                         Buffer<TSource> buffer = new Buffer<TSource>(_source);
                         _buffer = buffer._items;
-                        _index = buffer._count - 1;
-                        _state = 2;
-                        goto case 2;
-                    case 2:
-                        if (_index != -1)
+                        _state = buffer._count + 2;
+                        goto default;
+                    default:
+                        int index = _state - 3;
+                        if (index != -1)
                         {
-                            _current = _buffer[_index];
-                            --_index;
+                            _current = _buffer[index];
+                            --_state;
                             return true;
                         }
 

--- a/src/System.Linq/src/System/Linq/Select.cs
+++ b/src/System.Linq/src/System/Linq/Select.cs
@@ -843,6 +843,9 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
+                // _state - 1 represents the zero-based index into the list.
+                // Having a separate field for the index would be more readable. However, we save it
+                // into _state with a bias to minimize field size of the iterator.
                 int index = _state - 1;
                 if ((uint)index <= (uint)(_maxIndexInclusive - _minIndexInclusive) && index < _source.Count - _minIndexInclusive)
                 {

--- a/src/System.Linq/src/System/Linq/Select.cs
+++ b/src/System.Linq/src/System/Linq/Select.cs
@@ -823,7 +823,6 @@ namespace System.Linq
             private readonly Func<TSource, TResult> _selector;
             private readonly int _minIndexInclusive;
             private readonly int _maxIndexInclusive;
-            private int _index;
 
             public SelectListPartitionIterator(IList<TSource> source, Func<TSource, TResult> selector, int minIndexInclusive, int maxIndexInclusive)
             {
@@ -835,7 +834,6 @@ namespace System.Linq
                 _selector = selector;
                 _minIndexInclusive = minIndexInclusive;
                 _maxIndexInclusive = maxIndexInclusive;
-                _index = minIndexInclusive;
             }
 
             public override Iterator<TResult> Clone()
@@ -845,10 +843,11 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                if ((_state == 1 & _index <= _maxIndexInclusive) && _index < _source.Count)
+                int index = _state - 1;
+                if ((uint)index <= (uint)(_maxIndexInclusive - _minIndexInclusive) && index < _source.Count - _minIndexInclusive)
                 {
-                    _current = _selector(_source[_index]);
-                    ++_index;
+                    _current = _selector(_source[_minIndexInclusive + index]);
+                    ++_state;
                     return true;
                 }
 


### PR DESCRIPTION
There are some iterators where we can simply reuse `_state`, instead of defining another mutable int field. This PR removes all such fields & refactors their call sites to use `_state` instead, decreasing the number of fields in the object layout.

cc @stephentoub @JonHanna @VSadov 