### PR TITLE
Randomize ValueTuple hash codes

### DIFF
--- a/src/Common/src/System/Numerics/Hashing/HashHelpers.cs
+++ b/src/Common/src/System/Numerics/Hashing/HashHelpers.cs
@@ -6,12 +6,14 @@ namespace System.Numerics.Hashing
 {
     internal static class HashHelpers
     {
+        public static int RandomSeed { get; } = Guid.NewGuid().GetHashCode();
+
         public static int Combine(int h1, int h2)
         {
-            // The jit optimizes this to use the ROL instruction on x86
+            // RyuJIT optimizes this to use the ROL instruction
             // Related GitHub pull request: dotnet/coreclr#1830
-            uint shift5 = ((uint)h1 << 5) | ((uint)h1 >> 27);
-            return ((int)shift5 + h1) ^ h2;
+            uint rol5 = ((uint)h1 << 5) | ((uint)h1 >> 27);
+            return ((int)rol5 + h1) ^ h2;
         }
     }
 }

--- a/src/Common/src/System/Numerics/Hashing/HashHelpers.cs
+++ b/src/Common/src/System/Numerics/Hashing/HashHelpers.cs
@@ -6,7 +6,7 @@ namespace System.Numerics.Hashing
 {
     internal static class HashHelpers
     {
-        public static int RandomSeed { get; } = Guid.NewGuid().GetHashCode();
+        public static readonly int RandomSeed = Guid.NewGuid().GetHashCode();
 
         public static int Combine(int h1, int h2)
         {

--- a/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
@@ -244,42 +244,49 @@ namespace System
         public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>> Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8) =>
             new ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>>(item1, item2, item3, item4, item5, item6, item7, ValueTuple.Create(item8));
 
+        private static int Randomize(int value)
+        {
+            return HashHelpers.Combine(HashHelpers.RandomSeed, value);
+        }
+
+        private static int PureCombine(int h1, int h2)
+        {
+            return HashHelpers.Combine(h1, h2);
+        }
+
         internal static int CombineHashCodes(int h1, int h2)
         {
-            // Forward to helper class in Common for this
-            // We keep the actual hashing logic there, so
-            // other classes can use it for hashing
-            return HashHelpers.Combine(HashHelpers.Combine(h1, h2), HashHelpers.RandomSeed);
+            return PureCombine(Randomize(h1), h2);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2), h3);
+            return PureCombine(CombineHashCodes(h1, h2), h3);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3), h4);
+            return PureCombine(CombineHashCodes(h1, h2, h3), h4);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), h5);
+            return PureCombine(CombineHashCodes(h1, h2, h3, h4), h5);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4, h5), h6);
+            return PureCombine(CombineHashCodes(h1, h2, h3, h4, h5), h6);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4, h5, h6), h7);
+            return PureCombine(CombineHashCodes(h1, h2, h3, h4, h5, h6), h7);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7, int h8)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4, h5, h6, h7), h8);
+            return PureCombine(CombineHashCodes(h1, h2, h3, h4, h5, h6, h7), h8);
         }
     }
 

--- a/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
@@ -249,7 +249,7 @@ namespace System
             // Forward to helper class in Common for this
             // We keep the actual hashing logic there, so
             // other classes can use it for hashing
-            return HashHelpers.Combine(h1, h2);
+            return HashHelpers.Combine(HashHelpers.Combine(h1, h2), HashHelpers.RandomSeed);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3)

--- a/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
+++ b/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs
@@ -244,49 +244,39 @@ namespace System
         public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>> Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8) =>
             new ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>>(item1, item2, item3, item4, item5, item6, item7, ValueTuple.Create(item8));
 
-        private static int Randomize(int value)
-        {
-            return HashHelpers.Combine(HashHelpers.RandomSeed, value);
-        }
-
-        private static int PureCombine(int h1, int h2)
-        {
-            return HashHelpers.Combine(h1, h2);
-        }
-
         internal static int CombineHashCodes(int h1, int h2)
         {
-            return PureCombine(Randomize(h1), h2);
+            return HashHelpers.Combine(HashHelpers.Combine(HashHelpers.RandomSeed, h1), h2);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3)
         {
-            return PureCombine(CombineHashCodes(h1, h2), h3);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2), h3);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4)
         {
-            return PureCombine(CombineHashCodes(h1, h2, h3), h4);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3), h4);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5)
         {
-            return PureCombine(CombineHashCodes(h1, h2, h3, h4), h5);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4), h5);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6)
         {
-            return PureCombine(CombineHashCodes(h1, h2, h3, h4, h5), h6);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5), h6);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7)
         {
-            return PureCombine(CombineHashCodes(h1, h2, h3, h4, h5, h6), h7);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5, h6), h7);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7, int h8)
         {
-            return PureCombine(CombineHashCodes(h1, h2, h3, h4, h5, h6, h7), h8);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5, h6, h7), h8);
         }
     }
 

--- a/src/System.ValueTuple/tests/ValueTupleTests.cs
+++ b/src/System.ValueTuple/tests/ValueTupleTests.cs
@@ -1030,28 +1030,6 @@ namespace System.Tests
             Assert.Equal(1, sc.CompareTo(CreateLong(1, 1, 1, 1, 1, 1, 3, ValueTuple.Create(1)), TestComparer.Instance));
             Assert.Equal(1, sc.CompareTo(CreateLong(1, 1, 1, 1, 1, 1, 1, ValueTuple.Create(3)), TestComparer.Instance));
 
-            Assert.Equal(2138941962, CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create()).GetHashCode());
-            Assert.Equal(2138941954, CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8)).GetHashCode());
-            Assert.Equal(-1746596640, CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9)).GetHashCode());
-            Assert.Equal(121964360, CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10)).GetHashCode());
-            Assert.Equal(4363008, CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11)).GetHashCode());
-            Assert.Equal(9413384, CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12)).GetHashCode());
-            Assert.Equal(305131744, CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12, 13)).GetHashCode());
-            Assert.Equal(1479338186, CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12, 13, 14)).GetHashCode());
-            Assert.Equal(1573514559, CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create())).GetHashCode());
-            Assert.Equal(1573514711, CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15))).GetHashCode());
-
-            Assert.Equal(2138941962, ((IStructuralEquatable)CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create())).GetHashCode(TestEqualityComparer.Instance));
-            Assert.Equal(2138941954, ((IStructuralEquatable)CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8))).GetHashCode(TestEqualityComparer.Instance));
-            Assert.Equal(-1746596640, ((IStructuralEquatable)CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9))).GetHashCode(TestEqualityComparer.Instance));
-            Assert.Equal(121964360, ((IStructuralEquatable)CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10))).GetHashCode(TestEqualityComparer.Instance));
-            Assert.Equal(4363008, ((IStructuralEquatable)CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11))).GetHashCode(TestEqualityComparer.Instance));
-            Assert.Equal(9413384, ((IStructuralEquatable)CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12))).GetHashCode(TestEqualityComparer.Instance));
-            Assert.Equal(305131744, ((IStructuralEquatable)CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12, 13))).GetHashCode(TestEqualityComparer.Instance));
-            Assert.Equal(1479338186, ((IStructuralEquatable)CreateLong(1, 2, 3, 4, 5, 6, 7, ValueTuple.Create(8, 9, 10, 11, 12, 13, 14))).GetHashCode(TestEqualityComparer.Instance));
-            Assert.Equal(1573514559, ((IStructuralEquatable)CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create()))).GetHashCode(TestEqualityComparer.Instance));
-            Assert.Equal(1573514711, ((IStructuralEquatable)CreateLong(1, 2, 3, 4, 5, 6, 7, CreateLong(8, 9, 10, 11, 12, 13, 14, ValueTuple.Create(15)))).GetHashCode(TestEqualityComparer.Instance));
-
             Assert.False(se.Equals(t, DummyTestEqualityComparer.Instance));
 
             // Notice that 0-tuple prints as empty position
@@ -1128,18 +1106,10 @@ namespace System.Tests
         [Fact]
         public static void EightTuplesWithBadRest()
         {
-            // Change as necessary if in the future
-            // the hash algorithm is modified again.
-            const int ExpectedHash = 1291467969;
-
             var d = default(ValueTuple<int, int, int, int, int, int, int, int>);
             d.Item1 = 1;
             d.Rest = 42;
-            Assert.Equal(ExpectedHash, d.GetHashCode());
-            Assert.Equal(ExpectedHash, ((IStructuralEquatable)d).GetHashCode());
             Assert.Equal("(1, 0, 0, 0, 0, 0, 0, 42)", d.ToString());
-
-            Assert.Equal(ExpectedHash, CreateLong(1, 2, 3, 4, 5, 6, 7, d).GetHashCode());
 
             // GetHashCode only tries to hash the first 7 elements when rest is not ITupleInternal
             Assert.Equal(ValueTuple.Create(1, 0, 0, 0, 0, 0, 0).GetHashCode(), d.GetHashCode());


### PR DESCRIPTION
Per the comments in #14046, it was decided that the `ValueTuple` hash code should be randomized. This will allow for more flexibility if it needs to be changed again in the future.

cc @jkotas, @VSadov, @jcouv, @JonHanna 