### PR TITLE
Use ArrayPool for multiple buffers in CurlHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -87,7 +88,8 @@ namespace System.Net.Http
             /// When data is provided by libcurl, it must be consumed all or nothing: either all of the data is consumed, or
             /// we must pause the connection.  Since a read could need to be satisfied with only some of the data provided,
             /// we store the rest here until all reads can consume it.  If a subsequent write callback comes in to provide
-            /// more data, the connection will then be paused until this buffer is entirely consumed.
+            /// more data, the connection will then be paused until this buffer is entirely consumed. This buffer comes from
+            /// the ArrayPool and should be returned when we're done with it.
             /// </summary>
             private byte[] _remainingData;
 
@@ -220,11 +222,13 @@ namespace System.Net.Http
                         // Make sure our remaining data buffer exists and is big enough to hold the data
                         if (_remainingData == null)
                         {
-                            _remainingData = new byte[_remainingDataCount];
+                            _remainingData = ArrayPool<byte>.Shared.Rent(_remainingDataCount);
                         }
                         else if (_remainingData.Length < _remainingDataCount)
                         {
-                            _remainingData = new byte[Math.Max(_remainingData.Length * 2, _remainingDataCount)];
+                            byte[] old = _remainingData;
+                            _remainingData = ArrayPool<byte>.Shared.Rent(_remainingDataCount);
+                            ArrayPool<byte>.Shared.Return(old);
                         }
 
                         // Copy the remaining data to the buffer
@@ -411,6 +415,15 @@ namespace System.Net.Http
                         }
 
                         ClearPendingReadRequest();
+                    }
+
+                    // If we have a buffer, return it to the pool.
+                    byte[] buffer = _remainingData;
+                    if (buffer != null)
+                    {
+                        _remainingDataCount = _remainingDataOffset = 0;
+                        _remainingData = null;
+                        ArrayPool<byte>.Shared.Return(buffer);
                     }
                 }
             }


### PR DESCRIPTION
CurlHandler currently has two potentially large byte[] buffers:
- When sending request data, it allocates a buffer to transfer data from the request to libcurl, typically 16K (unless the request content is known to be smaller than that).
- When transferring response data, libcurl offers up data in large chunks, and we need to take all or none of it at a time.  If a response read on the response stream asks for less than what libcurl proferred, we need to buffer the remainder, typically up to 16K in size.

Currently these buffers are allocated per request.  This commit changes them to come from ArrayPool.

cc: @geoffkizer, @davidsh, @cipop