### PR TITLE
Enable CS2229 and CA2237

### DIFF
--- a/CodeAnalysis.ruleset
+++ b/CodeAnalysis.ruleset
@@ -16,10 +16,10 @@
     <Rule Id="CA1036" Action="None" /> <!-- Overload comparison operators when implementing System.IComparable -->
     <Rule Id="CA1715" Action="None" /> <!-- Type parameters names should be prefixed with T -->
     <Rule Id="CA2213" Action="None" /> <!-- Disposable Fields should be disposed -->
-    <Rule Id="CA2229" Action="None" /> <!-- Serializable type doesn't have a serialization constructor -->
+    <Rule Id="CA2229" Action="Error" /> <!-- Serializable type doesn't have a serialization constructor -->
     <Rule Id="CA2235" Action="None" /> <!-- Serializable type has non serializable field -->
     <Rule Id="CA2231" Action="None" /> <!-- Overload operator equals when overriding ValueType.Equals -->
-    <Rule Id="CA2237" Action="None" /> <!-- Add [Serializable] to types that implement ISerializable -->
+    <Rule Id="CA2237" Action="Error" /> <!-- Add [Serializable] to types that implement ISerializable -->
 
     <Rule Id="CA2200" Action="None"/> <!-- Rethrowing caught exception changes stack information -->
 

--- a/src/System.Collections/src/System/Collections/Generic/LinkedList.cs
+++ b/src/System.Collections/src/System/Collections/Generic/LinkedList.cs
@@ -562,7 +562,7 @@ namespace System.Collections.Generic
                 _siInfo = null;
             }
 
-            internal Enumerator(SerializationInfo info, StreamingContext context)
+            private Enumerator(SerializationInfo info, StreamingContext context)
             {
                 _siInfo = info;
                 _list = null;

--- a/src/System.Net.Http/src/System/Net/Http/HttpRequestException.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpRequestException.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace System.Net.Http
 {
     [Serializable]
+    [SuppressMessage("Microsoft.Serialization", "CA2229")]
     public class HttpRequestException : Exception
     {
         public HttpRequestException()

--- a/src/System.Net.Requests/src/FxCopBaseline.cs
+++ b/src/System.Net.Requests/src/FxCopBaseline.cs
@@ -1,0 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Microsoft.Design", "CA2237", Scope = "type", Target = "System.Net.FtpWebRequest")]
+[assembly: SuppressMessage("Microsoft.Design", "CA2237", Scope = "type", Target = "System.Net.FtpWebResponse")]

--- a/src/System.Net.Requests/src/System.Net.Requests.csproj
+++ b/src/System.Net.Requests/src/System.Net.Requests.csproj
@@ -20,6 +20,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net463_Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="FxCopBaseline.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net463'">
     <Compile Include="System\Net\AuthenticationManager.cs" />
     <Compile Include="System\Net\Authorization.cs" />

--- a/src/System.Net.Requests/src/project.json
+++ b/src/System.Net.Requests/src/project.json
@@ -10,6 +10,7 @@
         "System.Collections.Specialized": "4.4.0-beta-24721-02",
         "System.Diagnostics.Debug": "4.4.0-beta-24721-02",
         "System.Diagnostics.Tracing": "4.4.0-beta-24721-02",
+        "System.Diagnostics.Tools": "4.4.0-beta-24721-02",
         "System.Globalization": "4.4.0-beta-24721-02",
         "System.IO": "4.4.0-beta-24721-02",
         "System.IO.Compression": "4.4.0-beta-24721-02",

--- a/src/System.Private.Xml.Linq/src/System/Xml/Linq/XName.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/Linq/XName.cs
@@ -11,6 +11,7 @@ namespace System.Xml.Linq
     /// Represents a name of an XML element or attribute. This class cannot be inherited.
     /// </summary>
     [Serializable]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Serialization", "CA2229", Justification = "Serialized with custom proxy")]
     public sealed class XName : IEquatable<XName>, ISerializable
     {
         private XNamespace _ns;

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/PrivilegeNotHeldException.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/PrivilegeNotHeldException.cs
@@ -30,7 +30,7 @@ namespace System.Security.AccessControl
             _privilegeName = privilege;
         }
 
-        internal PrivilegeNotHeldException(SerializationInfo info, StreamingContext context) : base(info, context)
+        private PrivilegeNotHeldException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             _privilegeName = info.GetString(nameof(PrivilegeName));
         }

--- a/src/System.Threading.Thread/src/System/Threading/ThreadAbortException.cs
+++ b/src/System.Threading.Thread/src/System/Threading/ThreadAbortException.cs
@@ -18,7 +18,7 @@ namespace System.Threading
         {
         }
 
-        internal ThreadAbortException(SerializationInfo info, StreamingContext context) : base(info, context)
+        private ThreadAbortException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
 


### PR DESCRIPTION
This change enables FxCop serialization rules requiring serialization constructors on ISerializable types and [Serializable] on ISerializable types.