### PR TITLE
Allowing RegexOptions.Compiled along with RegexOptions.ECMAScript in Regex constructor

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -175,6 +175,9 @@ namespace System.Text.RegularExpressions
              && (options & ~(RegexOptions.ECMAScript |
                              RegexOptions.IgnoreCase |
                              RegexOptions.Multiline |
+#if !SILVERLIGHT || FEATURE_LEGACYNETCF
+                             RegexOptions.Compiled |
+#endif
                              RegexOptions.CultureInvariant
 #if DEBUG
                            | RegexOptions.Debug

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -175,9 +175,7 @@ namespace System.Text.RegularExpressions
              && (options & ~(RegexOptions.ECMAScript |
                              RegexOptions.IgnoreCase |
                              RegexOptions.Multiline |
-#if !SILVERLIGHT || FEATURE_LEGACYNETCF
                              RegexOptions.Compiled |
-#endif
                              RegexOptions.CultureInvariant
 #if DEBUG
                            | RegexOptions.Debug

--- a/src/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
@@ -14,7 +14,9 @@ namespace System.Text.RegularExpressions.Tests
         {
             yield return new object[] { "foo", RegexOptions.None, Timeout.InfiniteTimeSpan };
             yield return new object[] { "foo", RegexOptions.RightToLeft, Timeout.InfiniteTimeSpan };
+            yield return new object[] { "foo", RegexOptions.Compiled, Timeout.InfiniteTimeSpan };
             yield return new object[] { "foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant, Timeout.InfiniteTimeSpan };
+            yield return new object[] { "foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Compiled, Timeout.InfiniteTimeSpan };
             yield return new object[] { "foo", RegexOptions.None, new TimeSpan(1) };
             yield return new object[] { "foo", RegexOptions.None, TimeSpan.FromMilliseconds(int.MaxValue - 1) };
         }


### PR DESCRIPTION
Fixes #11270.

RegexOptions.Compiled is now allowed along with RegexOptions.ECMAScript in Regex constructor. Replicated behavior from http://referencesource.microsoft.com/#System/regex/system/text/regularexpressions/Regex.cs,204

cc @Priya91