### PR TITLE
Enable a thread pool test

### DIFF
--- a/src/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -108,8 +108,7 @@ namespace System.Threading.ThreadPools.Tests
             }
         }
 
-        // TODO: Enable this test after CoreCLR packages including the fix for this issue are updated
-        //[Fact]
+        [Fact]
         // Desktop framework doesn't check for this and instead, hits an assertion failure
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void SetMinMaxThreadsTest_ChangedInDotNetCore()


### PR DESCRIPTION
Fixes dotnet/coreclr#8236
- Enabled a failing test that was temporarily disabled by PR #13895
- The issue was fixed by PR dotnet/coreclr#8256