### PR TITLE
DefaultValueAttribute missing unsigned int / unsigned long constructor

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -3564,14 +3564,16 @@ namespace System.ComponentModel
         public DefaultValueAttribute(object value) { }
         public DefaultValueAttribute(float value) { }
         public DefaultValueAttribute(string value) { }
-        [CLSCompliant(false)]
+#if netcoreapp11
+        [System.CLSCompliantAttribute(false)]
         public DefaultValueAttribute(sbyte value) { }
-        [CLSCompliant(false)]
+        [System.CLSCompliantAttribute(false)]
         public DefaultValueAttribute(ushort value) { }
-        [CLSCompliant(false)]
+        [System.CLSCompliantAttribute(false)]
         public DefaultValueAttribute(uint value) { }
-        [CLSCompliant(false)]
+        [System.CLSCompliantAttribute(false)]
         public DefaultValueAttribute(ulong value) { }
+#endif
         public DefaultValueAttribute(System.Type type, string value) { }
         public virtual object Value { get { throw null; } }
         public override bool Equals(object obj) { throw null; }

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -3564,6 +3564,14 @@ namespace System.ComponentModel
         public DefaultValueAttribute(object value) { }
         public DefaultValueAttribute(float value) { }
         public DefaultValueAttribute(string value) { }
+        [CLSCompliant(false)]
+        public DefaultValueAttribute(sbyte value) { }
+        [CLSCompliant(false)]
+        public DefaultValueAttribute(ushort value) { }
+        [CLSCompliant(false)]
+        public DefaultValueAttribute(uint value) { }
+        [CLSCompliant(false)]
+        public DefaultValueAttribute(ulong value) { }
         public DefaultValueAttribute(System.Type type, string value) { }
         public virtual object Value { get { throw null; } }
         public override bool Equals(object obj) { throw null; }

--- a/src/System.Runtime/src/System/ComponentModel/DefaultValueAttribute.cs
+++ b/src/System.Runtime/src/System/ComponentModel/DefaultValueAttribute.cs
@@ -139,6 +139,46 @@ namespace System.ComponentModel
         }
 
         /// <devdoc>
+        /// <para>Initializes a new instance of the <see cref='System.ComponentModel.DefaultValueAttribute'/> class using a <see cref='System.SByte'/>
+        /// value.</para>
+        /// </devdoc>
+        [CLSCompliant(false)]
+        public DefaultValueAttribute(sbyte value)
+        {
+            this.value = value;
+        }
+
+        /// <devdoc>
+        /// <para>Initializes a new instance of the <see cref='System.ComponentModel.DefaultValueAttribute'/> class using a <see cref='System.UInt16'/>
+        /// value.</para>
+        /// </devdoc>
+        [CLSCompliant(false)]
+        public DefaultValueAttribute(ushort value)
+        {
+            this.value = value;
+        }
+
+        /// <devdoc>
+        /// <para>Initializes a new instance of the <see cref='System.ComponentModel.DefaultValueAttribute'/> class using a <see cref='System.UInt32'/>
+        /// value.</para>
+        /// </devdoc>
+        [CLSCompliant(false)]
+        public DefaultValueAttribute(uint value)
+        {
+            this.value = value;
+        }
+
+        /// <devdoc>
+        /// <para>Initializes a new instance of the <see cref='System.ComponentModel.DefaultValueAttribute'/> class using a <see cref='System.UInt64'/>
+        /// value.</para>
+        /// </devdoc>
+        [CLSCompliant(false)]
+        public DefaultValueAttribute(ulong value)
+        {
+            this.value = value;
+        }
+
+        /// <devdoc>
         ///    <para>
         ///       Gets the default value of the property this
         ///       attribute is

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="System\LazyTests.netcoreapp1.1.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuntimeHelpersTests.netcoreapp1.1.cs" />
     <Compile Include="System\UIntPtrTests.netcoreapp1.1.cs" />
+    <Compile Include="System\ComponentModel\DefaultValueAttributeTests.netcoreapp1.1.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'netcoreapp1.1'">
     <Compile Include="System\StringSplitExtensions.cs" />

--- a/src/System.Runtime/tests/System/ComponentModel/DefaultValueAttributeTests.cs
+++ b/src/System.Runtime/tests/System/ComponentModel/DefaultValueAttributeTests.cs
@@ -23,6 +23,11 @@ namespace System.ComponentModel.Tests
             Assert.Equal(42L, new DefaultValueAttribute(42L).Value);
             Assert.Equal((short)42, new DefaultValueAttribute((short)42).Value);
 
+            Assert.Equal((sbyte)42, new DefaultValueAttribute((sbyte)42).Value);
+            Assert.Equal((ushort)42, new DefaultValueAttribute((ushort)42).Value);
+            Assert.Equal((uint)42, new DefaultValueAttribute((uint)42).Value);
+            Assert.Equal((ulong)42, new DefaultValueAttribute((ulong)42).Value);
+
             Assert.Equal('c', new DefaultValueAttribute('c').Value);
             Assert.Equal("test", new DefaultValueAttribute("test").Value);
 

--- a/src/System.Runtime/tests/System/ComponentModel/DefaultValueAttributeTests.cs
+++ b/src/System.Runtime/tests/System/ComponentModel/DefaultValueAttributeTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace System.ComponentModel.Tests
 {
-    public static class DefaultValueAttributeTests
+    public static partial class DefaultValueAttributeTests
     {
         [Fact]
         public static void Ctor()
@@ -22,11 +22,6 @@ namespace System.ComponentModel.Tests
             Assert.Equal(42, new DefaultValueAttribute(42).Value);
             Assert.Equal(42L, new DefaultValueAttribute(42L).Value);
             Assert.Equal((short)42, new DefaultValueAttribute((short)42).Value);
-
-            Assert.Equal((sbyte)42, new DefaultValueAttribute((sbyte)42).Value);
-            Assert.Equal((ushort)42, new DefaultValueAttribute((ushort)42).Value);
-            Assert.Equal((uint)42, new DefaultValueAttribute((uint)42).Value);
-            Assert.Equal((ulong)42, new DefaultValueAttribute((ulong)42).Value);
 
             Assert.Equal('c', new DefaultValueAttribute('c').Value);
             Assert.Equal("test", new DefaultValueAttribute("test").Value);

--- a/src/System.Runtime/tests/System/ComponentModel/DefaultValueAttributeTests.netcoreapp1.1.cs
+++ b/src/System.Runtime/tests/System/ComponentModel/DefaultValueAttributeTests.netcoreapp1.1.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.ComponentModel.Tests
+{
+    public static partial class DefaultValueAttributeTests
+    {
+        [Fact]
+        public static void Ctor_netcoreapp11()
+        {
+            Assert.Equal((sbyte)42, new DefaultValueAttribute((sbyte)42).Value);
+            Assert.Equal((ushort)42, new DefaultValueAttribute((ushort)42).Value);
+            Assert.Equal((uint)42, new DefaultValueAttribute((uint)42).Value);
+            Assert.Equal((ulong)42, new DefaultValueAttribute((ulong)42).Value);
+        }
+    }
+}


### PR DESCRIPTION
The proposal is to add constructor overloads so that the conversions don't happen and Value gets the expected type. See https://github.com/dotnet/corefx/issues/11465