### PR TITLE
FixXsdDataContractExporterTestAndFragmentTests

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XsdDataContractExporter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XsdDataContractExporter.cs
@@ -62,7 +62,8 @@ namespace System.Runtime.Serialization
                 //{
                 //    dataContractSet = new DataContractSet((Options == null) ? null : Options.GetSurrogate());
                 //}
-                return _dataContractSet;
+                //return _dataContractSet;
+                throw new PlatformNotSupportedException();
             }
         }
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XsdDataContractExporter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XsdDataContractExporter.cs
@@ -58,11 +58,6 @@ namespace System.Runtime.Serialization
         {
             get
             {
-                //if (dataContractSet == null)
-                //{
-                //    dataContractSet = new DataContractSet((Options == null) ? null : Options.GetSurrogate());
-                //}
-                //return _dataContractSet;
                 throw new PlatformNotSupportedException();
             }
         }

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2748,24 +2748,12 @@ public static partial class DataContractSerializerTests
             t, mi, out xname);
     }
 
-    [ActiveIssue(12772)]
     [Fact]
     public static void XsdDataContractExporterTest()
     {
         XsdDataContractExporter exporter = new XsdDataContractExporter();
-        if (exporter.CanExport(typeof(Employee)))
-        {
-            exporter.Export(typeof(Employee));
-            Assert.Equal(3,exporter.Schemas.Count);
-
-            XmlSchemaSet mySchemas = exporter.Schemas;
-
-            XmlQualifiedName XmlNameValue = exporter.GetRootElementName(typeof(Employee));
-            string EmployeeNameSpace = XmlNameValue.Namespace;
-            Assert.Equal("www.msn.com/Examples/", EmployeeNameSpace);
-            XmlSchema schema = mySchemas.Schemas(EmployeeNameSpace).Cast<XmlSchema>().FirstOrDefault();
-            Assert.NotNull(schema);
-        }
+        Assert.Throws<PlatformNotSupportedException>(() => exporter.CanExport(typeof(Employee)));
+        Assert.Throws<PlatformNotSupportedException>(() => exporter.Export(typeof(Employee)));
     }
 
 #if ReflectionOnly

--- a/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
@@ -294,13 +294,11 @@ public static class XmlDictionaryWriterTest
         ReaderWriterFactory.ReaderWriterType rwType = (ReaderWriterFactory.ReaderWriterType)
             Enum.Parse(typeof(ReaderWriterFactory.ReaderWriterType), rwTypeStr, true);
         Encoding encoding = Encoding.GetEncoding("utf-8");
-        MemoryStream ms1 = new MemoryStream();
-        MemoryStream ms2 = new MemoryStream();
-        XmlDictionaryWriter writer1 = (XmlDictionaryWriter)ReaderWriterFactory.CreateXmlWriter(rwType, ms1, encoding);
-        XmlDictionaryWriter writer2 = (XmlDictionaryWriter)ReaderWriterFactory.CreateXmlWriter(rwType, ms2, encoding);
-        Assert.False(FragmentHelper.CanFragment(writer1));
-        Assert.False(FragmentHelper.CanFragment(writer2));
+        MemoryStream ms = new MemoryStream();
+        XmlDictionaryWriter writer = (XmlDictionaryWriter)ReaderWriterFactory.CreateXmlWriter(rwType, ms, encoding);
+        Assert.False(FragmentHelper.CanFragment(writer));
     }
+
     private static bool ReadTest(MemoryStream ms, Encoding encoding, ReaderWriterFactory.ReaderWriterType rwType, byte[] byteArray)
     {
         ms.Position = 0;

--- a/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
@@ -287,7 +287,6 @@ public static class XmlDictionaryWriterTest
         writer.SetOutput(ms, encoding, true);
     }
 
-    [ActiveIssue(13375)]
     [Fact]
     public static void FragmentTest()
     {
@@ -295,25 +294,12 @@ public static class XmlDictionaryWriterTest
         ReaderWriterFactory.ReaderWriterType rwType = (ReaderWriterFactory.ReaderWriterType)
             Enum.Parse(typeof(ReaderWriterFactory.ReaderWriterType), rwTypeStr, true);
         Encoding encoding = Encoding.GetEncoding("utf-8");
-        int numberOfNestedFragments = 1;
         MemoryStream ms1 = new MemoryStream();
         MemoryStream ms2 = new MemoryStream();
         XmlDictionaryWriter writer1 = (XmlDictionaryWriter)ReaderWriterFactory.CreateXmlWriter(rwType, ms1, encoding);
         XmlDictionaryWriter writer2 = (XmlDictionaryWriter)ReaderWriterFactory.CreateXmlWriter(rwType, ms2, encoding);
-        Assert.True(FragmentHelper.CanFragment(writer1));
-        Assert.True(FragmentHelper.CanFragment(writer2));
-        writer1.WriteStartDocument(); writer2.WriteStartDocument();
-        writer1.WriteStartElement(ReaderWriterConstants.RootElementName); writer2.WriteStartElement(ReaderWriterConstants.RootElementName);
-        SimulateWriteFragment(writer1, true, numberOfNestedFragments);
-        SimulateWriteFragment(writer2, false, numberOfNestedFragments);
-        writer1.WriteEndElement(); writer2.WriteEndElement();
-        writer1.WriteEndDocument(); writer2.WriteEndDocument();
-        writer1.Flush();
-        writer2.Flush();
-
-        byte[] doc1 = ms1.ToArray();
-        byte[] doc2 = ms2.ToArray();
-        CompareArrays(doc1, 0, doc2, 0, doc1.Length);
+        Assert.False(FragmentHelper.CanFragment(writer1));
+        Assert.False(FragmentHelper.CanFragment(writer2));
     }
     private static bool ReadTest(MemoryStream ms, Encoding encoding, ReaderWriterFactory.ReaderWriterType rwType, byte[] byteArray)
     {
@@ -414,15 +400,6 @@ public static class XmlDictionaryWriterTest
         }
 
     }
-
-    private static void CompareArrays(byte[] array1, int offset1, byte[] array2, int offset2, int count)
-    {
-        for (int i = 0; i < count; i++)
-        {
-            Assert.Equal(array1[i + offset1], array2[i + offset2]);
-        }
-    }
-
     private static void SimulateWriteFragment(XmlDictionaryWriter writer, bool useFragmentAPI, int nestedLevelsLeft)
     {
         if (nestedLevelsLeft <= 0)


### PR DESCRIPTION
1.Throw PlatformNotSupportedException when to call DataContractSet since it always returns null.
2. Fix #12772.
3. Fix #13375

@shmao @mconnew @zhenlan 
