### PR TITLE
Use optimized N-ary MethodCallExpression nodes for more calls.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
@@ -954,39 +954,39 @@ namespace System.Linq.Expressions
         /// <paramref name="instance"/>.Type is not assignable to the declaring type of the method represented by <paramref name="method"/>.-or-The number of elements in <paramref name="arguments"/> does not equal the number of parameters for the method represented by <paramref name="method"/>.-or-One or more of the elements of <paramref name="arguments"/> is not assignable to the corresponding parameter for the method represented by <paramref name="method"/>.</exception>
         public static MethodCallExpression Call(Expression instance, MethodInfo method, IEnumerable<Expression> arguments)
         {
-            IReadOnlyList<Expression> argumentList = arguments as IReadOnlyList<Expression>;
+            IReadOnlyList<Expression> argumentList = arguments as IReadOnlyList<Expression> ?? arguments.ToReadOnly();
 
-            if (argumentList != null)
+            int argCount = argumentList.Count;
+
+            switch (argCount)
             {
-                int argCount = argumentList.Count;
+                case 0:
+                    return Call(instance, method);
+                case 1:
+                    return Call(instance, method, argumentList[0]);
+                case 2:
+                    return Call(instance, method, argumentList[0], argumentList[1]);
+                case 3:
+                    return Call(instance, method, argumentList[0], argumentList[1], argumentList[2]);
+            }
 
+            if (instance == null)
+            {
                 switch (argCount)
                 {
-                    case 0:
-                        return Call(instance, method);
-                    case 1:
-                        return Call(instance, method, argumentList[0]);
-                    case 2:
-                        return Call(instance, method, argumentList[0], argumentList[1]);
-                    case 3:
-                        return Call(instance, method, argumentList[0], argumentList[1], argumentList[2]);
-                }
-
-                if (instance == null)
-                {
-                    switch (argCount)
-                    {
-                        case 4:
-                            return Call(method, argumentList[0], argumentList[1], argumentList[2], argumentList[3]);
-                        case 5:
-                            return Call(method, argumentList[0], argumentList[1], argumentList[2], argumentList[3], argumentList[4]);
-                    }
+                    case 4:
+                        return Call(method, argumentList[0], argumentList[1], argumentList[2], argumentList[3]);
+                    case 5:
+                        return Call(method, argumentList[0], argumentList[1], argumentList[2], argumentList[3], argumentList[4]);
                 }
             }
 
             ContractUtils.RequiresNotNull(method, nameof(method));
 
-            ReadOnlyCollection<Expression> argList = arguments.ToReadOnly();
+            // If this has resulted in a duplicate call to ToReadOnly (any case except arguments being
+            // a large IReadOnlyList that is not TrueReadOnlyCollection) it will return argumentList
+            // back again quickly.
+            ReadOnlyCollection<Expression> argList = argumentList.ToReadOnly();
 
             ValidateMethodInfo(method, nameof(method));
             ValidateStaticOrInstanceMethod(instance, method);

--- a/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
@@ -21,6 +21,14 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        public static void CheckCallFactoryOptimisedInstanceNullArgumentList()
+        {
+            var instance = Expression.Constant(new MS());
+            var expr = Expression.Call(instance, typeof(MS).GetMethod(nameof(MS.I0)), default(Expression[]));
+            AssertInstanceMethodCall(0, expr);
+        }
+
+        [Fact]
         public static void CheckCallFactoryOptimizationInstance2()
         {
             MethodCallExpression expr = Expression.Call(Expression.Parameter(typeof(MS)), typeof(MS).GetMethod("I2"), Expression.Constant(0), Expression.Constant(1));
@@ -93,6 +101,10 @@ namespace System.Linq.Expressions.Tests
         {
             AssertCallIsOptimizedStatic(arity);
         }
+
+        [Fact]
+        public static void CheckCallFactoryOptimisedStaticNullArgumentList() =>
+            AssertStaticMethodCall(0, Expression.Call(typeof(MS).GetMethod(nameof(MS.S0)), default(Expression[])));
 
         [Fact]
         public static void CheckCallFactoryOptimizationStatic1()


### PR DESCRIPTION
Building on #3288 from @bartdesmet this causes the arity-specialised forms of `MethodCallExpression` to be used in more cases:

1. When the arguments collection is null.
2. When the arguments collection doesn't implement `IReadOnlyList<>`

It does this by pre-emptively calling `ToReadOnly` in these cases.

That it's spending time building this isn't an issue, as that would have happened anyway.

It does mean the call after the switch on argument count is a duplicate much of the time, but `ToReadOnly` returns quickly in such cases.

c.f. #6004 which did much the same for `InvocationExpression`