### PR TITLE
Code cleanup in System.ComponentModel.TypeConverter

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AddingNewEventArgs.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AddingNewEventArgs.cs
@@ -22,7 +22,7 @@ namespace System.ComponentModel
         ///     Initializes a new instance of the <see cref='System.ComponentModel.AddingNewEventArgs'/> class,
         ///     with no new object defined.
         /// </summary>
-        public AddingNewEventArgs() : base()
+        public AddingNewEventArgs()
         {
         }
 
@@ -30,7 +30,7 @@ namespace System.ComponentModel
         ///     Initializes a new instance of the <see cref='System.ComponentModel.AddingNewEventArgs'/> class,
         ///     with the specified object defined as the default new object.
         /// </summary>
-        public AddingNewEventArgs(object newObject) : base()
+        public AddingNewEventArgs(object newObject)
         {
             _newObject = newObject;
         }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AddingNewEventArgs.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AddingNewEventArgs.cs
@@ -36,6 +36,6 @@ namespace System.ComponentModel
         /// <summary>
         ///     Gets or sets the new object that will be added to the list.
         /// </summary>
-        public object NewObject { get; set; } = null;
+        public object NewObject { get; set; }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AddingNewEventArgs.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AddingNewEventArgs.cs
@@ -16,8 +16,6 @@ namespace System.ComponentModel
     /// </summary>
     public class AddingNewEventArgs : EventArgs
     {
-        private object _newObject = null;
-
         /// <summary>
         ///     Initializes a new instance of the <see cref='System.ComponentModel.AddingNewEventArgs'/> class,
         ///     with no new object defined.
@@ -32,23 +30,12 @@ namespace System.ComponentModel
         /// </summary>
         public AddingNewEventArgs(object newObject)
         {
-            _newObject = newObject;
+            NewObject = newObject;
         }
 
         /// <summary>
         ///     Gets or sets the new object that will be added to the list.
         /// </summary>
-        public object NewObject
-        {
-            get
-            {
-                return _newObject;
-            }
-
-            set
-            {
-                _newObject = value;
-            }
-        }
+        public object NewObject { get; set; } = null;
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AmbientValueAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AmbientValueAttribute.cs
@@ -36,7 +36,7 @@ namespace System.ComponentModel
             }
             catch
             {
-                Debug.Fail("Ambient value attribute of type " + type.FullName + " threw converting from the string '" + value + "'.");
+                Debug.Fail($"Ambient value attribute of type {type.FullName} threw converting from the string '{value}'.");
             }
         }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AmbientValueAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AmbientValueAttribute.cs
@@ -19,8 +19,6 @@ namespace System.ComponentModel
     [AttributeUsage(AttributeTargets.All)]
     public sealed class AmbientValueAttribute : Attribute
     {
-        private readonly object _value;
-
         /// <summary>
         /// <para>Initializes a new instance of the <see cref='System.ComponentModel.AmbientValueAttribute'/> class, converting the
         ///    specified value to the
@@ -34,7 +32,7 @@ namespace System.ComponentModel
             // load an otherwise normal class.
             try
             {
-                _value = TypeDescriptor.GetConverter(type).ConvertFromInvariantString(value);
+                Value = TypeDescriptor.GetConverter(type).ConvertFromInvariantString(value);
             }
             catch
             {
@@ -48,7 +46,7 @@ namespace System.ComponentModel
         /// </summary>
         public AmbientValueAttribute(char value)
         {
-            _value = value;
+            Value = value;
         }
         /// <summary>
         /// <para>Initializes a new instance of the <see cref='System.ComponentModel.AmbientValueAttribute'/> class using an 8-bit unsigned
@@ -56,7 +54,7 @@ namespace System.ComponentModel
         /// </summary>
         public AmbientValueAttribute(byte value)
         {
-            _value = value;
+            Value = value;
         }
         /// <summary>
         /// <para>Initializes a new instance of the <see cref='System.ComponentModel.AmbientValueAttribute'/> class using a 16-bit signed
@@ -64,7 +62,7 @@ namespace System.ComponentModel
         /// </summary>
         public AmbientValueAttribute(short value)
         {
-            _value = value;
+            Value = value;
         }
         /// <summary>
         /// <para>Initializes a new instance of the <see cref='System.ComponentModel.AmbientValueAttribute'/> class using a 32-bit signed
@@ -72,7 +70,7 @@ namespace System.ComponentModel
         /// </summary>
         public AmbientValueAttribute(int value)
         {
-            _value = value;
+            Value = value;
         }
         /// <summary>
         /// <para>Initializes a new instance of the <see cref='System.ComponentModel.AmbientValueAttribute'/> class using a 64-bit signed
@@ -80,7 +78,7 @@ namespace System.ComponentModel
         /// </summary>
         public AmbientValueAttribute(long value)
         {
-            _value = value;
+            Value = value;
         }
         /// <summary>
         /// <para>Initializes a new instance of the <see cref='System.ComponentModel.AmbientValueAttribute'/> class using a
@@ -89,7 +87,7 @@ namespace System.ComponentModel
         /// </summary>
         public AmbientValueAttribute(float value)
         {
-            _value = value;
+            Value = value;
         }
         /// <summary>
         /// <para>Initializes a new instance of the <see cref='System.ComponentModel.AmbientValueAttribute'/> class using a
@@ -98,7 +96,7 @@ namespace System.ComponentModel
         /// </summary>
         public AmbientValueAttribute(double value)
         {
-            _value = value;
+            Value = value;
         }
         /// <summary>
         /// <para>Initializes a new instance of the <see cref='System.ComponentModel.AmbientValueAttribute'/> class using a <see cref='System.Boolean'/>
@@ -106,14 +104,14 @@ namespace System.ComponentModel
         /// </summary>
         public AmbientValueAttribute(bool value)
         {
-            _value = value;
+            Value = value;
         }
         /// <summary>
         /// <para>Initializes a new instance of the <see cref='System.ComponentModel.AmbientValueAttribute'/> class using a <see cref='System.String'/>.</para>
         /// </summary>
         public AmbientValueAttribute(string value)
         {
-            _value = value;
+            Value = value;
         }
 
         /// <summary>
@@ -122,7 +120,7 @@ namespace System.ComponentModel
         /// </summary>
         public AmbientValueAttribute(object value)
         {
-            _value = value;
+            Value = value;
         }
 
         /// <summary>
@@ -132,13 +130,7 @@ namespace System.ComponentModel
         ///       bound to.
         ///    </para>
         /// </summary>
-        public object Value
-        {
-            get
-            {
-                return _value;
-            }
-        }
+        public object Value { get; }
 
         public override bool Equals(object obj)
         {
@@ -151,9 +143,9 @@ namespace System.ComponentModel
 
             if (other != null)
             {
-                if (_value != null)
+                if (Value != null)
                 {
-                    return _value.Equals(other.Value);
+                    return Value.Equals(other.Value);
                 }
                 else
                 {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ArrayConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ArrayConverter.cs
@@ -73,7 +73,7 @@ namespace System.ComponentModel
             private readonly int _index;
 
             public ArrayPropertyDescriptor(Type arrayType, Type elementType, int index)
-                : base(arrayType, $"[{index}]", elementType, null)
+                : base(arrayType, "[" + index + "]", elementType, null)
             {
                 _index = index;
             }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ArrayConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ArrayConverter.cs
@@ -73,7 +73,7 @@ namespace System.ComponentModel
             private readonly int _index;
 
             public ArrayPropertyDescriptor(Type arrayType, Type elementType, int index)
-                : base(arrayType, "[" + index + "]", elementType, null)
+                : base(arrayType, $"[{index}]", elementType, null)
             {
                 _index = index;
             }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
@@ -107,7 +107,7 @@ namespace System.ComponentModel
             // Now, if we collapsed some attributes, create a new array.
             //
 
-            Attribute[] attributes = Array.Empty<Attribute>();
+            Attribute[] attributes;
             if (actualCount < newArray.Length)
             {
                 attributes = new Attribute[actualCount];

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
@@ -125,35 +125,17 @@ namespace System.ComponentModel
         ///     Gets the attributes collection.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Matches constructor input type")]
-        protected virtual Attribute[] Attributes
-        {
-            get
-            {
-                return _attributes;
-            }
-        }
+        protected virtual Attribute[] Attributes => _attributes;
 
         /// <summary>
         ///     Gets the number of attributes.
         /// </summary>
-        public int Count
-        {
-            get
-            {
-                return Attributes.Length;
-            }
-        }
+        public int Count => Attributes.Length;
 
         /// <summary>
         ///     Gets the attribute with the specified index number.
         /// </summary>
-        public virtual Attribute this[int index]
-        {
-            get
-            {
-                return Attributes[index];
-            }
-        }
+        public virtual Attribute this[int index] => Attributes[index];
 
         /// <summary>
         ///    Gets the attribute with the specified type.
@@ -361,30 +343,12 @@ namespace System.ComponentModel
         }
 
         /// <internalonly/>
-        bool ICollection.IsSynchronized
-        {
-            get
-            {
-                return false;
-            }
-        }
+        bool ICollection.IsSynchronized => false;
 
         /// <internalonly/>
-        object ICollection.SyncRoot
-        {
-            get
-            {
-                return null;
-            }
-        }
+        object ICollection.SyncRoot => null;
 
-        int ICollection.Count 
-        { 
-            get
-            {
-                return Count;
-            }
-        }
+        int ICollection.Count => Count;
 
         IEnumerator IEnumerable.GetEnumerator()
         {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
@@ -34,7 +34,7 @@ namespace System.ComponentModel
 
         private AttributeEntry[] _foundAttributeTypes;
 
-        private int _index = 0;
+        private int _index;
 
         /// <summary>
         ///     Creates a new AttributeCollection.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
@@ -107,7 +107,7 @@ namespace System.ComponentModel
             // Now, if we collapsed some attributes, create a new array.
             //
 
-            Attribute[] attributes = null;
+            Attribute[] attributes = Array.Empty<Attribute>();
             if (actualCount < newArray.Length)
             {
                 attributes = new Attribute[actualCount];

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeProviderAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeProviderAttribute.cs
@@ -10,9 +10,6 @@ namespace System.ComponentModel
     [AttributeUsage(AttributeTargets.Property)]
     public class AttributeProviderAttribute : Attribute
     {
-        private readonly string _typeName;
-        private readonly string _propertyName;
-
         /// <summary>
         ///     Creates a new AttributeProviderAttribute object.
         /// </summary>
@@ -23,7 +20,7 @@ namespace System.ComponentModel
                 throw new ArgumentNullException(nameof(typeName));
             }
 
-            _typeName = typeName;
+            TypeName = typeName;
         }
 
         /// <summary>
@@ -40,8 +37,8 @@ namespace System.ComponentModel
                 throw new ArgumentNullException(nameof(propertyName));
             }
 
-            _typeName = typeName;
-            _propertyName = propertyName;
+            TypeName = typeName;
+            PropertyName = propertyName;
         }
 
         /// <summary>
@@ -54,31 +51,19 @@ namespace System.ComponentModel
                 throw new ArgumentNullException(nameof(type));
             }
 
-            _typeName = type.AssemblyQualifiedName;
+            TypeName = type.AssemblyQualifiedName;
         }
 
         /// <summary>
         ///     The TypeName property returns the assembly qualified type name 
         ///     passed into the constructor.
         /// </summary>
-        public string TypeName
-        {
-            get
-            {
-                return _typeName;
-            }
-        }
+        public string TypeName { get; }
 
         /// <summary>
         ///     The TypeName property returns the property name that will be used to query attributes from.
         /// </summary>
-        public string PropertyName
-        {
-            get
-            {
-                return _propertyName;
-            }
-        }
+        public string PropertyName { get; }
     }
 }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BaseNumberConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BaseNumberConverter.cs
@@ -15,13 +15,7 @@ namespace System.ComponentModel
         /// <summary>
         /// Determines whether this editor will attempt to convert hex (0x or #) strings
         /// </summary>
-        internal virtual bool AllowHex
-        {
-            get
-            {
-                return true;
-            }
-        }
+        internal virtual bool AllowHex => true;
 
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindableAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindableAttribute.cs
@@ -41,9 +41,7 @@ namespace System.ComponentModel
         /// </summary>
         public static readonly BindableAttribute Default = No;
 
-        private bool _bindable = false;
         private bool _isDefault = false;
-        private BindingDirection _direction;
 
         /// <summary>
         ///    <para>
@@ -61,8 +59,8 @@ namespace System.ComponentModel
         /// </summary>
         public BindableAttribute(bool bindable, BindingDirection direction)
         {
-            _bindable = bindable;
-            _direction = direction;
+            Bindable = bindable;
+            Direction = direction;
         }
 
         /// <summary>
@@ -81,9 +79,9 @@ namespace System.ComponentModel
         /// </summary>
         public BindableAttribute(BindableSupport flags, BindingDirection direction)
         {
-            _bindable = (flags != BindableSupport.No);
+            Bindable = (flags != BindableSupport.No);
             _isDefault = (flags == BindableSupport.Default);
-            _direction = direction;
+            Direction = direction;
         }
 
         /// <summary>
@@ -92,13 +90,7 @@ namespace System.ComponentModel
         ///       whether a property is appropriate to bind data to.
         ///    </para>
         /// </summary>
-        public bool Bindable
-        {
-            get
-            {
-                return _bindable;
-            }
-        }
+        public bool Bindable { get; } = false;
 
         /// <summary>
         /// <para>
@@ -106,13 +98,7 @@ namespace System.ComponentModel
         /// the direction(s) this property be bound to data.
         /// </para>
         /// </summary>
-        public BindingDirection Direction
-        {
-            get
-            {
-                return _direction;
-            }
-        }
+        public BindingDirection Direction { get; }
 
         /// <internalonly/>
         /// <summary>
@@ -126,7 +112,7 @@ namespace System.ComponentModel
 
             if (obj != null && obj is BindableAttribute)
             {
-                return (((BindableAttribute)obj).Bindable == _bindable);
+                return (((BindableAttribute)obj).Bindable == Bindable);
             }
 
             return false;
@@ -137,7 +123,7 @@ namespace System.ComponentModel
         /// </summary>
         public override int GetHashCode()
         {
-            return _bindable.GetHashCode();
+            return Bindable.GetHashCode();
         }
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindableAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindableAttribute.cs
@@ -41,7 +41,7 @@ namespace System.ComponentModel
         /// </summary>
         public static readonly BindableAttribute Default = No;
 
-        private bool _isDefault = false;
+        private bool _isDefault;
 
         /// <summary>
         ///    <para>
@@ -90,7 +90,7 @@ namespace System.ComponentModel
         ///       whether a property is appropriate to bind data to.
         ///    </para>
         /// </summary>
-        public bool Bindable { get; } = false;
+        public bool Bindable { get; }
 
         /// <summary>
         /// <para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
@@ -93,7 +93,7 @@ namespace System.ComponentModel
                     return true;
                 }
 
-                if (itemType.GetConstructor(BindingFlags.Public | BindingFlags.Instance | BindingFlags.CreateInstance, null, new Type[0], null) != null)
+                if (itemType.GetConstructor(BindingFlags.Public | BindingFlags.Instance | BindingFlags.CreateInstance, null, Array.Empty<Type>(), null) != null)
                 {
                     return true;
                 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
@@ -50,7 +50,7 @@ namespace System.ComponentModel
         /// <summary>
         ///     Default constructor.
         /// </summary>
-        public BindingList() : base()
+        public BindingList()
         {
             Initialize();
         }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
@@ -23,13 +23,13 @@ namespace System.ComponentModel
     {
         private int _addNewPos = -1;
         private bool _raiseListChangedEvents = true;
-        private bool _raiseItemChangedEvents = false;
+        private bool _raiseItemChangedEvents;
 
         [NonSerialized]
-        private PropertyDescriptorCollection _itemTypeProperties = null;
+        private PropertyDescriptorCollection _itemTypeProperties;
 
         [NonSerialized]
-        private PropertyChangedEventHandler _propertyChangedEventHandler = null;
+        private PropertyChangedEventHandler _propertyChangedEventHandler;
 
         [NonSerialized]
         private AddingNewEventHandler _onAddingNew;
@@ -43,7 +43,7 @@ namespace System.ComponentModel
         private bool _allowNew = true;
         private bool _allowEdit = true;
         private bool _allowRemove = true;
-        private bool _userSetAllowNew = false;
+        private bool _userSetAllowNew;
 
         #region Constructors
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
@@ -348,13 +348,7 @@ namespace System.ComponentModel
             return newItem;
         }
 
-        private bool AddingNewHandled
-        {
-            get
-            {
-                return _onAddingNew != null && _onAddingNew.GetInvocationList().Length > 0;
-            }
-        }
+        private bool AddingNewHandled => _onAddingNew != null && _onAddingNew.GetInvocationList().Length > 0;
 
         /// <summary>
         ///     Creates a new item and adds it to the list.
@@ -415,13 +409,7 @@ namespace System.ComponentModel
         }
 
         /* private */
-        bool IBindingList.AllowNew
-        {
-            get
-            {
-                return AllowNew;
-            }
-        }
+        bool IBindingList.AllowNew => AllowNew;
 
         /// <summary>
         /// </summary>
@@ -442,13 +430,7 @@ namespace System.ComponentModel
         }
 
         /* private */
-        bool IBindingList.AllowEdit
-        {
-            get
-            {
-                return AllowEdit;
-            }
-        }
+        bool IBindingList.AllowEdit => AllowEdit;
 
         /// <summary>
         /// </summary>
@@ -469,109 +451,31 @@ namespace System.ComponentModel
         }
 
         /* private */
-        bool IBindingList.AllowRemove
-        {
-            get
-            {
-                return AllowRemove;
-            }
-        }
+        bool IBindingList.AllowRemove => AllowRemove;
 
-        bool IBindingList.SupportsChangeNotification
-        {
-            get
-            {
-                return SupportsChangeNotificationCore;
-            }
-        }
+        bool IBindingList.SupportsChangeNotification => SupportsChangeNotificationCore;
 
-        protected virtual bool SupportsChangeNotificationCore
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected virtual bool SupportsChangeNotificationCore => true;
 
-        bool IBindingList.SupportsSearching
-        {
-            get
-            {
-                return SupportsSearchingCore;
-            }
-        }
+        bool IBindingList.SupportsSearching => SupportsSearchingCore;
 
-        protected virtual bool SupportsSearchingCore
-        {
-            get
-            {
-                return false;
-            }
-        }
+        protected virtual bool SupportsSearchingCore => false;
 
-        bool IBindingList.SupportsSorting
-        {
-            get
-            {
-                return SupportsSortingCore;
-            }
-        }
+        bool IBindingList.SupportsSorting => SupportsSortingCore;
 
-        protected virtual bool SupportsSortingCore
-        {
-            get
-            {
-                return false;
-            }
-        }
+        protected virtual bool SupportsSortingCore => false;
 
-        bool IBindingList.IsSorted
-        {
-            get
-            {
-                return IsSortedCore;
-            }
-        }
+        bool IBindingList.IsSorted => IsSortedCore;
 
-        protected virtual bool IsSortedCore
-        {
-            get
-            {
-                return false;
-            }
-        }
+        protected virtual bool IsSortedCore => false;
 
-        PropertyDescriptor IBindingList.SortProperty
-        {
-            get
-            {
-                return SortPropertyCore;
-            }
-        }
+        PropertyDescriptor IBindingList.SortProperty => SortPropertyCore;
 
-        protected virtual PropertyDescriptor SortPropertyCore
-        {
-            get
-            {
-                return null;
-            }
-        }
+        protected virtual PropertyDescriptor SortPropertyCore => null;
 
-        ListSortDirection IBindingList.SortDirection
-        {
-            get
-            {
-                return SortDirectionCore;
-            }
-        }
+        ListSortDirection IBindingList.SortDirection => SortDirectionCore;
 
-        protected virtual ListSortDirection SortDirectionCore
-        {
-            get
-            {
-                return ListSortDirection.Ascending;
-            }
-        }
+        protected virtual ListSortDirection SortDirectionCore => ListSortDirection.Ascending;
 
         void IBindingList.ApplySort(PropertyDescriptor prop, ListSortDirection direction)
         {
@@ -718,13 +622,7 @@ namespace System.ComponentModel
         ///     of type ItemChanged as a result of property changes on individual list items
         ///     unless those items support INotifyPropertyChanged
         /// </summary>
-        bool IRaiseItemChangedEvents.RaisesItemChangedEvents
-        {
-            get
-            {
-                return _raiseItemChangedEvents;
-            }
-        }
+        bool IRaiseItemChangedEvents.RaisesItemChangedEvents => _raiseItemChangedEvents;
 
         #endregion
     }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
@@ -136,10 +136,7 @@ namespace System.ComponentModel
         /// </summary>
         protected virtual void OnAddingNew(AddingNewEventArgs e)
         {
-            if (_onAddingNew != null)
-            {
-                _onAddingNew(this, e);
-            }
+            _onAddingNew?.Invoke(this, e);
         }
 
         // Private helper method
@@ -174,10 +171,7 @@ namespace System.ComponentModel
         /// </summary>
         protected virtual void OnListChanged(ListChangedEventArgs e)
         {
-            if (_onListChanged != null)
-            {
-                _onListChanged(this, e);
-            }
+            _onListChanged?.Invoke(this, e);
         }
 
         public bool RaiseListChangedEvents

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
@@ -35,6 +35,9 @@ namespace System.ComponentModel
         private AddingNewEventHandler _onAddingNew;
 
         [NonSerialized]
+        private ListChangedEventHandler _onListChanged;
+
+        [NonSerialized]
         private int _lastChangeIndex = -1;
 
         private bool _allowNew = true;
@@ -151,7 +154,17 @@ namespace System.ComponentModel
         /// <summary>
         ///     Event that reports changes to the list or to items in the list.
         /// </summary>
-        public event ListChangedEventHandler ListChanged; 
+        public event ListChangedEventHandler ListChanged
+        {
+            add
+            {
+                _onListChanged += value;
+            }
+            remove
+            {
+                _onListChanged -= value;
+            }
+        }
         
 
         /// <summary>
@@ -159,7 +172,7 @@ namespace System.ComponentModel
         /// </summary>
         protected virtual void OnListChanged(ListChangedEventArgs e)
         {
-            ListChanged?.Invoke(this, e);
+            _onListChanged?.Invoke(this, e);
         }
 
         public bool RaiseListChangedEvents

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
@@ -35,9 +35,6 @@ namespace System.ComponentModel
         private AddingNewEventHandler _onAddingNew;
 
         [NonSerialized]
-        private ListChangedEventHandler _onListChanged;
-
-        [NonSerialized]
         private int _lastChangeIndex = -1;
 
         private bool _allowNew = true;
@@ -154,24 +151,15 @@ namespace System.ComponentModel
         /// <summary>
         ///     Event that reports changes to the list or to items in the list.
         /// </summary>
-        public event ListChangedEventHandler ListChanged
-        {
-            add
-            {
-                _onListChanged += value;
-            }
-            remove
-            {
-                _onListChanged -= value;
-            }
-        }
+        public event ListChangedEventHandler ListChanged; 
+        
 
         /// <summary>
         ///     Raises the ListChanged event.
         /// </summary>
         protected virtual void OnListChanged(ListChangedEventArgs e)
         {
-            _onListChanged?.Invoke(this, e);
+            ListChanged?.Invoke(this, e);
         }
 
         public bool RaiseListChangedEvents

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BooleanConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BooleanConverter.cs
@@ -51,11 +51,7 @@ namespace System.ComponentModel
         /// </summary>
         public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
         {
-            if (s_values == null)
-            {
-                s_values = new StandardValuesCollection(new object[] { true, false });
-            }
-            return s_values;
+            return s_values ?? (s_values = new StandardValuesCollection(new object[] {true, false}));
         }
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ByteConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ByteConverter.cs
@@ -16,7 +16,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType => typeof(Byte);
+        internal override Type TargetType => typeof(byte);
 
         /// <summary>
         /// Convert the given string to a Byte using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ByteConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ByteConverter.cs
@@ -16,13 +16,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType
-        {
-            get
-            {
-                return typeof(Byte);
-            }
-        }
+        internal override Type TargetType => typeof(Byte);
 
         /// <summary>
         /// Convert the given string to a Byte using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CollectionChangeEventArgs.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CollectionChangeEventArgs.cs
@@ -9,38 +9,23 @@ namespace System.ComponentModel
     /// </summary>
     public class CollectionChangeEventArgs : EventArgs
     {
-        private readonly CollectionChangeAction _action;
-        private readonly object _element;
-
         /// <summary>
         /// <para>Initializes a new instance of the <see cref='System.ComponentModel.CollectionChangeEventArgs'/> class.</para>
         /// </summary>
         public CollectionChangeEventArgs(CollectionChangeAction action, object element)
         {
-            _action = action;
-            _element = element;
+            Action = action;
+            Element = element;
         }
 
         /// <summary>
         ///    <para>Gets an action that specifies how the collection changed.</para>
         /// </summary>
-        public virtual CollectionChangeAction Action
-        {
-            get
-            {
-                return _action;
-            }
-        }
+        public virtual CollectionChangeAction Action { get; }
 
         /// <summary>
         ///    <para>Gets the instance of the collection with the change. </para>
         /// </summary>
-        public virtual object Element
-        {
-            get
-            {
-                return _element;
-            }
-        }
+        public virtual object Element { get; }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ComplexBindingPropertiesAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ComplexBindingPropertiesAttribute.cs
@@ -15,9 +15,6 @@ namespace System.ComponentModel
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class ComplexBindingPropertiesAttribute : Attribute
     {
-        private readonly string _dataSource;
-        private readonly string _dataMember;
-
         /// <summary>
         ///    <para>
         ///       Initializes a new instance of
@@ -26,8 +23,8 @@ namespace System.ComponentModel
         /// </summary>
         public ComplexBindingPropertiesAttribute()
         {
-            _dataSource = null;
-            _dataMember = null;
+            DataSource = null;
+            DataMember = null;
         }
 
         /// <summary>
@@ -38,8 +35,8 @@ namespace System.ComponentModel
         /// </summary>
         public ComplexBindingPropertiesAttribute(string dataSource)
         {
-            _dataSource = dataSource;
-            _dataMember = null;
+            DataSource = dataSource;
+            DataMember = null;
         }
 
         /// <summary>
@@ -50,8 +47,8 @@ namespace System.ComponentModel
         /// </summary>
         public ComplexBindingPropertiesAttribute(string dataSource, string dataMember)
         {
-            _dataSource = dataSource;
-            _dataMember = dataMember;
+            DataSource = dataSource;
+            DataMember = dataMember;
         }
 
         /// <summary>
@@ -60,13 +57,7 @@ namespace System.ComponentModel
         ///       bound to.
         ///    </para>
         /// </summary>
-        public string DataSource
-        {
-            get
-            {
-                return _dataSource;
-            }
-        }
+        public string DataSource { get; }
 
         /// <summary>
         ///    <para>
@@ -74,13 +65,7 @@ namespace System.ComponentModel
         ///       bound to.
         ///    </para>
         /// </summary>
-        public string DataMember
-        {
-            get
-            {
-                return _dataMember;
-            }
-        }
+        public string DataMember { get; }
 
         /// <summary>
         ///    <para>
@@ -94,8 +79,8 @@ namespace System.ComponentModel
         {
             ComplexBindingPropertiesAttribute other = obj as ComplexBindingPropertiesAttribute;
             return other != null &&
-                   other.DataSource == _dataSource &&
-                   other.DataMember == _dataMember;
+                   other.DataSource == DataSource &&
+                   other.DataMember == DataMember;
         }
 
         public override int GetHashCode()

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ComplexBindingPropertiesAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ComplexBindingPropertiesAttribute.cs
@@ -23,8 +23,6 @@ namespace System.ComponentModel
         /// </summary>
         public ComplexBindingPropertiesAttribute()
         {
-            DataSource = null;
-            DataMember = null;
         }
 
         /// <summary>
@@ -36,7 +34,6 @@ namespace System.ComponentModel
         public ComplexBindingPropertiesAttribute(string dataSource)
         {
             DataSource = dataSource;
-            DataMember = null;
         }
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ComponentResourceManager.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ComponentResourceManager.cs
@@ -22,7 +22,8 @@ namespace System.ComponentModel
         private Hashtable _resourceSets;
         private CultureInfo _neutralResourcesCulture;
 
-        public ComponentResourceManager() : base() {
+        public ComponentResourceManager()
+        {
         }
 
         public ComponentResourceManager(Type t) : base(t)

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Container.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Container.cs
@@ -292,25 +292,18 @@ namespace System.ComponentModel
 
         private class Site : ISite
         {
-            private IComponent _component;
             private Container _container;
             private String _name;
 
             internal Site(IComponent component, Container container, String name)
             {
-                _component = component;
+                Component = component;
                 _container = container;
                 _name = name;
             }
 
             // The component sited by this component site.
-            public IComponent Component
-            {
-                get
-                {
-                    return _component;
-                }
-            }
+            public IComponent Component { get; }
 
             // The container in which the component is sited.
             public IContainer Container
@@ -346,7 +339,7 @@ namespace System.ComponentModel
                     if (value == null || _name == null || !value.Equals(_name))
                     {
                         // UNDONE : This is a breaking change.  
-                        _container.ValidateName(_component, value);
+                        _container.ValidateName(Component, value);
                         _name = value;
                     }
                 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Container.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Container.cs
@@ -86,10 +86,7 @@ namespace System.ComponentModel
                     }
                 }
 
-                if (site != null)
-                {
-                    site.Container.Remove(component);
-                }
+                site?.Container.Remove(component);
 
                 ISite newSite = CreateSite(component, name);
                 _sites[_siteCount++] = newSite;
@@ -232,9 +229,7 @@ namespace System.ComponentModel
         {
             lock (_syncObj)
             {
-                if (component == null)
-                    return;
-                ISite site = component.Site;
+                ISite site = component?.Site;
                 if (site == null || site.Container != this)
                     return;
                 if (!preserveSite)
@@ -276,9 +271,7 @@ namespace System.ComponentModel
                 {
                     ISite s = _sites[i];
 
-                    if (s != null && s.Name != null
-                            && string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase)
-                            && s.Component != component)
+                    if (s?.Name != null && string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase) && s.Component != component)
                     {
                         InheritanceAttribute inheritanceAttribute = (InheritanceAttribute)TypeDescriptor.GetAttributes(s.Component)[typeof(InheritanceAttribute)];
                         if (inheritanceAttribute.InheritanceLevel != InheritanceLevel.InheritedReadOnly)

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Container.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Container.cs
@@ -285,13 +285,12 @@ namespace System.ComponentModel
 
         private class Site : ISite
         {
-            private Container _container;
             private String _name;
 
             internal Site(IComponent component, Container container, String name)
             {
                 Component = component;
-                _container = container;
+                Container = container;
                 _name = name;
             }
 
@@ -299,11 +298,11 @@ namespace System.ComponentModel
             public IComponent Component { get; }
 
             // The container in which the component is sited.
-            public IContainer Container => _container;
+            public IContainer Container { get; }
 
             public Object GetService(Type service)
             {
-                return ((service == typeof(ISite)) ? this : _container.GetService(service));
+                return ((service == typeof(ISite)) ? this : ((Container)Container).GetService(service));
             }
 
 
@@ -320,7 +319,7 @@ namespace System.ComponentModel
                     if (value == null || _name == null || !value.Equals(_name))
                     {
                         // UNDONE : This is a breaking change.  
-                        _container.ValidateName(Component, value);
+                       ((Container)Container).ValidateName(Component, value);
                         _name = value;
                     }
                 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Container.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Container.cs
@@ -25,7 +25,7 @@ namespace System.ComponentModel
         private ContainerFilterService _filter;
         private bool _checkedFilter;
 
-        private object _syncObj = new Object();
+        private readonly object _syncObj = new Object();
 
         ~Container()
         {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Container.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Container.cs
@@ -306,13 +306,7 @@ namespace System.ComponentModel
             public IComponent Component { get; }
 
             // The container in which the component is sited.
-            public IContainer Container
-            {
-                get
-                {
-                    return _container;
-                }
-            }
+            public IContainer Container => _container;
 
             public Object GetService(Type service)
             {
@@ -321,13 +315,7 @@ namespace System.ComponentModel
 
 
             // Indicates whether the component is in design mode.
-            public bool DesignMode
-            {
-                get
-                {
-                    return false;
-                }
-            }
+            public bool DesignMode => false;
 
             // The name of the component.
             //

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
@@ -105,17 +105,16 @@ namespace System.ComponentModel
                     //
                     if (retVal == null)
                     {
-                        ICollection values = GetStandardValues(context);
-                        IEnumerator e = values.GetEnumerator();
-                        while (e.MoveNext())
+                        foreach (var val in GetStandardValues(context))
                         {
-                            CultureInfo info = (CultureInfo)e.Current;
+                            CultureInfo info = (CultureInfo)val;
                             if (info != null && string.Compare(GetCultureName(info), text, StringComparison.Ordinal) == 0)
                             {
                                 retVal = info;
                                 break;
                             }
                         }
+                       
                     }
 
                     // Now try to create a new culture info from this value
@@ -134,16 +133,16 @@ namespace System.ComponentModel
                     if (retVal == null)
                     {
                         text = text.ToLower(CultureInfo.CurrentCulture);
-                        IEnumerator e = _values.GetEnumerator();
-                        while (e.MoveNext())
+                        foreach (var val in _values)
                         {
-                            CultureInfo info = (CultureInfo)e.Current;
+                            CultureInfo info = (CultureInfo)val;
                             if (info != null && GetCultureName(info).ToLower(CultureInfo.CurrentCulture).StartsWith(text))
                             {
                                 retVal = info;
                                 break;
                             }
                         }
+                        
                     }
                 }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Win32;
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel.Design.Serialization;
 using System.Diagnostics;
 using System.Globalization;
@@ -332,26 +333,12 @@ namespace System.ComponentModel
         {
             ///  Dictionary of CultureInfo.DisplayName, CultureInfo.Name for cultures that have changed DisplayName over releases.
             ///  This is to workaround an issue with CultureInfoConverter that serializes DisplayName (fixing it would introduce breaking changes).
-            private static volatile System.Collections.Generic.Dictionary<string, string> s_cultureInfoNameMap;
+            private static readonly Dictionary<string, string> s_cultureInfoNameMap = CreateMap();
 
-            public static string GetCultureInfoName(string cultureInfoDisplayName)
+            private static Dictionary<string,string> CreateMap()
             {
-                if (s_cultureInfoNameMap == null)
-                {
-                    InitializeCultureInfoMap();
-                }
-
-                if (s_cultureInfoNameMap.ContainsKey(cultureInfoDisplayName))
-                {
-                    return s_cultureInfoNameMap[cultureInfoDisplayName];
-                }
-
-                return cultureInfoDisplayName;
-            }
-
-            private static void InitializeCultureInfoMap()
-            {
-                s_cultureInfoNameMap = new System.Collections.Generic.Dictionary<string, string>() {
+                const int Count = 274;
+                var result = new Dictionary<string, string>(Count) {
                     {"Afrikaans", "af"},
                     {"Afrikaans (South Africa)", "af-ZA"},
                     {"Albanian", "sq"},
@@ -627,7 +614,19 @@ namespace System.ComponentModel
                     {"Yi (PRC)", "ii-CN"},
                     {"Yoruba (Nigeria)", "yo-NG"}
                 };
+
+                Debug.Assert(result.Count == Count);
+                return result;
             }
+
+            public static string GetCultureInfoName(string cultureInfoDisplayName)
+            {
+                string name;
+                return s_cultureInfoNameMap.TryGetValue(cultureInfoDisplayName, out name) ?
+                    name :
+                    cultureInfoDisplayName;
+            }
+
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
@@ -25,13 +25,7 @@ namespace System.ComponentModel
         /// <summary>
         ///      Retrieves the "default" name for our culture.
         /// </summary>
-        private string DefaultCultureString
-        {
-            get
-            {
-                return SR.CultureInfoConverterDefaultCultureString;
-            }
-        }
+        private string DefaultCultureString => SR.CultureInfoConverterDefaultCultureString;
 
         /// <summary>
         ///      Retrieves the Name for a input CultureInfo.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
@@ -106,9 +106,8 @@ namespace System.ComponentModel
                     //
                     if (retVal == null)
                     {
-                        foreach (var val in GetStandardValues(context))
+                        foreach (CultureInfo info in GetStandardValues(context))
                         {
-                            CultureInfo info = (CultureInfo)val;
                             if (info != null && string.Compare(GetCultureName(info), text, StringComparison.Ordinal) == 0)
                             {
                                 retVal = info;
@@ -134,9 +133,8 @@ namespace System.ComponentModel
                     if (retVal == null)
                     {
                         text = text.ToLower(CultureInfo.CurrentCulture);
-                        foreach (var val in _values)
+                        foreach (CultureInfo info in _values)
                         {
-                            CultureInfo info = (CultureInfo)val;
                             if (info != null && GetCultureName(info).ToLower(CultureInfo.CurrentCulture).StartsWith(text))
                             {
                                 retVal = info;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CustomTypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CustomTypeDescriptor.cs
@@ -60,12 +60,7 @@ namespace System.ComponentModel
         /// </summary>
         public virtual string GetClassName()
         {
-            if (_parent != null)
-            {
-                return _parent.GetClassName();
-            }
-
-            return null;
+            return _parent?.GetClassName();
         }
 
         /// <summary>
@@ -74,12 +69,7 @@ namespace System.ComponentModel
         /// </summary>
         public virtual string GetComponentName()
         {
-            if (_parent != null)
-            {
-                return _parent.GetComponentName();
-            }
-
-            return null;
+            return _parent?.GetComponentName();
         }
 
         /// <summary>
@@ -102,12 +92,7 @@ namespace System.ComponentModel
         /// </summary>
         public virtual EventDescriptor GetDefaultEvent()
         {
-            if (_parent != null)
-            {
-                return _parent.GetDefaultEvent();
-            }
-
-            return null;
+            return _parent?.GetDefaultEvent();
         }
 
         /// <summary>
@@ -116,12 +101,7 @@ namespace System.ComponentModel
         /// </summary>
         public virtual PropertyDescriptor GetDefaultProperty()
         {
-            if (_parent != null)
-            {
-                return _parent.GetDefaultProperty();
-            }
-
-            return null;
+            return _parent?.GetDefaultProperty();
         }
 
         /// <summary>
@@ -130,12 +110,7 @@ namespace System.ComponentModel
         /// </summary>
         public virtual object GetEditor(Type editorBaseType)
         {
-            if (_parent != null)
-            {
-                return _parent.GetEditor(editorBaseType);
-            }
-
-            return null;
+            return _parent?.GetEditor(editorBaseType);
         }
 
         /// <summary>
@@ -215,12 +190,7 @@ namespace System.ComponentModel
         /// </summary>
         public virtual object GetPropertyOwner(PropertyDescriptor pd)
         {
-            if (_parent != null)
-            {
-                return _parent.GetPropertyOwner(pd);
-            }
-
-            return null;
+            return _parent?.GetPropertyOwner(pd);
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DataObjectAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DataObjectAttribute.cs
@@ -18,24 +18,16 @@ namespace System.ComponentModel
 
         public static readonly DataObjectAttribute Default = NonDataObject;
 
-        private bool _isDataObject;
-
         public DataObjectAttribute() : this(true)
         {
         }
 
         public DataObjectAttribute(bool isDataObject)
         {
-            _isDataObject = isDataObject;
+            IsDataObject = isDataObject;
         }
 
-        public bool IsDataObject
-        {
-            get
-            {
-                return _isDataObject;
-            }
-        }
+        public bool IsDataObject { get; }
 
         /// <internalonly/>
         public override bool Equals(object obj)
@@ -52,7 +44,7 @@ namespace System.ComponentModel
         /// <internalonly/>
         public override int GetHashCode()
         {
-            return _isDataObject.GetHashCode();
+            return IsDataObject.GetHashCode();
         }
 
         /// <internalonly/>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DataObjectFieldAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DataObjectFieldAttribute.cs
@@ -14,11 +14,6 @@ namespace System.ComponentModel
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class DataObjectFieldAttribute : Attribute
     {
-        private bool _primaryKey;
-        private bool _isIdentity;
-        private bool _isNullable;
-        private int _length;
-
         public DataObjectFieldAttribute(bool primaryKey) : this(primaryKey, false, false, -1)
         {
         }
@@ -33,43 +28,19 @@ namespace System.ComponentModel
 
         public DataObjectFieldAttribute(bool primaryKey, bool isIdentity, bool isNullable, int length)
         {
-            _primaryKey = primaryKey;
-            _isIdentity = isIdentity;
-            _isNullable = isNullable;
-            _length = length;
+            PrimaryKey = primaryKey;
+            IsIdentity = isIdentity;
+            IsNullable = isNullable;
+            Length = length;
         }
 
-        public bool IsIdentity
-        {
-            get
-            {
-                return _isIdentity;
-            }
-        }
+        public bool IsIdentity { get; }
 
-        public bool IsNullable
-        {
-            get
-            {
-                return _isNullable;
-            }
-        }
+        public bool IsNullable { get; }
 
-        public int Length
-        {
-            get
-            {
-                return _length;
-            }
-        }
+        public int Length { get; }
 
-        public bool PrimaryKey
-        {
-            get
-            {
-                return _primaryKey;
-            }
-        }
+        public bool PrimaryKey { get; }
 
         public override bool Equals(object obj)
         {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DataObjectMethodAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DataObjectMethodAttribute.cs
@@ -12,34 +12,19 @@ namespace System.ComponentModel
     [AttributeUsage(AttributeTargets.Method)]
     public sealed class DataObjectMethodAttribute : Attribute
     {
-        private bool _isDefault;
-        private DataObjectMethodType _methodType;
-
         public DataObjectMethodAttribute(DataObjectMethodType methodType) : this(methodType, false)
         {
         }
 
         public DataObjectMethodAttribute(DataObjectMethodType methodType, bool isDefault)
         {
-            _methodType = methodType;
-            _isDefault = isDefault;
+            MethodType = methodType;
+            IsDefault = isDefault;
         }
 
-        public bool IsDefault
-        {
-            get
-            {
-                return _isDefault;
-            }
-        }
+        public bool IsDefault { get; }
 
-        public DataObjectMethodType MethodType
-        {
-            get
-            {
-                return _methodType;
-            }
-        }
+        public DataObjectMethodType MethodType { get; }
 
         /// <internalonly/>
         public override bool Equals(object obj)
@@ -56,7 +41,7 @@ namespace System.ComponentModel
         /// <internalonly/>
         public override int GetHashCode()
         {
-            return ((int)_methodType).GetHashCode() ^ _isDefault.GetHashCode();
+            return ((int)MethodType).GetHashCode() ^ IsDefault.GetHashCode();
         }
 
         /// <internalonly/>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DateTimeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DateTimeConverter.cs
@@ -124,7 +124,7 @@ namespace System.ComponentModel
                 }
                 else
                 {
-                    format = $"{formatInfo.ShortDatePattern} {formatInfo.ShortTimePattern}";
+                    format = formatInfo.ShortDatePattern + formatInfo.ShortTimePattern;
                 }
 
                 return dt.ToString(format, CultureInfo.CurrentCulture);

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DateTimeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DateTimeConverter.cs
@@ -124,7 +124,7 @@ namespace System.ComponentModel
                 }
                 else
                 {
-                    format = formatInfo.ShortDatePattern + " " + formatInfo.ShortTimePattern;
+                    format = $"{formatInfo.ShortDatePattern} {formatInfo.ShortTimePattern}";
                 }
 
                 return dt.ToString(format, CultureInfo.CurrentCulture);

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DateTimeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DateTimeConverter.cs
@@ -124,7 +124,7 @@ namespace System.ComponentModel
                 }
                 else
                 {
-                    format = formatInfo.ShortDatePattern + formatInfo.ShortTimePattern;
+                    format = formatInfo.ShortDatePattern + " " + formatInfo.ShortTimePattern;
                 }
 
                 return dt.ToString(format, CultureInfo.CurrentCulture);

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DateTimeOffsetConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DateTimeOffsetConverter.cs
@@ -138,7 +138,7 @@ namespace System.ComponentModel
                 {
                     // pattern just like DateTimeConverter when DateTime.TimeOfDay.TotalSeconds!=0
                     // but with ' zzz' offset pattern added.
-                    format = $"{formatInfo.ShortDatePattern} {formatInfo.ShortTimePattern} zzz";
+                    format = formatInfo.ShortDatePattern + formatInfo.ShortTimePattern + "zzz";
                 }
 
                 return dto.ToString(format, CultureInfo.CurrentCulture);

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DateTimeOffsetConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DateTimeOffsetConverter.cs
@@ -138,7 +138,7 @@ namespace System.ComponentModel
                 {
                     // pattern just like DateTimeConverter when DateTime.TimeOfDay.TotalSeconds!=0
                     // but with ' zzz' offset pattern added.
-                    format = formatInfo.ShortDatePattern + formatInfo.ShortTimePattern + "zzz";
+                    format = formatInfo.ShortDatePattern + " " + formatInfo.ShortTimePattern + " zzz";
                 }
 
                 return dto.ToString(format, CultureInfo.CurrentCulture);

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DateTimeOffsetConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DateTimeOffsetConverter.cs
@@ -138,7 +138,7 @@ namespace System.ComponentModel
                 {
                     // pattern just like DateTimeConverter when DateTime.TimeOfDay.TotalSeconds!=0
                     // but with ' zzz' offset pattern added.
-                    format = formatInfo.ShortDatePattern + " " + formatInfo.ShortTimePattern + " zzz";
+                    format = $"{formatInfo.ShortDatePattern} {formatInfo.ShortTimePattern} zzz";
                 }
 
                 return dto.ToString(format, CultureInfo.CurrentCulture);

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DecimalConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DecimalConverter.cs
@@ -24,7 +24,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType => typeof(Decimal);
+        internal override Type TargetType => typeof(decimal);
 
         /// <summary>
         ///    <para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DecimalConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DecimalConverter.cs
@@ -19,24 +19,12 @@ namespace System.ComponentModel
         /// <summary>
         /// Determines whether this editor will attempt to convert hex (0x or #) strings
         /// </summary>
-        internal override bool AllowHex
-        {
-            get
-            {
-                return false;
-            }
-        }
+        internal override bool AllowHex => false;
 
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType
-        {
-            get
-            {
-                return typeof(Decimal);
-            }
-        }
+        internal override Type TargetType => typeof(Decimal);
 
         /// <summary>
         ///    <para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DefaultBindingPropertyAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DefaultBindingPropertyAttribute.cs
@@ -22,7 +22,6 @@ namespace System.ComponentModel
         /// </summary>
         public DefaultBindingPropertyAttribute()
         {
-            Name = null;
         }
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DefaultBindingPropertyAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DefaultBindingPropertyAttribute.cs
@@ -14,8 +14,6 @@ namespace System.ComponentModel
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class DefaultBindingPropertyAttribute : Attribute
     {
-        private readonly string _name;
-
         /// <summary>
         ///    <para>
         ///       Initializes a new instance of
@@ -24,7 +22,7 @@ namespace System.ComponentModel
         /// </summary>
         public DefaultBindingPropertyAttribute()
         {
-            _name = null;
+            Name = null;
         }
 
         /// <summary>
@@ -35,7 +33,7 @@ namespace System.ComponentModel
         /// </summary>
         public DefaultBindingPropertyAttribute(string name)
         {
-            _name = name;
+            Name = name;
         }
 
         /// <summary>
@@ -44,13 +42,7 @@ namespace System.ComponentModel
         ///       bound to.
         ///    </para>
         /// </summary>
-        public string Name
-        {
-            get
-            {
-                return _name;
-            }
-        }
+        public string Name { get; }
 
         /// <summary>
         ///    <para>
@@ -63,7 +55,7 @@ namespace System.ComponentModel
         public override bool Equals(object obj)
         {
             DefaultBindingPropertyAttribute other = obj as DefaultBindingPropertyAttribute;
-            return other != null && other.Name == _name;
+            return other != null && other.Name == Name;
         }
 
         public override int GetHashCode()

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DefaultEventAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DefaultEventAttribute.cs
@@ -12,11 +12,6 @@ namespace System.ComponentModel
     public sealed class DefaultEventAttribute : Attribute
     {
         /// <summary>
-        ///     This is the default event name.
-        /// </summary>
-        private readonly string _name;
-
-        /// <summary>
         ///    <para>
         ///       Initializes
         ///       a new instance of the <see cref='System.ComponentModel.DefaultEventAttribute'/> class.
@@ -24,7 +19,7 @@ namespace System.ComponentModel
         /// </summary>
         public DefaultEventAttribute(string name)
         {
-            _name = name;
+            Name = name;
         }
 
         /// <summary>
@@ -33,7 +28,7 @@ namespace System.ComponentModel
         ///       the component this attribute is bound to.
         ///    </para>
         /// </summary>
-        public string Name => _name;
+        public string Name { get; }
 
         /// <summary>
         ///    <para>
@@ -47,7 +42,7 @@ namespace System.ComponentModel
         public override bool Equals(object obj)
         {
             DefaultEventAttribute other = obj as DefaultEventAttribute;
-            return (other != null) && other.Name == _name;
+            return (other != null) && other.Name == Name;
         }
 
         public override int GetHashCode()

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DefaultEventAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DefaultEventAttribute.cs
@@ -33,13 +33,7 @@ namespace System.ComponentModel
         ///       the component this attribute is bound to.
         ///    </para>
         /// </summary>
-        public string Name
-        {
-            get
-            {
-                return _name;
-            }
-        }
+        public string Name => _name;
 
         /// <summary>
         ///    <para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DefaultPropertyAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DefaultPropertyAttribute.cs
@@ -11,11 +11,6 @@ namespace System.ComponentModel
     public sealed class DefaultPropertyAttribute : Attribute
     {
         /// <summary>
-        ///     This is the default event name.
-        /// </summary>
-        private readonly string _name;
-
-        /// <summary>
         ///    <para>
         ///       Initializes a new instance of
         ///       the <see cref='System.ComponentModel.DefaultPropertyAttribute'/> class.
@@ -23,7 +18,7 @@ namespace System.ComponentModel
         /// </summary>
         public DefaultPropertyAttribute(string name)
         {
-            _name = name;
+            Name = name;
         }
 
         /// <summary>
@@ -32,7 +27,7 @@ namespace System.ComponentModel
         ///       bound to.
         ///    </para>
         /// </summary>
-        public string Name => _name;
+        public string Name { get; }
 
         /// <summary>
         ///    <para>
@@ -45,7 +40,7 @@ namespace System.ComponentModel
         public override bool Equals(object obj)
         {
             DefaultPropertyAttribute other = obj as DefaultPropertyAttribute;
-            return (other != null) && other.Name == _name;
+            return (other != null) && other.Name == Name;
         }
 
         public override int GetHashCode()

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DefaultPropertyAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DefaultPropertyAttribute.cs
@@ -32,13 +32,7 @@ namespace System.ComponentModel
         ///       bound to.
         ///    </para>
         /// </summary>
-        public string Name
-        {
-            get
-            {
-                return _name;
-            }
-        }
+        public string Name => _name;
 
         /// <summary>
         ///    <para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DelegatingTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DelegatingTypeDescriptionProvider.cs
@@ -28,13 +28,7 @@ namespace System.ComponentModel
         /// <summary>
         ///     
         /// </summary>
-        internal TypeDescriptionProvider Provider
-        {
-            get
-            {
-                return TypeDescriptor.GetProviderRecursive(_type);
-            }
-        }
+        internal TypeDescriptionProvider Provider => TypeDescriptor.GetProviderRecursive(_type);
 
         /// <summary>
         ///     This method is used to create an instance that can substitute for another 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ActiveDocumentEvent.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ActiveDocumentEvent.cs
@@ -17,23 +17,13 @@ namespace System.ComponentModel.Design
     public class ActiveDesignerEventArgs : EventArgs
     {
         /// <summary>
-        ///     The document that is losing activation.
-        /// </summary>
-        private readonly IDesignerHost _oldDesigner;
-
-        /// <summary>
-        ///     The document that is gaining activation.
-        /// </summary>
-        private readonly IDesignerHost _newDesigner;
-
-        /// <summary>
         /// <para>Initializes a new instance of the <see cref='System.ComponentModel.Design.ActiveDesignerEventArgs'/>
         /// class.</para>
         /// </summary>
         public ActiveDesignerEventArgs(IDesignerHost oldDesigner, IDesignerHost newDesigner)
         {
-            _oldDesigner = oldDesigner;
-            _newDesigner = newDesigner;
+            OldDesigner = oldDesigner;
+            NewDesigner = newDesigner;
         }
 
         /// <summary>
@@ -42,7 +32,7 @@ namespace System.ComponentModel.Design
         ///       sets the document that is losing activation.
         ///    </para>
         /// </summary>
-        public IDesignerHost OldDesigner => _oldDesigner;
+        public IDesignerHost OldDesigner { get; }
 
         /// <summary>
         ///    <para>
@@ -50,6 +40,6 @@ namespace System.ComponentModel.Design
         ///       sets the document that is gaining activation.
         ///    </para>
         /// </summary>
-        public IDesignerHost NewDesigner => _newDesigner;
+        public IDesignerHost NewDesigner { get; }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ActiveDocumentEvent.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ActiveDocumentEvent.cs
@@ -42,13 +42,7 @@ namespace System.ComponentModel.Design
         ///       sets the document that is losing activation.
         ///    </para>
         /// </summary>
-        public IDesignerHost OldDesigner
-        {
-            get
-            {
-                return _oldDesigner;
-            }
-        }
+        public IDesignerHost OldDesigner => _oldDesigner;
 
         /// <summary>
         ///    <para>
@@ -56,12 +50,6 @@ namespace System.ComponentModel.Design
         ///       sets the document that is gaining activation.
         ///    </para>
         /// </summary>
-        public IDesignerHost NewDesigner
-        {
-            get
-            {
-                return _newDesigner;
-            }
-        }
+        public IDesignerHost NewDesigner => _newDesigner;
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/CommandID.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/CommandID.cs
@@ -40,13 +40,7 @@ namespace System.ComponentModel.Design
         ///       Gets or sets the numeric command ID.
         ///    </para>
         /// </summary>
-        public virtual int ID
-        {
-            get
-            {
-                return _commandID;
-            }
-        }
+        public virtual int ID => _commandID;
 
         /// <summary>
         ///    <para>
@@ -79,13 +73,7 @@ namespace System.ComponentModel.Design
         ///       represents belongs to.
         ///    </para>
         /// </summary>
-        public virtual Guid Guid
-        {
-            get
-            {
-                return _menuGroup;
-            }
-        }
+        public virtual Guid Guid => _menuGroup;
 
         /// <summary>
         ///    <para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/CommandID.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/CommandID.cs
@@ -82,7 +82,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public override string ToString()
         {
-            return $"{_menuGroup.ToString()} : {_commandID.ToString(CultureInfo.CurrentCulture)}";
+            return _menuGroup.ToString() + " : " + _commandID.ToString(CultureInfo.CurrentCulture);
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/CommandID.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/CommandID.cs
@@ -19,9 +19,6 @@ namespace System.ComponentModel.Design
     /// </summary>
     public class CommandID
     {
-        private readonly Guid _menuGroup;
-        private readonly int _commandID;
-
         /// <summary>
         ///    <para>
         ///       Initializes a new instance of the <see cref='System.ComponentModel.Design.CommandID'/>
@@ -31,8 +28,8 @@ namespace System.ComponentModel.Design
         /// </summary>
         public CommandID(Guid menuGroup, int commandID)
         {
-            _menuGroup = menuGroup;
-            _commandID = commandID;
+            Guid = menuGroup;
+            ID = commandID;
         }
 
         /// <summary>
@@ -40,7 +37,7 @@ namespace System.ComponentModel.Design
         ///       Gets or sets the numeric command ID.
         ///    </para>
         /// </summary>
-        public virtual int ID => _commandID;
+        public virtual int ID { get; }
 
         /// <summary>
         ///    <para>
@@ -54,7 +51,7 @@ namespace System.ComponentModel.Design
                 return false;
             }
             CommandID cid = (CommandID)obj;
-            return cid._menuGroup.Equals(_menuGroup) && cid._commandID == _commandID;
+            return cid.Guid.Equals(Guid) && cid.ID == ID;
         }
 
         /// <summary>
@@ -62,7 +59,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public override int GetHashCode()
         {
-            return _menuGroup.GetHashCode() << 2 | _commandID;
+            return Guid.GetHashCode() << 2 | ID;
         }
 
         /// <summary>
@@ -73,7 +70,7 @@ namespace System.ComponentModel.Design
         ///       represents belongs to.
         ///    </para>
         /// </summary>
-        public virtual Guid Guid => _menuGroup;
+        public virtual Guid Guid { get; }
 
         /// <summary>
         ///    <para>
@@ -82,7 +79,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public override string ToString()
         {
-            return _menuGroup.ToString() + " : " + _commandID.ToString(CultureInfo.CurrentCulture);
+            return Guid.ToString() + " : " + ID.ToString(CultureInfo.CurrentCulture);
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/CommandID.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/CommandID.cs
@@ -82,7 +82,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public override string ToString()
         {
-            return _menuGroup.ToString() + " : " + _commandID.ToString(CultureInfo.CurrentCulture);
+            return $"{_menuGroup.ToString()} : {_commandID.ToString(CultureInfo.CurrentCulture)}";
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ComponentChangedEvent.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ComponentChangedEvent.cs
@@ -15,72 +15,43 @@ namespace System.ComponentModel.Design
     /// </summary>
     public sealed class ComponentChangedEventArgs : EventArgs
     {
-        private object _component;
-        private MemberDescriptor _member;
-        private object _oldValue;
-        private object _newValue;
-
         /// <summary>
         ///    <para>
         ///       Gets or sets the component that is the cause of this event.      
         ///    </para>
         /// </summary>
-        public object Component
-        {
-            get
-            {
-                return _component;
-            }
-        }
+        public object Component { get; }
 
         /// <summary>
         ///    <para>
         ///       Gets or sets the member that is about to change.      
         ///    </para>
         /// </summary>
-        public MemberDescriptor Member
-        {
-            get
-            {
-                return _member;
-            }
-        }
+        public MemberDescriptor Member { get; }
 
         /// <summary>
         ///    <para>
         ///       Gets or sets the new value of the changed member.
         ///    </para>
         /// </summary>
-        public object NewValue
-        {
-            get
-            {
-                return _newValue;
-            }
-        }
+        public object NewValue { get; }
 
         /// <summary>
         ///    <para>
         ///       Gets or sets the old value of the changed member.      
         ///    </para>
         /// </summary>
-        public object OldValue
-        {
-            get
-            {
-                return _oldValue;
-            }
-        }
+        public object OldValue { get; }
 
         /// <summary>
         /// <para>Initializes a new instance of the <see cref='System.ComponentModel.Design.ComponentChangedEventArgs'/> class.</para>
         /// </summary>
         public ComponentChangedEventArgs(object component, MemberDescriptor member, object oldValue, object newValue)
         {
-            _component = component;
-            _member = member;
-            _oldValue = oldValue;
-            _newValue = newValue;
+            Component = component;
+            Member = member;
+            OldValue = oldValue;
+            NewValue = newValue;
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ComponentChangingEvent.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ComponentChangingEvent.cs
@@ -15,34 +15,19 @@ namespace System.ComponentModel.Design
     /// </summary>
     public sealed class ComponentChangingEventArgs : EventArgs
     {
-        private object _component;
-        private MemberDescriptor _member;
-
         /// <summary>
         ///    <para>
         ///       Gets or sets the component that is being changed or that is the parent container of the member being changed.      
         ///    </para>
         /// </summary>
-        public object Component
-        {
-            get
-            {
-                return _component;
-            }
-        }
+        public object Component { get; }
 
         /// <summary>
         ///    <para>
         ///       Gets or sets the member of the component that is about to be changed.
         ///    </para>
         /// </summary>
-        public MemberDescriptor Member
-        {
-            get
-            {
-                return _member;
-            }
-        }
+        public MemberDescriptor Member { get; }
 
         /// <summary>
         ///    <para>
@@ -51,8 +36,8 @@ namespace System.ComponentModel.Design
         /// </summary>
         public ComponentChangingEventArgs(object component, MemberDescriptor member)
         {
-            _component = component;
-            _member = member;
+            Component = component;
+            Member = member;
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ComponentEvent.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ComponentEvent.cs
@@ -16,20 +16,12 @@ namespace System.ComponentModel.Design
     /// </summary>
     public class ComponentEventArgs : EventArgs
     {
-        private IComponent _component;
-
         /// <summary>
         ///    <para>
         ///       Gets or sets the component associated with the event.
         ///    </para>
         /// </summary>
-        public virtual IComponent Component
-        {
-            get
-            {
-                return _component;
-            }
-        }
+        public virtual IComponent Component { get; }
 
         /// <summary>
         ///    <para>
@@ -38,7 +30,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public ComponentEventArgs(IComponent component)
         {
-            _component = component;
+            Component = component;
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ComponentRenameEvent.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ComponentRenameEvent.cs
@@ -15,22 +15,12 @@ namespace System.ComponentModel.Design
     /// </summary>
     public class ComponentRenameEventArgs : EventArgs
     {
-        private object _component;
-        private string _oldName;
-        private string _newName;
-
         /// <summary>
         ///    <para>
         ///       Gets or sets the component that is being renamed.
         ///    </para>
         /// </summary>
-        public object Component
-        {
-            get
-            {
-                return _component;
-            }
-        }
+        public object Component { get; }
 
         /// <summary>
         ///    <para>
@@ -38,13 +28,7 @@ namespace System.ComponentModel.Design
         ///       sets the name of the component before the rename.
         ///    </para>
         /// </summary>
-        public virtual string OldName
-        {
-            get
-            {
-                return _oldName;
-            }
-        }
+        public virtual string OldName { get; }
 
         /// <summary>
         ///    <para>
@@ -52,13 +36,7 @@ namespace System.ComponentModel.Design
         ///       sets the current name of the component.
         ///    </para>
         /// </summary>
-        public virtual string NewName
-        {
-            get
-            {
-                return _newName;
-            }
-        }
+        public virtual string NewName { get; }
 
         /// <summary>
         ///    <para>
@@ -68,9 +46,9 @@ namespace System.ComponentModel.Design
         /// </summary>
         public ComponentRenameEventArgs(object component, string oldName, string newName)
         {
-            _oldName = oldName;
-            _newName = newName;
-            _component = component;
+            OldName = oldName;
+            NewName = newName;
+            Component = component;
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
@@ -363,49 +363,25 @@ namespace System.ComponentModel.Design
             /// <summary>
             /// Private ICollection implementation.
             /// </summary>
-            bool ICollection.IsSynchronized
-            {
-                get
-                {
-                    return false;
-                }
-            }
+            bool ICollection.IsSynchronized => false;
 
             /// <internalonly/>
             /// <summary>
             /// Private ICollection implementation.
             /// </summary>
-            object ICollection.SyncRoot
-            {
-                get
-                {
-                    return this;
-                }
-            }
+            object ICollection.SyncRoot => this;
 
             /// <internalonly/>
             /// <summary>
             /// Private IList implementation.
             /// </summary>
-            bool IList.IsFixedSize
-            {
-                get
-                {
-                    return true;
-                }
-            }
+            bool IList.IsFixedSize => true;
 
             /// <internalonly/>
             /// <summary>
             /// Private IList implementation.
             /// </summary>
-            bool IList.IsReadOnly
-            {
-                get
-                {
-                    return true;
-                }
-            }
+            bool IList.IsReadOnly => true;
 
             /// <internalonly/>
             /// <summary>
@@ -504,37 +480,13 @@ namespace System.ComponentModel.Design
                     _target = target;
                 }
 
-                public override AttributeCollection Attributes
-                {
-                    get
-                    {
-                        return _property.Attributes;
-                    }
-                }
+                public override AttributeCollection Attributes => _property.Attributes;
 
-                public override Type ComponentType
-                {
-                    get
-                    {
-                        return _property.ComponentType;
-                    }
-                }
+                public override Type ComponentType => _property.ComponentType;
 
-                public override bool IsReadOnly
-                {
-                    get
-                    {
-                        return _property.IsReadOnly;
-                    }
-                }
+                public override bool IsReadOnly => _property.IsReadOnly;
 
-                public override Type PropertyType
-                {
-                    get
-                    {
-                        return _property.PropertyType;
-                    }
-                }
+                public override Type PropertyType => _property.PropertyType;
 
                 public override bool CanResetValue(object component)
                 {
@@ -612,29 +564,11 @@ namespace System.ComponentModel.Design
                     _option = option;
                 }
 
-                public override Type ComponentType
-                {
-                    get
-                    {
-                        return _option.GetType();
-                    }
-                }
+                public override Type ComponentType => _option.GetType();
 
-                public override bool IsReadOnly
-                {
-                    get
-                    {
-                        return true;
-                    }
-                }
+                public override bool IsReadOnly => true;
 
-                public override Type PropertyType
-                {
-                    get
-                    {
-                        return _option.GetType();
-                    }
-                }
+                public override Type PropertyType => _option.GetType();
 
                 public override bool CanResetValue(object component)
                 {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
@@ -18,7 +18,7 @@ namespace System.ComponentModel.Design
     public abstract class DesignerOptionService : IDesignerOptionService
     {
         private DesignerOptionCollection _options;
-
+        private static readonly char[] c_slash = {'\\'};
         /// <summary>
         ///     Returns the options collection for this service.  There is 
         ///     always a global options collection that contains child collections.
@@ -73,7 +73,7 @@ namespace System.ComponentModel.Design
                 throw new ArgumentNullException(nameof(valueName));
             }
 
-            string[] optionNames = pageName.Split(new char[] { '\\' });
+            string[] optionNames = pageName.Split(c_slash);
 
             DesignerOptionCollection options = Options;
             foreach (string optionName in optionNames)

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
@@ -150,8 +150,6 @@ namespace System.ComponentModel.Design
         public sealed class DesignerOptionCollection : IList
         {
             private DesignerOptionService _service;
-            private DesignerOptionCollection _parent;
-            private string _name;
             private object _value;
             private ArrayList _children;
             private PropertyDescriptorCollection _properties;
@@ -162,17 +160,17 @@ namespace System.ComponentModel.Design
             internal DesignerOptionCollection(DesignerOptionService service, DesignerOptionCollection parent, string name, object value)
             {
                 _service = service;
-                _parent = parent;
-                _name = name;
+                Parent = parent;
+                Name = name;
                 _value = value;
 
-                if (_parent != null)
+                if (Parent != null)
                 {
-                    if (_parent._children == null)
+                    if (Parent._children == null)
                     {
-                        _parent._children = new ArrayList(1);
+                        Parent._children = new ArrayList(1);
                     }
-                    _parent._children.Add(this);
+                    Parent._children.Add(this);
                 }
             }
 
@@ -192,24 +190,12 @@ namespace System.ComponentModel.Design
             ///     The name of this collection.  Names are programmatic names and are not 
             ///     localized.  A name search is case insensitive.
             /// </summary>
-            public string Name
-            {
-                get
-                {
-                    return _name;
-                }
-            }
+            public string Name { get; }
 
             /// <summary>
             ///     Returns the parent collection object, or null if there is no parent.
             /// </summary>
-            public DesignerOptionCollection Parent
-            {
-                get
-                {
-                    return _parent;
-                }
-            }
+            public DesignerOptionCollection Parent { get; }
 
             /// <summary>
             ///     The collection of properties that this OptionCollection, along with all of 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
@@ -25,14 +25,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public DesignerOptionCollection Options
         {
-            get
-            {
-                if (_options == null)
-                {
-                    _options = new DesignerOptionCollection(this, null, string.Empty, null);
-                }
-                return _options;
-            }
+            get { return _options ?? (_options = new DesignerOptionCollection(this, null, string.Empty, null)); }
         }
 
         /// <summary>
@@ -119,11 +112,7 @@ namespace System.ComponentModel.Design
         object IDesignerOptionService.GetOptionValue(string pageName, string valueName)
         {
             PropertyDescriptor optionProp = GetOptionProperty(pageName, valueName);
-            if (optionProp != null)
-            {
-                return optionProp.GetValue(null);
-            }
-            return null;
+            return optionProp?.GetValue(null);
         }
 
         /// <internalonly/>
@@ -133,10 +122,7 @@ namespace System.ComponentModel.Design
         void IDesignerOptionService.SetOptionValue(string pageName, string valueName, object value)
         {
             PropertyDescriptor optionProp = GetOptionProperty(pageName, valueName);
-            if (optionProp != null)
-            {
-                optionProp.SetValue(null, value);
-            }
+            optionProp?.SetValue(null, value);
         }
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
@@ -4,11 +4,13 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Security.Permissions;
+using Enumerable = System.Linq.Enumerable;
 
 namespace System.ComponentModel.Design
 {
@@ -198,12 +200,12 @@ namespace System.ComponentModel.Design
                 {
                     if (_properties == null)
                     {
-                        ArrayList propList;
+                        List<PropertyDescriptor> propList;
 
                         if (_value != null)
                         {
                             PropertyDescriptorCollection props = TypeDescriptor.GetProperties(_value);
-                            propList = new ArrayList(props.Count);
+                            propList = new List<PropertyDescriptor>(props.Count);
                             foreach (PropertyDescriptor prop in props)
                             {
                                 propList.Add(new WrappedPropertyDescriptor(prop, _value));
@@ -211,16 +213,16 @@ namespace System.ComponentModel.Design
                         }
                         else
                         {
-                            propList = new ArrayList(1);
+                            propList = new List<PropertyDescriptor>(1);
                         }
 
                         EnsurePopulated();
                         foreach (DesignerOptionCollection child in _children)
                         {
-                            propList.AddRange(child.Properties);
+                            propList.AddRange(Enumerable.Cast<PropertyDescriptor>(child.Properties));
                         }
 
-                        PropertyDescriptor[] propArray = (PropertyDescriptor[])propList.ToArray(typeof(PropertyDescriptor));
+                        PropertyDescriptor[] propArray = propList.ToArray();
                         _properties = new PropertyDescriptorCollection(propArray, true);
                     }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
@@ -20,7 +20,7 @@ namespace System.ComponentModel.Design
     public abstract class DesignerOptionService : IDesignerOptionService
     {
         private DesignerOptionCollection _options;
-        private static readonly char[] c_slash = {'\\'};
+        private static readonly char[] s_slash = {'\\'};
         /// <summary>
         ///     Returns the options collection for this service.  There is 
         ///     always a global options collection that contains child collections.
@@ -75,7 +75,7 @@ namespace System.ComponentModel.Design
                 throw new ArgumentNullException(nameof(valueName));
             }
 
-            string[] optionNames = pageName.Split(c_slash);
+            string[] optionNames = pageName.Split(s_slash);
 
             DesignerOptionCollection options = Options;
             foreach (string optionName in optionNames)
@@ -200,12 +200,12 @@ namespace System.ComponentModel.Design
                 {
                     if (_properties == null)
                     {
-                        List<PropertyDescriptor> propList;
+                        ArrayList propList;
 
                         if (_value != null)
                         {
                             PropertyDescriptorCollection props = TypeDescriptor.GetProperties(_value);
-                            propList = new List<PropertyDescriptor>(props.Count);
+                            propList = new ArrayList(props.Count);
                             foreach (PropertyDescriptor prop in props)
                             {
                                 propList.Add(new WrappedPropertyDescriptor(prop, _value));
@@ -213,16 +213,16 @@ namespace System.ComponentModel.Design
                         }
                         else
                         {
-                            propList = new List<PropertyDescriptor>(1);
+                            propList = new ArrayList(1);
                         }
 
                         EnsurePopulated();
                         foreach (DesignerOptionCollection child in _children)
                         {
-                            propList.AddRange(Enumerable.Cast<PropertyDescriptor>(child.Properties));
+                            propList.AddRange(child.Properties);
                         }
 
-                        PropertyDescriptor[] propArray = propList.ToArray();
+                        PropertyDescriptor[] propArray = (PropertyDescriptor[])propList.ToArray(typeof(PropertyDescriptor));
                         _properties = new PropertyDescriptorCollection(propArray, true);
                     }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerTransaction.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerTransaction.cs
@@ -14,10 +14,7 @@ namespace System.ComponentModel.Design
     /// </summary>
     public abstract class DesignerTransaction : IDisposable
     {
-        private bool _committed = false;
-        private bool _canceled = false;
         private bool _suppressedFinalization = false;
-        private string _desc;
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
@@ -32,51 +29,33 @@ namespace System.ComponentModel.Design
         /// </summary>
         protected DesignerTransaction(string description)
         {
-            _desc = description;
+            Description = description;
         }
 
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        public bool Canceled
-        {
-            get
-            {
-                return _canceled;
-            }
-        }
+        public bool Canceled { get; private set; } = false;
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        public bool Committed
-        {
-            get
-            {
-                return _committed;
-            }
-        }
+        public bool Committed { get; private set; } = false;
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        public string Description
-        {
-            get
-            {
-                return _desc;
-            }
-        }
+        public string Description { get; }
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
         public void Cancel()
         {
-            if (!_canceled && !_committed)
+            if (!Canceled && !Committed)
             {
-                _canceled = true;
+                Canceled = true;
                 GC.SuppressFinalize(this);
                 _suppressedFinalization = true;
                 OnCancel();
@@ -92,9 +71,9 @@ namespace System.ComponentModel.Design
         /// </summary>
         public void Commit()
         {
-            if (!_committed && !_canceled)
+            if (!Committed && !Canceled)
             {
-                _committed = true;
+                Committed = true;
                 GC.SuppressFinalize(this);
                 _suppressedFinalization = true;
                 OnCommit();
@@ -144,7 +123,7 @@ namespace System.ComponentModel.Design
         protected virtual void Dispose(bool disposing)
         {
             System.Diagnostics.Debug.Assert(disposing, "Designer transaction garbage collected, unable to cancel, please Cancel, Close, or Dispose your transaction.");
-            System.Diagnostics.Debug.Assert(disposing || _canceled || _committed, "Disposing DesignerTransaction that has not been comitted or canceled; forcing Cancel");
+            System.Diagnostics.Debug.Assert(disposing || Canceled || Committed, "Disposing DesignerTransaction that has not been comitted or canceled; forcing Cancel");
             Cancel();
         }
     }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerTransaction.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerTransaction.cs
@@ -14,7 +14,7 @@ namespace System.ComponentModel.Design
     /// </summary>
     public abstract class DesignerTransaction : IDisposable
     {
-        private bool _suppressedFinalization = false;
+        private bool _suppressedFinalization;
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
@@ -36,12 +36,12 @@ namespace System.ComponentModel.Design
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        public bool Canceled { get; private set; } = false;
+        public bool Canceled { get; private set; }
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        public bool Committed { get; private set; } = false;
+        public bool Committed { get; private set; }
 
         /// <summary>
         ///    <para>[To be supplied.]</para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerTransactionCloseEvent.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerTransactionCloseEvent.cs
@@ -16,9 +16,6 @@ namespace System.ComponentModel.Design
     /// </summary>
     public class DesignerTransactionCloseEventArgs : EventArgs
     {
-        private bool _commit;
-        private bool _lastTransaction;
-
         /// <summary>
         ///     Creates a new event args.  Commit is true if the transaction is committed.  This
         ///     defaults the LastTransaction property to true.
@@ -34,30 +31,18 @@ namespace System.ComponentModel.Design
         /// </summary>
         public DesignerTransactionCloseEventArgs(bool commit, bool lastTransaction)
         {
-            _commit = commit;
-            _lastTransaction = lastTransaction;
+            TransactionCommitted = commit;
+            LastTransaction = lastTransaction;
         }
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        public bool TransactionCommitted
-        {
-            get
-            {
-                return _commit;
-            }
-        }
+        public bool TransactionCommitted { get; }
 
         /// <summary>
         ///    Returns true if this is the last transaction to close.
         /// </summary>
-        public bool LastTransaction
-        {
-            get
-            {
-                return _lastTransaction;
-            }
-        }
+        public bool LastTransaction { get; }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerVerb.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerVerb.cs
@@ -85,7 +85,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public override string ToString()
         {
-            return Text + " : " + base.ToString();
+            return $"{Text} : {base.ToString()}";
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerVerb.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerVerb.cs
@@ -85,7 +85,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public override string ToString()
         {
-            return $"{Text} : {base.ToString()}";
+            return Text + " : " + base.ToString();
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContext.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContext.cs
@@ -30,13 +30,8 @@ namespace System.ComponentModel.Design
         ///       Gets or sets the license usage mode.
         ///    </para>
         /// </summary>
-        public override LicenseUsageMode UsageMode
-        {
-            get
-            {
-                return LicenseUsageMode.Designtime;
-            }
-        }
+        public override LicenseUsageMode UsageMode => LicenseUsageMode.Designtime;
+
         /// <summary>
         ///    <para>
         ///       Gets a saved license key.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContext.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContext.cs
@@ -170,8 +170,8 @@ namespace System.ComponentModel.Design
 
                 if (licenseFile != null)
                 {
-                    Debug.WriteLineIf(s_runtimeLicenseContextSwitch.TraceVerbose, "licenseFile: " + licenseFile.ToString());
-                    Debug.WriteLineIf(s_runtimeLicenseContextSwitch.TraceVerbose, "opening licenses file over URI " + licenseFile.ToString());
+                    Debug.WriteLineIf(s_runtimeLicenseContextSwitch.TraceVerbose, $"licenseFile: {licenseFile.ToString()}");
+                    Debug.WriteLineIf(s_runtimeLicenseContextSwitch.TraceVerbose, $"opening licenses file over URI {licenseFile.ToString()}");
                     Stream s = OpenRead(licenseFile);
                     if (s != null)
                     {
@@ -182,7 +182,7 @@ namespace System.ComponentModel.Design
                     }
                 }
             }
-            Debug.WriteLineIf(s_runtimeLicenseContextSwitch.TraceVerbose, "returning : " + (string)savedLicenseKeys[type.AssemblyQualifiedName]);
+            Debug.WriteLineIf(s_runtimeLicenseContextSwitch.TraceVerbose, $"returning : {(string)savedLicenseKeys[type.AssemblyQualifiedName]}");
             return (string)savedLicenseKeys[type.AssemblyQualifiedName];
         }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DocumentCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DocumentCollection.cs
@@ -56,25 +56,13 @@ namespace System.ComponentModel.Design
         ///       sets the number
         ///       of documents in the collection.</para>
         /// </summary>
-        public int Count
-        {
-            get
-            {
-                return _designers.Count;
-            }
-        }
+        public int Count => _designers.Count;
 
         /// <summary>
         ///    <para> Gets
         ///       or sets the document at the specified index.</para>
         /// </summary>
-        public virtual IDesignerHost this[int index]
-        {
-            get
-            {
-                return (IDesignerHost)_designers[index];
-            }
-        }
+        public virtual IDesignerHost this[int index] => (IDesignerHost)_designers[index];
 
         /// <summary>
         ///    <para>Creates and retrieves a new enumerator for this collection.</para>
@@ -85,31 +73,13 @@ namespace System.ComponentModel.Design
         }
 
         /// <internalonly/>
-        int ICollection.Count
-        {
-            get
-            {
-                return Count;
-            }
-        }
+        int ICollection.Count => Count;
 
         /// <internalonly/>
-        bool ICollection.IsSynchronized
-        {
-            get
-            {
-                return false;
-            }
-        }
+        bool ICollection.IsSynchronized => false;
 
         /// <internalonly/>
-        object ICollection.SyncRoot
-        {
-            get
-            {
-                return null;
-            }
-        }
+        object ICollection.SyncRoot => null;
 
         /// <internalonly/>
         void ICollection.CopyTo(Array array, int index)

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DocumentEventArgs.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DocumentEventArgs.cs
@@ -16,8 +16,6 @@ namespace System.ComponentModel.Design
     /// </summary>
     public class DesignerEventArgs : EventArgs
     {
-        private readonly IDesignerHost _host;
-
         /// <summary>
         ///    <para>
         ///       Initializes a new instance of the System.ComponentModel.Design.DesignerEventArgs
@@ -26,7 +24,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public DesignerEventArgs(IDesignerHost host)
         {
-            _host = host;
+            Designer = host;
         }
 
         /// <summary>
@@ -35,13 +33,7 @@ namespace System.ComponentModel.Design
         ///       sets the host of the document.
         ///    </para>
         /// </summary>
-        public IDesignerHost Designer
-        {
-            get
-            {
-                return _host;
-            }
-        }
+        public IDesignerHost Designer { get; }
     }
 }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/HelpKeywordAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/HelpKeywordAttribute.cs
@@ -52,8 +52,6 @@ namespace System.ComponentModel.Design
         /// </summary>
         public static readonly HelpKeywordAttribute Default = new HelpKeywordAttribute();
 
-        private string _contextKeyword;
-
         /// <summary>
         /// Default constructor, which creates an attribute with a null HelpKeyword.
         /// </summary>
@@ -70,7 +68,7 @@ namespace System.ComponentModel.Design
             {
                 throw new ArgumentNullException(nameof(keyword));
             }
-            _contextKeyword = keyword;
+            HelpKeyword = keyword;
         }
 
         /// <summary>
@@ -82,19 +80,13 @@ namespace System.ComponentModel.Design
             {
                 throw new ArgumentNullException(nameof(t));
             }
-            _contextKeyword = t.FullName;
+            HelpKeyword = t.FullName;
         }
 
         /// <summary>
         /// Retrieves the HelpKeyword this attribute supplies.
         /// </summary>
-        public string HelpKeyword
-        {
-            get
-            {
-                return _contextKeyword;
-            }
-        }
+        public string HelpKeyword { get; }
 
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/InheritanceAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/InheritanceAttribute.cs
@@ -13,8 +13,6 @@ namespace System.ComponentModel
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event)]
     public sealed class InheritanceAttribute : Attribute
     {
-        private readonly InheritanceLevel _inheritanceLevel;
-
         /// <summary>
         ///    <para>
         ///       Specifies that the component is inherited. This field is
@@ -54,7 +52,7 @@ namespace System.ComponentModel
         /// </summary>
         public InheritanceAttribute()
         {
-            _inheritanceLevel = Default._inheritanceLevel;
+            InheritanceLevel = Default.InheritanceLevel;
         }
 
         /// <summary>
@@ -64,7 +62,7 @@ namespace System.ComponentModel
         /// </summary>
         public InheritanceAttribute(InheritanceLevel inheritanceLevel)
         {
-            _inheritanceLevel = inheritanceLevel;
+            InheritanceLevel = inheritanceLevel;
         }
 
         /// <summary>
@@ -73,13 +71,7 @@ namespace System.ComponentModel
         ///       the current inheritance level stored in this attribute.
         ///    </para>
         /// </summary>
-        public InheritanceLevel InheritanceLevel
-        {
-            get
-            {
-                return _inheritanceLevel;
-            }
-        }
+        public InheritanceLevel InheritanceLevel { get; }
 
         /// <summary>
         ///    <para>
@@ -99,7 +91,7 @@ namespace System.ComponentModel
             }
 
             InheritanceLevel valueLevel = ((InheritanceAttribute)value).InheritanceLevel;
-            return (valueLevel == _inheritanceLevel);
+            return (valueLevel == InheritanceLevel);
         }
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/MenuCommand.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/MenuCommand.cs
@@ -23,7 +23,6 @@ namespace System.ComponentModel.Design
         // Events that we suface or call on
         //
         private EventHandler _execHandler;
-        private EventHandler _statusHandler;
 
         private int _status;
         private IDictionary _properties;
@@ -159,17 +158,8 @@ namespace System.ComponentModel.Design
         ///       Occurs when the menu command changes.
         ///    </para>
         /// </summary>
-        public event EventHandler CommandChanged
-        {
-            add
-            {
-                _statusHandler += value;
-            }
-            remove
-            {
-                _statusHandler -= value;
-            }
-        }
+        public event EventHandler CommandChanged;
+        
 
         /// <summary>
         /// <para>Gets the <see cref='System.ComponentModel.Design.CommandID'/> associated with this menu command.</para>
@@ -224,7 +214,7 @@ namespace System.ComponentModel.Design
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2109:ReviewVisibleEventHandlers")] // Safe: FullTrust LinkDemand to instantiate an object of this class.
         protected virtual void OnCommandChanged(EventArgs e)
         {
-            _statusHandler?.Invoke(this, e);
+            CommandChanged?.Invoke(this, e);
         }
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/MenuCommand.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/MenuCommand.cs
@@ -228,13 +228,7 @@ namespace System.ComponentModel.Design
         ///       Gets the OLE command status code for this menu item.
         ///    </para>
         /// </summary>
-        public virtual int OleStatus
-        {
-            get
-            {
-                return _status;
-            }
-        }
+        public virtual int OleStatus => _status;
 
         /// <summary>
         ///    <para>Provides notification and is called in response to 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/MenuCommand.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/MenuCommand.cs
@@ -119,20 +119,7 @@ namespace System.ComponentModel.Design
 
         /// <summary>
         /// </summary>
-        public virtual IDictionary Properties
-        {
-            get
-            {
-                if (_properties == null)
-                {
-                    _properties = new HybridDictionary();
-                }
-
-                return _properties;
-            }
-        }
-
-
+        public virtual IDictionary Properties => _properties ?? (_properties = new HybridDictionary());
 
 
         /// <summary>
@@ -237,10 +224,7 @@ namespace System.ComponentModel.Design
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2109:ReviewVisibleEventHandlers")] // Safe: FullTrust LinkDemand to instantiate an object of this class.
         protected virtual void OnCommandChanged(EventArgs e)
         {
-            if (_statusHandler != null)
-            {
-                _statusHandler(this, e);
-            }
+            _statusHandler?.Invoke(this, e);
         }
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/MenuCommand.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/MenuCommand.cs
@@ -25,7 +25,6 @@ namespace System.ComponentModel.Design
         private EventHandler _execHandler;
         private EventHandler _statusHandler;
 
-        private CommandID _commandID;
         private int _status;
         private IDictionary _properties;
 
@@ -61,7 +60,7 @@ namespace System.ComponentModel.Design
         public MenuCommand(EventHandler handler, CommandID command)
         {
             _execHandler = handler;
-            _commandID = command;
+            CommandID = command;
             _status = SUPPORTED | ENABLED;
         }
 
@@ -188,13 +187,7 @@ namespace System.ComponentModel.Design
         /// <summary>
         /// <para>Gets the <see cref='System.ComponentModel.Design.CommandID'/> associated with this menu command.</para>
         /// </summary>
-        public virtual CommandID CommandID
-        {
-            get
-            {
-                return _commandID;
-            }
-        }
+        public virtual CommandID CommandID { get; }
 
         /// <summary>
         ///    <para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/PropertyTabAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/PropertyTabAttribute.cs
@@ -137,20 +137,7 @@ namespace System.ComponentModel
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        protected string[] TabClassNames
-        {
-            get
-            {
-                if (_tabClassNames != null)
-                {
-                    return (string[])_tabClassNames.Clone();
-                }
-                else
-                {
-                    return null;
-                }
-            }
-        }
+        protected string[] TabClassNames => (string[]) _tabClassNames?.Clone();
 
         /// <summary>
         /// <para>Gets the scopes of tabs for this System.ComponentModel.Design.PropertyTabAttribute, from System.ComponentModel.Design.PropertyTabScope.</para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/PropertyTabAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/PropertyTabAttribute.cs
@@ -28,8 +28,8 @@ namespace System.ComponentModel
         /// </summary>
         public PropertyTabAttribute()
         {
-            TabScopes = new PropertyTabScope[0];
-            _tabClassNames = new string[0];
+            TabScopes = Array.Empty<PropertyTabScope>();
+            _tabClassNames = Array.Empty<string>();
         }
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/PropertyTabAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/PropertyTabAttribute.cs
@@ -17,7 +17,6 @@ namespace System.ComponentModel
     [AttributeUsage(AttributeTargets.All)]
     public class PropertyTabAttribute : Attribute
     {
-        private PropertyTabScope[] _tabScopes;
         private Type[] _tabClasses;
         private string[] _tabClassNames;
 
@@ -29,7 +28,7 @@ namespace System.ComponentModel
         /// </summary>
         public PropertyTabAttribute()
         {
-            _tabScopes = new PropertyTabScope[0];
+            TabScopes = new PropertyTabScope[0];
             _tabClassNames = new string[0];
         }
 
@@ -66,7 +65,7 @@ namespace System.ComponentModel
             {
                 throw new ArgumentException(SR.Format(SR.PropertyTabAttributeBadPropertyTabScope), nameof(tabScope));
             }
-            _tabScopes = new PropertyTabScope[] { tabScope };
+            TabScopes = new PropertyTabScope[] { tabScope };
         }
 
 
@@ -83,7 +82,7 @@ namespace System.ComponentModel
             {
                 throw new ArgumentException(SR.Format(SR.PropertyTabAttributeBadPropertyTabScope), nameof(tabScope));
             }
-            _tabScopes = new PropertyTabScope[] { tabScope };
+            TabScopes = new PropertyTabScope[] { tabScope };
         }
 
         /// <summary>
@@ -156,13 +155,8 @@ namespace System.ComponentModel
         /// <summary>
         /// <para>Gets the scopes of tabs for this System.ComponentModel.Design.PropertyTabAttribute, from System.ComponentModel.Design.PropertyTabScope.</para>
         /// </summary>
-        public PropertyTabScope[] TabScopes
-        {
-            get
-            {
-                return _tabScopes;
-            }
-        }
+        public PropertyTabScope[] TabScopes { get; private set; }
+
         /// <internalonly/>
         public override bool Equals(object other)
         {
@@ -262,15 +256,15 @@ namespace System.ComponentModel
                         throw new ArgumentException(SR.PropertyTabAttributeBadPropertyTabScope);
                     }
                 }
-                _tabScopes = (PropertyTabScope[])tabScopes.Clone();
+                TabScopes = (PropertyTabScope[])tabScopes.Clone();
             }
             else
             {
-                _tabScopes = new PropertyTabScope[tabClasses.Length];
+                TabScopes = new PropertyTabScope[tabClasses.Length];
 
                 for (int i = 0; i < TabScopes.Length; i++)
                 {
-                    _tabScopes[i] = PropertyTabScope.Component;
+                    TabScopes[i] = PropertyTabScope.Component;
                 }
             }
         }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/DefaultSerializationProviderAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/DefaultSerializationProviderAttribute.cs
@@ -16,8 +16,6 @@ namespace System.ComponentModel.Design.Serialization
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     public sealed class DefaultSerializationProviderAttribute : Attribute
     {
-        private string _providerTypeName;
-
         /// <summary>
         ///     Creates a new DefaultSerializationProviderAttribute
         /// </summary>
@@ -28,7 +26,7 @@ namespace System.ComponentModel.Design.Serialization
                 throw new ArgumentNullException(nameof(providerType));
             }
 
-            _providerTypeName = providerType.AssemblyQualifiedName;
+            ProviderTypeName = providerType.AssemblyQualifiedName;
         }
 
         /// <summary>
@@ -41,19 +39,13 @@ namespace System.ComponentModel.Design.Serialization
                 throw new ArgumentNullException(nameof(providerTypeName));
             }
 
-            _providerTypeName = providerTypeName;
+            ProviderTypeName = providerTypeName;
         }
 
         /// <summary>
         ///     Returns the type name for the default serialization provider.
         /// </summary>
-        public string ProviderTypeName
-        {
-            get
-            {
-                return _providerTypeName;
-            }
-        }
+        public string ProviderTypeName { get; }
     }
 }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/DesignerLoader.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/DesignerLoader.cs
@@ -30,13 +30,7 @@ namespace System.ComponentModel.Design.Serialization
         ///     sinking notifications from the designer often want to ignore them while the desingner is loading
         ///     and only respond to them if they result from user interatcions.
         /// </summary>
-        public virtual bool Loading
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public virtual bool Loading => false;
 
         /// <summary>
         ///     Called by the designer host to begin the loading process.  The designer

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/DesignerSerializerAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/DesignerSerializerAttribute.cs
@@ -13,8 +13,6 @@ namespace System.ComponentModel.Design.Serialization
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true, Inherited = true)]
     public sealed class DesignerSerializerAttribute : Attribute
     {
-        private string _serializerTypeName;
-        private string _serializerBaseTypeName;
         private string _typeId;
 
         /// <summary>
@@ -22,8 +20,8 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         public DesignerSerializerAttribute(Type serializerType, Type baseSerializerType)
         {
-            _serializerTypeName = serializerType.AssemblyQualifiedName;
-            _serializerBaseTypeName = baseSerializerType.AssemblyQualifiedName;
+            SerializerTypeName = serializerType.AssemblyQualifiedName;
+            SerializerBaseTypeName = baseSerializerType.AssemblyQualifiedName;
         }
 
         /// <summary>
@@ -31,8 +29,8 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         public DesignerSerializerAttribute(string serializerTypeName, Type baseSerializerType)
         {
-            _serializerTypeName = serializerTypeName;
-            _serializerBaseTypeName = baseSerializerType.AssemblyQualifiedName;
+            SerializerTypeName = serializerTypeName;
+            SerializerBaseTypeName = baseSerializerType.AssemblyQualifiedName;
         }
 
         /// <summary>
@@ -40,31 +38,19 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         public DesignerSerializerAttribute(string serializerTypeName, string baseSerializerTypeName)
         {
-            _serializerTypeName = serializerTypeName;
-            _serializerBaseTypeName = baseSerializerTypeName;
+            SerializerTypeName = serializerTypeName;
+            SerializerBaseTypeName = baseSerializerTypeName;
         }
 
         /// <summary>
         ///     Retrieves the fully qualified type name of the serializer.
         /// </summary>
-        public string SerializerTypeName
-        {
-            get
-            {
-                return _serializerTypeName;
-            }
-        }
+        public string SerializerTypeName { get; }
 
         /// <summary>
         ///     Retrieves the fully qualified type name of the serializer base type.
         /// </summary>
-        public string SerializerBaseTypeName
-        {
-            get
-            {
-                return _serializerBaseTypeName;
-            }
-        }
+        public string SerializerBaseTypeName { get; }
 
         /// <internalonly/>
         /// <summary>
@@ -82,7 +68,7 @@ namespace System.ComponentModel.Design.Serialization
             {
                 if (_typeId == null)
                 {
-                    string baseType = _serializerBaseTypeName;
+                    string baseType = SerializerBaseTypeName;
                     int comma = baseType.IndexOf(',');
                     if (comma != -1)
                     {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/InstanceDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/InstanceDescriptor.cs
@@ -34,7 +34,7 @@ namespace System.ComponentModel.Design.Serialization
 
             if (arguments == null)
             {
-                Arguments = new object[0];
+                Arguments = Array.Empty<object>();
             }
             else
             {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/InstanceDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/InstanceDescriptor.cs
@@ -17,10 +17,6 @@ namespace System.ComponentModel.Design.Serialization
     /// </summary>
     public sealed class InstanceDescriptor
     {
-        private MemberInfo _member;
-        private ICollection _arguments;
-        private bool _isComplete;
-
         /// <summary>
         ///     Creates a new InstanceDescriptor.
         /// </summary>
@@ -33,18 +29,18 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         public InstanceDescriptor(MemberInfo member, ICollection arguments, bool isComplete)
         {
-            _member = member;
-            _isComplete = isComplete;
+            MemberInfo = member;
+            IsComplete = isComplete;
 
             if (arguments == null)
             {
-                _arguments = new object[0];
+                Arguments = new object[0];
             }
             else
             {
                 object[] args = new object[arguments.Count];
                 arguments.CopyTo(args, 0);
-                _arguments = args;
+                Arguments = args;
             }
 
             if (member is FieldInfo)
@@ -54,7 +50,7 @@ namespace System.ComponentModel.Design.Serialization
                 {
                     throw new ArgumentException(SR.InstanceDescriptorMustBeStatic);
                 }
-                if (_arguments.Count != 0)
+                if (Arguments.Count != 0)
                 {
                     throw new ArgumentException(SR.InstanceDescriptorLengthMismatch);
                 }
@@ -66,7 +62,7 @@ namespace System.ComponentModel.Design.Serialization
                 {
                     throw new ArgumentException(SR.InstanceDescriptorCannotBeStatic);
                 }
-                if (_arguments.Count != ci.GetParameters().Length)
+                if (Arguments.Count != ci.GetParameters().Length)
                 {
                     throw new ArgumentException(SR.InstanceDescriptorLengthMismatch);
                 }
@@ -78,7 +74,7 @@ namespace System.ComponentModel.Design.Serialization
                 {
                     throw new ArgumentException(SR.InstanceDescriptorMustBeStatic);
                 }
-                if (_arguments.Count != mi.GetParameters().Length)
+                if (Arguments.Count != mi.GetParameters().Length)
                 {
                     throw new ArgumentException(SR.InstanceDescriptorLengthMismatch);
                 }
@@ -102,13 +98,7 @@ namespace System.ComponentModel.Design.Serialization
         ///     The collection of arguments that should be passed to
         ///     MemberInfo in order to create an instance.
         /// </summary>
-        public ICollection Arguments
-        {
-            get
-            {
-                return _arguments;
-            }
-        }
+        public ICollection Arguments { get; }
 
         /// <summary>
         ///     Determines if the contents of this instance descriptor completely identify the instance.
@@ -116,25 +106,13 @@ namespace System.ComponentModel.Design.Serialization
         ///     or constructor to represent.  IsComplete can be used to identify these objects and take
         ///     additional steps to further describe their state.
         /// </summary>
-        public bool IsComplete
-        {
-            get
-            {
-                return _isComplete;
-            }
-        }
+        public bool IsComplete { get; }
 
         /// <summary>
         ///     The MemberInfo object that was passed into the constructor
         ///     of this InstanceDescriptor.
         /// </summary>
-        public MemberInfo MemberInfo
-        {
-            get
-            {
-                return _member;
-            }
-        }
+        public MemberInfo MemberInfo { get; }
 
         /// <summary>
         ///     Invokes this instance descriptor, returning the object
@@ -142,8 +120,8 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         public object Invoke()
         {
-            object[] translatedArguments = new object[_arguments.Count];
-            _arguments.CopyTo(translatedArguments, 0);
+            object[] translatedArguments = new object[Arguments.Count];
+            Arguments.CopyTo(translatedArguments, 0);
 
             // Instance descriptors can contain other instance
             // descriptors.  Translate them if necessary.
@@ -156,25 +134,25 @@ namespace System.ComponentModel.Design.Serialization
                 }
             }
 
-            if (_member is ConstructorInfo)
+            if (MemberInfo is ConstructorInfo)
             {
-                return ((ConstructorInfo)_member).Invoke(translatedArguments);
+                return ((ConstructorInfo)MemberInfo).Invoke(translatedArguments);
             }
-            else if (_member is MethodInfo)
+            else if (MemberInfo is MethodInfo)
             {
-                return ((MethodInfo)_member).Invoke(null, translatedArguments);
+                return ((MethodInfo)MemberInfo).Invoke(null, translatedArguments);
             }
-            else if (_member is PropertyInfo)
+            else if (MemberInfo is PropertyInfo)
             {
-                return ((PropertyInfo)_member).GetValue(null, translatedArguments);
+                return ((PropertyInfo)MemberInfo).GetValue(null, translatedArguments);
             }
-            else if (_member is FieldInfo)
+            else if (MemberInfo is FieldInfo)
             {
-                return ((FieldInfo)_member).GetValue(null);
+                return ((FieldInfo)MemberInfo).GetValue(null);
             }
             else
             {
-                Debug.Fail("Unrecognized reflection type in instance descriptor: " + _member.GetType().Name);
+                Debug.Fail("Unrecognized reflection type in instance descriptor: " + MemberInfo.GetType().Name);
             }
 
             return null;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/InstanceDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/InstanceDescriptor.cs
@@ -152,7 +152,7 @@ namespace System.ComponentModel.Design.Serialization
             }
             else
             {
-                Debug.Fail("Unrecognized reflection type in instance descriptor: " + MemberInfo.GetType().Name);
+                Debug.Fail($"Unrecognized reflection type in instance descriptor: {MemberInfo.GetType().Name}");
             }
 
             return null;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/MemberRelationshipService.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/MemberRelationshipService.cs
@@ -182,9 +182,6 @@ namespace System.ComponentModel.Design.Serialization
     /// </summary>
     public struct MemberRelationship
     {
-        private object _owner;
-        private MemberDescriptor _member;
-
         public static readonly MemberRelationship Empty = new MemberRelationship();
 
         /// <summary>
@@ -195,8 +192,8 @@ namespace System.ComponentModel.Design.Serialization
             if (owner == null) throw new ArgumentNullException(nameof(owner));
             if (member == null) throw new ArgumentNullException(nameof(member));
 
-            _owner = owner;
-            _member = member;
+            Owner = owner;
+            Member = member;
         }
 
         /// <summary>
@@ -206,31 +203,19 @@ namespace System.ComponentModel.Design.Serialization
         {
             get
             {
-                return _owner == null;
+                return Owner == null;
             }
         }
 
         /// <summary>
         ///    The member in this relationship.
         /// </summary>
-        public MemberDescriptor Member
-        {
-            get
-            {
-                return _member;
-            }
-        }
+        public MemberDescriptor Member { get; }
 
         /// <summary>
         ///    The object owning the member.
         /// </summary>
-        public object Owner
-        {
-            get
-            {
-                return _owner;
-            }
-        }
+        public object Owner { get; }
 
         /// <summary>
         ///    Infrastructure support to make this a first class struct
@@ -249,8 +234,8 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         public override int GetHashCode()
         {
-            if (_owner == null) return base.GetHashCode();
-            return _owner.GetHashCode() ^ _member.GetHashCode();
+            if (Owner == null) return base.GetHashCode();
+            return Owner.GetHashCode() ^ Member.GetHashCode();
         }
         /// <summary>
         ///    Infrastructure support to make this a first class struct

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/MemberRelationshipService.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/MemberRelationshipService.cs
@@ -199,13 +199,7 @@ namespace System.ComponentModel.Design.Serialization
         /// <summary>
         ///    Returns true if this relationship is empty.
         /// </summary>
-        public bool IsEmpty
-        {
-            get
-            {
-                return Owner == null;
-            }
-        }
+        public bool IsEmpty => Owner == null;
 
         /// <summary>
         ///    The member in this relationship.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/ResolveNameEventArgs.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/ResolveNameEventArgs.cs
@@ -14,43 +14,24 @@ namespace System.ComponentModel.Design.Serialization
     /// </summary>
     public class ResolveNameEventArgs : EventArgs
     {
-        private string _name;
-        private object _value;
-
         /// <summary>
         ///     Creates a new resolve name event args object.
         /// </summary>
         public ResolveNameEventArgs(string name)
         {
-            _name = name;
-            _value = null;
+            Name = name;
+            Value = null;
         }
 
         /// <summary>
         ///     The name of the object that needs to be resolved.
         /// </summary>
-        public string Name
-        {
-            get
-            {
-                return _name;
-            }
-        }
+        public string Name { get; }
 
         /// <summary>
         ///     The object that matches the name.
         /// </summary>
-        public object Value
-        {
-            get
-            {
-                return _value;
-            }
-            set
-            {
-                _value = value;
-            }
-        }
+        public object Value { get; set; }
     }
 }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/RootDesignerSerializerAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/RootDesignerSerializerAttribute.cs
@@ -15,9 +15,6 @@ namespace System.ComponentModel.Design.Serialization
     [Obsolete("This attribute has been deprecated. Use DesignerSerializerAttribute instead.  For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).  http://go.microsoft.com/fwlink/?linkid=14202")]
     public sealed class RootDesignerSerializerAttribute : Attribute
     {
-        private bool _reloadable;
-        private string _serializerTypeName;
-        private string _serializerBaseTypeName;
         private string _typeId;
 
         /// <summary>
@@ -25,9 +22,9 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         public RootDesignerSerializerAttribute(Type serializerType, Type baseSerializerType, bool reloadable)
         {
-            _serializerTypeName = serializerType.AssemblyQualifiedName;
-            _serializerBaseTypeName = baseSerializerType.AssemblyQualifiedName;
-            _reloadable = reloadable;
+            SerializerTypeName = serializerType.AssemblyQualifiedName;
+            SerializerBaseTypeName = baseSerializerType.AssemblyQualifiedName;
+            Reloadable = reloadable;
         }
 
         /// <summary>
@@ -35,9 +32,9 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         public RootDesignerSerializerAttribute(string serializerTypeName, Type baseSerializerType, bool reloadable)
         {
-            _serializerTypeName = serializerTypeName;
-            _serializerBaseTypeName = baseSerializerType.AssemblyQualifiedName;
-            _reloadable = reloadable;
+            SerializerTypeName = serializerTypeName;
+            SerializerBaseTypeName = baseSerializerType.AssemblyQualifiedName;
+            Reloadable = reloadable;
         }
 
         /// <summary>
@@ -45,9 +42,9 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         public RootDesignerSerializerAttribute(string serializerTypeName, string baseSerializerTypeName, bool reloadable)
         {
-            _serializerTypeName = serializerTypeName;
-            _serializerBaseTypeName = baseSerializerTypeName;
-            _reloadable = reloadable;
+            SerializerTypeName = serializerTypeName;
+            SerializerBaseTypeName = baseSerializerTypeName;
+            Reloadable = reloadable;
         }
 
         /// <summary>
@@ -55,35 +52,17 @@ namespace System.ComponentModel.Design.Serialization
         ///     will not automatically perform a reload on behalf of the user.  It will be the user's
         ///     responsibility to reload the document themselves.
         /// </summary>
-        public bool Reloadable
-        {
-            get
-            {
-                return _reloadable;
-            }
-        }
+        public bool Reloadable { get; }
 
         /// <summary>
         ///     Retrieves the fully qualified type name of the serializer.
         /// </summary>
-        public string SerializerTypeName
-        {
-            get
-            {
-                return _serializerTypeName;
-            }
-        }
+        public string SerializerTypeName { get; }
 
         /// <summary>
         ///     Retrieves the fully qualified type name of the serializer base type.
         /// </summary>
-        public string SerializerBaseTypeName
-        {
-            get
-            {
-                return _serializerBaseTypeName;
-            }
-        }
+        public string SerializerBaseTypeName { get; }
 
         /// <internalonly/>
         /// <summary>
@@ -101,7 +80,7 @@ namespace System.ComponentModel.Design.Serialization
             {
                 if (_typeId == null)
                 {
-                    string baseType = _serializerBaseTypeName;
+                    string baseType = SerializerBaseTypeName;
                     int comma = baseType.IndexOf(',');
                     if (comma != -1)
                     {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ServiceObjectContainer.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ServiceObjectContainer.cs
@@ -59,13 +59,7 @@ namespace System.ComponentModel.Design
         ///     types.  You may override this proeprty and return your own types, modifying the default behavior
         ///     of GetService.
         /// </summary>
-        protected virtual Type[] DefaultServices
-        {
-            get
-            {
-                return s_defaultServices;
-            }
-        }
+        protected virtual Type[] DefaultServices => s_defaultServices;
 
         /// <summary>
         ///     Our collection of services.  The service collection is demand

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ServiceObjectContainer.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ServiceObjectContainer.cs
@@ -65,17 +65,7 @@ namespace System.ComponentModel.Design
         ///     Our collection of services.  The service collection is demand
         ///     created here.
         /// </summary>
-        private ServiceCollection<object> Services
-        {
-            get
-            {
-                if (_services == null)
-                {
-                    _services = new ServiceCollection<object>();
-                }
-                return _services;
-            }
-        }
+        private ServiceCollection<object> Services => _services ?? (_services = new ServiceCollection<object>());
 
         /// <summary>
         ///     Adds the given service to the service container.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ServiceObjectContainer.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ServiceObjectContainer.cs
@@ -80,7 +80,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public virtual void AddService(Type serviceType, object serviceInstance, bool promote)
         {
-            Debug.WriteLineIf(s_TRACESERVICE.TraceVerbose, "Adding service (instance) " + serviceType.Name + ".  Promoting: " + promote.ToString());
+            Debug.WriteLineIf(s_TRACESERVICE.TraceVerbose, $"Adding service (instance) {serviceType.Name}.  Promoting: {promote.ToString()}");
             if (promote)
             {
                 IServiceContainer container = Container;
@@ -123,7 +123,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public virtual void AddService(Type serviceType, ServiceCreatorCallback callback, bool promote)
         {
-            Debug.WriteLineIf(s_TRACESERVICE.TraceVerbose, "Adding service (callback) " + serviceType.Name + ".  Promoting: " + promote.ToString());
+            Debug.WriteLineIf(s_TRACESERVICE.TraceVerbose, $"Adding service (callback) {serviceType.Name}.  Promoting: {promote.ToString()}");
             if (promote)
             {
                 IServiceContainer container = Container;
@@ -188,7 +188,7 @@ namespace System.ComponentModel.Design
         {
             object service = null;
 
-            Debug.WriteLineIf(s_TRACESERVICE.TraceVerbose, "Searching for service " + serviceType.Name);
+            Debug.WriteLineIf(s_TRACESERVICE.TraceVerbose, $"Searching for service {serviceType.Name}");
 
             // Try locally.  We first test for services we
             // implement and then look in our service collection.
@@ -214,12 +214,12 @@ namespace System.ComponentModel.Design
             {
                 Debug.WriteLineIf(s_TRACESERVICE.TraceVerbose, "Encountered a callback. Invoking it");
                 service = ((ServiceCreatorCallback)service)(this, serviceType);
-                Debug.WriteLineIf(s_TRACESERVICE.TraceVerbose, "Callback return object: " + (service == null ? "(null)" : service.ToString()));
+                Debug.WriteLineIf(s_TRACESERVICE.TraceVerbose, $"Callback return object: {(service == null ? "(null)" : service.ToString())}");
                 if (service != null && !service.GetType().IsCOMObject && !serviceType.IsAssignableFrom(service.GetType()))
                 {
                     // Callback passed us a bad service.  NULL it, rather than throwing an exception.
                     // Callers here do not need to be prepared to handle bad callback implemetations.
-                    Debug.Fail("Object " + service.GetType().Name + " was returned from a service creator callback but it does not implement the registered type of " + serviceType.Name);
+                    Debug.Fail($"Object {service.GetType().Name} was returned from a service creator callback but it does not implement the registered type of {serviceType.Name}");
                     Debug.WriteLineIf(s_TRACESERVICE.TraceVerbose, "**** Object does not implement service interface");
                     service = null;
                 }
@@ -261,7 +261,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public virtual void RemoveService(Type serviceType, bool promote)
         {
-            Debug.WriteLineIf(s_TRACESERVICE.TraceVerbose, "Removing service: " + serviceType.Name + ", Promote: " + promote.ToString());
+            Debug.WriteLineIf(s_TRACESERVICE.TraceVerbose, $"Removing service: {serviceType.Name}, Promote: {promote.ToString()}");
             if (promote)
             {
                 IServiceContainer container = Container;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ToolboxItemAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ToolboxItemAttribute.cs
@@ -70,7 +70,7 @@ namespace System.ComponentModel
         public ToolboxItemAttribute(string toolboxItemTypeName)
         {
             string temp = toolboxItemTypeName.ToUpper(CultureInfo.InvariantCulture);
-            Debug.Assert(temp.IndexOf(".DLL") == -1, "Came across: " + toolboxItemTypeName + " . Please remove the .dll extension");
+            Debug.Assert(temp.IndexOf(".DLL") == -1, $"Came across: {toolboxItemTypeName}. Please remove the .dll extension");
             _toolboxItemTypeName = toolboxItemTypeName;
         }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DesignTimeVisibleAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DesignTimeVisibleAttribute.cs
@@ -17,15 +17,13 @@ namespace System.ComponentModel
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
     public sealed class DesignTimeVisibleAttribute : Attribute
     {
-        private bool _visible;
-
         /// <summary>
         ///     Creates a new DesignTimeVisibleAttribute with the visible
         ///     property set to the given value.
         /// </summary>
         public DesignTimeVisibleAttribute(bool visible)
         {
-            _visible = visible;
+            Visible = visible;
         }
 
         /// <summary>
@@ -40,13 +38,7 @@ namespace System.ComponentModel
         ///     True if this component should be shown at design time, or false
         ///     if it shouldn't.
         /// </summary>
-        public bool Visible
-        {
-            get
-            {
-                return _visible;
-            }
-        }
+        public bool Visible { get; }
 
         /// <summary>
         ///     Marks a component as visible in a visual designer.
@@ -74,7 +66,7 @@ namespace System.ComponentModel
             }
 
             DesignTimeVisibleAttribute other = obj as DesignTimeVisibleAttribute;
-            return other != null && other.Visible == _visible;
+            return other != null && other.Visible == Visible;
         }
 
         /// <summary>
@@ -82,7 +74,7 @@ namespace System.ComponentModel
         /// </summary>
         public override int GetHashCode()
         {
-            return typeof(DesignTimeVisibleAttribute).GetHashCode() ^ (_visible ? -1 : 0);
+            return typeof(DesignTimeVisibleAttribute).GetHashCode() ^ (Visible ? -1 : 0);
         }
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DesignerAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DesignerAttribute.cs
@@ -28,7 +28,7 @@ namespace System.ComponentModel
         public DesignerAttribute(string designerTypeName)
         {
             string temp = designerTypeName.ToUpper(CultureInfo.InvariantCulture);
-            Debug.Assert(temp.IndexOf(".DLL") == -1, "Came across: " + designerTypeName + " . Please remove the .dll extension");
+            Debug.Assert(temp.IndexOf(".DLL") == -1, $"Came across: {designerTypeName}. Please remove the .dll extension");
             DesignerTypeName = designerTypeName;
             DesignerBaseTypeName = typeof(IDesigner).FullName;
         }
@@ -54,7 +54,7 @@ namespace System.ComponentModel
         public DesignerAttribute(string designerTypeName, string designerBaseTypeName)
         {
             string temp = designerTypeName.ToUpper(CultureInfo.InvariantCulture);
-            Debug.Assert(temp.IndexOf(".DLL") == -1, "Came across: " + designerTypeName + " . Please remove the .dll extension");
+            Debug.Assert(temp.IndexOf(".DLL") == -1, $"Came across: {designerTypeName}. Please remove the .dll extension");
             DesignerTypeName = designerTypeName;
             DesignerBaseTypeName = designerBaseTypeName;
         }
@@ -68,7 +68,7 @@ namespace System.ComponentModel
         public DesignerAttribute(string designerTypeName, Type designerBaseType)
         {
             string temp = designerTypeName.ToUpper(CultureInfo.InvariantCulture);
-            Debug.Assert(temp.IndexOf(".DLL") == -1, "Came across: " + designerTypeName + " . Please remove the .dll extension");
+            Debug.Assert(temp.IndexOf(".DLL") == -1, $"Came across: {designerTypeName}. Please remove the .dll extension");
             DesignerTypeName = designerTypeName;
             DesignerBaseTypeName = designerBaseType.AssemblyQualifiedName;
         }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DesignerAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DesignerAttribute.cs
@@ -17,8 +17,6 @@ namespace System.ComponentModel
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true, Inherited = true)]
     public sealed class DesignerAttribute : Attribute
     {
-        private readonly string _designerTypeName;
-        private readonly string _designerBaseTypeName;
         private string _typeId;
 
         /// <summary>
@@ -31,8 +29,8 @@ namespace System.ComponentModel
         {
             string temp = designerTypeName.ToUpper(CultureInfo.InvariantCulture);
             Debug.Assert(temp.IndexOf(".DLL") == -1, "Came across: " + designerTypeName + " . Please remove the .dll extension");
-            _designerTypeName = designerTypeName;
-            _designerBaseTypeName = typeof(IDesigner).FullName;
+            DesignerTypeName = designerTypeName;
+            DesignerBaseTypeName = typeof(IDesigner).FullName;
         }
 
         /// <summary>
@@ -43,8 +41,8 @@ namespace System.ComponentModel
         /// </summary>
         public DesignerAttribute(Type designerType)
         {
-            _designerTypeName = designerType.AssemblyQualifiedName;
-            _designerBaseTypeName = typeof(IDesigner).FullName;
+            DesignerTypeName = designerType.AssemblyQualifiedName;
+            DesignerBaseTypeName = typeof(IDesigner).FullName;
         }
 
         /// <summary>
@@ -57,8 +55,8 @@ namespace System.ComponentModel
         {
             string temp = designerTypeName.ToUpper(CultureInfo.InvariantCulture);
             Debug.Assert(temp.IndexOf(".DLL") == -1, "Came across: " + designerTypeName + " . Please remove the .dll extension");
-            _designerTypeName = designerTypeName;
-            _designerBaseTypeName = designerBaseTypeName;
+            DesignerTypeName = designerTypeName;
+            DesignerBaseTypeName = designerBaseTypeName;
         }
 
         /// <summary>
@@ -71,8 +69,8 @@ namespace System.ComponentModel
         {
             string temp = designerTypeName.ToUpper(CultureInfo.InvariantCulture);
             Debug.Assert(temp.IndexOf(".DLL") == -1, "Came across: " + designerTypeName + " . Please remove the .dll extension");
-            _designerTypeName = designerTypeName;
-            _designerBaseTypeName = designerBaseType.AssemblyQualifiedName;
+            DesignerTypeName = designerTypeName;
+            DesignerBaseTypeName = designerBaseType.AssemblyQualifiedName;
         }
 
         /// <summary>
@@ -83,8 +81,8 @@ namespace System.ComponentModel
         /// </summary>
         public DesignerAttribute(Type designerType, Type designerBaseType)
         {
-            _designerTypeName = designerType.AssemblyQualifiedName;
-            _designerBaseTypeName = designerBaseType.AssemblyQualifiedName;
+            DesignerTypeName = designerType.AssemblyQualifiedName;
+            DesignerBaseTypeName = designerBaseType.AssemblyQualifiedName;
         }
 
         /// <summary>
@@ -93,26 +91,14 @@ namespace System.ComponentModel
         ///       the name of the base type of this designer.
         ///    </para>
         /// </summary>
-        public string DesignerBaseTypeName
-        {
-            get
-            {
-                return _designerBaseTypeName;
-            }
-        }
+        public string DesignerBaseTypeName { get; }
 
         /// <summary>
         ///    <para>
         ///       Gets the name of the designer type associated with this designer attribute.
         ///    </para>
         /// </summary>
-        public string DesignerTypeName
-        {
-            get
-            {
-                return _designerTypeName;
-            }
-        }
+        public string DesignerTypeName { get; }
 
         /// <internalonly/>
         /// <summary>
@@ -130,7 +116,7 @@ namespace System.ComponentModel
             {
                 if (_typeId == null)
                 {
-                    string baseType = _designerBaseTypeName;
+                    string baseType = DesignerBaseTypeName;
                     int comma = baseType.IndexOf(',');
                     if (comma != -1)
                     {
@@ -151,12 +137,12 @@ namespace System.ComponentModel
 
             DesignerAttribute other = obj as DesignerAttribute;
 
-            return (other != null) && other._designerBaseTypeName == _designerBaseTypeName && other._designerTypeName == _designerTypeName;
+            return (other != null) && other.DesignerBaseTypeName == DesignerBaseTypeName && other.DesignerTypeName == DesignerTypeName;
         }
 
         public override int GetHashCode()
         {
-            return _designerTypeName.GetHashCode() ^ _designerBaseTypeName.GetHashCode();
+            return DesignerTypeName.GetHashCode() ^ DesignerBaseTypeName.GetHashCode();
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DoubleConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DoubleConverter.cs
@@ -21,7 +21,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType => typeof(Double);
+        internal override Type TargetType => typeof(double);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DoubleConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DoubleConverter.cs
@@ -16,24 +16,12 @@ namespace System.ComponentModel
         /// <summary>
         /// Determines whether this editor will attempt to convert hex (0x or #) strings
         /// </summary>
-        internal override bool AllowHex
-        {
-            get
-            {
-                return false;
-            }
-        }
+        internal override bool AllowHex => false;
 
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType
-        {
-            get
-            {
-                return typeof(Double);
-            }
-        }
+        internal override Type TargetType => typeof(Double);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EditorAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EditorAttribute.cs
@@ -33,7 +33,7 @@ namespace System.ComponentModel
         public EditorAttribute(string typeName, string baseTypeName)
         {
             string temp = typeName.ToUpper(CultureInfo.InvariantCulture);
-            Debug.Assert(temp.IndexOf(".DLL") == -1, "Came across: " + typeName + " . Please remove the .dll extension");
+            Debug.Assert(temp.IndexOf(".DLL") == -1, $"Came across: {typeName} . Please remove the .dll extension");
             EditorTypeName = typeName;
             EditorBaseTypeName = baseTypeName;
         }
@@ -44,7 +44,7 @@ namespace System.ComponentModel
         public EditorAttribute(string typeName, Type baseType)
         {
             string temp = typeName.ToUpper(CultureInfo.InvariantCulture);
-            Debug.Assert(temp.IndexOf(".DLL") == -1, "Came across: " + typeName + " . Please remove the .dll extension");
+            Debug.Assert(temp.IndexOf(".DLL") == -1, $"Came across: {typeName} . Please remove the .dll extension");
             EditorTypeName = typeName;
             EditorBaseTypeName = baseType.AssemblyQualifiedName;
         }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EditorAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EditorAttribute.cs
@@ -14,8 +14,6 @@ namespace System.ComponentModel
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = true)]
     public sealed class EditorAttribute : Attribute
     {
-        private string _baseTypeName;
-        private string _typeName;
         private string _typeId;
 
         /// <summary>
@@ -24,8 +22,8 @@ namespace System.ComponentModel
         /// </summary>
         public EditorAttribute()
         {
-            _typeName = string.Empty;
-            _baseTypeName = string.Empty;
+            EditorTypeName = string.Empty;
+            EditorBaseTypeName = string.Empty;
         }
 
         /// <summary>
@@ -36,8 +34,8 @@ namespace System.ComponentModel
         {
             string temp = typeName.ToUpper(CultureInfo.InvariantCulture);
             Debug.Assert(temp.IndexOf(".DLL") == -1, "Came across: " + typeName + " . Please remove the .dll extension");
-            _typeName = typeName;
-            _baseTypeName = baseTypeName;
+            EditorTypeName = typeName;
+            EditorBaseTypeName = baseTypeName;
         }
 
         /// <summary>
@@ -47,8 +45,8 @@ namespace System.ComponentModel
         {
             string temp = typeName.ToUpper(CultureInfo.InvariantCulture);
             Debug.Assert(temp.IndexOf(".DLL") == -1, "Came across: " + typeName + " . Please remove the .dll extension");
-            _typeName = typeName;
-            _baseTypeName = baseType.AssemblyQualifiedName;
+            EditorTypeName = typeName;
+            EditorBaseTypeName = baseType.AssemblyQualifiedName;
         }
 
         /// <summary>
@@ -57,31 +55,19 @@ namespace System.ComponentModel
         /// </summary>
         public EditorAttribute(Type type, Type baseType)
         {
-            _typeName = type.AssemblyQualifiedName;
-            _baseTypeName = baseType.AssemblyQualifiedName;
+            EditorTypeName = type.AssemblyQualifiedName;
+            EditorBaseTypeName = baseType.AssemblyQualifiedName;
         }
 
         /// <summary>
         ///    <para>Gets the name of the base class or interface serving as a lookup key for this editor.</para>
         /// </summary>
-        public string EditorBaseTypeName
-        {
-            get
-            {
-                return _baseTypeName;
-            }
-        }
+        public string EditorBaseTypeName { get; }
 
         /// <summary>
         ///    <para>Gets the name of the editor class.</para>
         /// </summary>
-        public string EditorTypeName
-        {
-            get
-            {
-                return _typeName;
-            }
-        }
+        public string EditorTypeName { get; }
 
         /// <internalonly/>
         /// <summary>
@@ -99,7 +85,7 @@ namespace System.ComponentModel
             {
                 if (_typeId == null)
                 {
-                    string baseType = _baseTypeName;
+                    string baseType = EditorBaseTypeName;
                     int comma = baseType.IndexOf(',');
                     if (comma != -1)
                     {
@@ -120,7 +106,7 @@ namespace System.ComponentModel
 
             EditorAttribute other = obj as EditorAttribute;
 
-            return (other != null) && other._typeName == _typeName && other._baseTypeName == _baseTypeName;
+            return (other != null) && other.EditorTypeName == EditorTypeName && other.EditorBaseTypeName == EditorBaseTypeName;
         }
 
         public override int GetHashCode()

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
@@ -234,11 +234,7 @@ namespace System.ComponentModel
                 // out fields marked Browsable(false). Note that if multiple fields have the same value,
                 // the behavior is undefined, since what we return are just enum values, not names.
 
-                Type reflectType = TypeDescriptor.GetReflectionType(_type);
-                if (reflectType == null)
-                {
-                    reflectType = _type;
-                }
+                Type reflectType = TypeDescriptor.GetReflectionType(_type) ?? _type;
 
                 FieldInfo[] fields = reflectType.GetFields(BindingFlags.Public | BindingFlags.Static);
                 ArrayList objValues = null;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
@@ -16,6 +16,7 @@ namespace System.ComponentModel
     /// </summary>
     public class EnumConverter : TypeConverter
     {
+        private static readonly char[] c_comma = {','};
         /// <summary>
         ///    <para>
         ///       Provides a <see cref='System.ComponentModel.TypeConverter.StandardValuesCollection'/> that specifies the
@@ -115,7 +116,7 @@ namespace System.ComponentModel
                     if (strValue.IndexOf(',') != -1)
                     {
                         long convertedValue = 0;
-                        string[] values = strValue.Split(new char[] { ',' });
+                        string[] values = strValue.Split(c_comma);
                         foreach (string v in values)
                         {
                             convertedValue |= Convert.ToInt64((Enum)Enum.Parse(_type, v, true), culture);

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
@@ -238,11 +238,11 @@ namespace System.ComponentModel
                 Type reflectType = TypeDescriptor.GetReflectionType(_type) ?? _type;
 
                 FieldInfo[] fields = reflectType.GetFields(BindingFlags.Public | BindingFlags.Static);
-                ArrayList objValues = null;
+                List<object> objValues = null;
 
                 if (fields != null && fields.Length > 0)
                 {
-                    objValues = new ArrayList(fields.Length);
+                    objValues = new List<object>(fields.Length);
                 }
 
                 if (objValues != null)
@@ -281,11 +281,11 @@ namespace System.ComponentModel
                     IComparer comparer = Comparer;
                     if (comparer != null)
                     {
-                        objValues.Sort(comparer);
+                        objValues.Sort((IComparer<object>) comparer);
                     }
                 }
 
-                Array arr = (objValues != null) ? objValues.ToArray() : null;
+                Array arr = objValues?.ToArray();
                 _values = new StandardValuesCollection(arr);
             }
             return _values;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
@@ -16,7 +16,7 @@ namespace System.ComponentModel
     /// </summary>
     public class EnumConverter : TypeConverter
     {
-        private static readonly char[] c_comma = {','};
+        private static readonly char[] s_comma = {','};
         /// <summary>
         ///    <para>
         ///       Provides a <see cref='System.ComponentModel.TypeConverter.StandardValuesCollection'/> that specifies the
@@ -116,7 +116,7 @@ namespace System.ComponentModel
                     if (strValue.IndexOf(',') != -1)
                     {
                         long convertedValue = 0;
-                        string[] values = strValue.Split(c_comma);
+                        string[] values = strValue.Split(s_comma);
                         foreach (string v in values)
                         {
                             convertedValue |= Convert.ToInt64((Enum)Enum.Parse(_type, v, true), culture);

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
@@ -48,13 +48,7 @@ namespace System.ComponentModel
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        protected Type EnumType
-        {
-            get
-            {
-                return _type;
-            }
-        }
+        protected Type EnumType => _type;
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
@@ -105,13 +99,7 @@ namespace System.ComponentModel
         ///         be used to sort the values of the enumerator.
         ///     </para>
         /// </summary>
-        protected virtual IComparer Comparer
-        {
-            get
-            {
-                return InvariantComparer.Default;
-            }
-        }
+        protected virtual IComparer Comparer => InvariantComparer.Default;
 
         /// <internalonly/>
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
@@ -16,7 +16,7 @@ namespace System.ComponentModel
     /// </summary>
     public class EnumConverter : TypeConverter
     {
-        private static readonly char[] s_comma = {','};
+        private static readonly char[] s_separators = {','};
         /// <summary>
         ///    <para>
         ///       Provides a <see cref='System.ComponentModel.TypeConverter.StandardValuesCollection'/> that specifies the
@@ -27,29 +27,19 @@ namespace System.ComponentModel
 
         /// <summary>
         ///    <para>
-        ///       Specifies
-        ///       the
-        ///       type of the enumerator this converter is
-        ///       associated with.
-        ///    </para>
-        /// </summary>
-        private readonly Type _type;
-
-        /// <summary>
-        ///    <para>
         ///       Initializes a new instance of the <see cref='System.ComponentModel.EnumConverter'/> class for the given
         ///       type.
         ///    </para>
         /// </summary>
         public EnumConverter(Type type)
         {
-            _type = type;
+            EnumType = type;
         }
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        protected Type EnumType => _type;
+        protected Type EnumType { get; }
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
@@ -116,21 +106,21 @@ namespace System.ComponentModel
                     if (strValue.IndexOf(',') != -1)
                     {
                         long convertedValue = 0;
-                        string[] values = strValue.Split(s_comma);
+                        string[] values = strValue.Split(s_separators);
                         foreach (string v in values)
                         {
-                            convertedValue |= Convert.ToInt64((Enum)Enum.Parse(_type, v, true), culture);
+                            convertedValue |= Convert.ToInt64((Enum)Enum.Parse(EnumType, v, true), culture);
                         }
-                        return Enum.ToObject(_type, convertedValue);
+                        return Enum.ToObject(EnumType, convertedValue);
                     }
                     else
                     {
-                        return Enum.Parse(_type, strValue, true);
+                        return Enum.Parse(EnumType, strValue, true);
                     }
                 }
                 catch (Exception e)
                 {
-                    throw new FormatException(SR.Format(SR.ConvertInvalidPrimitive, (string)value, _type.Name), e);
+                    throw new FormatException(SR.Format(SR.ConvertInvalidPrimitive, (string)value, EnumType.Name), e);
                 }
             }
             else if (value is Enum[])
@@ -140,7 +130,7 @@ namespace System.ComponentModel
                 {
                     finalValue |= Convert.ToInt64(e, culture);
                 }
-                return Enum.ToObject(_type, finalValue);
+                return Enum.ToObject(EnumType, finalValue);
             }
             return base.ConvertFrom(context, culture, value);
         }
@@ -163,21 +153,21 @@ namespace System.ComponentModel
                 // Raise an argument exception if the value isn't defined and if
                 // the enum isn't a flags style.
                 //
-                if (!_type.GetTypeInfo().IsDefined(typeof(FlagsAttribute), false) && !Enum.IsDefined(_type, value))
+                if (!EnumType.GetTypeInfo().IsDefined(typeof(FlagsAttribute), false) && !Enum.IsDefined(EnumType, value))
                 {
-                    throw new ArgumentException(SR.Format(SR.EnumConverterInvalidValue, value.ToString(), _type.Name));
+                    throw new ArgumentException(SR.Format(SR.EnumConverterInvalidValue, value.ToString(), EnumType.Name));
                 }
 
-                return Enum.Format(_type, value, "G");
+                return Enum.Format(EnumType, value, "G");
             }
 
             if (destinationType == typeof(Enum[]) && value != null)
             {
-                if (_type.GetTypeInfo().IsDefined(typeof(FlagsAttribute), false))
+                if (EnumType.GetTypeInfo().IsDefined(typeof(FlagsAttribute), false))
                 {
                     List<Enum> flagValues = new List<Enum>();
 
-                    Array objValues = Enum.GetValues(_type);
+                    Array objValues = Enum.GetValues(EnumType);
                     long[] ulValues = new long[objValues.Length];
                     for (int idx = 0; idx < objValues.Length; idx++)
                     {
@@ -193,7 +183,7 @@ namespace System.ComponentModel
                         {
                             if ((ul != 0 && (ul & longValue) == ul) || ul == longValue)
                             {
-                                flagValues.Add((Enum)Enum.ToObject(_type, ul));
+                                flagValues.Add((Enum)Enum.ToObject(EnumType, ul));
                                 valueFound = true;
                                 longValue &= ~ul;
                                 break;
@@ -208,14 +198,14 @@ namespace System.ComponentModel
 
                     if (!valueFound && longValue != 0)
                     {
-                        flagValues.Add((Enum)Enum.ToObject(_type, longValue));
+                        flagValues.Add((Enum)Enum.ToObject(EnumType, longValue));
                     }
 
                     return flagValues.ToArray();
                 }
                 else
                 {
-                    return new Enum[] { (Enum)Enum.ToObject(_type, value) };
+                    return new Enum[] { (Enum)Enum.ToObject(EnumType, value) };
                 }
             }
 
@@ -235,7 +225,7 @@ namespace System.ComponentModel
                 // out fields marked Browsable(false). Note that if multiple fields have the same value,
                 // the behavior is undefined, since what we return are just enum values, not names.
 
-                Type reflectType = TypeDescriptor.GetReflectionType(_type) ?? _type;
+                Type reflectType = TypeDescriptor.GetReflectionType(EnumType) ?? EnumType;
 
                 FieldInfo[] fields = reflectType.GetFields(BindingFlags.Public | BindingFlags.Static);
                 List<object> objValues = null;
@@ -263,7 +253,7 @@ namespace System.ComponentModel
                             {
                                 if (field.Name != null)
                                 {
-                                    value = Enum.Parse(_type, field.Name);
+                                    value = Enum.Parse(EnumType, field.Name);
                                 }
                             }
                             catch (ArgumentException)
@@ -299,7 +289,7 @@ namespace System.ComponentModel
         /// </summary>
         public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
         {
-            return !_type.GetTypeInfo().IsDefined(typeof(FlagsAttribute), false);
+            return !EnumType.GetTypeInfo().IsDefined(typeof(FlagsAttribute), false);
         }
 
         /// <internalonly/>
@@ -320,7 +310,7 @@ namespace System.ComponentModel
         /// </summary>
         public override bool IsValid(ITypeDescriptorContext context, object value)
         {
-            return Enum.IsDefined(_type, value);
+            return Enum.IsDefined(EnumType, value);
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EventDescriptorCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EventDescriptorCollection.cs
@@ -39,7 +39,6 @@ namespace System.ComponentModel
             if (events == null)
             {
                 _events = Array.Empty<EventDescriptor>();
-                Count = 0;
             }
             else
             {
@@ -368,7 +367,7 @@ namespace System.ComponentModel
 
             if (names != null && names.Length > 0)
             {
-                List<EventDescriptor> eventArrayList = new List<EventDescriptor>(_events);
+                List<EventDescriptor> eventList = new List<EventDescriptor>(_events);
                 int foundCount = 0;
                 int eventCount = _events.Length;
 
@@ -376,7 +375,7 @@ namespace System.ComponentModel
                 {
                     for (int j = 0; j < eventCount; j++)
                     {
-                        EventDescriptor currentEvent = eventArrayList[j];
+                        EventDescriptor currentEvent = eventList[j];
 
                         // Found a matching event.  Here, we add it to our array.  We also
                         // mark it as null in our array list so we don't add it twice later.
@@ -384,7 +383,7 @@ namespace System.ComponentModel
                         if (currentEvent != null && currentEvent.Name.Equals(names[i]))
                         {
                             _events[foundCount++] = currentEvent;
-                            eventArrayList[j] = null;
+                            eventList[j] = null;
                             break;
                         }
                     }
@@ -397,9 +396,9 @@ namespace System.ComponentModel
                 //
                 for (int i = 0; i < eventCount; i++)
                 {
-                    if (eventArrayList[i] != null)
+                    if (eventList[i] != null)
                     {
-                        _events[foundCount++] = eventArrayList[i];
+                        _events[foundCount++] = eventList[i];
                     }
                 }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EventDescriptorCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EventDescriptorCollection.cs
@@ -21,7 +21,6 @@ namespace System.ComponentModel
         private readonly IComparer _comparer;
         private bool _eventsOwned;
         private bool _needSort = false;
-        private int _eventCount;
         private readonly bool _readOnly = false;
 
         /// <summary>
@@ -39,12 +38,12 @@ namespace System.ComponentModel
             if (events == null)
             {
                 _events = Array.Empty<EventDescriptor>();
-                _eventCount = 0;
+                Count = 0;
             }
             else
             {
                 _events = events;
-                _eventCount = events.Length;
+                Count = events.Length;
             }
             _eventsOwned = true;
         }
@@ -67,7 +66,7 @@ namespace System.ComponentModel
             }
             _comparer = comparer;
             _events = events;
-            _eventCount = eventCount;
+            Count = eventCount;
             _needSort = true;
         }
 
@@ -77,13 +76,7 @@ namespace System.ComponentModel
         ///       of event descriptors in the collection.
         ///    </para>
         /// </summary>
-        public int Count
-        {
-            get
-            {
-                return _eventCount;
-            }
-        }
+        public int Count { get; private set; }
 
         /// <summary>
         ///    <para>Gets the event with the specified index 
@@ -93,7 +86,7 @@ namespace System.ComponentModel
         {
             get
             {
-                if (index >= _eventCount)
+                if (index >= Count)
                 {
                     throw new IndexOutOfRangeException();
                 }
@@ -125,9 +118,9 @@ namespace System.ComponentModel
                 throw new NotSupportedException();
             }
 
-            EnsureSize(_eventCount + 1);
-            _events[_eventCount++] = value;
-            return _eventCount - 1;
+            EnsureSize(Count + 1);
+            _events[Count++] = value;
+            return Count - 1;
         }
 
         /// <summary>
@@ -140,7 +133,7 @@ namespace System.ComponentModel
                 throw new NotSupportedException();
             }
 
-            _eventCount = 0;
+            Count = 0;
         }
 
         /// <summary>
@@ -187,7 +180,7 @@ namespace System.ComponentModel
 
             if (_events.Length == 0)
             {
-                _eventCount = 0;
+                Count = 0;
                 _events = new EventDescriptor[sizeNeeded];
                 return;
             }
@@ -196,7 +189,7 @@ namespace System.ComponentModel
 
             int newSize = Math.Max(sizeNeeded, _events.Length * 2);
             EventDescriptor[] newEvents = new EventDescriptor[newSize];
-            Array.Copy(_events, 0, newEvents, 0, _eventCount);
+            Array.Copy(_events, 0, newEvents, 0, Count);
             _events = newEvents;
         }
 
@@ -242,7 +235,7 @@ namespace System.ComponentModel
         /// </summary>
         public int IndexOf(EventDescriptor value)
         {
-            return Array.IndexOf(_events, value, 0, _eventCount);
+            return Array.IndexOf(_events, value, 0, Count);
         }
 
         /// <summary>
@@ -255,13 +248,13 @@ namespace System.ComponentModel
                 throw new NotSupportedException();
             }
 
-            EnsureSize(_eventCount + 1);
-            if (index < _eventCount)
+            EnsureSize(Count + 1);
+            if (index < Count)
             {
-                Array.Copy(_events, index, _events, index + 1, _eventCount - index);
+                Array.Copy(_events, index, _events, index + 1, Count - index);
             }
             _events[index] = value;
-            _eventCount++;
+            Count++;
         }
 
         /// <summary>
@@ -292,12 +285,12 @@ namespace System.ComponentModel
                 throw new NotSupportedException();
             }
 
-            if (index < _eventCount - 1)
+            if (index < Count - 1)
             {
-                Array.Copy(_events, index + 1, _events, index, _eventCount - index - 1);
+                Array.Copy(_events, index + 1, _events, index, Count - index - 1);
             }
-            _events[_eventCount - 1] = null;
-            _eventCount--;
+            _events[Count - 1] = null;
+            Count--;
         }
 
         /// <summary>
@@ -308,13 +301,13 @@ namespace System.ComponentModel
         public IEnumerator GetEnumerator()
         {
             // we can only return an enumerator on the events we actually have...
-            if (_events.Length == _eventCount)
+            if (_events.Length == Count)
             {
                 return _events.GetEnumerator();
             }
             else
             {
-                return new ArraySubsetEnumerator(_events, _eventCount);
+                return new ArraySubsetEnumerator(_events, Count);
             }
         }
 
@@ -326,7 +319,7 @@ namespace System.ComponentModel
         /// </summary>
         public virtual EventDescriptorCollection Sort()
         {
-            return new EventDescriptorCollection(_events, _eventCount, _namedSort, _comparer);
+            return new EventDescriptorCollection(_events, Count, _namedSort, _comparer);
         }
 
 
@@ -338,7 +331,7 @@ namespace System.ComponentModel
         /// </summary>
         public virtual EventDescriptorCollection Sort(string[] names)
         {
-            return new EventDescriptorCollection(_events, _eventCount, names, _comparer);
+            return new EventDescriptorCollection(_events, Count, names, _comparer);
         }
 
         /// <summary>
@@ -349,7 +342,7 @@ namespace System.ComponentModel
         /// </summary>
         public virtual EventDescriptorCollection Sort(string[] names, IComparer comparer)
         {
-            return new EventDescriptorCollection(_events, _eventCount, names, comparer);
+            return new EventDescriptorCollection(_events, Count, names, comparer);
         }
 
         /// <summary>
@@ -360,7 +353,7 @@ namespace System.ComponentModel
         /// </summary>
         public virtual EventDescriptorCollection Sort(IComparer comparer)
         {
-            return new EventDescriptorCollection(_events, _eventCount, _namedSort, comparer);
+            return new EventDescriptorCollection(_events, Count, _namedSort, comparer);
         }
 
         /// <summary>
@@ -481,7 +474,7 @@ namespace System.ComponentModel
                     throw new NotSupportedException();
                 }
 
-                if (index >= _eventCount)
+                if (index >= Count)
                 {
                     throw new IndexOutOfRangeException();
                 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EventDescriptorCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EventDescriptorCollection.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2112:SecuredTypesShouldNotExposeFields", Scope = "type", Target = "System.ComponentModel.EventDescriptorCollection")]
@@ -367,7 +368,7 @@ namespace System.ComponentModel
 
             if (names != null && names.Length > 0)
             {
-                ArrayList eventArrayList = new ArrayList(_events);
+                List<EventDescriptor> eventArrayList = new List<EventDescriptor>(_events);
                 int foundCount = 0;
                 int eventCount = _events.Length;
 
@@ -375,7 +376,7 @@ namespace System.ComponentModel
                 {
                     for (int j = 0; j < eventCount; j++)
                     {
-                        EventDescriptor currentEvent = (EventDescriptor)eventArrayList[j];
+                        EventDescriptor currentEvent = eventArrayList[j];
 
                         // Found a matching event.  Here, we add it to our array.  We also
                         // mark it as null in our array list so we don't add it twice later.
@@ -398,7 +399,7 @@ namespace System.ComponentModel
                 {
                     if (eventArrayList[i] != null)
                     {
-                        _events[foundCount++] = (EventDescriptor)eventArrayList[i];
+                        _events[foundCount++] = eventArrayList[i];
                     }
                 }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EventDescriptorCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EventDescriptorCollection.cs
@@ -100,13 +100,7 @@ namespace System.ComponentModel
         ///       Gets the event with the specified name.
         ///    </para>
         /// </summary>
-        public virtual EventDescriptor this[string name]
-        {
-            get
-            {
-                return Find(name, false);
-            }
-        }
+        public virtual EventDescriptor this[string name] => Find(name, false);
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
@@ -430,30 +424,12 @@ namespace System.ComponentModel
         }
 
         /// <internalonly/>
-        bool ICollection.IsSynchronized
-        {
-            get
-            {
-                return false;
-            }
-        }
+        bool ICollection.IsSynchronized => false;
 
         /// <internalonly/>
-        object ICollection.SyncRoot
-        {
-            get
-            {
-                return null;
-            }
-        }
+        object ICollection.SyncRoot => null;
 
-        int ICollection.Count 
-        {
-            get
-            {
-                return Count;
-            }
-        }
+        int ICollection.Count => Count;
 
         IEnumerator IEnumerable.GetEnumerator()
         {
@@ -524,22 +500,10 @@ namespace System.ComponentModel
         }        
 
         /// <internalonly/>
-        bool IList.IsReadOnly
-        {
-            get
-            {
-                return _readOnly;
-            }
-        }
+        bool IList.IsReadOnly => _readOnly;
 
         /// <internalonly/>
-        bool IList.IsFixedSize
-        {
-            get
-            {
-                return _readOnly;
-            }
-        }
+        bool IList.IsFixedSize => _readOnly;
 
         private class ArraySubsetEnumerator : IEnumerator
         {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EventDescriptorCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EventDescriptorCollection.cs
@@ -20,8 +20,8 @@ namespace System.ComponentModel
         private string[] _namedSort;
         private readonly IComparer _comparer;
         private bool _eventsOwned;
-        private bool _needSort = false;
-        private readonly bool _readOnly = false;
+        private bool _needSort;
+        private readonly bool _readOnly;
 
         /// <summary>
         /// An empty AttributeCollection that can used instead of creating a new one with no items.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtendedPropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtendedPropertyDescriptor.cs
@@ -72,35 +72,17 @@ namespace System.ComponentModel
         /// <summary>
         ///     Retrieves the type of the component this PropertyDescriptor is bound to.
         /// </summary>
-        public override Type ComponentType
-        {
-            get
-            {
-                return _extenderInfo.ComponentType;
-            }
-        }
+        public override Type ComponentType => _extenderInfo.ComponentType;
 
         /// <summary>
         ///     Determines if the property can be written to.
         /// </summary>
-        public override bool IsReadOnly
-        {
-            get
-            {
-                return Attributes[typeof(ReadOnlyAttribute)].Equals(ReadOnlyAttribute.Yes);
-            }
-        }
+        public override bool IsReadOnly => Attributes[typeof(ReadOnlyAttribute)].Equals(ReadOnlyAttribute.Yes);
 
         /// <summary>
         ///     Retrieves the data type of the property.
         /// </summary>
-        public override Type PropertyType
-        {
-            get
-            {
-                return _extenderInfo.ExtenderGetType(_provider);
-            }
-        }
+        public override Type PropertyType => _extenderInfo.ExtenderGetType(_provider);
 
         /// <summary>
         ///     Retrieves the display name of the property.  This is the name that will

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtendedPropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtendedPropertyDescriptor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace System.ComponentModel
@@ -29,7 +30,7 @@ namespace System.ComponentModel
             Debug.Assert(extenderInfo != null, "ExtendedPropertyDescriptor must have extenderInfo");
             Debug.Assert(provider != null, "ExtendedPropertyDescriptor must have provider");
 
-            ArrayList attrList = new ArrayList(AttributeArray);
+            List<Attribute> attrList = new List<Attribute>(AttributeArray);
             attrList.Add(ExtenderProvidedPropertyAttribute.Create(extenderInfo, receiverType, provider));
             if (extenderInfo.IsReadOnly)
             {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtendedPropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtendedPropertyDescriptor.cs
@@ -99,13 +99,10 @@ namespace System.ComponentModel
                 if (displayNameAttr == null || displayNameAttr.IsDefaultAttribute())
                 {
                     ISite site = GetSite(_provider);
-                    if (site != null)
+                    string providerName = site?.Name;
+                    if (providerName != null && providerName.Length > 0)
                     {
-                        string providerName = site.Name;
-                        if (providerName != null && providerName.Length > 0)
-                        {
-                            name = string.Format(SR.MetaExtenderName, name, providerName);
-                        }
+                        name = string.Format(SR.MetaExtenderName, name, providerName);
                     }
                 }
                 return name;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtenderProvidedPropertyAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtenderProvidedPropertyAttribute.cs
@@ -14,19 +14,15 @@ namespace System.ComponentModel
     [AttributeUsage(AttributeTargets.All)]
     public sealed class ExtenderProvidedPropertyAttribute : Attribute
     {
-        private PropertyDescriptor _extenderProperty;
-        private IExtenderProvider _provider;
-        private Type _receiverType;
-
         /// <summary>
         ///     Creates a new ExtenderProvidedPropertyAttribute.
         /// </summary>
         internal static ExtenderProvidedPropertyAttribute Create(PropertyDescriptor extenderProperty, Type receiverType, IExtenderProvider provider)
         {
             ExtenderProvidedPropertyAttribute e = new ExtenderProvidedPropertyAttribute();
-            e._extenderProperty = extenderProperty;
-            e._receiverType = receiverType;
-            e._provider = provider;
+            e.ExtenderProperty = extenderProperty;
+            e.ReceiverType = receiverType;
+            e.Provider = provider;
             return e;
         }
 
@@ -40,35 +36,17 @@ namespace System.ComponentModel
         /// <summary>
         ///     PropertyDescriptor of the property that is being provided.
         /// </summary>
-        public PropertyDescriptor ExtenderProperty
-        {
-            get
-            {
-                return _extenderProperty;
-            }
-        }
+        public PropertyDescriptor ExtenderProperty { get; private set; }
 
         /// <summary>
         ///     Extender provider that is providing the property.
         /// </summary>
-        public IExtenderProvider Provider
-        {
-            get
-            {
-                return _provider;
-            }
-        }
+        public IExtenderProvider Provider { get; private set; }
 
         /// <summary>
         ///     The type of object that can receive these properties.
         /// </summary>
-        public Type ReceiverType
-        {
-            get
-            {
-                return _receiverType;
-            }
-        }
+        public Type ReceiverType { get; private set; }
 
         public override bool Equals(object obj)
         {
@@ -79,7 +57,7 @@ namespace System.ComponentModel
 
             ExtenderProvidedPropertyAttribute other = obj as ExtenderProvidedPropertyAttribute;
 
-            return (other != null) && other._extenderProperty.Equals(_extenderProperty) && other._provider.Equals(_provider) && other._receiverType.Equals(_receiverType);
+            return (other != null) && other.ExtenderProperty.Equals(ExtenderProperty) && other.Provider.Equals(Provider) && other.ReceiverType.Equals(ReceiverType);
         }
 
         public override int GetHashCode()
@@ -89,7 +67,7 @@ namespace System.ComponentModel
 
         public override bool IsDefaultAttribute()
         {
-            return _receiverType == null;
+            return ReceiverType == null;
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/HandledEventArgs.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/HandledEventArgs.cs
@@ -29,7 +29,6 @@ namespace System.ComponentModel
         ///    </para>
         /// </summary>
         public HandledEventArgs(bool defaultHandledValue)
-        : base()
         {
             Handled = defaultHandledValue;
         }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/InstallerTypeAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/InstallerTypeAttribute.cs
@@ -37,13 +37,7 @@ namespace System.ComponentModel
         ///    <para> Gets the
         ///       type of installer associated with this attribute.</para>
         /// </summary>
-        public virtual Type InstallerType
-        {
-            get
-            {
-                return Type.GetType(_typeName);
-            }
-        }
+        public virtual Type InstallerType => Type.GetType(_typeName);
 
         public override bool Equals(object obj)
         {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/InstanceCreationEditor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/InstanceCreationEditor.cs
@@ -22,13 +22,7 @@ namespace System.ComponentModel
     {
         /// <summary>
         /// </summary>
-        public virtual string Text
-        {
-            get
-            {
-                return SR.InstanceCreationEditorDefaultText;
-            }
-        }
+        public virtual string Text => SR.InstanceCreationEditorDefaultText;
 
         /// <summary>
         /// This method is invoked when you user chooses the link displayed by the PropertyGrid for the InstanceCreationEditor.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Int16Converter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Int16Converter.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType => typeof(Int16);
+        internal override Type TargetType => typeof(short);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Int16Converter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Int16Converter.cs
@@ -15,13 +15,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType
-        {
-            get
-            {
-                return typeof(Int16);
-            }
-        }
+        internal override Type TargetType => typeof(Int16);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Int32Converter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Int32Converter.cs
@@ -15,13 +15,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType
-        {
-            get
-            {
-                return typeof(Int32);
-            }
-        }
+        internal override Type TargetType => typeof(Int32);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Int32Converter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Int32Converter.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType => typeof(Int32);
+        internal override Type TargetType => typeof(int);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Int64Converter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Int64Converter.cs
@@ -15,13 +15,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType
-        {
-            get
-            {
-                return typeof(Int64);
-            }
-        }
+        internal override Type TargetType => typeof(Int64);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Int64Converter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Int64Converter.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType => typeof(Int64);
+        internal override Type TargetType => typeof(long);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicFileLicenseProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicFileLicenseProvider.cs
@@ -81,7 +81,7 @@ namespace System.ComponentModel
                     }
 
                     string moduleDir = Path.GetDirectoryName(modulePath);
-                    string licenseFile = $"{moduleDir}\\{type.FullName}.lic";
+                    string licenseFile = moduleDir + "\\" + type.FullName + ".lic";
 
                     Debug.WriteLine($"Looking for license in: {licenseFile}");
                     if (File.Exists(licenseFile))

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicFileLicenseProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicFileLicenseProvider.cs
@@ -81,9 +81,9 @@ namespace System.ComponentModel
                     }
 
                     string moduleDir = Path.GetDirectoryName(modulePath);
-                    string licenseFile = moduleDir + "\\" + type.FullName + ".lic";
+                    string licenseFile = $"{moduleDir}\\{type.FullName}.lic";
 
-                    Debug.WriteLine("Looking for license in: " + licenseFile);
+                    Debug.WriteLine($"Looking for license in: {licenseFile}");
                     if (File.Exists(licenseFile))
                     {
                         Stream licStream = new FileStream(licenseFile, FileMode.Open, FileAccess.Read, FileShare.Read);

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicFileLicenseProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicFileLicenseProvider.cs
@@ -108,20 +108,14 @@ namespace System.ComponentModel
         private class LicFileLicense : License
         {
             private LicFileLicenseProvider _owner;
-            private string _key;
 
             public LicFileLicense(LicFileLicenseProvider owner, string key)
             {
                 _owner = owner;
-                _key = key;
+                LicenseKey = key;
             }
-            public override string LicenseKey
-            {
-                get
-                {
-                    return _key;
-                }
-            }
+            public override string LicenseKey { get; }
+
             public override void Dispose()
             {
                 GC.SuppressFinalize(this);

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseContext.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseContext.cs
@@ -18,13 +18,7 @@ namespace System.ComponentModel
         /// <summary>
         ///    <para>When overridden in a derived class, gets a value that specifies when a license can be used.</para>
         /// </summary>
-        public virtual LicenseUsageMode UsageMode
-        {
-            get
-            {
-                return LicenseUsageMode.Runtime;
-            }
-        }
+        public virtual LicenseUsageMode UsageMode => LicenseUsageMode.Runtime;
 
         /// <summary>
         ///    <para>When overridden in a derived class, gets a saved license 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseException.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseException.cs
@@ -17,7 +17,6 @@ namespace System.ComponentModel
     [Serializable]
     public class LicenseException : SystemException
     {
-        private Type _type;
         private object _instance;
 
         /// <summary>
@@ -40,7 +39,7 @@ namespace System.ComponentModel
         /// </summary>
         public LicenseException(Type type, object instance, string message) : base(message)
         {
-            _type = type;
+            LicensedType = type;
             _instance = instance;
             HResult = HResults.License;
         }
@@ -50,7 +49,7 @@ namespace System.ComponentModel
         /// </summary>
         public LicenseException(Type type, object instance, string message, Exception innerException) : base(message, innerException)
         {
-            _type = type;
+            LicensedType = type;
             _instance = instance;
             HResult = HResults.License;
         }
@@ -60,20 +59,14 @@ namespace System.ComponentModel
         /// </summary>
         protected LicenseException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
-            _type = (Type)info.GetValue("type", typeof(Type));
+            LicensedType = (Type)info.GetValue("type", typeof(Type));
             _instance = info.GetValue("instance", typeof(object));
         }
 
         /// <summary>
         ///    <para>Gets the type of the component that was not granted a license.</para>
         /// </summary>
-        public Type LicensedType
-        {
-            get
-            {
-                return _type;
-            }
-        }
+        public Type LicensedType { get; }
 
         /// <summary>
         ///     Need this since Exception implements ISerializable and we have fields to save out.
@@ -86,7 +79,7 @@ namespace System.ComponentModel
                 throw new ArgumentNullException(nameof(info));
             }
 
-            info.AddValue("type", _type);
+            info.AddValue("type", LicensedType);
             info.AddValue("instance", _instance);
 
             base.GetObjectData(info, context);

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseManager.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseManager.cs
@@ -26,7 +26,7 @@ namespace System.ComponentModel
         private static object s_contextLockHolder;
         private static volatile Hashtable s_providers;
         private static volatile Hashtable s_providerInstances;
-        private static object s_internalSyncObject = new object();
+        private static  readonly object s_internalSyncObject = new object();
 
         // not creatable...
         //

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseManager.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseManager.cs
@@ -118,7 +118,7 @@ namespace System.ComponentModel
         /// </summary>
         public static object CreateWithContext(Type type, LicenseContext creationContext)
         {
-            return CreateWithContext(type, creationContext, new object[0]);
+            return CreateWithContext(type, creationContext, Array.Empty<object>());
         }
 
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseManager.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseManager.cs
@@ -178,11 +178,7 @@ namespace System.ComponentModel
         /// </summary>
         private static LicenseProvider GetCachedProvider(Type type)
         {
-            if (s_providers != null)
-            {
-                return (LicenseProvider)s_providers[type];
-            }
-            return null;
+            return (LicenseProvider) s_providers?[type];
         }
 
 
@@ -193,11 +189,7 @@ namespace System.ComponentModel
         private static LicenseProvider GetCachedProviderInstance(Type providerType)
         {
             Debug.Assert(providerType != null, "Type cannot ever be null");
-            if (s_providerInstances != null)
-            {
-                return (LicenseProvider)s_providerInstances[providerType];
-            }
-            return null;
+            return (LicenseProvider) s_providerInstances?[providerType];
         }
 
         /// <summary>
@@ -308,12 +300,8 @@ namespace System.ComponentModel
                 if (attr != null)
                 {
                     Type providerType = attr.LicenseProvider;
-                    provider = GetCachedProviderInstance(providerType);
-
-                    if (provider == null)
-                    {
-                        provider = (LicenseProvider)SecurityUtils.SecureCreateInstance(providerType);
-                    }
+                    provider = GetCachedProviderInstance(providerType) ??
+                               (LicenseProvider)SecurityUtils.SecureCreateInstance(providerType);
                 }
 
                 CacheProvider(type, provider);

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseManager.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseManager.cs
@@ -600,23 +600,16 @@ namespace System.ComponentModel
             // of a single Type.
             internal class CLRLicenseContext : LicenseContext
             {
-                private LicenseUsageMode _usageMode;
                 private Type _type;
                 private string _key;
 
                 public CLRLicenseContext(LicenseUsageMode usageMode, Type type)
                 {
-                    _usageMode = usageMode;
+                    UsageMode = usageMode;
                     _type = type;
                 }
 
-                public override LicenseUsageMode UsageMode
-                {
-                    get
-                    {
-                        return _usageMode;
-                    }
-                }
+                public override LicenseUsageMode UsageMode { get; }
 
 
                 public override string GetSavedLicenseKey(Type type, Assembly resourceAssembly)

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseManager.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseManager.cs
@@ -22,8 +22,8 @@ namespace System.ComponentModel
     {
         private static readonly object s_selfLock = new object();
 
-        private static volatile LicenseContext s_context = null;
-        private static object s_contextLockHolder = null;
+        private static volatile LicenseContext s_context;
+        private static object s_contextLockHolder;
         private static volatile Hashtable s_providers;
         private static volatile Hashtable s_providerInstances;
         private static object s_internalSyncObject = new object();

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseProviderAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseProviderAttribute.cs
@@ -21,8 +21,8 @@ namespace System.ComponentModel
         /// </summary>
         public static readonly LicenseProviderAttribute Default = new LicenseProviderAttribute();
 
-        private Type _licenseProviderType = null;
-        private string _licenseProviderName = null;
+        private Type _licenseProviderType;
+        private string _licenseProviderName;
 
         /// <summary>
         /// <para>Initializes a new instance of the <see cref='System.ComponentModel.LicenseProviderAttribute'/> class without a license

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ListBindableAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ListBindableAttribute.cs
@@ -30,7 +30,6 @@ namespace System.ComponentModel
         /// </summary>
         public static readonly ListBindableAttribute Default = Yes;
 
-        private bool _listBindable = false;
         private bool _isDefault = false;
 
         /// <summary>
@@ -38,7 +37,7 @@ namespace System.ComponentModel
         /// </summary>
         public ListBindableAttribute(bool listBindable)
         {
-            _listBindable = listBindable;
+            ListBindable = listBindable;
         }
 
         /// <summary>
@@ -46,20 +45,14 @@ namespace System.ComponentModel
         /// </summary>
         public ListBindableAttribute(BindableSupport flags)
         {
-            _listBindable = (flags != BindableSupport.No);
+            ListBindable = (flags != BindableSupport.No);
             _isDefault = (flags == BindableSupport.Default);
         }
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        public bool ListBindable
-        {
-            get
-            {
-                return _listBindable;
-            }
-        }
+        public bool ListBindable { get; } = false;
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
@@ -72,7 +65,7 @@ namespace System.ComponentModel
             }
 
             ListBindableAttribute other = obj as ListBindableAttribute;
-            return other != null && other.ListBindable == _listBindable;
+            return other != null && other.ListBindable == ListBindable;
         }
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ListBindableAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ListBindableAttribute.cs
@@ -30,7 +30,7 @@ namespace System.ComponentModel
         /// </summary>
         public static readonly ListBindableAttribute Default = Yes;
 
-        private bool _isDefault = false;
+        private bool _isDefault;
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
@@ -52,7 +52,7 @@ namespace System.ComponentModel
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        public bool ListBindable { get; } = false;
+        public bool ListBindable { get; }
 
         /// <summary>
         ///    <para>[To be supplied.]</para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ListChangedEventArgs.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ListChangedEventArgs.cs
@@ -16,11 +16,6 @@ namespace System.ComponentModel
     /// </summary>
     public class ListChangedEventArgs : EventArgs
     {
-        private ListChangedType _listChangedType;
-        private int _newIndex;
-        private int _oldIndex;
-        private PropertyDescriptor _propDesc;
-
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
@@ -33,8 +28,8 @@ namespace System.ComponentModel
         /// </summary>
         public ListChangedEventArgs(ListChangedType listChangedType, int newIndex, PropertyDescriptor propDesc) : this(listChangedType, newIndex)
         {
-            _propDesc = propDesc;
-            _oldIndex = newIndex;
+            PropertyDescriptor = propDesc;
+            OldIndex = newIndex;
         }
 
         /// <summary>
@@ -47,8 +42,8 @@ namespace System.ComponentModel
             Debug.Assert(listChangedType != ListChangedType.ItemDeleted, "this constructor is used only for changes in the list MetaData");
             Debug.Assert(listChangedType != ListChangedType.ItemChanged, "this constructor is used only for changes in the list MetaData");
 
-            _listChangedType = listChangedType;
-            _propDesc = propDesc;
+            ListChangedType = listChangedType;
+            PropertyDescriptor = propDesc;
         }
 
         /// <summary>
@@ -59,54 +54,30 @@ namespace System.ComponentModel
             Debug.Assert(listChangedType != ListChangedType.PropertyDescriptorAdded, "this constructor is used only for item changed in the list");
             Debug.Assert(listChangedType != ListChangedType.PropertyDescriptorDeleted, "this constructor is used only for item changed in the list");
             Debug.Assert(listChangedType != ListChangedType.PropertyDescriptorChanged, "this constructor is used only for item changed in the list");
-            _listChangedType = listChangedType;
-            _newIndex = newIndex;
-            _oldIndex = oldIndex;
+            ListChangedType = listChangedType;
+            NewIndex = newIndex;
+            OldIndex = oldIndex;
         }
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        public ListChangedType ListChangedType
-        {
-            get
-            {
-                return _listChangedType;
-            }
-        }
+        public ListChangedType ListChangedType { get; }
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        public int NewIndex
-        {
-            get
-            {
-                return _newIndex;
-            }
-        }
+        public int NewIndex { get; }
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        public int OldIndex
-        {
-            get
-            {
-                return _oldIndex;
-            }
-        }
+        public int OldIndex { get; }
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        public PropertyDescriptor PropertyDescriptor
-        {
-            get
-            {
-                return _propDesc;
-            }
-        }
+        public PropertyDescriptor PropertyDescriptor { get; }
     }
 }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ListSortDescription.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ListSortDescription.cs
@@ -12,45 +12,23 @@ namespace System.ComponentModel
     /// </summary>
     public class ListSortDescription
     {
-        private PropertyDescriptor _property;
-        private ListSortDirection _sortDirection;
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
         public ListSortDescription(PropertyDescriptor property, ListSortDirection direction)
         {
-            _property = property;
-            _sortDirection = direction;
+            PropertyDescriptor = property;
+            SortDirection = direction;
         }
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        public PropertyDescriptor PropertyDescriptor
-        {
-            get
-            {
-                return _property;
-            }
-            set
-            {
-                _property = value;
-            }
-        }
+        public PropertyDescriptor PropertyDescriptor { get; set; }
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        public ListSortDirection SortDirection
-        {
-            get
-            {
-                return _sortDirection;
-            }
-            set
-            {
-                _sortDirection = value;
-            }
-        }
+        public ListSortDirection SortDirection { get; set; }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ListSortDescriptionCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ListSortDescriptionCollection.cs
@@ -56,24 +56,12 @@ namespace System.ComponentModel
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        bool IList.IsFixedSize
-        {
-            get
-            {
-                return true;
-            }
-        }
+        bool IList.IsFixedSize => true;
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        bool IList.IsReadOnly
-        {
-            get
-            {
-                return true;
-            }
-        }
+        bool IList.IsReadOnly => true;
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
@@ -152,36 +140,17 @@ namespace System.ComponentModel
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        public int Count
-        {
-            get
-            {
-                return _sorts.Count;
-            }
-        }
+        public int Count => _sorts.Count;
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        bool ICollection.IsSynchronized
-        {
-            get
-            {
-                // true because after the constructor finished running the ListSortDescriptionCollection is Read Only
-                return true;
-            }
-        }
+        bool ICollection.IsSynchronized => true;
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
         /// </summary>
-        object ICollection.SyncRoot
-        {
-            get
-            {
-                return this;
-            }
-        }
+        object ICollection.SyncRoot => this;
 
         /// <summary>
         ///    <para>[To be supplied.]</para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LookupBindingPropertiesAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LookupBindingPropertiesAttribute.cs
@@ -15,11 +15,6 @@ namespace System.ComponentModel
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class LookupBindingPropertiesAttribute : Attribute
     {
-        private readonly string _dataSource;
-        private readonly string _displayMember;
-        private readonly string _valueMember;
-        private readonly string _lookupMember;
-
         /// <summary>
         ///    <para>
         ///       Initializes a new instance of
@@ -28,10 +23,10 @@ namespace System.ComponentModel
         /// </summary>
         public LookupBindingPropertiesAttribute()
         {
-            _dataSource = null;
-            _displayMember = null;
-            _valueMember = null;
-            _lookupMember = null;
+            DataSource = null;
+            DisplayMember = null;
+            ValueMember = null;
+            LookupMember = null;
         }
 
         /// <summary>
@@ -42,10 +37,10 @@ namespace System.ComponentModel
         /// </summary>
         public LookupBindingPropertiesAttribute(string dataSource, string displayMember, string valueMember, string lookupMember)
         {
-            _dataSource = dataSource;
-            _displayMember = displayMember;
-            _valueMember = valueMember;
-            _lookupMember = lookupMember;
+            DataSource = dataSource;
+            DisplayMember = displayMember;
+            ValueMember = valueMember;
+            LookupMember = lookupMember;
         }
 
         /// <summary>
@@ -54,13 +49,7 @@ namespace System.ComponentModel
         ///       bound to.
         ///    </para>
         /// </summary>
-        public string DataSource
-        {
-            get
-            {
-                return _dataSource;
-            }
-        }
+        public string DataSource { get; }
 
         /// <summary>
         ///    <para>
@@ -68,13 +57,7 @@ namespace System.ComponentModel
         ///       bound to.
         ///    </para>
         /// </summary>
-        public string DisplayMember
-        {
-            get
-            {
-                return _displayMember;
-            }
-        }
+        public string DisplayMember { get; }
 
         /// <summary>
         ///    <para>
@@ -82,13 +65,7 @@ namespace System.ComponentModel
         ///       bound to.
         ///    </para>
         /// </summary>
-        public string ValueMember
-        {
-            get
-            {
-                return _valueMember;
-            }
-        }
+        public string ValueMember { get; }
 
         /// <summary>
         ///    <para>
@@ -96,13 +73,7 @@ namespace System.ComponentModel
         ///       bound to.
         ///    </para>
         /// </summary>
-        public string LookupMember
-        {
-            get
-            {
-                return _lookupMember;
-            }
-        }
+        public string LookupMember { get; }
 
         /// <summary>
         ///    <para>
@@ -116,10 +87,10 @@ namespace System.ComponentModel
         {
             LookupBindingPropertiesAttribute other = obj as LookupBindingPropertiesAttribute;
             return other != null &&
-                   other.DataSource == _dataSource &&
-                   other._displayMember == _displayMember &&
-                   other._valueMember == _valueMember &&
-                   other._lookupMember == _lookupMember;
+                   other.DataSource == DataSource &&
+                   other.DisplayMember == DisplayMember &&
+                   other.ValueMember == ValueMember &&
+                   other.LookupMember == LookupMember;
         }
 
         public override int GetHashCode()

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MarshalByValueComponent.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MarshalByValueComponent.cs
@@ -59,17 +59,7 @@ namespace System.ComponentModel
         /// <summary>
         ///    <para>Gets the list of event handlers that are attached to this component.</para>
         /// </summary>
-        protected EventHandlerList Events
-        {
-            get
-            {
-                if (_events == null)
-                {
-                    _events = new EventHandlerList();
-                }
-                return _events;
-            }
-        }
+        protected EventHandlerList Events => _events ?? (_events = new EventHandlerList());
 
         /// <summary>
         ///    <para>Gets or sets the site of the component.</para>
@@ -154,15 +144,8 @@ namespace System.ComponentModel
             {
                 lock (this)
                 {
-                    if (_site != null && _site.Container != null)
-                    {
-                        _site.Container.Remove(this);
-                    }
-                    if (_events != null)
-                    {
-                        EventHandler handler = (EventHandler)_events[s_eventDisposed];
-                        if (handler != null) handler(this, EventArgs.Empty);
-                    }
+                    _site?.Container?.Remove(this);
+                    ((EventHandler) _events?[s_eventDisposed])?.Invoke(this, EventArgs.Empty);
                 }
             }
         }
@@ -171,21 +154,14 @@ namespace System.ComponentModel
         ///    <para>Gets the container for the component.</para>
         /// </summary>
         [Browsable(false), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public virtual IContainer Container
-        {
-            get
-            {
-                ISite s = _site;
-                return s == null ? null : s.Container;
-            }
-        }
+        public virtual IContainer Container => _site?.Container;
 
         /// <summary>
         /// <para>Gets the implementer of the <see cref='System.IServiceProvider'/>.</para>
         /// </summary>
         public virtual object GetService(Type service)
         {
-            return ((_site == null) ? null : _site.GetService(service));
+            return _site?.GetService(service);
         }
 
 
@@ -198,7 +174,7 @@ namespace System.ComponentModel
             get
             {
                 ISite s = _site;
-                return (s == null) ? false : s.DesignMode;
+                return s?.DesignMode ?? false;
             }
         }
         /// <internalonly/>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MarshalByValueComponent.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MarshalByValueComponent.cs
@@ -190,7 +190,7 @@ namespace System.ComponentModel
             ISite s = _site;
 
             if (s != null)
-                return s.Name + " [" + GetType().FullName + "]";
+                return s.Name + $" [{GetType().FullName}]";
             else
                 return GetType().FullName;
         }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MarshalByValueComponent.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MarshalByValueComponent.cs
@@ -190,7 +190,7 @@ namespace System.ComponentModel
             ISite s = _site;
 
             if (s != null)
-                return s.Name + $" [{GetType().FullName}]";
+                return s.Name + " [" + GetType().FullName + "]";
             else
                 return GetType().FullName;
         }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
@@ -133,13 +133,11 @@ namespace System.ComponentModel
         private BitVector32 _flagState;
 
         // Used to obtained localized placeholder chars (date separator for instance).
-        private CultureInfo _culture;
 
         // the formatted string.
         private StringBuilder _testString;
 
         // the number of assigned edit chars.
-        private int _assignedCharCount;
 
         // the number of assigned required edit chars.
         private int _requiredCharCount;
@@ -151,7 +149,6 @@ namespace System.ComponentModel
         private int _optionalEditChars;
 
         // Properties backend fields (see corresponding property for info).
-        private string _mask;
         private char _passwordChar;
         private char _promptChar;
 
@@ -253,7 +250,7 @@ namespace System.ComponentModel
 
             // read only property-backend fields.
 
-            _mask = mask;
+            Mask = mask;
             _promptChar = promptChar;
             _passwordChar = passwordChar;
 
@@ -265,25 +262,25 @@ namespace System.ComponentModel
                 {
                     if (culture.Equals(tempCulture.Parent))
                     {
-                        _culture = tempCulture;
+                        Culture = tempCulture;
                         break;
                     }
                 }
 
                 // Last resort use invariant culture.
-                if (_culture == null)
+                if (Culture == null)
                 {
-                    _culture = CultureInfo.InvariantCulture;
+                    Culture = CultureInfo.InvariantCulture;
                 }
             }
             else
             {
-                _culture = culture;
+                Culture = culture;
             }
 
-            if (!_culture.IsReadOnly)
+            if (!Culture.IsReadOnly)
             {
-                _culture = CultureInfo.ReadOnly(_culture);
+                Culture = CultureInfo.ReadOnly(Culture);
             }
 
             _flagState[s_ALLOW_PROMPT_AS_INPUT] = allowPromptAsInput;
@@ -322,9 +319,9 @@ namespace System.ComponentModel
             // Traverse the mask to generate the test string and the string descriptor table so we don't have
             // to traverse those strings anymore.
             //
-            for (int maskPos = 0; maskPos < _mask.Length; maskPos++)
+            for (int maskPos = 0; maskPos < Mask.Length; maskPos++)
             {
-                ch = _mask[maskPos];
+                ch = Mask[maskPos];
                 if (!escapedChar)   // if false treat the char as literal.
                 {
                     switch (ch)
@@ -334,27 +331,27 @@ namespace System.ComponentModel
                         // set the corresponding localized char to be added to the test string.
                         //
                         case '.':   // decimal separator.
-                            locSymbol = _culture.NumberFormat.NumberDecimalSeparator;
+                            locSymbol = Culture.NumberFormat.NumberDecimalSeparator;
                             charType = CharType.Separator;
                             break;
 
                         case ',':   // thousands separator.
-                            locSymbol = _culture.NumberFormat.NumberGroupSeparator;
+                            locSymbol = Culture.NumberFormat.NumberGroupSeparator;
                             charType = CharType.Separator;
                             break;
 
                         case ':':   // time separator.
-                            locSymbol = _culture.DateTimeFormat.TimeSeparator;
+                            locSymbol = Culture.DateTimeFormat.TimeSeparator;
                             charType = CharType.Separator;
                             break;
 
                         case '/':   // date separator.
-                            locSymbol = _culture.DateTimeFormat.DateSeparator;
+                            locSymbol = Culture.DateTimeFormat.DateSeparator;
                             charType = CharType.Separator;
                             break;
 
                         case '$':   // currency symbol.
-                            locSymbol = _culture.NumberFormat.CurrencySymbol;
+                            locSymbol = Culture.NumberFormat.CurrencySymbol;
                             charType = CharType.Separator;
                             break;
 
@@ -466,13 +463,7 @@ namespace System.ComponentModel
         /// <summary>
         ///     Retreives the number of editable characters that have been set.
         /// </summary>
-        public int AssignedEditPositionCount
-        {
-            get
-            {
-                return _assignedCharCount;
-            }
-        }
+        public int AssignedEditPositionCount { get; private set; }
 
         /// <summary>
         ///     Retreives the number of editable characters that have been set.
@@ -481,7 +472,7 @@ namespace System.ComponentModel
         {
             get
             {
-                return EditPositionCount - _assignedCharCount;
+                return EditPositionCount - AssignedEditPositionCount;
             }
         }
 
@@ -548,13 +539,7 @@ namespace System.ComponentModel
         /// <summary>
         ///     The culture that determines the value of the localizable mask language separators and placeholders.
         /// </summary>
-        public CultureInfo Culture
-        {
-            get
-            {
-                return _culture;
-            }
-        }
+        public CultureInfo Culture { get; }
 
         /// <summary>
         ///       The system password char.
@@ -702,13 +687,7 @@ namespace System.ComponentModel
         /// <summary>
         ///     The mask to be applied to the test string.
         /// </summary>
-        public string Mask
-        {
-            get
-            {
-                return _mask;
-            }
-        }
+        public string Mask { get; }
 
         /// <summary>
         ///     Specifies whether all required inputs have been provided into the mask successfully.
@@ -717,7 +696,7 @@ namespace System.ComponentModel
         {
             get
             {
-                Debug.Assert(_assignedCharCount >= 0, "Invalid count of assigned chars.");
+                Debug.Assert(AssignedEditPositionCount >= 0, "Invalid count of assigned chars.");
                 return _requiredCharCount == _requiredEditChars;
             }
         }
@@ -729,8 +708,8 @@ namespace System.ComponentModel
         {
             get
             {
-                Debug.Assert(_assignedCharCount >= 0, "Invalid count of assigned chars.");
-                return _assignedCharCount == EditPositionCount;
+                Debug.Assert(AssignedEditPositionCount >= 0, "Invalid count of assigned chars.");
+                return AssignedEditPositionCount == EditPositionCount;
             }
         }
 
@@ -989,7 +968,7 @@ namespace System.ComponentModel
         /// </summary>
         public void Clear(out MaskedTextResultHint resultHint)
         {
-            if (_assignedCharCount == 0)
+            if (AssignedEditPositionCount == 0)
             {
                 resultHint = MaskedTextResultHint.NoEffect;
                 return;
@@ -1010,7 +989,7 @@ namespace System.ComponentModel
         /// </summary>
         public int FindAssignedEditPositionFrom(int position, bool direction)
         {
-            if (_assignedCharCount == 0)
+            if (AssignedEditPositionCount == 0)
             {
                 return invalidIndex;
             }
@@ -1039,7 +1018,7 @@ namespace System.ComponentModel
         /// </summary>
         public int FindAssignedEditPositionInRange(int startPosition, int endPosition, bool direction)
         {
-            if (_assignedCharCount == 0)
+            if (AssignedEditPositionCount == 0)
             {
                 return invalidIndex;
             }
@@ -1985,7 +1964,7 @@ namespace System.ComponentModel
                 return false;
             }
 
-            if (_assignedCharCount > 0)
+            if (AssignedEditPositionCount > 0)
             {
                 // cache out params to preserve the ones from the primary operation (in case of success).
                 int tempPos;
@@ -2077,14 +2056,14 @@ namespace System.ComponentModel
             {
                 chDex.IsAssigned = false;
                 _testString[testPosition] = _promptChar;
-                _assignedCharCount--;
+                AssignedEditPositionCount--;
 
                 if (chDex.CharType == CharType.EditRequired)
                 {
                     _requiredCharCount--;
                 }
 
-                Debug.Assert(_assignedCharCount >= 0, "Invalid count of assigned chars.");
+                Debug.Assert(AssignedEditPositionCount >= 0, "Invalid count of assigned chars.");
             }
         }
 
@@ -2204,14 +2183,14 @@ namespace System.ComponentModel
                 {
                     if (charDescriptor.CaseConversion == CaseConversion.ToLower)
                     {
-                        input = _culture.TextInfo.ToLower(input);
+                        input = Culture.TextInfo.ToLower(input);
                     }
                 }
                 else // Char.IsLower( input )
                 {
                     if (charDescriptor.CaseConversion == CaseConversion.ToUpper)
                     {
-                        input = _culture.TextInfo.ToUpper(input);
+                        input = Culture.TextInfo.ToUpper(input);
                     }
                 }
             }
@@ -2221,7 +2200,7 @@ namespace System.ComponentModel
             if (!charDescriptor.IsAssigned) // if position not counted for already (replace case) we do it (add case).
             {
                 charDescriptor.IsAssigned = true;
-                _assignedCharCount++;
+                AssignedEditPositionCount++;
 
                 if (charDescriptor.CharType == CharType.EditRequired)
                 {
@@ -2229,7 +2208,7 @@ namespace System.ComponentModel
                 }
             }
 
-            Debug.Assert(_assignedCharCount <= EditPositionCount, "Invalid count of assigned chars.");
+            Debug.Assert(AssignedEditPositionCount <= EditPositionCount, "Invalid count of assigned chars.");
         }
 
         /// <summary>
@@ -2374,7 +2353,7 @@ namespace System.ComponentModel
 
             // Test the character against the mask constraints.  The switch tests false conditions.
             // Space char succeeds the test if the char type is optional.
-            switch (_mask[charDex.MaskPosition])
+            switch (Mask[charDex.MaskPosition])
             {
                 case '#':   // digit or plus/minus sign optional.
                     if (!Char.IsDigit(input) && (input != '-') && (input != '+') && input != spaceChar)
@@ -2628,7 +2607,7 @@ namespace System.ComponentModel
         /// </summary>
         public string ToDisplayString()
         {
-            if (!IsPassword || _assignedCharCount == 0) // just return the testString since it contains the formatted text.
+            if (!IsPassword || AssignedEditPositionCount == 0) // just return the testString since it contains the formatted text.
             {
                 return _testString.ToString();
             }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
@@ -104,16 +104,16 @@ namespace System.ComponentModel
 
         //// class data.
 
-        private const char spaceChar = ' ';
-        private const char defaultPromptChar = '_';
-        private const char nullPasswordChar = '\0';
-        private const bool defaultAllowPrompt = true;
-        private const int invalidIndex = -1;
-        private const byte editAny = 0;
-        private const byte editUnassigned = 1;
-        private const byte editAssigned = 2;
-        private const bool forward = true;
-        private const bool backward = false;
+        private const char SPACE_CHAR = ' ';
+        private const char DEFAULT_PROMPT_CHAR = '_';
+        private const char NULL_PASSWORD_CHAR = '\0';
+        private const bool DEFAULT_ALLOW_PROMPT = true;
+        private const int  INVALID_INDEX = -1;
+        private const byte EDIT_ANY = 0;
+        private const byte EDIT_UNASSIGNED = 1;
+        private const byte EDIT_ASSIGNED = 2;
+        private const bool FORWARD = true;
+        private const bool BACKWARD = false;
 
         // Bit masks for bool properties.
         private static int s_ASCII_ONLY = BitVector32.CreateMask();
@@ -163,7 +163,7 @@ namespace System.ComponentModel
         ///     Creates a MaskedTextProvider object from the specified mask.
         /// </summary>
         public MaskedTextProvider(string mask)
-            : this(mask, null, defaultAllowPrompt, defaultPromptChar, nullPasswordChar, false)
+            : this(mask, null, DEFAULT_ALLOW_PROMPT, DEFAULT_PROMPT_CHAR, NULL_PASSWORD_CHAR, false)
         {
         }
 
@@ -172,7 +172,7 @@ namespace System.ComponentModel
         ///     'restrictToAscii' specifies whether the input characters should be restricted to ASCII characters only.
         /// </summary>
         public MaskedTextProvider(string mask, bool restrictToAscii)
-            : this(mask, null, defaultAllowPrompt, defaultPromptChar, nullPasswordChar, restrictToAscii)
+            : this(mask, null, DEFAULT_ALLOW_PROMPT, DEFAULT_PROMPT_CHAR, NULL_PASSWORD_CHAR, restrictToAscii)
         {
         }
 
@@ -182,7 +182,7 @@ namespace System.ComponentModel
         ///               culture is used.
         /// </summary>
         public MaskedTextProvider(string mask, CultureInfo culture)
-            : this(mask, culture, defaultAllowPrompt, defaultPromptChar, nullPasswordChar, false)
+            : this(mask, culture, DEFAULT_ALLOW_PROMPT, DEFAULT_PROMPT_CHAR, NULL_PASSWORD_CHAR, false)
         {
         }
 
@@ -193,7 +193,7 @@ namespace System.ComponentModel
         ///     'restrictToAscii' specifies whether the input characters should be restricted to ASCII characters only.
         /// </summary>
         public MaskedTextProvider(string mask, CultureInfo culture, bool restrictToAscii)
-            : this(mask, culture, defaultAllowPrompt, defaultPromptChar, nullPasswordChar, restrictToAscii)
+            : this(mask, culture, DEFAULT_ALLOW_PROMPT, DEFAULT_PROMPT_CHAR, NULL_PASSWORD_CHAR, restrictToAscii)
         {
         }
 
@@ -203,7 +203,7 @@ namespace System.ComponentModel
         ///     'allowPromptAsInput' specifies whether the prompt character should be accepted as a valid input or not.
         /// </summary>
         public MaskedTextProvider(string mask, char passwordChar, bool allowPromptAsInput)
-            : this(mask, null, allowPromptAsInput, defaultPromptChar, passwordChar, false)
+            : this(mask, null, allowPromptAsInput, DEFAULT_PROMPT_CHAR, passwordChar, false)
         {
         }
 
@@ -213,7 +213,7 @@ namespace System.ComponentModel
         ///     'allowPromptAsInput' specifies whether the prompt character should be accepted as a valid input or not.
         /// </summary>
         public MaskedTextProvider(string mask, CultureInfo culture, char passwordChar, bool allowPromptAsInput)
-            : this(mask, culture, allowPromptAsInput, defaultPromptChar, passwordChar, false)
+            : this(mask, culture, allowPromptAsInput, DEFAULT_PROMPT_CHAR, passwordChar, false)
         {
         }
 
@@ -617,7 +617,7 @@ namespace System.ComponentModel
             {
                 if (IsPassword != value)
                 {
-                    _passwordChar = value ? DefaultPasswordChar : nullPasswordChar;
+                    _passwordChar = value ? DefaultPasswordChar : NULL_PASSWORD_CHAR;
                 }
             }
         }
@@ -625,13 +625,13 @@ namespace System.ComponentModel
         /// <summary>
         ///     A negative value representing an index outside the test string.
         /// </summary>
-        public static int InvalidIndex => invalidIndex;
+        public static int InvalidIndex => INVALID_INDEX;
 
         /// <summary>
         ///     The last edit position (relative to the origin not to time) in the test string where 
         ///     an input character has been placed.  If no position has been assigned, InvalidIndex is returned.
         /// </summary>
-        public int LastAssignedPosition => FindAssignedEditPositionFrom(_testString.Length - 1, backward);
+        public int LastAssignedPosition => FindAssignedEditPositionFrom(_testString.Length - 1, BACKWARD);
 
         /// <summary>
         ///     Specifies the length of the test string.
@@ -686,7 +686,7 @@ namespace System.ComponentModel
                     throw new InvalidOperationException(SR.MaskedTextProviderPasswordAndPromptCharError);
                 }
 
-                if (!IsValidPasswordChar(value) && (value != nullPasswordChar))
+                if (!IsValidPasswordChar(value) && (value != NULL_PASSWORD_CHAR))
                 {
                     // Same message as in SR.MaskedTextBoxInvalidCharError.
                     throw new ArgumentException(SR.MaskedTextProviderInvalidCharError);
@@ -851,9 +851,9 @@ namespace System.ComponentModel
 
             // Get position after last assigned position.
             testPosition = lastAssignedPos + 1;
-            testPosition = FindEditPositionFrom(testPosition, forward);
+            testPosition = FindEditPositionFrom(testPosition, FORWARD);
 
-            if (testPosition == invalidIndex)
+            if (testPosition == INVALID_INDEX)
             {
                 resultHint = MaskedTextResultHint.UnavailableEditPosition;
                 testPosition = _testString.Length;
@@ -945,13 +945,13 @@ namespace System.ComponentModel
         {
             if (AssignedEditPositionCount == 0)
             {
-                return invalidIndex;
+                return INVALID_INDEX;
             }
 
             int startPosition;
             int endPosition;
 
-            if (direction == forward)
+            if (direction == FORWARD)
             {
                 startPosition = position;
                 endPosition = _testString.Length - 1;
@@ -974,10 +974,10 @@ namespace System.ComponentModel
         {
             if (AssignedEditPositionCount == 0)
             {
-                return invalidIndex;
+                return INVALID_INDEX;
             }
 
-            return FindEditPositionInRange(startPosition, endPosition, direction, editAssigned);
+            return FindEditPositionInRange(startPosition, endPosition, direction, EDIT_ASSIGNED);
         }
 
         /// <summary>
@@ -991,7 +991,7 @@ namespace System.ComponentModel
             int startPosition;
             int endPosition;
 
-            if (direction == forward)
+            if (direction == FORWARD)
             {
                 startPosition = position;
                 endPosition = _testString.Length - 1;
@@ -1032,7 +1032,7 @@ namespace System.ComponentModel
             {
                 testPosition = FindEditPositionInRange(startPosition, endPosition, direction);
 
-                if (testPosition == invalidIndex)  // didn't find any.
+                if (testPosition == INVALID_INDEX)  // didn't find any.
                 {
                     break;
                 }
@@ -1041,14 +1041,14 @@ namespace System.ComponentModel
 
                 switch (assignedStatus)
                 {
-                    case editUnassigned:
+                    case EDIT_UNASSIGNED:
                         if (!chDex.IsAssigned)
                         {
                             return testPosition;
                         }
                         break;
 
-                    case editAssigned:
+                    case EDIT_ASSIGNED:
                         if (chDex.IsAssigned)
                         {
                             return testPosition;
@@ -1059,7 +1059,7 @@ namespace System.ComponentModel
                         return testPosition;
                 }
 
-                if (direction == forward)
+                if (direction == FORWARD)
                 {
                     startPosition++;
                 }
@@ -1070,7 +1070,7 @@ namespace System.ComponentModel
             }
             while (startPosition <= endPosition);
 
-            return invalidIndex;
+            return INVALID_INDEX;
         }
 
         /// <summary>
@@ -1084,7 +1084,7 @@ namespace System.ComponentModel
             int startPosition;
             int endPosition;
 
-            if (direction == forward)
+            if (direction == FORWARD)
             {
                 startPosition = position;
                 endPosition = _testString.Length - 1;
@@ -1129,7 +1129,7 @@ namespace System.ComponentModel
 
             if (startPosition > endPosition)
             {
-                return invalidIndex;
+                return INVALID_INDEX;
             }
 
             // Iterate through the test string until we find an edit char position.
@@ -1137,7 +1137,7 @@ namespace System.ComponentModel
 
             while (startPosition <= endPosition)
             {
-                testPosition = (direction == forward) ? startPosition++ : endPosition--;
+                testPosition = (direction == FORWARD) ? startPosition++ : endPosition--;
 
                 CharDescriptor chDex = _stringDescriptor[testPosition];
 
@@ -1147,7 +1147,7 @@ namespace System.ComponentModel
                 }
             }
 
-            return invalidIndex;
+            return INVALID_INDEX;
         }
 
         /// <summary>
@@ -1160,7 +1160,7 @@ namespace System.ComponentModel
             int startPosition;
             int endPosition;
 
-            if (direction == forward)
+            if (direction == FORWARD)
             {
                 startPosition = position;
                 endPosition = _testString.Length - 1;
@@ -1171,7 +1171,7 @@ namespace System.ComponentModel
                 endPosition = position;
             }
 
-            return FindEditPositionInRange(startPosition, endPosition, direction, editUnassigned);
+            return FindEditPositionInRange(startPosition, endPosition, direction, EDIT_UNASSIGNED);
         }
 
         /// <summary>
@@ -1186,11 +1186,11 @@ namespace System.ComponentModel
 
             while (true)
             {
-                position = FindEditPositionInRange(startPosition, endPosition, direction, editAny);
+                position = FindEditPositionInRange(startPosition, endPosition, direction, EDIT_ANY);
 
-                if (position == invalidIndex)
+                if (position == INVALID_INDEX)
                 {
-                    return invalidIndex;
+                    return INVALID_INDEX;
                 }
 
                 CharDescriptor chDex = _stringDescriptor[position];
@@ -1200,7 +1200,7 @@ namespace System.ComponentModel
                     return position;
                 }
 
-                if (direction == forward)
+                if (direction == FORWARD)
                 {
                     startPosition++;
                 }
@@ -1314,8 +1314,8 @@ namespace System.ComponentModel
 
             // Now check if we need to open room for the input characters (shift characters right) and if so test the shifting characters.
 
-            int srcPos = FindEditPositionFrom(position, forward);               // source position.
-            bool shiftNeeded = FindAssignedEditPositionInRange(srcPos, testPosition, forward) != invalidIndex;
+            int srcPos = FindEditPositionFrom(position, FORWARD);               // source position.
+            bool shiftNeeded = FindAssignedEditPositionInRange(srcPos, testPosition, FORWARD) != INVALID_INDEX;
             int lastAssignedPos = LastAssignedPosition;
 
             if (shiftNeeded && (testPosition == _testString.Length - 1)) // no room for shifting.
@@ -1325,7 +1325,7 @@ namespace System.ComponentModel
                 return false;
             }
 
-            int dstPos = FindEditPositionFrom(testPosition + 1, forward);  // destination position.
+            int dstPos = FindEditPositionFrom(testPosition + 1, FORWARD);  // destination position.
 
             if (shiftNeeded)
             {
@@ -1335,7 +1335,7 @@ namespace System.ComponentModel
                 // Test shifting characters.
                 while (true)
                 {
-                    if (dstPos == invalidIndex)
+                    if (dstPos == INVALID_INDEX)
                     {
                         resultHint = MaskedTextResultHint.UnavailableEditPosition;
                         testPosition = _testString.Length;
@@ -1359,8 +1359,8 @@ namespace System.ComponentModel
                         break;
                     }
 
-                    srcPos = FindEditPositionFrom(srcPos + 1, forward);
-                    dstPos = FindEditPositionFrom(dstPos + 1, forward);
+                    srcPos = FindEditPositionFrom(srcPos + 1, FORWARD);
+                    dstPos = FindEditPositionFrom(dstPos + 1, FORWARD);
                 }
 
                 if (tempHint > resultHint)
@@ -1391,8 +1391,8 @@ namespace System.ComponentModel
                         ResetChar(dstPos);
                     }
 
-                    dstPos = FindEditPositionFrom(dstPos - 1, backward);
-                    srcPos = FindEditPositionFrom(srcPos - 1, backward);
+                    dstPos = FindEditPositionFrom(dstPos - 1, BACKWARD);
+                    srcPos = FindEditPositionFrom(srcPos - 1, BACKWARD);
                 }
             }
 
@@ -1484,7 +1484,7 @@ namespace System.ComponentModel
         /// </summary>
         private static bool IsPrintableChar(char c)
         {
-            return char.IsLetterOrDigit(c) || char.IsPunctuation(c) || char.IsSymbol(c) || (c == spaceChar);
+            return char.IsLetterOrDigit(c) || char.IsPunctuation(c) || char.IsSymbol(c) || (c == SPACE_CHAR);
         }
 
         /// <summary>
@@ -1532,7 +1532,7 @@ namespace System.ComponentModel
         {
             int lastAssignedPos = LastAssignedPosition;
 
-            if (lastAssignedPos == invalidIndex)
+            if (lastAssignedPos == INVALID_INDEX)
             {
                 testPosition = 0;
                 resultHint = MaskedTextResultHint.NoEffect;
@@ -1613,11 +1613,11 @@ namespace System.ComponentModel
 
             // Check if we need to shift characters left to occupied the positions left by the characters being removed.
             int lastAssignedPos = LastAssignedPosition;
-            int dstPos = FindEditPositionInRange(startPosition, endPosition, forward); // first edit position in range.
+            int dstPos = FindEditPositionInRange(startPosition, endPosition, FORWARD); // first edit position in range.
 
             resultHint = MaskedTextResultHint.NoEffect;
 
-            if (dstPos == invalidIndex || dstPos > lastAssignedPos) // nothing to remove.
+            if (dstPos == INVALID_INDEX || dstPos > lastAssignedPos) // nothing to remove.
             {
                 testPosition = startPosition;
                 return true;
@@ -1629,7 +1629,7 @@ namespace System.ComponentModel
 
             // if there are assigned characters to be removed (could be that the range doesn't have one, in such case we may be just 
             // be shifting chars), the result hint is success, let's check.
-            if (FindAssignedEditPositionInRange(startPosition, endPosition, forward) != invalidIndex)
+            if (FindAssignedEditPositionInRange(startPosition, endPosition, FORWARD) != INVALID_INDEX)
             {
                 resultHint = MaskedTextResultHint.Success;
             }
@@ -1638,7 +1638,7 @@ namespace System.ComponentModel
             {
                 // Test shifting characters.
 
-                int srcPos = FindEditPositionFrom(endPosition + 1, forward);  // first position to shift left.
+                int srcPos = FindEditPositionFrom(endPosition + 1, FORWARD);  // first position to shift left.
                 int shiftStart = srcPos; // cache it here so we don't have to search for it later if needed.
                 MaskedTextResultHint testHint;
 
@@ -1665,8 +1665,8 @@ namespace System.ComponentModel
                         break;
                     }
 
-                    srcPos = FindEditPositionFrom(srcPos + 1, forward);
-                    dstPos = FindEditPositionFrom(dstPos + 1, forward);
+                    srcPos = FindEditPositionFrom(srcPos + 1, FORWARD);
+                    dstPos = FindEditPositionFrom(dstPos + 1, FORWARD);
                 }
 
                 // shifting characters is a resultHint == sideEffect, update hint if no characters removed (which would be hint == success).
@@ -1705,8 +1705,8 @@ namespace System.ComponentModel
                         break;
                     }
 
-                    srcPos = FindEditPositionFrom(srcPos + 1, forward);
-                    dstPos = FindEditPositionFrom(dstPos + 1, forward);
+                    srcPos = FindEditPositionFrom(srcPos + 1, FORWARD);
+                    dstPos = FindEditPositionFrom(dstPos + 1, FORWARD);
                 }
 
                 // If shifting character are less than characters to remove in the range, we need to remove the remaining ones in the range; 
@@ -1758,10 +1758,10 @@ namespace System.ComponentModel
             // If character is not to be escaped, we need to find the first edit position to test it in.
             if (!TestEscapeChar(input, testPosition))
             {
-                testPosition = FindEditPositionFrom(testPosition, forward);
+                testPosition = FindEditPositionFrom(testPosition, FORWARD);
             }
 
-            if (testPosition == invalidIndex)
+            if (testPosition == INVALID_INDEX)
             {
                 resultHint = MaskedTextResultHint.UnavailableEditPosition;
                 testPosition = position;
@@ -1949,10 +1949,10 @@ namespace System.ComponentModel
 
                     while (true)
                     {
-                        srcPos = FindEditPositionFrom(srcPos, forward);
-                        dstPos = FindEditPositionFrom(dstPos, forward);
+                        srcPos = FindEditPositionFrom(srcPos, FORWARD);
+                        dstPos = FindEditPositionFrom(dstPos, FORWARD);
 
-                        if (dstPos == invalidIndex)
+                        if (dstPos == INVALID_INDEX)
                         {
                             testPosition = _testString.Length;
                             resultHint = MaskedTextResultHint.UnavailableEditPosition;
@@ -1987,8 +1987,8 @@ namespace System.ComponentModel
                     {
                         SetChar(_testString[srcPos], dstPos);
 
-                        srcPos = FindEditPositionFrom(srcPos - 1, backward);
-                        dstPos = FindEditPositionFrom(dstPos - 1, backward);
+                        srcPos = FindEditPositionFrom(srcPos - 1, BACKWARD);
+                        dstPos = FindEditPositionFrom(dstPos - 1, BACKWARD);
                     }
                 }
                 // else endPosition == testPosition, this means replacing the entire text which is the same as Set().
@@ -2029,15 +2029,15 @@ namespace System.ComponentModel
         {
             Debug.Assert(startPosition >= 0 && endPosition >= 0 && endPosition >= startPosition && endPosition < _testString.Length, "position out of range.");
 
-            startPosition = FindAssignedEditPositionFrom(startPosition, forward);
+            startPosition = FindAssignedEditPositionFrom(startPosition, FORWARD);
 
-            if (startPosition != invalidIndex)
+            if (startPosition != INVALID_INDEX)
             {
-                endPosition = FindAssignedEditPositionFrom(endPosition, backward);
+                endPosition = FindAssignedEditPositionFrom(endPosition, BACKWARD);
 
                 while (startPosition <= endPosition)
                 {
-                    startPosition = FindAssignedEditPositionFrom(startPosition, forward);
+                    startPosition = FindAssignedEditPositionFrom(startPosition, FORWARD);
                     ResetChar(startPosition);
                     startPosition++;
                 }
@@ -2087,9 +2087,9 @@ namespace System.ComponentModel
             }
 
             // Reset remaining characters (if any).
-            int resetPos = FindAssignedEditPositionFrom(testPosition + 1, forward);
+            int resetPos = FindAssignedEditPositionFrom(testPosition + 1, FORWARD);
 
-            if (resetPos != invalidIndex)
+            if (resetPos != INVALID_INDEX)
             {
                 ResetString(resetPos, _testString.Length - 1);
             }
@@ -2178,7 +2178,7 @@ namespace System.ComponentModel
                 // If character is not to be escaped, we need to find the first edit position to test it in.
                 if (!TestEscapeChar(ch, testPosition))
                 {
-                    testPosition = FindEditPositionFrom(testPosition, forward);
+                    testPosition = FindEditPositionFrom(testPosition, FORWARD);
                 }
 
                 SetChar(ch, testPosition);
@@ -2289,7 +2289,7 @@ namespace System.ComponentModel
                 }
             }
 
-            if (input == spaceChar && ResetOnSpace)
+            if (input == SPACE_CHAR && ResetOnSpace)
             {
                 if (IsEditPosition(charDex) && charDex.IsAssigned) // Position would be reset.
                 {
@@ -2310,7 +2310,7 @@ namespace System.ComponentModel
             switch (Mask[charDex.MaskPosition])
             {
                 case '#':   // digit or plus/minus sign optional.
-                    if (!Char.IsDigit(input) && (input != '-') && (input != '+') && input != spaceChar)
+                    if (!Char.IsDigit(input) && (input != '-') && (input != '+') && input != SPACE_CHAR)
                     {
                         resultHint = MaskedTextResultHint.DigitExpected;
                         return false;
@@ -2326,7 +2326,7 @@ namespace System.ComponentModel
                     break;
 
                 case '9':   // digit optional.
-                    if (!Char.IsDigit(input) && input != spaceChar)
+                    if (!Char.IsDigit(input) && input != SPACE_CHAR)
                     {
                         resultHint = MaskedTextResultHint.DigitExpected;
                         return false;
@@ -2347,7 +2347,7 @@ namespace System.ComponentModel
                     break;
 
                 case '?':   // letter optional.
-                    if (!Char.IsLetter(input) && input != spaceChar)
+                    if (!Char.IsLetter(input) && input != SPACE_CHAR)
                     {
                         resultHint = MaskedTextResultHint.LetterExpected;
                         return false;
@@ -2368,7 +2368,7 @@ namespace System.ComponentModel
                     break;
 
                 case 'C':   // any character optional.
-                    if ((!IsAscii(input) && AsciiOnly) && input != spaceChar)
+                    if ((!IsAscii(input) && AsciiOnly) && input != SPACE_CHAR)
                     {
                         resultHint = MaskedTextResultHint.AsciiCharacterExpected;
                         return false;
@@ -2389,7 +2389,7 @@ namespace System.ComponentModel
                     break;
 
                 case 'a':   // Alphanumeric optional.
-                    if (!IsAlphanumeric(input) && input != spaceChar)
+                    if (!IsAlphanumeric(input) && input != SPACE_CHAR)
                     {
                         resultHint = MaskedTextResultHint.AlphanumericCharacterExpected;
                         return false;
@@ -2439,7 +2439,7 @@ namespace System.ComponentModel
                 return SkipLiterals && input == _testString[position];
             }
 
-            if ((ResetOnPrompt && (input == _promptChar)) || (ResetOnSpace && (input == spaceChar)))
+            if ((ResetOnPrompt && (input == _promptChar)) || (ResetOnSpace && (input == SPACE_CHAR)))
             {
                 return true;
             }
@@ -2524,9 +2524,9 @@ namespace System.ComponentModel
                 // If character is not to be escaped, we need to find an edit position to test it in.
                 if (!TestEscapeChar(ch, testPosition))
                 {
-                    testPosition = FindEditPositionFrom(testPosition, forward);
+                    testPosition = FindEditPositionFrom(testPosition, FORWARD);
 
-                    if (testPosition == invalidIndex)
+                    if (testPosition == INVALID_INDEX)
                     {
                         testPosition = _testString.Length;
                         resultHint = MaskedTextResultHint.UnavailableEditPosition;
@@ -2687,8 +2687,8 @@ namespace System.ComponentModel
                 // the last assigned position or last literal position if including literals, whichever is higher; upper unassigned
                 // positions are not included in the resulting string.
 
-                int lastLiteralPos = includeLiterals ? FindNonEditPositionInRange(startPosition, lastPosition, backward) : InvalidIndex;
-                int lastAssignedPos = FindAssignedEditPositionInRange(lastLiteralPos == InvalidIndex ? startPosition : lastLiteralPos, lastPosition, backward);
+                int lastLiteralPos = includeLiterals ? FindNonEditPositionInRange(startPosition, lastPosition, BACKWARD) : InvalidIndex;
+                int lastAssignedPos = FindAssignedEditPositionInRange(lastLiteralPos == InvalidIndex ? startPosition : lastLiteralPos, lastPosition, BACKWARD);
 
                 // If lastLiteralPos is in the range and lastAssignedPos is not InvalidIndex, the lastAssignedPos is the upper limit
                 // we are looking for since it is searched in the range from lastLiteralPos and lastPosition.  In any other case
@@ -2724,7 +2724,7 @@ namespace System.ComponentModel
                         {
                             if (!includePrompt)
                             {
-                                st.Append(spaceChar); // replace prompt with space.
+                                st.Append(SPACE_CHAR); // replace prompt with space.
                                 break;
                             }
                         }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
@@ -532,6 +532,10 @@ namespace System.ComponentModel
         /// <summary>
         ///       The system password char.
         /// </summary>
+        /// <remarks> 
+        /// ComCtl32.dll V6 (WindowsXP) provides a nice black circle but we don't want to attempt to simulate it 
+        ///  here to avoid hard coding values.  MaskedTextBox picks up the right value at run time from comctl32.
+        /// </remarks>
         public static char DefaultPasswordChar => '*';
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
@@ -452,13 +452,7 @@ namespace System.ComponentModel
         /// <summary>
         ///     Specifies whether the prompt character should be treated as a valid input character or not.
         /// </summary>
-        public bool AllowPromptAsInput
-        {
-            get
-            {
-                return _flagState[s_ALLOW_PROMPT_AS_INPUT];
-            }
-        }
+        public bool AllowPromptAsInput => _flagState[s_ALLOW_PROMPT_AS_INPUT];
 
         /// <summary>
         ///     Retreives the number of editable characters that have been set.
@@ -468,13 +462,7 @@ namespace System.ComponentModel
         /// <summary>
         ///     Retreives the number of editable characters that have been set.
         /// </summary>
-        public int AvailableEditPositionCount
-        {
-            get
-            {
-                return EditPositionCount - AssignedEditPositionCount;
-            }
-        }
+        public int AvailableEditPositionCount => EditPositionCount - AssignedEditPositionCount;
 
         /// <summary>
         ///     Creates a 'clean' (no text assigned) MaskedTextProvider instance with the same property values as the 
@@ -544,26 +532,12 @@ namespace System.ComponentModel
         /// <summary>
         ///       The system password char.
         /// </summary>
-        public static char DefaultPasswordChar
-        {
-            get
-            {
-                // ComCtl32.dll V6 (WindowsXP) provides a nice black circle but we don't want to attempt to simulate it 
-                // here to avoid hard coding values.  MaskedTextBox picks up the right value at run time from comctl32.
-                return '*';
-            }
-        }
+        public static char DefaultPasswordChar => '*';
 
         /// <summary>
         ///       The number of editable positions in the test string.
         /// </summary>
-        public int EditPositionCount
-        {
-            get
-            {
-                return _optionalEditChars + _requiredEditChars;
-            }
-        }
+        public int EditPositionCount => _optionalEditChars + _requiredEditChars;
 
         /// <summary>
         ///       Returns a new IEnumerator object containing the editable positions in the test string.
@@ -623,13 +597,7 @@ namespace System.ComponentModel
         /// <summary>
         ///     Specifies whether only ASCII characters are accepted as valid input.
         /// </summary>
-        public bool AsciiOnly
-        {
-            get
-            {
-                return _flagState[s_ASCII_ONLY];
-            }
-        }
+        public bool AsciiOnly => _flagState[s_ASCII_ONLY];
 
         /// <summary>
         ///     Specifies whether the user text is to be rendered as password characters.
@@ -653,36 +621,18 @@ namespace System.ComponentModel
         /// <summary>
         ///     A negative value representing an index outside the test string.
         /// </summary>
-        public static int InvalidIndex
-        {
-            get
-            {
-                return invalidIndex;
-            }
-        }
+        public static int InvalidIndex => invalidIndex;
 
         /// <summary>
         ///     The last edit position (relative to the origin not to time) in the test string where 
         ///     an input character has been placed.  If no position has been assigned, InvalidIndex is returned.
         /// </summary>
-        public int LastAssignedPosition
-        {
-            get
-            {
-                return FindAssignedEditPositionFrom(_testString.Length - 1, backward);
-            }
-        }
+        public int LastAssignedPosition => FindAssignedEditPositionFrom(_testString.Length - 1, backward);
 
         /// <summary>
         ///     Specifies the length of the test string.
         /// </summary>
-        public int Length
-        {
-            get
-            {
-                return _testString.Length;
-            }
-        }
+        public int Length => _testString.Length;
 
         /// <summary>
         ///     The mask to be applied to the test string.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
@@ -97,7 +97,7 @@ namespace System.ComponentModel
             _displayName = oldMemberDescriptor.DisplayName;
             _nameHash = _name.GetHashCode();
 
-            List<Attribute> newArray  = new List<Attribute>();
+            List<Attribute> newArray = new List<Attribute>();
 
             if (oldMemberDescriptor.Attributes.Count != 0)
             {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
@@ -24,8 +24,8 @@ namespace System.ComponentModel
         private AttributeCollection _attributeCollection;
         private Attribute[] _attributes;
         private Attribute[] _originalAttributes;
-        private bool _attributesFiltered = false;
-        private bool _attributesFilled = false;
+        private bool _attributesFiltered;
+        private bool _attributesFilled;
         private int _metadataVersion;
         private string _category;
         private string _description;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
@@ -97,11 +97,11 @@ namespace System.ComponentModel
             _displayName = oldMemberDescriptor.DisplayName;
             _nameHash = _name.GetHashCode();
 
-            ArrayList newArray = new ArrayList();
+            List<Attribute> newArray  = new List<Attribute>();
 
             if (oldMemberDescriptor.Attributes.Count != 0)
             {
-                foreach (object o in oldMemberDescriptor.Attributes)
+                foreach (Attribute o in oldMemberDescriptor.Attributes)
                 {
                     newArray.Add(o);
                 }
@@ -109,7 +109,7 @@ namespace System.ComponentModel
 
             if (newAttributes != null)
             {
-                foreach (object o in newAttributes)
+                foreach (Attribute o in newAttributes)
                 {
                     newArray.Add(o);
                 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
@@ -213,13 +213,7 @@ namespace System.ComponentModel
         ///    <see cref='System.ComponentModel.BrowsableAttribute'/>. 
         ///    </para>
         /// </summary>
-        public virtual bool IsBrowsable
-        {
-            get
-            {
-                return ((BrowsableAttribute)Attributes[typeof(BrowsableAttribute)]).Browsable;
-            }
-        }
+        public virtual bool IsBrowsable => ((BrowsableAttribute)Attributes[typeof(BrowsableAttribute)]).Browsable;
 
         /// <summary>
         ///    <para>
@@ -245,13 +239,7 @@ namespace System.ComponentModel
         ///       code for the name of the member as specified in <see cref='System.String.GetHashCode'/>.
         ///    </para>
         /// </summary>
-        protected virtual int NameHashCode
-        {
-            get
-            {
-                return _nameHash;
-            }
-        }
+        protected virtual int NameHashCode => _nameHash;
 
         /// <summary>
         ///    <para>
@@ -259,13 +247,7 @@ namespace System.ComponentModel
         ///       design time as specified in the <see cref='System.ComponentModel.DesignOnlyAttribute'/>.
         ///    </para>
         /// </summary>
-        public virtual bool DesignTimeOnly
-        {
-            get
-            {
-                return (DesignOnlyAttribute.Yes.Equals(Attributes[typeof(DesignOnlyAttribute)]));
-            }
-        }
+        public virtual bool DesignTimeOnly => (DesignOnlyAttribute.Yes.Equals(Attributes[typeof(DesignOnlyAttribute)]));
 
         /// <summary>
         ///    <para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
@@ -177,17 +177,7 @@ namespace System.ComponentModel
         ///       in the <see cref='System.ComponentModel.CategoryAttribute'/>.
         ///    </para>
         /// </summary>
-        public virtual string Category
-        {
-            get
-            {
-                if (_category == null)
-                {
-                    _category = ((CategoryAttribute)Attributes[typeof(CategoryAttribute)]).Category;
-                }
-                return _category;
-            }
-        }
+        public virtual string Category => _category ?? (_category = ((CategoryAttribute) Attributes[typeof(CategoryAttribute)]).Category);
 
         /// <summary>
         ///    <para>
@@ -195,17 +185,8 @@ namespace System.ComponentModel
         ///       the member as specified in the <see cref='System.ComponentModel.DescriptionAttribute'/>.
         ///    </para>
         /// </summary>
-        public virtual string Description
-        {
-            get
-            {
-                if (_description == null)
-                {
-                    _description = ((DescriptionAttribute)Attributes[typeof(DescriptionAttribute)]).Description;
-                }
-                return _description;
-            }
-        }
+        public virtual string Description => _description ??
+                                             (_description = ((DescriptionAttribute) Attributes[typeof(DescriptionAttribute)]).Description);
 
         /// <summary>
         ///    <para>
@@ -221,17 +202,7 @@ namespace System.ComponentModel
         ///       name of the member.
         ///    </para>
         /// </summary>
-        public virtual string Name
-        {
-            get
-            {
-                if (_name == null)
-                {
-                    return "";
-                }
-                return _name;
-            }
-        }
+        public virtual string Name => _name ?? "";
 
         /// <summary>
         ///    <para>
@@ -507,12 +478,7 @@ namespace System.ComponentModel
         /// </summary>
         protected static ISite GetSite(object component)
         {
-            if (!(component is IComponent))
-            {
-                return null;
-            }
-
-            return ((IComponent)component).Site;
+            return (component as IComponent)?.Site;
         }
 
         [Obsolete("This method has been deprecated. Use GetInvocationTarget instead.  http://go.microsoft.com/fwlink/?linkid=14202")]

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
@@ -97,13 +97,13 @@ namespace System.ComponentModel
             _displayName = oldMemberDescriptor.DisplayName;
             _nameHash = _name.GetHashCode();
 
-            List<Attribute> newArray = new List<Attribute>();
+            List<Attribute> newList = new List<Attribute>();
 
             if (oldMemberDescriptor.Attributes.Count != 0)
             {
                 foreach (Attribute o in oldMemberDescriptor.Attributes)
                 {
-                    newArray.Add(o);
+                    newList.Add(o);
                 }
             }
 
@@ -111,12 +111,12 @@ namespace System.ComponentModel
             {
                 foreach (Attribute o in newAttributes)
                 {
-                    newArray.Add(o);
+                    newList.Add(o);
                 }
             }
 
-            _attributes = new Attribute[newArray.Count];
-            newArray.CopyTo(_attributes, 0);
+            _attributes = new Attribute[newList.Count];
+            newList.CopyTo(_attributes, 0);
             _attributesFiltered = false;
 
             _originalAttributes = _attributes;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/NestedContainer.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/NestedContainer.cs
@@ -132,13 +132,7 @@ namespace System.ComponentModel
             public IComponent Component { get; }
 
             // The container in which the component is sited.
-            public IContainer Container
-            {
-                get
-                {
-                    return _container;
-                }
-            }
+            public IContainer Container => _container;
 
             public Object GetService(Type service)
             {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/NestedContainer.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/NestedContainer.cs
@@ -19,8 +19,6 @@ namespace System.ComponentModel
     /// </summary>
     public class NestedContainer : Container, INestedContainer
     {
-        private IComponent _owner;
-
         /// <summary>
         ///     Creates a new NestedContainer.
         /// </summary>
@@ -30,20 +28,14 @@ namespace System.ComponentModel
             {
                 throw new ArgumentNullException(nameof(owner));
             }
-            _owner = owner;
-            _owner.Disposed += new EventHandler(OnOwnerDisposed);
+            Owner = owner;
+            Owner.Disposed += new EventHandler(OnOwnerDisposed);
         }
 
         /// <summary>
         ///     The component that owns this nested container.
         /// </summary>
-        public IComponent Owner
-        {
-            get
-            {
-                return _owner;
-            }
-        }
+        public IComponent Owner { get; }
 
         /// <summary>
         ///     Retrieves the name of the owning component.  This may be overridden to
@@ -56,16 +48,16 @@ namespace System.ComponentModel
             get
             {
                 string ownerName = null;
-                if (_owner != null && _owner.Site != null)
+                if (Owner != null && Owner.Site != null)
                 {
-                    INestedSite nestedOwnerSite = _owner.Site as INestedSite;
+                    INestedSite nestedOwnerSite = Owner.Site as INestedSite;
                     if (nestedOwnerSite != null)
                     {
                         ownerName = nestedOwnerSite.FullName;
                     }
                     else
                     {
-                        ownerName = _owner.Site.Name;
+                        ownerName = Owner.Site.Name;
                     }
                 }
 
@@ -92,7 +84,7 @@ namespace System.ComponentModel
         {
             if (disposing)
             {
-                _owner.Disposed -= new EventHandler(OnOwnerDisposed);
+                Owner.Disposed -= new EventHandler(OnOwnerDisposed);
             }
             base.Dispose(disposing);
         }
@@ -126,25 +118,18 @@ namespace System.ComponentModel
         /// </summary>
         private class Site : INestedSite
         {
-            private IComponent _component;
             private NestedContainer _container;
             private string _name;
 
             internal Site(IComponent component, NestedContainer container, string name)
             {
-                _component = component;
+                Component = component;
                 _container = container;
                 _name = name;
             }
 
             // The component sited by this component site.
-            public IComponent Component
-            {
-                get
-                {
-                    return _component;
-                }
-            }
+            public IComponent Component { get; }
 
             // The container in which the component is sited.
             public IContainer Container
@@ -206,7 +191,7 @@ namespace System.ComponentModel
                 {
                     if (value == null || _name == null || !value.Equals(_name))
                     {
-                        _container.ValidateName(_component, value);
+                        _container.ValidateName(Component, value);
                         _name = value;
                     }
                 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/NestedContainer.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/NestedContainer.cs
@@ -118,13 +118,12 @@ namespace System.ComponentModel
         /// </summary>
         private class Site : INestedSite
         {
-            private NestedContainer _container;
             private string _name;
 
             internal Site(IComponent component, NestedContainer container, string name)
             {
                 Component = component;
-                _container = container;
+                Container = container;
                 _name = name;
             }
 
@@ -132,11 +131,11 @@ namespace System.ComponentModel
             public IComponent Component { get; }
 
             // The container in which the component is sited.
-            public IContainer Container => _container;
+            public IContainer Container { get; }
 
             public Object GetService(Type service)
             {
-                return ((service == typeof(ISite)) ? this : _container.GetService(service));
+                return ((service == typeof(ISite)) ? this : ((NestedContainer)Container).GetService(service));
             }
 
             // Indicates whether the component is in design mode.
@@ -144,7 +143,7 @@ namespace System.ComponentModel
             {
                 get
                 {
-                    IComponent owner = _container.Owner;
+                    IComponent owner = ((NestedContainer)Container).Owner;
                     if (owner != null && owner.Site != null)
                     {
                         return owner.Site.DesignMode;
@@ -159,7 +158,7 @@ namespace System.ComponentModel
                 {
                     if (_name != null)
                     {
-                        string ownerName = _container.OwnerName;
+                        string ownerName = ((NestedContainer)Container).OwnerName;
                         string childName = _name;
                         if (ownerName != null)
                         {
@@ -185,7 +184,7 @@ namespace System.ComponentModel
                 {
                     if (value == null || _name == null || !value.Equals(_name))
                     {
-                        _container.ValidateName(Component, value);
+                        ((NestedContainer)Container).ValidateName(Component, value);
                         _name = value;
                     }
                 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/NullableConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/NullableConverter.cs
@@ -13,24 +13,20 @@ namespace System.ComponentModel
     /// </summary>
     public class NullableConverter : TypeConverter
     {
-        private readonly Type _nullableType;
-        private readonly Type _simpleType;
-        private readonly TypeConverter _simpleTypeConverter;
-
         /// <summary>
         /// Nullable converter is initialized with the underlying simple type.
         /// </summary>
         public NullableConverter(Type type)
         {
-            _nullableType = type;
+            NullableType = type;
 
-            _simpleType = Nullable.GetUnderlyingType(type);
-            if (_simpleType == null)
+            UnderlyingType = Nullable.GetUnderlyingType(type);
+            if (UnderlyingType == null)
             {
                 throw new ArgumentException(SR.NullableConverterBadCtorArg, nameof(type));
             }
 
-            _simpleTypeConverter = TypeDescriptor.GetConverter(_simpleType);
+            UnderlyingTypeConverter = TypeDescriptor.GetConverter(UnderlyingType);
         }
 
         /// <summary>
@@ -39,13 +35,13 @@ namespace System.ComponentModel
         /// </summary>
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
-            if (sourceType == _simpleType)
+            if (sourceType == UnderlyingType)
             {
                 return true;
             }
-            else if (_simpleTypeConverter != null)
+            else if (UnderlyingTypeConverter != null)
             {
-                return _simpleTypeConverter.CanConvertFrom(context, sourceType);
+                return UnderlyingTypeConverter.CanConvertFrom(context, sourceType);
             }
             else
             {
@@ -58,7 +54,7 @@ namespace System.ComponentModel
         /// </summary>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            if (value == null || value.GetType() == _simpleType)
+            if (value == null || value.GetType() == UnderlyingType)
             {
                 return value;
             }
@@ -66,9 +62,9 @@ namespace System.ComponentModel
             {
                 return null;
             }
-            else if (_simpleTypeConverter != null)
+            else if (UnderlyingTypeConverter != null)
             {
-                return _simpleTypeConverter.ConvertFrom(context, culture, value);
+                return UnderlyingTypeConverter.ConvertFrom(context, culture, value);
             }
             else
             {
@@ -81,13 +77,13 @@ namespace System.ComponentModel
         /// </summary>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
-            if (destinationType == _simpleType)
+            if (destinationType == UnderlyingType)
             {
                 return true;
             }
-            else if (_simpleTypeConverter != null)
+            else if (UnderlyingTypeConverter != null)
             {
-                return _simpleTypeConverter.CanConvertTo(context, destinationType);
+                return UnderlyingTypeConverter.CanConvertTo(context, destinationType);
             }
             else
             {
@@ -105,7 +101,7 @@ namespace System.ComponentModel
                 throw new ArgumentNullException(nameof(destinationType));
             }
 
-            if (destinationType == _simpleType && value != null && _nullableType.GetTypeInfo().IsAssignableFrom(value.GetType().GetTypeInfo()))
+            if (destinationType == UnderlyingType && value != null && NullableType.GetTypeInfo().IsAssignableFrom(value.GetType().GetTypeInfo()))
             {
                 return value;
             }
@@ -117,9 +113,9 @@ namespace System.ComponentModel
                     return string.Empty;
                 }
             }
-            else if (_simpleTypeConverter != null)
+            else if (UnderlyingTypeConverter != null)
             {
-                return _simpleTypeConverter.ConvertTo(context, culture, value, destinationType);
+                return UnderlyingTypeConverter.ConvertTo(context, culture, value, destinationType);
             }
 
             return base.ConvertTo(context, culture, value, destinationType);
@@ -129,9 +125,9 @@ namespace System.ComponentModel
         /// </summary>
         public override object CreateInstance(ITypeDescriptorContext context, IDictionary propertyValues)
         {
-            if (_simpleTypeConverter != null)
+            if (UnderlyingTypeConverter != null)
             {
-                object instance = _simpleTypeConverter.CreateInstance(context, propertyValues);
+                object instance = UnderlyingTypeConverter.CreateInstance(context, propertyValues);
                 return instance;
             }
 
@@ -147,9 +143,9 @@ namespace System.ComponentModel
         /// </summary>
         public override bool GetCreateInstanceSupported(ITypeDescriptorContext context)
         {
-            if (_simpleTypeConverter != null)
+            if (UnderlyingTypeConverter != null)
             {
-                return _simpleTypeConverter.GetCreateInstanceSupported(context);
+                return UnderlyingTypeConverter.GetCreateInstanceSupported(context);
             }
 
             return base.GetCreateInstanceSupported(context);
@@ -163,10 +159,10 @@ namespace System.ComponentModel
         /// </summary>
         public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
         {
-            if (_simpleTypeConverter != null)
+            if (UnderlyingTypeConverter != null)
             {
                 object unwrappedValue = value;
-                return _simpleTypeConverter.GetProperties(context, unwrappedValue, attributes);
+                return UnderlyingTypeConverter.GetProperties(context, unwrappedValue, attributes);
             }
 
             return base.GetProperties(context, value, attributes);
@@ -177,9 +173,9 @@ namespace System.ComponentModel
         /// </summary>
         public override bool GetPropertiesSupported(ITypeDescriptorContext context)
         {
-            if (_simpleTypeConverter != null)
+            if (UnderlyingTypeConverter != null)
             {
-                return _simpleTypeConverter.GetPropertiesSupported(context);
+                return UnderlyingTypeConverter.GetPropertiesSupported(context);
             }
 
             return base.GetPropertiesSupported(context);
@@ -190,9 +186,9 @@ namespace System.ComponentModel
         /// </summary>
         public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
         {
-            if (_simpleTypeConverter != null)
+            if (UnderlyingTypeConverter != null)
             {
-                StandardValuesCollection values = _simpleTypeConverter.GetStandardValues(context);
+                StandardValuesCollection values = UnderlyingTypeConverter.GetStandardValues(context);
                 if (GetStandardValuesSupported(context) && values != null)
                 {
                     // Create a set of standard values around nullable instances.  
@@ -221,9 +217,9 @@ namespace System.ComponentModel
         /// </summary>
         public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
         {
-            if (_simpleTypeConverter != null)
+            if (UnderlyingTypeConverter != null)
             {
-                return _simpleTypeConverter.GetStandardValuesExclusive(context);
+                return UnderlyingTypeConverter.GetStandardValuesExclusive(context);
             }
 
             return base.GetStandardValuesExclusive(context);
@@ -237,9 +233,9 @@ namespace System.ComponentModel
         /// </summary>
         public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
         {
-            if (_simpleTypeConverter != null)
+            if (UnderlyingTypeConverter != null)
             {
-                return _simpleTypeConverter.GetStandardValuesSupported(context);
+                return UnderlyingTypeConverter.GetStandardValuesSupported(context);
             }
 
             return base.GetStandardValuesSupported(context);
@@ -250,7 +246,7 @@ namespace System.ComponentModel
         /// </summary>
         public override bool IsValid(ITypeDescriptorContext context, object value)
         {
-            if (_simpleTypeConverter != null)
+            if (UnderlyingTypeConverter != null)
             {
                 object unwrappedValue = value;
                 if (unwrappedValue == null)
@@ -259,7 +255,7 @@ namespace System.ComponentModel
                 }
                 else
                 {
-                    return _simpleTypeConverter.IsValid(context, unwrappedValue);
+                    return UnderlyingTypeConverter.IsValid(context, unwrappedValue);
                 }
             }
 
@@ -269,34 +265,16 @@ namespace System.ComponentModel
         /// <summary>
         /// The type this converter was initialized with.
         /// </summary>
-        public Type NullableType
-        {
-            get
-            {
-                return _nullableType;
-            }
-        }
+        public Type NullableType { get; }
 
         /// <summary>
         /// The simple type that is represented as a nullable.
         /// </summary>
-        public Type UnderlyingType
-        {
-            get
-            {
-                return _simpleType;
-            }
-        }
+        public Type UnderlyingType { get; }
 
         /// <summary>
         /// Converter associated with the underlying simple type.
         /// </summary>
-        public TypeConverter UnderlyingTypeConverter
-        {
-            get
-            {
-                return _simpleTypeConverter;
-            }
-        }
+        public TypeConverter UnderlyingTypeConverter { get; }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PasswordPropertyTextAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PasswordPropertyTextAttribute.cs
@@ -34,8 +34,6 @@ namespace System.ComponentModel
         /// </summary>
         public static readonly PasswordPropertyTextAttribute Default = No;
 
-        private bool _password;
-
         /// <summary>
         ///    Creates a default PasswordPropertyTextAttribute.
         /// </summary>
@@ -48,19 +46,13 @@ namespace System.ComponentModel
         /// </summary>
         public PasswordPropertyTextAttribute(bool password)
         {
-            _password = password;
+            Password = password;
         }
 
         /// <summary>
         ///     Gets a value indicating if the property this attribute is defined for should be shown as password text.
         /// </summary>
-        public bool Password
-        {
-            get
-            {
-                return _password;
-            }
-        }
+        public bool Password { get; }
 
         /// <summary>
         ///     Overload for object equality
@@ -69,7 +61,7 @@ namespace System.ComponentModel
         {
             if (o is PasswordPropertyTextAttribute)
             {
-                return ((PasswordPropertyTextAttribute)o).Password == _password;
+                return ((PasswordPropertyTextAttribute)o).Password == Password;
             }
             return false;
         }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
@@ -103,13 +103,7 @@ namespace System.ComponentModel
         ///       specified in the <see cref='System.ComponentModel.LocalizableAttribute'/>.
         ///    </para>
         /// </summary>
-        public virtual bool IsLocalizable
-        {
-            get
-            {
-                return (LocalizableAttribute.Yes.Equals(Attributes[typeof(LocalizableAttribute)]));
-            }
-        }
+        public virtual bool IsLocalizable => (LocalizableAttribute.Yes.Equals(Attributes[typeof(LocalizableAttribute)]));
 
         /// <summary>
         ///    <para>
@@ -517,12 +511,6 @@ namespace System.ComponentModel
         ///     from direct calls made to PropertyDescriptor.SetValue (value=false). For example, the component may
         ///     implement the INotifyPropertyChanged interface, or may have an explicit '{name}Changed' event for this property.
         /// </summary>
-        public virtual bool SupportsChangeEvents
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public virtual bool SupportsChangeEvents => false;
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
@@ -436,9 +436,9 @@ namespace System.ComponentModel
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2109:ReviewVisibleEventHandlers")]
         protected virtual void OnValueChanged(object component, EventArgs e)
         {
-            if (component != null && _valueChangedHandlers != null)
+            if (component != null)
             {
-                ((EventHandler)_valueChangedHandlers[component])?.Invoke(component, e);
+                ((EventHandler) _valueChangedHandlers?[component])?.Invoke(component, e);
             }
         }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
@@ -12,7 +12,7 @@ namespace System.ComponentModel
     /// </summary>
     public abstract class PropertyDescriptor : MemberDescriptor
     {
-        private TypeConverter _converter = null;
+        private TypeConverter _converter;
         private Hashtable _valueChangedHandlers;
         private object[] _editors;
         private Type[] _editorTypes;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptorCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptorCollection.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters", Scope = "member", Target = "System.ComponentModel.PropertyDescriptorCollection.System.Collections.IDictionary.Add(System.Object,System.Object):System.Void")]
@@ -384,7 +385,7 @@ namespace System.ComponentModel
 
             if (names != null && names.Length > 0)
             {
-                ArrayList propArrayList = new ArrayList(_properties);
+                List<PropertyDescriptor> propArrayList = new List<PropertyDescriptor>(_properties);
                 int foundCount = 0;
                 int propCount = _properties.Length;
 
@@ -392,7 +393,7 @@ namespace System.ComponentModel
                 {
                     for (int j = 0; j < propCount; j++)
                     {
-                        PropertyDescriptor currentProp = (PropertyDescriptor)propArrayList[j];
+                        PropertyDescriptor currentProp = propArrayList[j];
 
                         // Found a matching property.  Here, we add it to our array.  We also
                         // mark it as null in our array list so we don't add it twice later.
@@ -415,7 +416,7 @@ namespace System.ComponentModel
                 {
                     if (propArrayList[i] != null)
                     {
-                        _properties[foundCount++] = (PropertyDescriptor)propArrayList[i];
+                        _properties[foundCount++] = propArrayList[i];
                     }
                 }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptorCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptorCollection.cs
@@ -109,13 +109,7 @@ namespace System.ComponentModel
         /// <summary>
         ///    <para>Gets the property with the specified name.</para>
         /// </summary>
-        public virtual PropertyDescriptor this[string name]
-        {
-            get
-            {
-                return Find(name, false);
-            }
-        }
+        public virtual PropertyDescriptor this[string name] => Find(name, false);
 
         /// <summary>
         ///    <para>[To be supplied.]</para>
@@ -465,30 +459,12 @@ namespace System.ComponentModel
         }
 
         /// <internalonly/>
-        bool ICollection.IsSynchronized
-        {
-            get
-            {
-                return false;
-            }
-        }
+        bool ICollection.IsSynchronized => false;
 
         /// <internalonly/>
-        object ICollection.SyncRoot
-        {
-            get
-            {
-                return null;
-            }
-        }
+        object ICollection.SyncRoot => null;
 
-        int ICollection.Count
-        {
-            get
-            {
-                return Count;
-            }
-        }
+        int ICollection.Count => Count;
 
         void IList.Clear()
         {
@@ -539,22 +515,10 @@ namespace System.ComponentModel
         }
 
         /// <internalonly/>
-        bool IDictionary.IsFixedSize
-        {
-            get
-            {
-                return _readOnly;
-            }
-        }
+        bool IDictionary.IsFixedSize => _readOnly;
 
         /// <internalonly/>
-        bool IDictionary.IsReadOnly
-        {
-            get
-            {
-                return _readOnly;
-            }
-        }
+        bool IDictionary.IsReadOnly => _readOnly;
 
         /// <internalonly/>
         object IDictionary.this[object key]
@@ -695,22 +659,10 @@ namespace System.ComponentModel
         }
 
         /// <internalonly/>
-        bool IList.IsReadOnly
-        {
-            get
-            {
-                return _readOnly;
-            }
-        }
+        bool IList.IsReadOnly => _readOnly;
 
         /// <internalonly/>
-        bool IList.IsFixedSize
-        {
-            get
-            {
-                return _readOnly;
-            }
-        }
+        bool IList.IsFixedSize => _readOnly;
 
         /// <internalonly/>
         void IList.Remove(object value)
@@ -758,13 +710,7 @@ namespace System.ComponentModel
                 _owner = owner;
             }
 
-            public object Current
-            {
-                get
-                {
-                    return Entry;
-                }
-            }
+            public object Current => Entry;
 
             public DictionaryEntry Entry
             {
@@ -775,21 +721,9 @@ namespace System.ComponentModel
                 }
             }
 
-            public object Key
-            {
-                get
-                {
-                    return _owner[_index].Name;
-                }
-            }
+            public object Key => _owner[_index].Name;
 
-            public object Value
-            {
-                get
-                {
-                    return _owner[_index].Name;
-                }
-            }
+            public object Value => _owner[_index].Name;
 
             public bool MoveNext()
             {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptorCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptorCollection.cs
@@ -385,7 +385,7 @@ namespace System.ComponentModel
 
             if (names != null && names.Length > 0)
             {
-                List<PropertyDescriptor> propArrayList = new List<PropertyDescriptor>(_properties);
+                List<PropertyDescriptor> propList = new List<PropertyDescriptor>(_properties);
                 int foundCount = 0;
                 int propCount = _properties.Length;
 
@@ -393,7 +393,7 @@ namespace System.ComponentModel
                 {
                     for (int j = 0; j < propCount; j++)
                     {
-                        PropertyDescriptor currentProp = propArrayList[j];
+                        PropertyDescriptor currentProp = propList[j];
 
                         // Found a matching property.  Here, we add it to our array.  We also
                         // mark it as null in our array list so we don't add it twice later.
@@ -401,7 +401,7 @@ namespace System.ComponentModel
                         if (currentProp != null && currentProp.Name.Equals(names[i]))
                         {
                             _properties[foundCount++] = currentProp;
-                            propArrayList[j] = null;
+                            propList[j] = null;
                             break;
                         }
                     }
@@ -414,9 +414,9 @@ namespace System.ComponentModel
                 //
                 for (int i = 0; i < propCount; i++)
                 {
-                    if (propArrayList[i] != null)
+                    if (propList[i] != null)
                     {
-                        _properties[foundCount++] = propArrayList[i];
+                        _properties[foundCount++] = propList[i];
                     }
                 }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptorCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptorCollection.cs
@@ -28,7 +28,6 @@ namespace System.ComponentModel
         private IDictionary _cachedFoundProperties;
         private bool _cachedIgnoreCase;
         private PropertyDescriptor[] _properties;
-        private int _propCount = 0;
         private readonly string[] _namedSort;
         private readonly IComparer _comparer;
         private bool _propsOwned;
@@ -48,12 +47,12 @@ namespace System.ComponentModel
             if (properties == null)
             {
                 _properties = Array.Empty<PropertyDescriptor>();
-                _propCount = 0;
+                Count = 0;
             }
             else
             {
                 _properties = properties;
-                _propCount = properties.Length;
+                Count = properties.Length;
             }
             _propsOwned = true;
         }
@@ -77,7 +76,7 @@ namespace System.ComponentModel
             }
             _comparer = comparer;
             _properties = properties;
-            _propCount = propCount;
+            Count = propCount;
             _needSort = true;
         }
 
@@ -88,13 +87,7 @@ namespace System.ComponentModel
         ///       collection.
         ///    </para>
         /// </summary>
-        public int Count
-        {
-            get
-            {
-                return _propCount;
-            }
-        }
+        public int Count { get; private set; } = 0;
 
         /// <summary>
         ///    <para>Gets the property with the specified index
@@ -104,7 +97,7 @@ namespace System.ComponentModel
         {
             get
             {
-                if (index >= _propCount)
+                if (index >= Count)
                 {
                     throw new IndexOutOfRangeException();
                 }
@@ -134,9 +127,9 @@ namespace System.ComponentModel
                 throw new NotSupportedException();
             }
 
-            EnsureSize(_propCount + 1);
-            _properties[_propCount++] = value;
-            return _propCount - 1;
+            EnsureSize(Count + 1);
+            _properties[Count++] = value;
+            return Count - 1;
         }
 
         /// <summary>
@@ -149,7 +142,7 @@ namespace System.ComponentModel
                 throw new NotSupportedException();
             }
 
-            _propCount = 0;
+            Count = 0;
             _cachedFoundProperties = null;
         }
 
@@ -199,7 +192,7 @@ namespace System.ComponentModel
 
             if (_properties.Length == 0)
             {
-                _propCount = 0;
+                Count = 0;
                 _properties = new PropertyDescriptor[sizeNeeded];
                 return;
             }
@@ -208,7 +201,7 @@ namespace System.ComponentModel
 
             int newSize = Math.Max(sizeNeeded, _properties.Length * 2);
             PropertyDescriptor[] newProps = new PropertyDescriptor[newSize];
-            Array.Copy(_properties, 0, newProps, 0, _propCount);
+            Array.Copy(_properties, 0, newProps, 0, Count);
             _properties = newProps;
         }
 
@@ -246,7 +239,7 @@ namespace System.ComponentModel
                 // Now start walking from where we last left off, filling
                 // the cache as we go.
                 //
-                for (int i = 0; i < _propCount; i++)
+                for (int i = 0; i < Count; i++)
                 {
                     if (ignoreCase)
                     {
@@ -277,7 +270,7 @@ namespace System.ComponentModel
         /// </summary>
         public int IndexOf(PropertyDescriptor value)
         {
-            return Array.IndexOf(_properties, value, 0, _propCount);
+            return Array.IndexOf(_properties, value, 0, Count);
         }
 
         /// <summary>
@@ -290,13 +283,13 @@ namespace System.ComponentModel
                 throw new NotSupportedException();
             }
 
-            EnsureSize(_propCount + 1);
-            if (index < _propCount)
+            EnsureSize(Count + 1);
+            if (index < Count)
             {
-                Array.Copy(_properties, index, _properties, index + 1, _propCount - index);
+                Array.Copy(_properties, index, _properties, index + 1, Count - index);
             }
             _properties[index] = value;
-            _propCount++;
+            Count++;
         }
 
         /// <summary>
@@ -327,12 +320,12 @@ namespace System.ComponentModel
                 throw new NotSupportedException();
             }
 
-            if (index < _propCount - 1)
+            if (index < Count - 1)
             {
-                Array.Copy(_properties, index + 1, _properties, index, _propCount - index - 1);
+                Array.Copy(_properties, index + 1, _properties, index, Count - index - 1);
             }
-            _properties[_propCount - 1] = null;
-            _propCount--;
+            _properties[Count - 1] = null;
+            Count--;
         }
 
         /// <summary>
@@ -343,7 +336,7 @@ namespace System.ComponentModel
         /// </summary>
         public virtual PropertyDescriptorCollection Sort()
         {
-            return new PropertyDescriptorCollection(_properties, _propCount, _namedSort, _comparer);
+            return new PropertyDescriptorCollection(_properties, Count, _namedSort, _comparer);
         }
 
 
@@ -355,7 +348,7 @@ namespace System.ComponentModel
         /// </summary>
         public virtual PropertyDescriptorCollection Sort(string[] names)
         {
-            return new PropertyDescriptorCollection(_properties, _propCount, names, _comparer);
+            return new PropertyDescriptorCollection(_properties, Count, names, _comparer);
         }
 
         /// <summary>
@@ -366,7 +359,7 @@ namespace System.ComponentModel
         /// </summary>
         public virtual PropertyDescriptorCollection Sort(string[] names, IComparer comparer)
         {
-            return new PropertyDescriptorCollection(_properties, _propCount, names, comparer);
+            return new PropertyDescriptorCollection(_properties, Count, names, comparer);
         }
 
         /// <summary>
@@ -377,7 +370,7 @@ namespace System.ComponentModel
         /// </summary>
         public virtual PropertyDescriptorCollection Sort(IComparer comparer)
         {
-            return new PropertyDescriptorCollection(_properties, _propCount, _namedSort, comparer);
+            return new PropertyDescriptorCollection(_properties, Count, _namedSort, comparer);
         }
 
         /// <summary>
@@ -462,10 +455,10 @@ namespace System.ComponentModel
         {
             EnsurePropsOwned();
             // we can only return an enumerator on the props we actually have...
-            if (_properties.Length != _propCount)
+            if (_properties.Length != Count)
             {
-                PropertyDescriptor[] enumProps = new PropertyDescriptor[_propCount];
-                Array.Copy(_properties, 0, enumProps, 0, _propCount);
+                PropertyDescriptor[] enumProps = new PropertyDescriptor[Count];
+                Array.Copy(_properties, 0, enumProps, 0, Count);
                 return enumProps.GetEnumerator();
             }
             return _properties.GetEnumerator();
@@ -593,14 +586,14 @@ namespace System.ComponentModel
                 {
                     index = (int)key;
 
-                    if (index < 0 || index >= _propCount)
+                    if (index < 0 || index >= Count)
                     {
                         throw new IndexOutOfRangeException();
                     }
                 }
                 else if (key is string)
                 {
-                    for (int i = 0; i < _propCount; i++)
+                    for (int i = 0; i < Count; i++)
                     {
                         if (_properties[i].Name.Equals((string)key))
                         {
@@ -635,8 +628,8 @@ namespace System.ComponentModel
         {
             get
             {
-                string[] keys = new string[_propCount];
-                for (int i = 0; i < _propCount; i++)
+                string[] keys = new string[Count];
+                for (int i = 0; i < Count; i++)
                 {
                     keys[i] = _properties[i].Name;
                 }
@@ -651,10 +644,10 @@ namespace System.ComponentModel
             {
                 // we can only return an enumerator on the props we actually have...
                 //
-                if (_properties.Length != _propCount)
+                if (_properties.Length != Count)
                 {
-                    PropertyDescriptor[] newProps = new PropertyDescriptor[_propCount];
-                    Array.Copy(_properties, 0, newProps, 0, _propCount);
+                    PropertyDescriptor[] newProps = new PropertyDescriptor[Count];
+                    Array.Copy(_properties, 0, newProps, 0, Count);
                     return newProps;
                 }
                 else
@@ -739,7 +732,7 @@ namespace System.ComponentModel
                     throw new NotSupportedException();
                 }
 
-                if (index >= _propCount)
+                if (index >= Count)
                 {
                     throw new IndexOutOfRangeException();
                 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptorCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptorCollection.cs
@@ -31,8 +31,8 @@ namespace System.ComponentModel
         private readonly string[] _namedSort;
         private readonly IComparer _comparer;
         private bool _propsOwned;
-        private bool _needSort = false;
-        private bool _readOnly = false;
+        private bool _needSort;
+        private bool _readOnly;
 
         private readonly object _internalSyncObject = new object();
 
@@ -87,7 +87,7 @@ namespace System.ComponentModel
         ///       collection.
         ///    </para>
         /// </summary>
-        public int Count { get; private set; } = 0;
+        public int Count { get; private set; }
 
         /// <summary>
         ///    <para>Gets the property with the specified index

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ProvidePropertyAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ProvidePropertyAttribute.cs
@@ -60,13 +60,7 @@ namespace System.ComponentModel
             return PropertyName.GetHashCode() ^ ReceiverTypeName.GetHashCode();
         }
 
-        public override object TypeId
-        {
-            get
-            {
-                return base.GetType().FullName + PropertyName;
-            }
-        }
+        public override object TypeId => base.GetType().FullName + PropertyName;
     }
 }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ProvidePropertyAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ProvidePropertyAttribute.cs
@@ -11,16 +11,13 @@ namespace System.ComponentModel
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public sealed class ProvidePropertyAttribute : Attribute
     {
-        private readonly string _propertyName;
-        private readonly string _receiverTypeName;
-
         /// <summary>
         /// <para>Initializes a new instance of the <see cref='System.ComponentModel.ProvidePropertyAttribute'/> class.</para>
         /// </summary>
         public ProvidePropertyAttribute(string propertyName, Type receiverType)
         {
-            _propertyName = propertyName;
-            _receiverTypeName = receiverType.AssemblyQualifiedName;
+            PropertyName = propertyName;
+            ReceiverTypeName = receiverType.AssemblyQualifiedName;
         }
 
         /// <summary>
@@ -28,8 +25,8 @@ namespace System.ComponentModel
         /// </summary>
         public ProvidePropertyAttribute(string propertyName, string receiverTypeName)
         {
-            _propertyName = propertyName;
-            _receiverTypeName = receiverTypeName;
+            PropertyName = propertyName;
+            ReceiverTypeName = receiverTypeName;
         }
 
         /// <summary>
@@ -37,26 +34,14 @@ namespace System.ComponentModel
         ///       Gets the name of a property that this class provides.
         ///    </para>
         /// </summary>
-        public string PropertyName
-        {
-            get
-            {
-                return _propertyName;
-            }
-        }
+        public string PropertyName { get; }
 
         /// <summary>
         ///    <para>
         ///       Gets the name of the data type this property can extend
         ///    </para>
         /// </summary>
-        public string ReceiverTypeName
-        {
-            get
-            {
-                return _receiverTypeName;
-            }
-        }
+        public string ReceiverTypeName { get; }
 
         public override bool Equals(object obj)
         {
@@ -67,19 +52,19 @@ namespace System.ComponentModel
 
             ProvidePropertyAttribute other = obj as ProvidePropertyAttribute;
 
-            return (other != null) && other._propertyName == _propertyName && other._receiverTypeName == _receiverTypeName;
+            return (other != null) && other.PropertyName == PropertyName && other.ReceiverTypeName == ReceiverTypeName;
         }
 
         public override int GetHashCode()
         {
-            return _propertyName.GetHashCode() ^ _receiverTypeName.GetHashCode();
+            return PropertyName.GetHashCode() ^ ReceiverTypeName.GetHashCode();
         }
 
         public override object TypeId
         {
             get
             {
-                return base.GetType().FullName + _propertyName;
+                return base.GetType().FullName + PropertyName;
             }
         }
     }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/RecommendedAsConfigurableAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/RecommendedAsConfigurableAttribute.cs
@@ -16,8 +16,6 @@ namespace System.ComponentModel
     [Obsolete("Use System.ComponentModel.SettingsBindableAttribute instead to work with the new settings model.")]
     public class RecommendedAsConfigurableAttribute : Attribute
     {
-        private bool _recommendedAsConfigurable = false;
-
         /// <summary>
         ///    <para>
         ///       Initializes a new instance of
@@ -26,20 +24,14 @@ namespace System.ComponentModel
         /// </summary>
         public RecommendedAsConfigurableAttribute(bool recommendedAsConfigurable)
         {
-            _recommendedAsConfigurable = recommendedAsConfigurable;
+            RecommendedAsConfigurable = recommendedAsConfigurable;
         }
 
         /// <summary>
         ///    <para>Gets a value indicating whether the property this
         ///       attribute is bound to can be used as an application setting.</para>
         /// </summary>
-        public bool RecommendedAsConfigurable
-        {
-            get
-            {
-                return _recommendedAsConfigurable;
-            }
-        }
+        public bool RecommendedAsConfigurable { get; } = false;
 
         /// <summary>
         ///    <para>
@@ -77,7 +69,7 @@ namespace System.ComponentModel
 
             RecommendedAsConfigurableAttribute other = obj as RecommendedAsConfigurableAttribute;
 
-            return other != null && other.RecommendedAsConfigurable == _recommendedAsConfigurable;
+            return other != null && other.RecommendedAsConfigurable == RecommendedAsConfigurable;
         }
 
         /// <summary>
@@ -95,7 +87,7 @@ namespace System.ComponentModel
         /// </summary>
         public override bool IsDefaultAttribute()
         {
-            return !_recommendedAsConfigurable;
+            return !RecommendedAsConfigurable;
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/RecommendedAsConfigurableAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/RecommendedAsConfigurableAttribute.cs
@@ -31,7 +31,7 @@ namespace System.ComponentModel
         ///    <para>Gets a value indicating whether the property this
         ///       attribute is bound to can be used as an application setting.</para>
         /// </summary>
-        public bool RecommendedAsConfigurable { get; } = false;
+        public bool RecommendedAsConfigurable { get; }
 
         /// <summary>
         ///    <para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReferenceConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReferenceConverter.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Win32;
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Globalization;
@@ -146,7 +147,7 @@ namespace System.ComponentModel
 
             if (context != null)
             {
-                ArrayList list = new ArrayList();
+                List<object> list = new List<object>();
                 list.Add(null);
 
                 // Try the reference service first.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReferenceConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReferenceConverter.cs
@@ -104,16 +104,13 @@ namespace System.ComponentModel
                 {
                     // Try the reference service first.
                     //
-                    if (context != null)
+                    IReferenceService refSvc = (IReferenceService) context?.GetService(typeof(IReferenceService));
+                    if (refSvc != null)
                     {
-                        IReferenceService refSvc = (IReferenceService)context.GetService(typeof(IReferenceService));
-                        if (refSvc != null)
+                        string name = refSvc.GetName(value);
+                        if (name != null)
                         {
-                            string name = refSvc.GetName(value);
-                            if (name != null)
-                            {
-                                return name;
-                            }
+                            return name;
                         }
                     }
 
@@ -123,13 +120,10 @@ namespace System.ComponentModel
                     {
                         IComponent comp = (IComponent)value;
                         ISite site = comp.Site;
-                        if (site != null)
+                        string name = site?.Name;
+                        if (name != null)
                         {
-                            string name = site.Name;
-                            if (name != null)
-                            {
-                                return name;
-                            }
+                            return name;
                         }
                     }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectEventDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectEventDescriptor.cs
@@ -199,10 +199,7 @@ namespace System.ComponentModel
 
                 // Now notify the change service that the change was successful.
                 //
-                if (changeService != null)
-                {
-                    changeService.OnComponentChanged(component, this, null, value);
-                }
+                changeService?.OnComponentChanged(component, this, null, value);
             }
         }
 
@@ -488,10 +485,7 @@ namespace System.ComponentModel
 
                 // Now notify the change service that the change was successful.
                 //
-                if (changeService != null)
-                {
-                    changeService.OnComponentChanged(component, this, null, value);
-                }
+                changeService?.OnComponentChanged(component, this, null, value);
             }
         }
     }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectEventDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectEventDescriptor.cs
@@ -66,7 +66,7 @@ namespace System.ComponentModel
         private MethodInfo _addMethod;     // the method to use when adding an event
         private MethodInfo _removeMethod;  // the method to use when removing an event
         private EventInfo _realEvent;      // actual event info... may be null
-        private bool _filledMethods = false;   // did we already call FillMethods() once?
+        private bool _filledMethods;   // did we already call FillMethods() once?
 
         /// <summary>
         ///     This is the main constructor for an ReflectEventDescriptor.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectEventDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectEventDescriptor.cs
@@ -82,7 +82,7 @@ namespace System.ComponentModel
             {
                 throw new ArgumentException(SR.Format(SR.ErrorInvalidEventType, name));
             }
-            Debug.Assert(type.GetTypeInfo().IsSubclassOf(typeof(Delegate)), "Not a valid ReflectEvent: " + componentClass.FullName + "." + name + " " + type.FullName);
+            Debug.Assert(type.GetTypeInfo().IsSubclassOf(typeof(Delegate)), $"Not a valid ReflectEvent: {componentClass.FullName}. {name} {type.FullName}");
             _componentClass = componentClass;
             _type = type;
         }
@@ -234,10 +234,10 @@ namespace System.ComponentModel
             }
             else
             {
-                Debug.Assert(_removeMethod != null, "Null remove method for " + Name);
+                Debug.Assert(_removeMethod != null, $"Null remove method for {Name}");
                 FillSingleMethodAttribute(_removeMethod, attributes);
 
-                Debug.Assert(_addMethod != null, "Null remove method for " + Name);
+                Debug.Assert(_addMethod != null, $"Null remove method for {Name}");
                 FillSingleMethodAttribute(_addMethod, attributes);
             }
 
@@ -360,11 +360,11 @@ namespace System.ComponentModel
                 }
 
                 Type[] argsType = new Type[] { _type };
-                _addMethod = FindMethod(_componentClass, "AddOn" + Name, argsType, typeof(void));
-                _removeMethod = FindMethod(_componentClass, "RemoveOn" + Name, argsType, typeof(void));
+                _addMethod = FindMethod(_componentClass, $"AddOn{Name}", argsType, typeof(void));
+                _removeMethod = FindMethod(_componentClass, $"RemoveOn{Name}", argsType, typeof(void));
                 if (_addMethod == null || _removeMethod == null)
                 {
-                    Debug.Fail("Missing event accessors for " + _componentClass.FullName + "." + Name);
+                    Debug.Fail($"Missing event accessors for {_componentClass.FullName}. {Name}");
                     throw new ArgumentException(SR.Format(SR.ErrorMissingEventAccessors, Name));
                 }
             }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectEventDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectEventDescriptor.cs
@@ -120,13 +120,7 @@ namespace System.ComponentModel
         /// <summary>
         ///     Retrieves the type of the component this EventDescriptor is bound to.
         /// </summary>
-        public override Type ComponentType
-        {
-            get
-            {
-                return _componentClass;
-            }
-        }
+        public override Type ComponentType => _componentClass;
 
         /// <summary>
         ///     Retrieves the type of the delegate for this event.
@@ -143,13 +137,7 @@ namespace System.ComponentModel
         /// <summary>
         ///     Indicates whether the delegate type for this event is a multicast delegate.
         /// </summary>
-        public override bool IsMulticast
-        {
-            get
-            {
-                return (typeof(MulticastDelegate)).IsAssignableFrom(EventType);
-            }
-        }
+        public override bool IsMulticast => (typeof(MulticastDelegate)).IsAssignableFrom(EventType);
 
         /// <summary>
         ///     This adds the delegate value as a listener to when this event is fired

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectEventDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectEventDescriptor.cs
@@ -360,8 +360,8 @@ namespace System.ComponentModel
                 }
 
                 Type[] argsType = new Type[] { _type };
-                _addMethod = FindMethod(_componentClass, $"AddOn{Name}", argsType, typeof(void));
-                _removeMethod = FindMethod(_componentClass, $"RemoveOn{Name}", argsType, typeof(void));
+                _addMethod = FindMethod(_componentClass, "AddOn" + Name, argsType, typeof(void));
+                _removeMethod = FindMethod(_componentClass, "RemoveOn" + Name, argsType, typeof(void));
                 if (_addMethod == null || _removeMethod == null)
                 {
                     Debug.Fail($"Missing event accessors for {_componentClass.FullName}. {Name}");

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
@@ -90,12 +90,12 @@ namespace System.ComponentModel
             {
                 if (type == null)
                 {
-                    Debug.WriteLine("type == null, name == " + name);
+                    Debug.WriteLine($"type == null, name == {name}");
                     throw new ArgumentException(string.Format(SR.ErrorInvalidPropertyType, name));
                 }
                 if (componentClass == null)
                 {
-                    Debug.WriteLine("componentClass == null, name == " + name);
+                    Debug.WriteLine($"componentClass == null, name == {name}");
                     throw new ArgumentException(string.Format(SR.InvalidNullArgument, nameof(componentClass)));
                 }
                 _type = type;
@@ -103,7 +103,7 @@ namespace System.ComponentModel
             }
             catch (Exception t)
             {
-                Debug.Fail("Property '" + name + "' on component " + componentClass.FullName + " failed to init.");
+                Debug.Fail($"Property '{name}' on component {componentClass.FullName} failed to init.");
                 Debug.Fail(t.ToString());
                 throw;
             }
@@ -330,12 +330,12 @@ namespace System.ComponentModel
                         }
                         if (_getMethod == null)
                         {
-                            throw new InvalidOperationException(string.Format(SR.ErrorMissingPropertyAccessors, _componentClass.FullName + "." + Name));
+                            throw new InvalidOperationException(string.Format(SR.ErrorMissingPropertyAccessors, $"{_componentClass.FullName}.{Name}"));
                         }
                     }
                     else
                     {
-                        _getMethod = FindMethod(_componentClass, "Get" + Name, new Type[] { _receiverType }, _type);
+                        _getMethod = FindMethod(_componentClass, $"Get {Name}", new Type[] { _receiverType }, _type);
                         if (_getMethod == null)
                         {
                             throw new ArgumentException(string.Format(SR.ErrorMissingPropertyAccessors, Name));
@@ -383,7 +383,7 @@ namespace System.ComponentModel
                         args = new Type[] { _receiverType };
                     }
 
-                    _resetMethod = FindMethod(_componentClass, "Reset" + Name, args, typeof(void), /* publicOnly= */ false);
+                    _resetMethod = FindMethod(_componentClass, $"Reset {Name}", args, typeof(void), /* publicOnly= */ false);
 
                     _state[s_bitResetQueried] = true;
                 }
@@ -444,7 +444,7 @@ namespace System.ComponentModel
                     }
                     else
                     {
-                        _setMethod = FindMethod(_componentClass, "Set" + Name,
+                        _setMethod = FindMethod(_componentClass, "Set {Name}",
                                                new Type[] { _receiverType, _type }, typeof(void));
                     }
 
@@ -474,7 +474,7 @@ namespace System.ComponentModel
                         args = new Type[] { _receiverType };
                     }
 
-                    _shouldSerializeMethod = FindMethod(_componentClass, "ShouldSerialize" + Name, args, typeof(Boolean), /* publicOnly= */ false);
+                    _shouldSerializeMethod = FindMethod(_componentClass, $"ShouldSerialize {Name}", args, typeof(Boolean), /* publicOnly= */ false);
                     _state[s_bitShouldSerializeQueried] = true;
                 }
                 return _shouldSerializeMethod;
@@ -820,7 +820,7 @@ namespace System.ComponentModel
                     if (IsExtender)
                     {
                         //receiverType is used to avoid ambitiousness when there are overloads for the get method.
-                        memberInfo = currentReflectType.GetTypeInfo().GetMethod("Get" + Name, new Type[] { _receiverType }, null);
+                        memberInfo = currentReflectType.GetTypeInfo().GetMethod($"Get{Name}", new Type[] { _receiverType }, null);
                     }
                     else
                     {
@@ -920,7 +920,7 @@ namespace System.ComponentModel
 
             if (IsExtender)
             {
-                Debug.WriteLine("[" + Name + "]:   ---> returning: null");
+                Debug.WriteLine($"[{Name}]:   ---> returning: null");
                 return null;
             }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
@@ -273,13 +273,7 @@ namespace System.ComponentModel
         /// <summary>
         ///     Retrieves the type of the component this PropertyDescriptor is bound to.
         /// </summary>
-        public override Type ComponentType
-        {
-            get
-            {
-                return _componentClass;
-            }
-        }
+        public override Type ComponentType => _componentClass;
 
         /// <summary>
         ///      Retrieves the default value for this property.
@@ -356,36 +350,18 @@ namespace System.ComponentModel
         /// <summary>
         ///     Determines if this property is an extender property.
         /// </summary>
-        private bool IsExtender
-        {
-            get
-            {
-                return (_receiverType != null);
-            }
-        }
+        private bool IsExtender => (_receiverType != null);
 
         /// <summary>
         ///     Indicates whether this property is read only.
         /// </summary>
-        public override bool IsReadOnly
-        {
-            get
-            {
-                return SetMethodValue == null || ((ReadOnlyAttribute)Attributes[typeof(ReadOnlyAttribute)]).IsReadOnly;
-            }
-        }
+        public override bool IsReadOnly => SetMethodValue == null || ((ReadOnlyAttribute)Attributes[typeof(ReadOnlyAttribute)]).IsReadOnly;
 
 
         /// <summary>
         ///     Retrieves the type of the property.
         /// </summary>
-        public override Type PropertyType
-        {
-            get
-            {
-                return _type;
-            }
-        }
+        public override Type PropertyType => _type;
 
         /// <summary>
         ///     Access to the reset method, if one exists for this property.
@@ -1273,12 +1249,6 @@ namespace System.ComponentModel
         ///     from direct calls made to PropertyDescriptor.SetValue (value=false). For example, the component may
         ///     implement the INotifyPropertyChanged interface, or may have an explicit '{name}Changed' event for this property.
         /// </summary>
-        public override bool SupportsChangeEvents
-        {
-            get
-            {
-                return IPropChangedEventValue != null || ChangedEventValue != null;
-            }
-        }
+        public override bool SupportsChangeEvents => IPropChangedEventValue != null || ChangedEventValue != null;
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
@@ -330,12 +330,12 @@ namespace System.ComponentModel
                         }
                         if (_getMethod == null)
                         {
-                            throw new InvalidOperationException(string.Format(SR.ErrorMissingPropertyAccessors, $"{_componentClass.FullName}.{Name}"));
+                            throw new InvalidOperationException(string.Format(SR.ErrorMissingPropertyAccessors, _componentClass.FullName + "." + Name));
                         }
                     }
                     else
                     {
-                        _getMethod = FindMethod(_componentClass, $"Get {Name}", new Type[] { _receiverType }, _type);
+                        _getMethod = FindMethod(_componentClass, "Get" + Name, new Type[] { _receiverType }, _type);
                         if (_getMethod == null)
                         {
                             throw new ArgumentException(string.Format(SR.ErrorMissingPropertyAccessors, Name));
@@ -383,7 +383,7 @@ namespace System.ComponentModel
                         args = new Type[] { _receiverType };
                     }
 
-                    _resetMethod = FindMethod(_componentClass, $"Reset {Name}", args, typeof(void), /* publicOnly= */ false);
+                    _resetMethod = FindMethod(_componentClass, "Reset" + Name, args, typeof(void), /* publicOnly= */ false);
 
                     _state[s_bitResetQueried] = true;
                 }
@@ -444,7 +444,7 @@ namespace System.ComponentModel
                     }
                     else
                     {
-                        _setMethod = FindMethod(_componentClass, "Set {Name}",
+                        _setMethod = FindMethod(_componentClass, "Set" + Name,
                                                new Type[] { _receiverType, _type }, typeof(void));
                     }
 
@@ -474,7 +474,7 @@ namespace System.ComponentModel
                         args = new Type[] { _receiverType };
                     }
 
-                    _shouldSerializeMethod = FindMethod(_componentClass, $"ShouldSerialize {Name}", args, typeof(Boolean), /* publicOnly= */ false);
+                    _shouldSerializeMethod = FindMethod(_componentClass, "ShouldSerialize" + Name, args, typeof(Boolean), /* publicOnly= */ false);
                     _state[s_bitShouldSerializeQueried] = true;
                 }
                 return _shouldSerializeMethod;
@@ -820,7 +820,7 @@ namespace System.ComponentModel
                     if (IsExtender)
                     {
                         //receiverType is used to avoid ambitiousness when there are overloads for the get method.
-                        memberInfo = currentReflectType.GetTypeInfo().GetMethod($"Get{Name}", new Type[] { _receiverType }, null);
+                        memberInfo = currentReflectType.GetTypeInfo().GetMethod("Get" + Name, new Type[] { _receiverType }, null);
                     }
                     else
                     {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
@@ -504,10 +504,7 @@ namespace System.ComponentModel
                 if (GetValueChangedHandler(component) == null)
                 {
                     EventDescriptor iPropChangedEvent = IPropChangedEventValue;
-                    if (iPropChangedEvent != null)
-                    {
-                        iPropChangedEvent.AddEventHandler(component, new PropertyChangedEventHandler(OnINotifyPropertyChanged));
-                    }
+                    iPropChangedEvent?.AddEventHandler(component, new PropertyChangedEventHandler(OnINotifyPropertyChanged));
                 }
 
                 base.AddValueChanged(component, handler);
@@ -663,10 +660,7 @@ namespace System.ComponentModel
 
                     // Now notify the change service that the change was successful.
                     //
-                    if (changeService != null)
-                    {
-                        changeService.OnComponentChanged(component, notifyDesc, oldValue, value);
-                    }
+                    changeService?.OnComponentChanged(component, notifyDesc, oldValue, value);
                 }
             }
         }
@@ -945,13 +939,10 @@ namespace System.ComponentModel
                 {
                     string name = null;
                     IComponent comp = component as IComponent;
-                    if (comp != null)
+                    ISite site = comp?.Site;
+                    if (site?.Name != null)
                     {
-                        ISite site = comp.Site;
-                        if (site != null && site.Name != null)
-                        {
-                            name = site.Name;
-                        }
+                        name = site.Name;
                     }
 
                     if (name == null)
@@ -964,11 +955,7 @@ namespace System.ComponentModel
                         t = t.InnerException;
                     }
 
-                    string message = t.Message;
-                    if (message == null)
-                    {
-                        message = t.GetType().Name;
-                    }
+                    string message = t.Message ?? t.GetType().Name;
 
                     throw new TargetInvocationException(string.Format(SR.ErrorPropertyAccessorException, Name, name, message), t);
                 }
@@ -1030,10 +1017,7 @@ namespace System.ComponentModel
                 if (GetValueChangedHandler(component) == null)
                 {
                     EventDescriptor iPropChangedEvent = IPropChangedEventValue;
-                    if (iPropChangedEvent != null)
-                    {
-                        iPropChangedEvent.RemoveEventHandler(component, new PropertyChangedEventHandler(OnINotifyPropertyChanged));
-                    }
+                    iPropChangedEvent?.RemoveEventHandler(component, new PropertyChangedEventHandler(OnINotifyPropertyChanged));
                 }
             }
         }
@@ -1192,10 +1176,7 @@ namespace System.ComponentModel
                     {
                         // Now notify the change service that the change was successful.
                         //
-                        if (changeService != null)
-                        {
-                            changeService.OnComponentChanged(component, this, oldValue, value);
-                        }
+                        changeService?.OnComponentChanged(component, this, oldValue, value);
                     }
                 }
             }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.ReflectedTypeData.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.ReflectedTypeData.cs
@@ -36,13 +36,7 @@ namespace System.ComponentModel
             ///     This method returns true if the data cache in this reflection 
             ///     type descriptor has data in it.
             /// </summary>
-            internal bool IsPopulated
-            {
-                get
-                {
-                    return (_attributes != null) | (_events != null) | (_properties != null);
-                }
-            }
+            internal bool IsPopulated => (_attributes != null) | (_events != null) | (_properties != null);
 
             /// <summary>
             ///     Retrieves custom attributes.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.ReflectedTypeData.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.ReflectedTypeData.cs
@@ -378,7 +378,7 @@ namespace System.ComponentModel
                     //
                     if (editor != null && !editorBaseType.GetTypeInfo().IsInstanceOfType(editor))
                     {
-                        Debug.Fail("Editor " + editor.GetType().FullName + " is not an instance of " + editorBaseType.FullName + " but it is in that base types table.");
+                        Debug.Fail($"Editor {editor.GetType().FullName} is not an instance of {editorBaseType.FullName} but it is in that base types table.");
                         editor = null;
                     }
                 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.ReflectedTypeData.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.ReflectedTypeData.cs
@@ -171,14 +171,7 @@ namespace System.ComponentModel
                 if (site != null)
                 {
                     INestedSite nestedSite = site as INestedSite;
-                    if (nestedSite != null)
-                    {
-                        return nestedSite.FullName;
-                    }
-                    else
-                    {
-                        return site.Name;
-                    }
+                    return (nestedSite?.FullName) ?? site.Name;
                 }
 
                 return null;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.ReflectedTypeData.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.ReflectedTypeData.cs
@@ -167,20 +167,17 @@ namespace System.ComponentModel
             internal string GetComponentName(object instance)
             {
                 IComponent comp = instance as IComponent;
-                if (comp != null)
+                ISite site = comp?.Site;
+                if (site != null)
                 {
-                    ISite site = comp.Site;
-                    if (site != null)
+                    INestedSite nestedSite = site as INestedSite;
+                    if (nestedSite != null)
                     {
-                        INestedSite nestedSite = site as INestedSite;
-                        if (nestedSite != null)
-                        {
-                            return nestedSite.FullName;
-                        }
-                        else
-                        {
-                            return site.Name;
-                        }
+                        return nestedSite.FullName;
+                    }
+                    else
+                    {
+                        return site.Name;
                     }
                 }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -62,7 +62,6 @@ namespace System.ComponentModel
         // These are keys we stuff into our object cache.  We use this
         // cache data to store extender provider info for an object.
         //
-        private static readonly Guid s_extenderProviderKey = Guid.NewGuid();
         private static readonly Guid s_extenderPropertiesKey = Guid.NewGuid();
         private static readonly Guid s_extenderProviderPropertiesKey = Guid.NewGuid();
 
@@ -78,13 +77,7 @@ namespace System.ComponentModel
         };
 
 
-        internal static Guid ExtenderProviderKey
-        {
-            get
-            {
-                return s_extenderProviderKey;
-            }
-        }
+        internal static Guid ExtenderProviderKey { get; } = Guid.NewGuid();
 
 
         private static object s_internalSyncObject = new object();
@@ -628,7 +621,7 @@ namespace System.ComponentModel
 
             if (cache != null)
             {
-                existingExtenders = cache[s_extenderProviderKey] as IExtenderProvider[];
+                existingExtenders = cache[ExtenderProviderKey] as IExtenderProvider[];
             }
 
             if (existingExtenders == null)
@@ -723,7 +716,7 @@ namespace System.ComponentModel
 
                 if (cache != null)
                 {
-                    cache[s_extenderProviderKey] = currentExtenders;
+                    cache[ExtenderProviderKey] = currentExtenders;
                     cache.Remove(s_extenderPropertiesKey);
                 }
             }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -221,12 +221,7 @@ namespace System.ComponentModel
                 obj = objectType.GetTypeInfo().GetConstructor(argTypes)?.Invoke(args);
             }
 
-            if (obj == null)
-            {
-                obj = Activator.CreateInstance(objectType, args);
-            }
-
-            return obj;
+            return obj ?? (obj = Activator.CreateInstance(objectType, args));
         }
 
 
@@ -758,13 +753,10 @@ namespace System.ComponentModel
         public override string GetFullComponentName(object component)
         {
             IComponent comp = component as IComponent;
-            if (comp != null)
+            INestedSite ns = comp?.Site as INestedSite;
+            if (ns != null)
             {
-                INestedSite ns = comp.Site as INestedSite;
-                if (ns != null)
-                {
-                    return ns.FullName;
-                }
+                return ns.FullName;
             }
 
             return TypeDescriptor.GetComponentName(component);
@@ -1289,10 +1281,7 @@ namespace System.ComponentModel
         internal void Refresh(Type type)
         {
             ReflectedTypeData td = GetTypeData(type, false);
-            if (td != null)
-            {
-                td.Refresh();
-            }
+            td?.Refresh();
         }
 
         /// <summary> 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Linq;
@@ -503,7 +504,7 @@ namespace System.ComponentModel
             // Unlike normal properties, it is fine for there to be properties with
             // duplicate names here.  
             //
-            ArrayList propertyList = null;
+            List<PropertyDescriptor> propertyList = null;
 
             for (int idx = 0; idx < extenders.Length; idx++)
             {
@@ -511,7 +512,7 @@ namespace System.ComponentModel
 
                 if (propertyList == null)
                 {
-                    propertyList = new ArrayList(propertyArray.Length * extenders.Length);
+                    propertyList = new List<PropertyDescriptor>(propertyArray.Length * extenders.Length);
                 }
 
                 for (int propIdx = 0; propIdx < propertyArray.Length; propIdx++)
@@ -767,7 +768,7 @@ namespace System.ComponentModel
         /// </summary>
         internal Type[] GetPopulatedTypes(Module module)
         {
-            ArrayList typeList = new ArrayList(); ;
+            List<Type> typeList = new List<Type>(); 
 
             // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
             IDictionaryEnumerator e = _typeData.GetEnumerator();
@@ -783,7 +784,7 @@ namespace System.ComponentModel
                 }
             }
 
-            return (Type[])typeList.ToArray(typeof(Type));
+            return typeList.ToArray();
         }
 
         /// <summary>
@@ -1126,7 +1127,7 @@ namespace System.ComponentModel
                     if (extendedProperties == null)
                     {
                         AttributeCollection attributes = TypeDescriptor.GetAttributes(providerType);
-                        ArrayList extendedList = new ArrayList(attributes.Count);
+                        List<ReflectPropertyDescriptor> extendedList = new List<ReflectPropertyDescriptor>(attributes.Count);
 
                         foreach (Attribute attr in attributes)
                         {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -519,7 +519,7 @@ namespace System.ComponentModel
                     PropertyDescriptor prop = propertyArray[propIdx];
                     ExtenderProvidedPropertyAttribute eppa = prop.Attributes[typeof(ExtenderProvidedPropertyAttribute)] as ExtenderProvidedPropertyAttribute;
 
-                    Debug.Assert(eppa != null, "Extender property " + prop.Name + " has no provider attribute.  We will skip it.");
+                    Debug.Assert(eppa != null, $"Extender property {prop.Name} has no provider attribute.  We will skip it.");
                     if (eppa != null)
                     {
                         Type receiverType = eppa.ReceiverType;
@@ -1139,11 +1139,11 @@ namespace System.ComponentModel
 
                                 if (receiverType != null)
                                 {
-                                    MethodInfo getMethod = providerType.GetTypeInfo().GetMethod("Get" + provideAttr.PropertyName, new Type[] { receiverType });
+                                    MethodInfo getMethod = providerType.GetTypeInfo().GetMethod($"Get{provideAttr.PropertyName}", new Type[] { receiverType });
 
                                     if (getMethod != null && !getMethod.IsStatic && getMethod.IsPublic)
                                     {
-                                        MethodInfo setMethod = providerType.GetTypeInfo().GetMethod("Set" + provideAttr.PropertyName, new Type[] { receiverType, getMethod.ReturnType });
+                                        MethodInfo setMethod = providerType.GetTypeInfo().GetMethod($"Set{provideAttr.PropertyName}", new Type[] { receiverType, getMethod.ReturnType });
 
                                         if (setMethod != null && (setMethod.IsStatic || !setMethod.IsPublic))
                                         {
@@ -1264,7 +1264,7 @@ namespace System.ComponentModel
                         properties = newProperties;
                     }
 
-                    Debug.Assert(!properties.Any(dbgProp => dbgProp == null), "Holes in property array for type " + type);
+                    Debug.Assert(!properties.Any(dbgProp => dbgProp == null), $"Holes in property array for type {type}");
 
                     s_propertyCache[type] = properties;
                 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -691,10 +691,9 @@ namespace System.ComponentModel
                     }
                     else if (extenderCount > 0)
                     {
-                        IEnumerator componentEnum = components.GetEnumerator();
-                        while (componentEnum.MoveNext())
+                        foreach (var component in components)
                         {
-                            IExtenderProvider p = componentEnum.Current as IExtenderProvider;
+                            IExtenderProvider p = component as IExtenderProvider;
 
                             if (p != null && ((curIdx < maxCanExtendResults && (canExtend & ((UInt64)1 << curIdx)) != 0) ||
                                                 (curIdx >= maxCanExtendResults && p.CanExtend(instance))))

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -222,7 +222,7 @@ namespace System.ComponentModel
                 obj = objectType.GetTypeInfo().GetConstructor(argTypes)?.Invoke(args);
             }
 
-            return obj ?? (obj = Activator.CreateInstance(objectType, args));
+            return obj ?? Activator.CreateInstance(objectType, args);
         }
 
 
@@ -1139,11 +1139,11 @@ namespace System.ComponentModel
 
                                 if (receiverType != null)
                                 {
-                                    MethodInfo getMethod = providerType.GetTypeInfo().GetMethod($"Get{provideAttr.PropertyName}", new Type[] { receiverType });
+                                    MethodInfo getMethod = providerType.GetTypeInfo().GetMethod("Get" + provideAttr.PropertyName, new Type[] { receiverType });
 
                                     if (getMethod != null && !getMethod.IsStatic && getMethod.IsPublic)
                                     {
-                                        MethodInfo setMethod = providerType.GetTypeInfo().GetMethod($"Set{provideAttr.PropertyName}", new Type[] { receiverType, getMethod.ReturnType });
+                                        MethodInfo setMethod = providerType.GetTypeInfo().GetMethod("Set" + provideAttr.PropertyName, new Type[] { receiverType, getMethod.ReturnType });
 
                                         if (setMethod != null && (setMethod.IsStatic || !setMethod.IsPublic))
                                         {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -80,7 +80,7 @@ namespace System.ComponentModel
         internal static Guid ExtenderProviderKey { get; } = Guid.NewGuid();
 
 
-        private static object s_internalSyncObject = new object();
+        private static readonly object s_internalSyncObject = new object();
         /// <summary>
         ///     Creates a new ReflectTypeDescriptionProvider.  The type is the
         ///     type we will obtain type information for.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/RefreshEventArgs.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/RefreshEventArgs.cs
@@ -11,9 +11,6 @@ namespace System.ComponentModel
     /// </summary>
     public class RefreshEventArgs : EventArgs
     {
-        private readonly object _componentChanged;
-        private readonly Type _typeChanged;
-
         /// <summary>
         ///    <para>
         ///       Initializes a new instance of the <see cref='System.ComponentModel.RefreshEventArgs'/> class with
@@ -22,8 +19,8 @@ namespace System.ComponentModel
         /// </summary>
         public RefreshEventArgs(object componentChanged)
         {
-            _componentChanged = componentChanged;
-            _typeChanged = componentChanged.GetType();
+            ComponentChanged = componentChanged;
+            TypeChanged = componentChanged.GetType();
         }
 
         /// <summary>
@@ -34,7 +31,7 @@ namespace System.ComponentModel
         /// </summary>
         public RefreshEventArgs(Type typeChanged)
         {
-            _typeChanged = typeChanged;
+            TypeChanged = typeChanged;
         }
 
         /// <summary>
@@ -42,25 +39,13 @@ namespace System.ComponentModel
         ///       Gets the component that has changed its properties, events, or extenders.
         ///    </para>
         /// </summary>
-        public object ComponentChanged
-        {
-            get
-            {
-                return _componentChanged;
-            }
-        }
+        public object ComponentChanged { get; }
 
         /// <summary>
         ///    <para>
         ///       Gets the type that has changed its properties, or events.
         ///    </para>
         /// </summary>
-        public Type TypeChanged
-        {
-            get
-            {
-                return _typeChanged;
-            }
-        }
+        public Type TypeChanged { get; }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/RunInstallerAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/RunInstallerAttribute.cs
@@ -15,9 +15,6 @@ namespace System.ComponentModel
     [AttributeUsage(AttributeTargets.Class)]
     public class RunInstallerAttribute : Attribute
     {
-        private bool _runInstaller;
-
-
         /// <summary>
         ///    <para>
         ///       Initializes a new instance of
@@ -26,7 +23,7 @@ namespace System.ComponentModel
         /// </summary>
         public RunInstallerAttribute(bool runInstaller)
         {
-            _runInstaller = runInstaller;
+            RunInstaller = runInstaller;
         }
 
 
@@ -36,13 +33,7 @@ namespace System.ComponentModel
         ///       invoked during installation of an assembly.
         ///    </para>
         /// </summary>
-        public bool RunInstaller
-        {
-            get
-            {
-                return _runInstaller;
-            }
-        }
+        public bool RunInstaller { get; }
 
 
         /// <summary>
@@ -86,7 +77,7 @@ namespace System.ComponentModel
             }
 
             RunInstallerAttribute other = obj as RunInstallerAttribute;
-            return other != null && other.RunInstaller == _runInstaller;
+            return other != null && other.RunInstaller == RunInstaller;
         }
 
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/SByteConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/SByteConverter.cs
@@ -16,7 +16,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType => typeof(SByte);
+        internal override Type TargetType => typeof(sbyte);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/SByteConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/SByteConverter.cs
@@ -16,13 +16,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType
-        {
-            get
-            {
-                return typeof(SByte);
-            }
-        }
+        internal override Type TargetType => typeof(SByte);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/SettingsBindableAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/SettingsBindableAttribute.cs
@@ -33,7 +33,7 @@ namespace System.ComponentModel
         /// <summary>
         ///     Gets a value indicating whether a property is appropriate to bind settings to.
         /// </summary>
-        public bool Bindable { get; } = false;
+        public bool Bindable { get; }
 
         public override bool Equals(object obj)
         {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/SettingsBindableAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/SettingsBindableAttribute.cs
@@ -25,23 +25,15 @@ namespace System.ComponentModel
         /// </summary>
         public static readonly SettingsBindableAttribute No = new SettingsBindableAttribute(false);
 
-        private bool _bindable = false;
-
         public SettingsBindableAttribute(bool bindable)
         {
-            _bindable = bindable;
+            Bindable = bindable;
         }
 
         /// <summary>
         ///     Gets a value indicating whether a property is appropriate to bind settings to.
         /// </summary>
-        public bool Bindable
-        {
-            get
-            {
-                return _bindable;
-            }
-        }
+        public bool Bindable { get; } = false;
 
         public override bool Equals(object obj)
         {
@@ -52,7 +44,7 @@ namespace System.ComponentModel
 
             if (obj != null && obj is SettingsBindableAttribute)
             {
-                return (((SettingsBindableAttribute)obj).Bindable == _bindable);
+                return (((SettingsBindableAttribute)obj).Bindable == Bindable);
             }
 
             return false;
@@ -60,7 +52,7 @@ namespace System.ComponentModel
 
         public override int GetHashCode()
         {
-            return _bindable.GetHashCode();
+            return Bindable.GetHashCode();
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/SingleConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/SingleConverter.cs
@@ -21,7 +21,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType => typeof(Single);
+        internal override Type TargetType => typeof(float);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/SingleConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/SingleConverter.cs
@@ -16,24 +16,12 @@ namespace System.ComponentModel
         /// <summary>
         /// Determines whether this editor will attempt to convert hex (0x or #) strings
         /// </summary>
-        internal override bool AllowHex
-        {
-            get
-            {
-                return false;
-            }
-        }
+        internal override bool AllowHex => false;
 
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType
-        {
-            get
-            {
-                return typeof(Single);
-            }
-        }
+        internal override Type TargetType => typeof(Single);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemFilterAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemFilterAttribute.cs
@@ -50,8 +50,6 @@ namespace System.ComponentModel
     ]
     public sealed class ToolboxItemFilterAttribute : Attribute
     {
-        private ToolboxItemFilterType _filterType;
-        private string _filterString;
         private string _typeId;
 
         /// <summary>
@@ -69,33 +67,21 @@ namespace System.ComponentModel
         {
             if (filterString == null) filterString = String.Empty;
 
-            _filterString = filterString;
-            _filterType = filterType;
+            FilterString = filterString;
+            FilterType = filterType;
         }
 
         /// <summary>
         ///     Retrieves the filter string for this attribute.  The filter string is a user-defined string that
         ///     is used to identify matching attributes.
         /// </summary>
-        public string FilterString
-        {
-            get
-            {
-                return _filterString;
-            }
-        }
+        public string FilterString { get; }
 
         /// <summary>
         ///     Retrieves the filter type for this attribute.  The filter type determines how the filter string should
         ///     be applied.
         /// </summary>
-        public ToolboxItemFilterType FilterType
-        {
-            get
-            {
-                return _filterType;
-            }
-        }
+        public ToolboxItemFilterType FilterType { get; }
 
         /// <summary>
         ///     The unique identifier for this attribute.  All ToolboxItemFilterAttributes with the same filter string
@@ -107,7 +93,7 @@ namespace System.ComponentModel
             {
                 if (_typeId == null)
                 {
-                    _typeId = GetType().FullName + _filterString;
+                    _typeId = GetType().FullName + FilterString;
                 }
                 return _typeId;
             }
@@ -127,7 +113,7 @@ namespace System.ComponentModel
         public override int GetHashCode()
         {
             // No need to hash on filter type as well; there shouldn't be that many duplicates.
-            return _filterString.GetHashCode();
+            return FilterString.GetHashCode();
         }
 
         public override bool Match(object obj)
@@ -150,7 +136,7 @@ namespace System.ComponentModel
 
         public override string ToString()
         {
-            return _filterString + "," + Enum.GetName(typeof(ToolboxItemFilterType), _filterType);
+            return FilterString + "," + Enum.GetName(typeof(ToolboxItemFilterType), FilterType);
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemFilterAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemFilterAttribute.cs
@@ -65,9 +65,7 @@ namespace System.ComponentModel
         /// </summary>
         public ToolboxItemFilterAttribute(string filterString, ToolboxItemFilterType filterType)
         {
-            if (filterString == null) filterString = String.Empty;
-
-            FilterString = filterString;
+            FilterString = filterString ?? string.Empty;
             FilterType = filterType;
         }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemFilterAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemFilterAttribute.cs
@@ -87,17 +87,7 @@ namespace System.ComponentModel
         ///     The unique identifier for this attribute.  All ToolboxItemFilterAttributes with the same filter string
         ///     are considered the same, so they return the same TypeId.
         /// </summary>
-        public override object TypeId
-        {
-            get
-            {
-                if (_typeId == null)
-                {
-                    _typeId = GetType().FullName + FilterString;
-                }
-                return _typeId;
-            }
-        }
+        public override object TypeId => _typeId ?? (_typeId = GetType().FullName + FilterString);
 
         public override bool Equals(object obj)
         {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemFilterAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemFilterAttribute.cs
@@ -126,7 +126,7 @@ namespace System.ComponentModel
 
         public override string ToString()
         {
-            return FilterString + "," + Enum.GetName(typeof(ToolboxItemFilterType), FilterType);
+            return $"{FilterString}, {Enum.GetName(typeof(ToolboxItemFilterType), FilterType)}";
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemFilterAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemFilterAttribute.cs
@@ -126,7 +126,7 @@ namespace System.ComponentModel
 
         public override string ToString()
         {
-            return $"{FilterString}, {Enum.GetName(typeof(ToolboxItemFilterType), FilterType)}";
+            return FilterString + "," + Enum.GetName(typeof(ToolboxItemFilterType), FilterType);
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeConverter.cs
@@ -211,14 +211,7 @@ namespace System.ComponentModel
         {
             string valueTypeName;
 
-            if (value == null)
-            {
-                valueTypeName = SR.Null;
-            }
-            else
-            {
-                valueTypeName = value.GetType().FullName;
-            }
+            valueTypeName = value == null ? SR.Null : value.GetType().FullName;
 
             throw new NotSupportedException(SR.Format(SR.ConvertFromException, GetType().Name, valueTypeName));
         }
@@ -231,14 +224,7 @@ namespace System.ComponentModel
         {
             string valueTypeName;
 
-            if (value == null)
-            {
-                valueTypeName = SR.Null;
-            }
-            else
-            {
-                valueTypeName = value.GetType().FullName;
-            }
+            valueTypeName = value == null ? SR.Null : value.GetType().FullName;
 
             throw new NotSupportedException(SR.Format(SR.ConvertToException, GetType().Name, valueTypeName, destinationType.FullName));
         }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeConverter.cs
@@ -416,7 +416,7 @@ namespace System.ComponentModel
             ///       Initializes a new instance of the <see cref='System.ComponentModel.TypeConverter.SimplePropertyDescriptor'/> class.
             ///    </para>
             /// </summary>
-            protected SimplePropertyDescriptor(Type componentType, string name, Type propertyType) : this(componentType, name, propertyType, new Attribute[0])
+            protected SimplePropertyDescriptor(Type componentType, string name, Type propertyType) : this(componentType, name, propertyType, Array.Empty<Attribute>())
             {
             }
 
@@ -499,7 +499,7 @@ namespace System.ComponentModel
             {
                 if (values == null)
                 {
-                    values = new object[0];
+                    values = Array.Empty<object>();
                 }
 
                 Array a = values as Array;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeConverter.cs
@@ -453,13 +453,7 @@ namespace System.ComponentModel
             /// <summary>
             ///    <para>Gets a value indicating whether this property is read-only.</para>
             /// </summary>
-            public override bool IsReadOnly
-            {
-                get
-                {
-                    return Attributes.Contains(ReadOnlyAttribute.Yes);
-                }
-            }
+            public override bool IsReadOnly => Attributes.Contains(ReadOnlyAttribute.Yes);
 
             /// <summary>
             ///    <para>Gets the type of the property.</para>
@@ -600,26 +594,14 @@ namespace System.ComponentModel
             /// Determines if this collection is synchronized. The ValidatorCollection is not synchronized for
             /// speed.  Also, since it is read-only, there is no need to synchronize it.
             /// </summary>
-            bool ICollection.IsSynchronized
-            {
-                get
-                {
-                    return false;
-                }
-            }
+            bool ICollection.IsSynchronized => false;
 
             /// <internalonly/>
             /// <summary>
             /// Retrieves the synchronization root for this collection.  Because we are not synchronized,
             /// this returns null.
             /// </summary>
-            object ICollection.SyncRoot
-            {
-                get
-                {
-                    return null;
-                }
-            }
+            object ICollection.SyncRoot => null;
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeConverter.cs
@@ -425,9 +425,6 @@ namespace System.ComponentModel
         /// </summary>
         protected abstract class SimplePropertyDescriptor : PropertyDescriptor
         {
-            private Type _componentType;
-            private Type _propertyType;
-
             /// <summary>
             ///    <para>
             ///       Initializes a new instance of the <see cref='System.ComponentModel.TypeConverter.SimplePropertyDescriptor'/> class.
@@ -444,20 +441,14 @@ namespace System.ComponentModel
             /// </summary>
             protected SimplePropertyDescriptor(Type componentType, string name, Type propertyType, Attribute[] attributes) : base(name, attributes)
             {
-                _componentType = componentType;
-                _propertyType = propertyType;
+                ComponentType = componentType;
+                PropertyType = propertyType;
             }
 
             /// <summary>
             ///    <para>Gets the type of the component this property description is bound to.</para>
             /// </summary>
-            public override Type ComponentType
-            {
-                get
-                {
-                    return _componentType;
-                }
-            }
+            public override Type ComponentType { get; }
 
             /// <summary>
             ///    <para>Gets a value indicating whether this property is read-only.</para>
@@ -473,13 +464,7 @@ namespace System.ComponentModel
             /// <summary>
             ///    <para>Gets the type of the property.</para>
             /// </summary>
-            public override Type PropertyType
-            {
-                get
-                {
-                    return _propertyType;
-                }
-            }
+            public override Type PropertyType { get; }
 
             /// <summary>
             ///    <para>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeConverterAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeConverterAttribute.cs
@@ -13,8 +13,6 @@ namespace System.ComponentModel
     [AttributeUsage(AttributeTargets.All)]
     public sealed class TypeConverterAttribute : Attribute
     {
-        private readonly string _typeName;
-
         /// <summary>
         ///    <para>
         ///        Specifies the type to use as a converter for the object this attribute is bound to. This
@@ -30,7 +28,7 @@ namespace System.ComponentModel
         /// </summary>
         public TypeConverterAttribute()
         {
-            _typeName = string.Empty;
+            ConverterTypeName = string.Empty;
         }
 
         /// <summary>
@@ -41,7 +39,7 @@ namespace System.ComponentModel
         /// </summary>
         public TypeConverterAttribute(Type type)
         {
-            _typeName = type.AssemblyQualifiedName;
+            ConverterTypeName = type.AssemblyQualifiedName;
         }
 
         /// <summary>
@@ -52,7 +50,7 @@ namespace System.ComponentModel
         /// </summary>
         public TypeConverterAttribute(string typeName)
         {
-            _typeName = typeName;
+            ConverterTypeName = typeName;
         }
 
         /// <summary>
@@ -61,23 +59,17 @@ namespace System.ComponentModel
         ///         the object this attribute is bound to.
         ///     </para>
         /// </summary>
-        public string ConverterTypeName
-        {
-            get
-            {
-                return _typeName;
-            }
-        }
+        public string ConverterTypeName { get; }
 
         public override bool Equals(object obj)
         {
             TypeConverterAttribute other = obj as TypeConverterAttribute;
-            return (other != null) && other.ConverterTypeName == _typeName;
+            return (other != null) && other.ConverterTypeName == ConverterTypeName;
         }
 
         public override int GetHashCode()
         {
-            return _typeName.GetHashCode();
+            return ConverterTypeName.GetHashCode();
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptionProvider.cs
@@ -79,12 +79,7 @@ namespace System.ComponentModel
         /// </summary>
         public virtual IDictionary GetCache(object instance)
         {
-            if (_parent != null)
-            {
-                return _parent.GetCache(instance);
-            }
-
-            return null;
+            return _parent?.GetCache(instance);
         }
 
         /// <summary>
@@ -108,12 +103,7 @@ namespace System.ComponentModel
                 return _parent.GetExtendedTypeDescriptor(instance);
             }
 
-            if (_emptyDescriptor == null)
-            {
-                _emptyDescriptor = new EmptyCustomTypeDescriptor();
-            }
-
-            return _emptyDescriptor;
+            return _emptyDescriptor ?? (_emptyDescriptor = new EmptyCustomTypeDescriptor());
         }
 
         protected internal virtual IExtenderProvider[] GetExtenderProviders(object instance)
@@ -276,12 +266,7 @@ namespace System.ComponentModel
                 return _parent.GetTypeDescriptor(objectType, instance);
             }
 
-            if (_emptyDescriptor == null)
-            {
-                _emptyDescriptor = new EmptyCustomTypeDescriptor();
-            }
-
-            return _emptyDescriptor;
+            return _emptyDescriptor ?? (_emptyDescriptor = new EmptyCustomTypeDescriptor());
         }
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptionProviderAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptionProviderAttribute.cs
@@ -9,8 +9,6 @@ namespace System.ComponentModel
     [AttributeUsage(AttributeTargets.Class, Inherited = true)]
     public sealed class TypeDescriptionProviderAttribute : Attribute
     {
-        private readonly string _typeName;
-
         /// <summary>
         ///     Creates a new TypeDescriptionProviderAttribute object.
         /// </summary>
@@ -21,7 +19,7 @@ namespace System.ComponentModel
                 throw new ArgumentNullException(nameof(typeName));
             }
 
-            _typeName = typeName;
+            TypeName = typeName;
         }
 
         /// <summary>
@@ -34,20 +32,14 @@ namespace System.ComponentModel
                 throw new ArgumentNullException(nameof(type));
             }
 
-            _typeName = type.AssemblyQualifiedName;
+            TypeName = type.AssemblyQualifiedName;
         }
 
         /// <summary>
         ///     The TypeName property returns the assembly qualified type name 
         ///     for the type description provider.
         /// </summary>
-        public string TypeName
-        {
-            get
-            {
-                return _typeName;
-            }
-        }
+        public string TypeName { get; }
     }
 }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -486,21 +486,13 @@ namespace System.ComponentModel
 
             // See if the provider wants to offer a TypeDescriptionProvider to delegate to.  This allows
             // a caller to have complete control over all object instantiation.
-            if (provider != null)
+            TypeDescriptionProvider p = provider?.GetService(typeof(TypeDescriptionProvider)) as TypeDescriptionProvider;
+            if (p != null)
             {
-                TypeDescriptionProvider p = provider.GetService(typeof(TypeDescriptionProvider)) as TypeDescriptionProvider;
-                if (p != null)
-                {
-                    instance = p.CreateInstance(provider, objectType, argTypes, args);
-                }
+                instance = p.CreateInstance(provider, objectType, argTypes, args);
             }
 
-            if (instance == null)
-            {
-                instance = NodeFor(objectType).CreateInstance(provider, objectType, argTypes, args);
-            }
-
-            return instance;
+            return instance ?? (instance = NodeFor(objectType).CreateInstance(provider, objectType, argTypes, args));
         }
         /// <summary>
         ///     This dynamically binds a PropertyDescriptor to a type.
@@ -580,9 +572,9 @@ namespace System.ComponentModel
                         }
                     }
                 }
-                else if (newMembers != null)
+                else
                 {
-                    newMembers.Add(members[idx]);
+                    newMembers?.Add(members[idx]);
                 }
             }
 
@@ -613,28 +605,25 @@ namespace System.ComponentModel
                 // Check our association table for a match.
                 //
                 Hashtable assocTable = s_associationTable;
-                if (assocTable != null)
+                IList associations = (IList) assocTable?[primary];
+                if (associations != null)
                 {
-                    IList associations = (IList)assocTable[primary];
-                    if (associations != null)
+                    lock (associations)
                     {
-                        lock (associations)
+                        for (int idx = associations.Count - 1; idx >= 0; idx--)
                         {
-                            for (int idx = associations.Count - 1; idx >= 0; idx--)
+                            // Look for an associated object that has a type that
+                            // matches the given type.
+                            //
+                            WeakReference weakRef = (WeakReference)associations[idx];
+                            object secondary = weakRef.Target;
+                            if (secondary == null)
                             {
-                                // Look for an associated object that has a type that
-                                // matches the given type.
-                                //
-                                WeakReference weakRef = (WeakReference)associations[idx];
-                                object secondary = weakRef.Target;
-                                if (secondary == null)
-                                {
-                                    associations.RemoveAt(idx);
-                                }
-                                else if (type.GetTypeInfo().IsInstanceOfType(secondary))
-                                {
-                                    associatedObject = secondary;
-                                }
+                                associations.RemoveAt(idx);
+                            }
+                            else if (type.GetTypeInfo().IsInstanceOfType(secondary))
+                            {
+                                associatedObject = secondary;
                             }
                         }
                     }
@@ -1197,28 +1186,25 @@ namespace System.ComponentModel
             string suffix = null;
 
             ExtenderProvidedPropertyAttribute exAttr = member.Attributes[typeof(ExtenderProvidedPropertyAttribute)] as ExtenderProvidedPropertyAttribute;
-            if (exAttr != null)
+            IExtenderProvider prov = exAttr?.Provider;
+
+            if (prov != null)
             {
-                IExtenderProvider prov = exAttr.Provider;
+                string name = null;
+                IComponent component = prov as IComponent;
 
-                if (prov != null)
+                if (component != null && component.Site != null)
                 {
-                    string name = null;
-                    IComponent component = prov as IComponent;
-
-                    if (component != null && component.Site != null)
-                    {
-                        name = component.Site.Name;
-                    }
-
-                    if (name == null || name.Length == 0)
-                    {
-                        int ci = System.Threading.Interlocked.Increment(ref s_collisionIndex) - 1;
-                        name = ci.ToString(CultureInfo.InvariantCulture);
-                    }
-
-                    suffix = string.Format(CultureInfo.InvariantCulture, "_{0}", name);
+                    name = component.Site.Name;
                 }
+
+                if (name == null || name.Length == 0)
+                {
+                    int ci = System.Threading.Interlocked.Increment(ref s_collisionIndex) - 1;
+                    name = ci.ToString(CultureInfo.InvariantCulture);
+                }
+
+                suffix = string.Format(CultureInfo.InvariantCulture, "_{0}", name);
             }
 
             return suffix;
@@ -1536,11 +1522,8 @@ namespace System.ComponentModel
 
             while (node == null)
             {
-                node = (TypeDescriptionNode)s_providerTypeTable[searchType];
-                if (node == null)
-                {
-                    node = (TypeDescriptionNode)s_providerTable[searchType];
-                }
+                node = (TypeDescriptionNode)s_providerTypeTable[searchType] ??
+                       (TypeDescriptionNode)s_providerTable[searchType];
 
                 if (node == null)
                 {
@@ -1708,8 +1691,7 @@ namespace System.ComponentModel
                         // In that case, we can remove the node
                         // altogether since no one is pointing to it.
 
-                        Type keyType = key as Type;
-                        if (keyType == null) keyType = key.GetType();
+                        Type keyType = key as Type ?? key.GetType();
 
                         target.Provider = new DelegatingTypeDescriptionProvider(keyType.GetTypeInfo().BaseType);
                     }
@@ -1810,13 +1792,10 @@ namespace System.ComponentModel
             IComponent component = instance as IComponent;
             ITypeDescriptorFilterService componentFilter = null;
 
-            if (component != null)
+            ISite site = component?.Site;
+            if (site != null)
             {
-                ISite site = component.Site;
-                if (site != null)
-                {
-                    componentFilter = site.GetService(typeof(ITypeDescriptorFilterService)) as ITypeDescriptorFilterService;
-                }
+                componentFilter = site.GetService(typeof(ITypeDescriptorFilterService)) as ITypeDescriptorFilterService;
             }
 
             // If we have no filter, there is nothing for us to do.
@@ -2058,43 +2037,40 @@ namespace System.ComponentModel
 
             // Next, if we were given a cache, see if it has accurate data.
             //
-            if (cache != null)
+            ICollection mergeCache = cache?[s_pipelineMergeKeys[pipelineType]] as ICollection;
+            if (mergeCache != null && mergeCache.Count == (primary.Count + secondary.Count))
             {
-                ICollection mergeCache = cache[s_pipelineMergeKeys[pipelineType]] as ICollection;
-                if (mergeCache != null && mergeCache.Count == (primary.Count + secondary.Count))
-                {
-                    // Walk the merge cache.
-                    IEnumerator mergeEnum = mergeCache.GetEnumerator();
-                    IEnumerator primaryEnum = primary.GetEnumerator();
-                    bool match = true;
+                // Walk the merge cache.
+                IEnumerator mergeEnum = mergeCache.GetEnumerator();
+                IEnumerator primaryEnum = primary.GetEnumerator();
+                bool match = true;
 
-                    while (primaryEnum.MoveNext() && mergeEnum.MoveNext())
+                while (primaryEnum.MoveNext() && mergeEnum.MoveNext())
+                {
+                    if (primaryEnum.Current != mergeEnum.Current)
                     {
-                        if (primaryEnum.Current != mergeEnum.Current)
+                        match = false;
+                        break;
+                    }
+                }
+
+                if (match)
+                {
+                    IEnumerator secondaryEnum = secondary.GetEnumerator();
+
+                    while (secondaryEnum.MoveNext() && mergeEnum.MoveNext())
+                    {
+                        if (secondaryEnum.Current != mergeEnum.Current)
                         {
                             match = false;
                             break;
                         }
                     }
+                }
 
-                    if (match)
-                    {
-                        IEnumerator secondaryEnum = secondary.GetEnumerator();
-
-                        while (secondaryEnum.MoveNext() && mergeEnum.MoveNext())
-                        {
-                            if (secondaryEnum.Current != mergeEnum.Current)
-                            {
-                                match = false;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (match)
-                    {
-                        return mergeCache;
-                    }
+                if (match)
+                {
+                    return mergeCache;
                 }
             }
 
@@ -2158,20 +2134,14 @@ namespace System.ComponentModel
             // the JIT makes those changes is mostly theoretical
             RefreshEventHandler handler = Volatile.Read(ref Refreshed);
 
-            if (handler != null)
-            {
-                handler(new RefreshEventArgs(component));
-            }
+            handler?.Invoke(new RefreshEventArgs(component));
         }
 
         private static void RaiseRefresh(Type type)
         {
             RefreshEventHandler handler = Volatile.Read(ref Refreshed);
 
-            if (handler != null)
-            {
-                handler(new RefreshEventArgs(type));
-            }
+            handler?.Invoke(new RefreshEventArgs(type));
         }
 
         /// <summary>
@@ -2441,14 +2411,11 @@ namespace System.ComponentModel
                     {
                         ISite site = component.Site;
                         bool flag = false;
-                        if (site != null)
+                        ITypeResolutionService typeResolutionService = (ITypeResolutionService) site?.GetService(typeof(ITypeResolutionService));
+                        if (typeResolutionService != null)
                         {
-                            ITypeResolutionService typeResolutionService = (ITypeResolutionService)site.GetService(typeof(ITypeResolutionService));
-                            if (typeResolutionService != null)
-                            {
-                                flag = true;
-                                type = typeResolutionService.GetType(designerAttribute.DesignerTypeName);
-                            }
+                            flag = true;
+                            type = typeResolutionService.GetType(designerAttribute.DesignerTypeName);
                         }
                         if (!flag)
                         {
@@ -2481,11 +2448,7 @@ namespace System.ComponentModel
                     typeDescriptionNode = typeDescriptionNode.Next;
                 }
                 while (typeDescriptionNode != null && comNativeDescriptionProvider == null);
-                if (comNativeDescriptionProvider != null)
-                {
-                    return comNativeDescriptionProvider.Handler;
-                }
-                return null;
+                return comNativeDescriptionProvider?.Handler;
             }
             set
             {
@@ -2521,24 +2484,21 @@ namespace System.ComponentModel
             }
 
             Hashtable assocTable = s_associationTable;
-            if (assocTable != null)
+            IList associations = (IList) assocTable?[primary];
+            if (associations != null)
             {
-                IList associations = (IList)assocTable[primary];
-                if (associations != null)
+                lock (associations)
                 {
-                    lock (associations)
+                    for (int idx = associations.Count - 1; idx >= 0; idx--)
                     {
-                        for (int idx = associations.Count - 1; idx >= 0; idx--)
+                        // Look for an associated object that has a type that
+                        // matches the given type.
+                        //
+                        WeakReference weakRef = (WeakReference)associations[idx];
+                        object secondaryItem = weakRef.Target;
+                        if (secondaryItem == null || secondaryItem == secondary)
                         {
-                            // Look for an associated object that has a type that
-                            // matches the given type.
-                            //
-                            WeakReference weakRef = (WeakReference)associations[idx];
-                            object secondaryItem = weakRef.Target;
-                            if (secondaryItem == null || secondaryItem == secondary)
-                            {
-                                associations.RemoveAt(idx);
-                            }
+                            associations.RemoveAt(idx);
                         }
                     }
                 }
@@ -2557,10 +2517,7 @@ namespace System.ComponentModel
             }
 
             Hashtable assocTable = s_associationTable;
-            if (assocTable != null)
-            {
-                assocTable.Remove(primary);
-            }
+            assocTable?.Remove(primary);
         }
 
         /// <summary>
@@ -3041,11 +2998,7 @@ namespace System.ComponentModel
             /// </summary>
             AttributeCollection ICustomTypeDescriptor.GetAttributes()
             {
-                AttributeCollection attrs = _primary.GetAttributes();
-                if (attrs == null)
-                {
-                    attrs = _secondary.GetAttributes();
-                }
+                AttributeCollection attrs = _primary.GetAttributes() ?? _secondary.GetAttributes();
 
                 Debug.Assert(attrs != null, "Someone should have handled this");
                 return attrs;
@@ -3056,11 +3009,7 @@ namespace System.ComponentModel
             /// </summary>
             string ICustomTypeDescriptor.GetClassName()
             {
-                string className = _primary.GetClassName();
-                if (className == null)
-                {
-                    className = _secondary.GetClassName();
-                }
+                string className = _primary.GetClassName() ?? _secondary.GetClassName();
 
                 Debug.Assert(className != null, "Someone should have handled this");
                 return className;
@@ -3071,11 +3020,7 @@ namespace System.ComponentModel
             /// </summary>
             string ICustomTypeDescriptor.GetComponentName()
             {
-                string name = _primary.GetComponentName();
-                if (name == null)
-                {
-                    name = _secondary.GetComponentName();
-                }
+                string name = _primary.GetComponentName() ?? _secondary.GetComponentName();
 
                 return name;
             }
@@ -3085,11 +3030,7 @@ namespace System.ComponentModel
             /// </summary>
             TypeConverter ICustomTypeDescriptor.GetConverter()
             {
-                TypeConverter converter = _primary.GetConverter();
-                if (converter == null)
-                {
-                    converter = _secondary.GetConverter();
-                }
+                TypeConverter converter = _primary.GetConverter() ?? _secondary.GetConverter();
 
                 Debug.Assert(converter != null, "Someone should have handled this");
                 return converter;
@@ -3100,11 +3041,7 @@ namespace System.ComponentModel
             /// </summary>
             EventDescriptor ICustomTypeDescriptor.GetDefaultEvent()
             {
-                EventDescriptor evt = _primary.GetDefaultEvent();
-                if (evt == null)
-                {
-                    evt = _secondary.GetDefaultEvent();
-                }
+                EventDescriptor evt = _primary.GetDefaultEvent() ?? _secondary.GetDefaultEvent();
 
                 return evt;
             }
@@ -3114,11 +3051,7 @@ namespace System.ComponentModel
             /// </summary>
             PropertyDescriptor ICustomTypeDescriptor.GetDefaultProperty()
             {
-                PropertyDescriptor prop = _primary.GetDefaultProperty();
-                if (prop == null)
-                {
-                    prop = _secondary.GetDefaultProperty();
-                }
+                PropertyDescriptor prop = _primary.GetDefaultProperty() ?? _secondary.GetDefaultProperty();
 
                 return prop;
             }
@@ -3133,11 +3066,7 @@ namespace System.ComponentModel
                     throw new ArgumentNullException(nameof(editorBaseType));
                 }
 
-                object editor = _primary.GetEditor(editorBaseType);
-                if (editor == null)
-                {
-                    editor = _secondary.GetEditor(editorBaseType);
-                }
+                object editor = _primary.GetEditor(editorBaseType) ?? _secondary.GetEditor(editorBaseType);
 
                 return editor;
             }
@@ -3147,11 +3076,7 @@ namespace System.ComponentModel
             /// </summary>
             EventDescriptorCollection ICustomTypeDescriptor.GetEvents()
             {
-                EventDescriptorCollection events = _primary.GetEvents();
-                if (events == null)
-                {
-                    events = _secondary.GetEvents();
-                }
+                EventDescriptorCollection events = _primary.GetEvents() ?? _secondary.GetEvents();
 
                 Debug.Assert(events != null, "Someone should have handled this");
                 return events;
@@ -3162,11 +3087,7 @@ namespace System.ComponentModel
             /// </summary>
             EventDescriptorCollection ICustomTypeDescriptor.GetEvents(Attribute[] attributes)
             {
-                EventDescriptorCollection events = _primary.GetEvents(attributes);
-                if (events == null)
-                {
-                    events = _secondary.GetEvents(attributes);
-                }
+                EventDescriptorCollection events = _primary.GetEvents(attributes) ?? _secondary.GetEvents(attributes);
 
                 Debug.Assert(events != null, "Someone should have handled this");
                 return events;
@@ -3177,11 +3098,7 @@ namespace System.ComponentModel
             /// </summary>
             PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties()
             {
-                PropertyDescriptorCollection properties = _primary.GetProperties();
-                if (properties == null)
-                {
-                    properties = _secondary.GetProperties();
-                }
+                PropertyDescriptorCollection properties = _primary.GetProperties() ?? _secondary.GetProperties();
 
                 Debug.Assert(properties != null, "Someone should have handled this");
                 return properties;
@@ -3207,11 +3124,7 @@ namespace System.ComponentModel
             /// </summary>
             object ICustomTypeDescriptor.GetPropertyOwner(PropertyDescriptor pd)
             {
-                object owner = _primary.GetPropertyOwner(pd);
-                if (owner == null)
-                {
-                    owner = _secondary.GetPropertyOwner(pd);
-                }
+                object owner = _primary.GetPropertyOwner(pd) ?? _secondary.GetPropertyOwner(pd);
 
                 return owner;
             }
@@ -3437,8 +3350,7 @@ namespace System.ComponentModel
 
                     ICustomTypeDescriptor desc = p.GetExtendedTypeDescriptor(_instance);
                     if (desc == null) throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetExtendedTypeDescriptor"));
-                    string name = desc.GetClassName();
-                    if (name == null) name = _instance.GetType().FullName;
+                    string name = desc.GetClassName() ?? _instance.GetType().FullName;
                     return name;
                 }
 
@@ -3684,8 +3596,7 @@ namespace System.ComponentModel
 
                     ICustomTypeDescriptor desc = p.GetExtendedTypeDescriptor(_instance);
                     if (desc == null) throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetExtendedTypeDescriptor"));
-                    object owner = desc.GetPropertyOwner(pd);
-                    if (owner == null) owner = _instance;
+                    object owner = desc.GetPropertyOwner(pd) ?? _instance;
                     return owner;
                 }
             }
@@ -3758,8 +3669,7 @@ namespace System.ComponentModel
                     {
                         ICustomTypeDescriptor desc = p.GetTypeDescriptor(_objectType, _instance);
                         if (desc == null) throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
-                        name = desc.GetClassName();
-                        if (name == null) name = _objectType.FullName;
+                        name = desc.GetClassName() ?? _objectType.FullName;
                     }
 
                     return name;
@@ -4039,8 +3949,7 @@ namespace System.ComponentModel
                     {
                         ICustomTypeDescriptor desc = p.GetTypeDescriptor(_objectType, _instance);
                         if (desc == null) throw new InvalidOperationException(SR.Format(SR.TypeDescriptorProviderError, _node.Provider.GetType().FullName, "GetTypeDescriptor"));
-                        owner = desc.GetPropertyOwner(pd);
-                        if (owner == null) owner = _instance;
+                        owner = desc.GetPropertyOwner(pd) ?? _instance;
                     }
 
                     return owner;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -84,24 +84,12 @@ namespace System.ComponentModel
         ///     AddProvider methods to define a type description provider for interface types.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
-        public static Type InterfaceType
-        {
-            get
-            {
-                return typeof(TypeDescriptorInterface);
-            }
-        }
+        public static Type InterfaceType => typeof(TypeDescriptorInterface);
 
         /// <summary>
         ///     This value increments each time someone refreshes or changes metadata.
         /// </summary>
-        internal static int MetadataVersion
-        {
-            get
-            {
-                return s_metadataVersion;
-            }
-        }
+        internal static int MetadataVersion => s_metadataVersion;
 
         /// <summary>
         ///    Occurs when Refreshed is raised for a component.
@@ -2436,13 +2424,7 @@ namespace System.ComponentModel
         }
 
         [EditorBrowsable(EditorBrowsableState.Advanced)]
-        public static Type ComObjectType
-        {
-            get
-            {
-                return typeof(TypeDescriptor.TypeDescriptorComObject);
-            }
-        }
+        public static Type ComObjectType => typeof(TypeDescriptor.TypeDescriptorComObject);
 
         public static IDesigner CreateDesigner(IComponent component, Type designerBaseType)
         {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -492,7 +492,7 @@ namespace System.ComponentModel
                 instance = p.CreateInstance(provider, objectType, argTypes, args);
             }
 
-            return instance ?? (instance = NodeFor(objectType).CreateInstance(provider, objectType, argTypes, args));
+            return instance ?? NodeFor(objectType).CreateInstance(provider, objectType, argTypes, args);
         }
         /// <summary>
         ///     This dynamically binds a PropertyDescriptor to a type.

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UInt16Converter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UInt16Converter.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType => typeof(UInt16);
+        internal override Type TargetType => typeof(short);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UInt16Converter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UInt16Converter.cs
@@ -15,13 +15,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType
-        {
-            get
-            {
-                return typeof(UInt16);
-            }
-        }
+        internal override Type TargetType => typeof(UInt16);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UInt32Converter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UInt32Converter.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType => typeof(UInt32);
+        internal override Type TargetType => typeof(uint);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UInt32Converter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UInt32Converter.cs
@@ -15,13 +15,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt32, etc.)
         /// </summary>
-        internal override Type TargetType
-        {
-            get
-            {
-                return typeof(UInt32);
-            }
-        }
+        internal override Type TargetType => typeof(UInt32);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UInt64Converter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UInt64Converter.cs
@@ -15,13 +15,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt64, etc.)
         /// </summary>
-        internal override Type TargetType
-        {
-            get
-            {
-                return typeof(UInt64);
-            }
-        }
+        internal override Type TargetType => typeof(UInt64);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UInt64Converter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UInt64Converter.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel
         /// <summary>
         /// The Type this converter is targeting (e.g. Int16, UInt64, etc.)
         /// </summary>
-        internal override Type TargetType => typeof(UInt64);
+        internal override Type TargetType => typeof(ulong);
 
         /// <summary>
         /// Convert the given value to a string using the given radix

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/WarningException.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/WarningException.cs
@@ -17,9 +17,6 @@ namespace System.ComponentModel
     [Serializable]
     public class WarningException : SystemException
     {
-        private readonly string _helpUrl;
-        private readonly string _helpTopic;
-
         /// <summary>
         /// <para>Initializes a new instance of the <see cref='System.ComponentModel.Win32Exception'/> class with the last Win32 error 
         ///    that occured.</para>
@@ -61,8 +58,8 @@ namespace System.ComponentModel
         public WarningException(string message, string helpUrl, string helpTopic)
             : base(message)
         {
-            _helpUrl = helpUrl;
-            _helpTopic = helpTopic;
+            HelpUrl = helpUrl;
+            HelpTopic = helpTopic;
         }
 
         /// <summary>
@@ -70,33 +67,21 @@ namespace System.ComponentModel
         /// </summary>
         protected WarningException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
-            _helpUrl = (string)info.GetValue("helpUrl", typeof(string));
-            _helpTopic = (string)info.GetValue("helpTopic", typeof(string));
+            HelpUrl = (string)info.GetValue("helpUrl", typeof(string));
+            HelpTopic = (string)info.GetValue("helpTopic", typeof(string));
         }
 
         /// <summary>
         ///    <para> Specifies the Help file associated with the 
         ///       warning. This field is read-only.</para>
         /// </summary>
-        public string HelpUrl
-        {
-            get
-            {
-                return _helpUrl;
-            }
-        }
+        public string HelpUrl { get; }
 
         /// <summary>
         ///    <para> Specifies the 
         ///       Help topic associated with the warning. This field is read-only. </para>
         /// </summary>
-        public string HelpTopic
-        {
-            get
-            {
-                return _helpTopic;
-            }
-        }
+        public string HelpTopic { get; }
 
         /// <summary>
         ///     Need this since Exception implements ISerializable and we have fields to save out.
@@ -109,8 +94,8 @@ namespace System.ComponentModel
                 throw new ArgumentNullException(nameof(info));
             }
 
-            info.AddValue("helpUrl", _helpUrl);
-            info.AddValue("helpTopic", _helpTopic);
+            info.AddValue("helpUrl", HelpUrl);
+            info.AddValue("helpTopic", HelpTopic);
 
             base.GetObjectData(info, context);
         }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/WeakHashtable.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/WeakHashtable.cs
@@ -180,12 +180,7 @@ namespace System.ComponentModel
 
             public override bool Equals(object o)
             {
-                if (o == null)
-                {
-                    return false;
-                }
-
-                if (o.GetHashCode() != _hashCode)
+                if (o?.GetHashCode() != _hashCode)
                 {
                     return false;
                 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/WeakHashtable.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/WeakHashtable.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Collections.Generic;
 
 namespace System.ComponentModel
 {
@@ -91,7 +92,7 @@ namespace System.ComponentModel
                 // Perform a scavenge through our keys, looking
                 // for dead references.
                 //
-                ArrayList cleanupList = null;
+                List<object> cleanupList = null;
                 foreach (object o in Keys)
                 {
                     WeakReference wr = o as WeakReference;
@@ -99,7 +100,7 @@ namespace System.ComponentModel
                     {
                         if (cleanupList == null)
                         {
-                            cleanupList = new ArrayList();
+                            cleanupList = new List<object>();
                         }
 
                         cleanupList.Add(wr);

--- a/src/System.ComponentModel.TypeConverter/src/System/Drawing/ColorConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/Drawing/ColorConverter.cs
@@ -174,7 +174,7 @@ namespace System.Drawing
                         }
                         else if (c.IsNamedColor)
                         {
-                            return "'" + c.Name + "'";
+                            return $"'{c.Name}'";
                         }
                         else
                         {

--- a/src/System.ComponentModel.TypeConverter/src/System/Drawing/ColorConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/Drawing/ColorConverter.cs
@@ -174,7 +174,7 @@ namespace System.Drawing
                         }
                         else if (c.IsNamedColor)
                         {
-                            return $"'{c.Name}'";
+                            return "'" + c.Name + "'";
                         }
                         else
                         {

--- a/src/System.ComponentModel.TypeConverter/src/System/Timers/Timer.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/Timers/Timer.cs
@@ -231,12 +231,9 @@ namespace System.Timers
                 if (_synchronizingObject == null && DesignMode)
                 {
                     IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                    if (host != null)
-                    {
-                        object baseComponent = host.RootComponent;
-                        if (baseComponent != null && baseComponent is ISynchronizeInvoke)
-                            _synchronizingObject = (ISynchronizeInvoke)baseComponent;
-                    }
+                    object baseComponent = host?.RootComponent;
+                    if (baseComponent != null && baseComponent is ISynchronizeInvoke)
+                        _synchronizingObject = (ISynchronizeInvoke)baseComponent;
                 }
 
                 return _synchronizingObject;

--- a/src/System.ComponentModel.TypeConverter/tests/SampleClasses.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/SampleClasses.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel.Tests
 {
     public class MyTypeDescriptorContext : ITypeDescriptorContext
     {
-        public IContainer Container { get { return null; } }
+        public IContainer Container => null;
         public object Instance { get { return null; } }
         public PropertyDescriptor PropertyDescriptor { get { return null; } }
         public bool OnComponentChanging() { return true; }


### PR DESCRIPTION
Resolves #12160 to clean up code in System.ComponentModel.TypeConverter
cc @AlexGhiondea 

- [x] Remove explicit base() from constructor calls
- [x] Replace explicitly implemented properties with auto-implemented properties when possible
- [x] Simplify members and properties with 1 lines of code to expression bodied members
- [x] Switch over to the ?. operator in C# for null checking
- [x] Switch to string interpolation instead of string concatenation
- [x] Remove unnecessary initialization (ie. Bool foo = false)
- [x] Replace empty arrays with Array.Empty()
- [x] Replace string literals with nameof wherever possible.
- [x] Simplify event handler declarations when no custom code is required
- [x] Introduce readonly modifier for sync objects.
- [x] Replace nongeneric collections with generic collections
- [x] Use foreach instead of manually writing the foreach logic.
- [x] Cache the char[] into a static readonly field (ie. new char[] { '' })
- [x] Simplify the CultureInfoMapper code

I created an individual commit for each improvement, didn't know if that would make review any easier.  I tried to search the project and make sure everything was accounted for. This is a decent size project so something may have been missed. Feel free to comment and I'll be glad to fix it.