### PR TITLE
Fix two bugs with goto expressions in interpreter.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LabelInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LabelInfo.cs
@@ -110,6 +110,10 @@ namespace System.Linq.Expressions.Interpreter
             }
 
             _acrossBlockJump = true;
+            if (_node != null && _node.Type != typeof(void))
+            {
+                throw Error.NonLocalJumpWithValue(_node.Name);
+            }
 
             if (HasMultipleDefinitions)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -340,6 +340,10 @@ namespace System.Linq.Expressions.Interpreter
         private Interpreter MakeInterpreter(string lambdaName)
         {
             DebugInfo[] debugInfos = _debugInfos.ToArray();
+            foreach (KeyValuePair<LabelTarget, LabelInfo> kvp in _treeLabels)
+            {
+                kvp.Value.ValidateFinish();
+            }
             return new Interpreter(lambdaName, _locals, _instructions.ToArray(), debugInfos);
         }
 

--- a/src/System.Linq.Expressions/tests/Goto/Break.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Break.cs
@@ -212,5 +212,81 @@ namespace System.Linq.Expressions.Tests
         {
             Assert.Throws<ArgumentException>("type", () => Expression.Break(Expression.Label(typeof(void)), typeof(int).MakeByRefType()));
         }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void UndefinedLabel(bool useInterpreter)
+        {
+            Expression<Action> breakNowhere = Expression.Lambda<Action>(Expression.Break(Expression.Label()));
+            Assert.Throws<InvalidOperationException>(() => breakNowhere.Compile(useInterpreter));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void AmbiguousJump(bool useInterpreter)
+        {
+            LabelTarget target = Expression.Label();
+            Expression<Action> exp = Expression.Lambda<Action>(
+                Expression.Block(
+                    Expression.Break(target),
+                    Expression.Block(Expression.Label(target)),
+                    Expression.Block(Expression.Label(target))
+                    )
+                );
+            Assert.Throws<InvalidOperationException>(() => exp.Compile(useInterpreter));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void MultipleDefinitionsInSeparateBlocks(bool useInterpreter)
+        {
+            LabelTarget target = Expression.Label(typeof(int));
+            Func<int> add = Expression.Lambda<Func<int>>(
+                Expression.Add(
+                    Expression.Add(
+                        Expression.Block(
+                            Expression.Break(target, Expression.Constant(6)),
+                            Expression.Throw(Expression.Constant(new Exception())),
+                            Expression.Label(target, Expression.Constant(0))
+                        ),
+                        Expression.Block(
+                            Expression.Break(target, Expression.Constant(4)),
+                            Expression.Throw(Expression.Constant(new Exception())),
+                            Expression.Label(target, Expression.Constant(0))
+                        )
+                    ),
+                    Expression.Block(
+                        Expression.Break(target, Expression.Constant(5)),
+                        Expression.Throw(Expression.Constant(new Exception())),
+                        Expression.Label(target, Expression.Constant(0))
+                    )
+                )
+            ).Compile(useInterpreter);
+            Assert.Equal(15, add());
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void JumpIntoExpression(bool useInterpreter)
+        {
+            LabelTarget target = Expression.Label();
+            Expression<Func<bool>> isInt = Expression.Lambda<Func<bool>>(
+                Expression.Block(
+                    Expression.Break(target),
+                    Expression.TypeIs(Expression.Label(target), typeof(int))
+                )
+            );
+            Assert.Throws<InvalidOperationException>(() => isInt.Compile(useInterpreter));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void JumpInWithValue(bool useInterpreter)
+        {
+            LabelTarget target = Expression.Label(typeof(int));
+            Expression<Func<int>> exp = Expression.Lambda<Func<int>>(
+                Expression.Block(
+                Expression.Break(target, Expression.Constant(2)),
+                Expression.Block(
+                    Expression.Label(target, Expression.Constant(3)))
+                )
+            );
+            Assert.Throws<InvalidOperationException>(() => exp.Compile(useInterpreter));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Goto/Continue.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Continue.cs
@@ -89,5 +89,62 @@ namespace System.Linq.Expressions.Tests
         {
             Assert.Throws<ArgumentException>("type", () => Expression.Continue(Expression.Label(typeof(void)), typeof(int).MakeByRefType()));
         }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void UndefinedLabel(bool useInterpreter)
+        {
+            Expression<Action> continueNowhere = Expression.Lambda<Action>(Expression.Continue(Expression.Label()));
+            Assert.Throws<InvalidOperationException>(() => continueNowhere.Compile(useInterpreter));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void AmbiguousJump(bool useInterpreter)
+        {
+            LabelTarget target = Expression.Label();
+            Expression<Action> exp = Expression.Lambda<Action>(
+                Expression.Block(
+                    Expression.Continue(target),
+                    Expression.Block(Expression.Label(target)),
+                    Expression.Block(Expression.Label(target))
+                    )
+                );
+            Assert.Throws<InvalidOperationException>(() => exp.Compile(useInterpreter));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void MultipleDefinitionsInSeparateBlocks(bool useInterpreter)
+        {
+            LabelTarget target = Expression.Label();
+            Func<int> add = Expression.Lambda<Func<int>>(
+                Expression.Add(
+                    Expression.Block(
+                        Expression.Continue(target),
+                        Expression.Throw(Expression.Constant(new Exception())),
+                        Expression.Label(target),
+                        Expression.Constant(10)
+                    ),
+                    Expression.Block(
+                        Expression.Continue(target),
+                        Expression.Throw(Expression.Constant(new Exception())),
+                        Expression.Label(target),
+                        Expression.Constant(5)
+                    )
+                )
+            ).Compile(useInterpreter);
+            Assert.Equal(15, add());
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void JumpIntoExpression(bool useInterpreter)
+        {
+            LabelTarget target = Expression.Label();
+            Expression<Func<bool>> isInt = Expression.Lambda<Func<bool>>(
+                Expression.Block(
+                    Expression.Continue(target),
+                    Expression.TypeIs(Expression.Label(target), typeof(int))
+                )
+            );
+            Assert.Throws<InvalidOperationException>(() => isInt.Compile(useInterpreter));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Goto/Goto.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Goto.cs
@@ -212,5 +212,81 @@ namespace System.Linq.Expressions.Tests
         {
             Assert.Throws<ArgumentException>("type", () => Expression.Goto(Expression.Label(typeof(void)), typeof(int).MakeByRefType()));
         }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void UndefinedLabel(bool useInterpreter)
+        {
+            Expression<Action> goNowhere = Expression.Lambda<Action>(Expression.Goto(Expression.Label()));
+            Assert.Throws<InvalidOperationException>(() => goNowhere.Compile(useInterpreter));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void AmbiguousJump(bool useInterpreter)
+        {
+            LabelTarget target = Expression.Label();
+            Expression<Action> exp = Expression.Lambda<Action>(
+                Expression.Block(
+                    Expression.Goto(target),
+                    Expression.Block(Expression.Label(target)),
+                    Expression.Block(Expression.Label(target))
+                    )
+                );
+            Assert.Throws<InvalidOperationException>(() => exp.Compile(useInterpreter));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void MultipleDefinitionsInSeparateBlocks(bool useInterpreter)
+        {
+            LabelTarget target = Expression.Label(typeof(int));
+            Func<int> add = Expression.Lambda<Func<int>>(
+                Expression.Add(
+                    Expression.Add(
+                        Expression.Block(
+                            Expression.Goto(target, Expression.Constant(6)),
+                            Expression.Throw(Expression.Constant(new Exception())),
+                            Expression.Label(target, Expression.Constant(0))
+                        ),
+                        Expression.Block(
+                            Expression.Goto(target, Expression.Constant(4)),
+                            Expression.Throw(Expression.Constant(new Exception())),
+                            Expression.Label(target, Expression.Constant(0))
+                        )
+                    ),
+                    Expression.Block(
+                        Expression.Goto(target, Expression.Constant(5)),
+                        Expression.Throw(Expression.Constant(new Exception())),
+                        Expression.Label(target, Expression.Constant(0))
+                    )
+                )
+            ).Compile(useInterpreter);
+            Assert.Equal(15, add());
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void JumpIntoExpression(bool useInterpreter)
+        {
+            LabelTarget target = Expression.Label();
+            Expression<Func<bool>> isInt = Expression.Lambda<Func<bool>>(
+                Expression.Block(
+                    Expression.Goto(target),
+                    Expression.TypeIs(Expression.Label(target), typeof(int))
+                )
+            );
+            Assert.Throws<InvalidOperationException>(() => isInt.Compile(useInterpreter));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void JumpInWithValue(bool useInterpreter)
+        {
+            LabelTarget target = Expression.Label(typeof(int));
+            Expression<Func<int>> exp = Expression.Lambda<Func<int>>(
+                Expression.Block(
+                Expression.Goto(target, Expression.Constant(2)),
+                Expression.Block(
+                    Expression.Label(target, Expression.Constant(3)))
+                )
+            );
+            Assert.Throws<InvalidOperationException>(() => exp.Compile(useInterpreter));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Goto/Return.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Return.cs
@@ -212,5 +212,81 @@ namespace System.Linq.Expressions.Tests
         {
             Assert.Throws<ArgumentException>("type", () => Expression.Return(Expression.Label(typeof(void)), typeof(int).MakeByRefType()));
         }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void UndefinedLabel(bool useInterpreter)
+        {
+            Expression<Action> returnNowhere = Expression.Lambda<Action>(Expression.Return(Expression.Label()));
+            Assert.Throws<InvalidOperationException>(() => returnNowhere.Compile(useInterpreter));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void AmbiguousJump(bool useInterpreter)
+        {
+            LabelTarget target = Expression.Label();
+            Expression<Action> exp = Expression.Lambda<Action>(
+                Expression.Block(
+                    Expression.Return(target),
+                    Expression.Block(Expression.Label(target)),
+                    Expression.Block(Expression.Label(target))
+                    )
+                );
+            Assert.Throws<InvalidOperationException>(() => exp.Compile(useInterpreter));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void MultipleDefinitionsInSeparateBlocks(bool useInterpreter)
+        {
+            LabelTarget target = Expression.Label(typeof(int));
+            Func<int> add = Expression.Lambda<Func<int>>(
+                Expression.Add(
+                    Expression.Add(
+                        Expression.Block(
+                            Expression.Return(target, Expression.Constant(6)),
+                            Expression.Throw(Expression.Constant(new Exception())),
+                            Expression.Label(target, Expression.Constant(0))
+                        ),
+                        Expression.Block(
+                            Expression.Return(target, Expression.Constant(4)),
+                            Expression.Throw(Expression.Constant(new Exception())),
+                            Expression.Label(target, Expression.Constant(0))
+                        )
+                    ),
+                    Expression.Block(
+                        Expression.Return(target, Expression.Constant(5)),
+                        Expression.Throw(Expression.Constant(new Exception())),
+                        Expression.Label(target, Expression.Constant(0))
+                    )
+                )
+            ).Compile(useInterpreter);
+            Assert.Equal(15, add());
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void JumpIntoExpression(bool useInterpreter)
+        {
+            LabelTarget target = Expression.Label();
+            Expression<Func<bool>> isInt = Expression.Lambda<Func<bool>>(
+                Expression.Block(
+                    Expression.Return(target),
+                    Expression.TypeIs(Expression.Label(target), typeof(int))
+                )
+            );
+            Assert.Throws<InvalidOperationException>(() => isInt.Compile(useInterpreter));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void JumpInWithValue(bool useInterpreter)
+        {
+            LabelTarget target = Expression.Label(typeof(int));
+            Expression<Func<int>> exp = Expression.Lambda<Func<int>>(
+                Expression.Block(
+                Expression.Return(target, Expression.Constant(2)),
+                Expression.Block(
+                    Expression.Label(target, Expression.Constant(3)))
+                )
+            );
+            Assert.Throws<InvalidOperationException>(() => exp.Compile(useInterpreter));
+        }
     }
 }


### PR DESCRIPTION
Correctly validate jumps to undefined labels in interpreter

Fixes #14032

Validate against jumping into an inner block with a value.

Fixes #14033

(The idea of allowing such jumps if they would be well-defined could be investigated, but this brings the interpreter behaviour into line with the compiler behaviour).

Tests included cover some other previously untested uses of branching expressions.