### PR TITLE
Add HashAlgorithm.HashSizeValue protected field

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -247,7 +247,6 @@ namespace System.Security.Cryptography
     {
         public HMACMD5() { }
         public HMACMD5(byte[] key) { }
-        public override int HashSize { get { throw null; } }
         public override byte[] Key { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }
         protected override void HashCore(byte[] rgb, int ib, int cb) { }
@@ -260,7 +259,6 @@ namespace System.Security.Cryptography
         public HMACSHA1(byte[] key) { }
         [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
         public HMACSHA1(byte[] key, bool useManagedSha1) { }
-        public override int HashSize { get { throw null; } }
         public override byte[] Key { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }
         protected override void HashCore(byte[] rgb, int ib, int cb) { }
@@ -271,7 +269,6 @@ namespace System.Security.Cryptography
     {
         public HMACSHA256() { }
         public HMACSHA256(byte[] key) { }
-        public override int HashSize { get { throw null; } }
         public override byte[] Key { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }
         protected override void HashCore(byte[] rgb, int ib, int cb) { }
@@ -283,7 +280,6 @@ namespace System.Security.Cryptography
         public HMACSHA384() { }
         public HMACSHA384(byte[] key) { }
         public bool ProduceLegacyHmacValues { get; set; }
-        public override int HashSize { get { throw null; } }
         public override byte[] Key { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }
         protected override void HashCore(byte[] rgb, int ib, int cb) { }
@@ -295,7 +291,6 @@ namespace System.Security.Cryptography
         public HMACSHA512() { }
         public HMACSHA512(byte[] key) { }
         public bool ProduceLegacyHmacValues { get; set; }
-        public override int HashSize { get { throw null; } }
         public override byte[] Key { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }
         protected override void HashCore(byte[] rgb, int ib, int cb) { }
@@ -532,7 +527,6 @@ namespace System.Security.Cryptography
     public sealed partial class SHA1Managed : System.Security.Cryptography.SHA1
     {
         public SHA1Managed() { }
-        public sealed override int HashSize { get { throw null; } }
         protected sealed override void Dispose(bool disposing) { }
         protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) { }
         protected sealed override byte[] HashFinal() { throw null; }
@@ -548,7 +542,6 @@ namespace System.Security.Cryptography
     public sealed partial class SHA256Managed : System.Security.Cryptography.SHA256
     {
         public SHA256Managed() { }
-        public sealed override int HashSize { get { throw null; } }
         protected sealed override void Dispose(bool disposing) { }
         protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) { }
         protected sealed override byte[] HashFinal() { throw null; }
@@ -564,7 +557,6 @@ namespace System.Security.Cryptography
     public sealed partial class SHA384Managed : System.Security.Cryptography.SHA384
     {
         public SHA384Managed() { }
-        public sealed override int HashSize { get { throw null; } }
         protected sealed override void Dispose(bool disposing) { }
         protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) { }
         protected sealed override byte[] HashFinal() { throw null; }
@@ -580,7 +572,6 @@ namespace System.Security.Cryptography
     public sealed partial class SHA512Managed : System.Security.Cryptography.SHA512
     {
         public SHA512Managed() { }
-        public sealed override int HashSize { get { throw null; } }
         protected sealed override void Dispose(bool disposing) { }
         protected sealed override void HashCore(byte[] array, int ibStart, int cbSize) { }
         protected sealed override byte[] HashFinal() { throw null; }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACMD5.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACMD5.cs
@@ -29,15 +29,8 @@ namespace System.Security.Cryptography
             base.Key = _hMacCommon.ActualKey;
             // this not really needed as it'll initialize BlockSizeValue with same value it has which is 64.
             // we just want to be explicit in all HMAC extended classes   
-            BlockSizeValue = BlockSize; 
-        }
-
-        public override int HashSize
-        {
-            get
-            {
-                return _hMacCommon.HashSizeInBits;
-            }
+            BlockSizeValue = BlockSize;
+            HashSizeValue = _hMacCommon.HashSizeInBits;
         }
 
         public override byte[] Key

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA1.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA1.cs
@@ -26,21 +26,14 @@ namespace System.Security.Cryptography
             base.Key = _hMacCommon.ActualKey; 
             // this not really needed as it'll initialize BlockSizeValue with same value it has which is 64.
             // we just want to be explicit in all HMAC extended classes   
-            BlockSizeValue = BlockSize; 
+            BlockSizeValue = BlockSize;
+            HashSizeValue = _hMacCommon.HashSizeInBits;
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public HMACSHA1(byte[] key, bool useManagedSha1) : this(key)
         {
             // useManagedSha1 is ignored
-        }
-
-        public override int HashSize
-        {
-            get
-            {
-                return _hMacCommon.HashSizeInBits;
-            }
         }
 
         public override byte[] Key

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA256.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA256.cs
@@ -29,15 +29,8 @@ namespace System.Security.Cryptography
             base.Key = _hMacCommon.ActualKey;
             // this not really needed as it'll initialize BlockSizeValue with same value it has which is 64.
             // we just want to be explicit in all HMAC extended classes   
-            BlockSizeValue = BlockSize; 
-        }
-
-        public override int HashSize
-        {
-            get
-            {
-                return _hMacCommon.HashSizeInBits;
-            }
+            BlockSizeValue = BlockSize;
+            HashSizeValue = _hMacCommon.HashSizeInBits;
         }
 
         public override byte[] Key

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA384.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA384.cs
@@ -28,7 +28,8 @@ namespace System.Security.Cryptography
             _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA384, key, BlockSize);
             base.Key = _hMacCommon.ActualKey;
             // change the default value of BlockSizeValue to 128 instead of 64 
-            BlockSizeValue = BlockSize; 
+            BlockSizeValue = BlockSize;
+            HashSizeValue = _hMacCommon.HashSizeInBits;
         }
 
         public bool ProduceLegacyHmacValues
@@ -45,14 +46,6 @@ namespace System.Security.Cryptography
                 {
                     throw new PlatformNotSupportedException();
                 }
-            }
-        }
-
-        public override int HashSize
-        {
-            get
-            {
-                return _hMacCommon.HashSizeInBits;
             }
         }
 

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA512.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA512.cs
@@ -28,7 +28,8 @@ namespace System.Security.Cryptography
             _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA512, key, BlockSize);
             base.Key = _hMacCommon.ActualKey;
             // change the default value of BlockSizeValue to 128 instead of 64 
-            BlockSizeValue = BlockSize; 
+            BlockSizeValue = BlockSize;
+            HashSizeValue = _hMacCommon.HashSizeInBits;
         }
 
         public bool ProduceLegacyHmacValues
@@ -45,14 +46,6 @@ namespace System.Security.Cryptography
                 {
                     throw new PlatformNotSupportedException();
                 }
-            }
-        }
-
-        public override int HashSize
-        {
-            get
-            {
-                return _hMacCommon.HashSizeInBits;
             }
         }
 

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/MD5.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/MD5.cs
@@ -33,14 +33,7 @@ namespace System.Security.Cryptography
             public Implementation()
             {
                 _hashProvider = HashProviderDispenser.CreateHashProvider(HashAlgorithmNames.MD5);
-            }
-
-            public sealed override int HashSize
-            {
-                get
-                {
-                    return _hashProvider.HashSizeInBytes * 8;
-                }
+                HashSizeValue = _hashProvider.HashSizeInBytes * 8;
             }
 
             protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA1.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA1.cs
@@ -34,14 +34,7 @@ namespace System.Security.Cryptography
             public Implementation()
             {
                 _hashProvider = HashProviderDispenser.CreateHashProvider(HashAlgorithmNames.SHA1);
-            }
-
-            public sealed override int HashSize
-            {
-                get
-                {
-                    return _hashProvider.HashSizeInBytes * 8;
-                }
+                HashSizeValue = _hashProvider.HashSizeInBytes * 8;
             }
 
             protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA1Managed.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA1Managed.cs
@@ -16,14 +16,7 @@ namespace System.Security.Cryptography
         public SHA1Managed()
         {
             _hashProvider = HashProviderDispenser.CreateHashProvider(HashAlgorithmNames.SHA1);
-        }
-
-        public sealed override int HashSize
-        {
-            get
-            {
-                return _hashProvider.HashSizeInBytes * 8;
-            }
+            HashSizeValue = _hashProvider.HashSizeInBytes * 8;
         }
 
         protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA256.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA256.cs
@@ -33,14 +33,7 @@ namespace System.Security.Cryptography
             public Implementation()
             {
                 _hashProvider = HashProviderDispenser.CreateHashProvider(HashAlgorithmNames.SHA256);
-            }
-
-            public sealed override int HashSize
-            {
-                get
-                {
-                    return _hashProvider.HashSizeInBytes * 8;
-                }
+                HashSizeValue = _hashProvider.HashSizeInBytes * 8;
             }
 
             protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA256Managed.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA256Managed.cs
@@ -16,14 +16,7 @@ namespace System.Security.Cryptography
         public SHA256Managed()
         {
             _hashProvider = HashProviderDispenser.CreateHashProvider(HashAlgorithmNames.SHA256);
-        }
-
-        public sealed override int HashSize
-        {
-            get
-            {
-                return _hashProvider.HashSizeInBytes * 8;
-            }
+            HashSizeValue = _hashProvider.HashSizeInBytes * 8;
         }
 
         protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA384.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA384.cs
@@ -33,14 +33,7 @@ namespace System.Security.Cryptography
             public Implementation()
             {
                 _hashProvider = HashProviderDispenser.CreateHashProvider(HashAlgorithmNames.SHA384);
-            }
-
-            public sealed override int HashSize
-            {
-                get
-                {
-                    return _hashProvider.HashSizeInBytes * 8;
-                }
+                HashSizeValue = _hashProvider.HashSizeInBytes * 8;
             }
 
             protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA384Managed.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA384Managed.cs
@@ -16,14 +16,7 @@ namespace System.Security.Cryptography
         public SHA384Managed()
         {
             _hashProvider = HashProviderDispenser.CreateHashProvider(HashAlgorithmNames.SHA384);
-        }
-
-        public sealed override int HashSize
-        {
-            get
-            {
-                return _hashProvider.HashSizeInBytes * 8;
-            }
+            HashSizeValue = _hashProvider.HashSizeInBytes * 8;
         }
 
         protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA512.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA512.cs
@@ -33,14 +33,7 @@ namespace System.Security.Cryptography
             public Implementation()
             {
                 _hashProvider = HashProviderDispenser.CreateHashProvider(HashAlgorithmNames.SHA512);
-            }
-
-            public sealed override int HashSize
-            {
-                get
-                {
-                    return _hashProvider.HashSizeInBytes * 8;
-                }
+                HashSizeValue = _hashProvider.HashSizeInBytes * 8;
             }
 
             protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA512Managed.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA512Managed.cs
@@ -16,14 +16,7 @@ namespace System.Security.Cryptography
         public SHA512Managed()
         {
             _hashProvider = HashProviderDispenser.CreateHashProvider(HashAlgorithmNames.SHA512);
-        }
-
-        public sealed override int HashSize
-        {
-            get
-            {
-                return _hashProvider.HashSizeInBytes * 8;
-            }
+            HashSizeValue = _hashProvider.HashSizeInBytes * 8;
         }
 
         protected sealed override void HashCore(byte[] array, int ibStart, int cbSize)

--- a/src/System.Security.Cryptography.Csp/ref/System.Security.Cryptography.Csp.cs
+++ b/src/System.Security.Cryptography.Csp/ref/System.Security.Cryptography.Csp.cs
@@ -123,7 +123,6 @@ namespace System.Security.Cryptography
     public sealed partial class MD5CryptoServiceProvider : System.Security.Cryptography.MD5
     {
         public MD5CryptoServiceProvider() { }
-        public override int HashSize { get { throw null; } }
         protected sealed override void Dispose(bool disposing) { }
         protected override void HashCore(byte[] array, int ibStart, int cbSize) { }
         protected override byte[] HashFinal() { throw null; }
@@ -194,7 +193,6 @@ namespace System.Security.Cryptography
     public sealed partial class SHA1CryptoServiceProvider : System.Security.Cryptography.SHA1
     {
         public SHA1CryptoServiceProvider() { }
-        public override int HashSize { get { throw null; } }
         protected sealed override void Dispose(bool disposing) { }
         protected override void HashCore(byte[] array, int ibStart, int cbSize) { }
         protected override byte[] HashFinal() { throw null; }

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/MD5CryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/MD5CryptoServiceProvider.cs
@@ -15,6 +15,7 @@ namespace System.Security.Cryptography
         public MD5CryptoServiceProvider()
         {
             _incrementalHash = IncrementalHash.CreateHash(HashAlgorithmName.MD5);
+            HashSizeValue = HashSizeBits;
         }
 
         public override void Initialize()
@@ -33,8 +34,7 @@ namespace System.Security.Cryptography
             return _incrementalHash.GetHashAndReset();
         }
 
-        // The Hash property is not overridden since the correct value exists on base.
-        public override int HashSize => HashSizeBits;
+        // The Hash and HashSize properties are not overridden since the correct values are returned from base.
 
         protected sealed override void Dispose(bool disposing)
         {

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA1CryptoServiceProvider.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SHA1CryptoServiceProvider.cs
@@ -15,6 +15,7 @@ namespace System.Security.Cryptography
         public SHA1CryptoServiceProvider()
         {
             _incrementalHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA1);
+            HashSizeValue = HashSizeBits;
         }
 
         public override void Initialize()
@@ -33,8 +34,7 @@ namespace System.Security.Cryptography
             return _incrementalHash.GetHashAndReset();
         }
 
-        // The Hash property is not overridden since the correct value exists on base.
-        public override int HashSize => HashSizeBits;
+        // The Hash and HashSize properties are not overridden since the correct values are returned from base.
 
         protected sealed override void Dispose(bool disposing)
         {

--- a/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -128,6 +128,9 @@
     <ProjectReference Include="..\..\System.Security.Cryptography.Algorithms\pkg\System.Security.Cryptography.Algorithms.pkgproj">
       <Name>System.Security.Cryptography.Algorithms</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\System.Security.Cryptography.Primitives\pkg\System.Security.Cryptography.Primitives.pkgproj">
+      <Name>System.Security.Cryptography.Primitives</Name>
+    </ProjectReference>    
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
+++ b/src/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
@@ -78,6 +78,7 @@ namespace System.Security.Cryptography
     public abstract partial class HashAlgorithm : System.IDisposable, System.Security.Cryptography.ICryptoTransform
     {
         protected internal byte[] HashValue;
+        protected int HashSizeValue;
         protected int State;
         protected HashAlgorithm() { }
         public virtual bool CanReuseTransform { get { throw null; } }

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HashAlgorithm.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HashAlgorithm.cs
@@ -8,6 +8,11 @@ namespace System.Security.Cryptography
 {
     public abstract class HashAlgorithm : IDisposable, ICryptoTransform
     {
+        private bool _disposed;
+        protected int HashSizeValue;
+        protected internal byte[] HashValue;
+        protected int State = 0;
+
         protected HashAlgorithm() { }
 
         public static HashAlgorithm Create()
@@ -20,13 +25,7 @@ namespace System.Security.Cryptography
             throw new PlatformNotSupportedException();
         }
 
-        public virtual int HashSize
-        {
-            get
-            {
-                return 0;  // For desktop compatibility, return 0 as this property was always initialized by a subclass.
-            }
-        }
+        public virtual int HashSize => HashSizeValue;
 
         public virtual byte[] Hash
         {
@@ -199,9 +198,5 @@ namespace System.Security.Cryptography
         protected abstract void HashCore(byte[] array, int ibStart, int cbSize);
         protected abstract byte[] HashFinal();
         public abstract void Initialize();
-
-        private bool _disposed;
-        protected internal byte[] HashValue;
-        protected int State = 0;
     }
 }

--- a/src/System.Security.Cryptography.Primitives/tests/Length32Hash.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/Length32Hash.cs
@@ -8,10 +8,17 @@ namespace System.Security.Cryptography.Hashing.Tests
     {
         private uint _length;
 
+#if netstandard17
+        public Length32Hash()
+        {
+            HashSizeValue = sizeof(uint);
+        }
+#else
         public override int HashSize
         {
             get { return sizeof(uint); }
         }
+#endif
 
         protected override void HashCore(byte[] array, int ibStart, int cbSize)
         {

--- a/src/System.Security.Cryptography.Primitives/tests/Sum32Hash.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/Sum32Hash.cs
@@ -8,10 +8,17 @@ namespace System.Security.Cryptography.Hashing.Tests
     {
         private uint _sum;
 
+#if netstandard17
+        public Sum32Hash()
+        {
+            HashSizeValue = sizeof(uint);
+        }
+#else
         public override int HashSize
         {
             get { return sizeof(uint); }
         }
+#endif
 
         protected override void HashCore(byte[] array, int ibStart, int cbSize)
         {


### PR DESCRIPTION
Addresses issue https://github.com/dotnet/corefx/issues/14131

Note that overrides on HashSize were removed as they are now not necessary. These overrides do not exist in netfx or netstandard2.0 so are OK to remove.

@bartonjs please review