### PR TITLE
Add missing attrib to SocketInformation

### DIFF
--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -380,6 +380,7 @@ namespace System.Net.Sockets
         Peek = 2,
         Truncated = 256,
     }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public struct SocketInformation
     {
         public SocketInformationOptions Options { get { throw null; } set { } }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketInformation.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketInformation.cs
@@ -12,6 +12,7 @@ namespace System.Net.Sockets
 #if !netcore50
     [Serializable]
 #endif
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public struct SocketInformation
     {
         private byte[] _protocolInformation;


### PR DESCRIPTION
This attrib is in standard but was overlooked in the port. Contributes to https://github.com/dotnet/corefx/issues/13900

@CIPop 