### PR TITLE
Use ArrayPool in ManagedWebSocket

### DIFF
--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -81,7 +82,9 @@ namespace System.Net.WebSockets
         /// <summary>CancellationTokenSource used to abort all current and future operations when anything is canceled or any error occurs.</summary>
         private readonly CancellationTokenSource _abortSource = new CancellationTokenSource();
         /// <summary>Buffer used for reading data from the network.</summary>
-        private readonly byte[] _receiveBuffer;
+        private byte[] _receiveBuffer;
+        /// <summary>Gets whether the receive buffer came from the ArrayPool.</summary>
+        private readonly bool _receiveBufferFromPool;
         /// <summary>
         /// Tracks the state of the validity of the UTF8 encoding of text payloads.  Text may be split across fragments.
         /// </summary>
@@ -132,9 +135,10 @@ namespace System.Net.WebSockets
         /// </summary>
         private int _receivedMaskOffsetOffset = 0;
         /// <summary>
-        /// Buffer used to store the complete message to be sent to the stream.  This is needed
-        /// rather than just sending a header and then the user's buffer, as we need to mutate the
-        /// buffered data with the mask, and we don't want to change the data in the user's buffer.
+        /// Temporary send buffer.  This should be released back to the ArrayPool once it's
+        /// no longer needed for the current send operation.  It is stored as an instance
+        /// field to minimize needing to pass it around and to avoid it becoming a field on
+        /// various async state machine objects.
         /// </summary>
         private byte[] _sendBuffer;
         /// <summary>
@@ -195,7 +199,8 @@ namespace System.Net.WebSockets
             }
             else
             {
-                _receiveBuffer = new byte[Math.Max(receiveBufferSize, MaxMessageHeaderLength)];
+                _receiveBufferFromPool = true;
+                _receiveBuffer = ArrayPool<byte>.Shared.Rent(Math.Max(receiveBufferSize, MaxMessageHeaderLength));
             }
 
             // Set up the abort source so that if it's triggered, we transition the instance appropriately.
@@ -238,6 +243,12 @@ namespace System.Net.WebSockets
                 _disposed = true;
                 _keepAliveTimer?.Dispose();
                 _stream?.Dispose();
+                if (_receiveBufferFromPool)
+                {
+                    byte[] old = _receiveBuffer;
+                    _receiveBuffer = null;
+                    ArrayPool<byte>.Shared.Return(old);
+                }
                 if (_state < WebSocketState.Aborted)
                 {
                     _state = WebSocketState.Closed;
@@ -382,7 +393,7 @@ namespace System.Net.WebSockets
             // If we get here, the cancellation token is not cancelable so we don't have to worry about it,
             // and we own the semaphore, so we don't need to asynchronously wait for it.
             Task writeTask = null;
-            bool releaseSemaphore = true;
+            bool releaseSemaphoreAndSendBuffer = true;
             try
             {
                 // Write the payload synchronously to the buffer, then write that buffer out to the network.
@@ -399,9 +410,9 @@ namespace System.Net.WebSockets
                 }
 
                 // Up until this point, if an exception occurred (such as when accessing _stream or when
-                // calling GetResult), we want to release the semaphore. After this point, the semaphore needs
-                // to remain held until writeTask completes.
-                releaseSemaphore = false;
+                // calling GetResult), we want to release the semaphore and the send buffer. After this point,
+                // both need to be held until writeTask completes.
+                releaseSemaphoreAndSendBuffer = false;
             }
             catch (Exception exc)
             {
@@ -411,9 +422,10 @@ namespace System.Net.WebSockets
             }
             finally
             {
-                if (releaseSemaphore)
+                if (releaseSemaphoreAndSendBuffer)
                 {
                     _sendFrameAsyncLock.Release();
+                    ReleaseSendBuffer();
                 }
             }
 
@@ -423,6 +435,7 @@ namespace System.Net.WebSockets
             {
                 var thisRef = (ManagedWebSocket)s;
                 thisRef._sendFrameAsyncLock.Release();
+                thisRef.ReleaseSendBuffer();
 
                 try { t.GetAwaiter().GetResult(); }
                 catch (Exception exc)
@@ -454,14 +467,15 @@ namespace System.Net.WebSockets
             finally
             {
                 _sendFrameAsyncLock.Release();
+                ReleaseSendBuffer();
             }
         }
 
         /// <summary>Writes a frame into the send buffer, which can then be sent over the network.</summary>
         private int WriteFrameToSendBuffer(MessageOpcode opcode, bool endOfMessage, ArraySegment<byte> payloadBuffer)
         {
-            // Grow our send buffer as needed.  We reuse the buffer for all messages, with it protected by the send frame lock.
-            EnsureBufferLength(ref _sendBuffer, payloadBuffer.Count + MaxMessageHeaderLength);
+            // Ensure we have a _sendBuffer.
+            AllocateSendBuffer(payloadBuffer.Count + MaxMessageHeaderLength);
 
             // Write the message header data to the buffer.
             int headerLength;
@@ -996,37 +1010,44 @@ namespace System.Net.WebSockets
                 $"Unexpected state {State}.");
 
             // Wait until we've received a close response
-            byte[] closeBuffer = new byte[MaxMessageHeaderLength + MaxControlPayloadLength];
-            while (!_receivedCloseFrame)
+            byte[] closeBuffer = ArrayPool<byte>.Shared.Rent(MaxMessageHeaderLength + MaxControlPayloadLength);
+            try
             {
-                Debug.Assert(!Monitor.IsEntered(StateUpdateLock), $"{nameof(StateUpdateLock)} must never be held when acquiring {nameof(ReceiveAsyncLock)}");
-                Task<WebSocketReceiveResult> receiveTask;
-                lock (ReceiveAsyncLock)
+                while (!_receivedCloseFrame)
                 {
-                    // Now that we're holding the ReceiveAsyncLock, double-check that we've not yet received the close frame.
-                    // It could have been received between our check above and now due to a concurrent receive completing.
-                    if (_receivedCloseFrame)
+                    Debug.Assert(!Monitor.IsEntered(StateUpdateLock), $"{nameof(StateUpdateLock)} must never be held when acquiring {nameof(ReceiveAsyncLock)}");
+                    Task<WebSocketReceiveResult> receiveTask;
+                    lock (ReceiveAsyncLock)
                     {
-                        break;
+                        // Now that we're holding the ReceiveAsyncLock, double-check that we've not yet received the close frame.
+                        // It could have been received between our check above and now due to a concurrent receive completing.
+                        if (_receivedCloseFrame)
+                        {
+                            break;
+                        }
+
+                        // We've not yet processed a received close frame, which means we need to wait for a received close to complete.
+                        // There may already be one in flight, in which case we want to just wait for that one rather than kicking off
+                        // another (we don't support concurrent receive operations).  We need to kick off a new receive if either we've
+                        // never issued a receive or if the last issued receive completed for reasons other than a close frame.  There is
+                        // a race condition here, e.g. if there's a in-flight receive that completes after we check, but that's fine: worst
+                        // case is we then await it, find that it's not what we need, and try again.
+                        receiveTask = _lastReceiveAsync;
+                        if (receiveTask == null ||
+                            (receiveTask.Status == TaskStatus.RanToCompletion && receiveTask.Result.MessageType != WebSocketMessageType.Close))
+                        {
+                            _lastReceiveAsync = receiveTask = ReceiveAsyncPrivate(new ArraySegment<byte>(closeBuffer), cancellationToken);
+                        }
                     }
 
-                    // We've not yet processed a received close frame, which means we need to wait for a received close to complete.
-                    // There may already be one in flight, in which case we want to just wait for that one rather than kicking off
-                    // another (we don't support concurrent receive operations).  We need to kick off a new receive if either we've
-                    // never issued a receive or if the last issued receive completed for reasons other than a close frame.  There is
-                    // a race condition here, e.g. if there's a in-flight receive that completes after we check, but that's fine: worst
-                    // case is we then await it, find that it's not what we need, and try again.
-                    receiveTask = _lastReceiveAsync;
-                    if (receiveTask == null ||
-                        (receiveTask.Status == TaskStatus.RanToCompletion && receiveTask.Result.MessageType != WebSocketMessageType.Close))
-                    {
-                        _lastReceiveAsync = receiveTask = ReceiveAsyncPrivate(new ArraySegment<byte>(closeBuffer), cancellationToken);
-                    }
+                    // Wait for whatever receive task we have.  We'll then loop around again to re-check our state.
+                    Debug.Assert(receiveTask != null);
+                    await receiveTask.ConfigureAwait(false);
                 }
-
-                // Wait for whatever receive task we have.  We'll then loop around again to re-check our state.
-                Debug.Assert(receiveTask != null);
-                await receiveTask.ConfigureAwait(false);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(closeBuffer);
             }
 
             // We're closed.  Close the connection and update the status.
@@ -1048,23 +1069,35 @@ namespace System.Net.WebSockets
         {
             // Close payload is two bytes containing the close status followed by a UTF8-encoding of the status description, if it exists.
 
-            byte[] buffer;
-            if (string.IsNullOrEmpty(closeStatusDescription))
+            byte[] buffer = null;
+            try
             {
-                buffer = new byte[2];
+                int count = 2;
+                if (string.IsNullOrEmpty(closeStatusDescription))
+                {
+                    buffer = ArrayPool<byte>.Shared.Rent(count);
+                }
+                else
+                {
+                    count += s_textEncoding.GetByteCount(closeStatusDescription);
+                    buffer = ArrayPool<byte>.Shared.Rent(count);
+                    int encodedLength = s_textEncoding.GetBytes(closeStatusDescription, 0, closeStatusDescription.Length, buffer, 2);
+                    Debug.Assert(count - 2 == encodedLength, $"GetByteCount and GetBytes encoded count didn't match");
+                }
+
+                ushort closeStatusValue = (ushort)closeStatus;
+                buffer[0] = (byte)(closeStatusValue >> 8);
+                buffer[1] = (byte)(closeStatusValue & 0xFF);
+
+                await SendFrameAsync(MessageOpcode.Close, true, new ArraySegment<byte>(buffer, 0, count), cancellationToken).ConfigureAwait(false);
             }
-            else
+            finally
             {
-                buffer = new byte[2 + s_textEncoding.GetByteCount(closeStatusDescription)];
-                int encodedLength = s_textEncoding.GetBytes(closeStatusDescription, 0, closeStatusDescription.Length, buffer, 2);
-                Debug.Assert(buffer.Length - 2 == encodedLength, $"GetByteCount and GetBytes encoded count didn't match");
+                if (buffer != null)
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                }
             }
-
-            ushort closeStatusValue = (ushort)closeStatus;
-            buffer[0] = (byte)(closeStatusValue >> 8);
-            buffer[1] = (byte)(closeStatusValue & 0xFF);
-
-            await SendFrameAsync(MessageOpcode.Close, true, new ArraySegment<byte>(buffer), cancellationToken).ConfigureAwait(false);
 
             lock (StateUpdateLock)
             {
@@ -1124,15 +1157,21 @@ namespace System.Net.WebSockets
             }
         }
 
-        /// <summary>
-        /// Grows the specified buffer if it's not at least the specified minimum length.
-        /// Data is not copied if the buffer is grown.
-        /// </summary>
-        private static void EnsureBufferLength(ref byte[] buffer, int minLength)
+        /// <summary>Gets a send buffer from the pool.</summary>
+        private void AllocateSendBuffer(int minLength)
         {
-            if (buffer == null || buffer.Length < minLength)
+            Debug.Assert(_sendBuffer == null); // would only fail if had some catastrophic error previously that prevented cleaning up
+            _sendBuffer = ArrayPool<byte>.Shared.Rent(minLength);
+        }
+
+        /// <summary>Releases the send buffer to the pool.</summary>
+        private void ReleaseSendBuffer()
+        {
+            byte[] old = _sendBuffer;
+            if (old != null)
             {
-                buffer = new byte[minLength];
+                _sendBuffer = null;
+                ArrayPool<byte>.Shared.Return(old);
             }
         }
 

--- a/src/System.Net.WebSockets.Client/src/project.json
+++ b/src/System.Net.WebSockets.Client/src/project.json
@@ -4,6 +4,7 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.1.0",
         "Microsoft.Win32.Primitives": "4.3.0",
+        "System.Buffers": "4.3.0",
         "System.Collections": "4.3.0",
         "System.Diagnostics.Debug": "4.3.0",
         "System.Diagnostics.Tools": "4.3.0",

--- a/src/System.Net.WebSockets.Client/src/unix/project.json
+++ b/src/System.Net.WebSockets.Client/src/unix/project.json
@@ -4,6 +4,7 @@
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.1.0",
         "Microsoft.Win32.Primitives": "4.3.0",
+        "System.Buffers": "4.3.0",
         "System.Console": "4.3.0",
         "System.Collections": "4.3.0",
         "System.Diagnostics.Debug": "4.3.0",


### PR DESCRIPTION
This switches from allocating byte arrays to getting them from ArrayPool.  There are two primary buffers, and then a few smaller ones.  The receive buffer is rented for the lifetime of the websocket, whereas the send buffer is rented only for the duration of a send.  By switching to using ArrayPool, memory consumption when many websockets are being used should be less, as they will only take up the space for the send buffer while it's in use.

cc: @benaadams, @CIPop, @davidsh, @anurse 