### PR TITLE
Rename to reflect latest configuration spec

### DIFF
--- a/src/Tools/CoreFx.Tools/FindBestConfiguration.cs
+++ b/src/Tools/CoreFx.Tools/FindBestConfiguration.cs
@@ -13,10 +13,10 @@ namespace Microsoft.DotNet.Build.Tasks
     public class FindBestConfiguration : ConfigurationTask
     {
         [Required]
-        public string[] ProjectConfigurations { get; set; }
+        public string BuildConfiguration { get; set; }
 
         [Required]
-        public string BuildConfiguration { get; set; }
+        public string[] BuildConfigurations { get; set; }
 
         public bool DoNotAllowCompatibleValues { get; set; }
 
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Build.Tasks
         {
             LoadConfiguration();
 
-            var supportedProjectConfigurations = new HashSet<Configuration>(ProjectConfigurations.Where(c => !string.IsNullOrWhiteSpace(c)).Select(c => ConfigurationFactory.ParseConfiguration(c)));
+            var supportedProjectConfigurations = new HashSet<Configuration>(BuildConfigurations.Where(c => !string.IsNullOrWhiteSpace(c)).Select(c => ConfigurationFactory.ParseConfiguration(c)));
 
             var buildConfiguration = ConfigurationFactory.ParseConfiguration(BuildConfiguration);
 

--- a/src/Tools/GenerateProps/GenerateProps.proj
+++ b/src/Tools/GenerateProps/GenerateProps.proj
@@ -35,7 +35,7 @@
 
   <Target Name="Build">
     <PropertyGroup>
-      <ConfigurationPropsFolder>$(CoreFxToolsDir)projectCongifuration</ConfigurationPropsFolder>
+      <ConfigurationPropsFolder>$(CoreFxToolsDir)configuration</ConfigurationPropsFolder>
     </PropertyGroup>
 
     <GenerateConfigurationProps Properties="@(Property)" PropertyValues="@(PropertyValue)" PropsFolder="$(ConfigurationPropsFolder)" />


### PR DESCRIPTION
ProjectConfigurations -> BuildConfigurations
ProjectConfiguration -> Configuration

/cc @weshaggard @chcosta 

You can see the resultant props here:
https://gist.github.com/ericstj/cb427010dbcb416fda82a8884143c32f

@weshaggard we might need to think about what other things to put in the Configuration property when it gets defaulted.