### PR TITLE
Add useSharedDesignerContext.txt marker

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -59,5 +59,11 @@
           Include="$(SyncInfoFile)" >
         <SkipPackageFileCheck>true</SkipPackageFileCheck>
     </File>
+    
+    <!-- Add a marker to help the designer optimize & share .NET Core packages -->
+    <File Condition="'$(IncludeDesignerMarker)' != 'false'"
+          Include="$(ProjectDir)pkg/useSharedDesignerContext.txt">
+        <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    </File>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #13934

The XAML designer needs to classify packages as safe to share and
avoid reload.

This is required to have reasonable performance in the designer, because
reloading the entire framework is currently quite expensive due to the
architecture of the designer and the fact that its running on Desktop.

The designer cannot reuse all NuGet assemblies since some may
register things in their static constructors (EG: dependency properties)
that need to be re-registered as the designer context is refreshed.

None of our assemblies do this so we're an easy target for optimization.
For now we'll add a marker that helps the designer identify our packages
for this optimization.

In the future the plan is to remove this once the designer can be
refactored to have a NETCore component that loads the user code
and is fast to restart/reload.

/cc @lutzroeder @chabiss