### PR TITLE
Provide value for FilterTestNugetTargetMoniker (Fix test build break)

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -496,6 +496,8 @@
     <TestTFM Condition="'$(TestTFM)'==''">$(DefaultTestTFM)</TestTFM>
     <!-- we default FilterToTestTFM to DefaultTestTFM if it is not explicity defined -->
     <FilterToTestTFM Condition="'$(FilterToTestTFM)'==''">$(DefaultTestTFM)</FilterToTestTFM>
+    <!-- FilterTestNugetTargetMoniker needs to stay in the long form to be used for Framework and Runtime filtering purposes -->
+    <FilterTestNugetTargetMoniker Condition="'$(FilterTestNugetTargetMoniker)'==''">.NETCoreApp,Version=v1.1</FilterTestNugetTargetMoniker>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
For filtering purposes, we need a long-form TxM, which is named FilterTestNugetTargetMoniker.  After taking the latest build tools update, we found that for package restore of CoreFX packages this will fail if not provided a value.

@karajas @weshaggard 

@hongdai @StephenBonikowsky  If WCF takes a build tools update and hits issues in package restore you'll want to make a similar change