### PR TITLE
Call FormatterServices.GetUninitializedObject Directly.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
@@ -31,14 +31,6 @@ namespace System.Runtime.Serialization
     internal sealed class XmlFormatReaderGenerator
 #endif
     {
-        private static readonly Func<Type, object> s_getUninitializedObjectDelegate = (Func<Type, object>)
-            typeof(string)
-            .GetTypeInfo()
-            .Assembly
-            .GetType("System.Runtime.Serialization.FormatterServices")
-            ?.GetMethod("GetUninitializedObject", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
-            ?.CreateDelegate(typeof(Func<Type, object>));
-
         private static readonly ConcurrentDictionary<Type, bool> s_typeHasDefaultConstructorMap = new ConcurrentDictionary<Type, bool>();
 
         private CriticalHelper _helper;
@@ -940,14 +932,7 @@ namespace System.Runtime.Serialization
         static internal object UnsafeGetUninitializedObject(Type type)
         {
 #if !NET_NATIVE
-            if (type.GetTypeInfo().IsValueType)
-            {
-                  return Activator.CreateInstance(type);
-            }
-
-            const BindingFlags Flags = BindingFlags.Public | BindingFlags.Instance;
-            bool hasDefaultConstructor = s_typeHasDefaultConstructorMap.GetOrAdd(type, t => t.GetConstructor(Flags, Array.Empty<Type>()) != null);
-            return hasDefaultConstructor ? Activator.CreateInstance(type) : TryGetUninitializedObjectWithFormatterServices(type) ?? Activator.CreateInstance(type);
+            return FormatterServices.GetUninitializedObject(type) ?? Activator.CreateInstance(type);
 #else
             return RuntimeAugments.NewObject(type.TypeHandle);
 #endif
@@ -967,8 +952,5 @@ namespace System.Runtime.Serialization
             var type = DataContract.GetDataContractForInitialization(id).TypeForInitialization;
             return UnsafeGetUninitializedObject(type);
         }
-
-        static internal object TryGetUninitializedObjectWithFormatterServices(Type type) =>
-            s_getUninitializedObjectDelegate?.Invoke(type);
     }
 }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
@@ -31,8 +31,6 @@ namespace System.Runtime.Serialization
     internal sealed class XmlFormatReaderGenerator
 #endif
     {
-        private static readonly ConcurrentDictionary<Type, bool> s_typeHasDefaultConstructorMap = new ConcurrentDictionary<Type, bool>();
-
         private CriticalHelper _helper;
 
         public XmlFormatReaderGenerator()
@@ -932,7 +930,7 @@ namespace System.Runtime.Serialization
         static internal object UnsafeGetUninitializedObject(Type type)
         {
 #if !NET_NATIVE
-            return FormatterServices.GetUninitializedObject(type) ?? Activator.CreateInstance(type);
+            return FormatterServices.GetUninitializedObject(type);
 #else
             return RuntimeAugments.NewObject(type.TypeHandle);
 #endif


### PR DESCRIPTION
Previously we called RuntimeHelpers.GetUninitializedObject via reflection. PR #13652 made it available on NetCore, so we now can call the API directly.

Fix #13677