### PR TITLE
Using GetParametersCached in more places in System.Linq.Expressions

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/Common/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -44,7 +44,7 @@ namespace System.Dynamic.Utils
             Type returnType = delegateInvokeMethod.ReturnType;
             bool hasReturnValue = returnType != typeof(void);
 
-            ParameterInfo[] parameters = delegateInvokeMethod.GetParameters();
+            ParameterInfo[] parameters = delegateInvokeMethod.GetParametersCached();
             Type[] paramTypes = new Type[parameters.Length + 1];
             paramTypes[0] = typeof(Func<object[], object>);
             for (int i = 0; i < parameters.Length; i++)

--- a/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
@@ -764,8 +764,8 @@ namespace System.Dynamic
 
                             if (baseMethod != null)
                             {
-                                ParameterInfo[] baseParams = baseMethod.GetParametersCached();
-                                ParameterInfo[] miParams = mi.GetParametersCached();
+                                ParameterInfo[] baseParams = baseMethod.GetParameters();
+                                ParameterInfo[] miParams = mi.GetParameters();
 
                                 if (baseParams.Length == miParams.Length)
                                 {

--- a/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
@@ -764,8 +764,8 @@ namespace System.Dynamic
 
                             if (baseMethod != null)
                             {
-                                ParameterInfo[] baseParams = baseMethod.GetParameters();
-                                ParameterInfo[] miParams = mi.GetParameters();
+                                ParameterInfo[] baseParams = baseMethod.GetParametersCached();
+                                ParameterInfo[] miParams = mi.GetParametersCached();
 
                                 if (baseParams.Length == miParams.Length)
                                 {

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
@@ -23,6 +23,7 @@ namespace System.Dynamic.Utils
                     return method;
                 }
             }
+
             return null;
         }
 
@@ -41,7 +42,8 @@ namespace System.Dynamic.Utils
             {
                 return false;
             }
-            ParameterInfo[] ps = mi.GetParameters();
+
+            ParameterInfo[] ps = mi.GetParametersCached();
 
             if (ps.Length != argTypes.Length)
             {
@@ -55,6 +57,7 @@ namespace System.Dynamic.Utils
                     return false;
                 }
             }
+
             return true;
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -28,7 +28,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static CallInstruction Create(MethodInfo info)
         {
-            return Create(info, info.GetParameters());
+            return Create(info, info.GetParametersCached());
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Dynamic.Utils;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -787,7 +788,7 @@ namespace System.Linq.Expressions.Interpreter
             ConstructorInfo ctor = _runtimeWrappedExceptionCtor
                 ?? (_runtimeWrappedExceptionCtor = typeof(RuntimeWrappedException)
                 .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
-                .First(c => c.GetParameters().Length == 1));
+                .First(c => c.GetParametersCached().Length == 1));
             return (RuntimeWrappedException)ctor.Invoke(new [] {thrown});
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -840,7 +840,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public void EmitNew(ConstructorInfo constructorInfo)
         {
-            EmitNew(constructorInfo, constructorInfo.GetParameters());
+            EmitNew(constructorInfo, constructorInfo.GetParametersCached());
         }
 
         public void EmitNew(ConstructorInfo constructorInfo, ParameterInfo[] parameters)
@@ -850,7 +850,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public void EmitByRefNew(ConstructorInfo constructorInfo, ByRefUpdater[] updaters)
         {
-            EmitByRefNew(constructorInfo, constructorInfo.GetParameters(), updaters);
+            EmitByRefNew(constructorInfo, constructorInfo.GetParametersCached(), updaters);
         }
 
         public void EmitByRefNew(ConstructorInfo constructorInfo, ParameterInfo[] parameters, ByRefUpdater[] updaters)
@@ -959,7 +959,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public void EmitCall(MethodInfo method)
         {
-            EmitCall(method, method.GetParameters());
+            EmitCall(method, method.GetParametersCached());
         }
 
         public void EmitCall(MethodInfo method, ParameterInfo[] parameters)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2126,7 +2126,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private void CompileMethodCallExpression(Expression @object, MethodInfo method, IArgumentProvider arguments)
         {
-            ParameterInfo[] parameters = method.GetParameters();
+            ParameterInfo[] parameters = method.GetParametersCached();
 
             // TODO: Support pass by reference.
             List<ByRefUpdater> updaters = null;
@@ -2380,7 +2380,7 @@ namespace System.Linq.Expressions.Interpreter
                 if (node.Constructor.DeclaringType.GetTypeInfo().IsAbstract)
                     throw Error.NonAbstractConstructorRequired();
 
-                ParameterInfo[] parameters = node.Constructor.GetParameters();
+                ParameterInfo[] parameters = node.Constructor.GetParametersCached();
                 List<ByRefUpdater> updaters = null;
 
                 for (int i = 0; i < parameters.Length; i++)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
@@ -212,8 +212,8 @@ namespace System.Linq.Expressions.Interpreter
 
         private static Func<LightLambda, Delegate> MakeRunDelegateCtor(Type delegateType)
         {
-            var method = delegateType.GetMethod("Invoke");
-            var paramInfos = method.GetParameters();
+            MethodInfo method = delegateType.GetMethod("Invoke");
+            ParameterInfo[] paramInfos = method.GetParametersCached();
             Type[] paramTypes;
             string name = "Run";
 
@@ -292,8 +292,8 @@ namespace System.Linq.Expressions.Interpreter
         {
             //PerfTrack.NoteEvent(PerfTrack.Categories.Compiler, "Synchronously compiling a custom delegate");
 
-            var method = delegateType.GetMethod("Invoke");
-            var paramInfos = method.GetParameters();
+            MethodInfo method = delegateType.GetMethod("Invoke");
+            ParameterInfo[] paramInfos = method.GetParametersCached();
             var parameters = new ParameterExpression[paramInfos.Length];
             var parametersAsObject = new Expression[paramInfos.Length];
             bool hasByRef = false;
@@ -305,13 +305,12 @@ namespace System.Linq.Expressions.Interpreter
                 parametersAsObject[i] = Expression.Convert(parameter, typeof(object));
             }
 
-            var data = Expression.NewArrayInit(typeof(object), parametersAsObject);
+            NewArrayExpression data = Expression.NewArrayInit(typeof(object), parametersAsObject);
             var dlg = new Func<object[], object>(Run);
 
-            var dlgExpr = AstUtils.Constant(dlg);
+            ConstantExpression dlgExpr = AstUtils.Constant(dlg);
 
-
-            var argsParam = Expression.Parameter(typeof(object[]), "$args");
+            ParameterExpression argsParam = Expression.Parameter(typeof(object[]), "$args");
 
             Expression body;
             if (method.ReturnType == typeof(void))
@@ -330,7 +329,6 @@ namespace System.Linq.Expressions.Interpreter
                 {
                     if (paramInfos[i].ParameterType.IsByRef)
                     {
-
                         updates.Add(
                             Expression.Assign(
                                 parameters[i],

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
@@ -193,7 +193,7 @@ namespace System.Linq.Expressions
 
             if (!type.GetTypeInfo().IsValueType)
             {
-                ConstructorInfo ci = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).SingleOrDefault(c => c.GetParameters().Length == 0);
+                ConstructorInfo ci = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).SingleOrDefault(c => c.GetParametersCached().Length == 0);
                 if (ci == null)
                 {
                     throw Error.TypeMissingDefaultConstructor(type, nameof(type));


### PR DESCRIPTION
Found a few places where we called `GetParameters` rather than `GetParametersCached` which we use pretty much everywhere. It seems a lot of code in the interpreter didn't use it and some code in the DLR didn't either, so introducing it in these places.