### PR TITLE
Set DEBUG in System.Private.Xml

### DIFF
--- a/src/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/System.Private.Xml/src/System.Private.Xml.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>System.Xml</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn),649</NoWarn>
-    <DefineConstants>ASYNC;ASTORIA_LIGHT</DefineConstants><!-- TODO: this should be prepended with $(DefineConstants); - otherwise DEBUG and TRACE are not being passed -->
+    <DefineConstants>$(DefineConstants);ASYNC;ASTORIA_LIGHT</DefineConstants>
     <!--<DefineConstants Condition="'$(TargetGroup)' == 'uap101aot'">$(DefineConstants);NET_NATIVE</DefineConstants> TODO: Bring this back when uap101aot support is added -->
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>

--- a/src/System.Private.Xml/src/System/Xml/BinaryXml/XmlBinaryReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/BinaryXml/XmlBinaryReader.cs
@@ -3213,9 +3213,9 @@ namespace System.Xml
                 if (decl.scope > 0)
                 {
 #if DEBUG
-                    if ((object)decl.prefix != (object)this.xnt.Get(decl.prefix))
+                    if ((object)decl.prefix != (object)this._xnt.Get(decl.prefix))
                         throw new Exception("Prefix not interned: \'" + decl.prefix + "\'");
-                    if ((object)decl.uri != (object)this.xnt.Get(decl.uri))
+                    if ((object)decl.uri != (object)this._xnt.Get(decl.uri))
                         throw new Exception("Uri not interned: \'" + decl.uri + "\'");
 #endif
                     xnm.AddNamespace(decl.prefix, decl.uri);

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
@@ -4982,9 +4982,9 @@ namespace System.Xml
                 if (tmpch3 == quoteChar)
                 {
 #if DEBUG
-                    if (normalize)
+                    if (_normalize)
                     {
-                        string val = new string(chars, ps.charPos, pos - ps.charPos);
+                        string val = new string(chars, _ps.charPos, pos - _ps.charPos);
                         Debug.Assert(val == XmlComplianceUtil.CDataNormalize(val), "The attribute value is not CDATA normalized!"); 
                     }
 #endif

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
@@ -2570,7 +2570,7 @@ namespace System.Xml
                 int attrNameLinePos = _ps.LinePos;
 
 #if DEBUG
-                int attrNameLineNo = ps.LineNo;
+                int attrNameLineNo = _ps.LineNo;
 #endif
 
                 // parse attribute name
@@ -2663,7 +2663,7 @@ namespace System.Xml
                 attr.SetLineInfo(_ps.LineNo, attrNameLinePos);
 
 #if DEBUG
-                Debug.Assert( attrNameLineNo == ps.LineNo );
+                Debug.Assert( attrNameLineNo == _ps.LineNo );
 #endif
 
                 // parse equals and quote char; 
@@ -2708,8 +2708,8 @@ namespace System.Xml
                 {
 #if DEBUG
 #if !SILVERLIGHT
-                    if ( normalize ) {
-                        string val = new string(chars, ps.charPos, pos - ps.charPos );
+                    if ( _normalize ) {
+                        string val = new string(chars, _ps.charPos, pos - _ps.charPos );
                         Debug.Assert( val == XmlComplianceUtil.CDataNormalize( val ), "The attribute value is not CDATA normalized!" ); 
                     }
 #endif

--- a/src/System.Private.Xml/src/System/Xml/Schema/Asttree.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/Asttree.cs
@@ -514,8 +514,8 @@ namespace System.Xml.Schema
         // only for debug
 #if DEBUG
         public void PrintTree (StreamWriter msw) {
-            for (int i = 0; i < fAxisArray.Count; ++i) {
-                ForwardAxis axis = (ForwardAxis)fAxisArray[i];
+            for (int i = 0; i < _fAxisArray.Count; ++i) {
+                ForwardAxis axis = (ForwardAxis)_fAxisArray[i];
                 msw.WriteLine("<Tree IsDss=\"{0}\" IsAttribute=\"{1}\">", axis.IsDss, axis.IsAttribute);
                 DoubleLinkAxis printaxis = axis.TopNode;
                 while ( printaxis != null ) {

--- a/src/System.Private.Xml/src/System/Xml/Schema/BitSet.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/BitSet.cs
@@ -257,7 +257,7 @@ namespace System.Xml.Schema
 
 #if DEBUG
         public void Dump(StringBuilder bb) {
-            for (int i = 0; i < count; i ++) {
+            for (int i = 0; i < _count; i ++) {
                 bb.Append( Get(i) ? "1" : "0");
             }
         }

--- a/src/System.Private.Xml/src/System/Xml/Schema/DtdParser.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/DtdParser.cs
@@ -546,8 +546,8 @@ namespace System.Xml
             ParseSubset();
 
 #if DEBUG
-            Debug.Assert( readerAdapter.EntityStackLength == 0 ||
-                         ( freeFloatingDtd && readerAdapter.EntityStackLength == 1 ) );
+            Debug.Assert( _readerAdapter.EntityStackLength == 0 ||
+                         ( _freeFloatingDtd && _readerAdapter.EntityStackLength == 1 ) );
 #endif
         }
 
@@ -630,8 +630,8 @@ namespace System.Xml
                             }
 #if DEBUG
                             // check entity nesting
-                            Debug.Assert( readerAdapter.EntityStackLength == 0 || 
-                                          ( freeFloatingDtd && readerAdapter.EntityStackLength == 1 ) );
+                            Debug.Assert( _readerAdapter.EntityStackLength == 0 || 
+                                          ( _freeFloatingDtd && _readerAdapter.EntityStackLength == 1 ) );
 #endif
                         }
                         else

--- a/src/System.Private.Xml/src/System/Xml/Schema/DtdParserAsync.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/DtdParserAsync.cs
@@ -164,8 +164,8 @@ namespace System.Xml
             await ParseSubsetAsync().ConfigureAwait(false);
 
 #if DEBUG
-            Debug.Assert( readerAdapter.EntityStackLength == 0 ||
-                         ( freeFloatingDtd && readerAdapter.EntityStackLength == 1 ) );
+            Debug.Assert( _readerAdapter.EntityStackLength == 0 ||
+                         ( _freeFloatingDtd && _readerAdapter.EntityStackLength == 1 ) );
 #endif
         }
 
@@ -248,8 +248,8 @@ namespace System.Xml
                             }
 #if DEBUG
                             // check entity nesting
-                            Debug.Assert( readerAdapter.EntityStackLength == 0 || 
-                                          ( freeFloatingDtd && readerAdapter.EntityStackLength == 1 ) );
+                            Debug.Assert( _readerAdapter.EntityStackLength == 0 || 
+                                          ( _freeFloatingDtd && _readerAdapter.EntityStackLength == 1 ) );
 #endif
                         }
                         else

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriter.cs
@@ -617,7 +617,7 @@ namespace System.Xml.Serialization
             {
 #if DEBUG
                     // use exception in the place of Debug.Assert to avoid throwing asserts from a server process such as aspnet_ewp.exe
-                    if (!objectsInUse.ContainsKey(o)) throw new InvalidOperationException(SR.Format(SR.XmlInternalErrorDetails, "missing stack object of type " + o.GetType().FullName));
+                    if (!_objectsInUse.ContainsKey(o)) throw new InvalidOperationException(SR.Format(SR.XmlInternalErrorDetails, "missing stack object of type " + o.GetType().FullName));
 #endif
 
                 _objectsInUse.Remove(o);

--- a/src/System.Private.Xml/src/System/Xml/XPath/Internal/CacheChildrenQuery.cs
+++ b/src/System.Private.Xml/src/System/Xml/XPath/Internal/CacheChildrenQuery.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Xml;
 using System.Xml.XPath;
 using StackInt = MS.Internal.Xml.XPath.ClonableStack<int>;
@@ -99,7 +100,7 @@ namespace MS.Internal.Xml.XPath
                         Debug.Assert(order == XmlNodeOrder.Before, "Algorith error. Nodes expected to be DocOrderDistinct");
                     }
                 }
-                lastNode = currentNode.Clone();
+                _lastNode = currentNode.Clone();
 #endif
                 if (matches(currentNode))
                 {

--- a/src/System.Private.Xml/src/System/Xml/Xsl/IlGen/GenerateHelper.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/IlGen/GenerateHelper.cs
@@ -661,10 +661,6 @@ namespace System.Xml.Xsl.IlGen
             LocalBuilder locBldr = _ilgen.DeclareLocal(type);
 #if DEBUG
             if (XmlILTrace.IsEnabled) {
-                // Set name for internal MS debugging.  This is not the user-defined name--that will be set later
-                if (this.isDebug)
-                    locBldr.SetLocalSymInfo(name + this.numLocals.ToString(CultureInfo.InvariantCulture));
-
                 this.symbols.Add(locBldr, name + this.numLocals.ToString(CultureInfo.InvariantCulture));
                 this.numLocals++;
             }

--- a/src/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlILModule.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlILModule.cs
@@ -111,12 +111,6 @@ namespace System.Xml.Xsl.IlGen
                 // 3. Never allow assembly to Assert permissions
                 asmName = CreateAssemblyName();
 
-#if DEBUG
-                if (XmlILTrace.IsEnabled) {
-                    this.modFile = "System.Xml.Xsl.CompiledQuery";
-                }
-#endif
-
                 asmBldr = AssemblyBuilder.DefineDynamicAssembly(
                             asmName, AssemblyBuilderAccess.Run);
 

--- a/src/System.Private.Xml/src/System/Xml/Xsl/QIL/QilValidationVisitor.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/QIL/QilValidationVisitor.cs
@@ -64,7 +64,7 @@ namespace System.Xml.Xsl.Qil
                     SetError(parent, "Type information missing");
                 }
                 else {
-                    XmlQueryType type = this.typeCheck.Check(parent);
+                    XmlQueryType type = this._typeCheck.Check(parent);
 
                     // BUGBUG: Hack to account for Xslt compiler type fixups
                     if (!type.IsSubtypeOf(parent.XmlType))

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltLibrary.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltLibrary.cs
@@ -234,6 +234,59 @@ namespace System.Xml.Xsl.Runtime
         }
 
         internal const int InvariantCultureLcid = 0x007f;
+
+        public int LangToLcid(string lang, bool forwardCompatibility)
+        {
+            return LangToLcidInternal(lang, forwardCompatibility, null);
+        }
+
+        internal static int LangToLcidInternal(string lang, bool forwardCompatibility, IErrorHelper errorHelper)
+        {
+            int lcid = InvariantCultureLcid;
+
+            if (lang != null)
+            {
+                // The value of the 'lang' attribute must be a non-empty nmtoken
+                if (lang.Length == 0)
+                {
+                    if (!forwardCompatibility)
+                    {
+                        if (errorHelper != null)
+                        {
+                            errorHelper.ReportError(SR.Xslt_InvalidAttrValue, "lang", lang);
+                        }
+                        else
+                        {
+                            throw new XslTransformException(SR.Xslt_InvalidAttrValue, "lang", lang);
+                        }
+                    }
+                }
+                else
+                {
+                    // Check if lang is a supported culture name
+                    try
+                    {
+                        lcid = new CultureInfo(lang).LCID;
+                    }
+                    catch (ArgumentException)
+                    {
+                        if (!forwardCompatibility)
+                        {
+                            if (errorHelper != null)
+                            {
+                                errorHelper.ReportError(SR.Xslt_InvalidLanguage, lang);
+                            }
+                            else
+                            {
+                                throw new XslTransformException(SR.Xslt_InvalidLanguage, lang);
+                            }
+                        }
+                    }
+                }
+            }
+            return lcid;
+        }
+
         internal const string InvariantCultureName = "";
 
         internal static string LangToNameInternal(string lang, bool forwardCompatibility, IErrorHelper errorHelper)

--- a/src/System.Private.Xml/src/System/Xml/Xsl/XPathConvert.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/XPathConvert.cs
@@ -2351,7 +2351,7 @@ namespace System.Xml.Xsl
                 InitFromDouble(dbl);
 
 #if DEBUG
-                if (0 != mantissaSize)
+                if (0 != _mantissaSize)
                 {
                     Debug.Assert(dbl == (double)this);
 
@@ -2370,12 +2370,12 @@ namespace System.Xml.Xsl
 
 #if DEBUG
             private bool Equals(FloatingDecimal other) {
-                if (_exponent != other._exponent || sign != other._sign || _mantissaSize != other._mantissaSize)
+                if (_exponent != other._exponent || _sign != other._sign || _mantissaSize != other._mantissaSize)
                 {
                     return false;
                 }
-                for (int idx = 0; idx < mantissaSize; idx++) {
-                    if (mantissa[idx] != other.mantissa[idx]) {
+                for (int idx = 0; idx < _mantissaSize; idx++) {
+                    if (_mantissa[idx] != other._mantissa[idx]) {
                         return false;
                     }
                 }

--- a/src/System.Private.Xml/src/System/Xml/Xsl/XmlIlGenerator.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/XmlIlGenerator.cs
@@ -88,10 +88,10 @@ namespace System.Xml.Xsl
 
 #if DEBUG
             // Trace Qil before optimization
-            XmlILTrace.WriteQil(this.qil, "qilbefore.xml");
+            XmlILTrace.WriteQil(this._qil, "qilbefore.xml");
 
             // Trace optimizations
-            XmlILTrace.TraceOptimizations(this.qil, "qilopt.xml");
+            XmlILTrace.TraceOptimizations(this._qil, "qilopt.xml");
 #endif
 
             // Optimize and annotate the Qil graph
@@ -103,7 +103,7 @@ namespace System.Xml.Xsl
 
 #if DEBUG
             // Trace Qil after optimization
-            XmlILTrace.WriteQil(this.qil, "qilafter.xml");
+            XmlILTrace.WriteQil(this._qil, "qilafter.xml");
 #endif
 
             // Create module in which methods will be generated

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/Compiler.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/Compiler.cs
@@ -70,12 +70,6 @@ namespace System.Xml.Xsl.Xslt
         {
             Debug.Assert(CompilerErrorColl == null, "Compiler cannot be reused");
 
-#if DEBUG
-            if (XmlILTrace.IsEnabled) {
-                tempFiles.KeepFiles = true;
-            }
-#endif
-
             Settings = settings;
             IsDebug = settings.IncludeDebugInformation | debug;
             ScriptAssemblyPath = scriptAssemblyPath;

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XPathPatternParser.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XPathPatternParser.cs
@@ -41,8 +41,8 @@ namespace System.Xml.Xsl.Xslt
             {
                 result = ptrnBuilder.EndBuild(result);
 #if DEBUG
-                this.ptrnBuilder = null;
-                this.scanner = null;
+                this._ptrnBuilder = null;
+                this._scanner = null;
 #endif
             }
             return result;

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XslAstAnalyzer.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XslAstAnalyzer.cs
@@ -306,7 +306,7 @@ namespace System.Xml.Xsl.Xslt
 #if DEBUG
             if (DiagnosticsSwitches.XslTypeInference.TraceVerbose) {
                 Debug.WriteLine(string.Empty);
-                foreach (ProtoTemplate tmpl in compiler.AllTemplates) {
+                foreach (ProtoTemplate tmpl in _compiler.AllTemplates) {
                     Debug.WriteLine(tmpl.TraceName + " = " + (tmpl.Flags & XslFlags.FocusFilter));
                 }
 
@@ -320,7 +320,7 @@ namespace System.Xml.Xsl.Xslt
             if (DiagnosticsSwitches.XslTypeInference.TraceInfo) {
                 int current = 0, position = 0, last = 0;
 
-                foreach (ProtoTemplate tmpl in compiler.AllTemplates) {
+                foreach (ProtoTemplate tmpl in _compiler.AllTemplates) {
                     if ((tmpl.Flags & XslFlags.Current) != 0) {
                         current++;
                     }
@@ -355,7 +355,7 @@ namespace System.Xml.Xsl.Xslt
 
                 Debug.WriteLine(string.Format(CultureInfo.InvariantCulture,
                     "Total => templates/attribute-sets: {0}, variables/parameters: {1}.",
-                    compiler.AllTemplates.Count, totalVarPars
+                    _compiler.AllTemplates.Count, totalVarPars
                 ));
 
                 Debug.WriteLine(string.Format(CultureInfo.InvariantCulture,

--- a/src/System.Private.Xml/src/System/Xml/Xsl/XsltOld/StringOutput.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/XsltOld/StringOutput.cs
@@ -32,7 +32,7 @@ namespace System.Xml.Xsl.XsltOld
             _builder.Append(outputChar);
 
 #if DEBUG
-            this.result = this.builder.ToString();
+            this._result = this._builder.ToString();
 #endif
         }
 
@@ -41,7 +41,7 @@ namespace System.Xml.Xsl.XsltOld
             _builder.Append(outputText);
 
 #if DEBUG
-            this.result = this.builder.ToString();
+            this._result = this._builder.ToString();
 #endif
         }
 


### PR DESCRIPTION
System.Private.Xml is not setting DEBUG in debug builds, which means Debug.Asserts aren't enabled, #if DEBUG code isn't compiled in, etc.  This fixes that.  After fixing the compilation issues, one of the newly enabled asserts highlighted missing code, which I ported from reference source.

cc: @danmosemsft, @sepidehMS 