### PR TITLE
Return self on XxxExpression.Update when children are the same

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
@@ -227,10 +227,9 @@ namespace System.Dynamic.Utils
             return pis;
         }
 
-        internal static bool SameElements<T>(IEnumerable<T> replacement, IReadOnlyList<T> current) where T : class
+        internal static bool SameElements<T>(ICollection<T> replacement, IReadOnlyList<T> current) where T : class
         {
             Debug.Assert(current != null);
-            Debug.Assert(replacement == null | replacement is ICollection<T>);
             if (replacement == current) // Relatively common case, so particularly useful to take the short-circuit.
             {
                 return true;
@@ -241,8 +240,38 @@ namespace System.Dynamic.Utils
                 return current.Count == 0;
             }
 
+            return SameElementsInCollection(replacement, current);
+        }
+
+        internal static bool SameElements<T>(ref IEnumerable<T> replacement, IReadOnlyList<T> current) where T : class
+        {
+            Debug.Assert(current != null);
+            if (replacement == current) // Relatively common case, so particularly useful to take the short-circuit.
+            {
+                return true;
+            }
+
+            if (replacement == null) // Treat null as empty.
+            {
+                return current.Count == 0;
+            }
+
+            // Ensure arguments is safe to enumerate twice.
+            // If we have to build a collection, build a TrueReadOnlyCollection<T>
+            // so it won't be built a second time if used.
+            ICollection<T> replacementCol = replacement as ICollection<T>;
+            if (replacementCol == null)
+            {
+                replacement = replacementCol = replacement.ToReadOnly();
+            }
+
+            return SameElementsInCollection(replacementCol, current);
+        }
+
+        private static bool SameElementsInCollection<T>(ICollection<T> replacement, IReadOnlyList<T> current) where T : class
+        { 
             int count = current.Count;
-            if (((ICollection<T>)replacement).Count != count)
+            if (replacement.Count != count)
             {
                 return false;
             }

--- a/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
@@ -247,15 +247,18 @@ namespace System.Dynamic.Utils
                 return false;
             }
 
-            int index = 0;
-            foreach(object replacementObject in replacement)
+            if (count != 0)
             {
-                if (replacementObject != current[index])
+                int index = 0;
+                foreach (T replacementObject in replacement)
                 {
-                    return false;
-                }
+                    if (replacementObject != current[index])
+                    {
+                        return false;
+                    }
 
-                index++;
+                    index++;
+                }
             }
 
             return true;

--- a/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
@@ -227,43 +227,38 @@ namespace System.Dynamic.Utils
             return pis;
         }
 
-        internal static bool SameElements<T>(IEnumerable<T> first, IEnumerable<T> second)
+        internal static bool SameElements<T>(IEnumerable<T> replacement, IReadOnlyList<T> current) where T : class
         {
-            if (first == second)
-                return true;
-
-            if (first == null | second == null)
+            Debug.Assert(current != null);
+            Debug.Assert(replacement == null | replacement is ICollection<T>);
+            if (replacement == current) // Relatively common case, so particularly useful to take the short-circuit.
             {
-                // Consider empty and null equivalent.
-                using (IEnumerator<T> en = (first ?? second).GetEnumerator())
-                {
-                    return !en.MoveNext();
-                }
+                return true;
             }
 
-            ICollection<T> firstCol = first as ICollection<T>;
-            if (firstCol != null)
+            if (replacement == null) // Treat null as empty.
             {
-                ICollection<T> secondCol = second as ICollection<T>;
-                if (secondCol != null && firstCol.Count != secondCol.Count)
+                return current.Count == 0;
+            }
+
+            int count = current.Count;
+            if (((ICollection<T>)replacement).Count != count)
+            {
+                return false;
+            }
+
+            int index = 0;
+            foreach(object replacementObject in replacement)
+            {
+                if (replacementObject != current[index])
                 {
                     return false;
                 }
+
+                index++;
             }
 
-            using (IEnumerator<T> e0 = first.GetEnumerator())
-            using (IEnumerator<T> e1 = second.GetEnumerator())
-            {
-                while (e0.MoveNext())
-                {
-                    if (!e1.MoveNext() || (object)e0.Current != (object)e1.Current)
-                    {
-                        return false;
-                    }
-                }
-
-                return !e1.MoveNext();
-            }
+            return true;
         }
     }
 }

--- a/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
@@ -226,5 +226,44 @@ namespace System.Dynamic.Utils
             }
             return pis;
         }
+
+        internal static bool SameElements<T>(IEnumerable<T> first, IEnumerable<T> second)
+        {
+            if (first == second)
+                return true;
+
+            if (first == null | second == null)
+            {
+                // Consider empty and null equivalent.
+                using (IEnumerator<T> en = (first ?? second).GetEnumerator())
+                {
+                    return !en.MoveNext();
+                }
+            }
+
+            ICollection<T> firstCol = first as ICollection<T>;
+            if (firstCol != null)
+            {
+                ICollection<T> secondCol = second as ICollection<T>;
+                if (secondCol != null && firstCol.Count != secondCol.Count)
+                {
+                    return false;
+                }
+            }
+
+            using (IEnumerator<T> e0 = first.GetEnumerator())
+            using (IEnumerator<T> e1 = second.GetEnumerator())
+            {
+                while (e0.MoveNext())
+                {
+                    if (!e1.MoveNext() || (object)e0.Current != (object)e1.Current)
+                    {
+                        return false;
+                    }
+                }
+
+                return !e1.MoveNext();
+            }
+        }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -67,12 +67,30 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public BlockExpression Update(IEnumerable<ParameterExpression> variables, IEnumerable<Expression> expressions)
         {
-            if (variables == Variables && expressions == Expressions)
+            if (expressions != null)
             {
-                return this;
+                // Ensure variables is safe to enumerate twice.
+                // (If this means a second call to ToReadOnly it will return quickly).
+                variables = variables as ICollection<ParameterExpression> ?? variables.ToReadOnly();
+                if (ExpressionUtils.SameElements(variables, Variables))
+                {
+                    // Ensure expressions is safe to enumerate twice.
+                    // (If this means a second call to ToReadOnly it will return quickly).
+                    expressions = expressions as ICollection<Expression> ?? expressions.ToReadOnly();
+                    if (SameExpressions(expressions))
+                    {
+                        return this;
+                    }
+                }
             }
 
-            return Expression.Block(Type, variables, expressions);
+            return Block(Type, variables, expressions);
+        }
+
+        [ExcludeFromCodeCoverage] // Unreachable
+        internal virtual bool SameExpressions(IEnumerable<Expression> expressions)
+        {
+            throw ContractUtils.Unreachable;
         }
 
         [ExcludeFromCodeCoverage] // Unreachable
@@ -171,6 +189,23 @@ namespace System.Linq.Expressions
             }
         }
 
+        internal override bool SameExpressions(IEnumerable<Expression> expressions)
+        {
+            Debug.Assert(expressions != null);
+            ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
+            if (alreadyCollection != null)
+            {
+                return ExpressionUtils.SameElements(alreadyCollection, expressions);
+            }
+
+            using (IEnumerator<Expression> en = expressions.GetEnumerator())
+            {
+                return en.MoveNext() && en.Current == _arg0
+                    && en.MoveNext() && en.Current == _arg1
+                    && !en.MoveNext();
+            }
+        }
+
         internal override int ExpressionCount => 2;
 
         internal override ReadOnlyCollection<Expression> GetOrMakeExpressions()
@@ -198,6 +233,24 @@ namespace System.Linq.Expressions
             _arg0 = arg0;
             _arg1 = arg1;
             _arg2 = arg2;
+        }
+
+        internal override bool SameExpressions(IEnumerable<Expression> expressions)
+        {
+            Debug.Assert(expressions != null);
+            ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
+            if (alreadyCollection != null)
+            {
+                return ExpressionUtils.SameElements(alreadyCollection, expressions);
+            }
+
+            using (IEnumerator<Expression> en = expressions.GetEnumerator())
+            {
+                return en.MoveNext() && en.Current == _arg0
+                    && en.MoveNext() && en.Current == _arg1
+                    && en.MoveNext() && en.Current == _arg2
+                    && !en.MoveNext();
+            }
         }
 
         internal override Expression GetExpression(int index)
@@ -239,6 +292,25 @@ namespace System.Linq.Expressions
             _arg1 = arg1;
             _arg2 = arg2;
             _arg3 = arg3;
+        }
+
+        internal override bool SameExpressions(IEnumerable<Expression> expressions)
+        {
+            Debug.Assert(expressions != null);
+            ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
+            if (alreadyCollection != null)
+            {
+                return ExpressionUtils.SameElements(alreadyCollection, expressions);
+            }
+
+            using (IEnumerator<Expression> en = expressions.GetEnumerator())
+            {
+                return en.MoveNext() && en.Current == _arg0
+                    && en.MoveNext() && en.Current == _arg1
+                    && en.MoveNext() && en.Current == _arg2
+                    && en.MoveNext() && en.Current == _arg3
+                    && !en.MoveNext();
+            }
         }
 
         internal override Expression GetExpression(int index)
@@ -297,6 +369,26 @@ namespace System.Linq.Expressions
             }
         }
 
+        internal override bool SameExpressions(IEnumerable<Expression> expressions)
+        {
+            Debug.Assert(expressions != null);
+            ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
+            if (alreadyCollection != null)
+            {
+                return ExpressionUtils.SameElements(alreadyCollection, expressions);
+            }
+
+            using (IEnumerator<Expression> en = expressions.GetEnumerator())
+            {
+                return en.MoveNext() && en.Current == _arg0
+                    && en.MoveNext() && en.Current == _arg1
+                    && en.MoveNext() && en.Current == _arg2
+                    && en.MoveNext() && en.Current == _arg3
+                    && en.MoveNext() && en.Current == _arg4
+                    && !en.MoveNext();
+            }
+        }
+
         internal override int ExpressionCount => 5;
 
         internal override ReadOnlyCollection<Expression> GetOrMakeExpressions()
@@ -324,6 +416,9 @@ namespace System.Linq.Expressions
 
             _expressions = expressions;
         }
+
+        internal override bool SameExpressions(IEnumerable<Expression> expressions) =>
+            ExpressionUtils.SameElements(_expressions, expressions);
 
         internal override Expression GetExpression(int index)
         {
@@ -395,6 +490,21 @@ namespace System.Linq.Expressions
             _body = body;
         }
 
+        internal override bool SameExpressions(IEnumerable<Expression> expressions)
+        {
+            Debug.Assert(expressions != null);
+            ReadOnlyCollection<Expression> alreadyCollection = _body as ReadOnlyCollection<Expression>;
+            if (alreadyCollection != null)
+            {
+                return ExpressionUtils.SameElements(alreadyCollection, expressions);
+            }
+
+            using (IEnumerator<Expression> en = expressions.GetEnumerator())
+            {
+                return en.MoveNext() && _body == en.Current && !en.MoveNext();
+            }
+        }
+
         internal override Expression GetExpression(int index)
         {
             switch (index)
@@ -435,6 +545,9 @@ namespace System.Linq.Expressions
         {
             _body = body;
         }
+
+        internal override bool SameExpressions(IEnumerable<Expression> expressions) =>
+            ExpressionUtils.SameElements(_body, expressions);
 
         protected IReadOnlyList<Expression> Body => _body;
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -71,13 +71,30 @@ namespace System.Linq.Expressions
             {
                 // Ensure variables is safe to enumerate twice.
                 // (If this means a second call to ToReadOnly it will return quickly).
-                variables = variables as ICollection<ParameterExpression> ?? variables.ToReadOnly();
-                if (ExpressionUtils.SameElements(variables, Variables))
+                ICollection<ParameterExpression> vars;
+                if (variables == null)
+                {
+                    vars = null;
+                }
+                else
+                {
+                    vars = variables as ICollection<ParameterExpression>;
+                    if (vars == null)
+                    {
+                        variables = vars = variables.ToReadOnly();
+                    }
+                }
+
+                if (SameVariables(vars))
                 {
                     // Ensure expressions is safe to enumerate twice.
                     // (If this means a second call to ToReadOnly it will return quickly).
-                    expressions = expressions as ICollection<Expression> ?? expressions.ToReadOnly();
-                    if (SameExpressions(expressions))
+                    ICollection<Expression> exps = expressions as ICollection<Expression>;
+                    if (exps == null)
+                    {
+                        expressions = exps = expressions.ToReadOnly();
+                    }
+                    if (SameExpressions(exps))
                     {
                         return this;
                     }
@@ -87,8 +104,11 @@ namespace System.Linq.Expressions
             return Block(Type, variables, expressions);
         }
 
+        internal virtual bool SameVariables(ICollection<ParameterExpression> variables) =>
+            variables == null || variables.Count == 0;
+
         [ExcludeFromCodeCoverage] // Unreachable
-        internal virtual bool SameExpressions(IEnumerable<Expression> expressions)
+        internal virtual bool SameExpressions(ICollection<Expression> expressions)
         {
             throw ContractUtils.Unreachable;
         }
@@ -189,21 +209,29 @@ namespace System.Linq.Expressions
             }
         }
 
-        internal override bool SameExpressions(IEnumerable<Expression> expressions)
+        internal override bool SameExpressions(ICollection<Expression> expressions)
         {
             Debug.Assert(expressions != null);
-            ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
-            if (alreadyCollection != null)
+            if (expressions.Count == 2)
             {
-                return ExpressionUtils.SameElements(alreadyCollection, expressions);
+                ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
+                if (alreadyCollection != null)
+                {
+                    return ExpressionUtils.SameElements(expressions, alreadyCollection);
+                }
+
+                using (IEnumerator<Expression> en = expressions.GetEnumerator())
+                {
+                    en.MoveNext();
+                    if (en.Current == _arg0)
+                    {
+                        en.MoveNext();
+                        return en.Current == _arg1;
+                    }
+                }
             }
 
-            using (IEnumerator<Expression> en = expressions.GetEnumerator())
-            {
-                return en.MoveNext() && en.Current == _arg0
-                    && en.MoveNext() && en.Current == _arg1
-                    && !en.MoveNext();
-            }
+            return false;
         }
 
         internal override int ExpressionCount => 2;
@@ -235,22 +263,33 @@ namespace System.Linq.Expressions
             _arg2 = arg2;
         }
 
-        internal override bool SameExpressions(IEnumerable<Expression> expressions)
+        internal override bool SameExpressions(ICollection<Expression> expressions)
         {
             Debug.Assert(expressions != null);
-            ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
-            if (alreadyCollection != null)
+            if (expressions.Count == 3)
             {
-                return ExpressionUtils.SameElements(alreadyCollection, expressions);
+                ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
+                if (alreadyCollection != null)
+                {
+                    return ExpressionUtils.SameElements(expressions, alreadyCollection);
+                }
+
+                using (IEnumerator<Expression> en = expressions.GetEnumerator())
+                {
+                    en.MoveNext();
+                    if (en.Current == _arg0)
+                    {
+                        en.MoveNext();
+                        if (en.Current == _arg1)
+                        {
+                            en.MoveNext();
+                            return en.Current == _arg2;
+                        }
+                    }
+                }
             }
 
-            using (IEnumerator<Expression> en = expressions.GetEnumerator())
-            {
-                return en.MoveNext() && en.Current == _arg0
-                    && en.MoveNext() && en.Current == _arg1
-                    && en.MoveNext() && en.Current == _arg2
-                    && !en.MoveNext();
-            }
+            return false;
         }
 
         internal override Expression GetExpression(int index)
@@ -294,23 +333,37 @@ namespace System.Linq.Expressions
             _arg3 = arg3;
         }
 
-        internal override bool SameExpressions(IEnumerable<Expression> expressions)
+        internal override bool SameExpressions(ICollection<Expression> expressions)
         {
             Debug.Assert(expressions != null);
-            ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
-            if (alreadyCollection != null)
+            if (expressions.Count == 4)
             {
-                return ExpressionUtils.SameElements(alreadyCollection, expressions);
+                ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
+                if (alreadyCollection != null)
+                {
+                    return ExpressionUtils.SameElements(expressions, alreadyCollection);
+                }
+
+                using (IEnumerator<Expression> en = expressions.GetEnumerator())
+                {
+                    en.MoveNext();
+                    if (en.Current == _arg0)
+                    {
+                        en.MoveNext();
+                        if (en.Current == _arg1)
+                        {
+                            en.MoveNext();
+                            if (en.Current == _arg2)
+                            {
+                                en.MoveNext();
+                                return en.Current == _arg3;
+                            }
+                        }
+                    }
+                }
             }
 
-            using (IEnumerator<Expression> en = expressions.GetEnumerator())
-            {
-                return en.MoveNext() && en.Current == _arg0
-                    && en.MoveNext() && en.Current == _arg1
-                    && en.MoveNext() && en.Current == _arg2
-                    && en.MoveNext() && en.Current == _arg3
-                    && !en.MoveNext();
-            }
+            return false;
         }
 
         internal override Expression GetExpression(int index)
@@ -369,24 +422,41 @@ namespace System.Linq.Expressions
             }
         }
 
-        internal override bool SameExpressions(IEnumerable<Expression> expressions)
+        internal override bool SameExpressions(ICollection<Expression> expressions)
         {
             Debug.Assert(expressions != null);
-            ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
-            if (alreadyCollection != null)
+            if (expressions.Count == 5)
             {
-                return ExpressionUtils.SameElements(alreadyCollection, expressions);
+                ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
+                if (alreadyCollection != null)
+                {
+                    return ExpressionUtils.SameElements(expressions, alreadyCollection);
+                }
+
+                using (IEnumerator<Expression> en = expressions.GetEnumerator())
+                {
+                    en.MoveNext();
+                    if (en.Current == _arg0)
+                    {
+                        en.MoveNext();
+                        if (en.Current == _arg1)
+                        {
+                            en.MoveNext();
+                            if (en.Current == _arg2)
+                            {
+                                en.MoveNext();
+                                if (en.Current == _arg3)
+                                {
+                                    en.MoveNext();
+                                    return en.Current == _arg4;
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
-            using (IEnumerator<Expression> en = expressions.GetEnumerator())
-            {
-                return en.MoveNext() && en.Current == _arg0
-                    && en.MoveNext() && en.Current == _arg1
-                    && en.MoveNext() && en.Current == _arg2
-                    && en.MoveNext() && en.Current == _arg3
-                    && en.MoveNext() && en.Current == _arg4
-                    && !en.MoveNext();
-            }
+            return false;
         }
 
         internal override int ExpressionCount => 5;
@@ -417,8 +487,8 @@ namespace System.Linq.Expressions
             _expressions = expressions;
         }
 
-        internal override bool SameExpressions(IEnumerable<Expression> expressions) =>
-            ExpressionUtils.SameElements(_expressions, expressions);
+        internal override bool SameExpressions(ICollection<Expression> expressions) =>
+            ExpressionUtils.SameElements(expressions, _expressions);
 
         internal override Expression GetExpression(int index)
         {
@@ -451,6 +521,9 @@ namespace System.Linq.Expressions
         {
             _variables = variables;
         }
+
+        internal override bool SameVariables(ICollection<ParameterExpression> variables) =>
+            ExpressionUtils.SameElements(variables, _variables);
 
         internal override ReadOnlyCollection<ParameterExpression> GetOrMakeVariables()
         {
@@ -490,19 +563,25 @@ namespace System.Linq.Expressions
             _body = body;
         }
 
-        internal override bool SameExpressions(IEnumerable<Expression> expressions)
+        internal override bool SameExpressions(ICollection<Expression> expressions)
         {
             Debug.Assert(expressions != null);
-            ReadOnlyCollection<Expression> alreadyCollection = _body as ReadOnlyCollection<Expression>;
-            if (alreadyCollection != null)
+            if (expressions.Count == 1)
             {
-                return ExpressionUtils.SameElements(alreadyCollection, expressions);
+                ReadOnlyCollection<Expression> alreadyCollection = _body as ReadOnlyCollection<Expression>;
+                if (alreadyCollection != null)
+                {
+                    return ExpressionUtils.SameElements(expressions, alreadyCollection);
+                }
+
+                using (IEnumerator<Expression> en = expressions.GetEnumerator())
+                {
+                    en.MoveNext();
+                    return ReturnObject<Expression>(_body) == en.Current;
+                }
             }
 
-            using (IEnumerator<Expression> en = expressions.GetEnumerator())
-            {
-                return en.MoveNext() && _body == en.Current && !en.MoveNext();
-            }
+            return false;
         }
 
         internal override Expression GetExpression(int index)
@@ -546,8 +625,8 @@ namespace System.Linq.Expressions
             _body = body;
         }
 
-        internal override bool SameExpressions(IEnumerable<Expression> expressions) =>
-            ExpressionUtils.SameElements(_body, expressions);
+        internal override bool SameExpressions(ICollection<Expression> expressions) =>
+            ExpressionUtils.SameElements(expressions, _body);
 
         protected IReadOnlyList<Expression> Body => _body;
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 using System.Linq.Expressions.Compiler;
 using System.Reflection;
@@ -174,12 +175,32 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public DynamicExpression Update(IEnumerable<Expression> arguments)
         {
-            if (arguments == Arguments)
+            ICollection<Expression> args;
+            if (arguments == null)
+            {
+                args = null;
+            }
+            else
+            {
+                args = arguments as ICollection<Expression>;
+                if (args == null)
+                {
+                    arguments = args = arguments.ToReadOnly();
+                }
+            }
+
+            if (SameArguments(args))
             {
                 return this;
             }
 
             return ExpressionExtension.MakeDynamic(DelegateType, Binder, arguments);
+        }
+
+        [ExcludeFromCodeCoverage] // Unreachable
+        internal virtual bool SameArguments(ICollection<Expression> arguments)
+        {
+            throw ContractUtils.Unreachable;
         }
 
         #region IArgumentProvider Members
@@ -468,6 +489,9 @@ namespace System.Linq.Expressions
 
         Expression IArgumentProvider.GetArgument(int index) => _arguments[index];
 
+        internal override bool SameArguments(ICollection<Expression> arguments) =>
+            ExpressionUtils.SameElements(arguments, _arguments);
+
         int IArgumentProvider.ArgumentCount => _arguments.Count;
 
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
@@ -516,6 +540,20 @@ namespace System.Linq.Expressions
 
         int IArgumentProvider.ArgumentCount => 1;
 
+        internal override bool SameArguments(ICollection<Expression> arguments)
+        {
+            if (arguments != null && arguments.Count == 1)
+            {
+                using (IEnumerator<Expression> en = arguments.GetEnumerator())
+                {
+                    en.MoveNext();
+                    return en.Current == ReturnObject<Expression>(_arg0);
+                }
+            }
+
+            return false;
+        }
+
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
             return ExpressionUtils.ReturnReadOnly(this, ref _arg0);
@@ -563,6 +601,30 @@ namespace System.Linq.Expressions
         }
 
         int IArgumentProvider.ArgumentCount => 2;
+
+        internal override bool SameArguments(ICollection<Expression> arguments)
+        {
+            if (arguments != null && arguments.Count == 2)
+            {
+                ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
+                if (alreadyCollection != null)
+                {
+                    return ExpressionUtils.SameElements(arguments, alreadyCollection);
+                }
+
+                using (IEnumerator<Expression> en = arguments.GetEnumerator())
+                {
+                    en.MoveNext();
+                    if (en.Current == _arg0)
+                    {
+                        en.MoveNext();
+                        return en.Current == _arg1;
+                    }
+                }
+            }
+
+            return false;
+        }
 
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
@@ -613,6 +675,34 @@ namespace System.Linq.Expressions
         }
 
         int IArgumentProvider.ArgumentCount => 3;
+
+        internal override bool SameArguments(ICollection<Expression> arguments)
+        {
+            if (arguments != null && arguments.Count == 3)
+            {
+                ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
+                if (alreadyCollection != null)
+                {
+                    return ExpressionUtils.SameElements(arguments, alreadyCollection);
+                }
+
+                using (IEnumerator<Expression> en = arguments.GetEnumerator())
+                {
+                    en.MoveNext();
+                    if (en.Current == _arg0)
+                    {
+                        en.MoveNext();
+                        if (en.Current == _arg1)
+                        {
+                            en.MoveNext();
+                            return en.Current == _arg2;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
 
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
@@ -665,6 +755,38 @@ namespace System.Linq.Expressions
         }
 
         int IArgumentProvider.ArgumentCount => 4;
+
+        internal override bool SameArguments(ICollection<Expression> arguments)
+        {
+            if (arguments != null && arguments.Count == 4)
+            {
+                ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
+                if (alreadyCollection != null)
+                {
+                    return ExpressionUtils.SameElements(arguments, alreadyCollection);
+                }
+
+                using (IEnumerator<Expression> en = arguments.GetEnumerator())
+                {
+                    en.MoveNext();
+                    if (en.Current == _arg0)
+                    {
+                        en.MoveNext();
+                        if (en.Current == _arg1)
+                        {
+                            en.MoveNext();
+                            if (en.Current == _arg2)
+                            {
+                                en.MoveNext();
+                                return en.Current == _arg3;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
 
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
@@ -88,10 +88,7 @@ namespace System.Linq.Expressions
         {
             if (@object == Object & arguments != null)
             {
-                // Ensure arguments is safe to enumerate twice.
-                // (If this means a second call to ToReadOnly it will return quickly).
-                arguments = arguments as ICollection<Expression> ?? arguments.ToReadOnly();
-                if (ExpressionUtils.SameElements(arguments, Arguments))
+                if (ExpressionUtils.SameElements(ref arguments, Arguments))
                 {
                     return this;
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
@@ -86,11 +86,18 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public IndexExpression Update(Expression @object, IEnumerable<Expression> arguments)
         {
-            if (@object == Object && arguments == Arguments)
+            if (@object == Object & arguments != null)
             {
-                return this;
+                // Ensure arguments is safe to enumerate twice.
+                // (If this means a second call to ToReadOnly it will return quickly).
+                arguments = arguments as ICollection<Expression> ?? arguments.ToReadOnly();
+                if (ExpressionUtils.SameElements(arguments, Arguments))
+                {
+                    return this;
+                }
             }
-            return Expression.MakeIndex(@object, Indexer, arguments);
+
+            return MakeIndex(@object, Indexer, arguments);
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
@@ -58,10 +58,7 @@ namespace System.Linq.Expressions
         {
             if (expression == Expression & arguments != null)
             {
-                // Ensure arguments is safe to enumerate twice.
-                // (If this means a second call to ToReadOnly it will return quickly).
-                arguments = arguments as ICollection<Expression> ?? arguments.ToReadOnly();
-                if (ExpressionUtils.SameElements(arguments, Arguments))
+                if (ExpressionUtils.SameElements(ref arguments, Arguments))
                 {
                     return this;
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
@@ -56,12 +56,18 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public InvocationExpression Update(Expression expression, IEnumerable<Expression> arguments)
         {
-            if (expression == Expression && arguments == Arguments)
+            if (expression == Expression & arguments != null)
             {
-                return this;
+                // Ensure arguments is safe to enumerate twice.
+                // (If this means a second call to ToReadOnly it will return quickly).
+                arguments = arguments as ICollection<Expression> ?? arguments.ToReadOnly();
+                if (ExpressionUtils.SameElements(arguments, Arguments))
+                {
+                    return this;
+                }
             }
 
-            return Expression.Invoke(expression, arguments);
+            return Invoke(expression, arguments);
         }
 
         [ExcludeFromCodeCoverage] // Unreachable

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -207,10 +207,17 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public Expression<TDelegate> Update(Expression body, IEnumerable<ParameterExpression> parameters)
         {
-            if (body == Body && parameters == Parameters)
+            if (body == Body & parameters != null)
             {
-                return this;
+                // Ensure parameters is safe to enumerate twice.
+                // (If this means a second call to ToReadOnly it will return quickly).
+                parameters = parameters as ICollection<ParameterExpression> ?? parameters.ToReadOnly();
+                if (ExpressionUtils.SameElements(parameters, Parameters))
+                {
+                    return this;
+                }
             }
+
             return Expression.Lambda<TDelegate>(body, Name, TailCall, parameters);
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -207,18 +207,37 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public Expression<TDelegate> Update(Expression body, IEnumerable<ParameterExpression> parameters)
         {
-            if (body == Body & parameters != null)
+            if (body == Body)
             {
                 // Ensure parameters is safe to enumerate twice.
                 // (If this means a second call to ToReadOnly it will return quickly).
-                parameters = parameters as ICollection<ParameterExpression> ?? parameters.ToReadOnly();
-                if (ExpressionUtils.SameElements(parameters, Parameters))
+                ICollection<ParameterExpression> pars;
+                if (parameters == null)
+                {
+                    pars = null;
+                }
+                else
+                {
+                    pars = parameters as ICollection<ParameterExpression>;
+                    if (pars == null)
+                    {
+                        parameters = pars = parameters.ToReadOnly();
+                    }
+                }
+
+                if (SameParameters(pars))
                 {
                     return this;
                 }
             }
 
-            return Expression.Lambda<TDelegate>(body, Name, TailCall, parameters);
+            return Lambda<TDelegate>(body, Name, TailCall, parameters);
+        }
+
+        [ExcludeFromCodeCoverage] // Unreachable
+        internal virtual bool SameParameters(ICollection<ParameterExpression> parameters)
+        {
+            throw ContractUtils.Unreachable;
         }
 
         [ExcludeFromCodeCoverage] // Unreachable
@@ -292,6 +311,9 @@ namespace System.Linq.Expressions
 
         internal override int ParameterCount => 0;
 
+        internal override bool SameParameters(ICollection<ParameterExpression> parameters) =>
+            parameters == null || parameters.Count == 0;
+
         internal override ParameterExpression GetParameter(int index)
         {
             throw Error.ArgumentOutOfRange(nameof(index));
@@ -327,6 +349,20 @@ namespace System.Linq.Expressions
                 case 0: return ReturnObject<ParameterExpression>(_par0);
                 default: throw Error.ArgumentOutOfRange(nameof(index));
             }
+        }
+
+        internal override bool SameParameters(ICollection<ParameterExpression> parameters)
+        {
+            if (parameters != null && parameters.Count == 1)
+            {
+                using (IEnumerator<ParameterExpression> en = parameters.GetEnumerator())
+                {
+                    en.MoveNext();
+                    return en.Current == ReturnObject<ParameterExpression>(_par0);
+                }
+            }
+
+            return false;
         }
 
         internal override ReadOnlyCollection<ParameterExpression> GetOrMakeParameters() => ReturnReadOnly(this, ref _par0);
@@ -368,6 +404,31 @@ namespace System.Linq.Expressions
                 default: throw Error.ArgumentOutOfRange(nameof(index));
             }
         }
+
+        internal override bool SameParameters(ICollection<ParameterExpression> parameters)
+        {
+            if (parameters != null && parameters.Count == 2)
+            {
+                ReadOnlyCollection<ParameterExpression> alreadyCollection = _par0 as ReadOnlyCollection<ParameterExpression>;
+                if (alreadyCollection != null)
+                {
+                    return ExpressionUtils.SameElements(parameters, alreadyCollection);
+                }
+
+                using (IEnumerator<ParameterExpression> en = parameters.GetEnumerator())
+                {
+                    en.MoveNext();
+                    if (en.Current == _par0)
+                    {
+                        en.MoveNext();
+                        return en.Current == _par1;
+                    }
+                }
+            }
+
+            return false;
+        }
+
 
         internal override ReadOnlyCollection<ParameterExpression> GetOrMakeParameters() => ReturnReadOnly(this, ref _par0);
 
@@ -412,6 +473,34 @@ namespace System.Linq.Expressions
             }
         }
 
+        internal override bool SameParameters(ICollection<ParameterExpression> parameters)
+        {
+            if (parameters != null && parameters.Count == 3)
+            {
+                ReadOnlyCollection<ParameterExpression> alreadyCollection = _par0 as ReadOnlyCollection<ParameterExpression>;
+                if (alreadyCollection != null)
+                {
+                    return ExpressionUtils.SameElements(parameters, alreadyCollection);
+                }
+
+                using (IEnumerator<ParameterExpression> en = parameters.GetEnumerator())
+                {
+                    en.MoveNext();
+                    if (en.Current == _par0)
+                    {
+                        en.MoveNext();
+                        if (en.Current == _par1)
+                        {
+                            en.MoveNext();
+                            return en.Current == _par2;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
         internal override ReadOnlyCollection<ParameterExpression> GetOrMakeParameters() => ReturnReadOnly(this, ref _par0);
 
         internal override Expression<TDelegate> Rewrite(Expression body, ParameterExpression[] parameters)
@@ -441,6 +530,9 @@ namespace System.Linq.Expressions
         internal override int ParameterCount => _parameters.Count;
 
         internal override ParameterExpression GetParameter(int index) => _parameters[index];
+
+        internal override bool SameParameters(ICollection<ParameterExpression> parameters) =>
+            ExpressionUtils.SameElements(parameters, _parameters);
 
         internal override ReadOnlyCollection<ParameterExpression> GetOrMakeParameters() => ReturnReadOnly(ref _parameters);
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
@@ -86,8 +86,7 @@ namespace System.Linq.Expressions
         {
             if (newExpression == NewExpression & initializers != null)
             {
-                initializers = initializers as ICollection<ElementInit> ?? initializers.ToReadOnly();
-                if (ExpressionUtils.SameElements(initializers, Initializers))
+                if (ExpressionUtils.SameElements(ref initializers, Initializers))
                 {
                     return this;
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
@@ -84,11 +84,16 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public ListInitExpression Update(NewExpression newExpression, IEnumerable<ElementInit> initializers)
         {
-            if (newExpression == NewExpression && initializers == Initializers)
+            if (newExpression == NewExpression & initializers != null)
             {
-                return this;
+                initializers = initializers as ICollection<ElementInit> ?? initializers.ToReadOnly();
+                if (ExpressionUtils.SameElements(initializers, Initializers))
+                {
+                    return this;
+                }
             }
-            return Expression.ListInit(newExpression, initializers);
+
+            return ListInit(newExpression, initializers);
         }
     }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
@@ -124,8 +124,7 @@ namespace System.Linq.Expressions
         {
             if (newExpression == NewExpression & bindings != null)
             {
-                bindings = bindings as ICollection<MemberBinding> ?? bindings.ToReadOnly();
-                if (ExpressionUtils.SameElements(bindings, Bindings))
+                if (ExpressionUtils.SameElements(ref bindings, Bindings))
                 {
                     return this;
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
@@ -122,10 +122,15 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public MemberInitExpression Update(NewExpression newExpression, IEnumerable<MemberBinding> bindings)
         {
-            if (newExpression == NewExpression && bindings == Bindings)
+            if (newExpression == NewExpression & bindings != null)
             {
-                return this;
+                bindings = bindings as ICollection<MemberBinding> ?? bindings.ToReadOnly();
+                if (ExpressionUtils.SameElements(bindings, Bindings))
+                {
+                    return this;
+                }
             }
+
             return Expression.MemberInit(newExpression, bindings);
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
@@ -39,8 +39,7 @@ namespace System.Linq.Expressions
         {
             if (initializers != null)
             {
-                initializers = initializers as ICollection<ElementInit> ?? initializers.ToReadOnly();
-                if (ExpressionUtils.SameElements(initializers, Initializers))
+                if (ExpressionUtils.SameElements(ref initializers, Initializers))
                 {
                     return this;
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
@@ -37,10 +37,15 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public MemberListBinding Update(IEnumerable<ElementInit> initializers)
         {
-            if (initializers == Initializers)
+            if (initializers != null)
             {
-                return this;
+                initializers = initializers as ICollection<ElementInit> ?? initializers.ToReadOnly();
+                if (ExpressionUtils.SameElements(initializers, Initializers))
+                {
+                    return this;
+                }
             }
+
             return Expression.ListBind(Member, initializers);
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
@@ -42,8 +42,7 @@ namespace System.Linq.Expressions
         {
             if (bindings != null)
             {
-                bindings = bindings as ICollection<MemberBinding> ?? bindings.ToReadOnly();
-                if (ExpressionUtils.SameElements(bindings, Bindings))
+                if (ExpressionUtils.SameElements(ref bindings, Bindings))
                 {
                     return this;
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
@@ -40,10 +40,15 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public MemberMemberBinding Update(IEnumerable<MemberBinding> bindings)
         {
-            if (bindings == Bindings)
+            if (bindings != null)
             {
-                return this;
+                bindings = bindings as ICollection<MemberBinding> ?? bindings.ToReadOnly();
+                if (ExpressionUtils.SameElements(bindings, Bindings))
+                {
+                    return this;
+                }
             }
+
             return Expression.MemberBind(Member, bindings);
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
@@ -62,11 +62,16 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public MethodCallExpression Update(Expression @object, IEnumerable<Expression> arguments)
         {
-            if (@object == Object && arguments == Arguments)
+            if (@object == Object & arguments != null)
             {
-                return this;
+                arguments = arguments as ICollection<Expression> ?? arguments.ToReadOnly();
+                if (ExpressionUtils.SameElements(arguments, Arguments))
+                {
+                    return this;
+                }
             }
-            return Expression.Call(@object, Method, arguments);
+
+            return Call(@object, Method, arguments);
         }
 
         [ExcludeFromCodeCoverage] // Unreachable

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
@@ -62,16 +62,37 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public MethodCallExpression Update(Expression @object, IEnumerable<Expression> arguments)
         {
-            if (@object == Object & arguments != null)
+            if (@object == Object)
             {
-                arguments = arguments as ICollection<Expression> ?? arguments.ToReadOnly();
-                if (ExpressionUtils.SameElements(arguments, Arguments))
+                // Ensure arguments is safe to enumerate twice.
+                // (If this means a second call to ToReadOnly it will return quickly).
+                ICollection<Expression> args;
+                if (arguments == null)
+                {
+                    args = null;
+                }
+                else
+                {
+                    args = arguments as ICollection<Expression>;
+                    if (args == null)
+                    {
+                        arguments = args = arguments.ToReadOnly();
+                    }
+                }
+
+                if (SameArguments(args))
                 {
                     return this;
                 }
             }
 
             return Call(@object, Method, arguments);
+        }
+
+        [ExcludeFromCodeCoverage] // Unreachable
+        internal virtual bool SameArguments(ICollection<Expression> arguments)
+        {
+            throw ContractUtils.Unreachable;
         }
 
         [ExcludeFromCodeCoverage] // Unreachable
@@ -163,6 +184,9 @@ namespace System.Linq.Expressions
             return ReturnReadOnly(ref _arguments);
         }
 
+        internal override bool SameArguments(ICollection<Expression> arguments) =>
+            ExpressionUtils.SameElements(arguments, _arguments);
+
         internal override MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)
         {
             Debug.Assert(instance == null);
@@ -185,6 +209,9 @@ namespace System.Linq.Expressions
         public override Expression GetArgument(int index) => _arguments[index];
 
         public override int ArgumentCount => _arguments.Count;
+
+        internal override bool SameArguments(ICollection<Expression> arguments) =>
+            ExpressionUtils.SameElements(arguments, _arguments);
 
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
@@ -219,6 +246,9 @@ namespace System.Linq.Expressions
             return EmptyReadOnlyCollection<Expression>.Instance;
         }
 
+        internal override bool SameArguments(ICollection<Expression> arguments) =>
+            arguments == null || arguments.Count == 0;
+
         internal override MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)
         {
             Debug.Assert(instance == null);
@@ -252,6 +282,20 @@ namespace System.Linq.Expressions
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
             return ReturnReadOnly(this, ref _arg0);
+        }
+
+        internal override bool SameArguments(ICollection<Expression> arguments)
+        {
+            if (arguments != null && arguments.Count == 1)
+            {
+                using (IEnumerator<Expression> en = arguments.GetEnumerator())
+                {
+                    en.MoveNext();
+                    return en.Current == ReturnObject<Expression>(_arg0);
+                }
+            }
+
+            return false;
         }
 
         internal override MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)
@@ -291,6 +335,30 @@ namespace System.Linq.Expressions
         }
 
         public override int ArgumentCount => 2;
+
+        internal override bool SameArguments(ICollection<Expression> arguments)
+        {
+            if (arguments != null && arguments.Count == 2)
+            {
+                ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
+                if (alreadyCollection != null)
+                {
+                    return ExpressionUtils.SameElements(arguments, alreadyCollection);
+                }
+
+                using (IEnumerator<Expression> en = arguments.GetEnumerator())
+                {
+                    en.MoveNext();
+                    if (en.Current == _arg0)
+                    {
+                        en.MoveNext();
+                        return en.Current == _arg1;
+                    }
+                }
+            }
+
+            return false;
+        }
 
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
@@ -335,6 +403,34 @@ namespace System.Linq.Expressions
         }
 
         public override int ArgumentCount => 3;
+
+        internal override bool SameArguments(ICollection<Expression> arguments)
+        {
+            if (arguments != null && arguments.Count == 3)
+            {
+                ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
+                if (alreadyCollection != null)
+                {
+                    return ExpressionUtils.SameElements(arguments, alreadyCollection);
+                }
+
+                using (IEnumerator<Expression> en = arguments.GetEnumerator())
+                {
+                    en.MoveNext();
+                    if (en.Current == _arg0)
+                    {
+                        en.MoveNext();
+                        if( en.Current == _arg1)
+                        {
+                            en.MoveNext();
+                            return en.Current == _arg2;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
 
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
@@ -381,6 +477,38 @@ namespace System.Linq.Expressions
         }
 
         public override int ArgumentCount => 4;
+
+        internal override bool SameArguments(ICollection<Expression> arguments)
+        {
+            if (arguments != null && arguments.Count == 4)
+            {
+                ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
+                if (alreadyCollection != null)
+                {
+                    return ExpressionUtils.SameElements(arguments, alreadyCollection);
+                }
+
+                using (IEnumerator<Expression> en = arguments.GetEnumerator())
+                {
+                    en.MoveNext();
+                    if (en.Current == _arg0)
+                    {
+                        en.MoveNext();
+                        if (en.Current == _arg1)
+                        {
+                            en.MoveNext();
+                            if (en.Current == _arg2)
+                            {
+                                en.MoveNext();
+                                return en.Current == _arg3;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
 
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
@@ -430,6 +558,42 @@ namespace System.Linq.Expressions
 
         public override int ArgumentCount => 5;
 
+        internal override bool SameArguments(ICollection<Expression> arguments)
+        {
+            if (arguments != null && arguments.Count == 5)
+            {
+                ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
+                if (alreadyCollection != null)
+                {
+                    return ExpressionUtils.SameElements(arguments, alreadyCollection);
+                }
+
+                using (IEnumerator<Expression> en = arguments.GetEnumerator())
+                {
+                    en.MoveNext();
+                    if (en.Current == _arg0)
+                    {
+                        en.MoveNext();
+                        if (en.Current == _arg1)
+                        {
+                            en.MoveNext();
+                            if (en.Current == _arg2)
+                            {
+                                en.MoveNext();
+                                if (en.Current == _arg3)
+                                {
+                                    en.MoveNext();
+                                    return en.Current == _arg4;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
             return ReturnReadOnly(this, ref _arg0);
@@ -468,6 +632,9 @@ namespace System.Linq.Expressions
             return EmptyReadOnlyCollection<Expression>.Instance;
         }
 
+        internal override bool SameArguments(ICollection<Expression> arguments) =>
+            arguments == null || arguments.Count == 0;
+
         internal override MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression> args)
         {
             Debug.Assert(instance != null);
@@ -497,6 +664,20 @@ namespace System.Linq.Expressions
         }
 
         public override int ArgumentCount => 1;
+
+        internal override bool SameArguments(ICollection<Expression> arguments)
+        {
+            if (arguments != null && arguments.Count == 1)
+            {
+                using (IEnumerator<Expression> en = arguments.GetEnumerator())
+                {
+                    en.MoveNext();
+                    return en.Current == ReturnObject<Expression>(_arg0);
+                }
+            }
+
+            return false;
+        }
 
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
@@ -539,6 +720,30 @@ namespace System.Linq.Expressions
         }
 
         public override int ArgumentCount => 2;
+
+        internal override bool SameArguments(ICollection<Expression> arguments)
+        {
+            if (arguments != null && arguments.Count == 2)
+            {
+                ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
+                if (alreadyCollection != null)
+                {
+                    return ExpressionUtils.SameElements(arguments, alreadyCollection);
+                }
+
+                using (IEnumerator<Expression> en = arguments.GetEnumerator())
+                {
+                    en.MoveNext();
+                    if (en.Current == _arg0)
+                    {
+                        en.MoveNext();
+                        return en.Current == _arg1;
+                    }
+                }
+            }
+
+            return false;
+        }
 
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
@@ -583,6 +788,34 @@ namespace System.Linq.Expressions
         }
 
         public override int ArgumentCount => 3;
+
+        internal override bool SameArguments(ICollection<Expression> arguments)
+        {
+            if (arguments != null && arguments.Count == 3)
+            {
+                ReadOnlyCollection<Expression> alreadyCollection = _arg0 as ReadOnlyCollection<Expression>;
+                if (alreadyCollection != null)
+                {
+                    return ExpressionUtils.SameElements(arguments, alreadyCollection);
+                }
+
+                using (IEnumerator<Expression> en = arguments.GetEnumerator())
+                {
+                    en.MoveNext();
+                    if (en.Current == _arg0)
+                    {
+                        en.MoveNext();
+                        if (en.Current == _arg1)
+                        {
+                            en.MoveNext();
+                            return en.Current == _arg2;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
 
         internal override ReadOnlyCollection<Expression> GetOrMakeArguments()
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
@@ -66,10 +66,7 @@ namespace System.Linq.Expressions
             // Explicit null check here as otherwise wrong parameter name will be used.
             ContractUtils.RequiresNotNull(expressions, nameof(expressions));
 
-            // Ensure expressions is safe to enumerate twice.
-            // (If this means a second call to ToReadOnly it will return quickly).
-            expressions = expressions as ICollection<Expression> ?? expressions.ToReadOnly();
-            if (ExpressionUtils.SameElements(expressions, Expressions))
+            if (ExpressionUtils.SameElements(ref expressions, Expressions))
             {
                 return this;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
@@ -63,15 +63,18 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public NewArrayExpression Update(IEnumerable<Expression> expressions)
         {
-            if (expressions == Expressions)
+            if (expressions != null)
             {
-                return this;
+                expressions = expressions as ICollection<Expression> ?? expressions.ToReadOnly();
+                if (ExpressionUtils.SameElements(expressions, Expressions))
+                {
+                    return this;
+                }
             }
-            if (NodeType == ExpressionType.NewArrayInit)
-            {
-                return Expression.NewArrayInit(Type.GetElementType(), expressions);
-            }
-            return Expression.NewArrayBounds(Type.GetElementType(), expressions);
+
+            return NodeType == ExpressionType.NewArrayInit
+                ? NewArrayInit(Type.GetElementType(), expressions)
+                : NewArrayBounds(Type.GetElementType(), expressions);
         }
     }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
@@ -63,13 +63,15 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public NewArrayExpression Update(IEnumerable<Expression> expressions)
         {
-            if (expressions != null)
+            // Explicit null check here as otherwise wrong parameter name will be used.
+            ContractUtils.RequiresNotNull(expressions, nameof(expressions));
+
+            // Ensure expressions is safe to enumerate twice.
+            // (If this means a second call to ToReadOnly it will return quickly).
+            expressions = expressions as ICollection<Expression> ?? expressions.ToReadOnly();
+            if (ExpressionUtils.SameElements(expressions, Expressions))
             {
-                expressions = expressions as ICollection<Expression> ?? expressions.ToReadOnly();
-                if (ExpressionUtils.SameElements(expressions, Expressions))
-                {
-                    return this;
-                }
+                return this;
             }
 
             return NodeType == ExpressionType.NewArrayInit

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
@@ -82,10 +82,7 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public NewExpression Update(IEnumerable<Expression> arguments)
         {
-            // Ensure arguments is safe to enumerate twice.
-            // (If this means a second call to ToReadOnly it will return quickly).
-            arguments = arguments as ICollection<Expression> ?? arguments.ToReadOnly();
-            if (ExpressionUtils.SameElements(arguments, Arguments))
+            if (ExpressionUtils.SameElements(ref arguments, Arguments))
             {
                 return this;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
@@ -82,15 +82,16 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public NewExpression Update(IEnumerable<Expression> arguments)
         {
-            if (arguments == Arguments)
+            if (arguments != null)
             {
-                return this;
+                arguments = arguments as ICollection<Expression> ?? arguments.ToReadOnly();
+                if (ExpressionUtils.SameElements(arguments, Arguments))
+                {
+                    return this;
+                }
             }
-            if (Members != null)
-            {
-                return Expression.New(Constructor, arguments, Members);
-            }
-            return Expression.New(Constructor, arguments);
+
+            return Members != null ? New(Constructor, arguments, Members) : New(Constructor, arguments);
         }
     }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
@@ -82,13 +82,12 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public NewExpression Update(IEnumerable<Expression> arguments)
         {
-            if (arguments != null)
+            // Ensure arguments is safe to enumerate twice.
+            // (If this means a second call to ToReadOnly it will return quickly).
+            arguments = arguments as ICollection<Expression> ?? arguments.ToReadOnly();
+            if (ExpressionUtils.SameElements(arguments, Arguments))
             {
-                arguments = arguments as ICollection<Expression> ?? arguments.ToReadOnly();
-                if (ExpressionUtils.SameElements(arguments, Arguments))
-                {
-                    return this;
-                }
+                return this;
             }
 
             return Members != null ? New(Constructor, arguments, Members) : New(Constructor, arguments);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/RuntimeVariablesExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/RuntimeVariablesExpression.cs
@@ -60,8 +60,7 @@ namespace System.Linq.Expressions
         {
             if (variables != null)
             {
-                variables = variables as ICollection<ParameterExpression> ?? variables.ToReadOnly();
-                if (ExpressionUtils.SameElements(variables, Variables))
+                if (ExpressionUtils.SameElements(ref variables, Variables))
                 {
                     return this;
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/RuntimeVariablesExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/RuntimeVariablesExpression.cs
@@ -58,11 +58,16 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public RuntimeVariablesExpression Update(IEnumerable<ParameterExpression> variables)
         {
-            if (variables == Variables)
+            if (variables != null)
             {
-                return this;
+                variables = variables as ICollection<ParameterExpression> ?? variables.ToReadOnly();
+                if (ExpressionUtils.SameElements(variables, Variables))
+                {
+                    return this;
+                }
             }
-            return Expression.RuntimeVariables(variables);
+
+            return RuntimeVariables(variables);
         }
     }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchCase.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchCase.cs
@@ -52,8 +52,7 @@ namespace System.Linq.Expressions
         {
             if (body == Body & testValues != null)
             {
-                testValues = testValues as ICollection<Expression> ?? testValues.ToReadOnly();
-                if (ExpressionUtils.SameElements(testValues, TestValues))
+                if (ExpressionUtils.SameElements(ref testValues, TestValues))
                 {
                     return this;
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchCase.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchCase.cs
@@ -50,10 +50,15 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public SwitchCase Update(IEnumerable<Expression> testValues, Expression body)
         {
-            if (testValues == TestValues && body == Body)
+            if (body == Body & testValues != null)
             {
-                return this;
+                testValues = testValues as ICollection<Expression> ?? testValues.ToReadOnly();
+                if (ExpressionUtils.SameElements(testValues, TestValues))
+                {
+                    return this;
+                }
             }
+
             return Expression.SwitchCase(body, testValues);
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchExpression.cs
@@ -92,8 +92,7 @@ namespace System.Linq.Expressions
         {
             if (switchValue == SwitchValue & defaultBody == DefaultBody & cases != null)
             {
-                cases = cases as ICollection<SwitchCase> ?? cases.ToReadOnly();
-                if (ExpressionUtils.SameElements(cases, Cases))
+                if (ExpressionUtils.SameElements(ref cases, Cases))
                 {
                     return this;
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchExpression.cs
@@ -90,9 +90,13 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public SwitchExpression Update(Expression switchValue, IEnumerable<SwitchCase> cases, Expression defaultBody)
         {
-            if (switchValue == SwitchValue && cases == Cases && defaultBody == DefaultBody)
+            if (switchValue == SwitchValue & defaultBody == DefaultBody & cases != null)
             {
-                return this;
+                cases = cases as ICollection<SwitchCase> ?? cases.ToReadOnly();
+                if (ExpressionUtils.SameElements(cases, Cases))
+                {
+                    return this;
+                }
             }
             return Expression.Switch(Type, switchValue, defaultBody, Comparison, cases);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TryExpression.cs
@@ -85,8 +85,7 @@ namespace System.Linq.Expressions
         {
             if (body == Body & @finally == Finally & fault == Fault)
             {
-                handlers = handlers as ICollection<CatchBlock> ?? handlers.ToReadOnly();
-                if (ExpressionUtils.SameElements(handlers, Handlers))
+                if (ExpressionUtils.SameElements(ref handlers, Handlers))
                 {
                     return this;
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TryExpression.cs
@@ -83,11 +83,16 @@ namespace System.Linq.Expressions
         /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
         public TryExpression Update(Expression body, IEnumerable<CatchBlock> handlers, Expression @finally, Expression fault)
         {
-            if (body == Body && handlers == Handlers && @finally == Finally && fault == Fault)
+            if (body == Body & @finally == Finally & fault == Fault)
             {
-                return this;
+                handlers = handlers as ICollection<CatchBlock> ?? handlers.ToReadOnly();
+                if (ExpressionUtils.SameElements(handlers, Handlers))
+                {
+                    return this;
+                }
             }
-            return Expression.MakeTry(Type, body, @finally, fault, handlers);
+
+            return MakeTry(Type, body, @finally, fault, handlers);
         }
     }
 

--- a/src/System.Linq.Expressions/tests/Array/NewArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NewArrayBoundsTests.cs
@@ -267,5 +267,23 @@ namespace System.Linq.Expressions.Tests
             Assert.NotSame(newArrayExpression, newArrayExpression.Update(new[] { bound0, bound1, bound0, bound1 }));
             Assert.NotSame(newArrayExpression, newArrayExpression.Update(newArrayExpression.Expressions.Reverse()));
         }
+
+        [Fact]
+        public static void UpdateDoesntRepeatEnumeration()
+        {
+            Expression bound0 = Expression.Constant(2);
+            Expression bound1 = Expression.Constant(3);
+            NewArrayExpression newArrayExpression = Expression.NewArrayBounds(typeof(string), bound0, bound1);
+            Assert.NotSame(newArrayExpression, newArrayExpression.Update(new RunOnceEnumerable<Expression>(new[] { bound0 })));
+        }
+
+        [Fact]
+        public static void UpdateNullThrows()
+        {
+            Expression bound0 = Expression.Constant(2);
+            Expression bound1 = Expression.Constant(3);
+            NewArrayExpression newArrayExpression = Expression.NewArrayBounds(typeof(string), bound0, bound1);
+            Assert.Throws<ArgumentNullException>("expressions", () => newArrayExpression.Update(null));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Array/NewArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NewArrayBoundsTests.cs
@@ -247,5 +247,25 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentException>("type", () => Expression.NewArrayBounds(typeof(List<>.Enumerator), Expression.Constant(2)));
             Assert.Throws<ArgumentException>("type", () => Expression.NewArrayBounds(typeof(List<>).MakeGenericType(typeof(List<>)), Expression.Constant(2)));
         }
+
+        [Fact]
+        public static void UpdateSameReturnsSame()
+        {
+            Expression bound0 = Expression.Constant(2);
+            Expression bound1 = Expression.Constant(3);
+            NewArrayExpression newArrayExpression = Expression.NewArrayBounds(typeof(string), bound0, bound1);
+            Assert.Same(newArrayExpression, newArrayExpression.Update(new [] {bound0, bound1}));
+        }
+
+        [Fact]
+        public static void UpdateDifferentReturnsDifferent()
+        {
+            Expression bound0 = Expression.Constant(2);
+            Expression bound1 = Expression.Constant(3);
+            NewArrayExpression newArrayExpression = Expression.NewArrayBounds(typeof(string), bound0, bound1);
+            Assert.NotSame(newArrayExpression, newArrayExpression.Update(new[] { bound0 }));
+            Assert.NotSame(newArrayExpression, newArrayExpression.Update(new[] { bound0, bound1, bound0, bound1 }));
+            Assert.NotSame(newArrayExpression, newArrayExpression.Update(newArrayExpression.Expressions.Reverse()));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
@@ -1733,5 +1733,24 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(1, arr.Length);
             Assert.Equal(26, arr[0](13));
         }
+
+        [Fact]
+        public static void UpdateSameReturnsSame()
+        {
+            Expression element0 = Expression.Constant(2);
+            Expression element1 = Expression.Constant(3);
+            NewArrayExpression newArrayExpression = Expression.NewArrayInit(typeof(int), element0, element1);
+            Assert.Same(newArrayExpression, newArrayExpression.Update(new[] { element0, element1 }));
+        }
+
+        [Fact]
+        public static void UpdateDifferentReturnsDifferent()
+        {
+            Expression element0 = Expression.Constant(2);
+            Expression element1 = Expression.Constant(3);
+            NewArrayExpression newArrayExpression = Expression.NewArrayInit(typeof(int), element0, element1);
+            Assert.NotSame(newArrayExpression, newArrayExpression.Update(new[] { element0 }));
+            Assert.NotSame(newArrayExpression, newArrayExpression.Update(newArrayExpression.Expressions.Reverse()));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
@@ -1752,5 +1752,23 @@ namespace System.Linq.Expressions.Tests
             Assert.NotSame(newArrayExpression, newArrayExpression.Update(new[] { element0 }));
             Assert.NotSame(newArrayExpression, newArrayExpression.Update(newArrayExpression.Expressions.Reverse()));
         }
+
+        [Fact]
+        public static void UpdateDoesntRepeatEnumeration()
+        {
+            Expression element0 = Expression.Constant(2);
+            Expression element1 = Expression.Constant(3);
+            NewArrayExpression newArrayExpression = Expression.NewArrayInit(typeof(int), element0, element1);
+            Assert.NotSame(newArrayExpression, newArrayExpression.Update(new RunOnceEnumerable<Expression>(new[] { element0 })));
+        }
+
+        [Fact]
+        public static void UpdateNullThrows()
+        {
+            Expression element0 = Expression.Constant(2);
+            Expression element1 = Expression.Constant(3);
+            NewArrayExpression newArrayExpression = Expression.NewArrayInit(typeof(int), element0, element1);
+            Assert.Throws<ArgumentNullException>("expressions", () => newArrayExpression.Update(null));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Block/BlockFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockFactoryTests.cs
@@ -143,7 +143,7 @@ namespace System.Linq.Expressions.Tests
 
             BlockExpression res = node.Update(node.Variables, node.Expressions.ToArray());
 
-            Assert.NotSame(node, res);
+            Assert.Same(node, res);
 
             return res;
         }

--- a/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
@@ -316,7 +316,6 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [MemberData(nameof(ConstantValuesAndSizes))]
-        [ActiveIssue(3958)]
         public void RewriteToSameWithSameValues(object value, int blockSize)
         {
             ConstantExpression constant = Expression.Constant(value, value.GetType());

--- a/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
@@ -324,6 +324,7 @@ namespace System.Linq.Expressions.Tests
             BlockExpression block = Expression.Block(expressions);
             Assert.Same(block, block.Update(null, expressions));
             Assert.Same(block, block.Update(Enumerable.Empty<ParameterExpression>(), expressions));
+            Assert.Same(block, NoOpVisitor.Instance.Visit(block));
         }
 
         [Theory]
@@ -406,6 +407,59 @@ namespace System.Linq.Expressions.Tests
             BlockExpression block = Expression.Block(typeof(object), expressions);
 
             Assert.NotSame(block, new TestVistor().Visit(block));
+        }
+
+        [Theory, MemberData(nameof(BlockSizes))]
+        public void UpdateToNullArguments(int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(0);
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant);
+
+            BlockExpression block = Expression.Block(expressions);
+
+            Assert.Throws<ArgumentNullException>("expressions", () => block.Update(null, null));
+        }
+
+        [Theory, MemberData(nameof(BlockSizes))]
+        public void UpdateDoesntRepeatEnumeration(int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(0);
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant).ToArray();
+
+            BlockExpression block = Expression.Block(expressions);
+
+            Assert.Same(block, block.Update(null, new RunOnceEnumerable<Expression>(expressions)));
+            Assert.NotSame(
+                block,
+                block.Update(null, new RunOnceEnumerable<Expression>(PadBlock(blockSize - 1, Expression.Constant(1)))));
+        }
+
+        [Theory, MemberData(nameof(BlockSizes))]
+        public void UpdateDifferentSizeReturnsDifferent(int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(0);
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant).ToArray();
+
+            BlockExpression block = Expression.Block(expressions);
+
+            Assert.NotSame(block, block.Update(null, block.Expressions.Prepend(Expression.Empty())));
+        }
+
+        [Theory, MemberData(nameof(BlockSizes))]
+        public void UpdateAnyExpressionDifferentReturnsDifferent(int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(0);
+            Expression[] expressions = PadBlock(blockSize - 1, constant).ToArray();
+
+            BlockExpression block = Expression.Block(expressions);
+
+            for (int i = 0; i != expressions.Length; ++i)
+            {
+                Expression[] newExps = new Expression[expressions.Length];
+                expressions.CopyTo(newExps, 0);
+                newExps[i] = Expression.Constant(1);
+                Assert.NotSame(block, block.Update(null, newExps));
+            }
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
@@ -189,7 +189,6 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [MemberData(nameof(ConstantValuesAndSizes))]
-        [ActiveIssue(3958)]
         public void RewriteToSameWithSameValues(object value, int blockSize)
         {
             ConstantExpression constant = Expression.Constant(value, value.GetType());

--- a/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
@@ -197,6 +197,7 @@ namespace System.Linq.Expressions.Tests
             BlockExpression block = Expression.Block(SingleParameter, expressions);
             Assert.Same(block, block.Update(block.Variables.ToArray(), expressions));
             Assert.Same(block, block.Update(block.Variables.ToArray(), expressions));
+            Assert.Same(block, NoOpVisitor.Instance.Visit(block));
         }
 
         [Theory]
@@ -320,5 +321,32 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentException>("variables[1]", () => Expression.Block(typeof(object), vars, expressions));
             Assert.Throws<ArgumentException>("variables[1]", () => Expression.Block(typeof(object), vars, expressions.ToArray()));
         }
+
+        [Theory, MemberData(nameof(BlockSizes))]
+        public void UpdateDoesntRepeatEnumeration(int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(0);
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant).ToArray();
+            ParameterExpression[] vars = {Expression.Variable(typeof(int)), Expression.Variable(typeof(string))};
+
+            BlockExpression block = Expression.Block(vars, expressions);
+
+            Assert.Same(block, block.Update(new RunOnceEnumerable<ParameterExpression>(vars), block.Expressions));
+            vars = new[] {Expression.Variable(typeof(int)), Expression.Variable(typeof(string))};
+            Assert.NotSame(block, block.Update(new RunOnceEnumerable<ParameterExpression>(vars), block.Expressions));
+        }
+
+        [Theory, MemberData(nameof(BlockSizes))]
+        public void UpdateDifferentSizeReturnsDifferent(int blockSize)
+        {
+            ConstantExpression constant = Expression.Constant(0);
+            IEnumerable<Expression> expressions = PadBlock(blockSize - 1, constant).ToArray();
+            ParameterExpression[] vars = { Expression.Variable(typeof(int)), Expression.Variable(typeof(string)) };
+
+            BlockExpression block = Expression.Block(vars, expressions);
+
+            Assert.NotSame(block, block.Update(vars, block.Expressions.Prepend(Expression.Empty())));
+        }
+
     }
 }

--- a/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
@@ -65,7 +65,7 @@ namespace System.Linq.Expressions.Tests
                 Assert.Same(args[i], arguments[i]);
             }
 
-            MethodCallExpression updated = expr.Update(obj, arguments);
+            MethodCallExpression updated = expr.Update(obj, arguments.ToList());
             Assert.Same(expr, updated);
 
             var visited = (MethodCallExpression)new NopVisitor().Visit(expr);
@@ -316,7 +316,7 @@ namespace System.Linq.Expressions.Tests
 
             MethodCallExpression res = node.Update(node.Object, node.Arguments.ToArray());
 
-            Assert.NotSame(node, res);
+            Assert.Same(node, res);
 
             return res;
         }

--- a/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
@@ -321,6 +321,109 @@ namespace System.Linq.Expressions.Tests
             return res;
         }
 
+        [Fact]
+        public static void UpdateStaticNull()
+        {
+            MethodCallExpression expr = Expression.Call(typeof(MS).GetMethod(nameof(MS.S0)));
+            Assert.Same(expr, expr.Update(null, null));
+
+            for (int argNum = 1; argNum != 7; ++argNum)
+            {
+                ConstantExpression[] args = Enumerable.Range(0, argNum).Select(i => Expression.Constant(i)).ToArray();
+
+                expr = Expression.Call(typeof(MS).GetMethod("S" + argNum), args);
+
+                // Should attempt to create new expression, and fail due to incorrect arguments.
+                Assert.Throws<ArgumentException>("method", () => expr.Update(null, null));
+            }
+        }
+
+        [Fact]
+        public static void UpdateInstanceNull()
+        {
+            ConstantExpression instance = Expression.Constant(new MS());
+            MethodCallExpression expr = Expression.Call(instance, typeof(MS).GetMethod(nameof(MS.I0)));
+            Assert.Same(expr, expr.Update(instance, null));
+
+            for (int argNum = 1; argNum != 6; ++argNum)
+            {
+                ConstantExpression[] args = Enumerable.Range(0, argNum).Select(i => Expression.Constant(i)).ToArray();
+
+                expr = Expression.Call(instance, typeof(MS).GetMethod("I" + argNum), args);
+
+                // Should attempt to create new expression, and fail due to incorrect arguments.
+                Assert.Throws<ArgumentException>("method", () => expr.Update(instance, null));
+            }
+        }
+
+        [Fact]
+        public static void UpdateStaticExtraArguments()
+        {
+            for (int argNum = 0; argNum != 7; ++argNum)
+            {
+                ConstantExpression[] args = Enumerable.Range(0, argNum).Select(i => Expression.Constant(i)).ToArray();
+
+                MethodCallExpression expr = Expression.Call(typeof(MS).GetMethod("S" + argNum), args);
+
+                // Should attempt to create new expression, and fail due to incorrect arguments.
+                Assert.Throws<ArgumentException>("method", () => expr.Update(null, args.Append(Expression.Constant(-1))));
+            }
+        }
+
+        [Fact]
+        public static void UpdateInstanceExtraArguments()
+        {
+            ConstantExpression instance = Expression.Constant(new MS());
+            for (int argNum = 0; argNum != 6; ++argNum)
+            {
+                ConstantExpression[] args = Enumerable.Range(0, argNum).Select(i => Expression.Constant(i)).ToArray();
+
+                MethodCallExpression expr = Expression.Call(instance, typeof(MS).GetMethod("I" + argNum), args);
+
+                // Should attempt to create new expression, and fail due to incorrect arguments.
+                Assert.Throws<ArgumentException>("method", () => expr.Update(instance, args.Append(Expression.Constant(-1))));
+            }
+        }
+
+        [Fact]
+        public static void UpdateStaticDifferentArguments()
+        {
+            for (int argNum = 1; argNum != 7; ++argNum)
+            {
+                ConstantExpression[] args = Enumerable.Range(0, argNum).Select(i => Expression.Constant(i)).ToArray();
+
+                MethodCallExpression expr = Expression.Call(typeof(MS).GetMethod("S" + argNum), args);
+
+                ConstantExpression[] newArgs = new ConstantExpression[argNum];
+                for (int i = 0; i != argNum; ++i)
+                {
+                    args.CopyTo(newArgs, 0);
+                    newArgs[i] = Expression.Constant(i);
+                    Assert.NotSame(expr, expr.Update(null, newArgs));
+                }
+            }
+        }
+
+        [Fact]
+        public static void UpdateInstanceDifferentArguments()
+        {
+            ConstantExpression instance = Expression.Constant(new MS());
+            for (int argNum = 1; argNum != 6; ++argNum)
+            {
+                ConstantExpression[] args = Enumerable.Range(0, argNum).Select(i => Expression.Constant(i)).ToArray();
+
+                MethodCallExpression expr = Expression.Call(instance, typeof(MS).GetMethod("I" + argNum), args);
+
+                ConstantExpression[] newArgs = new ConstantExpression[argNum];
+                for (int i = 0; i != argNum; ++i)
+                {
+                    args.CopyTo(newArgs, 0);
+                    newArgs[i] = Expression.Constant(i);
+                    Assert.NotSame(expr, expr.Update(instance, newArgs));
+                }
+            }
+        }
+
         private static MethodCallExpression UpdateObj(MethodCallExpression node)
         {
             // Tests the call of Update to Expression.Call factories.

--- a/src/System.Linq.Expressions/tests/DynamicExpression/DynamicExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/DynamicExpression/DynamicExpressionTests.cs
@@ -1,0 +1,298 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Microsoft.CSharp.RuntimeBinder;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class DynamicExpressionTests
+    {
+        [Fact]
+        public void UpdateToSameReturnsSame0()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] {CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)});
+            DynamicExpression exp = Expression.MakeDynamic(typeof(Func<CallSite, object>), binder);
+            Assert.Same(exp, exp.Update(null));
+            Assert.Same(exp, exp.Update(Array.Empty<Expression>()));
+            Assert.Same(exp, exp.Update(Enumerable.Repeat<Expression>(null, 0)));
+            Assert.Same(exp, exp.Update(exp.Arguments));
+        }
+
+        [Fact]
+        public void UpdateToSameReturnsSame1()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] {CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)});
+            Expression arg = Expression.Constant(null);
+            DynamicExpression exp = Expression.MakeDynamic(typeof(Func<CallSite, object, object>), binder, arg);
+            Assert.Same(exp, exp.Update(new[] {arg}));
+            Assert.Same(exp, exp.Update(Enumerable.Repeat(arg, 1)));
+            Assert.Same(exp, exp.Update(exp.Arguments));
+        }
+
+        [Fact]
+        public void UpdateToSameReturnsSame2()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] {CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)});
+            Expression arg0 = Expression.Constant(null);
+            Expression arg1 = Expression.Constant(null);
+            DynamicExpression exp = Expression.MakeDynamic(
+                typeof(Func<CallSite, object, object, object>), binder, arg0, arg1);
+            Assert.Same(exp, exp.Update(new[] {arg0, arg1}));
+            Assert.Same(exp, exp.Update(exp.Arguments));
+        }
+
+        [Fact]
+        public void UpdateToSameReturnsSame3()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] {CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)});
+            Expression arg0 = Expression.Constant(null);
+            Expression arg1 = Expression.Constant(null);
+            Expression arg2 = Expression.Constant(null);
+            DynamicExpression exp = Expression.MakeDynamic(
+                typeof(Func<CallSite, object, object, object, object>), binder, arg0, arg1, arg2);
+            Assert.Same(exp, exp.Update(new[] {arg0, arg1, arg2}));
+            Assert.Same(exp, exp.Update(exp.Arguments));
+        }
+
+        [Fact]
+        public void UpdateToSameReturnsSame4()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] {CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)});
+            Expression arg0 = Expression.Constant(null);
+            Expression arg1 = Expression.Constant(null);
+            Expression arg2 = Expression.Constant(null);
+            Expression arg3 = Expression.Constant(null);
+            DynamicExpression exp = Expression.MakeDynamic(
+                typeof(Func<CallSite, object, object, object, object, object>), binder, arg0, arg1, arg2, arg3);
+            Assert.Same(exp, exp.Update(new[] {arg0, arg1, arg2, arg3}));
+            Assert.Same(exp, exp.Update(exp.Arguments));
+        }
+
+        [Fact]
+        public void UpdateToSameReturnsSame5()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] {CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)});
+            Expression arg0 = Expression.Constant(null);
+            Expression arg1 = Expression.Constant(null);
+            Expression arg2 = Expression.Constant(null);
+            Expression arg3 = Expression.Constant(null);
+            Expression arg4 = Expression.Constant(null);
+            DynamicExpression exp = Expression.MakeDynamic(
+                typeof(Func<CallSite, object, object, object, object, object, object>), binder, arg0, arg1, arg2, arg3,
+                arg4);
+            Assert.Same(exp, exp.Update(new[] {arg0, arg1, arg2, arg3, arg4}));
+            Assert.Same(exp, exp.Update(exp.Arguments));
+        }
+
+        [Fact]
+        public void UpdateToSameReturnsSameTyped0()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) });
+            DynamicExpression exp = Expression.MakeDynamic(typeof(Func<CallSite, string>), binder);
+            Assert.Same(exp, exp.Update(null));
+            Assert.Same(exp, exp.Update(Array.Empty<Expression>()));
+            Assert.Same(exp, exp.Update(Enumerable.Repeat<Expression>(null, 0)));
+            Assert.Same(exp, exp.Update(exp.Arguments));
+        }
+
+        [Fact]
+        public void UpdateToSameReturnsSameTyped1()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) });
+            Expression arg = Expression.Constant(null);
+            DynamicExpression exp = Expression.MakeDynamic(typeof(Func<CallSite, object, string>), binder, arg);
+            Assert.Same(exp, exp.Update(new[] { arg }));
+            Assert.Same(exp, exp.Update(Enumerable.Repeat(arg, 1)));
+            Assert.Same(exp, exp.Update(exp.Arguments));
+        }
+
+        [Fact]
+        public void UpdateToSameReturnsSameTyped2()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) });
+            Expression arg0 = Expression.Constant(null);
+            Expression arg1 = Expression.Constant(null);
+            DynamicExpression exp = Expression.MakeDynamic(
+                typeof(Func<CallSite, object, object, string>), binder, arg0, arg1);
+            Assert.Same(exp, exp.Update(new[] { arg0, arg1 }));
+            Assert.Same(exp, exp.Update(exp.Arguments));
+        }
+
+        [Fact]
+        public void UpdateToSameReturnsSameTyped3()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) });
+            Expression arg0 = Expression.Constant(null);
+            Expression arg1 = Expression.Constant(null);
+            Expression arg2 = Expression.Constant(null);
+            DynamicExpression exp = Expression.MakeDynamic(
+                typeof(Func<CallSite, object, object, object, string>), binder, arg0, arg1, arg2);
+            Assert.Same(exp, exp.Update(new[] { arg0, arg1, arg2 }));
+            Assert.Same(exp, exp.Update(exp.Arguments));
+        }
+
+        [Fact]
+        public void UpdateToSameReturnsSameTyped4()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) });
+            Expression arg0 = Expression.Constant(null);
+            Expression arg1 = Expression.Constant(null);
+            Expression arg2 = Expression.Constant(null);
+            Expression arg3 = Expression.Constant(null);
+            DynamicExpression exp = Expression.MakeDynamic(
+                typeof(Func<CallSite, object, object, object, object, string>), binder, arg0, arg1, arg2, arg3);
+            Assert.Same(exp, exp.Update(new[] { arg0, arg1, arg2, arg3 }));
+            Assert.Same(exp, exp.Update(exp.Arguments));
+        }
+
+        [Fact]
+        public void UpdateToSameReturnsSameTyped5()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) });
+            Expression arg0 = Expression.Constant(null);
+            Expression arg1 = Expression.Constant(null);
+            Expression arg2 = Expression.Constant(null);
+            Expression arg3 = Expression.Constant(null);
+            Expression arg4 = Expression.Constant(null);
+            DynamicExpression exp = Expression.MakeDynamic(
+                typeof(Func<CallSite, object, object, object, object, object, string>), binder, arg0, arg1, arg2, arg3,
+                arg4);
+            Assert.Same(exp, exp.Update(new[] { arg0, arg1, arg2, arg3, arg4 }));
+            Assert.Same(exp, exp.Update(exp.Arguments));
+        }
+
+        [Fact]
+        public void UpdateToDifferentReturnsDifferent0()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) });
+            DynamicExpression exp = Expression.MakeDynamic(typeof(Func<CallSite, object>), binder);
+            // Wrong number of arguments continues to attempt to create new expression, which fails.
+            Assert.Throws<ArgumentException>("method", () => exp.Update(new [] {Expression.Constant(null)}));
+        }
+
+        [Fact]
+        public void UpdateToDifferentReturnsDifferent1()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) });
+            Expression arg = Expression.Constant(null);
+            DynamicExpression exp = Expression.MakeDynamic(typeof(Func<CallSite, object, object>), binder, arg);
+            Assert.NotSame(exp, exp.Update(new[] { Expression.Constant(null) }));
+            // Wrong number of arguments continues to attempt to create new expression, which fails.
+            Assert.Throws<ArgumentException>("method", () => exp.Update(null));
+            Assert.Throws<ArgumentException>("method", () => exp.Update(new[] { arg, arg }));
+        }
+
+        [Fact]
+        public void UpdateToDifferentReturnsDifferent2()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) });
+            Expression arg0 = Expression.Constant(null);
+            Expression arg1 = Expression.Constant(null);
+            DynamicExpression exp = Expression.MakeDynamic(
+                typeof(Func<CallSite, object, object, object>), binder, arg0, arg1);
+            Assert.NotSame(exp, exp.Update(new[] { arg0, arg0 }));
+            Assert.NotSame(exp, exp.Update(new[] { arg1, arg0 }));
+            // Wrong number of arguments continues to attempt to create new expression, which fails.
+            Assert.Throws<ArgumentException>("method", () => exp.Update(null));
+            Assert.Throws<ArgumentException>("method", () => exp.Update(new Expression[0]));
+        }
+
+        [Fact]
+        public void UpdateToDifferentReturnsDifferent3()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) });
+            Expression arg0 = Expression.Constant(null);
+            Expression arg1 = Expression.Constant(null);
+            Expression arg2 = Expression.Constant(null);
+            DynamicExpression exp = Expression.MakeDynamic(
+                typeof(Func<CallSite, object, object, object, object>), binder, arg0, arg1, arg2);
+            Assert.NotSame(exp, exp.Update(new[] { arg1, arg1, arg2 }));
+            Assert.NotSame(exp, exp.Update(new[] { arg0, arg0, arg2 }));
+            Assert.NotSame(exp, exp.Update(new[] { arg0, arg1, arg0 }));
+            // Wrong number of arguments continues to attempt to create new expression, which fails.
+            Assert.Throws<ArgumentException>("method", () => exp.Update(null));
+            Assert.Throws<ArgumentException>("method", () => exp.Update(new Expression[0]));
+        }
+
+        [Fact]
+        public void UpdateToDifferentReturnsDifferent4()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) });
+            Expression arg0 = Expression.Constant(null);
+            Expression arg1 = Expression.Constant(null);
+            Expression arg2 = Expression.Constant(null);
+            Expression arg3 = Expression.Constant(null);
+            DynamicExpression exp = Expression.MakeDynamic(
+                typeof(Func<CallSite, object, object, object, object, object>), binder, arg0, arg1, arg2, arg3);
+            Assert.NotSame(exp, exp.Update(new[] { arg1, arg1, arg2, arg3 }));
+            Assert.NotSame(exp, exp.Update(new[] { arg0, arg0, arg2, arg3 }));
+            Assert.NotSame(exp, exp.Update(new[] { arg0, arg1, arg0, arg3 }));
+            Assert.NotSame(exp, exp.Update(new[] { arg0, arg1, arg2, arg0 }));
+            // Wrong number of arguments continues to attempt to create new expression, which fails.
+            Assert.Throws<ArgumentException>("method", () => exp.Update(null));
+            Assert.Throws<ArgumentException>("method", () => exp.Update(new Expression[0]));
+        }
+
+        [Fact]
+        public void UpdateToDifferentReturnsDifferent5()
+        {
+            CallSiteBinder binder = Binder.GetMember(
+                CSharpBinderFlags.None, "Member", GetType(),
+                new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) });
+            Expression arg0 = Expression.Constant(null);
+            Expression arg1 = Expression.Constant(null);
+            Expression arg2 = Expression.Constant(null);
+            Expression arg3 = Expression.Constant(null);
+            Expression arg4 = Expression.Constant(null);
+            DynamicExpression exp = Expression.MakeDynamic(
+                typeof(Func<CallSite, object, object, object, object, object, object>), binder, arg0, arg1, arg2, arg3,
+                arg4);
+            Assert.NotSame(exp, exp.Update(new[] { arg1, arg1, arg2, arg3, arg4 }));
+            Assert.NotSame(exp, exp.Update(new[] { arg0, arg0, arg2, arg3, arg4 }));
+            Assert.NotSame(exp, exp.Update(new[] { arg0, arg1, arg0, arg3, arg4 }));
+            Assert.NotSame(exp, exp.Update(new[] { arg0, arg1, arg2, arg0, arg4 }));
+            Assert.NotSame(exp, exp.Update(new[] { arg0, arg1, arg2, arg3, arg0 }));
+            // Wrong number of arguments continues to attempt to create new expression, which fails.
+            Assert.Throws<ArgumentException>("method", () => exp.Update(null));
+            Assert.Throws<ArgumentException>("method", () => exp.Update(new Expression[0]));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -1278,7 +1278,6 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
-        [ActiveIssue(3958)]
         public void UpdateTrySameChildrenDifferentCollectionsSameNode()
         {
             TryExpression tryExp = Expression.TryCatchFinally(Expression.Empty(), Expression.Empty(), Expression.Catch(typeof(Exception), Expression.Empty()));

--- a/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -1303,6 +1303,15 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        public void UpdateDoesntRepeatEnumeration()
+        {
+            TryExpression tryExp = Expression.TryCatchFinally(Expression.Empty(), Expression.Empty(), Expression.Catch(typeof(Exception), Expression.Empty()));
+            IEnumerable<CatchBlock> newHandlers =
+                new RunOnceEnumerable<CatchBlock>(new[] {Expression.Catch(typeof(Exception), Expression.Empty())});
+            Assert.NotSame(tryExp, tryExp.Update(tryExp.Body, newHandlers, tryExp.Finally, null));
+        }
+
+        [Fact]
         public void UpdateTryDiffFinallyDiffNode()
         {
             TryExpression tryExp = Expression.TryCatchFinally(Expression.Empty(), Expression.Empty(), Expression.Catch(typeof(Exception), Expression.Empty()));

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
+using Xunit;
 
 namespace System.Linq.Expressions.Tests
 {
@@ -452,5 +453,25 @@ namespace System.Linq.Expressions.Tests
             expression.VerifyInstructions(instructions);
 #endif
         }
+    }
+
+    public class RunOnceEnumerable<T> : IEnumerable<T>
+    {
+        private readonly IEnumerable<T> _source;
+        private bool _called;
+
+        public RunOnceEnumerable(IEnumerable<T> source)
+        {
+            _source = source;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            Assert.False(_called);
+            _called = true;
+            return _source.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionTests.cs
@@ -28,6 +28,33 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        public void UpdateDoesntRepeatEnumeration()
+        {
+            SampleClassWithProperties instance = new SampleClassWithProperties { DefaultProperty = new List<int> { 100, 101 } };
+            IndexExpression expr = instance.DefaultIndexExpression;
+
+            Assert.Same(expr, expr.Update(expr.Object, new RunOnceEnumerable<Expression>(instance.DefaultArguments)));
+        }
+
+        [Fact]
+        public void UpdateDifferentObjectTest()
+        {
+            SampleClassWithProperties instance = new SampleClassWithProperties { DefaultProperty = new List<int> { 100, 101 } };
+            IndexExpression expr = instance.DefaultIndexExpression;
+
+            Assert.NotSame(expr, expr.Update(instance.DefaultPropertyExpression, instance.DefaultArguments));
+        }
+
+        [Fact]
+        public void UpdateDifferentArgumentsTest()
+        {
+            SampleClassWithProperties instance = new SampleClassWithProperties { DefaultProperty = new List<int> { 100, 101 } };
+            IndexExpression expr = instance.DefaultIndexExpression;
+
+            Assert.NotSame(expr, expr.Update(expr.Object, new [] { Expression.Constant(0)}));
+        }
+
+        [Fact]
         public void UpdateTest()
         {
             SampleClassWithProperties instance = new SampleClassWithProperties

--- a/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/IndexExpression/IndexExpressionTests.cs
@@ -17,7 +17,7 @@ namespace System.Linq.Expressions.Tests
             SampleClassWithProperties instance = new SampleClassWithProperties { DefaultProperty = new List<int> { 100, 101 } };
             IndexExpression expr = instance.DefaultIndexExpression;
 
-            IndexExpression exprUpdated = expr.Update(expr.Object, expr.Arguments);
+            IndexExpression exprUpdated = expr.Update(expr.Object, instance.DefaultArguments);
 
             // Has to be the same, because everything is the same.
             Assert.Same(expr, exprUpdated);

--- a/src/System.Linq.Expressions/tests/Invoke/InvokeFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvokeFactoryTests.cs
@@ -114,7 +114,7 @@ namespace System.Linq.Expressions.Tests
 
             InvocationExpression res = node.Update(node.Expression, node.Arguments.ToArray());
 
-            Assert.NotSame(node, res);
+            Assert.Same(node, res);
 
             return res;
         }

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -449,7 +449,7 @@ namespace System.Linq.Expressions.Tests
         {
             ParameterExpression param = Expression.Parameter(typeof(int));
             Expression<Func<int, int>> identExp = Expression.Lambda<Func<int, int>>(param, param);
-            Assert.Same(identExp, identExp.Update(param, identExp.Parameters));
+            Assert.Same(identExp, identExp.Update(param, new[] {param}));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -447,30 +447,111 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void UpdateSameReturnsSame()
         {
-            ParameterExpression param = Expression.Parameter(typeof(int));
-            Expression<Func<int, int>> identExp = Expression.Lambda<Func<int, int>>(param, param);
-            Assert.Same(identExp, identExp.Update(param, new[] {param}));
+            Expression body = Expression.Empty();
+            ParameterExpression[] pars = Array.Empty<ParameterExpression>();
+            Expression<Action> lambda0 = Expression.Lambda<Action>(body, pars);
+            Assert.Same(lambda0, lambda0.Update(body, null));
+            Assert.Same(lambda0, lambda0.Update(body, pars));
+            pars = pars.Append(Expression.Parameter(typeof(int))).ToArray();
+            Expression<Action<int>> lambda1 = Expression.Lambda<Action<int>>(body, pars);
+            Assert.Same(lambda1, lambda1.Update(body, pars));
+            pars = pars.Append(Expression.Parameter(typeof(int))).ToArray();
+            Expression<Action<int, int>> lambda2 = Expression.Lambda<Action<int, int>>(body, pars);
+            Assert.Same(lambda2, lambda2.Update(body, pars));
+            pars = pars.Append(Expression.Parameter(typeof(int))).ToArray();
+            Expression<Action<int, int, int>> lambda3 = Expression.Lambda<Action<int, int, int>>(body, pars);
+            Assert.Same(lambda3, lambda3.Update(body, pars));
+            pars = pars.Append(Expression.Parameter(typeof(int))).ToArray();
+            Expression<Action<int, int, int, int>> lambda4 = Expression.Lambda<Action<int, int, int, int>>(body, pars);
+            Assert.Same(lambda4, lambda4.Update(body, pars));
+        }
+
+        [Fact]
+        public void UpdateDoesntRepeatEnumeration()
+        {
+            Expression body = Expression.Empty();
+            ParameterExpression[] pars = Array.Empty<ParameterExpression>();
+            Expression<Action> lambda0 = Expression.Lambda<Action>(body, pars);
+            Assert.Same(lambda0, lambda0.Update(body, new RunOnceEnumerable<ParameterExpression>(pars)));
+            pars = pars.Append(Expression.Parameter(typeof(int))).ToArray();
+            Expression<Action<int>> lambda1 = Expression.Lambda<Action<int>>(body, pars);
+            Assert.Same(lambda1, lambda1.Update(body, new RunOnceEnumerable<ParameterExpression>(pars)));
+            pars = pars.Append(Expression.Parameter(typeof(int))).ToArray();
+            Expression<Action<int, int>> lambda2 = Expression.Lambda<Action<int, int>>(body, pars);
+            Assert.Same(lambda2, lambda2.Update(body, new RunOnceEnumerable<ParameterExpression>(pars)));
+            pars = pars.Append(Expression.Parameter(typeof(int))).ToArray();
+            Expression<Action<int, int, int>> lambda3 = Expression.Lambda<Action<int, int, int>>(body, pars);
+            Assert.Same(lambda3, lambda3.Update(body, new RunOnceEnumerable<ParameterExpression>(pars)));
+            pars = pars.Append(Expression.Parameter(typeof(int))).ToArray();
+            Expression<Action<int, int, int, int>> lambda4 = Expression.Lambda<Action<int, int, int, int>>(body, pars);
+            Assert.Same(lambda4, lambda4.Update(body, new RunOnceEnumerable<ParameterExpression>(pars)));
         }
 
         [Fact]
         public void UpdateDifferentBodyReturnsDifferent()
         {
-            ParameterExpression param = Expression.Parameter(typeof(int));
-            Expression<Func<int, int>> identExp = Expression.Lambda<Func<int, int>>(param, param);
-            Assert.NotSame(identExp, identExp.Update(Expression.UnaryPlus(param), identExp.Parameters));
+            Expression body = Expression.Empty();
+            Expression newBody = Expression.Empty();
+            ParameterExpression[] pars = Array.Empty<ParameterExpression>();
+            Expression<Action> lambda0 = Expression.Lambda<Action>(body, pars);
+            Assert.NotSame(lambda0, lambda0.Update(newBody, pars));
+            pars = pars.Append(Expression.Parameter(typeof(int))).ToArray();
+            Expression<Action<int>> lambda1 = Expression.Lambda<Action<int>>(body, pars);
+            Assert.NotSame(lambda1, lambda1.Update(newBody, pars));
+            pars = pars.Append(Expression.Parameter(typeof(int))).ToArray();
+            Expression<Action<int, int>> lambda2 = Expression.Lambda<Action<int, int>>(body, pars);
+            Assert.NotSame(lambda2, lambda2.Update(newBody, pars));
+            pars = pars.Append(Expression.Parameter(typeof(int))).ToArray();
+            Expression<Action<int, int, int>> lambda3 = Expression.Lambda<Action<int, int, int>>(body, pars);
+            Assert.NotSame(lambda3, lambda3.Update(newBody, pars));
+            pars = pars.Append(Expression.Parameter(typeof(int))).ToArray();
+            Expression<Action<int, int, int, int>> lambda4 = Expression.Lambda<Action<int, int, int, int>>(body, pars);
+            Assert.NotSame(lambda4, lambda4.Update(newBody, pars));
         }
 
         [Fact]
         public void UpdateDifferentParamsReturnsDifferent()
         {
-            ParameterExpression param0 = Expression.Parameter(typeof(int));
-            ParameterExpression param1 = Expression.Parameter(typeof(int));
-            Expression<Func<int, int, int>> add = Expression.Lambda<Func<int, int, int>>(
-                Expression.Add(param0, param1),
-                param0,
-                param1
-                );
-            Assert.NotSame(add, add.Update(add.Body, new[] {param1, param0}));
+            Expression body = Expression.Empty();
+            ParameterExpression[] pars = Array.Empty<ParameterExpression>();
+            Expression<Action> lambda0 = Expression.Lambda<Action>(body, pars);
+            VerifyUpdateDifferentParamsReturnsDifferent(lambda0, pars);
+            pars = pars.Append(Expression.Parameter(typeof(int))).ToArray();
+            Expression<Action<int>> lambda1 = Expression.Lambda<Action<int>>(body, pars);
+            VerifyUpdateDifferentParamsReturnsDifferent(lambda1, pars);
+            pars = pars.Append(Expression.Parameter(typeof(int))).ToArray();
+            Expression<Action<int, int>> lambda2 = Expression.Lambda<Action<int, int>>(body, pars);
+            VerifyUpdateDifferentParamsReturnsDifferent(lambda2, pars);
+            pars = pars.Append(Expression.Parameter(typeof(int))).ToArray();
+            Expression<Action<int, int, int>> lambda3 = Expression.Lambda<Action<int, int, int>>(body, pars);
+            VerifyUpdateDifferentParamsReturnsDifferent(lambda3, pars);
+            pars = pars.Append(Expression.Parameter(typeof(int))).ToArray();
+            Expression<Action<int, int, int, int>> lambda4 = Expression.Lambda<Action<int, int, int, int>>(body, pars);
+            VerifyUpdateDifferentParamsReturnsDifferent(lambda4, pars);
+        }
+
+        private static void VerifyUpdateDifferentParamsReturnsDifferent<TDelegate>(Expression<TDelegate> lamda, ParameterExpression[] pars)
+        {
+            // Should try to create new lambda, but should fail as should have wrong number of arguments.
+            Assert.Throws<ArgumentException>(() => lamda.Update(lamda.Body, pars.Append(Expression.Parameter(typeof(int)))));
+
+            if (pars.Length != 0)
+            {
+                Assert.Throws<ArgumentException>(() => lamda.Update(lamda.Body, null));
+                for (int i = 0; i != pars.Length; ++i)
+                {
+                    ParameterExpression[] newPars = new ParameterExpression[pars.Length];
+                    pars.CopyTo(newPars, 0);
+                    newPars[i] = Expression.Parameter(typeof(int));
+                    Assert.NotSame(lamda, lamda.Update(lamda.Body, newPars));
+                }
+
+                IEnumerable<ParameterExpression> diffPars = new RunOnceEnumerable<ParameterExpression>(
+                    Enumerable.Range(0, lamda.Parameters.Count) // Trigger Parameters collection build.
+                    .Select(_ => Expression.Parameter(typeof(int))));
+
+                Assert.NotSame(lamda, lamda.Update(lamda.Body, diffPars));
+            }
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
@@ -193,6 +193,18 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        public void UpdateNullThrows()
+        {
+            ListInitExpression init = Expression.ListInit(
+                Expression.New(typeof(List<int>)),
+                Expression.Constant(1),
+                Expression.Constant(2),
+                Expression.Constant(3));
+            Assert.Throws<ArgumentNullException>("newExpression", () => init.Update(null, init.Initializers));
+            Assert.Throws<ArgumentNullException>("initializers", () => init.Update(init.NewExpression, null));
+        }
+
+        [Fact]
         public void UpdateDifferentNewReturnsDifferent()
         {
             ListInitExpression init = Expression.ListInit(
@@ -220,7 +232,28 @@ namespace System.Linq.Expressions.Tests
                 Expression.ElementInit(meth, Expression.Constant(2)),
                 Expression.ElementInit(meth, Expression.Constant(3))
             };
-            Assert.NotSame(init, init.Update(Expression.New(typeof(List<int>)), inits));
+            Assert.NotSame(init, init.Update(init.NewExpression, inits));
+        }
+
+        [Fact]
+        public void UpdateDoesntRepeatEnumeration()
+        {
+            MethodInfo meth = typeof(List<int>).GetMethod("Add");
+            ElementInit[] inits = new[]
+            {
+                Expression.ElementInit(meth, Expression.Constant(1)),
+                Expression.ElementInit(meth, Expression.Constant(2)),
+                Expression.ElementInit(meth, Expression.Constant(3))
+            };
+            ListInitExpression init = Expression.ListInit(Expression.New(typeof(List<int>)), inits);
+            IEnumerable<ElementInit> newInits = new RunOnceEnumerable<ElementInit>(
+                new[]
+                {
+                    Expression.ElementInit(meth, Expression.Constant(1)),
+                    Expression.ElementInit(meth, Expression.Constant(2)),
+                    Expression.ElementInit(meth, Expression.Constant(3))
+                });
+            Assert.NotSame(init, init.Update(init.NewExpression, newInits));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
@@ -189,7 +189,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Constant(1),
                 Expression.Constant(2),
                 Expression.Constant(3));
-            Assert.Same(init, init.Update(init.NewExpression, init.Initializers));
+            Assert.Same(init, init.Update(init.NewExpression, init.Initializers.ToArray()));
         }
 
         [Fact]
@@ -214,6 +214,12 @@ namespace System.Linq.Expressions.Tests
                 Expression.ElementInit(meth, Expression.Constant(3))
             };
             ListInitExpression init = Expression.ListInit(Expression.New(typeof(List<int>)), inits);
+            inits = new[]
+            {
+                Expression.ElementInit(meth, Expression.Constant(1)),
+                Expression.ElementInit(meth, Expression.Constant(2)),
+                Expression.ElementInit(meth, Expression.Constant(3))
+            };
             Assert.NotSame(init, init.Update(Expression.New(typeof(List<int>)), inits));
         }
 

--- a/src/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
@@ -237,8 +237,12 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void UpdateSameReturnsSame()
         {
-            MemberListBinding binding = Expression.ListBind(typeof(ListWrapper<int>).GetProperty(nameof(ListWrapper<int>.ListProperty)), Enumerable.Range(0, 3).Select(i => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(i))));
-            Assert.Same(binding, binding.Update(binding.Initializers));
+            ElementInit[] initializers = Enumerable.Range(0, 3)
+                .Select(i => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(i)))
+                .ToArray();
+            MemberListBinding binding = Expression.ListBind(
+                typeof(ListWrapper<int>).GetProperty(nameof(ListWrapper<int>.ListProperty)), initializers);
+            Assert.Same(binding, binding.Update(initializers));
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
@@ -231,7 +231,35 @@ namespace System.Linq.Expressions.Tests
         public void UpdateDifferentReturnsDifferent()
         {
             MemberListBinding binding = Expression.ListBind(typeof(ListWrapper<int>).GetProperty(nameof(ListWrapper<int>.ListProperty)), Enumerable.Range(0, 3).Select(i => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(i))));
-            Assert.NotSame(binding, binding.Update(new[] {Expression.ElementInit(typeof(List<int>).GetMethod(nameof(List<int>.Add)), Expression.Constant(1))}));
+            Assert.NotSame(binding, binding.Update(new[] { Expression.ElementInit(typeof(List<int>).GetMethod(nameof(List<int>.Add)), Expression.Constant(1)) }));
+        }
+
+        [Fact]
+        public void UpdateDoesntRepeatEnumeration()
+        {
+            MemberListBinding binding = Expression.ListBind(
+                typeof(ListWrapper<int>).GetProperty(nameof(ListWrapper<int>.ListProperty)),
+                Enumerable.Range(0, 3)
+                    .Select(i => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(i))));
+            Assert.NotSame(
+                binding,
+                binding.Update(
+                    new RunOnceEnumerable<ElementInit>(
+                        new[]
+                        {
+                            Expression.ElementInit(
+                                typeof(List<int>).GetMethod(nameof(List<int>.Add)), Expression.Constant(1))
+                        })));
+        }
+
+        [Fact]
+        public void UpdateNullThrows()
+        {
+            MemberListBinding binding = Expression.ListBind(
+                typeof(ListWrapper<int>).GetProperty(nameof(ListWrapper<int>.ListProperty)),
+                Enumerable.Range(0, 3)
+                    .Select(i => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(i))));
+            Assert.Throws<ArgumentNullException>("initializers", () => binding.Update(null));
         }
 
         [Fact]

--- a/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
@@ -105,12 +105,28 @@ namespace System.Linq.Expressions.Tests
 
 
         [Fact]
-        public void UpdateDifferentReturnsDifferet()
+        public void UpdateDifferentReturnsDifferent()
         {
             MemberAssignment bind = Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(3));
             MemberMemberBinding memberBind = Expression.MemberBind(typeof(Outer).GetProperty(nameof(Outer.InnerProperty)), bind);
             Assert.NotSame(memberBind, memberBind.Update(new[] {Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(3))}));
             Assert.NotSame(memberBind, memberBind.Update(Enumerable.Empty<MemberBinding>()));
+        }
+
+        [Fact]
+        public void UpdateNullThrows()
+        {
+            MemberAssignment bind = Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(3));
+            MemberMemberBinding memberBind = Expression.MemberBind(typeof(Outer).GetProperty(nameof(Outer.InnerProperty)), bind);
+            Assert.Throws<ArgumentNullException>("bindings", () => memberBind.Update(null));
+        }
+
+        [Fact]
+        public void UpdateDoesntRepeatEnumeration()
+        {
+            MemberAssignment bind = Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(3));
+            MemberMemberBinding memberBind = Expression.MemberBind(typeof(Outer).GetProperty(nameof(Outer.InnerProperty)), bind);
+            Assert.NotSame(memberBind, memberBind.Update(new RunOnceEnumerable<MemberBinding>(new[] { Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(3)) })));
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]

--- a/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
@@ -95,6 +95,24 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentException>(() => Expression.MemberInit(newExp, bind));
         }
 
+        [Fact]
+        public void UpdateSameReturnsSame()
+        {
+            MemberAssignment bind = Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(3));
+            MemberMemberBinding memberBind = Expression.MemberBind(typeof(Outer).GetProperty(nameof(Outer.InnerProperty)), bind);
+            Assert.Same(memberBind, memberBind.Update(Enumerable.Repeat(bind, 1)));
+        }
+
+
+        [Fact]
+        public void UpdateDifferentReturnsDifferet()
+        {
+            MemberAssignment bind = Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(3));
+            MemberMemberBinding memberBind = Expression.MemberBind(typeof(Outer).GetProperty(nameof(Outer.InnerProperty)), bind);
+            Assert.NotSame(memberBind, memberBind.Update(new[] {Expression.Bind(typeof(Inner).GetProperty(nameof(Inner.Value)), Expression.Constant(3))}));
+            Assert.NotSame(memberBind, memberBind.Update(Enumerable.Empty<MemberBinding>()));
+        }
+
         [Theory, ClassData(typeof(CompilationTypes))]
         public void InnerProperty(bool useInterpreter)
         {

--- a/src/System.Linq.Expressions/tests/MemberInit/MemberInitTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/MemberInitTests.cs
@@ -41,6 +41,37 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal("new X() {XS = {Void Add(Int32)(a), Void Add(Int32)(b)}}", e6.ToString());
         }
 
+        [Fact]
+        public static void UpdateSameReturnsSame()
+        {
+            MemberAssignment bind0 = Expression.Bind(typeof(Y).GetProperty(nameof(Y.Z)), Expression.Parameter(typeof(int), "z"));
+            MemberAssignment bind1 = Expression.Bind(typeof(Y).GetProperty(nameof(Y.A)), Expression.Parameter(typeof(int), "a"));
+            NewExpression newExp = Expression.New(typeof(Y));
+            MemberInitExpression init = Expression.MemberInit(newExp, bind0, bind1);
+            Assert.Same(init, init.Update(newExp, new [] {bind0, bind1}));
+        }
+
+        [Fact]
+        public static void UpdateDifferentBindingsReturnsDifferent()
+        {
+            MemberAssignment bind0 = Expression.Bind(typeof(Y).GetProperty(nameof(Y.Z)), Expression.Parameter(typeof(int), "z"));
+            MemberAssignment bind1 = Expression.Bind(typeof(Y).GetProperty(nameof(Y.A)), Expression.Parameter(typeof(int), "a"));
+            NewExpression newExp = Expression.New(typeof(Y));
+            MemberInitExpression init = Expression.MemberInit(newExp, bind0, bind1);
+            Assert.NotSame(init, init.Update(newExp, new[] { bind0, bind1, bind0 }));
+            Assert.NotSame(init, init.Update(newExp, new[] { bind1, bind0 }));
+        }
+
+        [Fact]
+        public static void UpdateDifferentNewReturnsDifferent()
+        {
+            MemberAssignment bind0 = Expression.Bind(typeof(Y).GetProperty(nameof(Y.Z)), Expression.Parameter(typeof(int), "z"));
+            MemberAssignment bind1 = Expression.Bind(typeof(Y).GetProperty(nameof(Y.A)), Expression.Parameter(typeof(int), "a"));
+            NewExpression newExp = Expression.New(typeof(Y));
+            MemberInitExpression init = Expression.MemberInit(newExp, bind0, bind1);
+            Assert.NotSame(init, init.Update(Expression.New(typeof(Y)), new[] { bind0, bind1 }));
+        }
+
         #endregion
 
         #region Test verifiers

--- a/src/System.Linq.Expressions/tests/New/NewTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewTests.cs
@@ -460,6 +460,13 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal("new Bar(Foo = foo, Qux = qux)", e4.ToString());
         }
 
+        [Fact]
+        public static void NullUpdateValidForEmptyParameters()
+        {
+            NewExpression newExp = Expression.New(typeof(Bar).GetConstructor(Type.EmptyTypes));
+            Assert.Same(newExp, newExp.Update(null));
+        }
+
         public static IEnumerable<object[]> Type_InvalidType_TestData()
         {
             yield return new object[] { typeof(void) };

--- a/src/System.Linq.Expressions/tests/New/NewWithTwoParametersTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewWithTwoParametersTests.cs
@@ -14,8 +14,8 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNewWithTwoParametersStructWithValueTest(bool useInterpreter)
         {
-            int[] array1 = new int[] { 0, 1, -1, int.MinValue, int.MaxValue };
-            double[] array2 = new double[] { 0, 1, -1, double.MinValue, double.MaxValue, double.Epsilon, double.NegativeInfinity, double.PositiveInfinity, double.NaN };
+            int[] array1 = { 0, 1, -1, int.MinValue, int.MaxValue };
+            double[] array2 = { 0, 1, -1, double.MinValue, double.MaxValue, double.Epsilon, double.NegativeInfinity, double.PositiveInfinity, double.NaN };
             for (int i = 0; i < array1.Length; i++)
             {
                 for (int j = 0; j < array2.Length; j++)
@@ -28,8 +28,8 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNewWithTwoParametersCustom2Test(bool useInterpreter)
         {
-            int[] array1 = new int[] { 0, 1, -1, int.MinValue, int.MaxValue };
-            string[] array2 = new string[] { null, "", "a", "foo" }; ;
+            int[] array1 = { 0, 1, -1, int.MinValue, int.MaxValue };
+            string[] array2 = { null, "", "a", "foo" }; ;
             for (int i = 0; i < array1.Length; i++)
             {
                 for (int j = 0; j < array2.Length; j++)
@@ -42,8 +42,8 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNewWithTwoParametersStructWithStringAndValueTest(bool useInterpreter)
         {
-            string[] array1 = new string[] { null, "", "a", "foo" };
-            S[] array2 = new S[] { default(S), new S() };
+            string[] array1 = { null, "", "a", "foo" };
+            S[] array2 = { default(S), new S() };
             for (int i = 0; i < array1.Length; i++)
             {
                 for (int j = 0; j < array2.Length; j++)
@@ -59,8 +59,8 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyNewWithTwoParametersStructWithValue(int a, double b, bool useInterpreter)
         {
-            ConstructorInfo constructor = typeof(Sp).GetConstructor(new Type[] { typeof(int), typeof(double) });
-            Expression[] exprArgs = new Expression[] { Expression.Constant(a, typeof(int)), Expression.Constant(b, typeof(double)) };
+            ConstructorInfo constructor = typeof(Sp).GetConstructor(new[] { typeof(int), typeof(double) });
+            Expression[] exprArgs = { Expression.Constant(a, typeof(int)), Expression.Constant(b, typeof(double)) };
             Expression<Func<Sp>> e =
                 Expression.Lambda<Func<Sp>>(
                     Expression.New(constructor, exprArgs),
@@ -72,8 +72,8 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyNewWithTwoParametersCustom2(int a, string b, bool useInterpreter)
         {
-            ConstructorInfo constructor = typeof(D).GetConstructor(new Type[] { typeof(int), typeof(string) });
-            Expression[] exprArgs = new Expression[] { Expression.Constant(a, typeof(int)), Expression.Constant(b, typeof(string)) };
+            ConstructorInfo constructor = typeof(D).GetConstructor(new[] { typeof(int), typeof(string) });
+            Expression[] exprArgs = { Expression.Constant(a, typeof(int)), Expression.Constant(b, typeof(string)) };
             Expression<Func<D>> e =
                 Expression.Lambda<Func<D>>(
                     Expression.New(constructor, exprArgs),
@@ -85,8 +85,8 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyNewWithTwoParametersStructWithStringAndValue(string a, S b, bool useInterpreter)
         {
-            ConstructorInfo constructor = typeof(Scs).GetConstructor(new Type[] { typeof(string), typeof(S) });
-            Expression[] exprArgs = new Expression[] { Expression.Constant(a, typeof(string)), Expression.Constant(b, typeof(S)) };
+            ConstructorInfo constructor = typeof(Scs).GetConstructor(new[] { typeof(string), typeof(S) });
+            Expression[] exprArgs = { Expression.Constant(a, typeof(string)), Expression.Constant(b, typeof(S)) };
             Expression<Func<Scs>> e =
                 Expression.Lambda<Func<Scs>>(
                     Expression.New(constructor, exprArgs),
@@ -97,5 +97,48 @@ namespace System.Linq.Expressions.Tests
         }
 
         #endregion
+
+        [Fact]
+        public static void UpdateSameReturnsSame()
+        {
+            ConstructorInfo constructor = typeof(Sp).GetConstructor(new[] { typeof(int), typeof(double) });
+            Expression[] exprArgs = { Expression.Constant(23), Expression.Constant(40.0) };
+            NewExpression newExp = Expression.New(constructor, exprArgs);
+            Assert.Same(newExp, newExp.Update(exprArgs));
+
+            constructor = typeof(TestClass).GetConstructor(new[] { typeof(string), typeof(int) });
+            MemberInfo[] members = { typeof(TestClass).GetField(nameof(TestClass.S)), typeof(TestClass).GetProperty(nameof(TestClass.Val)) };
+            exprArgs = new Expression[] { Expression.Constant("x"), Expression.Constant(23) };
+
+            newExp = Expression.New(constructor, exprArgs, members);
+            Assert.Same(newExp, newExp.Update(exprArgs));
+        }
+
+        [Fact]
+        public static void UpdateDifferentReturnsDifferent()
+        {
+            ConstructorInfo constructor = typeof(Sp).GetConstructor(new[] { typeof(int), typeof(double) });
+            NewExpression newExp = Expression.New(constructor, Expression.Constant(23), Expression.Constant(40.0));
+            Assert.NotSame(newExp, newExp.Update(new[] {Expression.Constant(23), Expression.Constant(40.0)}));
+
+            constructor = typeof(TestClass).GetConstructor(new[] { typeof(string), typeof(int) });
+            MemberInfo[] members = { typeof(TestClass).GetField(nameof(TestClass.S)), typeof(TestClass).GetProperty(nameof(TestClass.Val)) };
+
+            newExp = Expression.New(constructor, new[] { Expression.Constant("x"), Expression.Constant(23) }, members);
+            Assert.NotSame(newExp, newExp.Update(new[] { Expression.Constant("x"), Expression.Constant(23) }));
+        }
+
+        private class TestClass
+        {
+            public TestClass(string s, int val)
+            {
+                S = s;
+                Val = val;
+            }
+
+            public string S;
+
+            public int Val { get; set; }
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/New/NewWithTwoParametersTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewWithTwoParametersTests.cs
@@ -128,6 +128,20 @@ namespace System.Linq.Expressions.Tests
             Assert.NotSame(newExp, newExp.Update(new[] { Expression.Constant("x"), Expression.Constant(23) }));
         }
 
+        [Fact]
+        public static void UpdateDoesntRepeatEnumeration()
+        {
+            ConstructorInfo constructor = typeof(Sp).GetConstructor(new[] { typeof(int), typeof(double) });
+            NewExpression newExp = Expression.New(constructor, Expression.Constant(23), Expression.Constant(40.0));
+            Assert.NotSame(newExp, newExp.Update(new[] { Expression.Constant(23), Expression.Constant(40.0) }));
+
+            constructor = typeof(TestClass).GetConstructor(new[] { typeof(string), typeof(int) });
+            MemberInfo[] members = { typeof(TestClass).GetField(nameof(TestClass.S)), typeof(TestClass).GetProperty(nameof(TestClass.Val)) };
+
+            newExp = Expression.New(constructor, new[] { Expression.Constant("x"), Expression.Constant(23) }, members);
+            Assert.NotSame(newExp, newExp.Update(new RunOnceEnumerable<Expression>(new[] { Expression.Constant("x"), Expression.Constant(23) })));
+        }
+
         private class TestClass
         {
             public TestClass(string s, int val)

--- a/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
+++ b/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
@@ -552,13 +552,19 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void SwitchUpdateSameToSame()
         {
+            SwitchCase[] cases =
+            {
+                Expression.SwitchCase(Expression.Constant(1), Expression.Constant(1)),
+                Expression.SwitchCase(Expression.Constant(2), Expression.Constant(2))
+            };
+
             SwitchExpression sw = Expression.Switch(
                 Expression.Constant(0),
                 Expression.Constant(0),
-                Expression.SwitchCase(Expression.Constant(1), Expression.Constant(1)),
-                Expression.SwitchCase(Expression.Constant(2), Expression.Constant(2))
+                cases
                 );
-            Assert.Same(sw, sw.Update(sw.SwitchValue, sw.Cases, sw.DefaultBody));
+            Assert.Same(sw, sw.Update(sw.SwitchValue, cases.Skip(0), sw.DefaultBody));
+            Assert.Same(sw, sw.Update(sw.SwitchValue, cases, sw.DefaultBody));
             Assert.Same(sw, NoOpVisitor.Instance.Visit(sw));
         }
 

--- a/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
+++ b/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
@@ -529,7 +529,9 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void SwitchCaseUpdateSameToSame()
         {
-            SwitchCase sc = Expression.SwitchCase(Expression.Constant(1), Expression.Constant(0), Expression.Constant(2));
+            Expression[] tests = {Expression.Constant(0), Expression.Constant(2)};
+            SwitchCase sc = Expression.SwitchCase(Expression.Constant(1), tests);
+            Assert.Same(sc, sc.Update(tests, sc.Body));
             Assert.Same(sc, sc.Update(sc.TestValues, sc.Body));
         }
 

--- a/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
+++ b/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
@@ -536,6 +536,14 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        public void SwitchCaseUpdateNullTestsToSame()
+        {
+            SwitchCase sc = Expression.SwitchCase(Expression.Constant(0), Expression.Constant(1));
+            Assert.Throws<ArgumentException>("testValues", () => sc.Update(null, sc.Body));
+            Assert.Throws<ArgumentNullException>("body", () => sc.Update(sc.TestValues, null));
+        }
+
+        [Fact]
         public void SwitchCaseDifferentBodyToDifferent()
         {
             SwitchCase sc = Expression.SwitchCase(Expression.Constant(1), Expression.Constant(0), Expression.Constant(2));
@@ -547,6 +555,13 @@ namespace System.Linq.Expressions.Tests
         {
             SwitchCase sc = Expression.SwitchCase(Expression.Constant(1), Expression.Constant(0), Expression.Constant(2));
             Assert.NotSame(sc, sc.Update(new[] { Expression.Constant(0), Expression.Constant(2) }, sc.Body));
+        }
+
+        [Fact]
+        public void SwitchCaseUpdateDoesntRepeatEnumeration()
+        {
+            SwitchCase sc = Expression.SwitchCase(Expression.Constant(1), Expression.Constant(0), Expression.Constant(2));
+            Assert.NotSame(sc, sc.Update(new RunOnceEnumerable<Expression>(new[] { Expression.Constant(0), Expression.Constant(2) }), sc.Body));
         }
 
         [Fact]
@@ -607,6 +622,27 @@ namespace System.Linq.Expressions.Tests
                 Expression.SwitchCase(Expression.Constant(1), Expression.Constant(1)),
                 Expression.SwitchCase(Expression.Constant(2), Expression.Constant(2))
             };
+
+            Assert.NotSame(sw, sw.Update(sw.SwitchValue, newCases, sw.DefaultBody));
+        }
+
+        [Fact]
+        public void SwitchUpdateDoesntRepeatEnumeration()
+        {
+            SwitchExpression sw = Expression.Switch(
+                Expression.Constant(0),
+                Expression.Constant(0),
+                Expression.SwitchCase(Expression.Constant(1), Expression.Constant(1)),
+                Expression.SwitchCase(Expression.Constant(2), Expression.Constant(2))
+                );
+
+            IEnumerable<SwitchCase> newCases =
+                new RunOnceEnumerable<SwitchCase>(
+                    new SwitchCase[]
+                    {
+                        Expression.SwitchCase(Expression.Constant(1), Expression.Constant(1)),
+                        Expression.SwitchCase(Expression.Constant(2), Expression.Constant(2))
+                    });
 
             Assert.NotSame(sw, sw.Update(sw.SwitchValue, newCases, sw.DefaultBody));
         }

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="DelegateType\DelegateCreationTests.cs" />
     <Compile Include="DelegateType\FuncTypeTests.cs" />
     <Compile Include="DelegateType\GetDelegateTypeTests.cs" />
+    <Compile Include="DynamicExpression\DynamicExpressionTests.cs" />
     <Compile Include="Dynamic\BinaryOperationTests.cs" />
     <Compile Include="Dynamic\BindingRestrictionsProxyTests.cs" />
     <Compile Include="Dynamic\BindingRestrictionsTests.cs" />

--- a/src/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
@@ -176,6 +176,21 @@ namespace System.Linq.Expressions.Tests
             Assert.NotSame(varExp, varExp.Update(new[] { Expression.Variable(typeof(RuntimeVariablesTests)) }));
         }
 
+
+        [Fact]
+        public void UpdateDoesntRepeatEnumeration()
+        {
+            RuntimeVariablesExpression varExp = Expression.RuntimeVariables(Enumerable.Repeat(Expression.Variable(typeof(RuntimeVariablesTests)), 1));
+            Assert.NotSame(varExp, varExp.Update(new RunOnceEnumerable<ParameterExpression>(new[] { Expression.Variable(typeof(RuntimeVariablesTests)) })));
+        }
+
+        [Fact]
+        public void UpdateNullThrows()
+        {
+            RuntimeVariablesExpression varExp = Expression.RuntimeVariables(Enumerable.Repeat(Expression.Variable(typeof(RuntimeVariablesTests)), 0));
+            Assert.Throws<ArgumentNullException>("variables", () => varExp.Update(null));
+        }
+
         [Fact]
         public void ToStringTest()
         {

--- a/src/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
@@ -162,7 +162,9 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void UpdateSameCollectionSameNode()
         {
-            RuntimeVariablesExpression varExp = Expression.RuntimeVariables(Enumerable.Repeat(Expression.Variable(typeof(RuntimeVariablesTests)), 1));
+            ParameterExpression[] variables = {Expression.Variable(typeof(RuntimeVariablesTests))};
+            RuntimeVariablesExpression varExp = Expression.RuntimeVariables(variables);
+            Assert.Same(varExp, varExp.Update(variables));
             Assert.Same(varExp, varExp.Update(varExp.Variables));
             Assert.Same(varExp, NoOpVisitor.Instance.Visit(varExp));
         }


### PR DESCRIPTION
Closes #3958 

Takes pains to avoid calls to `GetOrMakeExpressions()` and similar on the expressions with arity-specialised types.

Short-circuits on the case of identical collections being used on the update, as well as being a common case and hence worth as an optimisation, this reduces the possible penalty to those cases that already return the expression updated.