### PR TITLE
Obsolete serialization of 2 types

### DIFF
--- a/src/System.Net.Requests/ref/System.Net.Requests.cs
+++ b/src/System.Net.Requests/ref/System.Net.Requests.cs
@@ -126,6 +126,8 @@ namespace System.Net
     public partial class HttpWebRequest : System.Net.WebRequest, System.Runtime.Serialization.ISerializable
     {
         internal HttpWebRequest() { }
+        [System.ObsoleteAttribute("Serialization is obsoleted for this type.  http://go.microsoft.com/fwlink/?linkid=14202")]
+        protected HttpWebRequest(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }        
         public string Accept { get { throw null; } set { } }
         public virtual bool AllowReadStreamBuffering { get { throw null; } set { } }
         public override string ContentType { get { throw null; } set { } }
@@ -152,8 +154,7 @@ namespace System.Net
         public DateTime Date { get { throw null; } set { } }
         public static int DefaultMaximumResponseHeadersLength { get { throw null; } set { } }
         public static int DefaultMaximumErrorResponseLength { get { throw null; } set { } }
-        public System.Security.Cryptography.X509Certificates.X509CertificateCollection ClientCertificates {
-            get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509CertificateCollection ClientCertificates { get { throw null; } set { } }
         public string Expect { get { throw null; } set { } }
         public DateTime IfModifiedSince { get { throw null; } set { } }
         public bool KeepAlive { get { throw null; } set { } }
@@ -183,19 +184,24 @@ namespace System.Net
         public override string ConnectionGroupName { get { throw null; } set { } }
         public System.Net.Security.RemoteCertificateValidationCallback ServerCertificateValidationCallback { get; set; }
         public HttpContinueDelegate ContinueDelegate { get { throw null; } set { } }
-        protected HttpWebRequest(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { throw null; }
-        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { throw null; }
-        protected override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { throw null; }
         public string Connection { get { throw null; } set { } }
         public override System.Net.IWebProxy Proxy { get { throw null; } set { } }
         public static new System.Net.Cache.RequestCachePolicy DefaultCachePolicy { get { throw null; } set { } }
         public override bool PreAuthenticate { get { throw null; } set { } }
         public override int Timeout { get { throw null; } set { } }
         public override long ContentLength { get { throw null; } set { } }
+#pragma warning disable 0809 // Obsolete member overrides non-obsolete member
+        [ObsoleteAttribute("Serialization is obsoleted for this type.  http://go.microsoft.com/fwlink/?linkid=14202")]
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { throw null; }
+        [ObsoleteAttribute("Serialization is obsoleted for this type.  http://go.microsoft.com/fwlink/?linkid=14202")]
+        protected override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { throw null; }
+#pragma warning restore 0809
     }
-    public partial class HttpWebResponse : System.Net.WebResponse , System.Runtime.Serialization.ISerializable
+    public partial class HttpWebResponse : System.Net.WebResponse, System.Runtime.Serialization.ISerializable
     {
         public HttpWebResponse() { }
+        [System.ObsoleteAttribute("Serialization is obsoleted for this type.  http://go.microsoft.com/fwlink/?linkid=14202")]
+        protected HttpWebResponse(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }        
         public override long ContentLength { get { throw null; } }
         public override string ContentType { get { throw null; } }
         public virtual System.Net.CookieCollection Cookies { get { throw null; } set { } }
@@ -215,9 +221,12 @@ namespace System.Net
         public string Server { get { throw null; } }
         public override void Close() { throw null; }
         public override bool IsMutuallyAuthenticated { get { throw null; } }
-        protected HttpWebResponse(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { throw null; }
+#pragma warning disable 0809 // Obsolete member overrides non-obsolete member
+        [ObsoleteAttribute("Serialization is obsoleted for this type.  http://go.microsoft.com/fwlink/?linkid=14202")]
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { throw null; }
+        [ObsoleteAttribute("Serialization is obsoleted for this type.  http://go.microsoft.com/fwlink/?linkid=14202")]
         protected override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { throw null; }
+#pragma warning restore 0809
     }
     public interface IAuthenticationModule
     {

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -95,86 +95,17 @@ namespace System.Net
         [Obsolete("Serialization is obsoleted for this type.  http://go.microsoft.com/fwlink/?linkid=14202")]
         protected HttpWebRequest(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext)
         {
-#if DEBUG
-            using (DebugThreadTracking.SetThreadKind(ThreadKinds.User)) {
-#endif
-            _webHeaderCollection = (WebHeaderCollection)serializationInfo.GetValue("_HttpRequestHeaders", typeof(WebHeaderCollection));
-            Proxy = (IWebProxy)serializationInfo.GetValue("_Proxy", typeof(IWebProxy));
-            KeepAlive = serializationInfo.GetBoolean("_KeepAlive");
-            Pipelined = serializationInfo.GetBoolean("_Pipelined");
-            AllowAutoRedirect = serializationInfo.GetBoolean("_AllowAutoRedirect");
-            if (!serializationInfo.GetBoolean("_AllowWriteStreamBuffering"))
-            {
-                _booleans &= ~Booleans.AllowWriteStreamBuffering;
-            }            
-            _maximumAllowedRedirections = serializationInfo.GetInt32("_MaximumAllowedRedirections");
-            AllowAutoRedirect = serializationInfo.GetInt32("_AutoRedirects") > 0;
-            Timeout = serializationInfo.GetInt32("_Timeout");
-
-            try
-            {
-                ReadWriteTimeout = serializationInfo.GetInt32("_ReadWriteTimeout");
-            }
-            catch
-            { // default
-            }
-            try
-            {
-                MaximumResponseHeadersLength = serializationInfo.GetInt32("_MaximumResponseHeadersLength");
-            }
-            catch
-            {
-                // default
-            }
-            ContentLength = serializationInfo.GetInt64("_ContentLength");
-            MediaType = serializationInfo.GetString("_MediaType");
-            _originVerb = serializationInfo.GetString("_OriginVerb");
-            ConnectionGroupName = serializationInfo.GetString("_ConnectionGroupName");
-            ProtocolVersion = (Version)serializationInfo.GetValue("_Version", typeof(Version));
-            _requestUri = (Uri)serializationInfo.GetValue("_OriginUri", typeof(Uri));
-#if DEBUG
-            }
-#endif
+            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
         }
-
 
         void ISerializable.GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
         {
-#if DEBUG
-            using (DebugThreadTracking.SetThreadKind(ThreadKinds.User)) {
-#endif
-            GetObjectData(serializationInfo, streamingContext);
-#if DEBUG
-            }
-#endif
+            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
         }
         
         protected override void GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
         {
-#if DEBUG
-            using (DebugThreadTracking.SetThreadKind(ThreadKinds.User)) {
-#endif           
-            serializationInfo.AddValue("_HttpRequestHeaders", _webHeaderCollection, typeof(WebHeaderCollection));
-            serializationInfo.AddValue("_Proxy", _proxy, typeof(IWebProxy));
-            serializationInfo.AddValue("_KeepAlive", KeepAlive);
-            serializationInfo.AddValue("_Pipelined", Pipelined);
-            serializationInfo.AddValue("_AllowAutoRedirect", AllowAutoRedirect);
-            serializationInfo.AddValue("_AllowWriteStreamBuffering", AllowWriteStreamBuffering);
-            serializationInfo.AddValue("_MaximumAllowedRedirections", AllowAutoRedirect);
-            serializationInfo.AddValue("_AutoRedirects", AllowAutoRedirect);
-            serializationInfo.AddValue("_Timeout", Timeout);
-            serializationInfo.AddValue("_ReadWriteTimeout", ReadWriteTimeout);
-            serializationInfo.AddValue("_MaximumResponseHeadersLength", _defaultMaxResponseHeaderLength);
-            serializationInfo.AddValue("_ContentLength", ContentLength);
-            serializationInfo.AddValue("_MediaType", MediaType);
-            serializationInfo.AddValue("_OriginVerb", _originVerb);
-            serializationInfo.AddValue("_ConnectionGroupName", ConnectionGroupName);
-            serializationInfo.AddValue("_Version", ProtocolVersion, typeof(Version));
-            serializationInfo.AddValue("_OriginUri", Address, typeof(Uri));
-            base.GetObjectData(serializationInfo, streamingContext);
-#if DEBUG
-            }
-#endif
+            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
         }
 
         internal HttpWebRequest(Uri uri)

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -95,17 +95,17 @@ namespace System.Net
         [Obsolete("Serialization is obsoleted for this type.  http://go.microsoft.com/fwlink/?linkid=14202")]
         protected HttpWebRequest(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext)
         {
-            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+            throw new PlatformNotSupportedException();
         }
 
         void ISerializable.GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
         {
-            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+            throw new PlatformNotSupportedException();
         }
         
         protected override void GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
         {
-            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+            throw new PlatformNotSupportedException();
         }
 
         internal HttpWebRequest(Uri uri)

--- a/src/System.Net.Requests/src/System/Net/HttpWebResponse.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebResponse.cs
@@ -34,31 +34,18 @@ namespace System.Net
         [ObsoleteAttribute("Serialization is obsoleted for this type.  http://go.microsoft.com/fwlink/?linkid=14202")]
         protected HttpWebResponse(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext)
         {
-            // Trick the cloned object into not thinking it's disposed.
-            _httpResponseMessage = new HttpResponseMessage();
-            _webHeaderCollection = (WebHeaderCollection)serializationInfo.GetValue("_HttpResponseHeaders", typeof(WebHeaderCollection));
-            _requestUri = (Uri)serializationInfo.GetValue("_Uri", typeof(Uri));
-            Version version = (Version)serializationInfo.GetValue("_Version", typeof(Version));
-            _isVersionHttp11 = version.Equals(HttpVersion.Version11);
+            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
         }
      
         void ISerializable.GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
         {
-            GetObjectData(serializationInfo, streamingContext);
+            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
         }
 
         protected override void GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
         {           
-            serializationInfo.AddValue("_HttpResponseHeaders", _webHeaderCollection, typeof(WebHeaderCollection));
-            serializationInfo.AddValue("_Uri", _requestUri, typeof(Uri));
-            serializationInfo.AddValue("_Version", ProtocolVersion, typeof(Version));
-            serializationInfo.AddValue("_StatusCode", StatusCode);
-            serializationInfo.AddValue("_ContentLength", ContentLength);
-            serializationInfo.AddValue("_Verb", Method);
-            serializationInfo.AddValue("_StatusDescription", StatusDescription);
-            base.GetObjectData(serializationInfo, streamingContext);
+            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
         }
-
 
         internal HttpWebResponse(HttpResponseMessage _message, Uri requestUri, CookieContainer cookieContainer)
         {

--- a/src/System.Net.Requests/src/System/Net/HttpWebResponse.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebResponse.cs
@@ -34,17 +34,17 @@ namespace System.Net
         [ObsoleteAttribute("Serialization is obsoleted for this type.  http://go.microsoft.com/fwlink/?linkid=14202")]
         protected HttpWebResponse(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext)
         {
-            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+            throw new PlatformNotSupportedException();
         }
      
         void ISerializable.GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
         {
-            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+            throw new PlatformNotSupportedException();
         }
 
         protected override void GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
         {           
-            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+            throw new PlatformNotSupportedException();
         }
 
         internal HttpWebResponse(HttpResponseMessage _message, Uri requestUri, CookieContainer cookieContainer)

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 
 namespace System.Net.Tests
 {
-    public class HttpWebRequestTest
+    public partial class HttpWebRequestTest
     {
         private const string RequestBody = "This is data to POST.";
         private readonly byte[] _requestBodyBytes = Encoding.UTF8.GetBytes(RequestBody);

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.netstandard1.7.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.netstandard1.7.cs
@@ -11,17 +11,17 @@ using Xunit.Abstractions;
 
 namespace System.Net.Tests
 {
-    public partial class HttpWebRequestTest17
+    public partial class HttpWebRequestTest
     {
         [Fact]
-        public void Serialize()
+        public void HttpWebRequest_Serialize_Fails()
         {
             using (MemoryStream fs = new MemoryStream())
             {
                 BinaryFormatter formatter = new BinaryFormatter();
                 var hwr = HttpWebRequest.CreateHttp("http://localhost");
 
-                Assert.Throws<NotImplementedException>(() => formatter.Serialize(fs, hwr));
+                Assert.Throws<PlatformNotSupportedException>(() => formatter.Serialize(fs, hwr));
             }
         }
     }

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.netstandard1.7.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.netstandard1.7.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Net.Http;
+using System.Runtime.Serialization.Formatters.Binary;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Tests
+{
+    public partial class HttpWebRequestTest17
+    {
+        [Fact]
+        public void Serialize()
+        {
+            using (MemoryStream fs = new MemoryStream())
+            {
+                BinaryFormatter formatter = new BinaryFormatter();
+                var hwr = HttpWebRequest.CreateHttp("http://localhost");
+
+                Assert.Throws<NotImplementedException>(() => formatter.Serialize(fs, hwr));
+            }
+        }
+    }
+}

--- a/src/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using System.Net.Http;
 using System.Net.Test.Common;
 using System.Threading.Tasks;
+using System.Runtime.Serialization.Formatters.Binary;
 
 using Xunit;
 using Xunit.Abstractions;
@@ -100,5 +102,28 @@ namespace System.Net.Tests
             });
         }
 
+        [Fact]
+        public async Task Serialize()
+        {
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                HttpWebRequest request = WebRequest.CreateHttp(url);
+                request.Method = HttpMethod.Get.Method;
+                Task<WebResponse> getResponse = request.GetResponseAsync();
+                await LoopbackServer.ReadRequestAndSendResponseAsync(server, "HTTP/1.1 200 OK\r\n");
+
+                using (WebResponse response = await getResponse)
+                {
+                    HttpWebResponse httpResponse = (HttpWebResponse)response;
+                    using (MemoryStream fs = new MemoryStream())
+                    {
+                        BinaryFormatter formatter = new BinaryFormatter();
+                        HttpWebResponse hwr = (HttpWebResponse)response;
+
+                        Assert.Throws<NotImplementedException>(() => formatter.Serialize(fs, hwr));
+                    }
+                }
+            });
+        } 
     }
 }

--- a/src/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
@@ -103,7 +103,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        public async Task Serialize()
+        public async Task HttpWebResponse_Serialize_Fails()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>
             {
@@ -120,7 +120,7 @@ namespace System.Net.Tests
                         BinaryFormatter formatter = new BinaryFormatter();
                         HttpWebResponse hwr = (HttpWebResponse)response;
 
-                        Assert.Throws<NotImplementedException>(() => formatter.Serialize(fs, hwr));
+                        Assert.Throws<PlatformNotSupportedException>(() => formatter.Serialize(fs, hwr));
                     }
                 }
             });

--- a/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="LoggingTest.cs" />
     <Compile Include="HttpRequestCachePolicyTest.cs" />
     <Compile Include="HttpWebRequestHeaderTest.cs" />
+    <Compile Include="HttpWebRequestTest.netstandard1.7.cs" />
     <Compile Include="HttpWebResponseHeaderTest.cs" />
     <Compile Include="HttpRequestResponseSerializationTest.cs" />
     <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/14068

I made some attempt to fix serialization for each of these types, but they have been sufficiently rewritten that it would need some design work (eg., some of the state was moved to nested or nested-nested types). Given the serializers were marked obsolete in Full framework, I chose to abandon that effort and made them throw rather than be broken.

@stephentoub @davidsh @CIPop 