### PR TITLE
Caching boxes for default values of primitive types

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -114,40 +114,40 @@ namespace System.Linq.Expressions.Interpreter
                     result = Utils.BoxedFalse;
                     break;
                 case TypeCode.SByte:
-                    result = default(sbyte);
+                    result = Utils.BoxedDefaultSByte;
                     break;
                 case TypeCode.Byte:
-                    result = default(byte);
+                    result = Utils.BoxedDefaultByte;
                     break;
                 case TypeCode.Char:
-                    result = default(char);
+                    result = Utils.BoxedDefaultChar;
                     break;
                 case TypeCode.Int16:
-                    result = default(short);
+                    result = Utils.BoxedDefaultInt16;
                     break;
                 case TypeCode.Int32:
                     result = Utils.BoxedInt0;
                     break;
                 case TypeCode.Int64:
-                    result = default(long);
+                    result = Utils.BoxedDefaultInt64;
                     break;
                 case TypeCode.UInt16:
-                    result = default(ushort);
+                    result = Utils.BoxedDefaultUInt16;
                     break;
                 case TypeCode.UInt32:
-                    result = default(uint);
+                    result = Utils.BoxedDefaultUInt32;
                     break;
                 case TypeCode.UInt64:
-                    result = default(ulong);
+                    result = Utils.BoxedDefaultUInt64;
                     break;
                 case TypeCode.Single:
-                    return default(float);
+                    return Utils.BoxedDefaultSingle;
                 case TypeCode.Double:
-                    return default(double);
+                    return Utils.BoxedDefaultDouble;
                 case TypeCode.DateTime:
-                    return default(DateTime);
+                    return Utils.BoxedDefaultDateTime;
                 case TypeCode.Decimal:
-                    return default(decimal);
+                    return Utils.BoxedDefaultDecimal;
                 default:
                     // Also covers DBNull which is a class.
                     return null;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Utils.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Utils.cs
@@ -8,11 +8,25 @@ namespace System.Linq.Expressions
     {
         public static readonly object BoxedFalse = false;
         public static readonly object BoxedTrue = true;
+
         public static readonly object BoxedIntM1 = -1;
         public static readonly object BoxedInt0 = 0;
         public static readonly object BoxedInt1 = 1;
         public static readonly object BoxedInt2 = 2;
         public static readonly object BoxedInt3 = 3;
+
+        public static readonly object BoxedDefaultSByte = default(sbyte);
+        public static readonly object BoxedDefaultChar = default(char);
+        public static readonly object BoxedDefaultInt16 = default(short);
+        public static readonly object BoxedDefaultInt64 = default(long);
+        public static readonly object BoxedDefaultByte = default(byte);
+        public static readonly object BoxedDefaultUInt16 = default(ushort);
+        public static readonly object BoxedDefaultUInt32 = default(uint);
+        public static readonly object BoxedDefaultUInt64 = default(ulong);
+        public static readonly object BoxedDefaultSingle = default(float);
+        public static readonly object BoxedDefaultDouble = default(double);
+        public static readonly object BoxedDefaultDecimal = default(decimal);
+        public static readonly object BoxedDefaultDateTime = default(DateTime);
 
         private static readonly ConstantExpression s_true = Expression.Constant(BoxedTrue);
         private static readonly ConstantExpression s_false = Expression.Constant(BoxedFalse);


### PR DESCRIPTION
Keeping a cached boxed value for the value types listed in the `TypeCode` enum. These are used by the interpreter to initialize locals in generated code. We only had caching for `Int32` and `Boolean` but it makes sense to have these around for other types as well.