### PR TITLE
Update reporting parameters for package publish steps

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -1112,8 +1112,9 @@
             "GitHubRepositoryName": "corefx"
           },
           "ReportingParameters": {
-            "TargetQueue": null,
-            "Type": "build/tests/"
+            "TaskName": "Package Publish",
+            "Type": "build/publish/",
+            "ConfigurationGroup": "Release - Push to MyGet Feed"
           }
         }
       ],
@@ -1137,8 +1138,9 @@
             "GitHubRepositoryName": "corefx"
           },
           "ReportingParameters": {
-            "TargetQueue": null,
-            "Type": "build/tests/"
+            "TaskName": "Package Publish",
+            "Type": "build/publish/",
+            "ConfigurationGroup": "Debug - Push to Azure Storage"
           }
         }
       ],


### PR DESCRIPTION
Usage of TargetQueue and ConfigurationGroup seems a bit hacky but I checked with @maririos  and this should produce the right telemetry;  at a minimum the path is right.

@chcosta 