### PR TITLE
Remove unnecessary explicit boxing of Int32 in interpreter

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DecrementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DecrementInstruction.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Int32ToObject(unchecked((int)obj - 1)));
+                    frame.Push(unchecked((int)obj - 1));
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/IncrementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/IncrementInstruction.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Int32ToObject(unchecked(1 + (int)obj)));
+                    frame.Push(unchecked(1 + (int)obj));
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Int32ToObject(unchecked(-(int)obj)));
+                    frame.Push(unchecked(-(int)obj));
                 }
                 return +1;
             }
@@ -141,7 +141,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Int32ToObject(checked(-(int)obj)));
+                    frame.Push(checked(-(int)obj));
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OnesComplementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OnesComplementInstruction.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Int32ToObject(~(int)obj));
+                    frame.Push(~(int)obj);
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -250,7 +250,7 @@ namespace System.Linq.Expressions.Interpreter
                 object obj = frame.Pop();
                 if (obj == null)
                 {
-                    frame.Push(ScriptingRuntimeHelpers.Int32ToObject(0));
+                    frame.Push(0);
                 }
                 else
                 {


### PR DESCRIPTION
The overload of `Push` taking an `Int32` already goes through caching, so no need to have a call to cache the box here.