### PR TITLE
Add portableLinux option for build-native.sh

### DIFF
--- a/config.json
+++ b/config.json
@@ -186,6 +186,12 @@
       "values": ["Numeric values"],
       "defaultValue": "--numproc ${ProcessorCount}"
     },
+    "AdditionalArgs": {
+      "description": "Pass additional arguments to the native_build script",
+      "valueType": "passThrough",
+      "values": [],
+      "defaultValue": ""
+    },
     "Project": {
       "description": "Project where the commands are going to be applied.",
       "valueType": "passThrough",
@@ -355,6 +361,12 @@
           "settings": {
             "HostOs": "default"
           }
+        },
+        "portableLinux":{
+          "description": "Make the build-native script generate binaries that are portable over glibc based Linux distros.",
+          "settings": {
+            "AdditionalArgs": "portableLinux"
+          }
         }
       },
       "defaultValues": {
@@ -364,7 +376,8 @@
            "BuildArchitecture": "default", 
            "CmakeBuildType": "default",           
            "HostOs": "default",
-           "ProcessorCount": "default"
+           "ProcessorCount": "default",
+           "AdditionalArgs": "default"
          }
       }
     },

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -14,6 +14,7 @@ usage()
     echo "cross - optional argument to signify cross compilation,"
     echo "      - will use ROOTFS_DIR environment variable if set."
     echo "staticLibLink - Optional argument to statically link any native library."
+    echo "portableLinux - Optional argument to build native libraries portable over GLIBC based Linux distros."
     echo "generateversion - Pass this in to get a version on the build output."
     echo "cmakeargs - user-settable additional arguments passed to CMake."
     exit 1
@@ -112,6 +113,8 @@ __ServerGC=0
 __VerboseBuild=false
 __ClangMajorVersion=3
 __ClangMinorVersion=5
+__StaticLibLink=0
+__PortableLinux=0
 
 while :; do
     if [ $# -le 0 ]; then
@@ -166,7 +169,10 @@ while :; do
             __VerboseBuild=1
             ;;
         staticliblink)
-            __CMakeExtraArgs="$__CMakeExtraArgs -DCMAKE_STATIC_LIB_LINK=1"
+            __StaticLibLink=1
+            ;;
+        portablelinux)
+            __PortableLinux=1
             ;;
         generateversion)
             __generateversionsource=true
@@ -221,6 +227,9 @@ while :; do
 
     shift
 done
+
+__CMakeExtraArgs="$__CMakeExtraArgs -DFEATURE_DISTRO_AGNOSTIC_SSL=$__PortableLinux"
+__CMakeExtraArgs="$__CMakeExtraArgs -DCMAKE_STATIC_LIB_LINK=$__StaticLibLink"
 
 # Set cross build
 CPUName=$(uname -p)


### PR DESCRIPTION
This change adds portableLinux option to the src/Native/build-native.sh and also
enables its passing through from the root build-native.sh and build.sh.
This option enables or disables build of native binaries portable over
Linux distros based on glibc.

I have also modified the build-native.sh behavior for the staticLibLink option.
Before, if you ran build with this option and then later on ran the build
without this option, it was still considered as being set since the previous
value was cached. With my change, it rebuilds the binaries any time you change
the option.