### PR TITLE
Correct parameter name if passing generic type to Expression.New

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
@@ -189,6 +189,7 @@ namespace System.Linq.Expressions
             {
                 throw Error.ArgumentCannotBeOfTypeVoid(nameof(type));
             }
+            TypeUtils.ValidateType(type, nameof(type));
 
             if (!type.GetTypeInfo().IsValueType)
             {


### PR DESCRIPTION
Fixes #14022