### PR TITLE
Expose AddressFamily.Max and some Disposes

### DIFF
--- a/src/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -363,6 +363,7 @@ namespace System.Net.Sockets
         Irda = 26,
         Iso = 7,
         Lat = 14,
+        Max = 29,
         NetBios = 17,
         NetworkDesigners = 28,
         NS = 6,

--- a/src/System.Net.Requests/ref/System.Net.Requests.cs
+++ b/src/System.Net.Requests/ref/System.Net.Requests.cs
@@ -106,7 +106,7 @@ namespace System.Net
         public override System.IO.Stream GetRequestStream() { throw null; }
         public override System.Net.WebResponse GetResponse() { throw null; }
     }
-    public class FtpWebResponse : WebResponse
+    public class FtpWebResponse : WebResponse, IDisposable
     {
         internal FtpWebResponse() { }
         public override long ContentLength { get { throw null; } }

--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -75,6 +75,7 @@ namespace System.Net.Security
         public virtual IAsyncResult BeginAuthenticateAsServer(System.Net.NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy, System.Net.Security.ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel, System.AsyncCallback asyncCallback, object asyncState) { throw null; }
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState) { throw null; }
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState) { throw null; }
+        protected override void Dispose(bool disposing) { }
         public virtual void EndAuthenticateAsClient(System.IAsyncResult asyncResult) { }
         public virtual void EndAuthenticateAsServer(System.IAsyncResult asyncResult) { }
         public override int EndRead(IAsyncResult asyncResult) { throw null; }
@@ -155,6 +156,7 @@ namespace System.Net.Security
 #endif
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState) { throw null; }
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState) { throw null; }
+        protected override void Dispose(bool disposing) { }
         public virtual void EndAuthenticateAsClient(IAsyncResult asyncResult) { }
         public virtual void EndAuthenticateAsServer(IAsyncResult asyncResult) { }
         public override int EndRead(IAsyncResult asyncResult) { throw null; }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/14106
Fixes https://github.com/dotnet/corefx/issues/14107

The adding of IDisposable to FtpWebResponse isn't really necessary, as it's on the base class. It just removes the diff. The other two classes modified don't have it.

@CIPop 