### PR TITLE
Use TrueReadOnlyCollection<T> in a few more places

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/BindingRestrictions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/BindingRestrictions.cs
@@ -314,26 +314,28 @@ namespace System.Dynamic
                 ParameterExpression temp = Expression.Parameter(typeof(object), null);
                 return Expression.Block(
                     new TrueReadOnlyCollection<ParameterExpression>(temp),
+                    new TrueReadOnlyCollection<Expression>(
 #if ENABLEDYNAMICPROGRAMMING
-                    Expression.Assign(
-                        temp,
-                        Expression.Property(
-                            Expression.Constant(new WeakReference(_instance)),
-                            typeof(WeakReference).GetProperty("Target")
-                        )
-                    ),
+                        Expression.Assign(
+                            temp,
+                            Expression.Property(
+                                Expression.Constant(new WeakReference(_instance)),
+                                typeof(WeakReference).GetProperty("Target")
+                            )
+                        ),
 #else
-                    Expression.Assign(
-                        temp,
-                        Expression.Constant(_instance, typeof(object))
-                    ),
+                        Expression.Assign(
+                            temp,
+                            Expression.Constant(_instance, typeof(object))
+                        ),
 #endif
-                    Expression.AndAlso(
-                        //check that WeakReference was not collected.
-                        Expression.NotEqual(temp, AstUtils.Null),
-                        Expression.Equal(
-                            Expression.Convert(_expression, typeof(object)),
-                            temp
+                        Expression.AndAlso(
+                            //check that WeakReference was not collected.
+                            Expression.NotEqual(temp, AstUtils.Null),
+                            Expression.Equal(
+                                Expression.Convert(_expression, typeof(object)),
+                                temp
+                            )
                         )
                     )
                 );

--- a/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
@@ -556,19 +556,25 @@ namespace System.Dynamic
                         condition,
                         convert,
                         Expression.Throw(
-                            Expression.New(InvalidCastException_Ctor_String,
-                                Expression.Call(
-                                    String_Format_String_ObjectArray,
-                                    Expression.Constant(convertFailed),
-                                    Expression.NewArrayInit(typeof(object),
-                                        Expression.Condition(
-                                            Expression.Equal(resultMO.Expression, AstUtils.Null),
-                                            Expression.Constant("null"),
-                                            Expression.Call(
-                                                resultMO.Expression,
-                                                Object_GetType
-                                            ),
-                                            typeof(object)
+                            Expression.New(
+                                InvalidCastException_Ctor_String,
+                                new TrueReadOnlyCollection<Expression>(
+                                    Expression.Call(
+                                        String_Format_String_ObjectArray,
+                                        Expression.Constant(convertFailed),
+                                        Expression.NewArrayInit(
+                                            typeof(object),
+                                            new TrueReadOnlyCollection<Expression>(
+                                                Expression.Condition(
+                                                    Expression.Equal(resultMO.Expression, AstUtils.Null),
+                                                    Expression.Constant("null"),
+                                                    Expression.Call(
+                                                        resultMO.Expression,
+                                                        Object_GetType
+                                                    ),
+                                                    typeof(object)
+                                                )
+                                            )
                                         )
                                     )
                                 )
@@ -589,24 +595,26 @@ namespace System.Dynamic
                 var callDynamic = new DynamicMetaObject(
                     Expression.Block(
                         new TrueReadOnlyCollection<ParameterExpression>(result, callArgs),
-                        methodName != nameof(DynamicObject.TryBinaryOperation) ? Expression.Assign(callArgs, Expression.NewArrayInit(typeof(object), callArgsValue)) : Expression.Assign(callArgs, callArgsValue[0]),
-                        Expression.Condition(
-                            Expression.Call(
-                                GetLimitedSelf(),
-                                typeof(DynamicObject).GetMethod(methodName),
-                                BuildCallArgs(
-                                    binder,
-                                    args,
-                                    callArgs,
-                                    result
-                                )
-                            ),
-                            Expression.Block(
-                                methodName != nameof(DynamicObject.TryBinaryOperation) ? ReferenceArgAssign(callArgs, args) : AstUtils.Empty,
-                                resultMO.Expression
-                            ),
-                            fallbackResult.Expression,
-                            binder.ReturnType
+                        new TrueReadOnlyCollection<Expression>(
+                            methodName != nameof(DynamicObject.TryBinaryOperation) ? Expression.Assign(callArgs, Expression.NewArrayInit(typeof(object), callArgsValue)) : Expression.Assign(callArgs, callArgsValue[0]),
+                            Expression.Condition(
+                                Expression.Call(
+                                    GetLimitedSelf(),
+                                    typeof(DynamicObject).GetMethod(methodName),
+                                    BuildCallArgs(
+                                        binder,
+                                        args,
+                                        callArgs,
+                                        result
+                                    )
+                                ),
+                                Expression.Block(
+                                    methodName != nameof(DynamicObject.TryBinaryOperation) ? ReferenceArgAssign(callArgs, args) : AstUtils.Empty,
+                                    resultMO.Expression
+                                ),
+                                fallbackResult.Expression,
+                                binder.ReturnType
+                            )
                         )
                     ),
                     GetRestrictions().Merge(resultMO.Restrictions).Merge(fallbackResult.Restrictions)
@@ -647,24 +655,26 @@ namespace System.Dynamic
                 var callDynamic = new DynamicMetaObject(
                     Expression.Block(
                         new TrueReadOnlyCollection<ParameterExpression>(result, callArgs),
-                        Expression.Assign(callArgs, Expression.NewArrayInit(typeof(object), callArgsValue)),
-                        Expression.Condition(
-                            Expression.Call(
-                                GetLimitedSelf(),
-                                typeof(DynamicObject).GetMethod(methodName),
-                                BuildCallArgs(
-                                    binder,
-                                    args,
-                                    callArgs,
-                                    Expression.Assign(result, Expression.Convert(value, typeof(object)))
-                                )
-                            ),
-                            Expression.Block(
-                                ReferenceArgAssign(callArgs, args),
-                                result
-                            ),
-                            fallbackResult.Expression,
-                            typeof(object)
+                        new TrueReadOnlyCollection<Expression>(
+                            Expression.Assign(callArgs, Expression.NewArrayInit(typeof(object), callArgsValue)),
+                            Expression.Condition(
+                                Expression.Call(
+                                    GetLimitedSelf(),
+                                    typeof(DynamicObject).GetMethod(methodName),
+                                    BuildCallArgs(
+                                        binder,
+                                        args,
+                                        callArgs,
+                                        Expression.Assign(result, Expression.Convert(value, typeof(object)))
+                                    )
+                                ),
+                                Expression.Block(
+                                    ReferenceArgAssign(callArgs, args),
+                                    result
+                                ),
+                                fallbackResult.Expression,
+                                typeof(object)
+                            )
                         )
                     ),
                     GetRestrictions().Merge(fallbackResult.Restrictions)
@@ -708,24 +718,26 @@ namespace System.Dynamic
                 var callDynamic = new DynamicMetaObject(
                     Expression.Block(
                         new TrueReadOnlyCollection<ParameterExpression>(callArgs),
-                        Expression.Assign(callArgs, Expression.NewArrayInit(typeof(object), callArgsValue)),
-                        Expression.Condition(
-                            Expression.Call(
-                                GetLimitedSelf(),
-                                typeof(DynamicObject).GetMethod(methodName),
-                                BuildCallArgs(
-                                    binder,
-                                    args,
-                                    callArgs,
-                                    null
-                                )
-                            ),
-                            Expression.Block(
-                                ReferenceArgAssign(callArgs, args),
-                                AstUtils.Empty
-                            ),
-                            fallbackResult.Expression,
-                            typeof(void)
+                        new TrueReadOnlyCollection<Expression>(
+                            Expression.Assign(callArgs, Expression.NewArrayInit(typeof(object), callArgsValue)),
+                            Expression.Condition(
+                                Expression.Call(
+                                    GetLimitedSelf(),
+                                    typeof(DynamicObject).GetMethod(methodName),
+                                    BuildCallArgs(
+                                        binder,
+                                        args,
+                                        callArgs,
+                                        null
+                                    )
+                                ),
+                                Expression.Block(
+                                    ReferenceArgAssign(callArgs, args),
+                                    AstUtils.Empty
+                                ),
+                                fallbackResult.Expression,
+                                typeof(void)
+                            )
                         )
                     ),
                     GetRestrictions().Merge(fallbackResult.Restrictions)

--- a/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
@@ -807,11 +807,13 @@ namespace System.Dynamic
                 result = new DynamicMetaObject(
                     Expression.Block(
                         new TrueReadOnlyCollection<ParameterExpression>(value),
-                        Expression.Condition(
-                            tryGetValue,
-                            result.Expression,
-                            fallback.Expression,
-                            typeof(object)
+                        new TrueReadOnlyCollection<Expression>(
+                            Expression.Condition(
+                                tryGetValue,
+                                result.Expression,
+                                fallback.Expression,
+                                typeof(object)
+                            )
                         )
                     ),
                     result.Restrictions.Merge(fallback.Restrictions)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -231,7 +231,7 @@ namespace System.Linq.Expressions
 
                 return Expression.Block(
                     new TrueReadOnlyCollection<ParameterExpression>(temp1, temp2),
-                    e1, e2, e3, e4
+                    new TrueReadOnlyCollection<Expression>(e1, e2, e3, e4)
                 );
             }
         }
@@ -422,30 +422,34 @@ namespace System.Linq.Expressions
 
             return Block(
                 new TrueReadOnlyCollection<ParameterExpression>(left),
-                Assign(left, Left),
-                Condition(
-                    Property(left, "HasValue"),
+                new TrueReadOnlyCollection<Expression>(
+                    Assign(left, Left),
                     Condition(
-                        Call(opTrueFalse, Call(left, "GetValueOrDefault", null)),
-                        left,
-                        Block(
-                            new TrueReadOnlyCollection<ParameterExpression>(right),
-                            Assign(right, Right),
-                            Condition(
-                                Property(right, "HasValue"),
-                                Convert(
-                                    Call(
-                                        Method,
-                                        Call(left, "GetValueOrDefault", null),
-                                        Call(right, "GetValueOrDefault", null)
-                                    ),
-                                    Type
-                                ),
-                                Constant(null, Type)
+                        Property(left, "HasValue"),
+                        Condition(
+                            Call(opTrueFalse, Call(left, "GetValueOrDefault", null)),
+                            left,
+                            Block(
+                                new TrueReadOnlyCollection<ParameterExpression>(right),
+                                new TrueReadOnlyCollection<Expression>(
+                                    Assign(right, Right),
+                                    Condition(
+                                        Property(right, "HasValue"),
+                                        Convert(
+                                            Call(
+                                                Method,
+                                                Call(left, "GetValueOrDefault", null),
+                                                Call(right, "GetValueOrDefault", null)
+                                            ),
+                                            Type
+                                        ),
+                                        Constant(null, Type)
+                                    )
+                                )
                             )
-                        )
-                    ),
-                    Constant(null, Type)
+                        ),
+                        Constant(null, Type)
+                    )
                 )
             );
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
@@ -678,14 +678,14 @@ namespace System.Linq.Expressions.Compiler
                 {
                     if (t.Value != null)
                     {
-                        initializers.Add(Expression.ElementInit(add, t, Utils.Constant(i)));
+                        initializers.Add(Expression.ElementInit(add, new TrueReadOnlyCollection<Expression>(t, Utils.Constant(i))));
                     }
                     else
                     {
                         nullCase = i;
                     }
                 }
-                cases.UncheckedAdd(Expression.SwitchCase(node.Cases[i].Body, Utils.Constant(i)));
+                cases.UncheckedAdd(Expression.SwitchCase(node.Cases[i].Body, new TrueReadOnlyCollection<Expression>(Utils.Constant(i))));
             }
 
             // Create the field to hold the lazily initialized dictionary
@@ -701,7 +701,9 @@ namespace System.Linq.Expressions.Compiler
                     Expression.ListInit(
                         Expression.New(
                             DictionaryOfStringInt32_Ctor_Int32,
-                            Utils.Constant(initializers.Count)
+                            new TrueReadOnlyCollection<Expression>(
+                                Utils.Constant(initializers.Count)
+                            )
                         ),
                         initializers
                     )
@@ -734,17 +736,19 @@ namespace System.Linq.Expressions.Compiler
             ParameterExpression switchIndex = Expression.Variable(typeof(int), "switchIndex");
             BlockExpression reduced = Expression.Block(
                 new TrueReadOnlyCollection<ParameterExpression>(switchIndex, switchValue),
-                Expression.Assign(switchValue, node.SwitchValue),
-                Expression.IfThenElse(
-                    Expression.Equal(switchValue, Expression.Constant(null, typeof(string))),
-                    Expression.Assign(switchIndex, Utils.Constant(nullCase)),
+                new TrueReadOnlyCollection<Expression>(
+                    Expression.Assign(switchValue, node.SwitchValue),
                     Expression.IfThenElse(
-                        Expression.Call(dictInit, "TryGetValue", null, switchValue, switchIndex),
-                        Utils.Empty,
-                        Expression.Assign(switchIndex, Utils.Constant(-1))
-                    )
-                ),
-                Expression.Switch(node.Type, switchIndex, node.DefaultBody, null, cases.ToReadOnly())
+                        Expression.Equal(switchValue, Expression.Constant(null, typeof(string))),
+                        Expression.Assign(switchIndex, Utils.Constant(nullCase)),
+                        Expression.IfThenElse(
+                            Expression.Call(dictInit, "TryGetValue", null, switchValue, switchIndex),
+                            Utils.Empty,
+                            Expression.Assign(switchIndex, Utils.Constant(-1))
+                        )
+                    ),
+                    Expression.Switch(node.Type, switchIndex, node.DefaultBody, null, cases.ToReadOnly())
+                )
             );
 
             EmitExpression(reduced, flags);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
@@ -115,7 +115,7 @@ namespace System.Linq.Expressions.Compiler
                 Expression newBody = body.Node;
                 if (_tm.Temps.Count > 0)
                 {
-                    newBody = Expression.Block(_tm.Temps, newBody);
+                    newBody = Expression.Block(_tm.Temps, new TrueReadOnlyCollection<Expression>(newBody));
                 }
 
                 // Clone the lambda, replacing the body & variables.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
@@ -96,8 +96,10 @@ namespace System.Linq.Expressions
 
             return Expression.Block(
                 new TrueReadOnlyCollection<ParameterExpression>(parameter),
-                Expression.Assign(parameter, Expression),
-                ByValParameterTypeEqual(parameter)
+                new TrueReadOnlyCollection<Expression>(
+                    Expression.Assign(parameter, Expression),
+                    ByValParameterTypeEqual(parameter)
+                )
             );
         }
 
@@ -116,8 +118,10 @@ namespace System.Linq.Expressions
                 ParameterExpression temp = Expression.Parameter(typeof(Type));
                 getType = Expression.Block(
                     new TrueReadOnlyCollection<ParameterExpression>(temp),
-                    Expression.Assign(temp, getType),
-                    temp
+                    new TrueReadOnlyCollection<Expression>(
+                        Expression.Assign(temp, getType),
+                        temp
+                    )
                 );
             }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -165,9 +165,11 @@ namespace System.Linq.Expressions
             ParameterExpression temp = Parameter(Operand.Type, name: null);
             return Block(
                 new  TrueReadOnlyCollection<ParameterExpression>(temp),
-                Assign(temp, Operand),
-                Assign(Operand, FunctionalOp(temp)),
-                temp
+                new TrueReadOnlyCollection<Expression>(
+                    Assign(temp, Operand),
+                    Assign(Operand, FunctionalOp(temp)),
+                    temp
+                )
             );
         }
 
@@ -193,8 +195,10 @@ namespace System.Linq.Expressions
                     // temp1.member = op(temp1.member)
                     return Block(
                         new TrueReadOnlyCollection<ParameterExpression>(temp1),
-                        initTemp1,
-                        Assign(member, FunctionalOp(member))
+                        new TrueReadOnlyCollection<Expression>(
+                            initTemp1,
+                            Assign(member, FunctionalOp(member))
+                        )
                     );
                 }
 
@@ -207,10 +211,12 @@ namespace System.Linq.Expressions
                 ParameterExpression temp2 = Parameter(member.Type, name: null);
                 return Block(
                     new TrueReadOnlyCollection<ParameterExpression>(temp1, temp2),
-                    initTemp1,
-                    Assign(temp2, member),
-                    Assign(member, FunctionalOp(temp2)),
-                    temp2
+                    new TrueReadOnlyCollection<Expression>(
+                        initTemp1,
+                        Assign(temp2, member),
+                        Assign(member, FunctionalOp(temp2)),
+                        temp2
+                    )
                 );
             }
         }


### PR DESCRIPTION
Found a couple more places where we call the `params Expression[]` overload of expression factories which don't perform `IReadOnlyList<T>` type checks to fish elements out of the array in order to allocate an optimized instance. Instead, they'd call `ToReadOnly` causing the array to get cloned. By allocating a `TrueReadOnlyCollection<T>` at the caller side, we can avoid that unnecessary copy.