### PR TITLE
Removing partial modifier on CollectionExtensions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/CollectionExtensions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/CollectionExtensions.cs
@@ -4,12 +4,11 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 
 namespace System.Dynamic.Utils
 {
-    internal static partial class CollectionExtensions
+    internal static class CollectionExtensions
     {
         public static TrueReadOnlyCollection<T> AddFirst<T>(this ReadOnlyCollection<T> list, T item)
         {


### PR DESCRIPTION
No longer needs `partial` after all functionality from `Common` has been merged into `System.Linq.Expressions`.