### PR TITLE
Fixed Join_ObjectArray test in StringTests

### DIFF
--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1629,7 +1629,7 @@ namespace System.Tests
         [MemberData(nameof(Join_ObjectArray_TestData))]
         public static void Join_ObjectArray(string separator, object[] values, string expected)
         {
-            var enumerableExpected = expected;
+            string enumerableExpected = expected;
 #if !netstandard17
             if (values.Length > 0 && values[0] == null) // Join return nothing when first value is null
                 expected = "";

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1619,22 +1619,25 @@ namespace System.Tests
             yield return new object[] { "$$", new object[] { "Foo", null, "Baz" }, "Foo$$$$Baz" };
 
             // Join does nothing if array[0] is null
-            yield return new object[] { "$$", new object[] { null, "Bar", "Baz" }, "" };
+            yield return new object[] { "$$", new object[] { null, "Bar", "Baz" }, "$$Bar$$Baz" };
 
             // Join should ignore objects that have a null ToString() value
             yield return new object[] { "|", new object[] { new ObjectWithNullToString(), "Foo", new ObjectWithNullToString(), "Bar", new ObjectWithNullToString() }, "|Foo||Bar|" };
         }
 
-        [ActiveIssue(13747)]
         [Theory]
         [MemberData(nameof(Join_ObjectArray_TestData))]
         public static void Join_ObjectArray(string separator, object[] values, string expected)
         {
-            Assert.Equal(expected, string.Join(separator, values));
-            if (!(values.Length > 0 && values[0] == null))
-            {
-                Assert.Equal(expected, string.Join(separator, (IEnumerable<object>)values));
-            }
+            var exp = expected;
+            if (values.Length > 0 && values[0] == null) // Join return empty string if array[0] is null
+                exp = "";
+#if netstandard17
+            // In netstandard17 Join issue was fixed
+            exp = expected;
+#endif
+            Assert.Equal(exp, string.Join(separator, values));
+            Assert.Equal(expected, string.Join(separator, (IEnumerable<object>)values));
         }
 
         [Fact]

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1618,7 +1618,7 @@ namespace System.Tests
             yield return new object[] { null, new object[] { "Foo", "Bar", "Baz" }, "FooBarBaz" };
             yield return new object[] { "$$", new object[] { "Foo", null, "Baz" }, "Foo$$$$Baz" };
 
-            // Join does nothing if array[0] is null
+            // Test join when first value is null
             yield return new object[] { "$$", new object[] { null, "Bar", "Baz" }, "$$Bar$$Baz" };
 
             // Join should ignore objects that have a null ToString() value
@@ -1629,15 +1629,13 @@ namespace System.Tests
         [MemberData(nameof(Join_ObjectArray_TestData))]
         public static void Join_ObjectArray(string separator, object[] values, string expected)
         {
-            var exp = expected;
-            if (values.Length > 0 && values[0] == null) // Join return empty string if array[0] is null
-                exp = "";
-#if netstandard17
-            // In netstandard17 Join issue was fixed
-            exp = expected;
+            var enumerableExpected = expected;
+#if !netstandard17
+            if (values.Length > 0 && values[0] == null) // Join return nothing when first value is null
+                expected = "";
 #endif
-            Assert.Equal(exp, string.Join(separator, values));
-            Assert.Equal(expected, string.Join(separator, (IEnumerable<object>)values));
+            Assert.Equal(expected, string.Join(separator, values));
+            Assert.Equal(enumerableExpected, string.Join(separator, (IEnumerable<object>)values));
         }
 
         [Fact]

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1627,13 +1627,21 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Join_ObjectArray_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.NetcoreUwp | TargetFrameworkMonikers.Netcoreapp1_0)]
         public static void Join_ObjectArray(string separator, object[] values, string expected)
         {
+            Assert.Equal(expected, string.Join(separator, values));
+            Assert.Equal(expected, string.Join(separator, (IEnumerable<object>)values));
+        }
+
+        [Theory]
+        [MemberData(nameof(Join_ObjectArray_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_1)]
+        public static void Join_ObjectArray_WithNullIssue(string separator, object[] values, string expected)
+        {
             string enumerableExpected = expected;
-#if !netstandard17
             if (values.Length > 0 && values[0] == null) // Join return nothing when first value is null
                 expected = "";
-#endif
             Assert.Equal(expected, string.Join(separator, values));
             Assert.Equal(enumerableExpected, string.Join(separator, (IEnumerable<object>)values));
         }


### PR DESCRIPTION
Join issue for first null in object array is fixed. So calling string.Join(",", null, 1, 2, 3) now return ",1,2,3", but not empty string as before. See dotnet/coreclr#8114