### PR TITLE
BitArray shift operators

### DIFF
--- a/src/System.Collections/ref/System.Collections.cs
+++ b/src/System.Collections/ref/System.Collections.cs
@@ -31,6 +31,10 @@ namespace System.Collections
         public void SetAll(bool value) { }
         public void CopyTo(System.Array array, int index) { }
         public System.Collections.BitArray Xor(System.Collections.BitArray value) { throw null; }
+#if netcoreapp11
+        public System.Collections.BitArray RightShift(int count) { throw null; }
+        public System.Collections.BitArray LeftShift(int count) { throw null; }
+#endif //netcoreapp11
     }
     public static partial class StructuralComparisons
     {

--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -342,24 +342,23 @@ namespace System.Collections
         }
 
         /*=========================================================================
-        ** Shift all the bit values to right on count bits. When count less zero it
-        ** shift all the bit values to left. New bits are be set to zero. The 
-        ** current instance is updated and returned.
+        ** Shift all the bit values to right on count bits. The current instance is
+        ** updated and returned.
+        * 
+        ** Exceptions: ArgumentOutOfRangeException if count < 0
         =========================================================================*/
         public BitArray RightShift(int count)
         {
             if (count <= 0)
             {
-                if (count == 0)
-                {
-                    _version++;
-                    return this;
-                }
-                count = -count;
-                // Check int.MinValue case
                 if (count < 0)
-                    count = int.MaxValue;
-                return LeftShift(count);
+                {
+                    throw new ArgumentOutOfRangeException(nameof(count), count, SR.ArgumentOutOfRange_NeedNonNegNum);
+                }
+                Contract.EndContractBlock();
+
+                _version++;
+                return this;
             }
 
             int toIndex = 0;
@@ -405,24 +404,23 @@ namespace System.Collections
         }
 
         /*=========================================================================
-        ** Shift all the bit values to left on count bits. When count less zero it
-        ** shift all the bit values to right. New bits are be set to zero. The 
-        ** current instance is updated and returned.
+        ** Shift all the bit values to left on count bits. The current instance is
+        ** updated and returned.
+        * 
+        ** Exceptions: ArgumentOutOfRangeException if count < 0
         =========================================================================*/
         public BitArray LeftShift(int count)
         {
             if (count <= 0)
             {
-                if (count == 0)
-                {
-                    _version++;
-                    return this;
-                }
-                count = -count;
-                // Check int.MinValue case
                 if (count < 0)
-                    count = int.MaxValue;
-                return RightShift(count);
+                {
+                    throw new ArgumentOutOfRangeException(nameof(count), count, SR.ArgumentOutOfRange_NeedNonNegNum);
+                }
+                Contract.EndContractBlock();
+
+                _version++;
+                return this;
             }
 
             int lengthToClear;

--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -366,7 +366,7 @@ namespace System.Collections
             if (count < m_length)
             {
                 int shiftCount;
-                // int fromIndex = Math.DivRem(count, BitsPerInt32, out shiftCount); // Compilation error
+                // We can not use Math.DivRem due compilation error
                 int fromIndex = count / BitsPerInt32;
                 shiftCount = count - fromIndex * BitsPerInt32; // Optimized Rem
 
@@ -429,7 +429,7 @@ namespace System.Collections
                 int lastIndex = (m_length - 1) / BitsPerInt32;
 
                 int shiftCount;
-                //lengthToClear = Math.DivRem(count, BitsPerInt32, out shiftCount); // Compilation error
+                // We can not use Math.DivRem due compilation error
                 lengthToClear = count / BitsPerInt32;
                 shiftCount = count - lengthToClear * BitsPerInt32; // Optimized Rem
 

--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -355,7 +355,6 @@ namespace System.Collections
                 {
                     throw new ArgumentOutOfRangeException(nameof(count), count, SR.ArgumentOutOfRange_NeedNonNegNum);
                 }
-                Contract.EndContractBlock();
 
                 _version++;
                 return this;
@@ -366,7 +365,7 @@ namespace System.Collections
             if (count < m_length)
             {
                 int shiftCount;
-                // We can not use Math.DivRem due compilation error
+                // We can not use Math.DivRem without taking a dependency on System.Runtime.Extensions
                 int fromIndex = count / BitsPerInt32;
                 shiftCount = count - fromIndex * BitsPerInt32; // Optimized Rem
 
@@ -417,7 +416,6 @@ namespace System.Collections
                 {
                     throw new ArgumentOutOfRangeException(nameof(count), count, SR.ArgumentOutOfRange_NeedNonNegNum);
                 }
-                Contract.EndContractBlock();
 
                 _version++;
                 return this;
@@ -429,7 +427,7 @@ namespace System.Collections
                 int lastIndex = (m_length - 1) / BitsPerInt32;
 
                 int shiftCount;
-                // We can not use Math.DivRem due compilation error
+                // We can not use Math.DivRem without taking a dependency on System.Runtime.Extensions
                 lengthToClear = count / BitsPerInt32;
                 shiftCount = count - lengthToClear * BitsPerInt32; // Optimized Rem
 

--- a/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Collections.Tests
 {
-    public static class BitArray_OperatorsTests
+    public static partial class BitArray_OperatorsTests
     {
         private const int BitsPerByte = 8;
         private const int BitsPerInt32 = 32;
@@ -189,3 +189,4 @@ namespace System.Collections.Tests
         }
     }
 }
+

--- a/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.netcoreapp1.1.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.netcoreapp1.1.cs
@@ -1,0 +1,130 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    public static partial class BitArray_OperatorsTests
+    {
+        #region Shift Tests
+
+        public static IEnumerable<object> Shift_Data()
+        {
+            foreach (int size in new[] { 0, 1, BitsPerInt32 / 2, BitsPerInt32, BitsPerInt32 + 1, 2 * BitsPerInt32, 2 * BitsPerInt32 + 1 })
+            {
+                foreach (int shift in new[] { 0, 1, size / 2, size - 1, size }.Where(s => s >= 0).Distinct())
+                {
+                    yield return new object[] { size, new int[] { /* deliberately empty */ }, shift };
+                    yield return new object[] { size, Enumerable.Range(0, size), shift };
+
+                    if (size > 1)
+                    {
+                        foreach (int position in new[] { 0, size / 2, size - 1 })
+                        {
+                            yield return new object[] { size, new[] { position }, shift };
+                        }
+                        yield return new object[] { size, new[] { 0, size / 2, size - 1 }, shift };
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Shift_Data))]
+        public static void RightShift(int length, IEnumerable<int> set, int shift)
+        {
+            BitArray ba = new BitArray(GetBoolArray(length, set));
+            bool[] expected = GetBoolArray(length, set.Select(i => i - shift).Where(i => i >= 0));
+
+            BitArray returned = ba.RightShift(shift);
+            Assert.Same(ba, returned);
+
+            int index = 0;
+            Assert.All(ba.Cast<bool>(), bit => Assert.Equal(expected[index++], bit));
+        }
+
+        [Theory]
+        [MemberData(nameof(Shift_Data))]
+        public static void LeftShift(int length, IEnumerable<int> set, int shift)
+        {
+            BitArray ba = new BitArray(GetBoolArray(length, set));
+            bool[] expected = GetBoolArray(length, set.Select(i => i + shift).Where(i => i < length));
+
+            BitArray returned = ba.LeftShift(shift);
+            Assert.Same(ba, returned);
+
+            int index = 0;
+            Assert.All(ba.Cast<bool>(), bit => Assert.Equal(expected[index++], bit));
+        }
+
+        private static bool[] GetBoolArray(int length, IEnumerable<int> set)
+        {
+            bool[] b = new bool[length];
+            foreach (int position in set)
+            {
+                b[position] = true;
+            }
+            return b;
+        }
+
+        [Fact]
+        public static void LeftShift_Iterator()
+        {
+            BitArray ba = new BitArray(BitsPerInt32 / 2);
+            IEnumerator enumerator = ba.GetEnumerator();
+            Assert.True(enumerator.MoveNext());
+            ba.LeftShift(1);
+            Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
+        }
+
+        [Fact]
+        public static void RightShift_Iterator()
+        {
+            BitArray ba = new BitArray(BitsPerInt32 / 2);
+            IEnumerator enumerator = ba.GetEnumerator();
+            Assert.True(enumerator.MoveNext());
+            ba.RightShift(1);
+            Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
+        }
+
+        public static IEnumerable<object> RightShift_Hidden_Data()
+        {
+            yield return new object[] { "Constructor", Unset_Visible_Bits(new BitArray(BitsPerInt32 / 2, true)) };
+            yield return new object[] { "Not", Unset_Visible_Bits(new BitArray(BitsPerInt32 / 2, false).Not()) };
+            BitArray setAll = new BitArray(BitsPerInt32 / 2, false);
+            setAll.SetAll(true);
+            yield return new object[] { "SetAll", Unset_Visible_Bits(setAll) };
+            BitArray lengthShort = new BitArray(BitsPerInt32, true);
+            lengthShort.Length = BitsPerInt32 / 2;
+            yield return new object[] { "Length-Short", Unset_Visible_Bits(lengthShort) };
+            BitArray lengthLong = new BitArray(2 * BitsPerInt32, true);
+            lengthLong.Length = BitsPerInt32;
+            yield return new object[] { "Length-Long", Unset_Visible_Bits(lengthLong) };
+            BitArray leftShift = new BitArray(BitsPerInt32 / 2);
+            for (int i = 0; i < leftShift.Length; i++) leftShift[i] = true;
+            yield return new object[] { "LeftShift", leftShift.LeftShift(BitsPerInt32 / 2) };
+        }
+
+        private static BitArray Unset_Visible_Bits(BitArray ba)
+        {
+            for (int i = 0; i < ba.Length; i++) ba[i] = false;
+            return ba;
+        }
+
+        [Theory]
+        [MemberData(nameof(RightShift_Hidden_Data))]
+        public static void RightShift_Hidden(string label, BitArray bits)
+        {
+            Assert.All(bits.Cast<bool>(), bit => Assert.False(bit));
+            bits.RightShift(1);
+            Assert.All(bits.Cast<bool>(), bit => Assert.False(bit));
+        }
+
+        #endregion
+    }
+}
+

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="BitArray\BitArray_CtorTests.cs" />
     <Compile Include="BitArray\BitArray_GetSetTests.cs" />
     <Compile Include="BitArray\BitArray_OperatorsTests.cs" />
+    <Compile Include="BitArray\BitArray_OperatorsTests.netcoreapp1.1.cs" Condition="'$(TargetGroup)'=='netcoreapp1.1'" />
     <Compile Include="Generic\Comparers\Comparer.Generic.Tests.cs" />
     <Compile Include="Generic\Comparers\Comparer.Tests.cs" />
     <Compile Include="Generic\Comparers\Comparers.Generic.cs" />


### PR DESCRIPTION
The BitArray class in System.Collections should include BitWise right and left shift operations. BitArray is used to represent a collection of on\off values and currently contains And, Or, Xor, and Not operations. Adding RightShift and LeftShift would increase the usefulness of the class and provide a canonical, fast solution to save developers the hassle of coming up with their own.
See https://github.com/dotnet/corefx/issues/8719

Unit tests for the above API get from https://github.com/Clockwork-Muse/corefx/commit/4fc128660ad8c61310bbd10d9d767afda8b22910