### PR TITLE
Expose additional netstandard APIs in Sockets.

### DIFF
--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -272,6 +272,8 @@ namespace System.Net.Sockets
         public bool DisconnectAsync(SocketAsyncEventArgs e) { throw null; }
         public SocketInformation DuplicateAndClose(int targetProcessId) { throw null; }
         public Socket EndAccept(IAsyncResult asyncResult) { throw null; }
+        public Socket EndAccept(out byte[] buffer, IAsyncResult asyncResult) { throw null; }
+        public Socket EndAccept(out byte[] buffer, out int bytesTransferred, IAsyncResult asyncResult) { throw null; }
         public void EndConnect(IAsyncResult asyncResult) { }
         public void EndDisconnect(IAsyncResult asyncResult) { }
         public int EndReceive(IAsyncResult asyncResult) { throw null; }
@@ -343,6 +345,7 @@ namespace System.Net.Sockets
         public System.Net.Sockets.IPPacketInformation ReceiveMessageFromPacketInfo { get { throw null; } }
         public System.Net.EndPoint RemoteEndPoint { get { throw null; } set { } }
         public System.Net.Sockets.SendPacketsElement[] SendPacketsElements { get { throw null; } set { } }
+        public System.Net.Sockets.TransmitFileOptions SendPacketsFlags { get { throw null; } set { } }
         public int SendPacketsSendSize { get { throw null; } set { } }
         public System.Net.Sockets.SocketError SocketError { get { throw null; } set { } }
         public System.Net.Sockets.SocketFlags SocketFlags { get { throw null; } set { } }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
@@ -324,5 +324,5 @@ namespace System.Net.Sockets
                 int elementCount,
                 int sendSize,
                 SafeNativeOverlapped overlapped,
-                int flags);
+                TransmitFileOptions flags);
 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -117,13 +117,12 @@ namespace System.Net.Sockets
             return recvMsg_Blocking(socketHandle, msg, out bytesTransferred, overlapped, completionRoutine);
         }
 
-        internal bool TransmitPackets(SafeCloseSocket socketHandle, IntPtr packetArray, int elementCount, int sendSize, SafeNativeOverlapped overlapped)
+        internal bool TransmitPackets(SafeCloseSocket socketHandle, IntPtr packetArray, int elementCount, int sendSize, SafeNativeOverlapped overlapped, TransmitFileOptions flags)
         {
             EnsureDynamicWinsockMethods();
             TransmitPacketsDelegate transmitPackets = _dynamicWinsockMethods.GetDelegate<TransmitPacketsDelegate>(socketHandle);
 
-            // UseDefaultWorkerThread = 0.
-            return transmitPackets(socketHandle, packetArray, elementCount, sendSize, overlapped, 0);
+            return transmitPackets(socketHandle, packetArray, elementCount, sendSize, overlapped, flags);
         }
 
         internal static IntPtr[] SocketListToFileDescriptorSet(IList socketList)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3915,7 +3915,7 @@ namespace System.Net.Sockets
             return EndAccept(out buffer, out bytesTransferred, asyncResult);
         }
 
-        internal Socket EndAccept(out byte[] buffer, IAsyncResult asyncResult)
+        public Socket EndAccept(out byte[] buffer, IAsyncResult asyncResult)
         {
             int bytesTransferred;
             byte[] innerBuffer;
@@ -3926,7 +3926,7 @@ namespace System.Net.Sockets
             return socket;
         }
 
-        internal Socket EndAccept(out byte[] buffer, out int bytesTransferred, IAsyncResult asyncResult)
+        public Socket EndAccept(out byte[] buffer, out int bytesTransferred, IAsyncResult asyncResult)
         {
             if (NetEventSource.IsEnabled) NetEventSource.Enter(this, asyncResult);
             if (CleanedUp)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -637,7 +637,8 @@ namespace System.Net.Sockets
                 _ptrSendPacketsDescriptor,
                 _sendPacketsDescriptor.Length,
                 _sendPacketsSendSize,
-                _ptrNativeOverlapped);
+                _ptrNativeOverlapped,
+                _sendPacketsFlags);
 
             return result ? SocketError.Success : SocketPal.GetLastSocketError();
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -54,6 +54,9 @@ namespace System.Net.Sockets
         // SendPacketsElements property variables.
         internal SendPacketsElement[] _sendPacketsElements;
 
+        // SendPacketsFlags property variable.
+        internal TransmitFileOptions _sendPacketsFlags;
+
         // SocketError property variables.
         private SocketError _socketError;
         private Exception _connectByNameError;
@@ -115,6 +118,13 @@ namespace System.Net.Sockets
         public int Count
         {
             get { return _count; }
+        }
+
+        // SendPacketsFlags property.
+        public TransmitFileOptions SendPacketsFlags
+        {
+            get { return _sendPacketsFlags; }
+            set { _sendPacketsFlags = value; }
         }
 
         // NOTE: this property is mutually exclusive with Buffer.

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
@@ -10,6 +10,14 @@ namespace System.Net.Sockets.Tests
     public class SocketAsyncEventArgsTest
     {
         [Fact]
+        public void TestDefaultConstructor()
+        {
+            SocketAsyncEventArgs args = new SocketAsyncEventArgs();
+            Assert.Equal(0, args.SendPacketsSendSize);
+            Assert.Equal((TransmitFileOptions)0, args.SendPacketsFlags);
+        }
+
+        [Fact]
         public async Task ReuseSocketAsyncEventArgs_SameInstance_MultipleSockets()
         {
             using (var listen = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -112,7 +112,7 @@
       <Project>{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}</Project>
       <Name>System.Net.Sockets</Name>
     </ProjectReference>
-	<ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
       <Name>RemoteExecutorConsoleApp</Name>
     </ProjectReference>


### PR DESCRIPTION
cc @karelz @danmosemsft @CIPop @stephentoub 

Added tests for SendPacketsFlags. EndAccept methods are already tested through previously exposed EndAccept.

fixes #14182 