### PR TITLE
Remove dead branch from Linq.Expressions.Compiler.ILGen.EmitNew

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -510,9 +510,6 @@
   <data name="UnknownLiftType" xml:space="preserve">
     <value>unknown lift type: '{0}'.</value>
   </data>
-  <data name="IllegalNewGenericParams" xml:space="preserve">
-    <value>Cannot create instance of {0} because it contains generic parameters</value>
-  </data>
   <data name="UndefinedVariable" xml:space="preserve">
     <value>variable '{0}' of type '{1}' referenced from scope '{2}', but it is not defined</value>
   </data>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -347,11 +347,7 @@ namespace System.Linq.Expressions.Compiler
         internal static void EmitNew(this ILGenerator il, ConstructorInfo ci)
         {
             Debug.Assert(ci != null);
-
-            if (ci.DeclaringType.GetTypeInfo().ContainsGenericParameters)
-            {
-                throw Error.IllegalNewGenericParams(ci.DeclaringType, nameof(ci));
-            }
+            Debug.Assert(!ci.DeclaringType.GetTypeInfo().ContainsGenericParameters);
 
             il.Emit(OpCodes.Newobj, ci);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -1158,13 +1158,7 @@ namespace System.Linq.Expressions
         {
             return new InvalidOperationException(Strings.UnknownLiftType(p0));
         }
-        /// <summary>
-        /// ArgumentException with message like "Cannot create instance of {0} because it contains generic parameters"
-        /// </summary>
-        internal static Exception IllegalNewGenericParams(object p0, string paramName)
-        {
-            return new ArgumentException(Strings.IllegalNewGenericParams(p0), paramName);
-        }
+
         /// <summary>
         /// InvalidOperationException with message like "variable '{0}' of type '{1}' referenced from scope '{2}', but it is not defined"
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -742,11 +742,6 @@ namespace System.Linq.Expressions
         internal static string UnknownLiftType(object p0) => SR.Format(SR.UnknownLiftType, p0);
 
         /// <summary>
-        /// A string like "Cannot create instance of {0} because it contains generic parameters"
-        /// </summary>
-        internal static string IllegalNewGenericParams(object p0) => SR.Format(SR.IllegalNewGenericParams, p0);
-
-        /// <summary>
         /// A string like "variable '{0}' of type '{1}' referenced from scope '{2}', but it is not defined"
         /// </summary>
         internal static string UndefinedVariable(object p0, object p1, object p2) => SR.Format(SR.UndefinedVariable, p0, p1, p2);


### PR DESCRIPTION
The only way of hitting this method is either from some internal uses with cached ctors, or compiling a `NewExpression`. The tests included in #14024 demonstrate that these can never contain a ctor that contains generic parameters, so the check that they don't can never fail.

Remove it.