### PR TITLE
Fix and re-enable XSLT checksum tests

### DIFF
--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompiledTransform.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompiledTransform.cs
@@ -1108,18 +1108,23 @@ namespace System.Xml.Tests
         */
 
         //[Variation(id = 7, Desc = "document() has absolute URI", Pri = 0)]
-        [ActiveIssue(9877)]
+        [ActiveIssue(14071)]
         [InlineData()]
         [Theory]
         public void XmlResolver7()
         {
             AppContext.SetSwitch("Switch.System.Xml.DontProhibitDefaultResolver", true);
 
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>123</result>";
+
             // copy file on the local machine (this is now done with createAPItestfiles.js, see Oasys scenario.)
             if (LoadXSL("xmlResolver_document_function_absolute_uri.xsl") == 1)
             {
-                if ((Transform("fruits.xml") == 1) && (CheckResult(377.8217373898) == 1))
+                if (Transform("fruits.xml") == 1)
+                {
+                    VerifyResult(expected);
                     return;
+                }
                 else
                 {
                     _output.WriteLine("Failed to resolve document function with absolute URI.");
@@ -1310,14 +1315,16 @@ namespace System.Xml.Tests
         public void LoadGeneric7()
         {
             FileStream s2;
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result><fruit>Apple</fruit><fruit>orange</fruit></result>";
 
             // check immediately after load and after transform
             if (LoadXSL("XmlResolver_Main.xsl") == 1)
             {
                 s2 = new FileStream(FullFilePath("XmlResolver_Main.xsl"), FileMode.Open, FileAccess.Read, FileShare.Read);
                 s2.Dispose();
-                if ((Transform("fruits.xml") == 1) && (CheckResult(428.8541842246) == 1))
+                if (Transform("fruits.xml") == 1)
                 {
+                    VerifyResult(expected);
                     s2 = new FileStream(FullFilePath("XmlResolver_Main.xsl"), FileMode.Open, FileAccess.Read, FileShare.Read);
                     s2.Dispose();
                     return;
@@ -1358,14 +1365,16 @@ namespace System.Xml.Tests
         public void LoadGeneric9()
         {
             FileStream s2;
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result><fruit>Apple</fruit><fruit>orange</fruit></result>";
 
             // check immediately after load and after transform
             if (LoadXSL("XmlResolver_Main.xsl") == 1)
             {
                 s2 = new FileStream(FullFilePath("XmlResolver_Sub.xsl"), FileMode.Open, FileAccess.Read);
                 s2.Dispose();
-                if ((Transform("fruits.xml") == 1) && (CheckResult(428.8541842246) == 1))
+                if (Transform("fruits.xml") == 1)
                 {
+                    VerifyResult(expected);
                     s2 = new FileStream(FullFilePath("XmlResolver_Include.xsl"), FileMode.Open, FileAccess.Read, FileShare.Read);
                     s2.Dispose();
                     return;
@@ -1401,7 +1410,6 @@ namespace System.Xml.Tests
         */
 
         //[Variation(id = 11, Desc = "Load stylesheet with entity reference: Bug #68450 ")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void LoadGeneric11()
@@ -1411,14 +1419,20 @@ namespace System.Xml.Tests
                 return;
             else
             {
+                string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><Book>
+			Name
+		</Book>";
+
                 if (LoadXSL("books_entity_ref.xsl", XslInputType.Reader, new XmlUrlResolver()) != 1)
                 {
                     _output.WriteLine("Failed to load stylesheet books_entity_ref.xsl");
                     Assert.True(false);
                 }
-                if ((LoadXSL("books_entity_ref.xsl") == 1) && (Transform("books_entity_ref.xml") == 1)
-                    && (CheckResult(371.4148215954) == 1))
+                if ((LoadXSL("books_entity_ref.xsl") == 1) && (Transform("books_entity_ref.xml") == 1))
+                {
+                    VerifyResult(expected);
                     return;
+                }
                 Assert.True(false);
             }
         }
@@ -1654,6 +1668,8 @@ namespace System.Xml.Tests
         [Theory]
         public void LoadGeneric7(object param)
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result><fruit>Apple</fruit><fruit>orange</fruit></result>";
+
             string Baseline = Path.Combine("baseline", (string)param);
             CustomNullResolver myResolver = new CustomNullResolver(_output);
 
@@ -1677,8 +1693,11 @@ namespace System.Xml.Tests
 
                 if (LoadXSL("XmlResolver_Main.xsl") == 1)
                 {
-                    if ((Transform("fruits.xml") == 1) && (CheckResult(428.8541842246) == 1))
+                    if (Transform("fruits.xml") == 1)
+                    {
+                        VerifyResult(expected);
                         return;
+                    }
                     else
                         Assert.True(false);
                 }
@@ -1796,11 +1815,15 @@ namespace System.Xml.Tests
         [Theory]
         public void LoadGeneric9()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result><fruit>Apple</fruit><fruit>orange</fruit></result>";
+
             if ((LoadXSL_Resolver("XmlResolver_Main.xsl", GetDefaultCredResolver()) == 1))
             {
-                if ((LoadXSL("XmlResolver_Main.xsl") == 1) && (Transform("fruits.xml") == 1)
-                    && (CheckResult(428.8541842246) == 1))
+                if ((LoadXSL("XmlResolver_Main.xsl") == 1) && (Transform("fruits.xml") == 1))
+                {
+                    VerifyResult(expected);
                     return;
+                }
             }
             else
             {
@@ -1987,27 +2010,6 @@ namespace System.Xml.Tests
         public CLoadReaderResolverEvidenceTest(ITestOutputHelper output) : base(output)
         {
             _output = output;
-        }
-
-        // TODO: BinCompat - add this test back if Evidence is back
-        //[Variation("Call Load with null source value, null evidence")]
-        [ActiveIssue(9877)]
-        [InlineData()]
-        [Theory]
-        public void LoadGeneric1()
-        {
-            /*
-            try
-            {
-                LoadXSL_Resolver_Evidence(null, new XmlUrlResolver(), null);
-            }
-            catch (ArgumentNullException e)
-            {
-                _output.WriteLine(e.ToString());
-                return;
-            }
-            _output.WriteLine("Passing null stylesheet parameter should have thrown ArgumentNullException");
-            Assert.True(false);*/
         }
 
         //[Variation("Call Load with style sheet that has script, pass null evidence, should throw security exception")]
@@ -2305,6 +2307,8 @@ namespace System.Xml.Tests
             if (_isInProc)
                 return; //TEST_SKIPPED;
 
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><out>You are safe</out>";
+
             xslt = new XslCompiledTransform();
             XmlReader xrLoad = XmlReader.Create(FullFilePath("Bug80768.xsl"));
             XPathDocument xd = new XPathDocument(xrLoad, XmlSpace.Preserve);
@@ -2316,10 +2320,7 @@ namespace System.Xml.Tests
             xslt.Transform(xn, null, fs);
             fs.Dispose();
 
-            if (CheckResult(383.0855503831) == 1)
-                return;
-            else
-                Assert.True(false);
+            VerifyResult(expected);
         }
     }
 
@@ -2552,7 +2553,7 @@ namespace System.Xml.Tests
         [Theory]
         public void Bug380138()
         {
-            string xsl = @"<?xml version='1.0' encoding='utf-8'?>
+            string xsl = @"<?xml version=""1.0"" encoding=""utf-8""?>
     <xsl:stylesheet version='1.0' xmlns:xsl='http://www.w3.org/1999/XSL/Transform'
         xmlns:ms='urn:schemas-microsoft-com:xslt' exclude-result-prefixes='ms'>
       <xsl:template match='asf'><xsl:value-of select=""ms:namespace-uri('ms:b')""/></xsl:template>
@@ -2970,12 +2971,17 @@ namespace System.Xml.Tests
         [Theory]
         public void XmlResolver1()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result><fruit>Apple</fruit><fruit>orange</fruit></result>";
+
             try
             {
                 if (LoadXSL("XmlResolver_Main.xsl") == 1)
                 {
-                    if ((TransformResolver("fruits.xml", null) == 1) && (CheckResult(428.8541842246) == 1))
+                    if (TransformResolver("fruits.xml", null) == 1)
+                    {
+                        VerifyResult(expected);
                         return;
+                    }
                     else
                         Assert.True(false);
                 }
@@ -3042,12 +3048,14 @@ namespace System.Xml.Tests
         }
 
         //[Variation("document() has absolute URI")]
-        [ActiveIssue(9877)]
+        [ActiveIssue(14071)]
         [InlineData()]
         [Theory]
         public void XmlResolver5()
         {
             AppContext.SetSwitch("Switch.System.Xml.DontProhibitDefaultResolver", true);
+
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>123</result>";
 
             // copy file on the local machine
             try
@@ -3071,8 +3079,11 @@ namespace System.Xml.Tests
 
             if (LoadXSL("xmlResolver_document_function_absolute_uri.xsl") == 1)
             {
-                if ((TransformResolver("fruits.xml", new XmlUrlResolver()) == 1) && (CheckResult(377.8217373898) == 1))
+                if (TransformResolver("fruits.xml", new XmlUrlResolver()) == 1)
+                {
+                    VerifyResult(expected);
                     return;
+                }
                 else
                 {
                     _output.WriteLine("Failed to resolve document function with absolute URI.");
@@ -3487,31 +3498,25 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Pass null XmlResolver to Transform, load style sheet with import/include, should not affect transform")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void TransformStrStrResolver1()
         {
             String szFullFilename = FullFilePath("fruits.xml");
-            try
+            string expected = @"<result>
+  <fruit>Apple</fruit>
+  <fruit>orange</fruit>
+</result>";
+
+            if (LoadXSL("XmlResolver_Main.xsl", new XmlUrlResolver()) == 1)
             {
-                if (LoadXSL("XmlResolver_Main.xsl", new XmlUrlResolver()) == 1)
-                {
-                    XmlTextReader xr = new XmlTextReader(szFullFilename);
-                    XmlTextWriter xw = new XmlTextWriter("out.xml", Encoding.Unicode);
-                    xslt.Transform(xr, null, xw, null);
-                    xr.Dispose();
-                    xw.Dispose();
-                    if (CheckResult(403.7784431795) == 1)
-                        return;
-                    else
-                        Assert.True(false);
-                }
-            }
-            catch (Exception e)
-            {
-                _output.WriteLine(e.ToString());
-                Assert.True(false);
+                XmlTextReader xr = new XmlTextReader(szFullFilename);
+                XmlTextWriter xw = new XmlTextWriter("out.xml", Encoding.Unicode);
+                xslt.Transform(xr, null, xw, null);
+                xr.Dispose();
+                xw.Dispose();
+                VerifyResult(expected);
+                return;
             }
             Assert.True(false);
         }
@@ -3523,6 +3528,8 @@ namespace System.Xml.Tests
         {
             AppContext.SetSwitch("Switch.System.Xml.DontProhibitDefaultResolver", true);
 
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result><elem>1</elem><elem>2</elem><elem>3</elem></result>";
+
             // "xmlResolver_document_function.xsl" contains
             // <xsl:for-each select="document('xmlResolver_document_function.xml')//elem">
 
@@ -3531,15 +3538,13 @@ namespace System.Xml.Tests
             if (LoadXSL("xmlResolver_document_function.xsl") == 1)
             {
                 xslt.Transform(szFullFilename, "out.xml");
-                if (CheckResult(422.3877210723) == 1)
-                    return;
+                VerifyResult(expected);
             }
             else
             {
                 _output.WriteLine("Problem loading stylesheet!");
                 Assert.True(false);
             }
-            Assert.True(false);
         }
 
         //[Variation("Pass XmlUrlResolver, load style sheet with document function, should resolve during transform", Param = "xmlResolver_document_function.txt")]
@@ -3787,58 +3792,82 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Local parameter gets overwritten with global param value", Pri = 1)]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void var1()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><out>
+param1 (correct answer is 'local-param1-arg'): local-param1-arg
+param2 (correct answer is 'local-param2-arg'): local-param2-arg
+</out>";
             m_xsltArg = new XsltArgumentList();
             m_xsltArg.AddParam("param1", string.Empty, "global-param1-arg");
 
-            if ((LoadXSL("paramScope.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) && (CheckResult(473.4644857331) == 1))
+            if ((LoadXSL("paramScope.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Local parameter gets overwritten with global variable value", Pri = 1)]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void var2()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><out>
+param1 (correct answer is 'local-param1-arg'): local-param1-arg
+param2 (correct answer is 'local-param2-arg'): local-param2-arg
+</out>";
             m_xsltArg = new XsltArgumentList();
             m_xsltArg.AddParam("param1", string.Empty, "global-param1-arg");
 
-            if ((LoadXSL("varScope.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) && (CheckResult(473.4644857331) == 1))
+            if ((LoadXSL("varScope.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Subclassed XPathNodeIterator returned from an extension object or XsltFunction is not accepted by XPath", Pri = 1)]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void var3()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><distinct-countries>France, Spain, Austria, Germany</distinct-countries>";
+
             m_xsltArg = new XsltArgumentList();
             m_xsltArg.AddExtensionObject("http://foo.com", new MyXsltExtension());
 
-            if ((LoadXSL("Bug111075.xsl") == 1) && (Transform_ArgList("Bug111075.xml") == 1) && (CheckResult(441.288076277) == 1))
+            if ((LoadXSL("Bug111075.xsl") == 1) && (Transform_ArgList("Bug111075.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Iterator using for-each over a variable is not reset correctly while using msxsl:node-set()", Pri = 1)]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void var4()
         {
-            if ((LoadXSL("Bug109644.xsl") == 1) && (Transform("foo.xml") == 1) && (CheckResult(417.2501860011) == 1))
-                return;
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?>
+		Node Count: {3}
+
+		
+		Correct Output: (1)(2)(3)
+		Incorrect Output: [1][2][3]";
+
+            if ((LoadXSL("Bug109644.xsl") == 1) && (Transform("foo.xml") == 1))
+            {
+                Assert.Equal(expected, File.ReadAllText("out.xml"));
+            }
             else
                 Assert.True(false);
         }

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltApiV2.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltApiV2.cs
@@ -615,22 +615,19 @@ namespace System.Xml.Tests
             XmlTextReader tr1 = new XmlTextReader("out.xml");
             XmlTextReader tr2 = new XmlTextReader(new StringReader(expectedValue));
 
-            bool bResult = xmldiff.Compare(tr1, tr2);
+            bool result = xmldiff.Compare(tr1, tr2);
 
             //Close the readers
             tr1.Dispose();
             tr2.Dispose();
 
-            if (bResult)
-                return;
-            else
-                Assert.True(false);
+             Assert.True(result);
         }
 
         //VerifyResult which compares 2 arguments using XmlDiff.
         public void VerifyResult(string baseline, string outputFile)
         {
-            bool bResult = false;
+            bool result = false;
             FileStream fsExpected;
 
             baseline = FullFilePath(baseline);
@@ -645,7 +642,7 @@ namespace System.Xml.Tests
             _output.WriteLine("Verifying o/p with baseline result {0}...", baseline);
             try
             {
-                bResult = diff.Compare(new XmlTextReader(fsActual, XmlNodeType.Element, context), new XmlTextReader(fsExpected, XmlNodeType.Element, context));
+                result = diff.Compare(new XmlTextReader(fsActual, XmlNodeType.Element, context), new XmlTextReader(fsExpected, XmlNodeType.Element, context));
             }
             catch (Exception e)
             {
@@ -657,7 +654,7 @@ namespace System.Xml.Tests
                 fsExpected.Dispose();
                 fsActual.Dispose();
             }
-            if (!bResult)
+            if (!result)
             {
                 // Write out the actual and expected o/p
                 _output.WriteLine("Expected o/p: ");
@@ -680,13 +677,7 @@ namespace System.Xml.Tests
                 }
             }
 
-            if (bResult)
-                return;
-            else
-            {
-                _output.WriteLine("**** Baseline mis-matched ****");
-                Assert.True(false);
-            }
+            Assert.True(result, "**** Baseline mis-matched ****");
         }
 
         // --------------------------------------------------------------------------------------------------------------

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentList.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentList.cs
@@ -653,9 +653,11 @@ namespace System.Xml.Tests
             }
 
             string expXml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><result xmlns:myObj=\"urn:my-object\"><func1>1.Test1</func1><func2>2.Test2</func2><func3>3.Test3</func3></result>";
-            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(expXml) == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expXml);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -751,9 +753,11 @@ namespace System.Xml.Tests
             }
 
             string expXml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><result xmlns:myObj=\"http://www.microsoft.com/this/is/a/very/long/namespace/uri/to/do/the/api/testing/for/xslt/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/\"><func1>1.Test1</func1><func2>2.Test2</func2><func3>3.Test3</func3></result>";
-            if ((LoadXSL("myObjectLongNS.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(expXml) == 1))
+            if ((LoadXSL("myObjectLongNS.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expXml);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -872,9 +876,11 @@ namespace System.Xml.Tests
             }
 
             string expXml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><result xmlns:myObj=\"urn:my-object\"><func1>1.Test1</func1><func2>2.Test2</func2><func3>3.Test3</func3></result>";
-            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(expXml) == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expXml);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -965,9 +971,11 @@ namespace System.Xml.Tests
                 }
             }
             string expXml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><result xmlns:myObj=\"urn:my-object\"><func1>1.Test1</func1><func2>2.Test2</func2><func3>3.Test3</func3></result>";
-            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(expXml) == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expXml);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -1571,20 +1579,27 @@ namespace System.Xml.Tests
         [Theory]
         public void AddExtObject32()
         {
+            string expected1 = @"<?xml version=""1.0"" encoding=""utf-8""?><out>Param: first</out>";
+            string expected2 = @"<?xml version=""1.0"" encoding=""utf-8""?><out>Param: second</out>";
+
             if (LoadXSL("test_Param.xsl") == 1)
             {
                 m_xsltArg = new XsltArgumentList();
                 m_xsltArg.AddParam("myParam1", szEmpty, "first");
 
                 // Transform once
-                if ((Transform_ArgList("foo.xml") == 1) && (CheckResult(383.6292620645) == 1))
+                if (Transform_ArgList("foo.xml") == 1)
                 {
+                    VerifyResult(expected1);
                     m_xsltArg = new XsltArgumentList();
                     m_xsltArg.AddParam("myParam1", szEmpty, "second");
 
                     // Transform again to make sure that parameter from first transform are not cached
-                    if ((Transform_ArgList("foo.xml") == 1) && (CheckResult(384.9801823644) == 1))
+                    if (Transform_ArgList("foo.xml") == 1)
+                    {
+                        VerifyResult(expected2);
                         return;
+                    }
                 }
             }
             Assert.True(false);
@@ -2009,14 +2024,21 @@ namespace System.Xml.Tests
         [Theory]
         public void AddExtObject10()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+
+		Test1
+		Test2: 0</result>";
+
             MyObject obj = new MyObject(10, _output);
             m_xsltArg = new XsltArgumentList();
             ///nonePermSet.PermitOnly(); ;
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
             ///CodeAccessPermission.RevertPermitOnly();
-            if ((LoadXSL("MyObject_Null.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(424.8906559839) == 1 || CheckResult(425.0247531107) == 1 /* for writer */))
+            if ((LoadXSL("MyObject_Null.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -2192,14 +2214,20 @@ namespace System.Xml.Tests
         [Theory]
         public void AddExtObject17()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+		Here:End
+		</result>";
+
             MyObject obj = new MyObject(17, _output);
             m_xsltArg = new XsltArgumentList();
             ///nonePermSet.PermitOnly(); ;
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
             ///CodeAccessPermission.RevertPermitOnly();
-            if ((LoadXSL("MyObject_ConsoleWrite.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(421.8660259804) == 1 || CheckResult(421.8527116762) == 1 /* for writer */))
+            if ((LoadXSL("MyObject_ConsoleWrite.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -2360,7 +2388,6 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Deliberately Messing Up the Stylesheet", Param = "MyObject_KillerStrings.txt")]
-        [ActiveIssue(9877)]
         [InlineData("MyObject_KillerStrings.txt")]
         [Theory]
         public void AddExtObject28(object param)

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTArgumentList.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTArgumentList.cs
@@ -992,11 +992,18 @@ namespace System.Xml.Tests
         }
 
         //[Variation(Desc = "Basic Verification Test", Pri = 0)]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddParam1()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.Test1
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -1005,9 +1012,11 @@ namespace System.Xml.Tests
             if (retObj.ToString() != "Test1")
                 Assert.True(false);
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(457.6003003605) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -1051,11 +1060,13 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Very Long Param Name")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddParam4()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.Test1</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam(szLongString, szEmpty, "Test1");
@@ -1064,9 +1075,11 @@ namespace System.Xml.Tests
             if (retObj.ToString() != "Test1")
                 Assert.True(false);
 
-            if ((LoadXSL("showParamLongName.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(383.8692240713) == 1))
+            if ((LoadXSL("showParamLongName.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -1110,11 +1123,18 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Namespace URI is empty string")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddParam7()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.Test7
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test7");
@@ -1124,19 +1144,28 @@ namespace System.Xml.Tests
             if (retObj.ToString() != "Test7")
                 Assert.True(false);
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(457.7055635184) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Very long namespace System.Xml.Tests")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddParam8()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szLongNS, "Test8");
@@ -1145,9 +1174,11 @@ namespace System.Xml.Tests
             if (retObj.ToString() != "Test8")
                 Assert.True(false);
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -1176,19 +1207,28 @@ namespace System.Xml.Tests
         */
 
         //[Variation("Objects as different Data Types")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddParam10()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.My Custom Object has a value of 10
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
             MyObject m = new MyObject(10, _output);
 
             m_xsltArg.AddParam("myArg1", szEmpty, m);
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(473.4007803959) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -1214,11 +1254,18 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Object with same name, different namespace System.Xml.Tests")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddParam12()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.Test1
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -1240,19 +1287,28 @@ namespace System.Xml.Tests
             if (retObj.ToString() != "Test1")
                 Assert.True(false);
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(457.6003003605) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Object with same namespace System.Xml.Tests, different name")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddParam13()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.Test1
+		2.Test2
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -1274,19 +1330,28 @@ namespace System.Xml.Tests
             if (retObj.ToString() != "Test1")
                 Assert.True(false);
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(449.000354515) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Case Sensitivity")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddParam14()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.Test1
+		2.Test2
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -1313,9 +1378,11 @@ namespace System.Xml.Tests
             if (retObj.ToString() != "Test3")
                 Assert.True(false);
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(449.000354515) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -1340,11 +1407,18 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Add/remove object many times")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddParam16()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.Test1
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
             String obj = "Test";
 
@@ -1381,19 +1455,32 @@ namespace System.Xml.Tests
             retObj = m_xsltArg.GetParam("myArg2", szEmpty);
             if (retObj.ToString() != ("Test1"))
                 Assert.True(false);
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(458.7752486264) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Whitespace in URI and param")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddParam17()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.Test  
+		2.Test
+
+		3.Test	
+		4.Test
+
+		5.Test	
+  
+	
+		6.No Value Specified</result>";
+
             int i = 1;
             int errCount = 0;
             m_xsltArg = new XsltArgumentList();
@@ -1434,19 +1521,28 @@ namespace System.Xml.Tests
                 Assert.True(false);
             }
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(420.7138852814) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Adding many objects")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddParam18()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.Test1
+		2.Test2
+		3.Test3
+		4.Test4
+		5.Test5
+		6.Test6</result>";
+
             m_xsltArg = new XsltArgumentList();
             String obj = "Test";
 
@@ -1458,19 +1554,28 @@ namespace System.Xml.Tests
                     Assert.True(false);
             }
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(413.6341271694) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Add same object many times")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddParam19()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.Test1
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
             String obj = "Test";
 
@@ -1490,19 +1595,28 @@ namespace System.Xml.Tests
             retObj = m_xsltArg.GetParam("myArg2", szEmpty);
             if (retObj.ToString() != ("Test1"))
                 Assert.True(false);
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(458.7752486264) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Using Different XSLT namespace")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddParam20()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj1=""urn:http://www.w3.org/1999/XSL/Transform"" xmlns:myObj2=""urn:tmp"" xmlns:myObj3=""urn:my-object"" xmlns:myObj4=""urn:MY-OBJECT"">
+		1.Test1
+		2.Test2
+		3.Test3
+		4.Test4
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", "urn:" + szXslNS, "Test1");
@@ -1529,9 +1643,11 @@ namespace System.Xml.Tests
             if (retObj.ToString() != "Test4")
                 Assert.True(false);
 
-            if ((LoadXSL("showParamNS.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(509.315418596) == 1))
+            if ((LoadXSL("showParamNS.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -1551,20 +1667,28 @@ namespace System.Xml.Tests
         [Theory]
         public void AddExtObject32()
         {
+            string expected1 = @"<?xml version=""1.0"" encoding=""utf-8""?><out>Param: first</out>";
+            string expected2 = @"<?xml version=""1.0"" encoding=""utf-8""?><out>Param: second</out>";
+
             if (LoadXSL("test_Param.xsl") == 1)
             {
                 m_xsltArg = new XsltArgumentList();
                 m_xsltArg.AddParam("myParam1", szEmpty, "first");
 
                 // Transform once
-                if ((Transform_ArgList("foo.xml") == 1) && (CheckResult(383.6292620645) == 1))
+                if (Transform_ArgList("foo.xml") == 1)
                 {
+                    VerifyResult(expected1);
+
                     m_xsltArg = new XsltArgumentList();
                     m_xsltArg.AddParam("myParam1", szEmpty, "second");
 
                     // Transform again to make sure that parameter from first transform are not cached
-                    if ((Transform_ArgList("foo.xml") == 1) && (CheckResult(384.9801823644) == 1))
+                    if (Transform_ArgList("foo.xml") == 1)
+                    {
+                        VerifyResult(expected2);
                         return;
+                    }
                 }
             }
             Assert.True(false);
@@ -1810,18 +1934,24 @@ namespace System.Xml.Tests
         }
 
         //[Variation(Desc = "Basic Verification Test", Pri = 0)]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddExtObject1()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+		1.Test1
+		2.Test2
+		3.Test3</result>";
+
             MyObject obj = new MyObject(1, _output);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
-            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(430.402026847) == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -1859,29 +1989,43 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Very long namespace System.Xml.Tests")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddExtObject4()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""http://www.miocrosoft.com/this/is/a/very/long/namespace/uri/to/do/the/api/testing/for/xslt/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/0123456789/"">
+		1.Test1
+		2.Test2
+		3.Test3</result>";
+
             m_xsltArg = new XsltArgumentList();
             MyObject obj = new MyObject(4, _output);
 
             m_xsltArg.AddExtensionObject(szLongNS, obj);
 
-            if ((LoadXSL("MyObjectLongNS.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(522.0563223871) == 1))
+            if ((LoadXSL("myObjectLongNS.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Different Data Types")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddExtObject6()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+
+		String  Argument: System.String
+		Int32   Argument: System.Int32
+		Boolean Argument: System.Boolean
+		Boolean Argument: System.Boolean
+		Double  Argument: System.Double
+		String  Argument: System.String</result>";
+
             m_xsltArg = new XsltArgumentList();
             String obj = "0.00";
 
@@ -1952,9 +2096,11 @@ namespace System.Xml.Tests
             retObj = m_xsltArg.GetExtensionObject("myArg6");
             _output.WriteLine("Added Value:{0}\nRetrieved Value: {1}", bT.ToString(), retObj);
 
-            if ((LoadXSL("MyObject_DataTypes.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(499.4069850096) == 1))
+            if ((LoadXSL("MyObject_DataTypes.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -1982,11 +2128,15 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Case sensitivity")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddExtObject8()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+		1.Test1
+		2.Test2
+		3.Test3</result>";
+
             MyObject obj = new MyObject(1, _output);
             m_xsltArg = new XsltArgumentList();
 
@@ -2002,9 +2152,11 @@ namespace System.Xml.Tests
             m_xsltArg.AddExtensionObject("urn:My-Object", obj);
             m_xsltArg.AddExtensionObject("urn-my:object", obj);
 
-            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(430.402026847) == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -2030,28 +2182,38 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Unitialized and NULL return values from the methods in the extension object")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddExtObject10()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+
+		Test1
+		Test2: 0</result>";
+
             MyObject obj = new MyObject(10, _output);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
-            if ((LoadXSL("MyObject_Null.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(424.8906559839) == 1))
+            if ((LoadXSL("MyObject_Null.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Add many objects")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddExtObject11()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+		1.Test1
+		2.Test2
+		3.Test3</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             MyObject obj1 = new MyObject(100, _output);
@@ -2062,9 +2224,11 @@ namespace System.Xml.Tests
                 MyObject obj = new MyObject(i, _output);
                 m_xsltArg.AddExtensionObject(szDefaultNS + i, obj);
             }
-            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(430.402026847) == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -2118,11 +2282,15 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Add and Remove multiple times")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddExtObject14()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+		1.Test1
+		2.Test2
+		3.Test3</result>";
+
             MyObject obj = new MyObject(14, _output);
             m_xsltArg = new XsltArgumentList();
 
@@ -2133,9 +2301,11 @@ namespace System.Xml.Tests
             }
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
 
-            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(430.402026847) == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -2200,103 +2370,149 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Writing To Output")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddExtObject17()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+		Here:End
+		</result>";
+
             MyObject obj = new MyObject(17, _output);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
-            if ((LoadXSL("MyObject_ConsoleWrite.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(421.8660259804) == 1))
+            if ((LoadXSL("MyObject_ConsoleWrite.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Recursive Functions")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddExtObject18()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+		Recursive Function Returning the factorial of five:120</result>";
+
             MyObject obj = new MyObject(18, _output);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
-            if ((LoadXSL("MyObject_Recursion.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(459.4210605285) == 1))
+            if ((LoadXSL("MyObject_Recursion.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Overloaded Functions")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddExtObject19()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+		Overloaded Double: Int Overlaod
+		Overloaded Int: Int Overlaod
+		Overloaded String: String Overlaod</result>";
+
             MyObject obj = new MyObject(19, _output);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
-            if ((LoadXSL("MyObject_Overloads.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(481.1053900491) == 1))
+            if ((LoadXSL("MyObject_Overloads.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Function-exists tests")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddExtObject20()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+		DoNothing Function Test Pass
+		Construtor Function
+		Return Int  Function Test Pass
+		Return String Function Test Pass
+		ReturnInt  Function Test Pass
+		Taking in args  Test Pass
+		Public Function Test Pass
+		Protected Function
+		Private Function
+		Default Function</result>";
+
             MyObject obj = new MyObject(20, _output);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
-            if ((LoadXSL("MyObject_FnExists.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(534.2681508201) == 1))
+            if ((LoadXSL("MyObject_FnExists.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Argument Tests")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddExtObject21()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+
+		String  Argument: Received a string with value: Hello
+		Double  Argument: Received a double with value 3.14
+		Boolean Argument: Statement is True
+		Boolean True Argument: Statement is False</result>";
+
             MyObject obj = new MyObject(1, _output);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
-            if ((LoadXSL("MyObject_Arguments.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(513.296131727) == 1))
+            if ((LoadXSL("MyObject_Arguments.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Methods returning void and valid types")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddExtObject22()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+		Get A String:Hello world
+		Get A Double:22.41276
+		Get A True Boolean:true
+		Get A False Boolean:false
+		Get An Int:10
+		Get Other with ToString() Support:My Custom Object has a value of 22
+		Call function with no return type:</result>";
+
             MyObject obj = new MyObject(22, _output);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
-            if ((LoadXSL("MyObject_ReturnValidTypes.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(514.0958814743) == 1))
+            if ((LoadXSL("MyObject_ReturnValidTypes.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -2374,35 +2590,56 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Maintaining State")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddExtObject27()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+		A:27
+		B:23
+		C:23
+		D:23
+		E:37
+		F:Hello 
+		G:Hello World 
+		E:-13</result>";
+
             MyObject obj = new MyObject(27, _output);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
-            if ((LoadXSL("MyObject_KeepingState.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(439.7536748395) == 1))
+            if ((LoadXSL("MyObject_KeepingState.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Deliberately Messing Up the Stylesheet")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddExtObject28()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+
+		Aiming with Gun: &gt;"" $tmp &gt;;'	 
+&amp;
+		Aiming with Missile: &lt;xsl:variable name=""tmp""/&gt;
+		Aiming with Nuclear: &lt;/xsl:stylesheet&gt;
+		Wow...survived all killer ammo.
+	</result>";
+
             MyObject obj = new MyObject(28, _output);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
-            if ((LoadXSL("MyObject_KillerStrings.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(495.5795381156) == 1 || CheckResult(503.3730396353) == 1))  //multiple baseline
+            if ((LoadXSL("MyObject_KillerStrings.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -2444,11 +2681,18 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Extension objects should not be cached during Transform()")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void AddExtObject32()
         {
+            string expected1 = @"<?xml version=""1.0"" encoding=""utf-8""?><out xmlns:id=""id"" xmlns:cap=""capitalizer"">
+			ID: first
+			Capitalized ID: FIRST</out>";
+
+            string expected2 = @"<?xml version=""1.0"" encoding=""utf-8""?><out xmlns:id=""id"" xmlns:cap=""capitalizer"">
+			ID: second
+			Capitalized ID: SECOND</out>";
+
             if (LoadXSL("Bug78587.xsl") == 1)
             {
                 m_xsltArg = new XsltArgumentList();
@@ -2456,15 +2700,20 @@ namespace System.Xml.Tests
                 m_xsltArg.AddExtensionObject("capitalizer", new Capitalizer());
 
                 // Transform once
-                if ((Transform_ArgList("Bug78587.xml") == 1) && (CheckResult(438.9506396879) == 1))
+                if (Transform_ArgList("Bug78587.xml") == 1)
                 {
+                    VerifyResult(expected1);
+
                     m_xsltArg = new XsltArgumentList();
                     m_xsltArg.AddExtensionObject("id", new Id("second"));
                     m_xsltArg.AddExtensionObject("capitalizer", new Capitalizer());
 
                     // Transform again to make sure that extension objects from first transform are not cached
-                    if ((Transform_ArgList("Bug78587.xml") == 1) && (CheckResult(440.0296788876) == 1))
+                    if (Transform_ArgList("Bug78587.xml") == 1)
+                    {
+                        VerifyResult(expected2);
                         return;
+                    }
                 }
             }
             Assert.True(false);
@@ -2489,11 +2738,18 @@ namespace System.Xml.Tests
         }
 
         //[Variation(Desc = "Basic Verification Test", Pri = 0)]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void RemoveParam1()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.Test1
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test2");
@@ -2514,9 +2770,11 @@ namespace System.Xml.Tests
                 Assert.True(false);
             }
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(457.6003003605) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -2537,67 +2795,98 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Param name is empty string")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void RemoveParam3()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
             m_xsltArg.RemoveParam(szEmpty, szEmpty);
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Param name is non-existent")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void RemoveParam4()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
             m_xsltArg.RemoveParam(szSimple, szEmpty);
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Invalid Param name")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void RemoveParam5()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
             m_xsltArg.RemoveParam(szInvalid, szEmpty);
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Very long param name")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void RemoveParam6()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam(szLongString, szEmpty, "Test1");
             m_xsltArg.RemoveParam(szLongString, szEmpty);
 
-            if ((LoadXSL("showParamLongName.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(400.2204182193) == 1))
+            if ((LoadXSL("showParamLongName.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -2619,65 +2908,99 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Namespace URI is empty string")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void RemoveParam8()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
             m_xsltArg.RemoveParam("myArg1", szEmpty);
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Namespace URI is non-existent")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void RemoveParam9()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.Test1
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
             m_xsltArg.RemoveParam("myArg1", "http://www.xsltTest.com");
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(457.6003003605) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Very long namespace System.Xml.Tests")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void RemoveParam10()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szLongString, "Test1");
             m_xsltArg.RemoveParam("myArg1", szLongString);
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Different Data Types")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void RemoveParam11()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             double d1 = double.PositiveInfinity;
             double d2 = double.NegativeInfinity;
             double d3 = double.NaN;
@@ -2867,19 +3190,28 @@ namespace System.Xml.Tests
                 Assert.True(false);
             }
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Case Sensitivity")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void RemoveParam12()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.Test1
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -2888,19 +3220,28 @@ namespace System.Xml.Tests
             m_xsltArg.RemoveParam("myArg1 ", szEmpty);
 
             // perform a transform for kicks and ensure all is ok.
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(457.6003003605) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Whitespace")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void RemoveParam13()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.Test
+		2.Test
+		3.Test
+		4.Test
+		5.Test
+		6.No Value Specified</result>";
+
             int i = 1;
             m_xsltArg = new XsltArgumentList();
 
@@ -2932,19 +3273,28 @@ namespace System.Xml.Tests
             }
 
             // perform a transform for kicks and ensure all is ok.
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(421.3863242307) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Call Multiple Times")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void RemoveParam14()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -2952,9 +3302,11 @@ namespace System.Xml.Tests
             for (int i = 0; i < 500; i++)
                 m_xsltArg.RemoveParam("myArg1", szEmpty);
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -3033,11 +3385,18 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Call Multiple Times")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void RemoveExtObj3()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             MyObject obj = new MyObject(10, _output);
             m_xsltArg = new XsltArgumentList();
 
@@ -3046,28 +3405,36 @@ namespace System.Xml.Tests
             for (int i = 0; i < 500; i++)
                 m_xsltArg.RemoveExtensionObject(szDefaultNS);
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Namespace URI is non-existent")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void RemoveExtObj4()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+		1.Test1
+		2.Test2
+		3.Test3</result>";
+
             MyObject obj = new MyObject(4, _output);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddExtensionObject(szDefaultNS, obj);
             m_xsltArg.RemoveExtensionObject(szSimple);
 
-            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(430.402026847) == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -3097,11 +3464,18 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Different Data Types")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void RemoveExtObj6()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             MyObject obj = new MyObject(6, _output);
             m_xsltArg = new XsltArgumentList();
 
@@ -3123,19 +3497,25 @@ namespace System.Xml.Tests
             m_xsltArg.AddExtensionObject("urn:my-object", false);
             m_xsltArg.RemoveExtensionObject("urn:my-object");
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Case Sensitivity")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void RemoveExtObj7()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
+		1.Test1
+		2.Test2
+		3.Test3</result>";
+
             MyObject obj = new MyObject(7, _output);
             m_xsltArg = new XsltArgumentList();
 
@@ -3146,9 +3526,11 @@ namespace System.Xml.Tests
             m_xsltArg.RemoveExtensionObject("urn-my:object");
             m_xsltArg.RemoveExtensionObject("urn:my-object ");
 
-            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(430.402026847) == 1))
+            if ((LoadXSL("myObjectDef.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -3190,20 +3572,29 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Using default XSLT namespace - Bug305503")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void RemoveExtObj9()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             MyObject obj = new MyObject(10, _output);
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.RemoveExtensionObject(szDefaultNS);
 
             // ensure we can still do a transform
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -3223,11 +3614,18 @@ namespace System.Xml.Tests
         }
 
         //[Variation(Desc = "Basic Verification Test", Pri = 0)]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void Clear1()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -3240,35 +3638,53 @@ namespace System.Xml.Tests
             if (retObj != null)
                 Assert.True(false);
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Clear with nothing loaded")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void Clear2()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.Clear();
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Clear Params")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void Clear3()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -3281,9 +3697,11 @@ namespace System.Xml.Tests
             if (retObj != null)
                 Assert.True(false);
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -3321,11 +3739,18 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Clear Many Objects")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void Clear5()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
             String obj = "Test";
 
@@ -3354,23 +3779,30 @@ namespace System.Xml.Tests
                 }
             }
 
-            //	_output.WriteLine(retObj.GetType());
-
             m_xsltArg.Clear();
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Clear Multiple Times")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void Clear6()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -3384,19 +3816,28 @@ namespace System.Xml.Tests
             if (retObj != null)
                 Assert.True(false);
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Loading one object, but clearing another")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void Clear7()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.Test1
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
             XsltArgumentList m_2 = new XsltArgumentList();
 
@@ -3407,19 +3848,28 @@ namespace System.Xml.Tests
 
             m_2.Clear();
 
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) &&
-                (CheckResult(457.6003003605) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Clear after objects have been \"Removed\"")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void Clear8()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             m_xsltArg = new XsltArgumentList();
 
             m_xsltArg.AddParam("myArg1", szEmpty, "Test1");
@@ -3429,9 +3879,10 @@ namespace System.Xml.Tests
             retObj = m_xsltArg.RemoveParam("myArg1", szEmpty);
             m_xsltArg.Clear();
 
-            if ((LoadXSL("showParam.xsl") != 1) || (Transform_ArgList("fruits.xml") != 1) ||
-                (CheckResult(466.5112789241) != 1))
-                Assert.True(false);
+            if ((LoadXSL("showParam.xsl") != 1) || (Transform_ArgList("fruits.xml") != 1))
+            Assert.True(false);
+
+            VerifyResult(expected);
 
             MyObject obj = new MyObject(26, _output);
 

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
@@ -2545,24 +2545,15 @@ namespace System.Xml.Tests
             if (LoadXSL("showParam.xsl") == 1)
             {
                 CallTransform(xslt, szFullFilename, _strOutFile);
-                StreamReader fs = null;
 
                 // check if I can open and close the xml file
-                using (FileStream outFile = new FileStream(szFullFilename, FileMode.Open, FileAccess.Read))
-                {
-                    fs = new StreamReader(outFile);
-                    fs.Dispose();
-                }
+                File.ReadAllText(szFullFilename);
 
                 strmTemp = new FileStream(szFullFilename, FileMode.Open, FileAccess.Read);
                 strmTemp.Dispose();
 
                 // check if I can open and close the output file
-                using (FileStream outFile = new FileStream(_strOutFile, FileMode.Open, FileAccess.Read))
-                {
-                    fs = new StreamReader(outFile);
-                    fs.Dispose();
-                }
+                File.ReadAllText(_strOutFile);
 
                 strmTemp = new FileStream(_strOutFile, FileMode.Open, FileAccess.Read);
                 strmTemp.Dispose();

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
@@ -377,13 +377,18 @@ namespace System.Xml.Tests
         {
             AppContext.SetSwitch("Switch.System.Xml.DontProhibitDefaultResolver", true);
 
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result><fruit>Apple</fruit><fruit>orange</fruit></result>";
+
             try
             {
                 if (LoadXSL("XmlResolver_Main.xsl") == 1)
                 {
                     xslt.XmlResolver = null;
-                    if ((Transform("fruits.xml") == 1) && (CheckResult(428.8541842246) == 1))
+                    if (Transform("fruits.xml") == 1)
+                    {
+                        VerifyResult(expected);
                         return;
+                    }
                     else
                         Assert.True(false);
                 }
@@ -402,14 +407,19 @@ namespace System.Xml.Tests
         [Theory]
         public void XmlResolver2()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result></result>";
+
             // "xmlResolver_document_function.xsl" contains
             // <xsl:for-each select="document('xmlResolver_document_function.xml')//elem">
 
             if (LoadXSL("xmlResolver_document_function.xsl") == 1)
             {
                 xslt.XmlResolver = null;
-                if ((Transform("fruits.xml") == 1) && (CheckResult(375.6079891948) == 1))
+                if (Transform("fruits.xml") == 1)
+                {
+                    VerifyResult(expected);
                     return;
+                }
             }
             else
             {
@@ -567,31 +577,47 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Load an invalid, then a valid and transform")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void LoadGeneric3()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             try
             {
                 LoadXSL("IDontExist.xsl");
             }
             catch (System.IO.FileNotFoundException)
             {
-                if ((LoadXSL("ShowParam.xsl") == 1) && (Transform("fruits.xml") == 1)
-                && (CheckResult(466.5112789241) == 1))
+                if ((LoadXSL("showParam.xsl") == 1) && (Transform("fruits.xml") == 1))
+                {
+                    VerifyResult(expected);
                     return;
+                }
             }
             _output.WriteLine("Exception not generated for non-existent file name");
             Assert.True(false);
         }
 
         //[Variation("Call several overloaded functions")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void LoadGeneric4()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             if (MyInputType() != InputType.Reader)
                 LoadXSL("showParamLongName.xsl", InputType.Reader);
             if (MyInputType() != InputType.URI)
@@ -599,10 +625,11 @@ namespace System.Xml.Tests
             if (MyInputType() != InputType.Navigator)
                 LoadXSL("showParamLongName.xsl", InputType.Navigator);
 
-            if ((LoadXSL("ShowParam.xsl") == 0) || (Transform("fruits.xml") == 0)
-                    || (CheckResult(466.5112789241) == 0))
+            if ((LoadXSL("showParam.xsl") == 0) || (Transform("fruits.xml") == 0))
                 Assert.True(false);
 
+            VerifyResult(expected);
+
             if (MyInputType() != InputType.Navigator)
                 LoadXSL("showParamLongName.xsl", InputType.Navigator);
             if (MyInputType() != InputType.URI)
@@ -610,19 +637,28 @@ namespace System.Xml.Tests
             if (MyInputType() != InputType.Reader)
                 LoadXSL("showParamLongName.xsl", InputType.Reader);
 
-            if ((LoadXSL("ShowParam.xsl") == 1) && (Transform("fruits.xml") == 1)
-                    && (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
 
             Assert.True(false);
         }
 
         //[Variation("Call same overloaded Load() many times then transform")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void LoadGeneric5()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             for (int i = 0; i < 100; i++)
             {
                 if (LoadXSL("showParam.xsl") != 1)
@@ -631,9 +667,11 @@ namespace System.Xml.Tests
                     Assert.True(false);
                 }
             }
-            if ((LoadXSL("ShowParam.xsl") == 1) && (Transform("fruits.xml") == 1)
-                && (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             Assert.True(false);
         }
 
@@ -661,6 +699,8 @@ namespace System.Xml.Tests
         {
             AppContext.SetSwitch("Switch.System.Xml.DontProhibitDefaultResolver", true);
 
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result><fruit>Apple</fruit><fruit>orange</fruit></result>";
+
             FileStream s2;
 
             // check immediately after load and after transform
@@ -668,8 +708,9 @@ namespace System.Xml.Tests
             {
                 s2 = new FileStream(FullFilePath("XmlResolver_Main.xsl"), FileMode.Open, FileAccess.Read, FileShare.Read);
                 s2.Dispose();
-                if ((Transform("fruits.xml") == 1) && (CheckResult(428.8541842246) == 1))
+                if (Transform("fruits.xml") == 1)
                 {
+                    VerifyResult(expected);
                     s2 = new FileStream(FullFilePath("XmlResolver_Main.xsl"), FileMode.Open, FileAccess.Read, FileShare.Read);
                     s2.Dispose();
                     return;
@@ -711,6 +752,8 @@ namespace System.Xml.Tests
         {
             AppContext.SetSwitch("Switch.System.Xml.DontProhibitDefaultResolver", true);
 
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result><fruit>Apple</fruit><fruit>orange</fruit></result>";
+
             FileStream s2;
 
             // check immediately after load and after transform
@@ -718,8 +761,9 @@ namespace System.Xml.Tests
             {
                 s2 = new FileStream(FullFilePath("XmlResolver_Sub.xsl"), FileMode.Open, FileAccess.Read);
                 s2.Dispose();
-                if ((Transform("fruits.xml") == 1) && (CheckResult(428.8541842246) == 1))
+                if (Transform("fruits.xml") == 1)
                 {
+                    VerifyResult(expected);
                     s2 = new FileStream(FullFilePath("XmlResolver_Include.xsl"), FileMode.Open, FileAccess.Read, FileShare.Read);
                     s2.Dispose();
                     return;
@@ -755,11 +799,14 @@ namespace System.Xml.Tests
         */
 
         //[Variation("Load stylesheet with entity reference: Bug #68450 ")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void LoadGeneric11()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><Book>
+			Name
+		</Book>";
+
             if (MyDocType().ToString() == "DataDocument")
                 // Skip the test for DataDocument
                 return;
@@ -770,9 +817,11 @@ namespace System.Xml.Tests
                     _output.WriteLine("Failed to load stylesheet books_entity_ref.xsl");
                     Assert.True(false);
                 }
-                if ((LoadXSL("books_entity_ref.xsl") == 1) && (Transform("books_entity_ref.xml") == 1)
-                    && (CheckResult(371.4148215954) == 1))
+                if ((LoadXSL("books_entity_ref.xsl") == 1) && (Transform("books_entity_ref.xml") == 1))
+                {
+                    VerifyResult(expected);
                     return;
+                }
                 Assert.True(false);
             }
         }
@@ -869,15 +918,25 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Call Load with null XmlResolver, style sheet does not have include/import, should not error")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void LoadGeneric3()
         {
-            if (LoadXSL_Resolver("ShowParam.xsl", null) == 1)
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
+            if (LoadXSL_Resolver("showParam.xsl", null) == 1)
             {
-                if ((Transform("fruits.xml") == 1) && (CheckResult(466.5112789241) == 1))
+                if (Transform("fruits.xml") == 1)
+                {
+                    VerifyResult(expected);
                     return;
+                }
                 else
                     Assert.True(false);
             }
@@ -946,7 +1005,7 @@ namespace System.Xml.Tests
             //}
 
             CustomNullResolver myResolver = new CustomNullResolver(null);
-            if (LoadXSL_Resolver("ShowParam.xsl", myResolver) == 1)
+            if (LoadXSL_Resolver("showParam.xsl", myResolver) == 1)
             {
                 if ((Transform("fruits.xml") == 1) && (CheckResult(466.5112789241) == 1))
                     return;
@@ -1038,11 +1097,15 @@ namespace System.Xml.Tests
         {
             AppContext.SetSwitch("Switch.System.Xml.DontProhibitDefaultResolver", true);
 
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result><fruit>Apple</fruit><fruit>orange</fruit></result>";
+
             if ((LoadXSL_Resolver("XmlResolver_Main.xsl", GetDefaultCredResolver()) == 1))
             {
-                if ((LoadXSL("XmlResolver_Main.xsl") == 1) && (Transform("fruits.xml") == 1)
-                    && (CheckResult(428.8541842246) == 1))
+                if ((LoadXSL("XmlResolver_Main.xsl") == 1) && (Transform("fruits.xml") == 1))
+                {
+                    VerifyResult(expected);
                     return;
+                }
             }
             else
             {
@@ -1053,11 +1116,18 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Call Load() many times with null resolver then perform a transform")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void LoadGeneric10()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             for (int i = 0; i < 100; i++)
             {
                 if (LoadXSL_Resolver("showParam.xsl", null) != 1)
@@ -1066,9 +1136,11 @@ namespace System.Xml.Tests
                     Assert.True(false);
                 }
             }
-            if ((LoadXSL_Resolver("showParam.xsl", null) == 1) && (Transform("fruits.xml") == 1)
-                && (CheckResult(466.5112789241) == 1))
+            if ((LoadXSL_Resolver("showParam.xsl", null) == 1) && (Transform("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             Assert.True(false);
         }
 
@@ -1145,11 +1217,16 @@ namespace System.Xml.Tests
         [Theory]
         public void LoadUrlResolver1()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><out>Red50Orange25</out>";
+
             // XsltResolverTestMain.xsl is placed in IIS virtual directory
             // which requires integrated Windows NT authentication
             if ((LoadXSL_Resolver(("XmlResolver/XsltResolverTestMain.xsl"), GetDefaultCredResolver()) == 1) &&
-                (Transform("fruits.xml") == 1) && (CheckResult(382.4519733094) == 1))
+                (Transform("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
 
             Assert.True(false);
         }
@@ -1427,11 +1504,18 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Basic Verification Test")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void LoadNavigator1()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
 #pragma warning disable 0618
             xslt = new XslTransform();
 #pragma warning restore 0618
@@ -1447,17 +1531,27 @@ namespace System.Xml.Tests
             xrLoad.Dispose();
             xslt.Load(xdTemp);
 
-            if ((Transform("fruits.xml") == 1) && (CheckResult(466.5112789241) == 1))
+            if (Transform("fruits.xml") == 1)
+            {
+                VerifyResult(expected);
                 return;
+            }
             Assert.True(false);
         }
 
         //[Variation("Create Navigator and navigate away from root")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void LoadNavigator2()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
 #pragma warning disable 0618
             xslt = new XslTransform();
             XmlValidatingReader xrLoad = new XmlValidatingReader(new XmlTextReader(FullFilePath("showParam.xsl")));
@@ -1469,8 +1563,11 @@ namespace System.Xml.Tests
             xP.MoveToNext();
             xslt.Load(xP);
 
-            if ((Transform("fruits.xml") == 1) && (CheckResult(466.5112789241) == 1))
+            if (Transform("fruits.xml") == 1)
+            {
+                VerifyResult(expected);
                 return;
+            }
             Assert.True(false);
         }
 
@@ -1479,6 +1576,8 @@ namespace System.Xml.Tests
         [Theory]
         public void LoadNavigator3()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><out>Red50Orange25</out>";
+
 #pragma warning disable 0618
             xslt = new XslTransform();
             XmlValidatingReader xrLoad = new XmlValidatingReader(new XmlTextReader(FullFilePath("XmlResolver/XsltResolverTestMain.xsl")));
@@ -1489,8 +1588,11 @@ namespace System.Xml.Tests
             XPathNavigator xP = ((IXPathNavigable)xdTemp).CreateNavigator();
 
             xslt.Load(xP, GetDefaultCredResolver());
-            if ((Transform("fruits.xml") == 1) && (CheckResult(382.4519733094) == 1))
+            if (Transform("fruits.xml") == 1)
+            {
+                VerifyResult(expected);
                 return;
+            }
 
             Assert.True(false);
         }
@@ -1538,11 +1640,18 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Basic Verification Test")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void LoadXmlReader1()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             Boolean fTEST_FAIL = false;
 #pragma warning disable 0618
             xslt = new XslTransform();
@@ -1566,8 +1675,11 @@ namespace System.Xml.Tests
             }
             if (fTEST_FAIL)
                 Assert.True(false);
-            if ((Transform("fruits.xml") == 1) && (CheckResult(466.5112789241) == 1))
+            if (Transform("fruits.xml") == 1)
+            {
+                VerifyResult(expected);
                 return;
+            }
             Assert.True(false);
         }
 
@@ -1598,7 +1710,7 @@ namespace System.Xml.Tests
             Assert.True(false);
         }
 
-        //[Variation("Verify Reader isn't closed after Load")]
+        //[Variation("Verify Reader isn""t closed after Load")]
         [InlineData()]
         [Theory]
         public void LoadXmlReader3()
@@ -1730,6 +1842,8 @@ namespace System.Xml.Tests
         [Theory]
         public void LoadXmlReader7()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><out>Red50Orange25</out>";
+
 #pragma warning disable 0618
             xslt = new XslTransform();
             XmlValidatingReader xrLoad = new XmlValidatingReader(new XmlTextReader(FullFilePath("XmlResolver/XsltResolverTestMain.xsl")));
@@ -1738,8 +1852,11 @@ namespace System.Xml.Tests
             xslt.Load(xrLoad, GetDefaultCredResolver());
             xrLoad.Dispose();
 
-            if ((Transform("fruits.xml") == 1) && (CheckResult(382.4519733094) == 1))
+            if (Transform("fruits.xml") == 1)
+            {
+                VerifyResult(expected);
                 return;
+            }
 
             Assert.True(false);
         }
@@ -1770,48 +1887,72 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Basic Verification Test")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void TransformGeneric1()
         {
-            if ((LoadXSL("showParam.xsl") == 1) && (Transform("fruits.xml") == 1) &&
-                 (CheckResult(466.5112789241) == 1))
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
+            if ((LoadXSL("showParam.xsl") == 1) && (Transform("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Load and Transform multiple times")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void TransformGeneric2()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             for (int i = 0; i < 5; i++)
             {
-                if ((LoadXSL("showParam.xsl") != 1) || (Transform("fruits.xml") != 1) ||
-                     (CheckResult(466.5112789241) != 1))
+                if ((LoadXSL("showParam.xsl") != 1) || (Transform("fruits.xml") != 1))
                     Assert.True(false);
+                VerifyResult(expected);
             }
             return;
         }
 
         //[Variation("Load once, Transform many times")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void TransformGeneric3()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             if (LoadXSL("showParam.xsl") == 1)
             {
                 for (int i = 0; i < 100; i++)
                 {
-                    if ((Transform("fruits.xml") != 1) || (CheckResult(466.5112789241) != 1))
+                    if (Transform("fruits.xml") != 1)
                     {
                         _output.WriteLine("Test failed to transform after {0} iterations", i);
                         Assert.True(false);
                     }
+                    VerifyResult(expected);
                 }
                 return;
             }
@@ -1935,12 +2076,17 @@ namespace System.Xml.Tests
         {
             AppContext.SetSwitch("Switch.System.Xml.DontProhibitDefaultResolver", true);
 
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result><fruit>Apple</fruit><fruit>orange</fruit></result>";
+
             try
             {
                 if (LoadXSL("XmlResolver_Main.xsl") == 1)
                 {
-                    if ((TransformResolver("fruits.xml", null) == 1) && (CheckResult(428.8541842246) == 1))
+                    if (TransformResolver("fruits.xml", null) == 1)
+                    {
+                        VerifyResult(expected);
                         return;
+                    }
                     else
                         Assert.True(false);
                 }
@@ -1958,13 +2104,18 @@ namespace System.Xml.Tests
         [Theory]
         public void XmlResolver2()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result></result>";
+
             // "xmlResolver_document_function.xsl" contains
             // <xsl:for-each select="document('xmlResolver_document_function.xml')//elem">
 
             if (LoadXSL("xmlResolver_document_function.xsl") == 1)
             {
-                if ((TransformResolver("fruits.xml", null) == 1) && (CheckResult(375.6079891948) == 1))
+                if (TransformResolver("fruits.xml", null) == 1)
+                {
+                    VerifyResult(expected);
                     return;
+                }
             }
             else
             {
@@ -2063,18 +2214,25 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Basic Verification Test")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void TransformStrStr1()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             String szFullFilename = FullFilePath("fruits.xml");
 
             if (LoadXSL("showParam.xsl") == 1)
             {
                 CallTransform(xslt, szFullFilename, _strOutFile);
-                if (CheckResult(466.5112789241) == 1)
-                    return;
+                VerifyResult(expected);
+                return;
             }
             Assert.True(false);
         }
@@ -2088,7 +2246,7 @@ namespace System.Xml.Tests
             {
                 try
                 {
-                    xslt.Transform(null, _strOutFile);
+                    CallTransform(xslt, null, _strOutFile);
                 }
                 catch (System.ArgumentException)
                 { return; }
@@ -2128,7 +2286,7 @@ namespace System.Xml.Tests
             {
                 try
                 {
-                    xslt.Transform("IDontExist.xsl", _strOutFile);
+                    CallTransform(xslt, "IDontExist.xsl", _strOutFile);
                 }
                 catch (System.IO.FileNotFoundException)
                 {
@@ -2171,7 +2329,7 @@ namespace System.Xml.Tests
             {
                 try
                 {
-                    xslt.Transform(szEmpty, _strOutFile);
+                    CallTransform(xslt, szEmpty, _strOutFile);
                 }
                 catch (System.ArgumentException)
                 {
@@ -2205,11 +2363,18 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Call Transform many times")]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void TransformStrStr8()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
+		1.No Value Specified
+		2.No Value Specified
+		3.No Value Specified
+		4.No Value Specified
+		5.No Value Specified
+		6.No Value Specified</result>";
+
             String szFullFilename = FullFilePath("fruits.xml");
 
             for (int i = 0; i < 50; i++)
@@ -2217,10 +2382,14 @@ namespace System.Xml.Tests
                 if (LoadXSL("showParam.xsl") == 1)
                 {
                     CallTransform(xslt, szFullFilename, _strOutFile);
-                    if (CheckResult(466.5112789241) != 1)
+                    try
+                    {
+                        VerifyResult(expected);
+                    }
+                    catch(Exception)
                     {
                         _output.WriteLine("Failed to process Load after calling {0} times", i);
-                        Assert.True(false);
+                        throw;
                     }
                 }
             }
@@ -2237,7 +2406,7 @@ namespace System.Xml.Tests
 #pragma warning restore 0618
             try
             {
-                xslt.Transform(FullFilePath("fruits.xml"), _strOutFile);
+                CallTransform(xslt, FullFilePath("fruits.xml"), _strOutFile);
             }
             catch (System.InvalidOperationException e)
             {
@@ -2257,7 +2426,7 @@ namespace System.Xml.Tests
             {
                 try
                 {
-                    xslt.Transform("fruits.xml", "http://www.IdontExist.com/index.xml");
+                    xslt.Transform(FullFilePath("fruits.xml"), "http://www.IdontExist.com/index.xml");
                 }
                 catch (System.Exception e)
                 {
@@ -2279,7 +2448,7 @@ namespace System.Xml.Tests
             {
                 try
                 {
-                    xslt.Transform("..", _strOutFile);
+                    CallTransform(xslt, "..", _strOutFile);
                 }
                 catch (System.Exception)
                 {
@@ -2288,7 +2457,7 @@ namespace System.Xml.Tests
 
                 try
                 {
-                    xslt.Transform(".", _strOutFile);
+                    CallTransform(xslt, ".", _strOutFile);
                 }
                 catch (System.Exception)
                 {
@@ -2297,7 +2466,7 @@ namespace System.Xml.Tests
 
                 try
                 {
-                    xslt.Transform("\\\\", _strOutFile);
+                    CallTransform(xslt, "\\\\", _strOutFile);
                 }
                 catch (System.Exception)
                 {
@@ -2379,15 +2548,21 @@ namespace System.Xml.Tests
                 StreamReader fs = null;
 
                 // check if I can open and close the xml file
-                fs = new StreamReader(new FileStream(szFullFilename, FileMode.Open, FileAccess.Read));
-                fs.Dispose();
+                using (FileStream outFile = new FileStream(szFullFilename, FileMode.Open, FileAccess.Read))
+                {
+                    fs = new StreamReader(outFile);
+                    fs.Dispose();
+                }
 
                 strmTemp = new FileStream(szFullFilename, FileMode.Open, FileAccess.Read);
                 strmTemp.Dispose();
 
                 // check if I can open and close the output file
-                fs = new StreamReader(new FileStream(_strOutFile, FileMode.Open, FileAccess.Read));
-                fs.Dispose();
+                using (FileStream outFile = new FileStream(_strOutFile, FileMode.Open, FileAccess.Read))
+                {
+                    fs = new StreamReader(outFile);
+                    fs.Dispose();
+                }
 
                 strmTemp = new FileStream(_strOutFile, FileMode.Open, FileAccess.Read);
                 strmTemp.Dispose();
@@ -2446,17 +2621,16 @@ namespace System.Xml.Tests
         {
             AppContext.SetSwitch("Switch.System.Xml.DontProhibitDefaultResolver", true);
 
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result><fruit>Apple</fruit><fruit>orange</fruit></result>";
             String szFullFilename = FullFilePath("fruits.xml");
 
             try
             {
                 if (LoadXSL("XmlResolver_Main.xsl") == 1)
                 {
-                    xslt.Transform(szFullFilename, "out.xml", null);
-                    if (CheckResult(428.8541842246) == 1)
-                        return;
-                    else
-                        Assert.True(false);
+                    CallTransform(xslt, szFullFilename, "out.xml", null);
+                    VerifyResult(expected);
+                    return;
                 }
             }
             catch (Exception e)
@@ -2474,14 +2648,14 @@ namespace System.Xml.Tests
         {
             // "xmlResolver_document_function.xsl" contains
             // <xsl:for-each select="document('xmlResolver_document_function.xml')//elem">
-
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result></result>";
             String szFullFilename = FullFilePath("fruits.xml");
 
             if (LoadXSL("xmlResolver_document_function.xsl") == 1)
             {
                 CallTransform(xslt, szFullFilename, "out.xml", null);
-                if (CheckResult(375.6079891948) == 1)
-                    return;
+                VerifyResult(expected);
+                return;
             }
             else
             {
@@ -2507,7 +2681,7 @@ namespace System.Xml.Tests
 
             if (LoadXSL("xmlResolver_document_function.xsl") == 1)
             {
-                xslt.Transform(szFullFilename, "out.xml", new XmlUrlResolver());
+                CallTransform(xslt, szFullFilename, "out.xml", new XmlUrlResolver());
                 if (CheckResult(377.8217373898) == 1)
                     return;
             }
@@ -2532,31 +2706,45 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Local parameter gets overwritten with global param value", Pri = 1)]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void var1()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><out>
+param1 (correct answer is 'local-param1-arg'): local-param1-arg
+param2 (correct answer is 'local-param2-arg'): local-param2-arg
+</out>";
+
             m_xsltArg = new XsltArgumentList();
             m_xsltArg.AddParam("param1", string.Empty, "global-param1-arg");
 
-            if ((LoadXSL("paramScope.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) && (CheckResult(473.4644857331) == 1))
+            if ((LoadXSL("paramScope.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
 
         //[Variation("Local parameter gets overwritten with global variable value", Pri = 1)]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void var2()
         {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><out>
+param1 (correct answer is 'local-param1-arg'): local-param1-arg
+param2 (correct answer is 'local-param2-arg'): local-param2-arg
+</out>";
+
             m_xsltArg = new XsltArgumentList();
             m_xsltArg.AddParam("param1", string.Empty, "global-param1-arg");
 
-            if ((LoadXSL("varScope.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1) && (CheckResult(473.4644857331) == 1))
+            if ((LoadXSL("varScope.xsl") == 1) && (Transform_ArgList("fruits.xml") == 1))
+            {
+                VerifyResult(expected);
                 return;
+            }
             else
                 Assert.True(false);
         }
@@ -2580,13 +2768,22 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Iterator using for-each over a variable is not reset correctly while using msxsl:node-set()", Pri = 1)]
-        [ActiveIssue(9877)]
         [InlineData()]
         [Theory]
         public void var4()
         {
-            if ((LoadXSL("Bug109644.xsl") == 1) && (Transform("foo.xml") == 1) && (CheckResult(417.2501860011) == 1))
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?>
+		Node Count: {3}
+
+		
+		Correct Output: (1)(2)(3)
+		Incorrect Output: [1][2][3]";
+
+            if ((LoadXSL("Bug109644.xsl") == 1) && (Transform("foo.xml") == 1))
+            {
+                Assert.Equal(expected, File.ReadAllText("out.xml"));
                 return;
+            }
             else
                 Assert.True(false);
         }

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/XSLTransform.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/XSLTransform.cs
@@ -591,34 +591,22 @@ namespace System.Xml.Tests
                 XmlDiff.XmlDiff xmldiff = new XmlDiff.XmlDiff();
                 xmldiff.Option = XmlDiffOption.InfosetComparison | XmlDiffOption.IgnoreEmptyElement | XmlDiffOption.NormalizeNewline;
                 
-                string actualValue;
-                
-                using (FileStream outFile = new FileStream("out.xml", FileMode.Open, FileAccess.Read))
-                {
-                    StreamReader sr = new StreamReader(outFile);
-                    actualValue = sr.ReadToEnd();
-                    sr.Dispose();
-                }
+                string actualValue = File.ReadAllText(_strOutFile);
                 
                 //Output the expected and actual values
                 _output.WriteLine("Expected : " + expectedValue);
                 _output.WriteLine("Actual : " + actualValue);
                 
-                bool bResult;
+                bool result;
 
                 //Load into XmlTextReaders
-                using (XmlTextReader tr1 = new XmlTextReader("out.xml"))
+                using (XmlTextReader tr1 = new XmlTextReader(_strOutFile))
+                using (XmlTextReader tr2 = new XmlTextReader(new StringReader(expectedValue)))
                 {
-                    using (XmlTextReader tr2 = new XmlTextReader(new StringReader(expectedValue)))
-                    {
-                        bResult = xmldiff.Compare(tr1, tr2);
-                    }
+                    result = xmldiff.Compare(tr1, tr2);
                 }
 
-                if (bResult)
-                    return;
-                else
-                    Assert.True(false);
+                Assert.True(result);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/9877

Many XSLT tests used to calculate checksums to verify the result of a transformation. This type of verification caused flakiness in these tests. In this PR, we replace that verification (comparison with an expected checksum value) by comparing the transformed xml with the expected xml using `XmlDiff`.

cc: @danmosemsft @stephentoub @AlexGhiondea @joperezr 