### PR TITLE
Revert "Temporarily disable package publishing"

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -1095,6 +1095,56 @@
       "DependsOn": [
         "Trusted-All-Debug"
       ]
+    },
+    {
+      "Name": "Publish Packages to Feeds - Release",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "BuildParameters": {
+        "ConfigurationGroup": "Release"
+      },
+      "Definitions": [
+        {
+          "Name": "DotNet-Trusted-Publish",
+          "Parameters": {
+            "VstsRepositoryName": "DotNet-CoreFX-Trusted",
+            "GitHubRepositoryName": "corefx"
+          },
+          "ReportingParameters": {
+            "TargetQueue": null,
+            "Type": "build/tests/"
+          }
+        }
+      ],
+      "DependsOn": [
+        "Trusted-All-Release"
+      ]
+    },
+    {
+      "Name": "Publish Packages to Drop - Debug",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "BuildParameters": {
+        "ConfigurationGroup": "Debug"
+      },
+      "Definitions": [
+        {
+          "Name": "DotNet-Trusted-Publish",
+          "Parameters": {
+            "VstsRepositoryName": "DotNet-CoreFX-Trusted",
+            "GitHubRepositoryName": "corefx"
+          },
+          "ReportingParameters": {
+            "TargetQueue": null,
+            "Type": "build/tests/"
+          }
+        }
+      ],
+      "DependsOn": [
+        "Trusted-All-Debug"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This reverts commit 4617b94842c078e4ba2561edfc4d51c5bbc0c829.   Since moving Pipebuild over to using the checked in definitions, we've stopped publishing new builds to myget, leaving the feed stuck at 11/21/2016.

I'm not sure if "Type": "build/tests/" is actually correct but could find no history to contradict it.

@chcosta @naamunds @karajas @weshaggard 