### PR TITLE
Fix X509Certificiate copy ctor finalization issue

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/SafeHandles.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/SafeHandles.cs
@@ -44,9 +44,38 @@ namespace Internal.Cryptography.Pal.Native
     /// </summary>
     internal class SafeCertContextHandle : SafePointerHandle<SafeCertContextHandle>
     {
+        private SafeCertContextHandle _parent;
+
+        public SafeCertContextHandle() { }
+
+        public SafeCertContextHandle(SafeCertContextHandle parent)
+        {
+            if (parent == null)
+                throw new ArgumentNullException(nameof(parent));
+
+            Debug.Assert(!parent.IsInvalid);
+            Debug.Assert(!parent.IsClosed);
+
+            bool ignored = false;
+            parent.DangerousAddRef(ref ignored);
+            _parent = parent;
+
+            SetHandle(_parent.handle);
+        }
+
         protected override bool ReleaseHandle()
         {
-            Interop.crypt32.CertFreeCertificateContext(handle);  // CertFreeCertificateContext always returns true so checking the return value is pointless.
+            if (_parent != null)
+            {
+                _parent.DangerousRelease();
+                _parent = null;
+            }
+            else
+            {
+                Interop.crypt32.CertFreeCertificateContext(handle);
+            }
+
+            SetHandle(IntPtr.Zero);
             return true;
         }
 
@@ -135,7 +164,7 @@ namespace Internal.Cryptography.Pal.Native
                     {
                         // dwProvType being 0 indicates that the key is stored in CNG.
                         // dwProvType being non-zero indicates that the key is stored in CAPI.
-                            
+
                         string providerName = Marshal.PtrToStringUni((IntPtr)(pProvInfo->pwszProvName));
                         string keyContainerName = Marshal.PtrToStringUni((IntPtr)(pProvInfo->pwszContainerName));
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
@@ -217,6 +217,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 c1.Dispose();
                 rsa.Dispose();
 
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+
                 // Verify other cert and previous key do not affect cert
                 using (rsa = c2.GetRSAPrivateKey())
                 {
@@ -236,10 +239,16 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             TestPrivateKey(c2, true);
 
             c1.Dispose();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
             TestPrivateKey(c1, false);
             TestPrivateKey(c2, true);
 
             c2.Dispose();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
             TestPrivateKey(c2, false);
         }
 
@@ -252,10 +261,16 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             TestPrivateKey(c2, true);
 
             c2.Dispose();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
             TestPrivateKey(c1, true);
             TestPrivateKey(c2, false);
 
             c1.Dispose();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
             TestPrivateKey(c1, false);
         }
 


### PR DESCRIPTION
Addresses https://github.com/dotnet/corefx/issues/13501

The test TestCopyConstructor_Lifetime_Cloned was able to fail consistently with added GC.Collect() and .WaitForPendingFinalizers.

The issue was premature finalization of the original context which was copied for the failing test.

The documentation on CertDuplicateCertificateContext states it just increments the ref count and expects a call later to CertFreeCertificateContext to decrement the ref count. However, it appears from testing that if the original context handle has CertFreeCertificateContext called on it then the other (copied) contexts are affected which causes the issue. Thus for the copy of the cert, avoid calling CertDuplicateCertificateContext as the original cert can then be collected\finalized causing the context to become invalidated (or at least prevents a private key from being extracted).

cc @bartonjs 