### PR TITLE
Improve ConcurrentBag.ToArray/GetEnumerator/CopyTo/IsEmpty performance

### DIFF
--- a/src/System.Collections.Concurrent/src/Resources/Strings.resx
+++ b/src/System.Collections.Concurrent/src/Resources/Strings.resx
@@ -144,7 +144,7 @@
   <data name="BlockingCollection_CopyTo_NonNegative" xml:space="preserve">
     <value>The index argument must be greater than or equal zero.</value>
   </data>
-  <data name="BlockingCollection_CopyTo_TooManyElems" xml:space="preserve">
+  <data name="Collection_CopyTo_TooManyElems" xml:space="preserve">
     <value>The number of elements in the collection is greater than the available space from index to the end of the destination array.</value>
   </data>
   <data name="BlockingCollection_ctor_BoundedCapacityRange" xml:space="preserve">

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -1617,7 +1617,7 @@ nameof(boundedCapacity), boundedCapacity,
             }
             catch (ArgumentException)
             {
-                throw new ArgumentException(SR.BlockingCollection_CopyTo_TooManyElems, nameof(index));
+                throw new ArgumentException(SR.Collection_CopyTo_TooManyElems, nameof(index));
             }
             catch (RankException)
             {

--- a/src/System.Collections.Concurrent/tests/ConcurrentBagTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentBagTests.cs
@@ -12,6 +12,7 @@ namespace System.Collections.Concurrent.Tests
 {
     public class ConcurrentBagTests : ProducerConsumerCollectionTests
     {
+        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
         protected override IProducerConsumerCollection<int> CreateProducerConsumerCollection() => new ConcurrentBag<int>();
         protected override IProducerConsumerCollection<int> CreateProducerConsumerCollection(IEnumerable<int> collection) => new ConcurrentBag<int>(collection);
         protected override bool IsEmpty(IProducerConsumerCollection<int> pcc) => ((ConcurrentBag<int>)pcc).IsEmpty;
@@ -125,6 +126,44 @@ namespace System.Collections.Concurrent.Tests
             }
 
             Assert.Equal(initialCount, bag.Count);
+        }
+
+        [Fact]
+        public static void ICollectionCopyTo_TypeMismatch()
+        {
+            const int Size = 10;
+            ICollection c;
+
+            c = new ConcurrentBag<Exception>(Enumerable.Range(0, Size).Select(_ => new Exception()));
+            c.CopyTo(new Exception[Size], 0);
+            Assert.Throws<InvalidCastException>(() => c.CopyTo(new InvalidOperationException[Size], 0));
+
+            c = new ConcurrentBag<ArgumentException>(Enumerable.Range(0, Size).Select(_ => new ArgumentException()));
+            c.CopyTo(new Exception[Size], 0);
+            c.CopyTo(new ArgumentException[Size], 0);
+            Assert.Throws<InvalidCastException>(() => c.CopyTo(new ArgumentNullException[Size], 0));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(10)]
+        public static void ToArray_AddTakeDifferentThreads_ExpectedResultsAfterAddsAndTakes(int initialCount)
+        {
+            var bag = new ConcurrentBag<int>(Enumerable.Range(0, initialCount));
+            int items = 20 + initialCount;
+
+            for (int i = 0; i < items; i++)
+            {
+                bag.Add(i + initialCount);
+                ThreadFactory.StartNew(() =>
+                {
+                    int item;
+                    Assert.True(bag.TryTake(out item));
+                    Assert.Equal(item, i);
+                }).GetAwaiter().GetResult();
+                Assert.Equal(Enumerable.Range(i + 1, initialCount), bag.ToArray());
+            }
         }
 
         protected sealed class BagOracle : IProducerConsumerCollection<int>


### PR DESCRIPTION
ToArray and CopyTo take a moment-in-time snapshot of the bag by freezing it, copying the contents to an array, and unfreezing.  However, that copy is done via an intermediate List, which results in potentially many unnecessary allocations and copies.

Changes:
- This commit fixes that by first counting how many items there are in the bag and either presizing the array (in the case of ToArray) or comparing the length (in the case of CopyTo) and then copying directly into the target, eliminating the extra allocations.
- There is still an intermediate allocation for the non-generic ICollection.CopyTo(Array, int) method, but to avoid that in common cases, it now special-cases T[] and uses the more efficient CopyTo(T[], int) implementation for that common case.
- GetEnumerator was similarly implemented to first copy to a list and then get its enumerator.  It now uses the ToArray implementation instead.  This also means that for empty bags, we end up returning Array.Empty, which means the returned enumerator from it is also a singleton.
- Additional fast paths were added to IsEmpty.  It also had a fast path to check to see if the bag was void of any queues, in which case we know the bag is empty.  I've also added checks for the local queue.  If the local queue isn't empty, then we know the bag isn't empty and we can avoid freezing/unfreezing.  If the local queue is empty and it's the only one in the bag, then we can similarly avoid freezing/unfreezing, as we know the whole bag is empty.
- Added some additional tests.

Note: There are two small technically breaking changes here:
- ((ICollection)bag).CopyTo when passed a T[] with a bad index would previously throw an ArgumentOutOfRangeException with the name "dstIndex".  That's because that's what Array's CopyTo implementation uses as the parameter name, even though this makes very little sense: the name of that property in both ICollection.CopyTo and in ConcurrentBag.CopyTo is "index".  As a side-effect of the CopyTo(Array, int) optimization that checks for T[] and forwards it to CopyTo(T[], int), we end up using "index" instead of "dstIndex" for the argument name in the exception.
- GetEnumerator used to return the result of calling GetEnumerator on the generated ```List<T>```; now it calls GetEnumerator on the generated ```T[]```.  ```List<T>``` and ```T[]``` have different implemented behaviors for the undefined situation of calling Current on an enumerator after MoveNext has returned false: for ```List<T>``` it returns default(T) and for array it throws an exception.  By switching from using a ```List<T>``` to a ```T[]```, this behavior has also switched.  If we wanted to deal with this, we could by writing a custom enumerator implementation, but it seemed unnecessary.

For this perf test that fills a bag with N queues and M items per queue and then calls ToArray on it 10M times:
```C#
using System;
using System.Diagnostics;
using System.Threading;
using System.Threading.Tasks;
using System.Collections.Concurrent;
using System.Linq;

class Test
{
    public static void Main()
    {
        var sw = new Stopwatch();
        var counts = new[] { 1, 4, 16, 64 };
        foreach (int threads in counts)
        {
            foreach (int itemsPerQueue in counts)
            {
                var bag = new ConcurrentBag<int>();

                var b = new Barrier(threads);
                Task.WaitAll(Enumerable.Range(0, threads).Select(_ => Task.Factory.StartNew(() =>
                {
                    b.SignalAndWait();
                    for (int perQueue = 0; perQueue < itemsPerQueue; perQueue++) bag.Add(perQueue);
                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default)).ToArray());

                int gen0 = GC.CollectionCount(0);
                sw.Restart();
                for (int i = 0; i < 10000000; i++) bag.ToArray();
                sw.Stop();
                gen0 = GC.CollectionCount(0) - gen0;
                Console.WriteLine($"Threads: {threads,3} PerThread: {itemsPerQueue,3}. Time: {sw.Elapsed} Gen0: {gen0}");
            }
        }
    }
}
```
I get the following results:
Before:
```
Threads:   1 PerThread:   1. Time: 00:00:01.1500330 Gen0: 534
Threads:   1 PerThread:   4. Time: 00:00:01.3972260 Gen0: 572
Threads:   1 PerThread:  16. Time: 00:00:02.8350332 Gen0: 1488
Threads:   1 PerThread:  64. Time: 00:00:06.9316286 Gen0: 4463
Threads:   4 PerThread:   1. Time: 00:00:02.1913958 Gen0: 572
Threads:   4 PerThread:   4. Time: 00:00:03.6266836 Gen0: 1487
Threads:   4 PerThread:  16. Time: 00:00:07.0374684 Gen0: 4462
Threads:   4 PerThread:  64. Time: 00:00:20.0522162 Gen0: 15674
Threads:  16 PerThread:   1. Time: 00:00:05.9808988 Gen0: 1487
Threads:  16 PerThread:   4. Time: 00:00:10.7812079 Gen0: 4463
Threads:  16 PerThread:  16. Time: 00:00:22.5223754 Gen0: 15674
Threads:  16 PerThread:  64. Time: 00:01:09.4600190 Gen0: 59791
Threads:  64 PerThread:   1. Time: 00:00:21.1134136 Gen0: 4463
Threads:  64 PerThread:   4. Time: 00:00:33.4638482 Gen0: 15674
Threads:  64 PerThread:  16. Time: 00:01:30.1069096 Gen0: 59791
Threads:  64 PerThread:  64. Time: 00:04:55.3938445 Gen0: 235294
```
After:
```
Threads:   1 PerThread:   1. Time: 00:00:00.7471809 Gen0: 152
Threads:   1 PerThread:   4. Time: 00:00:00.9599024 Gen0: 191
Threads:   1 PerThread:  16. Time: 00:00:01.0244813 Gen0: 420
Threads:   1 PerThread:  64. Time: 00:00:01.2910293 Gen0: 1335
Threads:   4 PerThread:   1. Time: 00:00:01.5348352 Gen0: 190
Threads:   4 PerThread:   4. Time: 00:00:02.6237707 Gen0: 420
Threads:   4 PerThread:  16. Time: 00:00:02.7698953 Gen0: 1335
Threads:   4 PerThread:  64. Time: 00:00:04.0346238 Gen0: 4995
Threads:  16 PerThread:   1. Time: 00:00:04.8559514 Gen0: 420
Threads:  16 PerThread:   4. Time: 00:00:08.8832032 Gen0: 1335
Threads:  16 PerThread:  16. Time: 00:00:10.0114349 Gen0: 4995
Threads:  16 PerThread:  64. Time: 00:00:15.1769433 Gen0: 19608
Threads:  64 PerThread:   1. Time: 00:00:19.3902392 Gen0: 1335
Threads:  64 PerThread:   4. Time: 00:00:35.8097217 Gen0: 4995
Threads:  64 PerThread:  16. Time: 00:00:40.8270685 Gen0: 19608
Threads:  64 PerThread:  64. Time: 00:01:01.7713918 Gen0: 78125
```

cc: @kouvel, @alexperovich, @weshaggard
