### PR TITLE
Start running netcoreapp tests against the built runtime folder

### DIFF
--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <UsingTask TaskName="GetTargetMachineInfo" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+
+  <PropertyGroup>
+    <TestRuntimeDir>$(RuntimeDir)</TestRuntimeDir>
+    <TestHostExecutable>$(TestRuntimeDir)/corerun</TestHostExecutable>
+    <XunitExecutable>$(TestRuntimeDir)/xunit.console.netcore.exe</XunitExecutable>
+  </PropertyGroup>
+
+    <!-- Which categories of tests to run by default -->
+  <PropertyGroup>
+    <TestDisabled>false</TestDisabled>
+    <TestDisabled Condition="'$(IsTestProject)'!='true' Or '$(SkipTests)'=='true' Or '$(RunTestsForProject)'=='false'">true</TestDisabled>
+    <TestsSuccessfulSemaphore>tests.passed</TestsSuccessfulSemaphore>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Split semicolon separated lists -->
+    <WithCategoriesItems Include="$(WithCategories)" />
+    <WithoutCategoriesItems Include="$(WithoutCategories)" />
+    <DefaultNoCategories Include="$(DefaultNoCategories)" />
+    <UnsupportedPlatformsItems Include="$(UnsupportedPlatforms)"/>
+  </ItemGroup>
+
+  <!-- General xunit options -->
+  <PropertyGroup>
+    <XunitResultsFileName>testResults.xml</XunitResultsFileName>
+
+    <XunitOptions Condition="'$(TestWithCore)' != 'true'">$(XunitOptions) -noshadow </XunitOptions>
+    <XunitOptions>$(XunitOptions) -xml $(XunitResultsFileName)</XunitOptions>
+
+    <XunitOptions Condition="'$(Performance)'!='true'">$(XunitOptions) -notrait Benchmark=true</XunitOptions>
+
+    <XunitOptions Condition="'$(UseDotNetNativeToolchain)'=='true'">$(XunitOptions) -redirectoutput</XunitOptions>
+
+    <XunitOptions Condition="'$(TestTFM)'!=''">$(XunitOptions) -notrait category=non$(TestTFM)tests</XunitOptions>
+    <XunitOptions Condition="'$(XunitMaxThreads)'!=''">$(XunitOptions) -maxthreads $(XunitMaxThreads)</XunitOptions>
+    <XunitTestAssembly Condition="'$(XunitTestAssembly)' == ''">$(TargetPath)</XunitTestAssembly>
+    <XunitArguments>$(XunitTestAssembly) $(XunitOptions)</XunitArguments>
+
+    <TestProgram Condition="'$(TestHostExecutable)'!=''">$(TestHostExecutable)</TestProgram>
+    <TestArguments Condition="'$(TestHostExecutable)'!=''">$(XunitExecutable) $(XunitArguments)</TestArguments>
+
+    <TestProgram Condition="'$(TestHostExecutable)'==''">$(XunitExecutable)</TestProgram>
+    <TestArguments Condition="'$(TestHostExecutable)'==''">$(XunitArguments)</TestArguments>
+
+    <TestCommandLine Condition="'$(Performance)'!='true'">$(TestProgram) $(TestArguments) {XunitTraitOptions}</TestCommandLine>
+  </PropertyGroup>
+
+  <!-- Needs to run before RunTestsForProject target as it computes categories and set TestDisabled -->
+  <Target Name="CheckTestCategories">
+
+    <!-- Default behavior is to disable OuterLoop and failing tests if not specified in WithCategories. -->
+    <ItemGroup>
+      <DefaultNoCategories Condition="'$(Outerloop)'!='true'" Include="OuterLoop" />
+      <DefaultNoCategories Include="failing" />
+      <WithoutCategoriesItems Include="@(DefaultNoCategories)" Exclude="@(WithCategoriesItems)" />
+      <WithoutCategoriesItemsDistinct Include="@(WithoutCategoriesItems->Distinct())" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <RunWithTraits Condition="'@(WithCategoriesItems)'!=''" Include="@(WithCategoriesItems)" />
+      <RunWithoutTraits Condition="'@(WithoutCategoriesItemsDistinct)'!=''" Include="@(WithoutCategoriesItemsDistinct)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <TestsSuccessfulSemaphore Condition="'@(RunWithTraits)' != ''">$(TestsSuccessfulSemaphore).with.@(RunWithTraits, '.')</TestsSuccessfulSemaphore>
+      <TestsSuccessfulSemaphore Condition="'@(RunWithoutTraits)' != ''">$(TestsSuccessfulSemaphore).without.@(RunWithoutTraits, '.')</TestsSuccessfulSemaphore>
+      <TestsSuccessfulSemaphore>$(TestPath)/$(TestsSuccessfulSemaphore)</TestsSuccessfulSemaphore>
+    </PropertyGroup>
+
+    <Delete Condition="'$(ForceRunTests)'=='true' And Exists($(TestsSuccessfulSemaphore))"
+            Files="$(TestsSuccessfulSemaphore)" />
+  </Target>
+
+  <Target Name="RunTestsForProject">
+
+    <ItemGroup>
+      <RunWithoutTraits Condition="'$(TargetOS)'=='Windows_NT'" Include="nonwindowstests" />
+      <RunWithoutTraits Condition="'$(TargetOS)'=='Linux'" Include="nonlinuxtests" />
+      <RunWithoutTraits Condition="'$(TargetOS)'=='OSX'" Include="nonosxtests"/>
+      <RunWithoutTraits Condition="'$(TargetOS)'=='FreeBSD'" Include="nonfreebsdtests"/>
+      <RunWithoutTraits Condition="'$(TargetOS)'=='NetBSD'" Include="nonnetbsdtests"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <XunitTraitOptions Condition="'@(RunWithTraits)'!=''">$(XunitTraitOptions) -trait category=@(RunWithTraits, ' -trait category=') </XunitTraitOptions>
+      <XunitTraitOptions Condition="'@(RunWithoutTraits)'!=''">$(XunitTraitOptions) -notrait category=@(RunWithoutTraits, ' -notrait category=') </XunitTraitOptions>
+      <TestCommandLine>$(TestCommandLine.Replace('{XunitTraitOptions}', '$(XunitTraitOptions)'))</TestCommandLine>
+    </PropertyGroup>
+
+    <Exec Command="$(TestCommandLine)"
+          Condition="'$(TestDisabled)' != 'true'"
+          WorkingDirectory="$(TestRuntimeDir)"
+          CustomErrorRegularExpression="Failed: [^0]"
+          ContinueOnError="true"
+          IgnoreStandardErrorWarningFormat="true"
+          EnvironmentVariables="CORE_LIBRARIES=$(OutDir)"
+          >
+      <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />
+    </Exec>
+  </Target>
+
+
+  <!-- Needs to run before RunTestsForProject target as it computes categories and set TestDisabled -->
+  <Target Name="CheckTestCategories">
+
+    <!-- Default behavior is to disable OuterLoop and failing tests if not specified in WithCategories. -->
+    <ItemGroup>
+      <DefaultNoCategories Condition="'$(Outerloop)'!='true'" Include="OuterLoop" />
+      <DefaultNoCategories Include="failing" />
+      <WithoutCategoriesItems Include="@(DefaultNoCategories)" Exclude="@(WithCategoriesItems)" />
+      <WithoutCategoriesItemsDistinct Include="@(WithoutCategoriesItems->Distinct())" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <RunWithTraits Condition="'@(WithCategoriesItems)'!=''" Include="@(WithCategoriesItems)" />
+      <RunWithoutTraits Condition="'@(WithoutCategoriesItemsDistinct)'!=''" Include="@(WithoutCategoriesItemsDistinct)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <TestsSuccessfulSemaphore Condition="'@(RunWithTraits)' != ''">$(TestsSuccessfulSemaphore).with.@(RunWithTraits, '.')</TestsSuccessfulSemaphore>
+      <TestsSuccessfulSemaphore Condition="'@(RunWithoutTraits)' != ''">$(TestsSuccessfulSemaphore).without.@(RunWithoutTraits, '.')</TestsSuccessfulSemaphore>
+      <TestsSuccessfulSemaphore>$(TestPath)/$(TestsSuccessfulSemaphore)</TestsSuccessfulSemaphore>
+    </PropertyGroup>
+
+    <Delete Condition="'$(ForceRunTests)'=='true' And Exists($(TestsSuccessfulSemaphore))"
+            Files="$(TestsSuccessfulSemaphore)" />
+  </Target>
+
+  <PropertyGroup>
+    <ResolvePkgProjReferencesDependsOn>GetDefaultTestRid;$(ResolvePkgProjReferencesDependsOn)</ResolvePkgProjReferencesDependsOn>
+  </PropertyGroup>
+
+  <Target Name="CheckTestPlatforms">
+    <GetTargetMachineInfo Condition="'$(TargetOS)' == ''">
+      <Output TaskParameter="TargetOS" PropertyName="TargetOS" />
+    </GetTargetMachineInfo>
+    <PropertyGroup>
+      <TestDisabled Condition="'%(UnsupportedPlatformsItems.Identity)' == '$(TargetOS)'">true</TestDisabled>
+    </PropertyGroup>
+    <Message Condition="'%(UnsupportedPlatformsItems.Identity)' == '$(TargetOS)'"
+      Text="Skipping tests in $(AssemblyName) because it is not supported on $(TargetOS)" />
+  </Target>
+
+  <Target Name="SetupTestProperties" DependsOnTargets="CheckTestPlatforms;CheckTestCategories" />
+
+  <PropertyGroup>
+    <TestDependsOn>
+      $(TestDependsOn);
+      SetupTestProperties;
+      RunTestsForProject;
+    </TestDependsOn>
+  </PropertyGroup>
+
+  <Target Name="Test" DependsOnTargets="$(TestDependsOn)" />
+  <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />
+  <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" />
+
+</Project>

--- a/src/Common/test-runtime/XUnit.Runtime.depproj
+++ b/src/Common/test-runtime/XUnit.Runtime.depproj
@@ -23,7 +23,12 @@
                                                                               '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='xunit.extensibility.execution' And 
                                                                               '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='xunit.console.netcore' And 
                                                                               '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='xunit.runner.utility' And 
-                                                                              '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='Microsoft.xunit.netcore.extensions'" />
+                                                                              '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='Microsoft.xunit.netcore.extensions' And
+                                                                              '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR' And
+                                                                              '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='runtime.win7-x64.Microsoft.NETCore.TestHost' And
+                                                                              '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets' And
+                                                                              '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='runtime.win7-x64.Microsoft.NETCore.Jit'
+                                                                              " />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -2,7 +2,10 @@
    "dependencies": {
       "xunit.console.netcore": "1.0.3-prerelease-00921-01",
       "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04",
-      "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04"
+      "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
+      "Microsoft.NETCore.Runtime.CoreCLR": "1.2.0-beta-24728-02",
+      "Microsoft.NETCore.TestHost": "1.2.0-beta-24728-02",
+      "Microsoft.NETCore.Windows.ApiSets": "1.0.2-beta-24727-00",
    },
    "frameworks": {
       "netstandard1.7": {}

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -5,32 +5,11 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{57E8F8D4-0766-4CC7-B3F9-B243B81DB6A5}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AssemblyName>System.IO.FileSystem.Tests</AssemblyName>
     <TestCategories>InnerLoop;OuterLoop</TestCategories>
-    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-  </PropertyGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\pkg\System.IO.FileSystem.pkgproj">
-      <Project>{879c23dc-d828-4dfb-8e92-abbc11b71035}</Project>
-      <UndefineProperties>%(ProjectReference.UndefineProperties);TargetGroup</UndefineProperties>
-      <Name>System.IO.FileSystem</Name>
-      <Private>True</Private>
-    </ProjectReference>
-  </ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)'==''">
     <Compile Include="FileInfo\Serialization.cs" />
     <Compile Include="FileInfo\Replace.cs" />
@@ -178,16 +157,6 @@
       <Name>RemoteExecutorConsoleApp</Name>
       <UndefineProperties>%(ProjectReference.UndefineProperties);TargetGroup</UndefineProperties>
     </ProjectReference>
-    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
-    <ProjectReference Include="..\..\System.IO\pkg\System.IO.pkgproj" />
-    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
-    <ProjectReference Include="..\..\System.Runtime\pkg\System.Runtime.pkgproj" />
-    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
-    <ProjectReference Include="..\..\System.Runtime.Extensions\pkg\System.Runtime.Extensions.pkgproj" />
-    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
-    <ProjectReference Include="..\..\System.Security.Permissions\pkg\System.Security.Permissions.pkgproj" />
-    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
-    <ProjectReference Include="..\..\System.IO.FileSystem.Primitives\pkg\System.IO.FileSystem.Primitives.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -2,11 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{8CBA022C-635F-4C8D-9D29-CD8AAC68C8E6}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -107,11 +103,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\System.Security.Principal.Windows\pkg\System.Security.Principal.Windows.pkgproj" />
-    <ProjectReference Include="..\..\pkg\System.Net.Sockets.pkgproj">
-      <Project>{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}</Project>
-      <Name>System.Net.Sockets</Name>
-    </ProjectReference>
 	<ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
       <Name>RemoteExecutorConsoleApp</Name>

--- a/src/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
+++ b/src/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
@@ -2,23 +2,12 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{A7074928-82C3-4739-88FE-9B528977950C}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>System.Numerics.Tests</RootNamespace>
-    <AssemblyName>System.Numerics.Vectors.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NuGetPackageImportStamp>11f13d9c</NuGetPackageImportStamp>
-    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Compile Include="..\src\System\Numerics\ConstantHelper.cs">
       <AutoGen>True</AutoGen>
@@ -42,16 +31,6 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\pkg\System.Numerics.Vectors.pkgproj">
-      <Project>{53134b0c-0d57-481b-b84e-d1991e8d54ff}</Project>
-      <Name>System.Numerics.Vectors</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\src\System\Numerics\ConstantHelper.tt">

--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -2,17 +2,11 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{7061832A-E8CF-4AB6-A8DC-44D2F5A43A13}</ProjectGuid>
-    <OutputType>Library</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ExternallyShipping>false</ExternallyShipping>
     <AssemblyName>System.Reflection.Metadata.Tests</AssemblyName>
     <RootNamespace>System.Reflection.Metadata.Tests</RootNamespace>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <FileAlignment>512</FileAlignment>
-    <ExternallyShipping>false</ExternallyShipping>
-    <NuGetPackageImportStamp>83230753</NuGetPackageImportStamp>
-    <NugetTargetMoniker>.NETStandard,Version=v1.5</NugetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -27,12 +21,6 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\pkg\System.Reflection.Metadata.pkgproj">
-      <Project>{f3e433c8-352f-4944-bf7f-765ce435370d}</Project>
-      <Name>System.Reflection.Metadata</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="..\..\Common\src\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
@@ -44,9 +32,6 @@
     </Compile>
     <Compile Include="..\..\Common\src\Interop\Windows\kernel32\Interop.LoadLibraryEx.cs">
       <Link>Common\Interop\Windows\Interop.LoadLibraryEx.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\Microsoft\Win32\SafeHandles\SafeHandleZeroOrMinusOneIsInvalid.cs">
-      <Link>Common\Microsoft\Win32\Handles\SafeHandleZeroOrMinusOneIsInvalid.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
       <Link>Common\Microsoft\Win32\Handles\SafeLibraryHandle.cs</Link>
@@ -158,7 +143,8 @@
     <EmbeddedResource Include="Resources\Misc\Signed.exe" />
   </ItemGroup>
   <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+    <ProjectReference Include="..\src\System.Reflection.Metadata.csproj" />
+    <ProjectReference Include="..\..\System.Collections.Immutable\src\System.Collections.Immutable.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Extensions/tests/AssemblyResolveTests/AssemblyResolveTests.csproj
+++ b/src/System.Runtime.Extensions/tests/AssemblyResolveTests/AssemblyResolveTests.csproj
@@ -3,12 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>ad83807c-8be5-4f27-85df-9793613233e1</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>AssemblyResolveTests</RootNamespace>
-    <AssemblyName>AssemblyResolveTests</AssemblyName>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <CopyNuGetImplementations>false</CopyNuGetImplementations>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -28,9 +26,6 @@
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="System.Core" />
     <TargetingPackReference Include="System.Runtime" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
  </Project>

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -5,15 +5,9 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>System.Runtime.Extensions.Tests</RootNamespace>
-    <AssemblyName>System.Runtime.Extensions.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
-    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.5</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Folder logic needs moved into common targets: https://github.com/dotnet/corefx/issues/11468 -->
   <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
@@ -120,16 +114,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\System.Diagnostics.Debug\pkg\System.Diagnostics.Debug.pkgproj" />
-    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
-    <ProjectReference Include="..\..\System.IO.FileSystem.Primitives\pkg\System.IO.FileSystem.Primitives.pkgproj" />
-    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
-    <ProjectReference Include="..\..\System.IO.FileSystem\pkg\System.IO.FileSystem.pkgproj" />
-    <ProjectReference Include="..\pkg\System.Runtime.Extensions.pkgproj">
-      <Project>{1e689c1b-690c-4799-bde9-6e7990585894}</Project>
-      <Name>System.Runtime.Extensions.CoreCLR</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\System.Private.Uri\pkg\System.Private.Uri.pkgproj" />
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
       <Name>RemoteExecutorConsoleApp</Name>
@@ -152,8 +136,6 @@
       <Name>TestApp</Name>
       <UndefineProperties>TargetGroup;OSGroup</UndefineProperties>
     </ProjectReference>
-    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
-    <ProjectReference Include="..\..\System.IO\pkg\System.IO.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Extensions/tests/TestApp/TestApp.csproj
+++ b/src/System.Runtime.Extensions/tests/TestApp/TestApp.csproj
@@ -4,11 +4,10 @@
   <PropertyGroup>
     <ProjectGuid>{24BCEC6B-B9D2-47BC-9D66-725BD6B526FA}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>TestApp</RootNamespace>
-    <AssemblyName>TestApp</AssemblyName>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <CopyNuGetImplementations>false</CopyNuGetImplementations>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Runtime.Extensions/tests/TestAppOutsideOfTPA/TestAppOutsideOfTPA.csproj
+++ b/src/System.Runtime.Extensions/tests/TestAppOutsideOfTPA/TestAppOutsideOfTPA.csproj
@@ -4,11 +4,9 @@
   <PropertyGroup>
     <ProjectGuid>{C44B33E3-F89F-40B9-B353-D380C1524988}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>TestAppOutsideOfTPA</RootNamespace>
-    <AssemblyName>TestAppOutsideOfTPA</AssemblyName>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <CopyNuGetImplementations>false</CopyNuGetImplementations>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -28,9 +26,6 @@
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="System.Core" />
     <TargetingPackReference Include="System.Runtime" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AssemblyResolveTests\AssemblyResolveTests.csproj">

--- a/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.csproj
+++ b/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.csproj
@@ -4,11 +4,9 @@
   <PropertyGroup>
     <ProjectGuid>{9F312D76-9AF1-4E90-B3B0-815A1EC6C346}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>VoidMainWithExitCodeApp</RootNamespace>
-    <AssemblyName>VoidMainWithExitCodeApp</AssemblyName>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <CopyNuGetImplementations>false</CopyNuGetImplementations>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -28,9 +26,6 @@
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="System.Core" />
     <TargetingPackReference Include="System.Runtime" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/targetingpacks.props
+++ b/targetingpacks.props
@@ -7,7 +7,6 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TestRuntimeDir>$(BinDir)/tests/test-runtime/netcoreapp</TestRuntimeDir>
     <ContractOutputPath>$(BinDir)netcoreapp/TargetingPack</ContractOutputPath>
     <FrameworkPathOverride>$(ContractOutputPath)</FrameworkPathOverride>
     <AssemblySearchPaths>$(AssemblySearchPaths);$(ContractOutputPath);{RawFileName}</AssemblySearchPaths>
@@ -16,6 +15,9 @@
   <!-- Adds test references to the targeting pack and runtime assemblies. -->
   <Target Name="AddTestTargetingPackReferences" BeforeTargets="ResolveAssemblyReferences" Condition="'$(IsTestProject)' == 'true'">
     <ItemGroup>
+      <TargetingPackExclusions Include="System.Private.CoreLib" />
+      <TargetingPackExclusions Include="System.Runtime.WindowsRuntime.UI.Xaml" /> <!-- Harmless, but causes PRI targets to run -->
+
       <!-- Whitelisted runtime assemblies that are OK to reference. -->
       <RuntimeReferencedAssemblyNames Include="xunit.core" />
       <RuntimeReferencedAssemblyNames Include="Xunit.NetCore.Extensions" />
@@ -24,7 +26,9 @@
 
       <!-- Add Reference's to all files in the targeting pack folder, and to whitelisted items from the group above in the runtime folder. -->
       <TargetingPackItems Include="%(TargetingPackDirs.Identity)/*" />
-      <Reference Include="%(TargetingPackItems.Filename)" Exclude="System.Private.CoreLib" /> <!-- TODO: System.Private.CoreLib shouldn't even be in the targeting pack. -->
+      <Reference Include="%(TargetingPackItems.Filename)" Exclude="@(TargetingPackExclusions)"> <!-- TODO: System.Private.CoreLib shouldn't even be in the targeting pack. -->
+        <Private>false</Private>
+      </Reference>
       <Reference Include="@(RuntimeReferencedAssemblyNames)" />
     </ItemGroup>
 


### PR DESCRIPTION
This puts a tests.targets override into Tools-Override which has basic steps for running tests out of the live-built runtime folder for netcoreapp. Currently this is using corerun, and sets the `CORE_LIBRARIES` environment variable in order to load test assemblies from another folder. We may end up overhauling that part of the process.

Additionally, I've fixed up a few more projects and verified that they all build and run successfully.

NOTE: tests are still disabled in the CI runs.

@joperezr 