### PR TITLE
Avoid an array allocation in BindBinaryOperation for DynamicObject

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/DynamicMetaObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/DynamicMetaObject.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Dynamic.Utils;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -261,7 +262,7 @@ namespace System.Dynamic
                 DynamicMetaObject mo = objects[i];
                 ContractUtils.RequiresNotNull(mo, nameof(objects));
                 Expression expr = mo.Expression;
-                ContractUtils.RequiresNotNull(expr, nameof(objects));
+                Debug.Assert(expr != null, "Unexpected null expression; ctor should have caught this.");
                 res[i] = expr;
             }
 

--- a/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
@@ -308,7 +308,7 @@ namespace System.Dynamic
                 DynamicMetaObject call = BuildCallMethodWithResult(
                     nameof(DynamicObject.TryInvokeMember),
                     binder,
-                    DynamicMetaObject.GetExpressions(args),
+                    GetExpressions(args),
                     BuildCallMethodWithResult<GetMemberBinder>(
                         nameof(DynamicObject.TryGetMember),
                         new GetBinderAdapter(binder),
@@ -331,7 +331,7 @@ namespace System.Dynamic
                     return CallMethodWithResult(
                         nameof(DynamicObject.TryCreateInstance),
                         binder,
-                        DynamicMetaObject.GetExpressions(args),
+                        GetExpressions(args),
                         (MetaDynamic @this, CreateInstanceBinder b, DynamicMetaObject e) => b.FallbackCreateInstance(@this, localArgs, e)
                     );
                 }
@@ -348,7 +348,7 @@ namespace System.Dynamic
                     return CallMethodWithResult(
                         nameof(DynamicObject.TryInvoke),
                         binder,
-                        DynamicMetaObject.GetExpressions(args),
+                        GetExpressions(args),
                         (MetaDynamic @this, InvokeBinder b, DynamicMetaObject e) => b.FallbackInvoke(@this, localArgs, e)
                     );
                 }
@@ -365,7 +365,7 @@ namespace System.Dynamic
                     return CallMethodWithResult(
                         nameof(DynamicObject.TryBinaryOperation),
                         binder,
-                        DynamicMetaObject.GetExpressions(new DynamicMetaObject[] { arg }),
+                        new[] { arg.Expression },
                         (MetaDynamic @this, BinaryOperationBinder b, DynamicMetaObject e) => b.FallbackBinaryOperation(@this, localArg, e)
                     );
                 }
@@ -397,7 +397,7 @@ namespace System.Dynamic
                     return CallMethodWithResult(
                         nameof(DynamicObject.TryGetIndex),
                         binder,
-                        DynamicMetaObject.GetExpressions(indexes),
+                        GetExpressions(indexes),
                         (MetaDynamic @this, GetIndexBinder b, DynamicMetaObject e) => b.FallbackGetIndex(@this, localIndexes, e)
                     );
                 }
@@ -415,7 +415,7 @@ namespace System.Dynamic
                     return CallMethodReturnLast(
                         nameof(DynamicObject.TrySetIndex),
                         binder,
-                        DynamicMetaObject.GetExpressions(indexes),
+                        GetExpressions(indexes),
                         value.Expression,
                         (MetaDynamic @this, SetIndexBinder b, DynamicMetaObject e) => b.FallbackSetIndex(@this, localIndexes, localValue, e)
                     );
@@ -433,7 +433,7 @@ namespace System.Dynamic
                     return CallMethodNoResult(
                         nameof(DynamicObject.TryDeleteIndex),
                         binder,
-                        DynamicMetaObject.GetExpressions(indexes),
+                        GetExpressions(indexes),
                         (MetaDynamic @this, DeleteIndexBinder b, DynamicMetaObject e) => b.FallbackDeleteIndex(@this, localIndexes, e)
                     );
                 }


### PR DESCRIPTION
Also simplifying method calls for `GetExpressions` on the base class to omit the type name.