### PR TITLE
System.IO.FileSystem.Tests project fail ValidFileOptions test if FileOptions contains Encrypted flag

### DIFF
--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
@@ -29,14 +29,12 @@ namespace System.IO.Tests
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(FileOptions.None)]
         [InlineData(FileOptions.DeleteOnClose)]
-        //[InlineData(FileOptions.Encrypted)] may not be allowed for some users
         [InlineData(FileOptions.RandomAccess)]
         [InlineData(FileOptions.SequentialScan)]
         [InlineData(FileOptions.WriteThrough)]
         [InlineData((FileOptions)0x20000000)] // FILE_FLAG_NO_BUFFERING on Windows
         [InlineData(FileOptions.Asynchronous)]
         [InlineData(FileOptions.Asynchronous | FileOptions.DeleteOnClose)]
-        //[InlineData(FileOptions.Asynchronous | FileOptions.Encrypted)] may not be allowed for some users
         [InlineData(FileOptions.Asynchronous | FileOptions.RandomAccess)]
         [InlineData(FileOptions.Asynchronous | FileOptions.SequentialScan)]
         [InlineData(FileOptions.Asynchronous | FileOptions.WriteThrough)]

--- a/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
@@ -29,19 +29,19 @@ namespace System.IO.Tests
         [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(FileOptions.None)]
         [InlineData(FileOptions.DeleteOnClose)]
-        [InlineData(FileOptions.Encrypted)]
+        //[InlineData(FileOptions.Encrypted)] may not be allowed for some users
         [InlineData(FileOptions.RandomAccess)]
         [InlineData(FileOptions.SequentialScan)]
         [InlineData(FileOptions.WriteThrough)]
         [InlineData((FileOptions)0x20000000)] // FILE_FLAG_NO_BUFFERING on Windows
         [InlineData(FileOptions.Asynchronous)]
         [InlineData(FileOptions.Asynchronous | FileOptions.DeleteOnClose)]
-        [InlineData(FileOptions.Asynchronous | FileOptions.Encrypted)]
+        //[InlineData(FileOptions.Asynchronous | FileOptions.Encrypted)] may not be allowed for some users
         [InlineData(FileOptions.Asynchronous | FileOptions.RandomAccess)]
         [InlineData(FileOptions.Asynchronous | FileOptions.SequentialScan)]
         [InlineData(FileOptions.Asynchronous | FileOptions.WriteThrough)]
         [InlineData(FileOptions.Asynchronous | (FileOptions)0x20000000)]
-        [InlineData(FileOptions.Asynchronous | FileOptions.DeleteOnClose | FileOptions.Encrypted | FileOptions.RandomAccess | FileOptions.SequentialScan | FileOptions.WriteThrough)]
+        [InlineData(FileOptions.Asynchronous | FileOptions.DeleteOnClose | FileOptions.RandomAccess | FileOptions.SequentialScan | FileOptions.WriteThrough)]
         public void ValidFileOptions(FileOptions option)
         {
             byte[] data = new byte[c_DefaultBufferSize];
@@ -64,6 +64,16 @@ namespace System.IO.Tests
                     totalRead += numRead;
                 }
             }
+        }
+
+        [ConditionalTheory(nameof(PlatformDetection) + "." + nameof(PlatformDetection.IsNotWindowsNanoServer))]
+        [InlineData(FileOptions.Encrypted)]
+        [InlineData(FileOptions.Asynchronous | FileOptions.Encrypted)]
+        [InlineData(FileOptions.Asynchronous | FileOptions.DeleteOnClose | FileOptions.Encrypted | FileOptions.RandomAccess | FileOptions.SequentialScan | FileOptions.WriteThrough)]
+        public void ValidFileOptions_Encrypted(FileOptions option)
+        {
+            try { ValidFileOptions(option); }
+            catch (UnauthorizedAccessException) { /* may not be allowed for some users */ }
         }
 
         [Theory]


### PR DESCRIPTION
Creating encrypted files or folder can be disabled for some users. I split ValidFileOptions test on two.