### PR TITLE
Reordering inner instruction types to be consistent for code-generation

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
@@ -17,25 +17,6 @@ namespace System.Linq.Expressions.Interpreter
 
         private AddInstruction() { }
 
-        private sealed class AddInt32 : AddInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
-                {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(unchecked((int)l + (int)r));
-                }
-                frame.StackIndex--;
-                return 1;
-            }
-        }
-
         private sealed class AddInt16 : AddInstruction
         {
             public override int Run(InterpretedFrame frame)
@@ -49,6 +30,25 @@ namespace System.Linq.Expressions.Interpreter
                 else
                 {
                     frame.Data[frame.StackIndex - 2] = unchecked((short)((short)l + (short)r));
+                }
+                frame.StackIndex--;
+                return 1;
+            }
+        }
+
+        private sealed class AddInt32 : AddInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object l = frame.Data[frame.StackIndex - 2];
+                object r = frame.Data[frame.StackIndex - 1];
+                if (l == null || r == null)
+                {
+                    frame.Data[frame.StackIndex - 2] = null;
+                }
+                else
+                {
+                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(unchecked((int)l + (int)r));
                 }
                 frame.StackIndex--;
                 return 1;
@@ -198,25 +198,6 @@ namespace System.Linq.Expressions.Interpreter
 
         private AddOvfInstruction() { }
 
-        private sealed class AddOvfInt32 : AddOvfInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
-                {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(checked((int)l + (int)r));
-                }
-                frame.StackIndex--;
-                return 1;
-            }
-        }
-
         private sealed class AddOvfInt16 : AddOvfInstruction
         {
             public override int Run(InterpretedFrame frame)
@@ -230,6 +211,25 @@ namespace System.Linq.Expressions.Interpreter
                 else
                 {
                     frame.Data[frame.StackIndex - 2] = checked((short)((short)l + (short)r));
+                }
+                frame.StackIndex--;
+                return 1;
+            }
+        }
+
+        private sealed class AddOvfInt32 : AddOvfInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object l = frame.Data[frame.StackIndex - 2];
+                object r = frame.Data[frame.StackIndex - 1];
+                if (l == null || r == null)
+                {
+                    frame.Data[frame.StackIndex - 2] = null;
+                }
+                else
+                {
+                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(checked((int)l + (int)r));
                 }
                 frame.StackIndex--;
                 return 1;
@@ -323,7 +323,6 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new AddOvfUInt16());
                 case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new AddOvfUInt32());
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new AddOvfUInt64());
-
                 default:
                     return AddInstruction.Create(type);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
@@ -145,7 +145,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private sealed class AndBool : AndInstruction
+        private sealed class AndBoolean : AndInstruction
         {
             public override int Run(InterpretedFrame frame)
             {
@@ -182,15 +182,14 @@ namespace System.Linq.Expressions.Interpreter
             switch (underlyingType.GetTypeCode())
             {
                 case TypeCode.SByte: return s_SByte ?? (s_SByte = new AndSByte());
-                case TypeCode.Byte: return s_Byte ?? (s_Byte = new AndByte());
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new AndInt16());
                 case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new AndInt32());
                 case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new AndInt64());
+                case TypeCode.Byte: return s_Byte ?? (s_Byte = new AndByte());
                 case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new AndUInt16());
                 case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new AndUInt32());
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new AndUInt64());
-                case TypeCode.Boolean: return s_Boolean ?? (s_Boolean = new AndBool());
-
+                case TypeCode.Boolean: return s_Boolean ?? (s_Boolean = new AndBoolean());
                 default:
                     throw Error.ExpressionNotSupportedForType("And", type);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DecrementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DecrementInstruction.cs
@@ -18,23 +18,6 @@ namespace System.Linq.Expressions.Interpreter
 
         private DecrementInstruction() { }
 
-        private sealed class DecrementInt32 : DecrementInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object obj = frame.Pop();
-                if (obj == null)
-                {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked((int)obj - 1));
-                }
-                return 1;
-            }
-        }
-
         private sealed class DecrementInt16 : DecrementInstruction
         {
             public override int Run(InterpretedFrame frame)
@@ -47,6 +30,23 @@ namespace System.Linq.Expressions.Interpreter
                 else
                 {
                     frame.Push(unchecked((short)((short)obj - 1)));
+                }
+                return 1;
+            }
+        }
+
+        private sealed class DecrementInt32 : DecrementInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object obj = frame.Pop();
+                if (obj == null)
+                {
+                    frame.Push(null);
+                }
+                else
+                {
+                    frame.Push(unchecked((int)obj - 1));
                 }
                 return 1;
             }
@@ -167,7 +167,6 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new DecrementUInt64());
                 case TypeCode.Single: return s_Single ?? (s_Single = new DecrementSingle());
                 case TypeCode.Double: return s_Double ?? (s_Double = new DecrementDouble());
-
                 default:
                     throw Error.ExpressionNotSupportedForType("Decrement", type);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
@@ -18,25 +18,6 @@ namespace System.Linq.Expressions.Interpreter
 
         private DivInstruction() { }
 
-        private sealed class DivInt32 : DivInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
-                {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject((int)l / (int)r);
-                }
-                frame.StackIndex--;
-                return 1;
-            }
-        }
-
         private sealed class DivInt16 : DivInstruction
         {
             public override int Run(InterpretedFrame frame)
@@ -50,6 +31,25 @@ namespace System.Linq.Expressions.Interpreter
                 else
                 {
                     frame.Data[frame.StackIndex - 2] = (short)((short)l / (short)r);
+                }
+                frame.StackIndex--;
+                return 1;
+            }
+        }
+
+        private sealed class DivInt32 : DivInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object l = frame.Data[frame.StackIndex - 2];
+                object r = frame.Data[frame.StackIndex - 1];
+                if (l == null || r == null)
+                {
+                    frame.Data[frame.StackIndex - 2] = null;
+                }
+                else
+                {
+                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject((int)l / (int)r);
                 }
                 frame.StackIndex--;
                 return 1;
@@ -183,7 +183,6 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new DivUInt64());
                 case TypeCode.Single: return s_Single ?? (s_Single = new DivSingle());
                 case TypeCode.Double: return s_Double ?? (s_Double = new DivDouble());
-
                 default:
                     throw Error.ExpressionNotSupportedForType("Div", type);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
@@ -521,16 +521,14 @@ namespace System.Linq.Expressions.Interpreter
                 {
                     case TypeCode.Boolean: return s_BooleanLiftedToNull ?? (s_BooleanLiftedToNull = new EqualBooleanLiftedToNull());
                     case TypeCode.SByte: return s_SByteLiftedToNull ?? (s_SByteLiftedToNull = new EqualSByteLiftedToNull());
-                    case TypeCode.Byte: return s_ByteLiftedToNull ?? (s_ByteLiftedToNull = new EqualByteLiftedToNull());
-                    case TypeCode.Char: return s_CharLiftedToNull ?? (s_CharLiftedToNull = new EqualCharLiftedToNull());
                     case TypeCode.Int16: return s_Int16LiftedToNull ?? (s_Int16LiftedToNull = new EqualInt16LiftedToNull());
+                    case TypeCode.Char: return s_CharLiftedToNull ?? (s_CharLiftedToNull = new EqualCharLiftedToNull());
                     case TypeCode.Int32: return s_Int32LiftedToNull ?? (s_Int32LiftedToNull = new EqualInt32LiftedToNull());
                     case TypeCode.Int64: return s_Int64LiftedToNull ?? (s_Int64LiftedToNull = new EqualInt64LiftedToNull());
-
+                    case TypeCode.Byte: return s_ByteLiftedToNull ?? (s_ByteLiftedToNull = new EqualByteLiftedToNull());
                     case TypeCode.UInt16: return s_UInt16LiftedToNull ?? (s_UInt16LiftedToNull = new EqualUInt16LiftedToNull());
                     case TypeCode.UInt32: return s_UInt32LiftedToNull ?? (s_UInt32LiftedToNull = new EqualUInt32LiftedToNull());
                     case TypeCode.UInt64: return s_UInt64LiftedToNull ?? (s_UInt64LiftedToNull = new EqualUInt64LiftedToNull());
-
                     case TypeCode.Single: return s_SingleLiftedToNull ?? (s_SingleLiftedToNull = new EqualSingleLiftedToNull());
                     default:
                         Debug.Assert(underlyingType.GetTypeCode() == TypeCode.Double);
@@ -543,24 +541,20 @@ namespace System.Linq.Expressions.Interpreter
                 {
                     case TypeCode.Boolean: return s_Boolean ?? (s_Boolean = new EqualBoolean());
                     case TypeCode.SByte: return s_SByte ?? (s_SByte = new EqualSByte());
-                    case TypeCode.Byte: return s_Byte ?? (s_Byte = new EqualByte());
-                    case TypeCode.Char: return s_Char ?? (s_Char = new EqualChar());
                     case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new EqualInt16());
+                    case TypeCode.Char: return s_Char ?? (s_Char = new EqualChar());
                     case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new EqualInt32());
                     case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new EqualInt64());
-
+                    case TypeCode.Byte: return s_Byte ?? (s_Byte = new EqualByte());
                     case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new EqualUInt16());
                     case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new EqualUInt32());
                     case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new EqualUInt64());
-
                     case TypeCode.Single: return s_Single ?? (s_Single = new EqualSingle());
                     case TypeCode.Double: return s_Double ?? (s_Double = new EqualDouble());
-
                     default:
                         // Nullable only valid if one operand is constant null, so this assert is slightly too broad.
                         Debug.Assert(type.IsNullableOrReferenceType());
                         return s_reference ?? (s_reference = new EqualReference());
-
                 }
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ExclusiveOrInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ExclusiveOrInstruction.cs
@@ -145,7 +145,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private sealed class ExclusiveOrBool : ExclusiveOrInstruction
+        private sealed class ExclusiveOrBoolean : ExclusiveOrInstruction
         {
             public override int Run(InterpretedFrame frame)
             {
@@ -170,16 +170,14 @@ namespace System.Linq.Expressions.Interpreter
             switch (underlyingType.GetTypeCode())
             {
                 case TypeCode.SByte: return s_SByte ?? (s_SByte = new ExclusiveOrSByte());
-                case TypeCode.Byte: return s_Byte ?? (s_Byte = new ExclusiveOrByte());
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new ExclusiveOrInt16());
                 case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new ExclusiveOrInt32());
                 case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new ExclusiveOrInt64());
-
+                case TypeCode.Byte: return s_Byte ?? (s_Byte = new ExclusiveOrByte());
                 case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new ExclusiveOrUInt16());
                 case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new ExclusiveOrUInt32());
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new ExclusiveOrUInt64());
-                case TypeCode.Boolean: return s_Boolean ?? (s_Boolean = new ExclusiveOrBool());
-
+                case TypeCode.Boolean: return s_Boolean ?? (s_Boolean = new ExclusiveOrBoolean());
                 default:
                     throw Error.ExpressionNotSupportedForType("ExclusiveOr", type);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
@@ -284,17 +284,16 @@ namespace System.Linq.Expressions.Interpreter
                 switch (type.GetNonNullableType().GetTypeCode())
                 {
                     case TypeCode.SByte: return s_liftedToNullSByte ?? (s_liftedToNullSByte = new GreaterThanSByte(null));
-                    case TypeCode.Byte: return s_liftedToNullByte ?? (s_liftedToNullByte = new GreaterThanByte(null));
-                    case TypeCode.Char: return s_liftedToNullChar ?? (s_liftedToNullChar = new GreaterThanChar(null));
                     case TypeCode.Int16: return s_liftedToNullInt16 ?? (s_liftedToNullInt16 = new GreaterThanInt16(null));
+                    case TypeCode.Char: return s_liftedToNullChar ?? (s_liftedToNullChar = new GreaterThanChar(null));
                     case TypeCode.Int32: return s_liftedToNullInt32 ?? (s_liftedToNullInt32 = new GreaterThanInt32(null));
                     case TypeCode.Int64: return s_liftedToNullInt64 ?? (s_liftedToNullInt64 = new GreaterThanInt64(null));
+                    case TypeCode.Byte: return s_liftedToNullByte ?? (s_liftedToNullByte = new GreaterThanByte(null));
                     case TypeCode.UInt16: return s_liftedToNullUInt16 ?? (s_liftedToNullUInt16 = new GreaterThanUInt16(null));
                     case TypeCode.UInt32: return s_liftedToNullUInt32 ?? (s_liftedToNullUInt32 = new GreaterThanUInt32(null));
                     case TypeCode.UInt64: return s_liftedToNullUInt64 ?? (s_liftedToNullUInt64 = new GreaterThanUInt64(null));
                     case TypeCode.Single: return s_liftedToNullSingle ?? (s_liftedToNullSingle = new GreaterThanSingle(null));
                     case TypeCode.Double: return s_liftedToNullDouble ?? (s_liftedToNullDouble = new GreaterThanDouble(null));
-
                     default:
                         throw Error.ExpressionNotSupportedForType("GreaterThan", type);
                 }
@@ -304,17 +303,16 @@ namespace System.Linq.Expressions.Interpreter
                 switch (type.GetNonNullableType().GetTypeCode())
                 {
                     case TypeCode.SByte: return s_SByte ?? (s_SByte = new GreaterThanSByte(Utils.BoxedFalse));
-                    case TypeCode.Byte: return s_Byte ?? (s_Byte = new GreaterThanByte(Utils.BoxedFalse));
-                    case TypeCode.Char: return s_Char ?? (s_Char = new GreaterThanChar(Utils.BoxedFalse));
                     case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new GreaterThanInt16(Utils.BoxedFalse));
+                    case TypeCode.Char: return s_Char ?? (s_Char = new GreaterThanChar(Utils.BoxedFalse));
                     case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new GreaterThanInt32(Utils.BoxedFalse));
                     case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new GreaterThanInt64(Utils.BoxedFalse));
+                    case TypeCode.Byte: return s_Byte ?? (s_Byte = new GreaterThanByte(Utils.BoxedFalse));
                     case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new GreaterThanUInt16(Utils.BoxedFalse));
                     case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new GreaterThanUInt32(Utils.BoxedFalse));
                     case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new GreaterThanUInt64(Utils.BoxedFalse));
                     case TypeCode.Single: return s_Single ?? (s_Single = new GreaterThanSingle(Utils.BoxedFalse));
                     case TypeCode.Double: return s_Double ?? (s_Double = new GreaterThanDouble(Utils.BoxedFalse));
-
                     default:
                         throw Error.ExpressionNotSupportedForType("GreaterThan", type);
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanOrEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanOrEqualInstruction.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Expressions.Interpreter
     internal abstract class GreaterThanOrEqualInstruction : Instruction
     {
         private readonly object _nullValue;
-        private static Instruction s_SByte, s_Int16, s_char, s_Int32, s_Int64, s_Byte, s_UInt16, s_UInt32, s_UInt64, s_Single, s_Double;
+        private static Instruction s_SByte, s_Int16, s_Char, s_Int32, s_Int64, s_Byte, s_UInt16, s_UInt32, s_UInt64, s_Single, s_Double;
         private static Instruction s_liftedToNullSByte, s_liftedToNullInt16, s_liftedToNullChar, s_liftedToNullInt32, s_liftedToNullInt64, s_liftedToNullByte, s_liftedToNullUInt16, s_liftedToNullUInt32, s_liftedToNullUInt64, s_liftedToNullSingle, s_liftedToNullDouble;
 
         public override int ConsumedStack => 2;
@@ -284,17 +284,16 @@ namespace System.Linq.Expressions.Interpreter
                 switch (type.GetNonNullableType().GetTypeCode())
                 {
                     case TypeCode.SByte: return s_liftedToNullSByte ?? (s_liftedToNullSByte = new GreaterThanOrEqualSByte(null));
-                    case TypeCode.Byte: return s_liftedToNullByte ?? (s_liftedToNullByte = new GreaterThanOrEqualByte(null));
-                    case TypeCode.Char: return s_liftedToNullChar ?? (s_liftedToNullChar = new GreaterThanOrEqualChar(null));
                     case TypeCode.Int16: return s_liftedToNullInt16 ?? (s_liftedToNullInt16 = new GreaterThanOrEqualInt16(null));
+                    case TypeCode.Char: return s_liftedToNullChar ?? (s_liftedToNullChar = new GreaterThanOrEqualChar(null));
                     case TypeCode.Int32: return s_liftedToNullInt32 ?? (s_liftedToNullInt32 = new GreaterThanOrEqualInt32(null));
                     case TypeCode.Int64: return s_liftedToNullInt64 ?? (s_liftedToNullInt64 = new GreaterThanOrEqualInt64(null));
+                    case TypeCode.Byte: return s_liftedToNullByte ?? (s_liftedToNullByte = new GreaterThanOrEqualByte(null));
                     case TypeCode.UInt16: return s_liftedToNullUInt16 ?? (s_liftedToNullUInt16 = new GreaterThanOrEqualUInt16(null));
                     case TypeCode.UInt32: return s_liftedToNullUInt32 ?? (s_liftedToNullUInt32 = new GreaterThanOrEqualUInt32(null));
                     case TypeCode.UInt64: return s_liftedToNullUInt64 ?? (s_liftedToNullUInt64 = new GreaterThanOrEqualUInt64(null));
                     case TypeCode.Single: return s_liftedToNullSingle ?? (s_liftedToNullSingle = new GreaterThanOrEqualSingle(null));
                     case TypeCode.Double: return s_liftedToNullDouble ?? (s_liftedToNullDouble = new GreaterThanOrEqualDouble(null));
-
                     default:
                         throw Error.ExpressionNotSupportedForType("GreaterThanOrEqual", type);
                 }
@@ -304,17 +303,16 @@ namespace System.Linq.Expressions.Interpreter
                 switch (type.GetNonNullableType().GetTypeCode())
                 {
                     case TypeCode.SByte: return s_SByte ?? (s_SByte = new GreaterThanOrEqualSByte(Utils.BoxedFalse));
-                    case TypeCode.Byte: return s_Byte ?? (s_Byte = new GreaterThanOrEqualByte(Utils.BoxedFalse));
-                    case TypeCode.Char: return s_char ?? (s_char = new GreaterThanOrEqualChar(Utils.BoxedFalse));
                     case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new GreaterThanOrEqualInt16(Utils.BoxedFalse));
+                    case TypeCode.Char: return s_Char ?? (s_Char = new GreaterThanOrEqualChar(Utils.BoxedFalse));
                     case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new GreaterThanOrEqualInt32(Utils.BoxedFalse));
                     case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new GreaterThanOrEqualInt64(Utils.BoxedFalse));
+                    case TypeCode.Byte: return s_Byte ?? (s_Byte = new GreaterThanOrEqualByte(Utils.BoxedFalse));
                     case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new GreaterThanOrEqualUInt16(Utils.BoxedFalse));
                     case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new GreaterThanOrEqualUInt32(Utils.BoxedFalse));
                     case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new GreaterThanOrEqualUInt64(Utils.BoxedFalse));
                     case TypeCode.Single: return s_Single ?? (s_Single = new GreaterThanOrEqualSingle(Utils.BoxedFalse));
                     case TypeCode.Double: return s_Double ?? (s_Double = new GreaterThanOrEqualDouble(Utils.BoxedFalse));
-
                     default:
                         throw Error.ExpressionNotSupportedForType("GreaterThanOrEqual", type);
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/IncrementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/IncrementInstruction.cs
@@ -18,23 +18,6 @@ namespace System.Linq.Expressions.Interpreter
 
         private IncrementInstruction() { }
 
-        private sealed class IncrementInt32 : IncrementInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object obj = frame.Pop();
-                if (obj == null)
-                {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked(1 + (int)obj));
-                }
-                return 1;
-            }
-        }
-
         private sealed class IncrementInt16 : IncrementInstruction
         {
             public override int Run(InterpretedFrame frame)
@@ -47,6 +30,23 @@ namespace System.Linq.Expressions.Interpreter
                 else
                 {
                     frame.Push(unchecked((short)(1 + (short)obj)));
+                }
+                return 1;
+            }
+        }
+
+        private sealed class IncrementInt32 : IncrementInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object obj = frame.Pop();
+                if (obj == null)
+                {
+                    frame.Push(null);
+                }
+                else
+                {
+                    frame.Push(unchecked(1 + (int)obj));
                 }
                 return 1;
             }
@@ -167,7 +167,6 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new IncrementUInt64());
                 case TypeCode.Single: return s_Single ?? (s_Single = new IncrementSingle());
                 case TypeCode.Double: return s_Double ?? (s_Double = new IncrementDouble());
-
                 default:
                     throw Error.ExpressionNotSupportedForType("Increment", type);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LeftShiftInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LeftShiftInstruction.cs
@@ -170,15 +170,13 @@ namespace System.Linq.Expressions.Interpreter
             switch (underlyingType.GetTypeCode())
             {
                 case TypeCode.SByte: return s_SByte ?? (s_SByte = new LeftShiftSByte());
-                case TypeCode.Byte: return s_Byte ?? (s_Byte = new LeftShiftByte());
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new LeftShiftInt16());
                 case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new LeftShiftInt32());
                 case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new LeftShiftInt64());
-
+                case TypeCode.Byte: return s_Byte ?? (s_Byte = new LeftShiftByte());
                 case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new LeftShiftUInt16());
                 case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new LeftShiftUInt32());
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new LeftShiftUInt64());
-
                 default:
                     throw Error.ExpressionNotSupportedForType("LeftShift", type);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
@@ -11,7 +11,6 @@ namespace System.Linq.Expressions.Interpreter
     internal abstract class LessThanInstruction : Instruction
     {
         private readonly object _nullValue;
-
         private static Instruction s_SByte, s_Int16, s_Char, s_Int32, s_Int64, s_Byte, s_UInt16, s_UInt32, s_UInt64, s_Single, s_Double;
         private static Instruction s_liftedToNullSByte, s_liftedToNullInt16, s_liftedToNullChar, s_liftedToNullInt32, s_liftedToNullInt64, s_liftedToNullByte, s_liftedToNullUInt16, s_liftedToNullUInt32, s_liftedToNullUInt64, s_liftedToNullSingle, s_liftedToNullDouble;
 
@@ -284,17 +283,16 @@ namespace System.Linq.Expressions.Interpreter
                 switch (type.GetNonNullableType().GetTypeCode())
                 {
                     case TypeCode.SByte: return s_liftedToNullSByte ?? (s_liftedToNullSByte = new LessThanSByte(null));
-                    case TypeCode.Byte: return s_liftedToNullByte ?? (s_liftedToNullByte = new LessThanByte(null));
-                    case TypeCode.Char: return s_liftedToNullChar ?? (s_liftedToNullChar = new LessThanChar(null));
                     case TypeCode.Int16: return s_liftedToNullInt16 ?? (s_liftedToNullInt16 = new LessThanInt16(null));
+                    case TypeCode.Char: return s_liftedToNullChar ?? (s_liftedToNullChar = new LessThanChar(null));
                     case TypeCode.Int32: return s_liftedToNullInt32 ?? (s_liftedToNullInt32 = new LessThanInt32(null));
                     case TypeCode.Int64: return s_liftedToNullInt64 ?? (s_liftedToNullInt64 = new LessThanInt64(null));
+                    case TypeCode.Byte: return s_liftedToNullByte ?? (s_liftedToNullByte = new LessThanByte(null));
                     case TypeCode.UInt16: return s_liftedToNullUInt16 ?? (s_liftedToNullUInt16 = new LessThanUInt16(null));
                     case TypeCode.UInt32: return s_liftedToNullUInt32 ?? (s_liftedToNullUInt32 = new LessThanUInt32(null));
                     case TypeCode.UInt64: return s_liftedToNullUInt64 ?? (s_liftedToNullUInt64 = new LessThanUInt64(null));
                     case TypeCode.Single: return s_liftedToNullSingle ?? (s_liftedToNullSingle = new LessThanSingle(null));
                     case TypeCode.Double: return s_liftedToNullDouble ?? (s_liftedToNullDouble = new LessThanDouble(null));
-
                     default:
                         throw Error.ExpressionNotSupportedForType("LessThan", type);
                 }
@@ -304,17 +302,16 @@ namespace System.Linq.Expressions.Interpreter
                 switch (type.GetNonNullableType().GetTypeCode())
                 {
                     case TypeCode.SByte: return s_SByte ?? (s_SByte = new LessThanSByte(Utils.BoxedFalse));
-                    case TypeCode.Byte: return s_Byte ?? (s_Byte = new LessThanByte(Utils.BoxedFalse));
-                    case TypeCode.Char: return s_Char ?? (s_Char = new LessThanChar(Utils.BoxedFalse));
                     case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new LessThanInt16(Utils.BoxedFalse));
+                    case TypeCode.Char: return s_Char ?? (s_Char = new LessThanChar(Utils.BoxedFalse));
                     case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new LessThanInt32(Utils.BoxedFalse));
                     case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new LessThanInt64(Utils.BoxedFalse));
+                    case TypeCode.Byte: return s_Byte ?? (s_Byte = new LessThanByte(Utils.BoxedFalse));
                     case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new LessThanUInt16(Utils.BoxedFalse));
                     case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new LessThanUInt32(Utils.BoxedFalse));
                     case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new LessThanUInt64(Utils.BoxedFalse));
                     case TypeCode.Single: return s_Single ?? (s_Single = new LessThanSingle(Utils.BoxedFalse));
                     case TypeCode.Double: return s_Double ?? (s_Double = new LessThanDouble(Utils.BoxedFalse));
-
                     default:
                         throw Error.ExpressionNotSupportedForType("LessThan", type);
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanOrEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanOrEqualInstruction.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Expressions.Interpreter
     internal abstract class LessThanOrEqualInstruction : Instruction
     {
         private readonly object _nullValue;
-        private static Instruction s_SByte, s_Int16, s_char, s_Int32, s_Int64, s_Byte, s_UInt16, s_UInt32, s_UInt64, s_Single, s_Double;
+        private static Instruction s_SByte, s_Int16, s_Char, s_Int32, s_Int64, s_Byte, s_UInt16, s_UInt32, s_UInt64, s_Single, s_Double;
         private static Instruction s_liftedToNullSByte, s_liftedToNullInt16, s_liftedToNullChar, s_liftedToNullInt32, s_liftedToNullInt64, s_liftedToNullByte, s_liftedToNullUInt16, s_liftedToNullUInt32, s_liftedToNullUInt64, s_liftedToNullSingle, s_liftedToNullDouble;
 
         public override int ConsumedStack => 2;
@@ -284,17 +284,16 @@ namespace System.Linq.Expressions.Interpreter
                 switch (type.GetNonNullableType().GetTypeCode())
                 {
                     case TypeCode.SByte: return s_liftedToNullSByte ?? (s_liftedToNullSByte = new LessThanOrEqualSByte(null));
-                    case TypeCode.Byte: return s_liftedToNullByte ?? (s_liftedToNullByte = new LessThanOrEqualByte(null));
-                    case TypeCode.Char: return s_liftedToNullChar ?? (s_liftedToNullChar = new LessThanOrEqualChar(null));
                     case TypeCode.Int16: return s_liftedToNullInt16 ?? (s_liftedToNullInt16 = new LessThanOrEqualInt16(null));
+                    case TypeCode.Char: return s_liftedToNullChar ?? (s_liftedToNullChar = new LessThanOrEqualChar(null));
                     case TypeCode.Int32: return s_liftedToNullInt32 ?? (s_liftedToNullInt32 = new LessThanOrEqualInt32(null));
                     case TypeCode.Int64: return s_liftedToNullInt64 ?? (s_liftedToNullInt64 = new LessThanOrEqualInt64(null));
+                    case TypeCode.Byte: return s_liftedToNullByte ?? (s_liftedToNullByte = new LessThanOrEqualByte(null));
                     case TypeCode.UInt16: return s_liftedToNullUInt16 ?? (s_liftedToNullUInt16 = new LessThanOrEqualUInt16(null));
                     case TypeCode.UInt32: return s_liftedToNullUInt32 ?? (s_liftedToNullUInt32 = new LessThanOrEqualUInt32(null));
                     case TypeCode.UInt64: return s_liftedToNullUInt64 ?? (s_liftedToNullUInt64 = new LessThanOrEqualUInt64(null));
                     case TypeCode.Single: return s_liftedToNullSingle ?? (s_liftedToNullSingle = new LessThanOrEqualSingle(null));
                     case TypeCode.Double: return s_liftedToNullDouble ?? (s_liftedToNullDouble = new LessThanOrEqualDouble(null));
-
                     default:
                         throw Error.ExpressionNotSupportedForType("LessThanOrEqual", type);
                 }
@@ -304,17 +303,16 @@ namespace System.Linq.Expressions.Interpreter
                 switch (type.GetNonNullableType().GetTypeCode())
                 {
                     case TypeCode.SByte: return s_SByte ?? (s_SByte = new LessThanOrEqualSByte(Utils.BoxedFalse));
-                    case TypeCode.Byte: return s_Byte ?? (s_Byte = new LessThanOrEqualByte(Utils.BoxedFalse));
-                    case TypeCode.Char: return s_char ?? (s_char = new LessThanOrEqualChar(Utils.BoxedFalse));
                     case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new LessThanOrEqualInt16(Utils.BoxedFalse));
+                    case TypeCode.Char: return s_Char ?? (s_Char = new LessThanOrEqualChar(Utils.BoxedFalse));
                     case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new LessThanOrEqualInt32(Utils.BoxedFalse));
                     case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new LessThanOrEqualInt64(Utils.BoxedFalse));
+                    case TypeCode.Byte: return s_Byte ?? (s_Byte = new LessThanOrEqualByte(Utils.BoxedFalse));
                     case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new LessThanOrEqualUInt16(Utils.BoxedFalse));
                     case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new LessThanOrEqualUInt32(Utils.BoxedFalse));
                     case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new LessThanOrEqualUInt64(Utils.BoxedFalse));
                     case TypeCode.Single: return s_Single ?? (s_Single = new LessThanOrEqualSingle(Utils.BoxedFalse));
                     case TypeCode.Double: return s_Double ?? (s_Double = new LessThanOrEqualDouble(Utils.BoxedFalse));
-
                     default:
                         throw Error.ExpressionNotSupportedForType("LessThanOrEqual", type);
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ModuloInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ModuloInstruction.cs
@@ -10,32 +10,13 @@ namespace System.Linq.Expressions.Interpreter
 {
     internal abstract class ModuloInstruction : Instruction
     {
-        private static Instruction s_int16, s_int32, s_int64, s_UInt16, s_UInt32, s_UInt64, s_single, s_double;
+        private static Instruction s_Int16, s_Int32, s_Int64, s_UInt16, s_UInt32, s_UInt64, s_Single, s_Double;
 
         public override int ConsumedStack => 2;
         public override int ProducedStack => 1;
         public override string InstructionName => "Modulo";
 
         private ModuloInstruction() { }
-
-        private sealed class ModuloInt32 : ModuloInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
-                {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject((int)l % (int)r);
-                }
-                frame.StackIndex--;
-                return 1;
-            }
-        }
 
         private sealed class ModuloInt16 : ModuloInstruction
         {
@@ -50,6 +31,25 @@ namespace System.Linq.Expressions.Interpreter
                 else
                 {
                     frame.Data[frame.StackIndex - 2] = (short)((short)l % (short)r);
+                }
+                frame.StackIndex--;
+                return 1;
+            }
+        }
+
+        private sealed class ModuloInt32 : ModuloInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object l = frame.Data[frame.StackIndex - 2];
+                object r = frame.Data[frame.StackIndex - 1];
+                if (l == null || r == null)
+                {
+                    frame.Data[frame.StackIndex - 2] = null;
+                }
+                else
+                {
+                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject((int)l % (int)r);
                 }
                 frame.StackIndex--;
                 return 1;
@@ -175,15 +175,14 @@ namespace System.Linq.Expressions.Interpreter
             Debug.Assert(!type.GetTypeInfo().IsEnum);
             switch (type.GetNonNullableType().GetTypeCode())
             {
-                case TypeCode.Int16: return s_int16 ?? (s_int16 = new ModuloInt16());
-                case TypeCode.Int32: return s_int32 ?? (s_int32 = new ModuloInt32());
-                case TypeCode.Int64: return s_int64 ?? (s_int64 = new ModuloInt64());
+                case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new ModuloInt16());
+                case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new ModuloInt32());
+                case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new ModuloInt64());
                 case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new ModuloUInt16());
                 case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new ModuloUInt32());
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new ModuloUInt64());
-                case TypeCode.Single: return s_single ?? (s_single = new ModuloSingle());
-                case TypeCode.Double: return s_double ?? (s_double = new ModuloDouble());
-
+                case TypeCode.Single: return s_Single ?? (s_Single = new ModuloSingle());
+                case TypeCode.Double: return s_Double ?? (s_Double = new ModuloDouble());
                 default:
                     throw Error.ExpressionNotSupportedForType("Modulo", type);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
@@ -17,25 +17,6 @@ namespace System.Linq.Expressions.Interpreter
 
         private MulInstruction() { }
 
-        private sealed class MulInt32 : MulInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
-                {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(unchecked((int)l * (int)r));
-                }
-                frame.StackIndex--;
-                return 1;
-            }
-        }
-
         private sealed class MulInt16 : MulInstruction
         {
             public override int Run(InterpretedFrame frame)
@@ -49,6 +30,25 @@ namespace System.Linq.Expressions.Interpreter
                 else
                 {
                     frame.Data[frame.StackIndex - 2] = unchecked((short)((short)l * (short)r));
+                }
+                frame.StackIndex--;
+                return 1;
+            }
+        }
+
+        private sealed class MulInt32 : MulInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object l = frame.Data[frame.StackIndex - 2];
+                object r = frame.Data[frame.StackIndex - 1];
+                if (l == null || r == null)
+                {
+                    frame.Data[frame.StackIndex - 2] = null;
+                }
+                else
+                {
+                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(unchecked((int)l * (int)r));
                 }
                 frame.StackIndex--;
                 return 1;
@@ -199,25 +199,6 @@ namespace System.Linq.Expressions.Interpreter
 
         private MulOvfInstruction() { }
 
-        private sealed class MulOvfInt32 : MulOvfInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
-                {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(checked((int)l * (int)r));
-                }
-                frame.StackIndex--;
-                return 1;
-            }
-        }
-
         private sealed class MulOvfInt16 : MulOvfInstruction
         {
             public override int Run(InterpretedFrame frame)
@@ -231,6 +212,25 @@ namespace System.Linq.Expressions.Interpreter
                 else
                 {
                     frame.Data[frame.StackIndex - 2] = checked((short)((short)l * (short)r));
+                }
+                frame.StackIndex--;
+                return 1;
+            }
+        }
+
+        private sealed class MulOvfInt32 : MulOvfInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object l = frame.Data[frame.StackIndex - 2];
+                object r = frame.Data[frame.StackIndex - 1];
+                if (l == null || r == null)
+                {
+                    frame.Data[frame.StackIndex - 2] = null;
+                }
+                else
+                {
+                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(checked((int)l * (int)r));
                 }
                 frame.StackIndex--;
                 return 1;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
@@ -18,23 +18,6 @@ namespace System.Linq.Expressions.Interpreter
 
         private NegateInstruction() { }
 
-        private sealed class NegateInt32 : NegateInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object obj = frame.Pop();
-                if (obj == null)
-                {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(unchecked(-(int)obj));
-                }
-                return 1;
-            }
-        }
-
         private sealed class NegateInt16 : NegateInstruction
         {
             public override int Run(InterpretedFrame frame)
@@ -47,6 +30,23 @@ namespace System.Linq.Expressions.Interpreter
                 else
                 {
                     frame.Push(unchecked((short)(-(short)obj)));
+                }
+                return 1;
+            }
+        }
+
+        private sealed class NegateInt32 : NegateInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object obj = frame.Pop();
+                if (obj == null)
+                {
+                    frame.Push(null);
+                }
+                else
+                {
+                    frame.Push(unchecked(-(int)obj));
                 }
                 return 1;
             }
@@ -113,7 +113,6 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new NegateInt64());
                 case TypeCode.Single: return s_Single ?? (s_Single = new NegateSingle());
                 case TypeCode.Double: return s_Double ?? (s_Double = new NegateDouble());
-
                 default:
                     throw Error.ExpressionNotSupportedForType("Negate", type);
             }
@@ -180,6 +179,7 @@ namespace System.Linq.Expressions.Interpreter
                 return 1;
             }
         }
+
         private sealed class NegateCheckedSingle : NegateCheckedInstruction
         {
             public override int Run(InterpretedFrame frame)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
@@ -521,16 +521,14 @@ namespace System.Linq.Expressions.Interpreter
                 {
                     case TypeCode.Boolean: return s_BooleanLiftedToNull ?? (s_BooleanLiftedToNull = new NotEqualBooleanLiftedToNull());
                     case TypeCode.SByte: return s_SByteLiftedToNull ?? (s_SByteLiftedToNull = new NotEqualSByteLiftedToNull());
-                    case TypeCode.Byte: return s_ByteLiftedToNull ?? (s_ByteLiftedToNull = new NotEqualByteLiftedToNull());
-                    case TypeCode.Char: return s_CharLiftedToNull ?? (s_CharLiftedToNull = new NotEqualCharLiftedToNull());
                     case TypeCode.Int16: return s_Int16LiftedToNull ?? (s_Int16LiftedToNull = new NotEqualInt16LiftedToNull());
+                    case TypeCode.Char: return s_CharLiftedToNull ?? (s_CharLiftedToNull = new NotEqualCharLiftedToNull());
                     case TypeCode.Int32: return s_Int32LiftedToNull ?? (s_Int32LiftedToNull = new NotEqualInt32LiftedToNull());
                     case TypeCode.Int64: return s_Int64LiftedToNull ?? (s_Int64LiftedToNull = new NotEqualInt64LiftedToNull());
-
+                    case TypeCode.Byte: return s_ByteLiftedToNull ?? (s_ByteLiftedToNull = new NotEqualByteLiftedToNull());
                     case TypeCode.UInt16: return s_UInt16LiftedToNull ?? (s_UInt16LiftedToNull = new NotEqualUInt16LiftedToNull());
                     case TypeCode.UInt32: return s_UInt32LiftedToNull ?? (s_UInt32LiftedToNull = new NotEqualUInt32LiftedToNull());
                     case TypeCode.UInt64: return s_UInt64LiftedToNull ?? (s_UInt64LiftedToNull = new NotEqualUInt64LiftedToNull());
-
                     case TypeCode.Single: return s_SingleLiftedToNull ?? (s_SingleLiftedToNull = new NotEqualSingleLiftedToNull());
                     default:
                         Debug.Assert(underlyingType.GetTypeCode() == TypeCode.Double);
@@ -543,19 +541,16 @@ namespace System.Linq.Expressions.Interpreter
                 {
                     case TypeCode.Boolean: return s_Boolean ?? (s_Boolean = new NotEqualBoolean());
                     case TypeCode.SByte: return s_SByte ?? (s_SByte = new NotEqualSByte());
-                    case TypeCode.Byte: return s_Byte ?? (s_Byte = new NotEqualByte());
-                    case TypeCode.Char: return s_Char ?? (s_Char = new NotEqualChar());
                     case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new NotEqualInt16());
+                    case TypeCode.Char: return s_Char ?? (s_Char = new NotEqualChar());
                     case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new NotEqualInt32());
                     case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new NotEqualInt64());
-
+                    case TypeCode.Byte: return s_Byte ?? (s_Byte = new NotEqualByte());
                     case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new NotEqualUInt16());
                     case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new NotEqualUInt32());
                     case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new NotEqualUInt64());
-
                     case TypeCode.Single: return s_Single ?? (s_Single = new NotEqualSingle());
                     case TypeCode.Double: return s_Double ?? (s_Double = new NotEqualDouble());
-
                     default:
                         // Nullable only valid if one operand is constant null, so this assert is slightly too broad.
                         Debug.Assert(type.IsNullableOrReferenceType());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotInstruction.cs
@@ -50,7 +50,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private sealed class NotIn32 : NotInstruction
+        private sealed class NotInt32 : NotInstruction
         {
             public override int Run(InterpretedFrame frame)
             {
@@ -175,7 +175,7 @@ namespace System.Linq.Expressions.Interpreter
             {
                 case TypeCode.Boolean: return s_Boolean ?? (s_Boolean = new NotBoolean());
                 case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new NotInt64());
-                case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new NotIn32());
+                case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new NotInt32());
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new NotInt16());
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new NotUInt64());
                 case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new NotUInt32());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotInstruction.cs
@@ -16,7 +16,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "Not";
 
-        private sealed class BoolNot : NotInstruction
+        private sealed class NotBoolean : NotInstruction
         {
             public override int Run(InterpretedFrame frame)
             {
@@ -33,7 +33,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private sealed class Int64Not : NotInstruction
+        private sealed class NotInt64 : NotInstruction
         {
             public override int Run(InterpretedFrame frame)
             {
@@ -50,7 +50,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private sealed class Int32Not : NotInstruction
+        private sealed class NotIn32 : NotInstruction
         {
             public override int Run(InterpretedFrame frame)
             {
@@ -67,7 +67,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private sealed class Int16Not : NotInstruction
+        private sealed class NotInt16 : NotInstruction
         {
             public override int Run(InterpretedFrame frame)
             {
@@ -84,7 +84,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private sealed class UInt64Not : NotInstruction
+        private sealed class NotUInt64 : NotInstruction
         {
             public override int Run(InterpretedFrame frame)
             {
@@ -101,7 +101,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private sealed class UInt32Not : NotInstruction
+        private sealed class NotUInt32 : NotInstruction
         {
             public override int Run(InterpretedFrame frame)
             {
@@ -118,7 +118,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private sealed class UInt16Not : NotInstruction
+        private sealed class NotUInt16 : NotInstruction
         {
             public override int Run(InterpretedFrame frame)
             {
@@ -135,7 +135,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private sealed class ByteNot : NotInstruction
+        private sealed class NotByte : NotInstruction
         {
             public override int Run(InterpretedFrame frame)
             {
@@ -152,7 +152,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private sealed class SByteNot : NotInstruction
+        private sealed class NotSByte : NotInstruction
         {
             public override int Run(InterpretedFrame frame)
             {
@@ -173,16 +173,15 @@ namespace System.Linq.Expressions.Interpreter
         {
             switch (type.GetNonNullableType().GetTypeCode())
             {
-                case TypeCode.Boolean: return s_Boolean ?? (s_Boolean = new BoolNot());
-                case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new Int64Not());
-                case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new Int32Not());
-                case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new Int16Not());
-                case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new UInt64Not());
-                case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new UInt32Not());
-                case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new UInt16Not());
-                case TypeCode.Byte: return s_Byte ?? (s_Byte = new ByteNot());
-                case TypeCode.SByte: return s_SByte ?? (s_SByte = new SByteNot());
-
+                case TypeCode.Boolean: return s_Boolean ?? (s_Boolean = new NotBoolean());
+                case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new NotInt64());
+                case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new NotIn32());
+                case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new NotInt16());
+                case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new NotUInt64());
+                case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new NotUInt32());
+                case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new NotUInt16());
+                case TypeCode.Byte: return s_Byte ?? (s_Byte = new NotByte());
+                case TypeCode.SByte: return s_SByte ?? (s_SByte = new NotSByte());
                 default:
                     throw Error.ExpressionNotSupportedForType("Not", type);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OnesComplementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OnesComplementInstruction.cs
@@ -10,30 +10,13 @@ namespace System.Linq.Expressions.Interpreter
 {
     internal abstract class OnesComplementInstruction : Instruction
     {
-        private static Instruction s_Byte, s_SByte, s_Int16, s_Int32, s_Int64, s_UInt16, s_UInt32, s_UInt64;
+        private static Instruction s_SByte, s_Int16, s_Int32, s_Int64, s_Byte, s_UInt16, s_UInt32, s_UInt64;
 
         public override int ConsumedStack => 1;
         public override int ProducedStack => 1;
         public override string InstructionName => "OnesComplement";
 
         private OnesComplementInstruction() { }
-
-        private sealed class OnesComplementInt32 : OnesComplementInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object obj = frame.Pop();
-                if (obj == null)
-                {
-                    frame.Push(null);
-                }
-                else
-                {
-                    frame.Push(~(int)obj);
-                }
-                return 1;
-            }
-        }
 
         private sealed class OnesComplementInt16 : OnesComplementInstruction
         {
@@ -47,6 +30,23 @@ namespace System.Linq.Expressions.Interpreter
                 else
                 {
                     frame.Push((short)(~(short)obj));
+                }
+                return 1;
+            }
+        }
+
+        private sealed class OnesComplementInt32 : OnesComplementInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object obj = frame.Pop();
+                if (obj == null)
+                {
+                    frame.Push(null);
+                }
+                else
+                {
+                    frame.Push(~(int)obj);
                 }
                 return 1;
             }
@@ -159,15 +159,14 @@ namespace System.Linq.Expressions.Interpreter
             Debug.Assert(!type.GetTypeInfo().IsEnum);
             switch (type.GetNonNullableType().GetTypeCode())
             {
-                case TypeCode.Byte: return s_Byte ?? (s_Byte = new OnesComplementByte());
                 case TypeCode.SByte: return s_SByte ?? (s_SByte = new OnesComplementSByte());
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new OnesComplementInt16());
                 case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new OnesComplementInt32());
                 case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new OnesComplementInt64());
+                case TypeCode.Byte: return s_Byte ?? (s_Byte = new OnesComplementByte());
                 case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new OnesComplementUInt16());
                 case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new OnesComplementUInt32());
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new OnesComplementUInt64());
-
                 default:
                     throw Error.ExpressionNotSupportedForType("OnesComplement", type);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
@@ -145,7 +145,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        private sealed class OrBool : OrInstruction
+        private sealed class OrBoolean : OrInstruction
         {
             public override int Run(InterpretedFrame frame)
             {
@@ -184,16 +184,14 @@ namespace System.Linq.Expressions.Interpreter
             switch (underlyingType.GetTypeCode())
             {
                 case TypeCode.SByte: return s_SByte ?? (s_SByte = new OrSByte());
-                case TypeCode.Byte: return s_Byte ?? (s_Byte = new OrByte());
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new OrInt16());
                 case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new OrInt32());
                 case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new OrInt64());
-
+                case TypeCode.Byte: return s_Byte ?? (s_Byte = new OrByte());
                 case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new OrUInt16());
                 case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new OrUInt32());
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new OrUInt64());
-                case TypeCode.Boolean: return s_Boolean ?? (s_Boolean = new OrBool());
-
+                case TypeCode.Boolean: return s_Boolean ?? (s_Boolean = new OrBoolean());
                 default:
                     throw Error.ExpressionNotSupportedForType("Or", type);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RightShiftInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RightShiftInstruction.cs
@@ -170,15 +170,13 @@ namespace System.Linq.Expressions.Interpreter
             switch (underlyingType.GetTypeCode())
             {
                 case TypeCode.SByte: return s_SByte ?? (s_SByte = new RightShiftSByte());
-                case TypeCode.Byte: return s_Byte ?? (s_Byte = new RightShiftByte());
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new RightShiftInt16());
                 case TypeCode.Int32: return s_Int32 ?? (s_Int32 = new RightShiftInt32());
                 case TypeCode.Int64: return s_Int64 ?? (s_Int64 = new RightShiftInt64());
-
+                case TypeCode.Byte: return s_Byte ?? (s_Byte = new RightShiftByte());
                 case TypeCode.UInt16: return s_UInt16 ?? (s_UInt16 = new RightShiftUInt16());
                 case TypeCode.UInt32: return s_UInt32 ?? (s_UInt32 = new RightShiftUInt32());
                 case TypeCode.UInt64: return s_UInt64 ?? (s_UInt64 = new RightShiftUInt64());
-
                 default:
                     throw Error.ExpressionNotSupportedForType("RightShift", type);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
@@ -17,25 +17,6 @@ namespace System.Linq.Expressions.Interpreter
 
         private SubInstruction() { }
 
-        private sealed class SubInt32 : SubInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
-                {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(unchecked((int)l - (int)r));
-                }
-                frame.StackIndex--;
-                return 1;
-            }
-        }
-
         private sealed class SubInt16 : SubInstruction
         {
             public override int Run(InterpretedFrame frame)
@@ -49,6 +30,25 @@ namespace System.Linq.Expressions.Interpreter
                 else
                 {
                     frame.Data[frame.StackIndex - 2] = unchecked((short)((short)l - (short)r));
+                }
+                frame.StackIndex--;
+                return 1;
+            }
+        }
+
+        private sealed class SubInt32 : SubInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object l = frame.Data[frame.StackIndex - 2];
+                object r = frame.Data[frame.StackIndex - 1];
+                if (l == null || r == null)
+                {
+                    frame.Data[frame.StackIndex - 2] = null;
+                }
+                else
+                {
+                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(unchecked((int)l - (int)r));
                 }
                 frame.StackIndex--;
                 return 1;
@@ -198,25 +198,6 @@ namespace System.Linq.Expressions.Interpreter
 
         private SubOvfInstruction() { }
 
-        private sealed class SubOvfInt32 : SubOvfInstruction
-        {
-            public override int Run(InterpretedFrame frame)
-            {
-                object l = frame.Data[frame.StackIndex - 2];
-                object r = frame.Data[frame.StackIndex - 1];
-                if (l == null || r == null)
-                {
-                    frame.Data[frame.StackIndex - 2] = null;
-                }
-                else
-                {
-                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(checked((int)l - (int)r));
-                }
-                frame.StackIndex--;
-                return 1;
-            }
-        }
-
         private sealed class SubOvfInt16 : SubOvfInstruction
         {
             public override int Run(InterpretedFrame frame)
@@ -230,6 +211,25 @@ namespace System.Linq.Expressions.Interpreter
                 else
                 {
                     frame.Data[frame.StackIndex - 2] = checked((short)((short)l - (short)r));
+                }
+                frame.StackIndex--;
+                return 1;
+            }
+        }
+
+        private sealed class SubOvfInt32 : SubOvfInstruction
+        {
+            public override int Run(InterpretedFrame frame)
+            {
+                object l = frame.Data[frame.StackIndex - 2];
+                object r = frame.Data[frame.StackIndex - 1];
+                if (l == null || r == null)
+                {
+                    frame.Data[frame.StackIndex - 2] = null;
+                }
+                else
+                {
+                    frame.Data[frame.StackIndex - 2] = ScriptingRuntimeHelpers.Int32ToObject(checked((int)l - (int)r));
                 }
                 frame.StackIndex--;
                 return 1;


### PR DESCRIPTION
One more tedious pull request in preparation of https://github.com/dotnet/corefx/pull/14195 where these instructions are auto-generated from T4 templates, with the aim at reducing the diff over there so only functional changes stand out for the review.

This PR makes the order of the inner types in instruction classes consistent across the board such that these are all listed in the same order:

* The `static` fields holding the cached instruction instances for primitive types
* The inner `class` declaration which specialize for primitive types
* The `case` labels in the `TypeCode`-based switch for `Create`

The order of the fields was already sorted in a logical manner (signed, unsigned, floating; each group sorted by the number of bytes), so making the rest reflect that order.

Note that the `Not` instruction has major inconsistencies with the rest, both for naming of the types and the order of the primitive types (reverse somehow). I'm addressing the first part here and can tackle the sorting issue separately to reduce the diff.