### PR TITLE
Cleanup Reverse tests, and refactor First/Last.

### DIFF
--- a/src/System.Linq/src/System/Linq/First.cs
+++ b/src/System.Linq/src/System/Linq/First.cs
@@ -23,31 +23,15 @@ namespace System.Linq
 
         public static TSource First<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null)
+            bool found;
+            TSource first = source.TryGetFirst(predicate, out found);
+
+            if (!found)
             {
-                throw Error.ArgumentNull(nameof(source));
+                throw Error.NoMatch();
             }
 
-            if (predicate == null)
-            {
-                throw Error.ArgumentNull(nameof(predicate));
-            }
-
-            OrderedEnumerable<TSource> ordered = source as OrderedEnumerable<TSource>;
-            if (ordered != null)
-            {
-                return ordered.First(predicate);
-            }
-
-            foreach (TSource element in source)
-            {
-                if (predicate(element))
-                {
-                    return element;
-                }
-            }
-
-            throw Error.NoMatch();
+            return first;
         }
 
         public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source)
@@ -58,31 +42,8 @@ namespace System.Linq
 
         public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null)
-            {
-                throw Error.ArgumentNull(nameof(source));
-            }
-
-            if (predicate == null)
-            {
-                throw Error.ArgumentNull(nameof(predicate));
-            }
-
-            OrderedEnumerable<TSource> ordered = source as OrderedEnumerable<TSource>;
-            if (ordered != null)
-            {
-                return ordered.FirstOrDefault(predicate);
-            }
-
-            foreach (TSource element in source)
-            {
-                if (predicate(element))
-                {
-                    return element;
-                }
-            }
-
-            return default(TSource);
+            bool found;
+            return source.TryGetFirst(predicate, out found);
         }
 
         internal static TSource TryGetFirst<TSource>(this IEnumerable<TSource> source, out bool found)
@@ -116,6 +77,37 @@ namespace System.Linq
                         found = true;
                         return e.Current;
                     }
+                }
+            }
+
+            found = false;
+            return default(TSource);
+        }
+
+        internal static TSource TryGetFirst<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, out bool found)
+        {
+            if (source == null)
+            {
+                throw Error.ArgumentNull(nameof(source));
+            }
+
+            if (predicate == null)
+            {
+                throw Error.ArgumentNull(nameof(predicate));
+            }
+
+            OrderedEnumerable<TSource> ordered = source as OrderedEnumerable<TSource>;
+            if (ordered != null)
+            {
+                return ordered.TryGetFirst(predicate, out found);
+            }
+
+            foreach (TSource element in source)
+            {
+                if (predicate(element))
+                {
+                    found = true;
+                    return element;
                 }
             }
 

--- a/src/System.Linq/src/System/Linq/First.cs
+++ b/src/System.Linq/src/System/Linq/First.cs
@@ -10,44 +10,15 @@ namespace System.Linq
     {
         public static TSource First<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null)
+            bool found;
+            TSource first = source.TryGetFirst(out found);
+            
+            if (!found)
             {
-                throw Error.ArgumentNull(nameof(source));
+                throw Error.NoElements();
             }
 
-            IPartition<TSource> partition = source as IPartition<TSource>;
-            if (partition != null)
-            {
-                bool found;
-                TSource first = partition.TryGetFirst(out found);
-                if (found)
-                {
-                    return first;
-                }
-            }
-            else
-            {
-                IList<TSource> list = source as IList<TSource>;
-                if (list != null)
-                {
-                    if (list.Count > 0)
-                    {
-                        return list[0];
-                    }
-                }
-                else
-                {
-                    using (IEnumerator<TSource> e = source.GetEnumerator())
-                    {
-                        if (e.MoveNext())
-                        {
-                            return e.Current;
-                        }
-                    }
-                }
-            }
-
-            throw Error.NoElements();
+            return first;
         }
 
         public static TSource First<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
@@ -81,38 +52,8 @@ namespace System.Linq
 
         public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null)
-            {
-                throw Error.ArgumentNull(nameof(source));
-            }
-
-            IPartition<TSource> partition = source as IPartition<TSource>;
-            if (partition != null)
-            {
-                bool found;
-                return partition.TryGetFirst(out found);
-            }
-
-            IList<TSource> list = source as IList<TSource>;
-            if (list != null)
-            {
-                if (list.Count > 0)
-                {
-                    return list[0];
-                }
-            }
-            else
-            {
-                using (IEnumerator<TSource> e = source.GetEnumerator())
-                {
-                    if (e.MoveNext())
-                    {
-                        return e.Current;
-                    }
-                }
-            }
-
-            return default(TSource);
+            bool found;
+            return source.TryGetFirst(out found);
         }
 
         public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
@@ -141,6 +82,44 @@ namespace System.Linq
                 }
             }
 
+            return default(TSource);
+        }
+
+        internal static TSource TryGetFirst<TSource>(this IEnumerable<TSource> source, out bool found)
+        {
+            if (source == null)
+            {
+                throw Error.ArgumentNull(nameof(source));
+            }
+
+            IPartition<TSource> partition = source as IPartition<TSource>;
+            if (partition != null)
+            {
+                return partition.TryGetFirst(out found);
+            }
+            
+            IList<TSource> list = source as IList<TSource>;
+            if (list != null)
+            {
+                if (list.Count > 0)
+                {
+                    found = true;
+                    return list[0];
+                }
+            }
+            else
+            {
+                using (IEnumerator<TSource> e = source.GetEnumerator())
+                {
+                    if (e.MoveNext())
+                    {
+                        found = true;
+                        return e.Current;
+                    }
+                }
+            }
+
+            found = false;
             return default(TSource);
         }
     }

--- a/src/System.Linq/src/System/Linq/Last.cs
+++ b/src/System.Linq/src/System/Linq/Last.cs
@@ -28,7 +28,7 @@ namespace System.Linq
 
             if (!found)
             {
-                throw Error.NoElements();
+                throw Error.NoMatch();
             }
 
             return last;

--- a/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -270,7 +270,7 @@ namespace System.Linq
             }
         }
 
-        public TElement First(Func<TElement, bool> predicate)
+        public TElement TryGetFirst(Func<TElement, bool> predicate, out bool found)
         {
             CachingComparer<TElement> comparer = GetComparer();
             using (IEnumerator<TElement> e = _source.GetEnumerator())
@@ -280,37 +280,7 @@ namespace System.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        throw Error.NoMatch();
-                    }
-
-                    value = e.Current;
-                }
-                while (!predicate(value));
-
-                comparer.SetElement(value);
-                while (e.MoveNext())
-                {
-                    TElement x = e.Current;
-                    if (predicate(x) && comparer.Compare(x, true) < 0)
-                    {
-                        value = x;
-                    }
-                }
-
-                return value;
-            }
-        }
-
-        public TElement FirstOrDefault(Func<TElement, bool> predicate)
-        {
-            CachingComparer<TElement> comparer = GetComparer();
-            using (IEnumerator<TElement> e = _source.GetEnumerator())
-            {
-                TElement value;
-                do
-                {
-                    if (!e.MoveNext())
-                    {
+                        found = false;
                         return default(TElement);
                     }
 
@@ -328,6 +298,7 @@ namespace System.Linq
                     }
                 }
 
+                found = true;
                 return value;
             }
         }
@@ -392,7 +363,7 @@ namespace System.Linq
             return value;
         }
 
-        public TElement Last(Func<TElement, bool> predicate)
+        public TElement TryGetLast(Func<TElement, bool> predicate, out bool found)
         {
             CachingComparer<TElement> comparer = GetComparer();
             using (IEnumerator<TElement> e = _source.GetEnumerator())
@@ -402,37 +373,7 @@ namespace System.Linq
                 {
                     if (!e.MoveNext())
                     {
-                        throw Error.NoMatch();
-                    }
-
-                    value = e.Current;
-                }
-                while (!predicate(value));
-
-                comparer.SetElement(value);
-                while (e.MoveNext())
-                {
-                    TElement x = e.Current;
-                    if (predicate(x) && comparer.Compare(x, false) >= 0)
-                    {
-                        value = x;
-                    }
-                }
-
-                return value;
-            }
-        }
-
-        public TElement LastOrDefault(Func<TElement, bool> predicate)
-        {
-            CachingComparer<TElement> comparer = GetComparer();
-            using (IEnumerator<TElement> e = _source.GetEnumerator())
-            {
-                TElement value;
-                do
-                {
-                    if (!e.MoveNext())
-                    {
+                        found = false;
                         return default(TElement);
                     }
 
@@ -450,6 +391,7 @@ namespace System.Linq
                     }
                 }
 
+                found = true;
                 return value;
             }
         }

--- a/src/System.Linq/src/System/Linq/Reverse.cs
+++ b/src/System.Linq/src/System/Linq/Reverse.cs
@@ -122,38 +122,21 @@ namespace System.Linq
 
             public TSource TryGetElementAt(int index, out bool found)
             {
-                if ((uint)index < (uint)_source.Length)
+                var buffer = new Buffer<TSource>(_source);
+
+                if ((uint)index < (uint)buffer._count)
                 {
                     found = true;
-                    return _selector(_source[index]);
+                    return buffer._items[buffer._count - index - 1];
                 }
 
                 found = false;
                 return default(TSource);
             }
 
-            public TSource TryGetFirst(out bool found)
-            {
-                Debug.Assert(_source.Length > 0); // See assert in constructor
+            public TSource TryGetFirst(out bool found) => _source.TryGetLast(out found);
 
-                found = true;
-                return _selector(_source[0]);
-            }
-
-            public TSource TryGetLast(out bool found)
-            {
-                using (IEnumerator<TSource> en = _source.GetEnumerator())
-                {
-                    if (en.MoveNext())
-                    {
-                        found = true;
-                        return en.Current;
-                    }
-                }
-
-                found = false;
-                return default(TSource);
-            }
+            public TSource TryGetLast(out bool found) => _source.TryGetFirst(out found);
         }
     }
 }

--- a/src/System.Linq/src/System/Linq/Reverse.cs
+++ b/src/System.Linq/src/System/Linq/Reverse.cs
@@ -20,7 +20,7 @@ namespace System.Linq
             return new ReverseIterator<TSource>(source);
         }
 
-        private sealed class ReverseIterator<TSource> : Iterator<TSource>, IIListProvider<TSource>
+        private sealed class ReverseIterator<TSource> : Iterator<TSource>, IPartition<TSource>
         {
             private readonly IEnumerable<TSource> _source;
             private TSource[] _buffer;
@@ -108,6 +108,51 @@ namespace System.Linq
                 }
 
                 return _source.Count();
+            }
+
+            public IPartition<TSource> Skip(int count)
+            {
+                return new EnumerablePartition<TSource>(this, count, -1);
+            }
+
+            public IPartition<TSource> Take(int count)
+            {
+                return new EnumerablePartition<TSource>(this, 0, count - 1);
+            }
+
+            public TSource TryGetElementAt(int index, out bool found)
+            {
+                if ((uint)index < (uint)_source.Length)
+                {
+                    found = true;
+                    return _selector(_source[index]);
+                }
+
+                found = false;
+                return default(TSource);
+            }
+
+            public TSource TryGetFirst(out bool found)
+            {
+                Debug.Assert(_source.Length > 0); // See assert in constructor
+
+                found = true;
+                return _selector(_source[0]);
+            }
+
+            public TSource TryGetLast(out bool found)
+            {
+                using (IEnumerator<TSource> en = _source.GetEnumerator())
+                {
+                    if (en.MoveNext())
+                    {
+                        found = true;
+                        return en.Current;
+                    }
+                }
+
+                found = false;
+                return default(TSource);
             }
         }
     }

--- a/src/System.Linq/src/System/Linq/Reverse.cs
+++ b/src/System.Linq/src/System/Linq/Reverse.cs
@@ -20,7 +20,7 @@ namespace System.Linq
             return new ReverseIterator<TSource>(source);
         }
 
-        private sealed class ReverseIterator<TSource> : Iterator<TSource>, IPartition<TSource>
+        private sealed class ReverseIterator<TSource> : Iterator<TSource>, IIListProvider<TSource>
         {
             private readonly IEnumerable<TSource> _source;
             private TSource[] _buffer;
@@ -109,34 +109,6 @@ namespace System.Linq
 
                 return _source.Count();
             }
-
-            public IPartition<TSource> Skip(int count)
-            {
-                return new EnumerablePartition<TSource>(this, count, -1);
-            }
-
-            public IPartition<TSource> Take(int count)
-            {
-                return new EnumerablePartition<TSource>(this, 0, count - 1);
-            }
-
-            public TSource TryGetElementAt(int index, out bool found)
-            {
-                var buffer = new Buffer<TSource>(_source);
-
-                if ((uint)index < (uint)buffer._count)
-                {
-                    found = true;
-                    return buffer._items[buffer._count - index - 1];
-                }
-
-                found = false;
-                return default(TSource);
-            }
-
-            public TSource TryGetFirst(out bool found) => _source.TryGetLast(out found);
-
-            public TSource TryGetLast(out bool found) => _source.TryGetFirst(out found);
         }
     }
 }

--- a/src/System.Linq/tests/ReverseTests.cs
+++ b/src/System.Linq/tests/ReverseTests.cs
@@ -63,9 +63,7 @@ namespace System.Linq.Tests
             return integers
                 .Select(collection => new object[] { collection, 0 })
                 .Concat(
-                    integers
-                        .Select(collection => collection.Select(i => i.ToString()))
-                        .Select(collection => new object[] { collection, string.Empty })
+                    integers.Select(c => new object[] { c.Select(i => i.ToString()), string.Empty })
                 );
         }
 

--- a/src/System.Linq/tests/ReverseTests.cs
+++ b/src/System.Linq/tests/ReverseTests.cs
@@ -14,86 +14,59 @@ namespace System.Linq.Tests
         {
             Assert.Throws<ArgumentNullException>("source", () => Enumerable.Reverse<string>(null));
         }
-
+        
         [Theory]
-        [InlineData(new int[] { })]
-        [InlineData(new int[] { 1 })]
-        [InlineData(new int[] { 5 })]
-        [InlineData(new int[] { 1, 3, 5 })]
-        [InlineData(new int[] { 2, 4, 6, 8 })]
-        public void ReverseMatches(int[] input)
+        [MemberData(nameof(ReverseData))]
+        public void Reverse<T>(IEnumerable<T> source, T dummy)
         {
-            int[] expectedResults = new int[input.Length];
-            for (int i = 0; i < input.Length; i++)
+            T[] expected = source.ToArray();
+            Array.Reverse(expected);
+
+            IEnumerable<T> actual = source.Reverse();
+
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.Count(), actual.Count()); // Count may be optimized.
+            Assert.Equal(expected, actual.ToArray());
+            Assert.Equal(expected, actual.ToList());
+
+            Assert.Equal(expected.FirstOrDefault(), actual.FirstOrDefault());
+            Assert.Equal(expected.LastOrDefault(), actual.LastOrDefault());
+
+            for (int i = 0; i < expected.Length; i++)
             {
-                expectedResults[i] = input[input.Length - 1 - i];
+                Assert.Equal(expected[i], actual.ElementAt(i));
+                
+                Assert.Equal(expected.Skip(i), actual.Skip(i));
+                Assert.Equal(expected.Take(i), actual.Take(i));
             }
 
-            Assert.NotSame(input, Enumerable.Reverse(input));
+            Assert.Equal(default(T), actual.ElementAtOrDefault(-1));
+            Assert.Equal(default(T), actual.ElementAtOrDefault(expected.Length));
 
-            Assert.Equal(expectedResults, input.Reverse());
-            Assert.Equal(expectedResults, new TestCollection<int>(input).Reverse());
-            Assert.Equal(expectedResults, new TestEnumerable<int>(input).Reverse());
-            Assert.Equal(expectedResults, new TestReadOnlyCollection<int>(input).Reverse());
+            Assert.Equal(expected, actual.Select(_ => _));
+            Assert.Equal(expected, actual.Where(_ => true));
 
-            Assert.Equal(expectedResults.Select(i => i * 2), input.Select(i => i * 2).Reverse());
-            Assert.Equal(expectedResults.Where(i => true).Select(i => i * 2), input.Where(i => true).Select(i => i * 2).Reverse());
-            Assert.Equal(expectedResults.Where(i => false).Select(i => i * 2), input.Where(i => false).Select(i => i * 2).Reverse());
+            Assert.Equal(actual, actual); // Repeat the enumeration against itself.
         }
 
-        [Fact]
-        public void SameResultsRepeatCallsIntQuery()
+        public static IEnumerable<object[]> ReverseData()
         {
-            var q = from x in new[] { 9999, 0, 888, -1, 66, -777, 1, 2, -12345 }
-                    where x > Int32.MinValue
-                    select x;
-
-            Assert.Equal(q.Reverse(), q.Reverse());
-        }
-
-        [Fact]
-        public void SameResultsRepeatCallsStringQuery()
-        {
-            var q = from x in new[] { "!@#$%^", "C", "AAA", "", "Calling Twice", "SoS", String.Empty }
-                    where !String.IsNullOrEmpty(x)
-                    select x;
-
-            Assert.Equal(q.Reverse(), q.Reverse());
-        }
-
-        [Fact]
-        public void SomeRepeatedElements()
-        {
-            int?[] source = new int?[] { -10, 0, 5, null, 0, 9, 100, null, 9 };
-            int?[] expected = new int?[] { 9, null, 100, 9, 0, null, 5, 0, -10 };
-
-            Assert.Equal(expected, source.Reverse());
-        }
-
-        [Fact]
-        public void ToArray()
-        {
-            int?[] source = new int?[] { -10, 0, 5, null, 0, 9, 100, null, 9 };
-            int?[] expected = new int?[] { 9, null, 100, 9, 0, null, 5, 0, -10 };
-
-            Assert.Equal(expected, source.Reverse().ToArray());
-        }
-
-        [Fact]
-        public void ToList()
-        {
-            int?[] source = new int?[] { -10, 0, 5, null, 0, 9, 100, null, 9 };
-            int?[] expected = new int?[] { 9, null, 100, 9, 0, null, 5, 0, -10 };
-
-            Assert.Equal(expected, source.Reverse().ToList());
-        }
-
-        [Fact]
-        public void Count()
-        {
-            int?[] source = new int?[] { -10, 0, 5, null, 0, 9, 100, null, 9 };
-
-            Assert.Equal(9, source.Reverse().Count());
+            var integers = new[]
+            {
+                Array.Empty<int>(), // No elements.
+                new[] { 1 }, // One element.
+                new[] { 9999, 0, 888, -1, 66, -777, 1, 2, -12345 }, // Distinct elements.
+                new[] { -10, 0, 5, 0, 9, 100, 9 }, // Some repeating elements.
+            };
+            
+            // TODO: Remove workarounds when xUnit is updated to include xunit/xunit#965.
+            return integers
+                .Select(collection => new object[] { collection, 0 })
+                .Concat(
+                    integers
+                        .Select(collection => collection.Select(i => i.ToString()))
+                        .Select(collection => new object[] { collection, string.Empty })
+                );
         }
 
         [Fact]
@@ -103,14 +76,6 @@ namespace System.Linq.Tests
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
-        }
-
-        [Fact]
-        public void RepeatEnumerating()
-        {
-            var reverse = new int?[] { -10, 0, 5, null, 0, 9, 100, null, 9 }.Reverse();
-
-            Assert.Equal(reverse, reverse);
         }
     }
 }


### PR DESCRIPTION
Refactor `First` and `FirstOrDefault` and `Last` and `LastOrDefault` to share some code. Also, cleanup the tests for `Reverse` (previously, this PR contained changes related to that method).

cc @stephentoub @VSadov @JonHanna 