### PR TITLE
Improving static typing on CollectionExtensions helpers

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/CollectionExtensions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/CollectionExtensions.cs
@@ -11,19 +11,27 @@ namespace System.Dynamic.Utils
 {
     internal static partial class CollectionExtensions
     {
-        public static T[] AddFirst<T>(this IList<T> list, T item)
+        public static TrueReadOnlyCollection<T> AddFirst<T>(this ReadOnlyCollection<T> list, T item)
         {
             T[] res = new T[list.Count + 1];
             res[0] = item;
             list.CopyTo(res, 1);
+            return new TrueReadOnlyCollection<T>(res);
+        }
+
+        public static T[] AddFirst<T>(this T[] array, T item)
+        {
+            T[] res = new T[array.Length + 1];
+            res[0] = item;
+            array.CopyTo(res, 1);
             return res;
         }
 
-        public static T[] AddLast<T>(this IList<T> list, T item)
+        public static T[] AddLast<T>(this T[] array, T item)
         {
-            T[] res = new T[list.Count + 1];
-            list.CopyTo(res, 0);
-            res[list.Count] = item;
+            T[] res = new T[array.Length + 1];
+            array.CopyTo(res, 0);
+            res[array.Length] = item;
             return res;
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/HoistedLocals.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/HoistedLocals.cs
@@ -63,7 +63,7 @@ namespace System.Linq.Expressions.Compiler
             if (parent != null)
             {
                 // Add the parent locals array as the 0th element in the array
-                vars = new TrueReadOnlyCollection<ParameterExpression>(vars.AddFirst(parent.SelfVariable));
+                vars = vars.AddFirst(parent.SelfVariable);
             }
 
             Dictionary<Expression, int> indexes = new Dictionary<Expression, int>(vars.Count);

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteBinder.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteBinder.cs
@@ -194,7 +194,7 @@ namespace System.Runtime.CompilerServices
                                 Expression.Convert(site, siteType),
                                 typeof(CallSite<T>).GetProperty(nameof(CallSite<T>.Update))
                             ),
-                            new TrueReadOnlyCollection<Expression>(@params)
+                            @params
                         )
                     )
                 )
@@ -204,7 +204,7 @@ namespace System.Runtime.CompilerServices
                 Expression.Block(body),
                 CallSite.CallSiteTargetMethodName,
                 true, // always compile the rules with tail call optimization
-                new TrueReadOnlyCollection<ParameterExpression>(@params)
+                @params
             );
         }
 


### PR DESCRIPTION
`AddLast` never needed an `IList<T>` as the input, so we can tighten it to `T[]`.

`AddFirst` is used in two different contexts, one where a want to operate on `T[]` and one where we operate on `ReadOnlyCollection<T>` and always wrap the result in a `TrueReadOnlyCollection<T>`. Adding a helper for both cases, removing code elsewhere and also making a call to `Expression.Invoke` cheaper because it now receives a `TrueReadOnlyCollection<T>` rather than a `T[]` in its `IEnumerable<T>` argument.