### PR TITLE
Add ConfigurationGroup and ArchGroup

### DIFF
--- a/src/Tools/CoreFx.Tools/Configuration/ConfigurationFactory.cs
+++ b/src/Tools/CoreFx.Tools/Configuration/ConfigurationFactory.cs
@@ -24,6 +24,8 @@ namespace Microsoft.DotNet.Build.Tasks
 
         private Dictionary<string, PropertyValue> AllPropertyValues { get; }
 
+        public Configuration IdentityConfiguration { get; }
+
         public ConfigurationFactory(ITaskItem[] properties, ITaskItem[] propertyValues)
         {
             Properties = properties.Select(p => new PropertyInfo(p))
@@ -59,6 +61,8 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 property.ConnectDefault(AllPropertyValues);
             }
+
+            IdentityConfiguration = new Configuration(PropertiesByOrder.Select(p => p.IdentityValue).ToArray());
         }
 
         public IEnumerable<PropertyInfo> GetProperties()
@@ -136,6 +140,15 @@ namespace Microsoft.DotNet.Build.Tasks
         public IEnumerable<Configuration> GetAllConfigurations()
         {
             return GetConfigurations(p => GetValues(p));
+        }
+
+        /// <summary>
+        /// Gets all significant combinations in order of precedence
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<Configuration> GetSignficantConfigurations()
+        {
+            return GetConfigurations(p => p.Insignificant ? new[] { p.IdentityValue } : GetValues(p));
         }
 
         /// <summary>

--- a/src/Tools/CoreFx.Tools/Configuration/PropertyInfo.cs
+++ b/src/Tools/CoreFx.Tools/Configuration/PropertyInfo.cs
@@ -20,19 +20,41 @@ namespace Microsoft.DotNet.Build.Tasks
     {
         private string defaultValue;
         public PropertyValue DefaultValue { get; private set; }
-        
+
+        public PropertyValue IdentityValue { get; }
+
         public string Name { get; }
 
         public int Order { get; }
 
         public int Precedence { get; }
 
+        public bool Insignificant { get; }
+
+        public bool Ignored { get; }
+
         public PropertyInfo(ITaskItem propertyItem)
         {
             Name = propertyItem.ItemSpec;
             defaultValue = propertyItem.GetMetadata(nameof(DefaultValue));
-            Precedence = ParseIntMetadata(propertyItem, nameof(Precedence));
-            Order = ParseIntMetadata(propertyItem, nameof(Order)); ;
+            Order = ParseIntMetadata(propertyItem, nameof(Order));
+
+            Precedence = int.MaxValue;
+            var precedence = propertyItem.GetMetadata(nameof(Precedence));
+            if (precedence.Equals(nameof(Ignored), StringComparison.OrdinalIgnoreCase))
+            {
+                Ignored = Insignificant = true;
+            }
+            else if (precedence.Equals(nameof(Insignificant), StringComparison.OrdinalIgnoreCase))
+            {
+                Insignificant = true;
+            }
+            else
+            {
+                Precedence = ParseIntMetadata(propertyItem, nameof(Precedence));
+            }
+
+            IdentityValue = new PropertyValue($"$({Name})", this);
         }
 
         private static int ParseIntMetadata(ITaskItem item, string name)

--- a/src/Tools/CoreFx.Tools/FindBestConfiguration.cs
+++ b/src/Tools/CoreFx.Tools/FindBestConfiguration.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Utilities;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
@@ -27,7 +28,9 @@ namespace Microsoft.DotNet.Build.Tasks
         {
             LoadConfiguration();
 
-            var supportedProjectConfigurations = new HashSet<Configuration>(BuildConfigurations.Where(c => !string.IsNullOrWhiteSpace(c)).Select(c => ConfigurationFactory.ParseConfiguration(c)));
+            var supportedProjectConfigurations = new HashSet<Configuration>(
+                BuildConfigurations.Where(c => !string.IsNullOrWhiteSpace(c)).Select(c => ConfigurationFactory.ParseConfiguration(c)),
+                Configuration.CompatibleComparer);
 
             var buildConfiguration = ConfigurationFactory.ParseConfiguration(BuildConfiguration);
 

--- a/src/Tools/GenerateProps/GenerateProps.proj
+++ b/src/Tools/GenerateProps/GenerateProps.proj
@@ -22,8 +22,8 @@
     
     <FindBestConfiguration Properties="@(Property)" 
                            PropertyValues="@(PropertyValue)" 
-                           ProjectConfigurations="$(ProjectConfigurations)"
-                           BuildConfiguration="netcoreapp1.1-Windows_NT">
+                           BuildConfigurations="$(ProjectConfigurations)"
+                           BuildConfiguration="netcoreapp1.1-Windows_NT-Debug-x64">
       <Output TaskParameter="BestConfiguration" ItemName="ProjectConfiguration" />
     </FindBestConfiguration>
   </Target>

--- a/src/Tools/GenerateProps/GenerateProps.proj
+++ b/src/Tools/GenerateProps/GenerateProps.proj
@@ -2,33 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
-  <Import Project="osgroups.props"/>
-  <Import Project="targetgroups.props"/>
-
-  <ItemGroup>
-    <Property Include="OSGroup">
-      <DefaultValue>AnyOS</DefaultValue>
-      <!-- OSGroup has higest precedence -->
-      <Precedence>1</Precedence>
-      <!-- OSGroup appears second in configuration string -->
-      <Order>2</Order>
-    </Property>
-    <Property Include="TargetGroup">
-      <!-- No default value -->
-      <DefaultValue></DefaultValue>
-      <!-- TargetGroup has lower precedence -->
-      <Precedence>2</Precedence>
-      <!-- TargetGroup appears first in configuration string -->
-      <Order>1</Order>
-    </Property>
-
-    <PropertyValue Include="@(OSGroups)">
-      <Property>OSGroup</Property>
-    </PropertyValue>
-    <PropertyValue Include="@(TargetGroups)">
-      <Property>TargetGroup</Property>
-    </PropertyValue>
-  </ItemGroup>
+  <Import Project="properties.props"/>
 
   <UsingTask TaskName="GenerateConfigurationProps" AssemblyFile="$(CoreFxToolsTaskDir)CoreFx.Tools.dll"/>
   <UsingTask TaskName="FindBestConfiguration" AssemblyFile="$(CoreFxToolsTaskDir)CoreFx.Tools.dll"/>

--- a/src/Tools/GenerateProps/archgroups.props
+++ b/src/Tools/GenerateProps/archgroups.props
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ArchGroups Include="AnyCPU" />
+    <ArchGroups Include="x86" />
+    <ArchGroups Include="x64" />
+    <ArchGroups Include="ARM" />
+    <ArchGroups Include="ARM64" />
+  </ItemGroup>
+</Project>

--- a/src/Tools/GenerateProps/configurationgroups.props
+++ b/src/Tools/GenerateProps/configurationgroups.props
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ConfigurationGroups Include="Debug" />
+    <ConfigurationGroups Include="Release" />
+  </ItemGroup>
+</Project>

--- a/src/Tools/GenerateProps/properties.props
+++ b/src/Tools/GenerateProps/properties.props
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="osgroups.props"/>
+  <Import Project="targetgroups.props"/>
+  
+  <ItemGroup>
+    <Property Include="OSGroup">
+      <DefaultValue>AnyOS</DefaultValue>
+      <!-- OSGroup has higest precedence -->
+      <Precedence>1</Precedence>
+      <!-- OSGroup appears second in configuration string -->
+      <Order>2</Order>
+    </Property>
+    <Property Include="TargetGroup">
+      <!-- No default value -->
+      <DefaultValue></DefaultValue>
+      <!-- TargetGroup has lower precedence -->
+      <Precedence>2</Precedence>
+      <!-- TargetGroup appears first in configuration string -->
+      <Order>1</Order>
+    </Property>
+
+    <PropertyValue Include="@(OSGroups)">
+      <Property>OSGroup</Property>
+    </PropertyValue>
+    <PropertyValue Include="@(TargetGroups)">
+      <Property>TargetGroup</Property>
+    </PropertyValue>
+  </ItemGroup>
+</Project>

--- a/src/Tools/GenerateProps/properties.props
+++ b/src/Tools/GenerateProps/properties.props
@@ -2,6 +2,8 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="osgroups.props"/>
   <Import Project="targetgroups.props"/>
+  <Import Project="configurationgroups.props"/>
+  <Import Project="archgroups.props"/>
   
   <ItemGroup>
     <Property Include="OSGroup">
@@ -19,12 +21,30 @@
       <!-- TargetGroup appears first in configuration string -->
       <Order>1</Order>
     </Property>
+    <Property Include="ConfigurationGroup">
+      <DefaultValue>Debug</DefaultValue>
+      <!-- Property is insignificant to compatibility decisions, but persisted in configuration strings -->
+      <Precedence>Insignificant</Precedence>
+      <Order>3</Order>
+    </Property>
+    <Property Include="ArchGroup">
+      <DefaultValue>AnyCPU</DefaultValue>
+      <!-- Property is insignificant to compatibility decisions, and ignored from configuration strings -->
+      <Precedence>Ignored</Precedence>
+      <Order>4</Order>
+    </Property>
 
     <PropertyValue Include="@(OSGroups)">
       <Property>OSGroup</Property>
     </PropertyValue>
     <PropertyValue Include="@(TargetGroups)">
       <Property>TargetGroup</Property>
+    </PropertyValue>
+    <PropertyValue Include="@(ConfigurationGroups)">
+      <Property>ConfigurationGroup</Property>
+    </PropertyValue>
+    <PropertyValue Include="@(ArchGroups)">
+      <Property>ArchGroup</Property>
     </PropertyValue>
   </ItemGroup>
 </Project>

--- a/src/Tools/Tools.sln
+++ b/src/Tools/Tools.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreFx.Tools", "CoreFx.Tool
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GenerateProps", "GenerateProps", "{976C66AC-9E5A-476C-A474-DD82322E4B64}"
 	ProjectSection(SolutionItems) = preProject
+		GenerateProps\archgroups.props = GenerateProps\archgroups.props
+		GenerateProps\configurationgroups.props = GenerateProps\configurationgroups.props
 		GenerateProps\GenerateProps.proj = GenerateProps\GenerateProps.proj
 		GenerateProps\osgroups.props = GenerateProps\osgroups.props
 		GenerateProps\properties.props = GenerateProps\properties.props

--- a/src/Tools/Tools.sln
+++ b/src/Tools/Tools.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GenerateProps", "GeneratePr
 	ProjectSection(SolutionItems) = preProject
 		GenerateProps\GenerateProps.proj = GenerateProps\GenerateProps.proj
 		GenerateProps\osgroups.props = GenerateProps\osgroups.props
+		GenerateProps\properties.props = GenerateProps\properties.props
 		GenerateProps\targetgroups.props = GenerateProps\targetgroups.props
 	EndProjectSection
 EndProject


### PR DESCRIPTION
Adds additional properties to configuration string.

ConfigurationGroup is treated as "insignificant"; meaning it is
preserved in the configuration string but not used when making
compatibility decisions.

ArchGroup is treated as "ignored"; meaning it is not preserved
in the configuration string nor when making compatibility
decisions.

/cc @weshaggard @chcosta 