### PR TITLE
Reduces branching in VisitAndConvert and similar.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/ExpressionVisitorUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/ExpressionVisitorUtils.cs
@@ -10,77 +10,87 @@ namespace System.Dynamic.Utils
     {
         public static Expression[] VisitBlockExpressions(ExpressionVisitor visitor, BlockExpression block)
         {
-            Expression[] newNodes = null;
             for (int i = 0, n = block.ExpressionCount; i < n; i++)
             {
                 Expression curNode = block.GetExpression(i);
                 Expression node = visitor.Visit(curNode);
 
-                if (newNodes != null)
+                if (node != curNode)
                 {
-                    newNodes[i] = node;
-                }
-                else if (!object.ReferenceEquals(node, curNode))
-                {
-                    newNodes = new Expression[n];
+                    Expression[] newNodes = new Expression[n];
                     for (int j = 0; j < i; j++)
                     {
                         newNodes[j] = block.GetExpression(j);
                     }
+
                     newNodes[i] = node;
+                    while (++i < n)
+                    {
+                        newNodes[i] = visitor.Visit(block.GetExpression(i));
+                    }
+
+                    return newNodes;
                 }
             }
-            return newNodes;
+
+            return null;
         }
 
         public static ParameterExpression[] VisitParameters(ExpressionVisitor visitor, IParameterProvider nodes, string callerName)
         {
-            ParameterExpression[] newNodes = null;
             for (int i = 0, n = nodes.ParameterCount; i < n; i++)
             {
                 ParameterExpression curNode = nodes.GetParameter(i);
                 ParameterExpression node = visitor.VisitAndConvert(curNode, callerName);
 
-                if (newNodes != null)
+                if (node != curNode)
                 {
-                    newNodes[i] = node;
-                }
-                else if (!object.ReferenceEquals(node, curNode))
-                {
-                    newNodes = new ParameterExpression[n];
+                    ParameterExpression[] newNodes = new ParameterExpression[n];
                     for (int j = 0; j < i; j++)
                     {
                         newNodes[j] = nodes.GetParameter(j);
                     }
+
                     newNodes[i] = node;
+                    while (++i < n)
+                    {
+                        newNodes[i] = visitor.VisitAndConvert(nodes.GetParameter(i), callerName);
+                    }
+
+                    return newNodes;
                 }
             }
-            return newNodes;
+
+            return null;
         }
 
         public static Expression[] VisitArguments(ExpressionVisitor visitor, IArgumentProvider nodes)
         {
-            Expression[] newNodes = null;
             for (int i = 0, n = nodes.ArgumentCount; i < n; i++)
             {
                 Expression curNode = nodes.GetArgument(i);
                 Expression node = visitor.Visit(curNode);
 
-                if (newNodes != null)
+                if (node != curNode)
                 {
-                    newNodes[i] = node;
-                }
-                else if (!object.ReferenceEquals(node, curNode))
-                {
-                    newNodes = new Expression[n];
+                    Expression[] newNodes = new Expression[n];
                     for (int j = 0; j < i; j++)
                     {
                         newNodes[j] = nodes.GetArgument(j);
                     }
+
                     newNodes[i] = node;
+                    while (++i < n)
+                    {
+                        newNodes[i] = visitor.Visit(nodes.GetArgument(i));
+                    }
+
+                    return newNodes;
                 }
+
             }
-            return newNodes;
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Each of these methods continuously tests for the existence of an array to see whether it should add to it. Failing that it tests to see whether it should create it.

Instead just test as to whether it should create it, and then finish the loop expecting it to exist.