### PR TITLE
Restoring the use of GetBaseDefinition in IsOverridden in DynamicObject

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
@@ -748,42 +748,13 @@ namespace System.Dynamic
             /// </summary>
             private bool IsOverridden(string method)
             {
-                MemberInfo[] members = Value.GetType().GetMember(method, BindingFlags.Public | BindingFlags.Instance);
+                MemberInfo[] methods = Value.GetType().GetMember(method, MemberTypes.Method, BindingFlags.Public | BindingFlags.Instance);
 
-                foreach (MemberInfo member in members)
+                foreach (MethodInfo mi in methods)
                 {
-                    var mi = member as MethodInfo;
-
-                    if (mi != null && mi.DeclaringType != typeof(DynamicObject))
+                    if (mi.DeclaringType != typeof(DynamicObject) && mi.GetBaseDefinition().DeclaringType == typeof(DynamicObject))
                     {
-                        MemberInfo[] baseMembers = typeof(DynamicObject).GetMember(method, BindingFlags.Public | BindingFlags.Instance);
-
-                        foreach (MemberInfo baseMember in baseMembers)
-                        {
-                            var baseMethod = baseMember as MethodInfo;
-
-                            if (baseMethod != null)
-                            {
-                                ParameterInfo[] baseParams = baseMethod.GetParameters();
-                                ParameterInfo[] miParams = mi.GetParameters();
-
-                                if (baseParams.Length == miParams.Length)
-                                {
-                                    bool mismatch = false;
-                                    for (int i = 0; i < baseParams.Length; i++)
-                                    {
-                                        if (baseParams[i].ParameterType != miParams[i].ParameterType)
-                                        {
-                                            mismatch = true;
-                                        }
-                                    }
-                                    if (!mismatch)
-                                    {
-                                        return true;
-                                    }
-                                }
-                            }
-                        }
+                        return true;
                     }
                 }
 


### PR DESCRIPTION
Looking at the original code in https://referencesource.microsoft.com/#System.Core/Microsoft/Scripting/Actions/DynamicObject.cs,42ff7d1d8461d3f2 it seems that this method was changed to a suboptimal algorithm to compensate for the removal of `GetBaseDefinition` a while back. Now that this method is back, it seems we can revert back to the original.

Note that the (now reverted) replacement would also pick up shadowing methods (using `new`) if their name and parameter types match. It didn't bother to check for the return type, so some weirdness would have occurred when it picked up such an unexpected method.