### PR TITLE
Removing unnecessary SuppressFinalize call in ReadOnlyCollectionBuilder

### DIFF
--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/ReadOnlyCollectionBuilder.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/ReadOnlyCollectionBuilder.cs
@@ -527,7 +527,6 @@ namespace System.Runtime.CompilerServices
 
             public void Dispose()
             {
-                GC.SuppressFinalize(this);
             }
 
             #endregion


### PR DESCRIPTION
The enumerator is not finalizable not do subclasses exist (in fact, we should likely mark it `sealed` too), so it seems the call to `GC.SuppressFinalize` is redundant.