### PR TITLE
Using InterpretedFrame.Dup helper

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/StackOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/StackOperations.cs
@@ -84,8 +84,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int Run(InterpretedFrame frame)
         {
-            object value = frame.Peek();
-            frame.Data[frame.StackIndex++] = value;
+            frame.Dup();
             return +1;
         }
 


### PR DESCRIPTION
For some reason, we never used the `Dup` method here.