### PR TITLE
Add logging for divrem tests

### DIFF
--- a/src/System.Runtime.Numerics/tests/BigInteger/divrem.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/divrem.cs
@@ -192,8 +192,8 @@ namespace System.Numerics.Tests
             }
             catch(Exception e) when (!(e is DivideByZeroException))
             {
-                Console.WriteLine($"VerifyDivRemString failed: {opstring} {e.ToString()}");
-                throw;
+                // Log the original parameters, so we can reproduce any failure given the log
+                throw new Exception($"VerifyDivRemString failed: {opstring} {e.ToString()}", e);
             }
         }
 

--- a/src/System.Runtime.Numerics/tests/BigInteger/divrem.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/divrem.cs
@@ -181,11 +181,19 @@ namespace System.Numerics.Tests
 
         private static void VerifyDivRemString(string opstring)
         {
-            StackCalc sc = new StackCalc(opstring);
-            while (sc.DoNextOperation())
+            try
             {
-                Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
-                sc.VerifyOutParameter();
+                StackCalc sc = new StackCalc(opstring);
+                while (sc.DoNextOperation())
+                {
+                    Assert.Equal(sc.snCalc.Peek().ToString(), sc.myCalc.Peek().ToString());
+                    sc.VerifyOutParameter();
+                }
+            }
+            catch(Exception e) when (!(e is DivideByZeroException))
+            {
+                Console.WriteLine($"VerifyDivRemString failed: {opstring} {e.ToString()}");
+                throw;
             }
         }
 


### PR DESCRIPTION
In the case of a failure in divrem, log the random parameters being operated on. This should make the next hit on https://github.com/dotnet/corefx/issues/7806 reproducible.

@mellinoe 