### PR TITLE
Maintain stable sort behaviour in OrderBy().LastOrDefault(predicate)

### DIFF
--- a/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -444,7 +444,7 @@ namespace System.Linq
                 while (e.MoveNext())
                 {
                     TElement x = e.Current;
-                    if (predicate(x) && comparer.Compare(x, false) > 0)
+                    if (predicate(x) && comparer.Compare(x, false) >= 0)
                     {
                         value = x;
                     }

--- a/src/System.Linq/tests/OrderByTests.cs
+++ b/src/System.Linq/tests/OrderByTests.cs
@@ -297,6 +297,16 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void LastOnOrderedMatchingCases()
+        {
+            object[] boxedInts = new object[] {0, 1, 2, 9, 1, 2, 3, 9, 4, 5, 7, 8, 9, 0, 1};
+            Assert.Same(boxedInts[12], boxedInts.OrderBy(o => (int)o).Last());
+            Assert.Same(boxedInts[12], boxedInts.OrderBy(o => (int)o).LastOrDefault());
+            Assert.Same(boxedInts[12], boxedInts.OrderBy(o => (int)o).Last(o => (int)o % 2 == 1));
+            Assert.Same(boxedInts[12], boxedInts.OrderBy(o => (int)o).LastOrDefault(o => (int)o % 2 == 1));
+        }
+
+        [Fact]
         public void LastOnEmptyOrderedThrows()
         {
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<int>().OrderBy(i => i).Last());


### PR DESCRIPTION
Fixes #14183