### PR TITLE
[WIP] Use RuntimeHelpers.Equals to avoid spurious events in ExpandoObject

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
@@ -173,7 +173,7 @@ namespace System.Dynamic
 
             // Notify property changed outside the lock
             PropertyChangedEventHandler propertyChanged = _propertyChanged;
-            if (propertyChanged != null && value != oldValue)
+            if (propertyChanged != null && !RuntimeHelpers.Equals(value, oldValue))
             {
                 propertyChanged(this, new PropertyChangedEventArgs(data.Class.Keys[index]));
             }


### PR DESCRIPTION
As well as not raising the event when set with the same instance as the current value, will also not raise it when set to an identical valuetype value.

Fixes #13831