### PR TITLE
Using ExceptionDispatchInfo to preserve stack traces in interpreter

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -247,7 +247,7 @@ namespace System.Linq.Expressions.Interpreter
             }
             catch (TargetInvocationException e)
             {
-                throw ExceptionHelpers.UpdateForRethrow(e.InnerException);
+                ExceptionHelpers.UnwrapAndRethrow(e);
             }
         }
 #endif
@@ -329,7 +329,8 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 catch (TargetInvocationException e)
                 {
-                    throw ExceptionHelpers.UnwrapAndRethrow(e);
+                    ExceptionHelpers.UnwrapAndRethrow(e);
+                    throw ContractUtils.Unreachable;
                 }
             }
             else
@@ -353,7 +354,8 @@ namespace System.Linq.Expressions.Interpreter
                     }
                     catch (TargetInvocationException e)
                     {
-                        throw ExceptionHelpers.UnwrapAndRethrow(e);
+                        ExceptionHelpers.UnwrapAndRethrow(e);
+                        throw ContractUtils.Unreachable;
                     }
                 }
             }
@@ -425,7 +427,8 @@ namespace System.Linq.Expressions.Interpreter
                     }
                     catch (TargetInvocationException e)
                     {
-                        throw ExceptionHelpers.UnwrapAndRethrow(e);
+                        ExceptionHelpers.UnwrapAndRethrow(e);
+                        throw ContractUtils.Unreachable;
                     }
                 }
                 else
@@ -449,7 +452,8 @@ namespace System.Linq.Expressions.Interpreter
                         }
                         catch (TargetInvocationException e)
                         {
-                            throw ExceptionHelpers.UnwrapAndRethrow(e);
+                            ExceptionHelpers.UnwrapAndRethrow(e);
+                            throw ContractUtils.Unreachable;
                         }
                     }
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -329,7 +329,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 catch (TargetInvocationException e)
                 {
-                    throw ExceptionHelpers.UpdateForRethrow(e.InnerException);
+                    throw ExceptionHelpers.UnwrapAndRethrow(e);
                 }
             }
             else
@@ -353,7 +353,7 @@ namespace System.Linq.Expressions.Interpreter
                     }
                     catch (TargetInvocationException e)
                     {
-                        throw ExceptionHelpers.UpdateForRethrow(e.InnerException);
+                        throw ExceptionHelpers.UnwrapAndRethrow(e);
                     }
                 }
             }
@@ -425,7 +425,7 @@ namespace System.Linq.Expressions.Interpreter
                     }
                     catch (TargetInvocationException e)
                     {
-                        throw ExceptionHelpers.UpdateForRethrow(e.InnerException);
+                        throw ExceptionHelpers.UnwrapAndRethrow(e);
                     }
                 }
                 else
@@ -449,7 +449,7 @@ namespace System.Linq.Expressions.Interpreter
                         }
                         catch (TargetInvocationException e)
                         {
-                            throw ExceptionHelpers.UpdateForRethrow(e.InnerException);
+                            throw ExceptionHelpers.UnwrapAndRethrow(e);
                         }
                     }
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -248,6 +248,7 @@ namespace System.Linq.Expressions.Interpreter
             catch (TargetInvocationException e)
             {
                 ExceptionHelpers.UnwrapAndRethrow(e);
+                throw ContractUtils.Unreachable;
             }
         }
 #endif

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -3197,8 +3197,7 @@ namespace System.Linq.Expressions.Interpreter
             }
             catch (TargetInvocationException e)
             {
-                ExceptionHelpers.UpdateForRethrow(e.InnerException);
-                throw e.InnerException;
+                throw ExceptionHelpers.UnwrapAndRethrow(e);
             }
         }
 
@@ -3242,8 +3241,7 @@ namespace System.Linq.Expressions.Interpreter
             }
             catch (TargetInvocationException e)
             {
-                ExceptionHelpers.UpdateForRethrow(e.InnerException);
-                throw e.InnerException;
+                throw ExceptionHelpers.UnwrapAndRethrow(e);
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -3197,7 +3197,8 @@ namespace System.Linq.Expressions.Interpreter
             }
             catch (TargetInvocationException e)
             {
-                throw ExceptionHelpers.UnwrapAndRethrow(e);
+                ExceptionHelpers.UnwrapAndRethrow(e);
+                throw ContractUtils.Unreachable;
             }
         }
 
@@ -3241,7 +3242,8 @@ namespace System.Linq.Expressions.Interpreter
             }
             catch (TargetInvocationException e)
             {
-                throw ExceptionHelpers.UnwrapAndRethrow(e);
+                ExceptionHelpers.UnwrapAndRethrow(e);
+                throw ContractUtils.Unreachable;
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
@@ -388,8 +388,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 catch (TargetInvocationException e)
                 {
-                    ExceptionHelpers.UpdateForRethrow(e.InnerException);
-                    throw e.InnerException;
+                    throw ExceptionHelpers.UnwrapAndRethrow(e);
                 }
 
                 return 1;
@@ -423,8 +422,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 catch (TargetInvocationException e)
                 {
-                    ExceptionHelpers.UpdateForRethrow(e.InnerException);
-                    throw e.InnerException;
+                    throw ExceptionHelpers.UnwrapAndRethrow(e);
                 }
 
                 frame.Data[_index] = new StrongBox<object>(value);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Dynamic.Utils;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -388,7 +389,8 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 catch (TargetInvocationException e)
                 {
-                    throw ExceptionHelpers.UnwrapAndRethrow(e);
+                    ExceptionHelpers.UnwrapAndRethrow(e);
+                    throw ContractUtils.Unreachable;
                 }
 
                 return 1;
@@ -422,7 +424,8 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 catch (TargetInvocationException e)
                 {
-                    throw ExceptionHelpers.UnwrapAndRethrow(e);
+                    ExceptionHelpers.UnwrapAndRethrow(e);
+                    throw ContractUtils.Unreachable;
                 }
 
                 frame.Data[_index] = new StrongBox<object>(value);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NewInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NewInstruction.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Dynamic.Utils;
 using System.Reflection;
 
 namespace System.Linq.Expressions.Interpreter
@@ -35,7 +36,8 @@ namespace System.Linq.Expressions.Interpreter
             }
             catch (TargetInvocationException e)
             {
-                throw ExceptionHelpers.UnwrapAndRethrow(e);
+                ExceptionHelpers.UnwrapAndRethrow(e);
+                throw ContractUtils.Unreachable;
             }
 
             frame.Data[first] = ret;
@@ -94,7 +96,8 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 catch (TargetInvocationException e)
                 {
-                    throw ExceptionHelpers.UnwrapAndRethrow(e);
+                    ExceptionHelpers.UnwrapAndRethrow(e);
+                    throw ContractUtils.Unreachable;
                 }
 
                 frame.Data[first] = ret;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NewInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NewInstruction.cs
@@ -35,8 +35,7 @@ namespace System.Linq.Expressions.Interpreter
             }
             catch (TargetInvocationException e)
             {
-                ExceptionHelpers.UpdateForRethrow(e.InnerException);
-                throw e.InnerException;
+                throw ExceptionHelpers.UnwrapAndRethrow(e);
             }
 
             frame.Data[first] = ret;
@@ -95,7 +94,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 catch (TargetInvocationException e)
                 {
-                    throw ExceptionHelpers.UpdateForRethrow(e.InnerException);
+                    throw ExceptionHelpers.UnwrapAndRethrow(e);
                 }
 
                 frame.Data[first] = ret;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -169,10 +169,9 @@ namespace System.Linq.Expressions.Interpreter
         /// Updates an exception before it's getting re-thrown so
         /// we can present a reasonable stack trace to the user.
         /// </summary>
-        public static Exception UnwrapAndRethrow(TargetInvocationException exception)
+        public static void UnwrapAndRethrow(TargetInvocationException exception)
         {
             ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
-            return ContractUtils.Unreachable;
         }
     }
 

--- a/src/System.Linq.Expressions/tests/CompilerTests.cs
+++ b/src/System.Linq.Expressions/tests/CompilerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Xunit;
 
@@ -9,6 +10,21 @@ namespace System.Linq.Expressions.Tests
 {
     public static class CompilerTests
     {
+        [Fact]
+        public static void Test()
+        {
+            var e = (Expression<Func<List<int>, int>>)(xs => xs[-1]);
+            var f = e.Compile(true);
+            try
+            {
+                f(new List<int>());
+            }
+            catch (Exception ex)
+            {
+                Assert.NotNull(ex);
+            }
+        }
+
         [Theory]
         [ClassData(typeof(CompilationTypes))]
         [OuterLoop("Takes over a minute to complete")]

--- a/src/System.Linq.Expressions/tests/CompilerTests.cs
+++ b/src/System.Linq.Expressions/tests/CompilerTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Xunit;
 
@@ -10,21 +9,6 @@ namespace System.Linq.Expressions.Tests
 {
     public static class CompilerTests
     {
-        [Fact]
-        public static void Test()
-        {
-            var e = (Expression<Func<List<int>, int>>)(xs => xs[-1]);
-            var f = e.Compile(true);
-            try
-            {
-                f(new List<int>());
-            }
-            catch (Exception ex)
-            {
-                Assert.NotNull(ex);
-            }
-        }
-
         [Theory]
         [ClassData(typeof(CompilationTypes))]
         [OuterLoop("Takes over a minute to complete")]

--- a/src/System.Linq.Expressions/tests/InterpreterTests.cs
+++ b/src/System.Linq.Expressions/tests/InterpreterTests.cs
@@ -99,6 +99,57 @@ namespace System.Linq.Expressions.Tests
                   }");
         }
 
+        [Fact]
+        public static void ConstructorThrows_StackTrace()
+        {
+            Expression<Func<Thrower>> e = () => new Thrower(true);
+            Func<Thrower> f = e.Compile(preferInterpretation: true);
+            AssertStackTrace(() => f(), "Thrower..ctor");
+        }
+
+        [Fact]
+        public static void PropertyGetterThrows_StackTrace()
+        {
+            Expression<Func<Thrower, int>> e = t => t.Bar;
+            Func<Thrower, int> f = e.Compile(preferInterpretation: true);
+            AssertStackTrace(() => f(new Thrower(error: false)), "Thrower.get_Bar");
+        }
+
+        [Fact]
+        public static void PropertySetterThrows_StackTrace()
+        {
+            ParameterExpression t = Expression.Parameter(typeof(Thrower), "t");
+            Expression<Action<Thrower>> e = Expression.Lambda<Action<Thrower>>(Expression.Assign(Expression.Property(t, nameof(Thrower.Bar)), Expression.Constant(0)), t);
+            Action<Thrower> f = e.Compile(preferInterpretation: true);
+            AssertStackTrace(() => f(new Thrower(error: false)), "Thrower.set_Bar");
+        }
+
+        [Fact]
+        public static void IndexerGetterThrows_StackTrace()
+        {
+            ParameterExpression t = Expression.Parameter(typeof(Thrower), "t");
+            Expression<Func<Thrower, int>> e = Expression.Lambda<Func<Thrower, int>>(Expression.MakeIndex(t, typeof(Thrower).GetProperty("Item"), new[] { Expression.Constant(0) }), t);
+            Func<Thrower, int> f = e.Compile(preferInterpretation: true);
+            AssertStackTrace(() => f(new Thrower(error: false)), "Thrower.get_Item");
+        }
+
+        [Fact]
+        public static void IndexerSetterThrows_StackTrace()
+        {
+            ParameterExpression t = Expression.Parameter(typeof(Thrower), "t");
+            Expression<Action<Thrower>> e = Expression.Lambda<Action<Thrower>>(Expression.Assign(Expression.MakeIndex(t, typeof(Thrower).GetProperty("Item"), new[] { Expression.Constant(0) }), Expression.Constant(0)), t);
+            Action<Thrower> f = e.Compile(preferInterpretation: true);
+            AssertStackTrace(() => f(new Thrower(error: false)), "Thrower.set_Item");
+        }
+
+        [Fact]
+        public static void MethodThrows_StackTrace()
+        {
+            Expression<Action<Thrower>> e = t => t.Foo();
+            Action<Thrower> f = e.Compile(preferInterpretation: true);
+            AssertStackTrace(() => f(new Thrower(error: false)), "Thrower.Foo");
+        }
+
         public static void VerifyInstructions(this LambdaExpression expression, string expected)
         {
             string actual = expression.GetInstructions();
@@ -128,6 +179,53 @@ namespace System.Linq.Expressions.Tests
             var lambda = (LightLambda)thunk.Target;
             var debugView = (string)s_debugView.GetValue(lambda);
             return debugView;
+        }
+
+        private static void AssertStackTrace(Action a, string searchTerm)
+        {
+            bool hasThrown = false;
+            try
+            {
+                a();
+            }
+            catch (Exception ex)
+            {
+                AssertStackTrace(ex, searchTerm);
+                hasThrown = true;
+            }
+
+            Assert.True(hasThrown);
+        }
+
+        private static void AssertStackTrace(Exception ex, string searchTerm)
+        {
+            Assert.True(ex.StackTrace.Contains(searchTerm));
+        }
+
+        private sealed class Thrower
+        {
+            public Thrower(bool error)
+            {
+                if (error)
+                    throw new Exception();
+            }
+
+            public int this[int x]
+            {
+                get { throw new Exception(); }
+                set { throw new Exception(); }
+            }
+
+            public int Bar
+            {
+                get { throw new Exception(); }
+                set { throw new Exception(); }
+            }
+
+            public void Foo()
+            {
+                throw new Exception();
+            }
         }
     }
 }


### PR DESCRIPTION
This should result in better stack traces when using the interpreter.

Also removing `FEATURE_STACK_TRACES` code that's no longer used.