### PR TITLE
Fix DateTimeFormatInfo test

### DIFF
--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetInstance.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetInstance.cs
@@ -39,11 +39,43 @@ namespace System.Globalization.Tests
             Assert.NotNull(DateTimeFormatInfo.GetInstance(provider));
         }
 
+        private void AssertSameValues(DateTimeFormatInfo expected, DateTimeFormatInfo value)
+        {
+            if (value.Equals(expected))
+            {
+                // same instance, we don't have to test the values 
+                return;
+            }
+
+            Assert.Equal(expected.AbbreviatedDayNames, value.AbbreviatedDayNames);
+            Assert.Equal(expected.AbbreviatedMonthGenitiveNames, value.AbbreviatedMonthGenitiveNames);
+            Assert.Equal(expected.AbbreviatedMonthNames, value.AbbreviatedMonthNames);
+            Assert.Equal(expected.DayNames, value.DayNames);
+            Assert.Equal(expected.MonthGenitiveNames, value.MonthGenitiveNames);
+            Assert.Equal(expected.MonthNames, value.MonthNames);
+            Assert.Equal(expected.ShortestDayNames, value.ShortestDayNames);
+
+            Assert.Equal(expected.AMDesignator, value.AMDesignator);
+            Assert.Equal(expected.FullDateTimePattern, value.FullDateTimePattern);
+            Assert.Equal(expected.LongDatePattern, value.LongDatePattern);
+            Assert.Equal(expected.LongTimePattern, value.LongTimePattern);
+            Assert.Equal(expected.MonthDayPattern, value.MonthDayPattern);
+            Assert.Equal(expected.PMDesignator, value.PMDesignator);
+            Assert.Equal(expected.RFC1123Pattern, value.RFC1123Pattern);
+            Assert.Equal(expected.ShortDatePattern, value.ShortDatePattern);
+            Assert.Equal(expected.ShortTimePattern, value.ShortTimePattern);
+            Assert.Equal(expected.SortableDateTimePattern, value.SortableDateTimePattern);
+            Assert.Equal(expected.UniversalSortableDateTimePattern, value.UniversalSortableDateTimePattern);
+            Assert.Equal(expected.YearMonthPattern, value.YearMonthPattern);
+            Assert.Equal(expected.CalendarWeekRule, value.CalendarWeekRule);
+            Assert.Equal(expected.FirstDayOfWeek, value.FirstDayOfWeek);
+        }
+
         [Fact]
         public void GetInstance_ExpectedCurrent()
         {
-            Assert.Same(DateTimeFormatInfo.CurrentInfo, DateTimeFormatInfo.GetInstance(null));
-            Assert.Same(DateTimeFormatInfo.CurrentInfo, DateTimeFormatInfo.GetInstance(new TestIFormatProviderClass()));
+            AssertSameValues(DateTimeFormatInfo.CurrentInfo, DateTimeFormatInfo.GetInstance(null));
+            AssertSameValues(DateTimeFormatInfo.CurrentInfo, DateTimeFormatInfo.GetInstance(new TestIFormatProviderClass()));
         }
     }
 }


### PR DESCRIPTION
GetInstance test depends on DateTimeFormatInfo.CurrentInfo which depends on CurrentCulture. it is not guarantees calling CurrentInfo twice to return the exact same instance because 2 threads can race in initializing current culture and we can end up overriding the current culture which cause having 2 CurrentInfo objects.
The fix here is to test the values if we are getting 2 different instances