### PR TITLE
Fixing ToString of DefaultValueInstruction

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DefaultValueInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DefaultValueInstruction.cs
@@ -26,6 +26,6 @@ namespace System.Linq.Expressions.Interpreter
             return +1;
         }
 
-        public override string ToString() => "New " + _type;
+        public override string ToString() => "DefaultValue " + _type;
     }
 }

--- a/src/System.Linq.Expressions/tests/StackSpillerTests.cs
+++ b/src/System.Linq.Expressions/tests/StackSpillerTests.cs
@@ -1257,7 +1257,7 @@ namespace System.Linq.Expressions.Tests
                       .maxcontinuation 1
 
                       IP_0000: InitMutableValue(0)
-                      IP_0001: New System.Linq.Expressions.Tests.StackSpillerTests+ValueList
+                      IP_0001: DefaultValue System.Linq.Expressions.Tests.StackSpillerTests+ValueList
                       IP_0002: Dup()
                       .try
                       {
@@ -1364,7 +1364,7 @@ namespace System.Linq.Expressions.Tests
                       .maxcontinuation 1
 
                       IP_0000: InitMutableValue(0)
-                      IP_0001: New System.Linq.Expressions.Tests.StackSpillerTests+ValueBar
+                      IP_0001: DefaultValue System.Linq.Expressions.Tests.StackSpillerTests+ValueBar
                       IP_0002: Dup()
                       .try
                       {
@@ -1471,7 +1471,7 @@ namespace System.Linq.Expressions.Tests
                       .maxcontinuation 1
 
                       IP_0000: InitMutableValue(0)
-                      IP_0001: New System.Linq.Expressions.Tests.StackSpillerTests+ValueBar
+                      IP_0001: DefaultValue System.Linq.Expressions.Tests.StackSpillerTests+ValueBar
                       IP_0002: Dup()
                       .try
                       {
@@ -1653,7 +1653,7 @@ namespace System.Linq.Expressions.Tests
                       .maxcontinuation 1
 
                       IP_0000: InitMutableValue(0)
-                      IP_0001: New System.Linq.Expressions.Tests.StackSpillerTests+ValueBar
+                      IP_0001: DefaultValue System.Linq.Expressions.Tests.StackSpillerTests+ValueBar
                       IP_0002: Dup()
                       IP_0003: Call(System.Collections.Generic.List`1[System.Int32] get_Xs())
                       IP_0004: Dup()


### PR DESCRIPTION
The `ToString` output of this instruction is a bit counter-intuitive. Fixing it and updating tests accordingly. Note that the string representation of these instructions is not publicly accessible and is solely used for debugging and inspection purposes.