### PR TITLE
Fix issues in validation of indexed property expressions.

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -156,6 +156,9 @@
   <data name="SetterMustBeVoid" xml:space="preserve">
     <value>Setter should have void type.</value>
   </data>
+  <data name="PropertyTypeMustMatchGetter" xml:space="preserve">
+    <value>Property type must match the value type of getter</value>
+  </data>
   <data name="PropertyTypeMustMatchSetter" xml:space="preserve">
     <value>Property type must match the value type of setter</value>
   </data>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -223,6 +223,15 @@ namespace System.Linq.Expressions
         {
             return new ArgumentException(Strings.SetterMustBeVoid, paramName);
         }
+
+        /// <summary>
+        /// ArgumentException with message like "Property type must match the value type of getter"
+        /// </summary>
+        internal static Exception PropertyTypeMustMatchGetter(string paramName)
+        {
+            return new ArgumentException(Strings.PropertyTypeMustMatchGetter, paramName);
+        }
+        
         /// <summary>
         /// ArgumentException with message like "Property type must match the value type of setter"
         /// </summary>
@@ -864,9 +873,9 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "Instance property '{0}{1}' is not defined for type '{2}'"
         /// </summary>
-        internal static Exception InstancePropertyWithSpecifiedParametersNotDefinedForType(object p0, object p1, object p2)
+        internal static Exception InstancePropertyWithSpecifiedParametersNotDefinedForType(object p0, object p1, object p2, string paramName)
         {
-            return new ArgumentException(Strings.InstancePropertyWithSpecifiedParametersNotDefinedForType(p0, p1, p2));
+            return new ArgumentException(Strings.InstancePropertyWithSpecifiedParametersNotDefinedForType(p0, p1, p2), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Method '{0}' declared on type '{1}' cannot be called with instance of type '{2}'"

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -75,6 +75,11 @@ namespace System.Linq.Expressions
         internal static string SetterMustBeVoid => SR.SetterMustBeVoid;
 
         /// <summary>
+        /// A string like "Property type must match the value type of getter"
+        /// </summary>
+        internal static string PropertyTypeMustMatchGetter => SR.PropertyTypeMustMatchGetter;
+
+        /// <summary>
         /// A string like "Property type must match the value type of setter"
         /// </summary>
         internal static string PropertyTypeMustMatchSetter => SR.PropertyTypeMustMatchSetter;

--- a/src/System.Linq.Expressions/tests/Array/ArrayAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayAccessTests.cs
@@ -41,5 +41,37 @@ namespace System.Linq.Expressions.Tests
             Func<int> get = Expression.Lambda<Func<int>>(e).Compile(useInterpreter);
             Assert.Equal(42, get());
         }
+
+        [Fact]
+        public static void InstanceIsNotArray()
+        {
+            ConstantExpression instance = Expression.Constant(46);
+            ConstantExpression index = Expression.Constant(2);
+            Assert.Throws<ArgumentException>("array", () => Expression.ArrayAccess(instance, index));
+        }
+
+        [Fact]
+        public static void WrongNumberIndices()
+        {
+            ConstantExpression instance = Expression.Constant(new int[2,3]);
+            ConstantExpression index = Expression.Constant(2);
+            Assert.Throws<ArgumentException>(() => Expression.ArrayAccess(instance, index));
+        }
+
+        [Fact]
+        public static void NonInt32Index()
+        {
+            ConstantExpression instance = Expression.Constant(new int[4]);
+            ConstantExpression index = Expression.Constant("2");
+            Assert.Throws<ArgumentException>("indexes", () => Expression.ArrayAccess(instance, index));
+        }
+
+        [Fact]
+        public static void UnreadableIndex()
+        {
+            ConstantExpression instance = Expression.Constant(new int[4]);
+            MemberExpression index = Expression.Property(null, typeof(Unreadable<int>).GetProperty(nameof(Unreadable<int>.WriteOnly)));
+            Assert.Throws<ArgumentException>("indexes", () => Expression.ArrayAccess(instance, index));
+        }
     }
 }


### PR DESCRIPTION
Use "propertyName" as parameter to `ArgumentException` when appropriate.

Throw correct error on setter with no parameters.

Check getter type matches property.

Mention "property" in attempt to use static method for instance or vice versa, not "method".

Do not throw trying to build error message for null indexer expression.

Do not throw in by-name search for property if one with no getter or setter is found (throw later if it was the only overload).

Fixes #14051