### PR TITLE
Removing Map helper method in favor of Array.ConvertAll

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/CollectionExtensions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/CollectionExtensions.cs
@@ -41,21 +41,6 @@ namespace System.Dynamic.Utils
             return result;
         }
 
-        // Name needs to be different so it doesn't conflict with Enumerable.Select
-        public static U[] Map<T, U>(this T[] array, Func<T, U> select)
-        {
-            int count = array.Length;
-
-            U[] result = new U[count];
-
-            for (int i = 0; i < count; i++)
-            {
-                result[i] = select(array[i]);
-            }
-
-            return result;
-        }
-
         /// <summary>
         /// Wraps the provided enumerable into a ReadOnlyCollection{T}
         ///

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
@@ -367,7 +367,7 @@ namespace System.Runtime.CompilerServices
             var body = new List<Expression>();
             var vars = new List<ParameterExpression>();
 
-            ParameterExpression[] @params = invoke.GetParametersCached().Map(p => Expression.Parameter(p.ParameterType, p.Name));
+            ParameterExpression[] @params = Array.ConvertAll(invoke.GetParametersCached(), p => Expression.Parameter(p.ParameterType, p.Name));
             LabelTarget @return = Expression.Label(invoke.GetReturnType());
             Type[] typeArgs = new[] { typeof(T) };
 
@@ -581,7 +581,7 @@ namespace System.Runtime.CompilerServices
             body.Add(Expression.Assign(rule, Expression.Constant(null, rule.Type)));
 
             ParameterExpression args = Expression.Variable(typeof(object[]), "args");
-            Expression[] argsElements = arguments.Map(p => Convert(p, typeof(object)));
+            Expression[] argsElements = Array.ConvertAll(arguments, p => Convert(p, typeof(object)));
             vars.Add(args);
             body.Add(
                 Expression.Assign(
@@ -651,7 +651,7 @@ namespace System.Runtime.CompilerServices
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
         private T CreateCustomNoMatchDelegate(MethodInfo invoke)
         {
-            ParameterExpression[] @params = invoke.GetParametersCached().Map(p => Expression.Parameter(p.ParameterType, p.Name));
+            ParameterExpression[] @params = Array.ConvertAll(invoke.GetParametersCached(), p => Expression.Parameter(p.ParameterType, p.Name));
             return Expression.Lambda<T>(
                 Expression.Block(
                     Expression.Call(


### PR DESCRIPTION
As suggested by @stephentoub in a previous PR, we can do away with our `Map` extension method (which slowly moved from `IList<T>` to `T[]` for the input) and now offers the same functionality as `Array.ConvertAll`.