### PR TITLE
Updated ConcurrentDictionary get values and keys to use arrays

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1903,13 +1903,14 @@ namespace System.Collections.Concurrent
                 int count = GetCountInternal();
                 if (count < 0) throw new OutOfMemoryException();
 
-                List<TKey> keys = new List<TKey>(count);
+                int keyIndex = 0;
+                TKey[] keys = new TKey[count];
                 for (int i = 0; i < _tables._buckets.Length; i++)
                 {
                     Node current = _tables._buckets[i];
                     while (current != null)
                     {
-                        keys.Add(current._key);
+                        keys[keyIndex++] = current._key;
                         current = current._next;
                     }
                 }
@@ -1935,13 +1936,14 @@ namespace System.Collections.Concurrent
                 int count = GetCountInternal();
                 if (count < 0) throw new OutOfMemoryException();
 
-                List<TValue> values = new List<TValue>(count);
+                int valueIndex = 0;
+                TValue[] values = new TValue[count];
                 for (int i = 0; i < _tables._buckets.Length; i++)
                 {
                     Node current = _tables._buckets[i];
                     while (current != null)
                     {
-                        values.Add(current._value);
+                        values[valueIndex++] = current._value;
                         current = current._next;
                     }
                 }


### PR DESCRIPTION
In PR #13751, @stephentoub mentioned the possibility of updating ConcurrentDictionary.GetKeys and ConcurrentDictionary.GetValues to use arrays instead of lists.

This update seems to increase performance by %10, please see this test for details:
(https://gist.github.com/tdupont750/bcabe006dcb6ba8bf8ffe64bd9e0a644)