### PR TITLE
Remove FEATURE_TRACING from System.Collections.Concurrent

### DIFF
--- a/src/System.Collections.Concurrent/src/System.Collections.Concurrent.csproj
+++ b/src/System.Collections.Concurrent/src/System.Collections.Concurrent.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{96AA2060-C846-4E56-9509-E8CB9C114C8F}</ProjectGuid>
     <AssemblyName>System.Collections.Concurrent</AssemblyName>
     <RootNamespace>System.Collections.Concurrent</RootNamespace>
-    <DefineConstants>$(DefineConstants);FEATURE_TRACING</DefineConstants>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NuGetTargetMoniker>
   </PropertyGroup>

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/CDSCollectionETWBCLProvider.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/CDSCollectionETWBCLProvider.cs
@@ -14,10 +14,6 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-#if FEATURE_TRACING
 using System.Diagnostics.Tracing;
 
 namespace System.Collections.Concurrent
@@ -118,4 +114,3 @@ namespace System.Collections.Concurrent
         }
     }
 }
-#endif // FEATURE_TRACING

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
@@ -205,7 +205,6 @@ namespace System.Collections.Concurrent
         /// <returns>True if succeeded, false otherwise.</returns>
         private bool TrySteal(out T result, bool take)
         {
-#if FEATURE_TRACING
             if (take)
             {
                 CDSCollectionETWBCLProvider.Log.ConcurrentBag_TryTakeSteals();
@@ -214,7 +213,6 @@ namespace System.Collections.Concurrent
             {
                 CDSCollectionETWBCLProvider.Log.ConcurrentBag_TryPeekSteals();
             }
-#endif
 
             // If there's no local queue for this thread, just start from the head queue
             // and try to steal from each queue until we get a result.

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1834,12 +1834,10 @@ namespace System.Collections.Concurrent
         /// </summary>
         private void AcquireAllLocks(ref int locksAcquired)
         {
-#if FEATURE_TRACING
             if (CDSCollectionETWBCLProvider.Log.IsEnabled())
             {
                 CDSCollectionETWBCLProvider.Log.ConcurrentDictionary_AcquiringAllLocks(_tables._buckets.Length);
             }
-#endif
 
             // First, acquire lock 0
             AcquireLocks(0, 1, ref locksAcquired);

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
@@ -437,12 +437,10 @@ namespace System.Collections.Concurrent
             while (Interlocked.CompareExchange(
                 ref _head, head, tail._next) != tail._next);
 
-#if FEATURE_TRACING
             if (CDSCollectionETWBCLProvider.Log.IsEnabled())
             {
                 CDSCollectionETWBCLProvider.Log.ConcurrentStack_FastPushFailed(spin.Count);
             }
-#endif
         }
 
         /// <summary>
@@ -662,12 +660,11 @@ namespace System.Collections.Concurrent
                 // Is the stack empty?
                 if (head == null)
                 {
-#if FEATURE_TRACING
                     if (count == 1 && CDSCollectionETWBCLProvider.Log.IsEnabled())
                     {
                         CDSCollectionETWBCLProvider.Log.ConcurrentStack_FastPopFailed(spin.Count);
                     }
-#endif
+
                     poppedHead = null;
                     return 0;
                 }
@@ -681,12 +678,11 @@ namespace System.Collections.Concurrent
                 // Try to swap the new head.  If we succeed, break out of the loop.
                 if (Interlocked.CompareExchange(ref _head, next._next, head) == head)
                 {
-#if FEATURE_TRACING
                     if (count == 1 && CDSCollectionETWBCLProvider.Log.IsEnabled())
                     {
                         CDSCollectionETWBCLProvider.Log.ConcurrentStack_FastPopFailed(spin.Count);
                     }
-#endif
+
                     // Return the popped Node.
                     poppedHead = head;
                     return nodesCount;


### PR DESCRIPTION
This compilation constant is always set.  We can just delete it.

cc: @kouvel, @alexperovich 