### PR TITLE
SslStream override FlushAsync

### DIFF
--- a/src/Common/tests/System/Net/VirtualNetwork/VirtualNetworkStream.cs
+++ b/src/Common/tests/System/Net/VirtualNetwork/VirtualNetworkStream.cs
@@ -15,6 +15,7 @@ namespace System.Net.Test.Common
         private readonly bool _isServer;
         private object _readStreamLock = new object();
         private TaskCompletionSource<object> _flushTcs;
+        private bool _isFlushed;
 
         public VirtualNetworkStream(VirtualNetwork network, bool isServer)
         {
@@ -69,7 +70,7 @@ namespace System.Net.Test.Common
 
         public override void Flush()
         {
-            // No-op.
+            _isFlushed = true;
         }
 
         public override Task FlushAsync(CancellationToken cancellationToken)
@@ -82,6 +83,8 @@ namespace System.Net.Test.Common
 
             return _flushTcs.Task;
         }
+
+        public bool HasBeenSyncFlushed => _isFlushed;
 
         public void CompleteAsyncFlush()
         {

--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -81,6 +81,7 @@ namespace System.Net.Security
         public override int EndRead(IAsyncResult asyncResult) { throw null; }
         public override void EndWrite(IAsyncResult asyncResult) { }
         public override void Flush() { }
+        public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
         public override void SetLength(long value) { }
@@ -162,6 +163,7 @@ namespace System.Net.Security
         public override int EndRead(IAsyncResult asyncResult) { throw null; }
         public override void EndWrite(IAsyncResult asyncResult) { }
         public override void Flush() { }
+        public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
         public override void SetLength(long value) { }

--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -81,7 +81,9 @@ namespace System.Net.Security
         public override int EndRead(IAsyncResult asyncResult) { throw null; }
         public override void EndWrite(IAsyncResult asyncResult) { }
         public override void Flush() { }
+#if netcoreapp11
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+#endif
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
         public override void SetLength(long value) { }
@@ -163,7 +165,9 @@ namespace System.Net.Security
         public override int EndRead(IAsyncResult asyncResult) { throw null; }
         public override void EndWrite(IAsyncResult asyncResult) { }
         public override void Flush() { }
+#if netcoreapp11
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+#endif
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
         public override void SetLength(long value) { }

--- a/src/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
@@ -507,7 +507,7 @@ namespace System.Net.Security
         {
             using (DebugThreadTracking.SetThreadKind(ThreadKinds.User | ThreadKinds.Async))
             {
-                await InnerStream.FlushAsync(cancellationToken);
+                await InnerStream.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
         }
 #else

--- a/src/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
@@ -502,6 +502,21 @@ namespace System.Net.Security
 #endif
         }
 
+#if DEBUG
+        public override async Task FlushAsync(CancellationToken cancellationToken)
+        {
+            using (DebugThreadTracking.SetThreadKind(ThreadKinds.User | ThreadKinds.Async))
+            {
+                await InnerStream.FlushAsync(cancellationToken);
+            }
+        }
+#else
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return InnerStream.FlushAsync(cancellationToken);
+        }
+#endif
+
         protected override void Dispose(bool disposing)
         {
 #if DEBUG

--- a/src/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
@@ -502,20 +502,10 @@ namespace System.Net.Security
 #endif
         }
 
-#if DEBUG
-        public override async Task FlushAsync(CancellationToken cancellationToken)
-        {
-            using (DebugThreadTracking.SetThreadKind(ThreadKinds.User | ThreadKinds.Async))
-            {
-                await InnerStream.FlushAsync(cancellationToken).ConfigureAwait(false);
-            }
-        }
-#else
         public override Task FlushAsync(CancellationToken cancellationToken)
         {
             return InnerStream.FlushAsync(cancellationToken);
         }
-#endif
 
         protected override void Dispose(bool disposing)
         {

--- a/src/System.Net.Security/src/System/Net/Security/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslState.cs
@@ -11,6 +11,7 @@ using System.Security.Authentication;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Security
 {
@@ -475,6 +476,11 @@ namespace System.Net.Security
         internal void Flush()
         {
             InnerStream.Flush();
+        }
+
+        internal Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return InnerStream.FlushAsync(cancellationToken);
         }
 
         //

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -490,6 +490,11 @@ namespace System.Net.Security
             _sslState.Flush();
         }
 
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return _sslState.FlushAsync(cancellationToken);
+        }
+
         protected override void Dispose(bool disposing)
         {
             try

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
@@ -261,6 +261,22 @@ namespace System.Net.Security.Tests
             }
         }
 
+
+        [OuterLoop] // TODO: Issue #11345
+        [Fact]
+        public void NegotiateStream_StreamToStream_Flush_Propagated()
+        {
+            VirtualNetwork network = new VirtualNetwork();
+
+            using (var stream = new VirtualNetworkStream(network, isServer: false))
+            using (var negotiateStream = new NegotiateStream(stream))
+            {
+                Assert.False(stream.HasBeenSyncFlushed);
+                negotiateStream.Flush();
+                Assert.True(stream.HasBeenSyncFlushed);
+            }
+        }
+
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void NegotiateStream_StreamToStream_FlushAsync_Propagated()

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
@@ -260,6 +260,23 @@ namespace System.Net.Security.Tests
                 Assert.True(_sampleMsg.SequenceEqual(recvBuf));
             }
         }
+
+        [OuterLoop] // TODO: Issue #11345
+        [Fact]
+        public void NegotiateStream_StreamToStream_FlushAsync_Propagated()
+        {
+            VirtualNetwork network = new VirtualNetwork();
+
+            using (var stream = new VirtualNetworkStream(network, isServer: false))
+            using (var negotiateStream = new NegotiateStream(stream))
+            {
+                Task task = negotiateStream.FlushAsync();
+
+                Assert.False(task.IsCompleted);
+                stream.CompleteAsyncFlush();
+                Assert.True(task.IsCompleted);
+            }
+        }
     }
 
     public sealed class NegotiateStreamStreamToStreamTest_Async : NegotiateStreamStreamToStreamTest

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -258,6 +258,23 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [OuterLoop] // TODO: Issue #11345
+        [Fact]
+        public void SslStream_StreamToStream_FlushAsync_Propagated()
+        {
+            VirtualNetwork network = new VirtualNetwork();
+
+            using (var stream = new VirtualNetworkStream(network, isServer: false))
+            using (var sslStream = new SslStream(stream, false, AllowAnyServerCertificate))
+            {
+                Task task = sslStream.FlushAsync();
+
+                Assert.False(task.IsCompleted);
+                stream.CompleteAsyncFlush();
+                Assert.True(task.IsCompleted);
+            }
+        }
+
         private bool VerifyOutput(byte[] actualBuffer, byte[] expectedBuffer)
         {
             return expectedBuffer.SequenceEqual(actualBuffer);

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -260,6 +260,21 @@ namespace System.Net.Security.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Fact]
+        public void SslStream_StreamToStream_Flush_Propagated()
+        {
+            VirtualNetwork network = new VirtualNetwork();
+
+            using (var stream = new VirtualNetworkStream(network, isServer: false))
+            using (var sslStream = new SslStream(stream, false, AllowAnyServerCertificate))
+            {
+                Assert.False(stream.HasBeenSyncFlushed);
+                sslStream.Flush();
+                Assert.True(stream.HasBeenSyncFlushed);
+            }
+        }
+
+        [OuterLoop] // TODO: Issue #11345
+        [Fact]
         public void SslStream_StreamToStream_FlushAsync_Propagated()
         {
             VirtualNetwork network = new VirtualNetwork();

--- a/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
+++ b/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
@@ -6,6 +6,8 @@ using System.IO;
 using System.Security.Authentication;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Security
 {
@@ -155,6 +157,11 @@ namespace System.Net.Security
         {
         }
 
+        internal Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
         //
         // This is to not depend on GC&SafeHandle class if the context is not needed anymore.
         //
@@ -235,6 +242,11 @@ namespace System.Net.Security
         public override void Flush()
         {
             throw new NotImplementedException();
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromException(new NotImplementedException());
         }
 
         public override int Read(byte[] buffer, int offset, int count)


### PR DESCRIPTION
SslStream should override FlushAsync over its internal stream; otherwise the default Stream implementation is used; which creates a new task which runs the sync/blocking flush and queues it to the threadpool.

Default Stream implementation:
```csharp
public virtual Task FlushAsync(CancellationToken cancellationToken)
{
	return Task.Factory.StartNew(state => ((Stream)state).Flush(), this,
		cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
}
```

Resolves https://github.com/dotnet/corefx/issues/14038

/cc @stephentoub 