### PR TITLE
Use TypeCode for CastReferenceToEnumInstruction

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -450,55 +450,47 @@ namespace System.Linq.Expressions.Interpreter
             object from = frame.Pop();
             Debug.Assert(from != null);
             Type underlying = Enum.GetUnderlyingType(_t);
-            // Order checks in order of likelihood. int first as the vast majority of enums
-            // are int-based, then long as that is sometimes used when required for a large set of flags
-            // and so-on.
-            if (underlying == typeof(int))
+
+            // If from is neither a T nor a type assignable to T (viz. an T-backed enum)
+            // this will cause an InvalidCastException, which is what this operation should
+            // throw in this case.
+
+            switch (underlying.GetTypeCode())
             {
-                // If from is neither an int nor a type assignable to int (viz. an int-backed enum)
-                // this will cause an InvalidCastException, which is what this operation should
-                // throw in this case.
-                frame.Push(Enum.ToObject(_t, (int)from));
-            }
-            else if (underlying == typeof(long))
-            {
-                frame.Push(Enum.ToObject(_t, (long)from));
-            }
-            else if (underlying == typeof(uint))
-            {
-                frame.Push(Enum.ToObject(_t, (uint)from));
-            }
-            else if (underlying == typeof(ulong))
-            {
-                frame.Push(Enum.ToObject(_t, (ulong)from));
-            }
-            else if (underlying == typeof(byte))
-            {
-                frame.Push(Enum.ToObject(_t, (byte)from));
-            }
-            else if (underlying == typeof(sbyte))
-            {
-                frame.Push(Enum.ToObject(_t, (sbyte)from));
-            }
-            else if (underlying == typeof(short))
-            {
-                frame.Push(Enum.ToObject(_t, (short)from));
-            }
-            else if (underlying == typeof(ushort))
-            {
-                frame.Push(Enum.ToObject(_t, (ushort)from));
-            }
-            else if (underlying == typeof(char))
-            {
-                // Disallowed in C#, but allowed in CIL
-                frame.Push(Enum.ToObject(_t, (char)from));
-            }
-            else
-            {
-                // Only remaining possible type.
-                // Disallowed in C#, but allowed in CIL
-                Debug.Assert(underlying == typeof(bool));
-                frame.Push(Enum.ToObject(_t, (bool)from));
+                case TypeCode.Int32:
+                    frame.Push(Enum.ToObject(_t, (int)from));
+                    break;
+                case TypeCode.Int64:
+                    frame.Push(Enum.ToObject(_t, (long)from));
+                    break;
+                case TypeCode.UInt32:
+                    frame.Push(Enum.ToObject(_t, (uint)from));
+                    break;
+                case TypeCode.UInt64:
+                    frame.Push(Enum.ToObject(_t, (ulong)from));
+                    break;
+                case TypeCode.Byte:
+                    frame.Push(Enum.ToObject(_t, (byte)from));
+                    break;
+                case TypeCode.SByte:
+                    frame.Push(Enum.ToObject(_t, (sbyte)from));
+                    break;
+                case TypeCode.Int16:
+                    frame.Push(Enum.ToObject(_t, (short)from));
+                    break;
+                case TypeCode.UInt16:
+                    frame.Push(Enum.ToObject(_t, (ushort)from));
+                    break;
+                case TypeCode.Char:
+                    // Disallowed in C#, but allowed in CIL
+                    frame.Push(Enum.ToObject(_t, (char)from));
+                    break;
+                default:
+                    // Only remaining possible type.
+                    // Disallowed in C#, but allowed in CIL
+                    Debug.Assert(underlying == typeof(bool));
+                    frame.Push(Enum.ToObject(_t, (bool)from));
+                    break;
             }
 
             return 1;


### PR DESCRIPTION
Now that `GetTypeCode` is back, this code can use a `switch` over `TypeCode` rather than a series of `if` checks.