### PR TITLE
Removing unncessary parentheses in instructions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
@@ -28,7 +28,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((sbyte)(((sbyte)left) & ((sbyte)right)));
+                frame.Push((sbyte)((sbyte)left & (sbyte)right));
                 return +1;
             }
         }
@@ -44,7 +44,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((short)(((short)left) & ((short)right)));
+                frame.Push((short)((short)left & (short)right));
                 return +1;
             }
         }
@@ -60,7 +60,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((int)left) & ((int)right));
+                frame.Push((int)left & (int)right);
                 return +1;
             }
         }
@@ -76,7 +76,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((long)left) & ((long)right));
+                frame.Push((long)left & (long)right);
                 return +1;
             }
         }
@@ -92,7 +92,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((byte)(((byte)left) & ((byte)right)));
+                frame.Push((byte)((byte)left & (byte)right));
                 return +1;
             }
         }
@@ -108,7 +108,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((ushort)(((ushort)left) & ((ushort)right)));
+                frame.Push((ushort)((ushort)left & (ushort)right));
                 return +1;
             }
         }
@@ -124,7 +124,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((uint)left) & ((uint)right));
+                frame.Push((uint)left & (uint)right);
                 return +1;
             }
         }
@@ -140,7 +140,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((ulong)left) & ((ulong)right));
+                frame.Push((ulong)left & (ulong)right);
                 return +1;
             }
         }
@@ -168,7 +168,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push((bool)left ? null : Utils.BoxedFalse);
                     return +1;
                 }
-                frame.Push(((bool)left) & ((bool)right));
+                frame.Push((bool)left & (bool)right);
                 return +1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ExclusiveOrInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ExclusiveOrInstruction.cs
@@ -28,7 +28,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((sbyte)(((sbyte)left) ^ ((sbyte)right)));
+                frame.Push((sbyte)((sbyte)left ^ (sbyte)right));
                 return +1;
             }
         }
@@ -44,7 +44,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((short)(((short)left) ^ ((short)right)));
+                frame.Push((short)((short)left ^ (short)right));
                 return +1;
             }
         }
@@ -60,7 +60,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((int)left) ^ ((int)right));
+                frame.Push((int)left ^ (int)right);
                 return +1;
             }
         }
@@ -76,7 +76,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((long)left) ^ ((long)right));
+                frame.Push((long)left ^ (long)right);
                 return +1;
             }
         }
@@ -92,7 +92,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((byte)(((byte)left) ^ ((byte)right)));
+                frame.Push((byte)((byte)left ^ (byte)right));
                 return +1;
             }
         }
@@ -108,7 +108,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((ushort)(((ushort)left) ^ ((ushort)right)));
+                frame.Push((ushort)((ushort)left ^ (ushort)right));
                 return +1;
             }
         }
@@ -124,7 +124,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((uint)left) ^ ((uint)right));
+                frame.Push((uint)left ^ (uint)right);
                 return +1;
             }
         }
@@ -140,7 +140,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((ulong)left) ^ ((ulong)right));
+                frame.Push((ulong)left ^ (ulong)right);
                 return +1;
             }
         }
@@ -156,7 +156,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((bool)left) ^ ((bool)right));
+                frame.Push((bool)left ^ (bool)right);
                 return +1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LeftShiftInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LeftShiftInstruction.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((sbyte)(((sbyte)value) << ((int)shift)));
+                    frame.Push((sbyte)((sbyte)value << (int)shift));
                 }
                 return +1;
             }
@@ -47,7 +47,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((short)(((short)value) << ((int)shift)));
+                    frame.Push((short)((short)value << (int)shift));
                 }
                 return +1;
             }
@@ -65,7 +65,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((int)value) << ((int)shift));
+                    frame.Push((int)value << (int)shift);
                 }
                 return +1;
             }
@@ -83,7 +83,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((long)value) << ((int)shift));
+                    frame.Push((long)value << (int)shift);
                 }
                 return +1;
             }
@@ -101,7 +101,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((byte)(((byte)value) << ((int)shift)));
+                    frame.Push((byte)((byte)value << (int)shift));
                 }
                 return +1;
             }
@@ -119,7 +119,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((ushort)(((ushort)value) << ((int)shift)));
+                    frame.Push((ushort)((ushort)value << (int)shift));
                 }
                 return +1;
             }
@@ -137,7 +137,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((uint)value) << ((int)shift));
+                    frame.Push((uint)value << (int)shift);
                 }
                 return +1;
             }
@@ -155,7 +155,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((ulong)value) << ((int)shift));
+                    frame.Push((ulong)value << (int)shift);
                 }
                 return +1;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
@@ -28,7 +28,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((sbyte)(((sbyte)left) | ((sbyte)right)));
+                frame.Push((sbyte)((sbyte)left | (sbyte)right));
                 return +1;
             }
         }
@@ -44,7 +44,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((short)(((short)left) | ((short)right)));
+                frame.Push((short)((short)left | (short)right));
                 return +1;
             }
         }
@@ -60,7 +60,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((int)left) | ((int)right));
+                frame.Push((int)left | (int)right);
                 return +1;
             }
         }
@@ -76,7 +76,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((long)left) | ((long)right));
+                frame.Push((long)left | (long)right);
                 return +1;
             }
         }
@@ -92,7 +92,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((byte)(((byte)left) | ((byte)right)));
+                frame.Push((byte)((byte)left | (byte)right));
                 return +1;
             }
         }
@@ -108,7 +108,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push((ushort)(((ushort)left) | ((ushort)right)));
+                frame.Push((ushort)((ushort)left | (ushort)right));
                 return +1;
             }
         }
@@ -124,7 +124,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((uint)left) | ((uint)right));
+                frame.Push((uint)left | (uint)right);
                 return +1;
             }
         }
@@ -140,7 +140,7 @@ namespace System.Linq.Expressions.Interpreter
                     frame.Push(null);
                     return +1;
                 }
-                frame.Push(((ulong)left) | ((ulong)right));
+                frame.Push((ulong)left | (ulong)right);
                 return +1;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RightShiftInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RightShiftInstruction.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((sbyte)(((sbyte)value) >> ((int)shift)));
+                    frame.Push((sbyte)((sbyte)value >> (int)shift));
                 }
                 return +1;
             }
@@ -47,7 +47,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((short)(((short)value) >> ((int)shift)));
+                    frame.Push((short)((short)value >> (int)shift));
                 }
                 return +1;
             }
@@ -65,7 +65,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((int)value) >> ((int)shift));
+                    frame.Push((int)value >> (int)shift);
                 }
                 return +1;
             }
@@ -83,7 +83,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((long)value) >> ((int)shift));
+                    frame.Push((long)value >> (int)shift);
                 }
                 return +1;
             }
@@ -101,7 +101,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((byte)(((byte)value) >> ((int)shift)));
+                    frame.Push((byte)((byte)value >> (int)shift));
                 }
                 return +1;
             }
@@ -119,7 +119,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push((ushort)(((ushort)value) >> ((int)shift)));
+                    frame.Push((ushort)((ushort)value >> (int)shift));
                 }
                 return +1;
             }
@@ -137,7 +137,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((uint)value) >> ((int)shift));
+                    frame.Push((uint)value >> (int)shift);
                 }
                 return +1;
             }
@@ -155,7 +155,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    frame.Push(((ulong)value) >> ((int)shift));
+                    frame.Push((ulong)value >> (int)shift);
                 }
                 return +1;
             }


### PR DESCRIPTION
Increases readability. Casts take precedence over binary operators.