### PR TITLE
Improve ConcurrentBag performance

### DIFF
--- a/src/System.Collections.Concurrent/src/System.Collections.Concurrent.csproj
+++ b/src/System.Collections.Concurrent/src/System.Collections.Concurrent.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{96AA2060-C846-4E56-9509-E8CB9C114C8F}</ProjectGuid>
     <AssemblyName>System.Collections.Concurrent</AssemblyName>
     <RootNamespace>System.Collections.Concurrent</RootNamespace>
-    <DefineConstants>FEATURE_TRACING</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_TRACING</DefineConstants>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
@@ -2,23 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// =+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
-//
-// ConcurrentBag.cs
-//
-// An unordered collection that allows duplicates and that provides add and get operations.
-// =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Threading;
 
 namespace System.Collections.Concurrent
 {
     /// <summary>
-    /// Represents an thread-safe, unordered collection of objects. 
+    /// Represents a thread-safe, unordered collection of objects. 
     /// </summary>
     /// <typeparam name="T">Specifies the type of elements in the bag.</typeparam>
     /// <remarks>
@@ -41,29 +33,19 @@ namespace System.Collections.Concurrent
     [Serializable]
     public class ConcurrentBag<T> : IProducerConsumerCollection<T>, IReadOnlyCollection<T>
     {
-        // ThreadLocalList object that contains the data per thread
+        /// <summary>The per-bag, per-thread work-stealing queues.</summary>
         [NonSerialized]
-        private ThreadLocal<ThreadLocalList> _locals;
-
-        // This head and tail pointers points to the first and last local lists, to allow enumeration on the thread locals objects
+        private ThreadLocal<WorkStealingQueue> _locals;
+        /// <summary>The head work stealing queue in a linked list of queues.</summary>
         [NonSerialized]
-        private volatile ThreadLocalList _headList, _tailList;
-
-        // A flag used to tell the operations thread that it must synchronize the operation, this flag is set/unset within
-        // GlobalListsLock lock
-        [NonSerialized]
-        private bool _needSync;
-
-        // Used for custom serialization.
+        private volatile WorkStealingQueue _workStealingQueues;
+        /// <summary>Temporary storage of the bag's contents used during serialization.</summary>
         private T[] _serializationArray;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ConcurrentBag{T}"/>
-        /// class.
-        /// </summary>
+        /// <summary>Initializes a new instance of the <see cref="ConcurrentBag{T}"/> class.</summary>
         public ConcurrentBag()
         {
-            Initialize(null);
+            _locals = new ThreadLocal<WorkStealingQueue>();
         }
 
         /// <summary>
@@ -80,26 +62,13 @@ namespace System.Collections.Concurrent
             {
                 throw new ArgumentNullException(nameof(collection), SR.ConcurrentBag_Ctor_ArgumentNullException);
             }
-            Initialize(collection);
-        }
 
+            _locals = new ThreadLocal<WorkStealingQueue>();
 
-        /// <summary>
-        /// Local helper function to initialize a new bag object
-        /// </summary>
-        /// <param name="collection">An enumeration containing items with which to initialize this bag.</param>
-        private void Initialize(IEnumerable<T> collection)
-        {
-            _locals = new ThreadLocal<ThreadLocalList>();
-
-            // Copy the collection to the bag
-            if (collection != null)
+            WorkStealingQueue queue = GetCurrentThreadWorkStealingQueue(forceCreate: true);
+            foreach (T item in collection)
             {
-                ThreadLocalList list = GetThreadList(true);
-                foreach (T item in collection)
-                {
-                    list.Add(item, false);
-                }
+                queue.LocalPush(item);
             }
         }
 
@@ -118,21 +87,21 @@ namespace System.Collections.Concurrent
             _serializationArray = null;
         }
 
-        /// <summary>Construct the stack from a previously seiralized one.</summary>
+        /// <summary>Construct the stack from a previously serialized one.</summary>
         [OnDeserialized]
         private void OnDeserialized(StreamingContext context)
         {
-            _locals = new ThreadLocal<ThreadLocalList>();
+            Debug.Assert(_locals == null);
+            _locals = new ThreadLocal<WorkStealingQueue>();
 
-            ThreadLocalList list = GetThreadList(true);
+            WorkStealingQueue queue = GetCurrentThreadWorkStealingQueue(forceCreate: true);
             foreach (T item in _serializationArray)
             {
-                list.Add(item, false);
+                queue.LocalPush(item);
             }
-            _headList = list;
-            _tailList = list;
-
             _serializationArray = null;
+
+            _workStealingQueues = queue;
         }
 
         /// <summary>
@@ -141,46 +110,7 @@ namespace System.Collections.Concurrent
         /// <param name="item">The object to be added to the
         /// <see cref="ConcurrentBag{T}"/>. The value can be a null reference
         /// (Nothing in Visual Basic) for reference types.</param>
-        public void Add(T item)
-        {
-            // Get the local list for that thread, create a new list if this thread doesn't exist 
-            //(first time to call add)
-            ThreadLocalList list = GetThreadList(true);
-            AddInternal(list, item);
-        }
-
-        /// <summary>
-        /// </summary>
-        /// <param name="list"></param>
-        /// <param name="item"></param>
-        private void AddInternal(ThreadLocalList list, T item)
-        {
-            bool lockTaken = false;
-            try
-            {
-#pragma warning disable 0420
-                Interlocked.Exchange(ref list._currentOp, (int)ListOperation.Add);
-#pragma warning restore 0420
-                //Synchronization cases:
-                // if the list count is less than two to avoid conflict with any stealing thread
-                // if _needSync is set, this means there is a thread that needs to freeze the bag
-                if (list.Count < 2 || _needSync)
-                {
-                    // reset it back to zero to avoid deadlock with stealing thread
-                    list._currentOp = (int)ListOperation.None;
-                    Monitor.Enter(list, ref lockTaken);
-                }
-                list.Add(item, lockTaken);
-            }
-            finally
-            {
-                list._currentOp = (int)ListOperation.None;
-                if (lockTaken)
-                {
-                    Monitor.Exit(list);
-                }
-            }
-        }
+        public void Add(T item) => GetCurrentThreadWorkStealingQueue(forceCreate: true).LocalPush(item);
 
         /// <summary>
         /// Attempts to add an object to the <see cref="ConcurrentBag{T}"/>.
@@ -196,8 +126,7 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Attempts to remove and return an object from the <see
-        /// cref="ConcurrentBag{T}"/>.
+        /// Attempts to remove and return an object from the <see cref="ConcurrentBag{T}"/>.
         /// </summary>
         /// <param name="result">When this method returns, <paramref name="result"/> contains the object
         /// removed from the <see cref="ConcurrentBag{T}"/> or the default value
@@ -205,12 +134,12 @@ namespace System.Collections.Concurrent
         /// <returns>true if an object was removed successfully; otherwise, false.</returns>
         public bool TryTake(out T result)
         {
-            return TryTakeOrPeek(out result, true);
+            WorkStealingQueue queue = GetCurrentThreadWorkStealingQueue(forceCreate: false);
+            return (queue != null && queue.TryLocalPop(out result)) || TrySteal(out result, take: true);
         }
 
         /// <summary>
-        /// Attempts to return an object from the <see cref="ConcurrentBag{T}"/>
-        /// without removing it.
+        /// Attempts to return an object from the <see cref="ConcurrentBag{T}"/> without removing it.
         /// </summary>
         /// <param name="result">When this method returns, <paramref name="result"/> contains an object from
         /// the <see cref="ConcurrentBag{T}"/> or the default value of
@@ -218,236 +147,108 @@ namespace System.Collections.Concurrent
         /// <returns>true if and object was returned successfully; otherwise, false.</returns>
         public bool TryPeek(out T result)
         {
-            return TryTakeOrPeek(out result, false);
+            WorkStealingQueue queue = GetCurrentThreadWorkStealingQueue(forceCreate: false);
+            return (queue != null && queue.TryLocalPeek(out result)) || TrySteal(out result, take: false);
+        }
+
+        /// <summary>Gets the work-stealing queue data structure for the current thread.</summary>
+        /// <param name="forceCreate">Whether to create a new queue if this thread doesn't have one.</param>
+        /// <returns>The local queue object, or null if the thread doesn't have one.</returns>
+        private WorkStealingQueue GetCurrentThreadWorkStealingQueue(bool forceCreate) =>
+            _locals.Value ??
+            (forceCreate ? CreateWorkStealingQueueForCurrentThread() : null);
+
+        private WorkStealingQueue CreateWorkStealingQueueForCurrentThread()
+        {
+            lock (GlobalQueuesLock) // necessary to update _workStealingQueues, so as to synchronize with freezing operations
+            {
+                WorkStealingQueue head = _workStealingQueues;
+
+                WorkStealingQueue queue = head != null ? GetUnownedWorkStealingQueue() : null;
+                if (queue == null)
+                {
+                    _workStealingQueues = queue = new WorkStealingQueue(head);
+                }
+                _locals.Value = queue;
+
+                return queue;
+            }
         }
 
         /// <summary>
-        /// Local helper function to Take or Peek an item from the bag
+        /// Try to reuse an unowned queue.  If a thread interacts with the bag and then exits,
+        /// the bag purposefully retains its queue, as it contains data associated with the bag.
         /// </summary>
-        /// <param name="result">To receive the item retrieved from the bag</param>
-        /// <param name="take">True means Take operation, false means Peek operation</param>
-        /// <returns>True if succeeded, false otherwise</returns>
-        private bool TryTakeOrPeek(out T result, bool take)
+        /// <returns>The queue object, or null if no unowned queue could be gathered.</returns>
+        private WorkStealingQueue GetUnownedWorkStealingQueue()
         {
-            // Get the local list for that thread, return null if the thread doesn't exit 
-            //(this thread never add before) 
-            ThreadLocalList list = GetThreadList(false);
-            if (list == null || list.Count == 0)
-            {
-                return Steal(out result, take);
-            }
+            Debug.Assert(Monitor.IsEntered(GlobalQueuesLock));
 
-            bool lockTaken = false;
-            try
-            {
-                if (take) // Take operation
-                {
-#pragma warning disable 0420
-                    Interlocked.Exchange(ref list._currentOp, (int)ListOperation.Take);
-#pragma warning restore 0420
-                    //Synchronization cases:
-                    // if the list count is less than or equal two to avoid conflict with any stealing thread
-                    // if _needSync is set, this means there is a thread that needs to freeze the bag
-                    if (list.Count <= 2 || _needSync)
-                    {
-                        // reset it back to zero to avoid deadlock with stealing thread
-                        list._currentOp = (int)ListOperation.None;
-                        Monitor.Enter(list, ref lockTaken);
-
-                        // Double check the count and steal if it became empty
-                        if (list.Count == 0)
-                        {
-                            // Release the lock before stealing
-                            if (lockTaken)
-                            {
-                                try { }
-                                finally
-                                {
-                                    lockTaken = false; // reset lockTaken to avoid calling Monitor.Exit again in the finally block
-                                    Monitor.Exit(list);
-                                }
-                            }
-                            return Steal(out result, true);
-                        }
-                    }
-                    list.Remove(out result);
-                }
-                else
-                {
-                    if (!list.Peek(out result))
-                    {
-                        return Steal(out result, false);
-                    }
-                }
-            }
-            finally
-            {
-                list._currentOp = (int)ListOperation.None;
-                if (lockTaken)
-                {
-                    Monitor.Exit(list);
-                }
-            }
-            return true;
-        }
-
-
-        /// <summary>
-        /// Local helper function to retrieve a thread local list by a thread object
-        /// </summary>
-        /// <param name="forceCreate">Create a new list if the thread does not exist</param>
-        /// <returns>The local list object</returns>
-        private ThreadLocalList GetThreadList(bool forceCreate)
-        {
-            ThreadLocalList list = _locals.Value;
-
-            if (list != null)
-            {
-                return list;
-            }
-            else if (forceCreate)
-            {
-                // Acquire the lock to update the _tailList pointer
-                lock (GlobalListsLock)
-                {
-                    if (_headList == null)
-                    {
-                        list = new ThreadLocalList(Environment.CurrentManagedThreadId);
-                        _headList = list;
-                        _tailList = list;
-                    }
-                    else
-                    {
-                        list = GetUnownedList();
-                        if (list == null)
-                        {
-                            list = new ThreadLocalList(Environment.CurrentManagedThreadId);
-                            _tailList._nextList = list;
-                            _tailList = list;
-                        }
-                    }
-                    _locals.Value = list;
-                }
-            }
-            else
-            {
-                return null;
-            }
-            Debug.Assert(list != null);
-            return list;
-        }
-
-        /// <summary>
-        /// Try to reuse an unowned list if exist
-        /// unowned lists are the lists that their owner threads are aborted or terminated
-        /// this is workaround to avoid memory leaks.
-        /// </summary>
-        /// <returns>The list object, null if all lists are owned</returns>
-        private ThreadLocalList GetUnownedList()
-        {
-            //the global lock must be held at this point
-            Debug.Assert(Monitor.IsEntered(GlobalListsLock));
-
+            // Look for a thread that has the same ID as this one.  It won't have come from the same thread,
+            // but if our thread ID is reused, we know that no other thread can have the same ID and thus
+            // no other thread can be using this queue.
             int currentThreadId = Environment.CurrentManagedThreadId;
-            ThreadLocalList currentList = _headList;
-            while (currentList != null)
+            for (WorkStealingQueue queue = _workStealingQueues; queue != null; queue = queue._nextQueue)
             {
-                if (currentList._ownerThreadId == currentThreadId)
+                if (queue._ownerThreadId == currentThreadId)
                 {
-                    return currentList;
+                    return queue;
                 }
-                currentList = currentList._nextList;
             }
+
             return null;
         }
 
-
-        /// <summary>
-        /// Local helper method to steal an item from any other non empty thread
-        /// </summary>
+        /// <summary>Local helper method to steal an item from any other non empty thread.</summary>
         /// <param name="result">To receive the item retrieved from the bag</param>
         /// <param name="take">Whether to remove or peek.</param>
         /// <returns>True if succeeded, false otherwise.</returns>
-        private bool Steal(out T result, bool take)
+        private bool TrySteal(out T result, bool take)
         {
 #if FEATURE_TRACING
             if (take)
+            {
                 CDSCollectionETWBCLProvider.Log.ConcurrentBag_TryTakeSteals();
+            }
             else
+            {
                 CDSCollectionETWBCLProvider.Log.ConcurrentBag_TryPeekSteals();
+            }
 #endif
 
-            bool loop;
-            List<int> versionsList = new List<int>(); // save the lists version
-            do
+            // If there's no local queue for this thread, just start from the head queue
+            // and try to steal from each queue until we get a result.
+            WorkStealingQueue localQueue = GetCurrentThreadWorkStealingQueue(forceCreate: false);
+            if (localQueue == null)
             {
-                versionsList.Clear(); //clear the list from the previous iteration
-                loop = false;
+                return TryStealFromTo(_workStealingQueues, null, out result, take);
+            }
 
+            // If there is a local queue from this thread, then start from the next queue
+            // after it, and then iterate around back from the head to this queue, not including it.
+            return
+                TryStealFromTo(localQueue._nextQueue, null, out result, take) ||
+                TryStealFromTo(_workStealingQueues, localQueue, out result, take);
 
-                ThreadLocalList currentList = _headList;
-                while (currentList != null)
+            // TODO: Investigate storing the queues in an array instead of a linked list, and then
+            // randomly choosing a starting location from which to start iterating.
+        }
+
+        /// <summary>
+        /// Attempts to steal from each queue starting from <paramref name="startInclusive"/> to <paramref name="endExclusive"/>.
+        /// </summary>
+        private bool TryStealFromTo(WorkStealingQueue startInclusive, WorkStealingQueue endExclusive, out T result, bool take)
+        {
+            for (WorkStealingQueue queue = startInclusive; queue != endExclusive; queue = queue._nextQueue)
+            {
+                if (queue.TrySteal(out result, take))
                 {
-                    versionsList.Add(currentList._version);
-                    if (currentList._head != null && TrySteal(currentList, out result, take))
-                    {
-                        return true;
-                    }
-                    currentList = currentList._nextList;
+                    return true;
                 }
-
-                // verify versioning, if other items are added to this list since we last visit it, we should retry
-                currentList = _headList;
-                foreach (int version in versionsList)
-                {
-                    if (version != currentList._version) //oops state changed
-                    {
-                        loop = true;
-                        if (currentList._head != null && TrySteal(currentList, out result, take))
-                            return true;
-                    }
-                    currentList = currentList._nextList;
-                }
-            } while (loop);
-
+            }
 
             result = default(T);
             return false;
-        }
-
-        /// <summary>
-        /// local helper function tries to steal an item from given local list
-        /// </summary>
-        private bool TrySteal(ThreadLocalList list, out T result, bool take)
-        {
-            lock (list)
-            {
-                if (CanSteal(list))
-                {
-                    list.Steal(out result, take);
-                    return true;
-                }
-                result = default(T);
-                return false;
-            }
-        }
-        /// <summary>
-        /// Local helper function to check the list if it became empty after acquiring the lock
-        /// and wait if there is unsynchronized Add/Take operation in the list to be done
-        /// </summary>
-        /// <param name="list">The list to steal</param>
-        /// <returns>True if can steal, false otherwise</returns>
-        private static bool CanSteal(ThreadLocalList list)
-        {
-            if (list.Count <= 2 && list._currentOp != (int)ListOperation.None)
-            {
-                SpinWait spinner = new SpinWait();
-                while (list._currentOp != (int)ListOperation.None)
-                {
-                    spinner.SpinOnce();
-                }
-            }
-            return list.Count > 0;
         }
 
         /// <summary>
@@ -478,13 +279,14 @@ namespace System.Collections.Concurrent
             }
             if (index < 0)
             {
-                throw new ArgumentOutOfRangeException
-                    (nameof(index), SR.ConcurrentBag_CopyTo_ArgumentOutOfRangeException);
+                throw new ArgumentOutOfRangeException(nameof(index), SR.ConcurrentBag_CopyTo_ArgumentOutOfRangeException);
             }
 
             // Short path if the bag is empty
-            if (_headList == null)
+            if (_workStealingQueues == null)
+            {
                 return;
+            }
 
             bool lockTaken = false;
             try
@@ -542,7 +344,6 @@ namespace System.Collections.Concurrent
             }
         }
 
-
         /// <summary>
         /// Copies the <see cref="ConcurrentBag{T}"/> elements to a new array.
         /// </summary>
@@ -551,8 +352,10 @@ namespace System.Collections.Concurrent
         public T[] ToArray()
         {
             // Short path if the bag is empty
-            if (_headList == null)
+            if (_workStealingQueues == null)
+            {
                 return Array.Empty<T>();
+            }
 
             bool lockTaken = false;
             try
@@ -581,8 +384,10 @@ namespace System.Collections.Concurrent
         public IEnumerator<T> GetEnumerator()
         {
             // Short path if the bag is empty
-            if (_headList == null)
+            if (_workStealingQueues == null)
+            {
                 return ((IEnumerable<T>)Array.Empty<T>()).GetEnumerator();
+            }
 
             bool lockTaken = false;
             try
@@ -607,10 +412,7 @@ namespace System.Collections.Concurrent
         /// of the bag.  It does not reflect any update to the collection after 
         /// <see cref="GetEnumerator"/> was called.
         /// </remarks>
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return ((ConcurrentBag<T>)this).GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <summary>
         /// Gets the number of elements contained in the <see cref="ConcurrentBag{T}"/>.
@@ -626,8 +428,10 @@ namespace System.Collections.Concurrent
             get
             {
                 // Short path if the bag is empty
-                if (_headList == null)
+                if (_workStealingQueues == null)
+                {
                     return 0;
+                }
 
                 bool lockTaken = false;
                 try
@@ -650,29 +454,27 @@ namespace System.Collections.Concurrent
         {
             get
             {
-                if (_headList == null)
-                    return true;
-
-                bool lockTaken = false;
-                try
+                if (_workStealingQueues != null)
                 {
-                    FreezeBag(ref lockTaken);
-                    ThreadLocalList currentList = _headList;
-                    while (currentList != null)
+                    bool lockTaken = false;
+                    try
                     {
-                        if (currentList._head != null)
-                        //at least this list is not empty, we return false
+                        FreezeBag(ref lockTaken);
+                        for (WorkStealingQueue queue = _workStealingQueues; queue != null; queue = queue._nextQueue)
                         {
-                            return false;
+                            if (!queue.IsEmpty)
+                            {
+                                return false;
+                            }
                         }
-                        currentList = currentList._nextList;
                     }
-                    return true;
+                    finally
+                    {
+                        UnfreezeBag(lockTaken);
+                    }
                 }
-                finally
-                {
-                    UnfreezeBag(lockTaken);
-                }
+
+                return true;
             }
         }
 
@@ -683,10 +485,7 @@ namespace System.Collections.Concurrent
         /// <value>true if access to the <see cref="T:System.Collections.ICollection"/> is synchronized
         /// with the SyncRoot; otherwise, false. For <see cref="ConcurrentBag{T}"/>, this property always
         /// returns false.</value>
-        bool ICollection.IsSynchronized
-        {
-            get { return false; }
-        }
+        bool ICollection.IsSynchronized => false;
 
         /// <summary>
         /// Gets an object that can be used to synchronize access to the <see
@@ -695,19 +494,11 @@ namespace System.Collections.Concurrent
         /// <exception cref="T:System.NotSupportedException">The SyncRoot property is not supported.</exception>
         object ICollection.SyncRoot
         {
-            get
-            {
-                throw new NotSupportedException(SR.ConcurrentCollection_SyncRoot_NotSupported);
-            }
+            get { throw new NotSupportedException(SR.ConcurrentCollection_SyncRoot_NotSupported); }
         }
 
-
-        /// <summary>
-        ///  A global lock object, used in two cases:
-        ///  1- To  maintain the _tailList pointer for each new list addition process ( first time a thread called Add )
-        ///  2- To freeze the bag in GetEnumerator, CopyTo, ToArray and Count members
-        /// </summary>
-        private object GlobalListsLock
+        /// <summary>Global lock used to synchronize the queues pointer and all bag-wide operations (e.g. ToArray, Count, etc.).</summary>
+        private object GlobalQueuesLock
         {
             get
             {
@@ -716,111 +507,55 @@ namespace System.Collections.Concurrent
             }
         }
 
-
-        #region Freeze bag helper methods
-        /// <summary>
-        /// Local helper method to freeze all bag operations, it
-        /// 1- Acquire the global lock to prevent any other thread to freeze the bag, and also new thread can be added
-        /// to the dictionary
-        /// 2- Then Acquire all local lists locks to prevent steal and synchronized operations
-        /// 3- Wait for all un-synchronized operations to be done
-        /// </summary>
-        /// <param name="lockTaken">Retrieve the lock taken result for the global lock, to be passed to Unfreeze method</param>
+        /// <summary>"Freezes" the bag, such that no concurrent operations will be mutating the bag when it returns.</summary>
+        /// <param name="lockTaken">true if the global lock was taken; otherwise, false.</param>
         private void FreezeBag(ref bool lockTaken)
         {
-            Debug.Assert(!Monitor.IsEntered(GlobalListsLock));
+            // Take the global lock to start freezing the bag.  This helps, for example,
+            // to prevent other threads from joining the bag (adding their local queues)
+            // while a global operation is in progress.
+            Debug.Assert(!Monitor.IsEntered(GlobalQueuesLock));
+            Monitor.Enter(GlobalQueuesLock, ref lockTaken);
+            WorkStealingQueue head = _workStealingQueues; // stable at least until GlobalQueuesLock is released in UnfreezeBag
 
-            // global lock to be safe against multi threads calls count and corrupt _needSync
-            Monitor.Enter(GlobalListsLock, ref lockTaken);
+            // Then acquire all local queue locks, noting on each that it's been taken.
+            for (WorkStealingQueue queue = head; queue != null; queue = queue._nextQueue)
+            {
+                Monitor.Enter(queue, ref queue._frozen);
+            }
+            Interlocked.MemoryBarrier(); // prevent reads of _currentOp from moving before writes to _frozen
 
-            // This will force any future add/take operation to be synchronized
-            _needSync = true;
-
-            //Acquire all local lists locks
-            AcquireAllLocks();
-
-            // Wait for all un-synchronized operation to be done
-            WaitAllOperations();
+            // Finally, wait for all unsynchronized operations on each queue to be done.
+            for (WorkStealingQueue queue = head; queue != null; queue = queue._nextQueue)
+            {
+                if (queue._currentOp != (int)Operation.None)
+                {
+                    var spinner = new SpinWait();
+                    do { spinner.SpinOnce(); }
+                    while (queue._currentOp != (int)Operation.None);
+                }
+            }
         }
 
-        /// <summary>
-        /// Local helper method to unfreeze the bag from a frozen state
-        /// </summary>
-        /// <param name="lockTaken">The lock taken result from the Freeze method</param>
+        /// <summary>"Unfreezes" a bag frozen with <see cref="FreezeBag(ref bool)"/>.</summary>
+        /// <param name="lockTaken">The result of the <see cref="FreezeBag(ref bool)"/> method.</param>
         private void UnfreezeBag(bool lockTaken)
         {
-            ReleaseAllLocks();
-            _needSync = false;
+            Debug.Assert(Monitor.IsEntered(GlobalQueuesLock) == lockTaken);
             if (lockTaken)
             {
-                Monitor.Exit(GlobalListsLock);
-            }
-        }
-
-        /// <summary>
-        /// local helper method to acquire all local lists locks
-        /// </summary>
-        private void AcquireAllLocks()
-        {
-            Debug.Assert(Monitor.IsEntered(GlobalListsLock));
-
-            bool lockTaken = false;
-            ThreadLocalList currentList = _headList;
-            while (currentList != null)
-            {
-                // Try/Finally block to avoid thread abort between acquiring the lock and setting the taken flag
-                try
+                // Release all of the individual queue locks.
+                for (WorkStealingQueue queue = _workStealingQueues; queue != null; queue = queue._nextQueue)
                 {
-                    Monitor.Enter(currentList, ref lockTaken);
-                }
-                finally
-                {
-                    if (lockTaken)
+                    if (queue._frozen)
                     {
-                        currentList._lockTaken = true;
-                        lockTaken = false;
+                        queue._frozen = false;
+                        Monitor.Exit(queue);
                     }
                 }
-                currentList = currentList._nextList;
-            }
-        }
 
-        /// <summary>
-        /// Local helper method to release all local lists locks
-        /// </summary>
-        private void ReleaseAllLocks()
-        {
-            ThreadLocalList currentList = _headList;
-            while (currentList != null)
-            {
-                if (currentList._lockTaken)
-                {
-                    currentList._lockTaken = false;
-                    Monitor.Exit(currentList);
-                }
-                currentList = currentList._nextList;
-            }
-        }
-
-        /// <summary>
-        /// Local helper function to wait all unsynchronized operations
-        /// </summary>
-        private void WaitAllOperations()
-        {
-            Debug.Assert(Monitor.IsEntered(GlobalListsLock));
-
-            ThreadLocalList currentList = _headList;
-            while (currentList != null)
-            {
-                if (currentList._currentOp != (int)ListOperation.None)
-                {
-                    SpinWait spinner = new SpinWait();
-                    while (currentList._currentOp != (int)ListOperation.None)
-                    {
-                        spinner.SpinOnce();
-                    }
-                }
-                currentList = currentList._nextList;
+                // Then release the global lock.
+                Monitor.Exit(GlobalQueuesLock);
             }
         }
 
@@ -830,224 +565,360 @@ namespace System.Collections.Concurrent
         /// <returns>The current bag count</returns>
         private int GetCountInternal()
         {
-            Debug.Assert(Monitor.IsEntered(GlobalListsLock));
+            Debug.Assert(Monitor.IsEntered(GlobalQueuesLock));
 
             int count = 0;
-            ThreadLocalList currentList = _headList;
-            while (currentList != null)
+            for (WorkStealingQueue queue = _workStealingQueues; queue != null; queue = queue._nextQueue)
             {
-                checked
-                {
-                    count += currentList.Count;
-                }
-                currentList = currentList._nextList;
+                checked { count += queue.Count; }
             }
             return count;
         }
 
         /// <summary>
-        /// Local helper function to return the bag item in a list, this is mainly used by CopyTo and ToArray
+        /// Local helper function to return the bag's contents in a list, this is mainly used by CopyTo and ToArray
         /// This is not thread safe, should be called in Freeze/UnFreeze bag block
         /// </summary>
         /// <returns>List the contains the bag items</returns>
         private List<T> ToList()
         {
-            Debug.Assert(Monitor.IsEntered(GlobalListsLock));
+            Debug.Assert(Monitor.IsEntered(GlobalQueuesLock));
 
-            List<T> list = new List<T>();
-            ThreadLocalList currentList = _headList;
-            while (currentList != null)
+            var list = new List<T>();
+
+            for (WorkStealingQueue queue = _workStealingQueues; queue != null; queue = queue._nextQueue)
             {
-                Node currentNode = currentList._head;
-                while (currentNode != null)
-                {
-                    list.Add(currentNode._value);
-                    currentNode = currentNode._next;
-                }
-                currentList = currentList._nextList;
+                queue.AddToList(list);
             }
 
             return list;
         }
 
-        #endregion
-
-
-        #region Inner Classes
-
-        /// <summary>
-        /// A class that represents a node in the lock thread list
-        /// </summary>
-        internal class Node
+        /// <summary>Provides a work-stealing queue data structure stored per thread.</summary>
+        private sealed class WorkStealingQueue
         {
-            public Node(T value)
-            {
-                _value = value;
-            }
-            public readonly T _value;
-            public Node _next;
-            public Node _prev;
-        }
-
-        /// <summary>
-        /// A class that represents the lock thread list
-        /// </summary>
-        internal class ThreadLocalList
-        {
-            // Head node in the list, null means the list is empty
-            internal volatile Node _head;
-
-            // Tail node for the list
-            private volatile Node _tail;
-
-            // The current list operation
+            /// <summary>Initial size of the queue's array.</summary>
+            private const int InitialSize = 32;
+            /// <summary>Starting index for the head and tail indices.</summary>
+            private const int StartIndex =
+#if DEBUG
+                int.MaxValue; // in debug builds, start at the end so we exercise the index reset logic
+#else
+                0;
+#endif
+            /// <summary>Head index from which to steal.  This and'd with the <see cref="_mask"/> is the index into <see cref="_array"/>.</summary>
+            private volatile int _headIndex = StartIndex;
+            /// <summary>Tail index at which local pushes/pops happen. This and'd with the <see cref="_mask"/> is the index into <see cref="_array"/>.</summary>
+            private volatile int _tailIndex = StartIndex;
+            /// <summary>The array storing the queue's data.</summary>
+            private volatile T[] _array = new T[InitialSize];
+            /// <summary>Mask and'd with <see cref="_headIndex"/> and <see cref="_tailIndex"/> to get an index into <see cref="_array"/>.</summary>
+            private volatile int _mask = InitialSize - 1;
+            /// <summary>Numbers of elements in the queue from the local perspective; needs to be combined with <see cref="_stealCount"/> to get an actual Count.</summary>
+            private int _addTakeCount;
+            /// <summary>Number of steals; needs to be combined with <see cref="_addTakeCount"/> to get an actual Count.</summary>
+            private int _stealCount;
+            /// <summary>The current queue operation. Used to quiesce before performing operations from one thread onto another.</summary>
             internal volatile int _currentOp;
+            /// <summary>true if this queue's lock is held as part of a global freeze.</summary>
+            internal bool _frozen;
+            /// <summary>Next queue in the <see cref="ConcurrentBag{T}"/>'s set of thread-local queues.</summary>
+            internal readonly WorkStealingQueue _nextQueue;
+            /// <summary>Thread ID that owns this queue.</summary>
+            internal readonly int _ownerThreadId;
 
-            // The list count from the Add/Take perspective
-            private int _count;
-
-            // The stealing count
-            internal int _stealCount;
-
-            // Next list in the dictionary values
-            internal volatile ThreadLocalList _nextList;
-
-            // Set if the locl lock is taken
-            internal bool _lockTaken;
-
-            // The owner thread for this list
-            internal int _ownerThreadId;
-
-            // the version of the list, incremented only when the list changed from empty to non empty state
-            internal volatile int _version;
-
-            /// <summary>
-            /// ThreadLocalList constructor
-            /// </summary>
-            /// <param name="ownerThread">The owner thread for this list</param>
-            internal ThreadLocalList(int ownerThreadId)
+            /// <summary>Initialize the WorkStealingQueue.</summary>
+            /// <param name="nextQueue">The next queue in the linked list of work-stealing queues.</param>
+            internal WorkStealingQueue(WorkStealingQueue nextQueue)
             {
-                _ownerThreadId = ownerThreadId;
+                _ownerThreadId = Environment.CurrentManagedThreadId;
+                _nextQueue = nextQueue;
             }
+
+            /// <summary>Gets whether the queue is empty.</summary>
+            internal bool IsEmpty => _headIndex >= _tailIndex;
+
             /// <summary>
-            /// Add new item to head of the list
+            /// Add new item to the tail of the queue.
             /// </summary>
             /// <param name="item">The item to add.</param>
-            /// <param name="updateCount">Whether to update the count.</param>
-            internal void Add(T item, bool updateCount)
+            internal void LocalPush(T item)
             {
-                checked
+                Debug.Assert(Environment.CurrentManagedThreadId == _ownerThreadId);
+                bool lockTaken = false;
+                try
                 {
-                    _count++;
+                    // Full fence to ensure subsequent reads don't get reordered before this
+                    Interlocked.Exchange(ref _currentOp, (int)Operation.Add);
+                    int tail = _tailIndex;
+
+                    // Rare corner case (at most once every 2 billion pushes on this thread):
+                    // We're going to increment the tail; if we'll overflow, then we need to reset our counts
+                    if (tail == int.MaxValue)
+                    {
+                        _currentOp = (int)Operation.None; // set back to None temporarily to avoid a deadlock
+                        lock (this)
+                        {
+                            Debug.Assert(_tailIndex == int.MaxValue, "No other thread should be changing _tailIndex");
+
+                            // Rather than resetting to zero, we'll just mask off the bits we don't care about.
+                            // This way we don't need to rearrange the items already in the queue; they'll be found
+                            // correctly exactly where they are.  One subtlety here is that we need to make sure that
+                            // if head is currently < tail, it remains that way.  This happens to just fall out from
+                            // the bit-masking, because we only do this if tail == int.MaxValue, meaning that all
+                            // bits are set, so all of the bits we're keeping will also be set.  Thus it's impossible
+                            // for the head to end up > than the tail, since you can't set any more bits than all of them.
+                            _headIndex = _headIndex & _mask;
+                            _tailIndex = tail = _tailIndex & _mask;
+                            Debug.Assert(_headIndex <= _tailIndex);
+
+                            _currentOp = (int)Operation.Add;
+                        }
+                    }
+
+                    // We'd like to take the fast path that doesn't require locking, if possible. It's not possible if another
+                    // thread is currently requesting that the whole bag synchronize, e.g. a ToArray operation.  It's also
+                    // not possible if there are fewer than two spaces available.  One space is necessary for obvious reasons:
+                    // to store the element we're trying to push.  The other is necessary due to synchronization with steals.
+                    // A stealing thread first increments _headIndex to reserve the slot at its old value, and then tries to
+                    // read from that slot.  We could potentially have a race condition whereby _headIndex is incremented just
+                    // before this check, in which case we could overwrite the element being stolen as that slot would appear
+                    // to be empty.  Thus, we only allow the fast path if there are two empty slots.
+                    if (!_frozen && tail < (_headIndex + _mask))
+                    {
+                        _array[tail & _mask] = item;
+                        _tailIndex = tail + 1;
+                    }
+                    else
+                    {
+                        // We need to contend with foreign operations (e.g. steals, enumeration, etc.), so we lock.
+                        _currentOp = (int)Operation.None; // set back to None to avoid a deadlock
+                        Monitor.Enter(this, ref lockTaken);
+
+                        int head = _headIndex;
+                        int count = _tailIndex - _headIndex;
+
+                        // If we're full, expand the array.
+                        if (count >= _mask)
+                        {
+                            // Expand the queue by doubling its size.
+                            var newArray = new T[_array.Length << 1];
+                            int headIdx = head & _mask;
+                            if (headIdx == 0)
+                            {
+                                Array.Copy(_array, 0, newArray, 0, _array.Length);
+                            }
+                            else
+                            {
+                                Array.Copy(_array, headIdx, newArray, 0, _array.Length - headIdx);
+                                Array.Copy(_array, 0, newArray, _array.Length - headIdx, headIdx);
+                            }
+
+                            // Reset the field values
+                            _array = newArray;
+                            _headIndex = 0;
+                            _tailIndex = tail = count;
+                            _mask = (_mask << 1) | 1;
+                        }
+
+                        // Add the element
+                        _array[tail & _mask] = item;
+                        _tailIndex = tail + 1;
+
+                        // Update the count to avoid overflow.  We can trust _stealCount here,
+                        // as we're inside the lock and it's only manipulated there.
+                        _addTakeCount -= _stealCount;
+                        _stealCount = 0;
+                    }
+
+                    // Increment the count from the add/take perspective
+                    checked { _addTakeCount++; }
                 }
-                Node node = new Node(item);
-                if (_head == null)
+                finally
                 {
-                    Debug.Assert(_tail == null);
-                    _head = node;
-                    _tail = node;
-                    _version++; // changing from empty state to non empty state
-                }
-                else
-                {
-                    node._next = _head;
-                    _head._prev = node;
-                    _head = node;
-                }
-                if (updateCount) // update the count to avoid overflow if this add is synchronized
-                {
-                    _count = _count - _stealCount;
-                    _stealCount = 0;
+                    _currentOp = (int)Operation.None;
+                    if (lockTaken)
+                    {
+                        Monitor.Exit(this);
+                    }
                 }
             }
 
-            /// <summary>
-            /// Remove an item from the head of the list
-            /// </summary>
+            /// <summary>Remove an item from the tail of the queue.</summary>
             /// <param name="result">The removed item</param>
-            internal void Remove(out T result)
+            internal bool TryLocalPop(out T result)
             {
-                Debug.Assert(_head != null);
-                Node head = _head;
-                _head = _head._next;
-                if (_head != null)
+                Debug.Assert(Environment.CurrentManagedThreadId == _ownerThreadId);
+
+                int tail = _tailIndex;
+                if (_headIndex >= tail)
                 {
-                    _head._prev = null;
+                    result = default(T);
+                    return false;
                 }
-                else
+
+                bool lockTaken = false;
+                try
                 {
-                    _tail = null;
+                    // Decrement the tail using a full fence to ensure subsequent reads don't reorder before this.
+                    // If the read of _headIndex moved before this write to _tailIndex, we could erroneously end up
+                    // popping an element that's concurrently being stolen, leading to the same element being
+                    // dequeued from the bag twice.
+                    _currentOp = (int)Operation.Take;
+                    Interlocked.Exchange(ref _tailIndex, --tail);
+
+                    // If there is no interaction with a steal, we can head down the fast path.
+                    // Note that we use _headIndex < tail rather than _headIndex <= tail to account
+                    // for stealing peeks, which don't increment _headIndex, and which could observe
+                    // the written default(T) in a race condition to peek at the element.
+                    if (!_frozen && _headIndex < tail)
+                    {
+                        int idx = tail & _mask;
+                        result = _array[idx];
+                        _array[idx] = default(T);
+                        _addTakeCount--;
+                        return true;
+                    }
+                    else
+                    {
+                        // Interaction with steals: 0 or 1 elements left.
+                        _currentOp = (int)Operation.None; // set back to None to avoid a deadlock
+                        Monitor.Enter(this, ref lockTaken);
+                        if (_headIndex <= tail)
+                        {
+                            // Element still available. Take it.
+                            int idx = tail & _mask;
+                            result = _array[idx];
+                            _array[idx] = default(T);
+                            _addTakeCount--;
+                            return true;
+                        }
+                        else
+                        {
+                            // We encountered a race condition and the element was stolen, restore the tail.
+                            _tailIndex = tail + 1;
+                            result = default(T);
+                            return false;
+                        }
+                    }
                 }
-                _count--;
-                result = head._value;
+                finally
+                {
+                    _currentOp = (int)Operation.None;
+                    if (lockTaken)
+                    {
+                        Monitor.Exit(this);
+                    }
+                }
             }
 
-            /// <summary>
-            /// Peek an item from the head of the list
-            /// </summary>
+            /// <summary>Peek an item from the tail of the queue.</summary>
             /// <param name="result">the peeked item</param>
             /// <returns>True if succeeded, false otherwise</returns>
-            internal bool Peek(out T result)
+            internal bool TryLocalPeek(out T result)
             {
-                Node head = _head;
-                if (head != null)
+                Debug.Assert(Environment.CurrentManagedThreadId == _ownerThreadId);
+
+                int tail = _tailIndex;
+                if (_headIndex < tail)
                 {
-                    result = head._value;
-                    return true;
+                    // It is possible to enable lock-free peeks, following the same general approach
+                    // that's used in TryLocalPop.  However, peeks are more complicated as we can't
+                    // do the same kind of index reservation that's done in TryLocalPop; doing so could
+                    // end up making a steal think that no item is available, even when one is. To do
+                    // it correctly, then, we'd need to add spinning to TrySteal in case of a concurrent
+                    // peek happening. With a lock, the common case (no contention with steals) will
+                    // effectively only incur two interlocked operations (entering/exiting the lock) instead
+                    // of one (setting Peek as the _currentOp).  Combined with Peeks on a bag being rare,
+                    // for now we'll use the simpler/safer code.
+                    lock (this)
+                    {
+                        if (_headIndex < tail)
+                        {
+                            result = _array[(tail - 1) & _mask];
+                            return true;
+                        }
+                    }
                 }
+
                 result = default(T);
                 return false;
             }
 
-            /// <summary>
-            /// Steal an item from the tail of the list
-            /// </summary>
+            /// <summary>Steal an item from the head of the queue.</summary>
             /// <param name="result">the removed item</param>
-            /// <param name="remove">remove or peek flag</param>
-            internal void Steal(out T result, bool remove)
+            /// <param name="take">true to take the item; false to simply peek at it</param>
+            internal bool TrySteal(out T result, bool take)
             {
-                Node tail = _tail;
-                Debug.Assert(tail != null);
-                if (remove) // Take operation
+                // Fast-path check to see if the queue is empty.
+                if (_headIndex < _tailIndex)
                 {
-                    _tail = _tail._prev;
-                    if (_tail != null)
+                    // Anything other than empty requires synchronization.
+                    lock (this)
                     {
-                        _tail._next = null;
+                        int head = _headIndex;
+                        if (take)
+                        {
+                            // Increment head to tentatively take an element: a full fence is used to ensure the read
+                            // of _tailIndex doesn't move earlier, as otherwise we could potentially end up stealing
+                            // the same element that's being popped locally.
+                            Interlocked.Exchange(ref _headIndex, head + 1);
+
+                            // If there's an element to steal, do it.
+                            if (head < _tailIndex)
+                            {
+                                int idx = head & _mask;
+                                result = _array[idx];
+                                _array[idx] = default(T);
+                                _stealCount++;
+                                return true;
+                            }
+                            else
+                            {
+                                // We contended with the local thread and lost the race, so restore the head.
+                                _headIndex = head;
+                            }
+                        }
+                        else if (head < _tailIndex)
+                        {
+                            // Peek, if there's an element available
+                            result = _array[head & _mask];
+                            return true;
+                        }
                     }
-                    else
-                    {
-                        _head = null;
-                    }
-                    // Increment the steal count
-                    _stealCount++;
                 }
-                result = tail._value;
+
+                // The queue was empty.
+                result = default(T);
+                return false;
             }
 
-
-            /// <summary>
-            /// Gets the total list count, it's not thread safe, may provide incorrect count if it is called concurrently
-            /// </summary>
-            internal int Count
+            /// <summary>Add the contents of this queue to the specified list.</summary>
+            internal void AddToList(List<T> list)
             {
-                get
+                Debug.Assert(Monitor.IsEntered(this));
+                Debug.Assert(_frozen);
+
+                for (int i = _headIndex; i < _tailIndex; i++)
                 {
-                    return _count - _stealCount;
+                    list.Add(_array[i & _mask]);
                 }
             }
+
+            /// <summary>Gets the total number of items in the queue.</summary>
+            /// <remarks>
+            /// This is not thread safe, only providing an accurate result either from the owning
+            /// thread while its lock is held or from any thread while the bag is frozen.
+            /// </remarks>
+            internal int Count => _addTakeCount - _stealCount;
         }
-        #endregion
+
+        /// <summary>Lock-free operations performed on a queue.</summary>
+        internal enum Operation
+        {
+            None,
+            Add,
+            Take
+        };
     }
-
-    /// <summary>
-    /// List operations for ConcurrentBag
-    /// </summary>
-    internal enum ListOperation
-    {
-        None,
-        Add,
-        Take
-    };
-
 }

--- a/src/System.Collections.Concurrent/tests/ConcurrentBagTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentBagTests.cs
@@ -21,253 +21,185 @@ namespace System.Collections.Concurrent.Tests
         protected override EnumerableOrder Order => EnumerableOrder.Unspecified;
         protected override bool ResetImplemented => true;
 
-        [Fact]
-        public static void TestBasicScenarios()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(3)]
+        [InlineData(1000)]
+        public static void Ctor_InitializeFromCollection_ContainsExpectedItems(int numItems)
         {
-            ConcurrentBag<int> cb = new ConcurrentBag<int>();
-            Assert.True(cb.IsEmpty);
-            Task[] tks = new Task[2];
-            tks[0] = Task.Run(() =>
-                {
-                    cb.Add(4);
-                    cb.Add(5);
-                    cb.Add(6);
-                });
+            var expected = new HashSet<int>(Enumerable.Range(0, numItems));
 
-            // Consume the items in the bag 
-            tks[1] = Task.Run(() =>
-                {
-                    int item;
-                    while (!cb.IsEmpty)
-                    {
-                        bool ret = cb.TryTake(out item);
-                        Assert.True(ret);
-                        // loose check
-                        Assert.Contains(item, new[] { 4, 5, 6 });
-                    }
-                });
+            var bag = new ConcurrentBag<int>(expected);
+            Assert.Equal(numItems == 0, bag.IsEmpty);
+            Assert.Equal(expected.Count, bag.Count);
 
-            Task.WaitAll(tks);
-        }
-
-        [Fact]
-        public static void RTest1_Ctor()
-        {
-            ConcurrentBag<int> bag = new ConcurrentBag<int>(new int[] { 1, 2, 3 });
-            Assert.False(bag.IsEmpty);
-            Assert.Equal(3, bag.Count);
-
-            Assert.Throws<ArgumentNullException>( () => {bag = new ConcurrentBag<int>(null);} );
-        }
-
-        [Fact]
-        public static void RTest2_Add()
-        {
-            RTest2_Add(1, 10);
-            RTest2_Add(3, 100);
-        }
-
-        [Fact]
-        [OuterLoop]
-        public static void RTest2_Add01()
-        {
-            RTest2_Add(8, 1000);
-        }
-
-        [Fact]
-        public static void RTest3_TakeOrPeek()
-        {
-            ConcurrentBag<int> bag = CreateBag(100);
-            RTest3_TakeOrPeek(bag, 1, 100, true);
-
-            bag = CreateBag(100);
-            RTest3_TakeOrPeek(bag, 4, 10, false);
-
-            bag = CreateBag(1000);
-            RTest3_TakeOrPeek(bag, 11, 100, true);
-        }
-
-        [Fact]
-        public static void RTest4_AddAndTake()
-        {
-            RTest4_AddAndTake(8);
-            RTest4_AddAndTake(16);
-        }
-
-        [Fact]
-        public static void RTest5_CopyTo()
-        {
-            const int SIZE = 10;
-            Array array = new int[SIZE];
-            int index = 0;
-
-            ConcurrentBag<int> bag = CreateBag(SIZE);
-            bag.CopyTo((int[])array, index);
-
-            Assert.Throws<ArgumentNullException>(() => bag.CopyTo(null, index));
-            Assert.Throws<ArgumentOutOfRangeException>(() => bag.CopyTo((int[]) array, -1));
-            Assert.Throws<ArgumentException>(() => bag.CopyTo((int[])array, SIZE));
-            Assert.Throws<ArgumentException>(() => bag.CopyTo((int[])array, SIZE-2));
-        }
-
-        [Fact]
-        public static void RTest5_ICollectionCopyTo()
-        {
-            const int SIZE = 10;
-            Array array = new int[SIZE];
-            int index = 0;
-
-            ConcurrentBag<int> bag = CreateBag(SIZE);
-            ICollection collection = bag as ICollection;
-            Assert.NotNull(collection);
-            collection.CopyTo(array, index);
-
-            Assert.Throws<ArgumentNullException>(() => collection.CopyTo(null, index));
-            Assert.Throws<ArgumentOutOfRangeException>(() => collection.CopyTo((int[])array, -1));
-            Assert.Throws<ArgumentException>(() => collection.CopyTo((int[])array, SIZE));
-            Assert.Throws<ArgumentException>(() => collection.CopyTo((int[])array, SIZE - 2));
-
-            Array array2 = new int[SIZE, 5];
-            Assert.Throws<ArgumentException>(() => collection.CopyTo(array2, 0));
-        }
-
-        /// <summary>
-        /// Test bag addition
-        /// </summary>
-        /// <param name="threadsCount"></param>
-        /// <param name="itemsPerThread"></param>
-        /// <returns>True if succeeded, false otherwise</returns>
-        private static void RTest2_Add(int threadsCount, int itemsPerThread)
-        {
-            int failures = 0;
-            ConcurrentBag<int> bag = new ConcurrentBag<int>();
-
-            Task[] threads = new Task[threadsCount];
-            for (int i = 0; i < threads.Length; i++)
+            int item;
+            var actual = new HashSet<int>();
+            for (int i = 0; i < expected.Count; i++)
             {
-                threads[i] = Task.Run(() =>
-                {
-                    for (int j = 0; j < itemsPerThread; j++)
-                    {
-                        try
-                        {
-                            bag.Add(j);
-                            int item;
-                            if (!bag.TryPeek(out item) || item != j)
-                            {
-                                Interlocked.Increment(ref failures);
-                            }
-                        }
-                        catch
-                        {
-                            Interlocked.Increment(ref failures);
-                        }
-                    }
-                });
+                Assert.Equal(expected.Count - i, bag.Count);
+                Assert.True(bag.TryTake(out item));
+                actual.Add(item);
             }
 
-            Task.WaitAll(threads);
+            Assert.False(bag.TryTake(out item));
+            Assert.Equal(0, item);
+            Assert.True(bag.IsEmpty);
+            AssertSetsEqual(expected, actual);
+        }
 
-            Assert.Equal(0, failures);
+        [Fact]
+        public static void Ctor_InvalidArgs_Throws()
+        {
+            Assert.Throws<ArgumentNullException>("collection", () => new ConcurrentBag<int>(null));
+        }
+
+        [Fact]
+        public static void Add_TakeFromAnotherThread_ExpectedItemsTaken()
+        {
+            var cb = new ConcurrentBag<int>();
+            Assert.True(cb.IsEmpty);
+            Assert.Equal(0, cb.Count);
+
+            const int NumItems = 100000;
+
+            Task producer = Task.Run(() => Parallel.For(1, NumItems + 1, cb.Add));
+
+            var hs = new HashSet<int>();
+            while (hs.Count < NumItems)
+            {
+                int item;
+                if (cb.TryTake(out item)) hs.Add(item);
+            }
+
+            producer.GetAwaiter().GetResult();
+
+            Assert.True(cb.IsEmpty);
+            Assert.Equal(0, cb.Count);
+            AssertSetsEqual(new HashSet<int>(Enumerable.Range(1, NumItems)), hs);
+        }
+
+        [Theory]
+        [InlineData(1, 10)]
+        [InlineData(3, 100)]
+        [InlineData(8, 1000)]
+        public static void AddThenPeek_LatestLocalItemRetuned(int threadsCount, int itemsPerThread)
+        {
+            var bag = new ConcurrentBag<int>();
+
+            using (var b = new Barrier(threadsCount))
+            {
+                WaitAllOrAnyFailed((Enumerable.Range(0, threadsCount).Select(_ => Task.Factory.StartNew(() =>
+                {
+                    b.SignalAndWait();
+                    for (int i = 1; i < itemsPerThread + 1; i++)
+                    {
+                        bag.Add(i);
+                        int item;
+                        Assert.True(bag.TryPeek(out item));
+                        Assert.Equal(i, item);
+                    }
+                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default))).ToArray());
+            }
+
             Assert.Equal(itemsPerThread * threadsCount, bag.Count);
         }
 
-        /// <summary>
-        /// Test bag Take and Peek operations
-        /// </summary>
-        /// <param name="bag"></param>
-        /// <param name="threadsCount"></param>
-        /// <param name="itemsPerThread"></param>
-        /// <param name="take"></param>
-        /// <returns>True if succeeded, false otherwise</returns>
-        private static void RTest3_TakeOrPeek(ConcurrentBag<int> bag, int threadsCount, int itemsPerThread, bool take)
+        [Fact]
+        public static void AddOnOneThread_PeekOnAnother_EnsureWeCanTakeOnTheOriginal()
         {
-            int bagCount = bag.Count;
-            int succeeded = 0;
-            int failures = 0;
-            Task[] threads = new Task[threadsCount];
-            for (int i = 0; i < threads.Length; i++)
+            var bag = new ConcurrentBag<int>(Enumerable.Range(1, 5));
+
+            Task.Factory.StartNew(() =>
             {
-                threads[i] = Task.Run(() =>
+                int item;
+                for (int i = 1; i <= 5; i++)
                 {
-                    for (int j = 0; j < itemsPerThread; j++)
-                    {
-                        int data;
-                        bool result = false;
-                        if (take)
-                        {
-                            result = bag.TryTake(out data);
-                        }
-                        else
-                        {
-                            result = bag.TryPeek(out data);
-                        }
+                    Assert.True(bag.TryPeek(out item));
+                    Assert.Equal(1, item);
+                }
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).GetAwaiter().GetResult();
 
-                        if (result)
-                        {
-                            Interlocked.Increment(ref succeeded);
-                        }
-                        else
-                        {
-                            Interlocked.Increment(ref failures);
-                        }
-                    }
-                });
-            }
+            Assert.Equal(5, bag.Count);
 
-            Task.WaitAll(threads);
-
-            if (take)
+            for (int i = 5; i > 0; i--)
             {
-                Assert.Equal(bagCount - succeeded, bag.Count);
-            }
-            else
-            {
-                Assert.Equal(0, failures);
+                int item;
+
+                Assert.True(bag.TryPeek(out item));
+                Assert.Equal(i, item); // ordering implementation detail that's not guaranteed
+
+                Assert.Equal(i, bag.Count);
+                Assert.True(bag.TryTake(out item));
+                Assert.Equal(i - 1, bag.Count);
+                Assert.Equal(i, item); // ordering implementation detail that's not guaranteed
             }
         }
 
-        /// <summary>
-        /// Test parallel Add/Take, insert unique elements in the bag, and each element should be removed once
-        /// </summary>
-        /// <param name="threadsCount"></param>
-        /// <returns>True if succeeded, false otherwise</returns>
-        private static void RTest4_AddAndTake(int threadsCount)
+        [Theory]
+        [InlineData(100, 1, 100, true)]
+        [InlineData(100, 4, 10, false)]
+        [InlineData(1000, 11, 100, true)]
+        [InlineData(100000, 2, 50000, true)]
+        public static void Initialize_ThenTakeOrPeekInParallel_ItemsObtainedAsExpected(int numStartingItems, int threadsCount, int itemsPerThread, bool take)
         {
-            ConcurrentBag<int> bag = new ConcurrentBag<int>();
+            var bag = new ConcurrentBag<int>(Enumerable.Range(1, numStartingItems));
+            int successes = 0;
 
-            Task[] threads = new Task[threadsCount];
+            using (var b = new Barrier(threadsCount))
+            {
+                WaitAllOrAnyFailed(Enumerable.Range(0, threadsCount).Select(threadNum => Task.Factory.StartNew(() =>
+                {
+                    b.SignalAndWait();
+                    for (int j = 0; j < itemsPerThread; j++)
+                    {
+                        int data;
+                        if (take ? bag.TryTake(out data) : bag.TryPeek(out data))
+                        {
+                            Interlocked.Increment(ref successes);
+                            Assert.NotEqual(0, data); // shouldn't be default(T)
+                        }
+                    }
+                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default)).ToArray());
+            }
+
+            Assert.Equal(
+                take ? numStartingItems : threadsCount * itemsPerThread,
+                successes);
+        }
+
+        [Theory]
+        [InlineData(8)]
+        [InlineData(16)]
+        public static void AddAndTake_ExpectedValuesTransferred(int threadsCount)
+        {
+            var bag = new ConcurrentBag<int>();
+
             int start = 0;
             int end = 10;
 
+            Task[] threads = new Task[threadsCount];
             int[] validation = new int[(end - start) * threads.Length / 2];
             for (int i = 0; i < threads.Length; i += 2)
             {
-                Interval v = new Interval(start, end);
-                threads[i] = Task.Factory.StartNew(
-                    (o) =>
-                    {
-                        Interval n = (Interval)o;
-                        Add(bag, n.m_start, n.m_end);
-                    }, v, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
-
-                threads[i + 1] = Task.Run(() => Take(bag, end - start - 1, validation));
+                int localStart = start, localEnd = end;
+                threads[i] = Task.Run(() => AddRange(bag, localStart, localEnd));
+                threads[i + 1] = Task.Run(() => TakeRange(bag, localEnd - localStart - 1, validation));
 
                 int step = end - start;
                 start = end;
                 end += step;
             }
-
-            Task.WaitAll(threads);
-
-            int value = -1;
+            WaitAllOrAnyFailed(threads);
 
             //validation
+            int value = -1;
             for (int i = 0; i < validation.Length; i++)
             {
                 if (validation[i] == 0)
                 {
-                    Assert.True(bag.TryTake(out value), String.Format("Add/Take failed, the list is not empty and TryTake returned false; thread count={0}", threadsCount));
+                    Assert.True(bag.TryTake(out value));
                 }
                 else
                 {
@@ -275,174 +207,625 @@ namespace System.Collections.Concurrent.Tests
                 }
             }
 
-            Assert.False(bag.Count > 0 || bag.TryTake(out value), String.Format("Add/Take failed, this list is not empty after all remove operations; thread count={0}", threadsCount));
+            Assert.False(bag.Count > 0 || bag.TryTake(out value));
         }
 
         [Fact]
-        public static void RTest6_GetEnumerator()
-        {
-            ConcurrentBag<int> bag = new ConcurrentBag<int>();
-
-            // Empty bag should not enumerate
-            Assert.Empty(bag);
-
-            for (int i = 0; i < 100; i++)
-            {
-                bag.Add(i);
-            }
-
-            int count = 0;
-            foreach (int x in bag)
-            {
-                count++;
-            }
-
-            Assert.Equal(count, bag.Count);
-        }
-
-        [Fact]
-        public static void RTest7_BugFix575975()
-        {
-            BlockingCollection<int> bc = new BlockingCollection<int>(new ConcurrentBag<int>());
-            bool succeeded = true;
-            Task[] threads = new Task[4];
-            for (int t = 0; t < threads.Length; t++)
-            {
-                threads[t] = Task.Factory.StartNew((obj) =>
-                {
-                    int index = (int)obj;
-                    for (int i = 0; i < 100000; i++)
-                    {
-                        if (index < threads.Length / 2)
-                        {
-                            int k = 0;
-                            for (int j = 0; j < 1000; j++)
-                                k++;
-                            bc.Add(i);
-                        }
-                        else
-                        {
-                            try
-                            {
-                                bc.Take();
-                            }
-                            catch // Take must not fail
-                            {
-                                succeeded = false;
-                                break;
-                            }
-                        }
-                    }
-
-                }, t, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
-            }
-
-            Task.WaitAll(threads);
-            Assert.True(succeeded);
-        }
-
-        [Fact]
-        public static void RTest8_Interfaces()
-        {
-            ConcurrentBag<int> bag = new ConcurrentBag<int>();
-            //IPCC
-            IProducerConsumerCollection<int> ipcc = bag as IProducerConsumerCollection<int>;
-            Assert.False(ipcc == null, "RTest8_Interfaces:  ConcurrentBag<T> doesn't implement IPCC<T>");
-            Assert.True(ipcc.TryAdd(1), "RTest8_Interfaces:  IPCC<T>.TryAdd failed");
-            Assert.Equal(1, bag.Count);
-
-            int result = -1;
-            Assert.True(ipcc.TryTake(out result), "RTest8_Interfaces:  IPCC<T>.TryTake failed");
-            Assert.True(1 == result, "RTest8_Interfaces:  IPCC<T>.TryTake failed");
-            Assert.Equal(0, bag.Count);
-
-            //ICollection
-            ICollection collection = bag as ICollection;
-            Assert.False(collection == null, "RTest8_Interfaces:  ConcurrentBag<T> doesn't implement ICollection");
-            Assert.False(collection.IsSynchronized, "RTest8_Interfaces:  IsSynchronized returned true");
-
-            //IEnumerable
-            IEnumerable enumerable = bag as IEnumerable;
-            Assert.False(enumerable == null, "RTest8_Interfaces:  ConcurrentBag<T> doesn't implement IEnumerable");
-            // Empty bag shouldn't enumerate.
-            Assert.Empty(enumerable);
-        }
-
-        [Fact]
-        public static void RTest8_Interfaces_Negative()
-        {
-            ConcurrentBag<int> bag = new ConcurrentBag<int>();
-            //IPCC
-            IProducerConsumerCollection<int> ipcc = bag as IProducerConsumerCollection<int>;
-            ICollection collection = bag as ICollection;
-            Assert.Throws<NotSupportedException>(() => { object obj = collection.SyncRoot; });
-        }
-
-        [Fact]
-        public static void RTest9_ToArray()
+        public static void AddFromMultipleThreads_ItemsRemainAfterThreadsGoAway()
         {
             var bag = new ConcurrentBag<int>();
 
-            Assert.NotNull(bag.ToArray());
-            Assert.Equal(0, bag.ToArray().Length);
-
-            int[] allItems = new int[10000];
-            for (int i = 0; i < allItems.Length; i++)
-                allItems[i] = i;
-
-            bag = new ConcurrentBag<int>(allItems);
-            int failCount = 0;
-            Task[] tasks = new Task[10];
-            for (int i = 0; i < tasks.Length; i++)
+            for (int i = 0; i < 1000; i += 100)
             {
-                tasks[i] = Task.Run(() =>
+                // Create a thread that adds items to the bag
+                Task.Factory.StartNew(() =>
+                {
+                    for (int j = i; j < i + 100; j++)
                     {
-                        int[] array = bag.ToArray();
-                        if (array == null || array.Length != 10000)
-                            Interlocked.Increment(ref failCount);
-                    });
+                        bag.Add(j);
+                    }
+                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).GetAwaiter().GetResult();
+
+                // Allow threads to be collected
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
             }
 
-            Task.WaitAll(tasks);
-            Assert.True(0 == failCount, "RTest9_ToArray:  One or more thread failed to get the correct bag items from ToArray");
+            AssertSetsEqual(new HashSet<int>(Enumerable.Range(0, 1000)), new HashSet<int>(bag));
         }
 
         [Fact]
-        public static void RTest10_DebuggerAttributes()
+        public static void AddManyItems_ThenTakeOnSameThread_ItemsOutputInExpectedOrder()
+        {
+            var bag = new ConcurrentBag<int>(Enumerable.Range(0, 100000));
+            for (int i = 99999; i >= 0; --i)
+            {
+                int item;
+                Assert.True(bag.TryTake(out item));
+                Assert.Equal(i, item); // Testing an implementation detail rather than guaranteed ordering
+            }
+        }
+
+        [Fact]
+        public static void AddManyItems_ThenTakeOnDifferentThread_ItemsOutputInExpectedOrder()
+        {
+            var bag = new ConcurrentBag<int>(Enumerable.Range(0, 100000));
+            Task.Factory.StartNew(() =>
+            {
+                for (int i = 0; i < 100000; i++)
+                {
+                    int item;
+                    Assert.True(bag.TryTake(out item));
+                    Assert.Equal(i, item); // Testing an implementation detail rather than guaranteed ordering
+                }
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).GetAwaiter().GetResult();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(10)]
+        [InlineData(33)]
+        public static void IterativelyAddOnOneThreadThenTakeOnAnother_OrderMaintained(int initialCount)
+        {
+            var bag = new ConcurrentBag<int>(Enumerable.Range(0, initialCount));
+
+            const int Iterations = 100;
+            using (AutoResetEvent itemConsumed = new AutoResetEvent(false), itemProduced = new AutoResetEvent(false))
+            {
+                Task t = Task.Run(() =>
+                {
+                    for (int i = 0; i < Iterations; i++)
+                    {
+                        itemProduced.WaitOne();
+                        int item;
+                        Assert.True(bag.TryTake(out item));
+                        Assert.Equal(i, item); // Testing an implementation detail rather than guaranteed ordering
+                        itemConsumed.Set();
+                    }
+                });
+
+                for (int i = initialCount; i < Iterations + initialCount; i++)
+                {
+                    bag.Add(i);
+                    itemProduced.Set();
+                    itemConsumed.WaitOne();
+                }
+
+                t.GetAwaiter().GetResult();
+            }
+
+            Assert.Equal(initialCount, bag.Count);
+        }
+
+        [Fact]
+        public static void Peek_SucceedsOnEmptyBagThatWasOnceNonEmpty()
+        {
+            var bag = new ConcurrentBag<int>();
+            int item;
+
+            Assert.False(bag.TryPeek(out item));
+            Assert.Equal(0, item);
+
+            bag.Add(42);
+            for (int i = 0; i < 2; i++)
+            {
+                Assert.True(bag.TryPeek(out item));
+                Assert.Equal(42, item);
+            }
+
+            Assert.True(bag.TryTake(out item));
+            Assert.Equal(42, item);
+
+            Assert.False(bag.TryPeek(out item));
+            Assert.Equal(0, item);
+        }
+
+        [Fact]
+        public static void CopyTo_Empty_NothingCopied()
+        {
+            var bag = new ConcurrentBag<int>();
+            bag.CopyTo(new int[0], 0);
+            bag.CopyTo(new int[10], 10);
+        }
+
+        [Fact]
+        public static void CopyTo_ExpectedElementsCopied()
+        {
+            const int Size = 10;
+            int[] dest;
+
+            // Copy to array in which data fits perfectly
+            dest = new int[Size];
+            var bag = new ConcurrentBag<int>(Enumerable.Range(0, Size));
+            bag.CopyTo(dest, 0);
+            Assert.Equal(Enumerable.Range(0, Size), dest.OrderBy(i => i));
+
+            // Copy to non-0 index in array where the data fits
+            dest = new int[Size + 3];
+            bag = new ConcurrentBag<int>(Enumerable.Range(0, Size));
+            bag.CopyTo(dest, 1);
+            var results = new int[Size];
+            Array.Copy(dest, 1, results, 0, results.Length);
+            Assert.Equal(Enumerable.Range(0, Size), results.OrderBy(i => i));
+        }
+
+        [Fact]
+        public static void CopyTo_InvalidArgs_Throws()
+        {
+            var bag = new ConcurrentBag<int>(Enumerable.Range(0, 10));
+            int[] dest = new int[10];
+
+            Assert.Throws<ArgumentNullException>("array", () => bag.CopyTo(null, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => bag.CopyTo(dest, -1));
+            Assert.Throws<ArgumentException>(() => bag.CopyTo(dest, dest.Length));
+            Assert.Throws<ArgumentException>(() => bag.CopyTo(dest, dest.Length - 2));
+        }
+
+        [Fact]
+        public static void ICollectionCopyTo_ExpectedElementsCopied()
+        {
+            const int Size = 10;
+            int[] dest;
+
+            // Copy to array in which data fits perfectly
+            dest = new int[Size];
+            ICollection c = new ConcurrentBag<int>(Enumerable.Range(0, Size));
+            c.CopyTo(dest, 0);
+            Assert.Equal(Enumerable.Range(0, Size), dest.OrderBy(i => i));
+
+            // Copy to non-0 index in array where the data fits
+            dest = new int[Size + 3];
+            c = new ConcurrentBag<int>(Enumerable.Range(0, Size));
+            c.CopyTo(dest, 1);
+            var results = new int[Size];
+            Array.Copy(dest, 1, results, 0, results.Length);
+            Assert.Equal(Enumerable.Range(0, Size), results.OrderBy(i => i));
+        }
+
+        [Fact]
+        public static void ICollectionCopyTo_InvalidArgs_Throws()
+        {
+            ICollection bag = new ConcurrentBag<int>(Enumerable.Range(0, 10));
+            Array dest = new int[10];
+
+            Assert.Throws<ArgumentNullException>("array", () => bag.CopyTo(null, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => bag.CopyTo(dest, -1));
+            Assert.Throws<ArgumentException>(() => bag.CopyTo(dest, dest.Length));
+            Assert.Throws<ArgumentException>(() => bag.CopyTo(dest, dest.Length - 2));
+        }
+
+        [Theory]
+        [InlineData(0, true)]
+        [InlineData(1, true)]
+        [InlineData(1, false)]
+        [InlineData(10, true)]
+        [InlineData(100, true)]
+        [InlineData(100, false)]
+        public static async Task GetEnumerator_Generic_ExpectedElementsYielded(int numItems, bool consumeFromSameThread)
+        {
+            var bag = new ConcurrentBag<int>();
+            using (var e = bag.GetEnumerator())
+            {
+                Assert.False(e.MoveNext());
+            }
+
+            // Add, and validate enumeration after each item added
+            for (int i = 1; i <= numItems; i++)
+            {
+                bag.Add(i);
+                Assert.Equal(i, bag.Count);
+                Assert.Equal(i, bag.Distinct().Count());
+            }
+
+            // Take, and validate enumerate after each item removed.
+            Action consume = () =>
+            {
+                for (int i = 1; i <= numItems; i++)
+                {
+                    int item;
+                    Assert.True(bag.TryTake(out item));
+                    Assert.Equal(numItems - i, bag.Count);
+                    Assert.Equal(numItems - i, bag.Distinct().Count());
+                }
+            };
+            if (consumeFromSameThread)
+            {
+                consume();
+            }
+            else
+            {
+                await Task.Factory.StartNew(consume, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+            }
+        }
+
+        [Fact]
+        public static void GetEnumerator_NonGeneric()
+        {
+            var bag = new ConcurrentBag<int>();
+            var ebag = (IEnumerable)bag;
+
+            Assert.False(ebag.GetEnumerator().MoveNext());
+
+            bag.Add(42);
+            bag.Add(84);
+
+            var hs = new HashSet<int>(ebag.Cast<int>());
+            Assert.Equal(2, hs.Count);
+            Assert.Contains(42, hs);
+            Assert.Contains(84, hs);
+        }
+
+        [Fact]
+        public static void GetEnumerator_EnumerationsAreSnapshots()
+        {
+            var bag = new ConcurrentBag<int>();
+            Assert.Empty(bag);
+
+            using (IEnumerator<int> e1 = bag.GetEnumerator())
+            {
+                bag.Add(1);
+                using (IEnumerator<int> e2 = bag.GetEnumerator())
+                {
+                    bag.Add(2);
+                    using (IEnumerator<int> e3 = bag.GetEnumerator())
+                    {
+                        int item;
+                        Assert.True(bag.TryTake(out item));
+                        using (IEnumerator<int> e4 = bag.GetEnumerator())
+                        {
+                            Assert.False(e1.MoveNext());
+
+                            Assert.True(e2.MoveNext());
+                            Assert.False(e2.MoveNext());
+
+                            Assert.True(e3.MoveNext());
+                            Assert.True(e3.MoveNext());
+                            Assert.False(e3.MoveNext());
+
+                            Assert.True(e4.MoveNext());
+                            Assert.False(e4.MoveNext());
+                        }
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(100, 1, 10)] 
+        [InlineData(4, 100000, 10)]
+        public static void BlockingCollection_WrappingBag_ExpectedElementsTransferred(int numThreadsPerConsumerProducer, int numItemsPerThread, int producerSpin)
+        {
+            var bc = new BlockingCollection<int>(new ConcurrentBag<int>());
+            long dummy = 0;
+
+            Task[] producers = Enumerable.Range(0, numThreadsPerConsumerProducer).Select(_ => Task.Factory.StartNew(() =>
+            {
+                for (int i = 1; i <= numItemsPerThread; i++)
+                {
+                    for (int j = 0; j < producerSpin; j++) dummy *= j; // spin a little
+                    bc.Add(i);
+                }
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default)).ToArray();
+
+            Task[] consumers = Enumerable.Range(0, numThreadsPerConsumerProducer).Select(_ => Task.Factory.StartNew(() =>
+            {
+                for (int i = 0; i < numItemsPerThread; i++)
+                {
+                    const int TimeoutMs = 100000;
+                    int item;
+                    Assert.True(bc.TryTake(out item, TimeoutMs), $"Couldn't get {i}th item after {TimeoutMs}ms");
+                    Assert.NotEqual(0, item);
+                }
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default)).ToArray();
+
+            WaitAllOrAnyFailed(producers);
+            WaitAllOrAnyFailed(consumers);
+        }
+
+        [Fact]
+        public static void IProducerConsumerCollection_TryAdd_TryTake_ToArray()
+        {
+            IProducerConsumerCollection<int> bag = new ConcurrentBag<int>();
+
+            Assert.True(bag.TryAdd(42));
+            Assert.Equal(new[] { 42 }, bag.ToArray());
+
+            Assert.True(bag.TryAdd(84));
+            Assert.Equal(new[] { 42, 84 }, bag.ToArray().OrderBy(i => i));
+
+            int item;
+
+            Assert.True(bag.TryTake(out item));
+            int remainingItem = item == 42 ? 84 : 42;
+            Assert.Equal(new[] { remainingItem }, bag.ToArray());
+            Assert.True(bag.TryTake(out item));
+            Assert.Equal(remainingItem, item);
+            Assert.Empty(bag.ToArray());
+        }
+
+        [Fact]
+        public static void ICollection_IsSynchronized_SyncRoot()
+        {
+            ICollection bag = new ConcurrentBag<int>();
+            Assert.False(bag.IsSynchronized);
+            Assert.Throws<NotSupportedException>(() => bag.SyncRoot);
+        }
+
+        [Fact]
+        public static void ToArray_ParallelInvocations_Succeed()
+        {
+            var bag = new ConcurrentBag<int>();
+            Assert.Empty(bag.ToArray());
+
+            const int NumItems = 10000;
+
+            Parallel.For(0, NumItems, bag.Add);
+            Assert.Equal(NumItems, bag.Count);
+
+            Parallel.For(0, 10, i =>
+            {
+                var hs = new HashSet<int>(bag.ToArray());
+                Assert.Equal(NumItems, hs.Count);
+            });
+        }
+
+        [OuterLoop("Runs for several seconds")]
+        [Fact]
+        public static void ManyConcurrentAddsTakes_BagRemainsConsistent_LongRunning() =>
+            ManyConcurrentAddsTakes_BagRemainsConsistent(3.0);
+
+        [Theory]
+        [InlineData(0.5)]
+        public static void ManyConcurrentAddsTakes_BagRemainsConsistent(double seconds)
+        {
+            var bag = new ConcurrentBag<long>();
+
+            DateTime end = DateTime.UtcNow + TimeSpan.FromSeconds(seconds);
+
+            // Thread that adds
+            Task<HashSet<long>> adds = Task.Run(() =>
+            {
+                var added = new HashSet<long>();
+                long i = long.MinValue;
+                while (DateTime.UtcNow < end)
+                {
+                    i++;
+                    bag.Add(i);
+                    added.Add(i);
+                }
+                return added;
+            });
+
+            // Thread that adds and takes
+            Task<KeyValuePair<HashSet<long>,HashSet<long>>> addsAndTakes = Task.Run(() =>
+            {
+                var added = new HashSet<long>();
+                var taken = new HashSet<long>();
+
+                long i = 1; // avoid 0 as default(T), to detect accidentally reading a default value
+                while (DateTime.UtcNow < end)
+                {
+                    i++;
+                    bag.Add(i);
+                    added.Add(i);
+
+                    long item;
+                    if (bag.TryTake(out item))
+                    {
+                        Assert.NotEqual(0, item);
+                        taken.Add(item);
+                    }
+                }
+
+                return new KeyValuePair<HashSet<long>, HashSet<long>>(added, taken);
+            });
+
+            // Thread that just takes
+            Task<HashSet<long>> takes = Task.Run(() =>
+            {
+                var taken = new HashSet<long>();
+                while (DateTime.UtcNow < end)
+                {
+                    long item;
+                    if (bag.TryTake(out item))
+                    {
+                        Assert.NotEqual(0, item);
+                        taken.Add(item);
+                    }
+                }
+                return taken;
+            });
+
+            // Wait for them all to finish
+            WaitAllOrAnyFailed(adds, addsAndTakes, takes);
+
+            // Combine everything they added and remove everything they took
+            var total = new HashSet<long>(adds.Result);
+            total.UnionWith(addsAndTakes.Result.Key);
+            total.ExceptWith(addsAndTakes.Result.Value);
+            total.ExceptWith(takes.Result);
+
+            // What's left should match what's in the bag
+            Assert.Equal(total.OrderBy(i => i), bag.OrderBy(i => i));
+        }
+
+        [OuterLoop("Runs for several seconds")]
+        [Fact]
+        public static void ManyConcurrentAddsTakesPeeks_ForceContentionWithSteals_LongRunning() =>
+            ManyConcurrentAddsTakesPeeks_ForceContentionWithSteals(3.0);
+
+        [Theory]
+        [InlineData(0.5)]
+        public static void ManyConcurrentAddsTakesPeeks_ForceContentionWithSteals(double seconds)
+        {
+            var bag = new ConcurrentBag<int>();
+            const int MaxCount = 4;
+
+            DateTime end = DateTime.UtcNow + TimeSpan.FromSeconds(seconds);
+
+            Task<long> addsTakes = Task.Factory.StartNew(() =>
+            {
+                long total = 0;
+                while (DateTime.UtcNow < end)
+                {
+                    for (int i = 1; i <= MaxCount; i++)
+                    {
+                        bag.Add(i);
+                        total++;
+                    }
+
+                    int item;
+                    if (bag.TryPeek(out item))
+                    {
+                        Assert.InRange(item, 1, MaxCount);
+                    }
+
+                    for (int i = 1; i <= MaxCount; i++)
+                    {
+                        if (bag.TryTake(out item))
+                        {
+                            total--;
+                            Assert.InRange(item, 1, MaxCount);
+                        }
+                    }
+                }
+                return total;
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+
+            Task<long> steals = Task.Factory.StartNew(() =>
+            {
+                long total = 0;
+                int item;
+                while (DateTime.UtcNow < end)
+                {
+                    if (bag.TryTake(out item))
+                    {
+                        total++;
+                        Assert.InRange(item, 1, MaxCount);
+                    }
+                }
+                return total;
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+
+            WaitAllOrAnyFailed(addsTakes, steals);
+            long remaining = addsTakes.Result - steals.Result;
+            Assert.InRange(remaining, 0, long.MaxValue);
+            Assert.Equal(remaining, bag.Count);
+        }
+
+        [OuterLoop("Runs for several seconds")]
+        [Fact]
+        public static void ManyConcurrentAddsTakesPeeks_ForceContentionWithStealingPeeks_LongRunning() =>
+            ManyConcurrentAddsTakesPeeks_ForceContentionWithStealingPeeks(3.0);
+
+        [Theory]
+        [InlineData(0.5)]
+        public static void ManyConcurrentAddsTakesPeeks_ForceContentionWithStealingPeeks(double seconds)
+        {
+            var bag = new ConcurrentBag<int>();
+            const int MaxCount = 4;
+
+            DateTime end = DateTime.UtcNow + TimeSpan.FromSeconds(seconds);
+
+            Task<long> addsTakes = Task.Factory.StartNew(() =>
+            {
+                long total = 0;
+                while (DateTime.UtcNow < end)
+                {
+                    for (int i = 1; i <= MaxCount; i++)
+                    {
+                        bag.Add(i);
+                        total++;
+                    }
+
+                    int item;
+                    Assert.True(bag.TryPeek(out item));
+                    Assert.Equal(MaxCount, item);
+
+                    for (int i = 1; i <= MaxCount; i++)
+                    {
+                        if (bag.TryTake(out item))
+                        {
+                            total--;
+                            Assert.InRange(item, 1, MaxCount);
+                        }
+                    }
+                }
+                return total;
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+
+            Task steals = Task.Factory.StartNew(() =>
+            {
+                int item;
+                while (DateTime.UtcNow < end)
+                {
+                    if (bag.TryPeek(out item))
+                    {
+                        Assert.InRange(item, 1, MaxCount);
+                    }
+                }
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+
+            WaitAllOrAnyFailed(addsTakes, steals);
+            Assert.Equal(0, addsTakes.Result);
+            Assert.Equal(0, bag.Count);
+        }
+
+        [OuterLoop("Runs for several seconds")]
+        [Fact]
+        public static void ManyConcurrentAddsTakes_ForceContentionWithFreezing_LongRunning() =>
+            ManyConcurrentAddsTakes_ForceContentionWithFreezing(3.0);
+
+        [Theory]
+        [InlineData(0.5)]
+        public static void ManyConcurrentAddsTakes_ForceContentionWithFreezing(double seconds)
+        {
+            var bag = new ConcurrentBag<int>();
+            const int MaxCount = 4;
+
+            DateTime end = DateTime.UtcNow + TimeSpan.FromSeconds(seconds);
+
+            Task addsTakes = Task.Factory.StartNew(() =>
+            {
+                while (DateTime.UtcNow < end)
+                {
+                    for (int i = 1; i <= MaxCount; i++)
+                    {
+                        bag.Add(i);
+                    }
+                    for (int i = 1; i <= MaxCount; i++)
+                    {
+                        int item;
+                        Assert.True(bag.TryTake(out item));
+                        Assert.InRange(item, 1, MaxCount);
+                    }
+                }
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+
+            while (DateTime.UtcNow < end)
+            {
+                int[] arr = bag.ToArray();
+                Assert.InRange(arr.Length, 0, MaxCount);
+                Assert.DoesNotContain(0, arr); // make sure we didn't get default(T)
+            }
+
+            addsTakes.GetAwaiter().GetResult();
+            Assert.Equal(0, bag.Count);
+        }
+
+        [Fact]
+        public static void ValidateDebuggerAttributes()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new ConcurrentBag<int>());
             DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new ConcurrentBag<int>());
+
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(new ConcurrentBag<int>(Enumerable.Range(0, 10)));
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new ConcurrentBag<int>(Enumerable.Range(0, 10)));
         }
 
-        #region Helper Methods / Classes
-
-        private struct Interval
-        {
-            public Interval(int start, int end)
-            {
-                m_start = start;
-                m_end = end;
-            }
-            internal int m_start;
-            internal int m_end;
-        }
-
-        /// <summary>
-        /// Create a ComcurrentBag object
-        /// </summary>
-        /// <param name="numbers">number of the elements in the bag</param>
-        /// <returns>The bag object</returns>
-        private static ConcurrentBag<int> CreateBag(int numbers)
-        {
-            ConcurrentBag<int> bag = new ConcurrentBag<int>();
-            for (int i = 0; i < numbers; i++)
-            {
-                bag.Add(i);
-            }
-            return bag;
-        }
-
-        private static void Add(ConcurrentBag<int> bag, int start, int end)
+        private static void AddRange(ConcurrentBag<int> bag, int start, int end)
         {
             for (int i = start; i < end; i++)
             {
@@ -450,19 +833,56 @@ namespace System.Collections.Concurrent.Tests
             }
         }
 
-        private static void Take(ConcurrentBag<int> bag, int count, int[] validation)
+        private static void TakeRange(ConcurrentBag<int> bag, int count, int[] validation)
         {
             for (int i = 0; i < count; i++)
             {
-                int value = -1;
-
-                if (bag.TryTake(out value) && validation != null)
+                int value;
+                if (bag.TryTake(out value))
                 {
                     Interlocked.Increment(ref validation[value]);
                 }
             }
         }
 
-        #endregion
+        private static void AssertSetsEqual<T>(HashSet<T> expected, HashSet<T> actual)
+        {
+            Assert.Equal(expected.Count, actual.Count);
+            Assert.Subset(expected, actual);
+            Assert.Subset(actual, expected);
+        }
+
+        private static void WaitAllOrAnyFailed(params Task[] tasks)
+        {
+            if (tasks.Length == 0)
+            {
+                return;
+            }
+
+            int remaining = tasks.Length;
+            var mres = new ManualResetEventSlim();
+
+            foreach (Task task in tasks)
+            {
+                task.ContinueWith(t =>
+                {
+                    if (Interlocked.Decrement(ref remaining) == 0 || t.IsFaulted)
+                    {
+                        mres.Set();
+                    }
+                }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+            }
+
+            mres.Wait();
+
+            // Either all tasks are completed or at least one failed
+            foreach (Task t in tasks)
+            {
+                if (t.IsFaulted)
+                {
+                    t.GetAwaiter().GetResult(); // propagate for the first one that failed
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
The primary purpose of this change is to remove allocations prevalent in the use of ConcurrentBag:
- Every Add allocates a Node object to be stored in a linked list.
- Every Take that needs to steal allocates a List (and the associated underlying array) to store version information for all peer lists examined.

This PR removes all of those allocations:
- The first allocation (per-Add Node) is addressed by changing from a linked-list-based scheme to an array-based scheme; the logic for the latter is taken from ThreadPool (https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Threading/ThreadPool.cs#L133), which uses an array-based work-stealing implementation for the thread-local queues in the pool.
- The second allocation is avoided by caching a per-thread list in TLS, so that any steal operation can just use that list from TLS.  These changes effectively eliminate all per-operation allocations in ConcurrentBag.

In addition to the GC impact, these changes have a beneficial impact on throughput, due to better memory locality with the array vs with a linked list, less code needed for pushes/pops, etc.

In a test that adds 10M items from a single thread:
Before (elapsed time and gen0 GCs):
```
00:00:02.2688554 67
00:00:02.6047316 66
00:00:02.1908836 65
00:00:02.7931760 68
```
After:
```
00:00:00.8325350 0
00:00:00.8284697 0
00:00:00.8600504 0
00:00:00.8094874 0
```

In a test that has 4 threads each adding 2 items then taking 2 items (no steals), repeatedly, 5M times:
Before:
```
00:00:02.9780786 767
00:00:02.7218693 767
00:00:02.7535170 767
00:00:02.7547491 767
```
After:
```
00:00:01.5986701 0
00:00:01.3661083 0
00:00:01.4061545 0
00:00:01.3687102 0
```

In a test that has one thread adding 10M items and another thread taking until all 10M are stolen (effectively the worst case for ConcurrentBag):
Before:
```
00:00:03.1549239 332
00:00:03.2892691 340
00:00:03.1984057 349
00:00:03.3697942 346
```
After:
```
00:00:02.5558069 0
00:00:01.8004534 0
00:00:02.5968542 0
00:00:02.1146025 0
```

Prior to this change, devs were often hesitant to use ConcurrentBag as an object pool for small objects, as each added object involved its own small Node allocation.  After this change, there shouldn't be any such objections.

cc: @kouvel, @alexperovich, @benaadams
Fixes #14090 
Fixes https://github.com/dotnet/corefx/issues/7917