### PR TITLE
Eliminating some code duplication in ParameterExpression

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
@@ -177,18 +177,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="ParameterExpression"/> node with the specified name and type.</returns>
         public static ParameterExpression Parameter(Type type, string name)
         {
-            ContractUtils.RequiresNotNull(type, nameof(type));
-            TypeUtils.ValidateType(type, nameof(type));
-
-            if (type == typeof(void))
-            {
-                throw Error.ArgumentCannotBeOfTypeVoid(nameof(type));
-            }
-
-            if (type.IsPointer)
-            {
-                throw Error.TypeMustNotBePointer(nameof(type));
-            }
+            Validate(type);
 
             bool byref = type.IsByRef;
             if (byref)
@@ -207,17 +196,30 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="ParameterExpression"/> node with the specified name and type.</returns>
         public static ParameterExpression Variable(Type type, string name)
         {
+            Validate(type);
+
+            if (type.IsByRef)
+            {
+                throw Error.TypeMustNotBeByRef(nameof(type));
+            }
+
+            return ParameterExpression.Make(type, name, isByRef: false);
+        }
+
+        private static void Validate(Type type)
+        {
             ContractUtils.RequiresNotNull(type, nameof(type));
             TypeUtils.ValidateType(type, nameof(type));
-            if (type == typeof(void)) throw Error.ArgumentCannotBeOfTypeVoid(nameof(type));
-            if (type.IsByRef) throw Error.TypeMustNotBeByRef(nameof(type));
+
+            if (type == typeof(void))
+            {
+                throw Error.ArgumentCannotBeOfTypeVoid(nameof(type));
+            }
 
             if (type.IsPointer)
             {
                 throw Error.TypeMustNotBePointer(nameof(type));
             }
-
-            return ParameterExpression.Make(type, name, isByRef: false);
         }
     }
 }


### PR DESCRIPTION
Validation of arguments has overlap. Found while investigating whether we should use `Variable` instead of `Parameter` in various places where we do expression lowering.