### PR TITLE
Short-circuit within nullable arithmetic instructions.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
@@ -22,14 +22,18 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(unchecked((int)l + (int)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] =
+                            ScriptingRuntimeHelpers.Int32ToObject(unchecked((int)l + (int)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -41,14 +45,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = unchecked((short)((short)l + (short)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = unchecked((short)((short)l + (short)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -60,14 +67,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = unchecked((long)((long)l + (long)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = unchecked((long)((long)l + (long)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -79,14 +89,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = unchecked((ushort)((ushort)l + (ushort)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = unchecked((ushort)((ushort)l + (ushort)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -98,14 +111,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = unchecked((uint)((uint)l + (uint)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = unchecked((uint)((uint)l + (uint)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -117,14 +133,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = unchecked((ulong)((ulong)l + (ulong)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = unchecked((ulong)((ulong)l + (ulong)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -136,14 +155,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (float)((float)l + (float)r);
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (float)((float)l + (float)r);
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -155,14 +177,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (double)l + (double)r;
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (double)l + (double)r;
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -203,14 +228,18 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(checked((int)l + (int)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] =
+                            ScriptingRuntimeHelpers.Int32ToObject(checked((int)l + (int)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -222,14 +251,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = checked((short)((short)l + (short)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = checked((short)((short)l + (short)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -241,14 +273,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = checked((long)((long)l + (long)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = checked((long)((long)l + (long)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -260,14 +295,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = checked((ushort)((ushort)l + (ushort)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = checked((ushort)((ushort)l + (ushort)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -279,14 +317,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = checked((uint)((uint)l + (uint)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = checked((uint)((uint)l + (uint)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -298,14 +339,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = checked((ulong)((ulong)l + (ulong)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = checked((ulong)((ulong)l + (ulong)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
@@ -23,14 +23,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject((int)l / (int)r);
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject((int)l / (int)r);
+                    }
                 }
                 frame.StackIndex--;
                 return 1;
@@ -42,14 +45,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (short)((short)l / (short)r);
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (short)((short)l / (short)r);
+                    }
                 }
                 frame.StackIndex--;
                 return 1;
@@ -61,14 +67,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (long)((long)l / (long)r);
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (long)((long)l / (long)r);
+                    }
                 }
                 frame.StackIndex--;
                 return 1;
@@ -80,14 +89,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (ushort)((ushort)l / (ushort)r);
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (ushort)((ushort)l / (ushort)r);
+                    }
                 }
                 frame.StackIndex--;
                 return 1;
@@ -99,14 +111,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (uint)((uint)l / (uint)r);
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (uint)((uint)l / (uint)r);
+                    }
                 }
                 frame.StackIndex--;
                 return 1;
@@ -118,14 +133,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (ulong)((ulong)l / (ulong)r);
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (ulong)((ulong)l / (ulong)r);
+                    }
                 }
                 frame.StackIndex--;
                 return 1;
@@ -137,14 +155,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (float)((float)l / (float)r);
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (float)((float)l / (float)r);
+                    }
                 }
                 frame.StackIndex--;
                 return 1;
@@ -156,14 +177,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (double)l / (double)r;
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (double)l / (double)r;
+                    }
                 }
                 frame.StackIndex--;
                 return 1;
@@ -205,14 +229,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject((int)l % (int)r);
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject((int)l % (int)r);
+                    }
                 }
                 frame.StackIndex--;
                 return 1;
@@ -224,14 +251,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (short)((short)l % (short)r);
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (short)((short)l % (short)r);
+                    }
                 }
                 frame.StackIndex--;
                 return 1;
@@ -243,14 +273,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (long)((long)l % (long)r);
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (long)((long)l % (long)r);
+                    }
                 }
                 frame.StackIndex--;
                 return 1;
@@ -262,14 +295,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (ushort)((ushort)l % (ushort)r);
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (ushort)((ushort)l % (ushort)r);
+                    }
                 }
                 frame.StackIndex--;
                 return 1;
@@ -281,14 +317,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (uint)((uint)l % (uint)r);
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (uint)((uint)l % (uint)r);
+                    }
                 }
                 frame.StackIndex--;
                 return 1;
@@ -300,14 +339,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (ulong)((ulong)l % (ulong)r);
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (ulong)((ulong)l % (ulong)r);
+                    }
                 }
                 frame.StackIndex--;
                 return 1;
@@ -319,14 +361,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (float)((float)l % (float)r);
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (float)((float)l % (float)r);
+                    }
                 }
                 frame.StackIndex--;
                 return 1;
@@ -338,14 +383,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (double)l % (double)r;
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (double)l % (double)r;
+                    }
                 }
                 frame.StackIndex--;
                 return 1;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
@@ -22,14 +22,18 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(unchecked((int)l * (int)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] =
+                            ScriptingRuntimeHelpers.Int32ToObject(unchecked((int)l * (int)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -41,14 +45,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = unchecked((short)((short)l * (short)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = unchecked((short)((short)l * (short)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -60,14 +67,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = unchecked((long)((long)l * (long)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = unchecked((long)((long)l * (long)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -79,14 +89,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = unchecked((ushort)((ushort)l * (ushort)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = unchecked((ushort)((ushort)l * (ushort)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -98,14 +111,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = unchecked((uint)((uint)l * (uint)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = unchecked((uint)((uint)l * (uint)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -117,14 +133,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = unchecked((ulong)((ulong)l * (ulong)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = unchecked((ulong)((ulong)l * (ulong)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -136,14 +155,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (float)((float)l * (float)r);
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (float)((float)l * (float)r);
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -155,14 +177,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (double)l * (double)r;
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (double)l * (double)r;
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -204,14 +229,18 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(checked((int)l * (int)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] =
+                            ScriptingRuntimeHelpers.Int32ToObject(checked((int)l * (int)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -223,14 +252,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = checked((short)((short)l * (short)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = checked((short)((short)l * (short)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -242,14 +274,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = checked((long)((long)l * (long)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = checked((long)((long)l * (long)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -261,14 +296,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = checked((ushort)((ushort)l * (ushort)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = checked((ushort)((ushort)l * (ushort)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -280,14 +318,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = checked((uint)((uint)l * (uint)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = checked((uint)((uint)l * (uint)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -299,14 +340,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = checked((ulong)((ulong)l * (ulong)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = checked((ulong)((ulong)l * (ulong)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
@@ -22,14 +22,18 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(unchecked((int)l - (int)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] =
+                            ScriptingRuntimeHelpers.Int32ToObject(unchecked((int)l - (int)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -41,14 +45,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = unchecked((short)((short)l - (short)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = unchecked((short)((short)l - (short)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -60,14 +67,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = unchecked((long)((long)l - (long)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = unchecked((long)((long)l - (long)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -79,14 +89,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = unchecked((ushort)((ushort)l - (ushort)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = unchecked((ushort)((ushort)l - (ushort)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -98,14 +111,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = unchecked((uint)((uint)l - (uint)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = unchecked((uint)((uint)l - (uint)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -117,14 +133,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = unchecked((ulong)((ulong)l - (ulong)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = unchecked((ulong)((ulong)l - (ulong)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -136,14 +155,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (float)((float)l - (float)r);
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (float)((float)l - (float)r);
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -155,14 +177,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = (double)l - (double)r;
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = (double)l - (double)r;
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -203,14 +228,18 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(checked((int)l - (int)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] =
+                            ScriptingRuntimeHelpers.Int32ToObject(checked((int)l - (int)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -222,14 +251,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = checked((short)((short)l - (short)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = checked((short)((short)l - (short)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -241,14 +273,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = checked((long)((long)l - (long)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = checked((long)((long)l - (long)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -260,14 +295,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = checked((ushort)((ushort)l - (ushort)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = checked((ushort)((ushort)l - (ushort)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -279,14 +317,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = checked((uint)((uint)l - (uint)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = checked((uint)((uint)l - (uint)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;
@@ -298,14 +339,17 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
+                if (l != null)
                 {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = checked((ulong)((ulong)l - (ulong)r));
+                    object r = frame.Data[frame.StackIndex - 1];
+                    if (r == null)
+                    {
+                        frame.Data[frame.StackIndex - 2] = null;
+                    }
+                    else
+                    {
+                        frame.Data[frame.StackIndex - 2] = checked((ulong)((ulong)l - (ulong)r));
+                    }
                 }
                 frame.StackIndex--;
                 return +1;


### PR DESCRIPTION
The Add, Div, Mul and Sub instructions are already using an optimised by-pass of Pop()/Push(). In the case of the LHS value being null though, they still read the RHS and then set the position on the stack occupied by the (null) LHS to null.

Skip this.