### PR TITLE
Fix ConcurrentBag enumeration undefined behavior

### DIFF
--- a/src/System.Collections.Concurrent/src/Resources/Strings.resx
+++ b/src/System.Collections.Concurrent/src/Resources/Strings.resx
@@ -237,4 +237,7 @@
   <data name="PartitionerStatic_CurrentCalledBeforeMoveNext" xml:space="preserve">
     <value>MoveNext must be called at least once before calling Current.</value>
   </data>
+  <data name="ConcurrentBag_Enumerator_EnumerationNotStartedOrAlreadyFinished" xml:space="preserve">
+    <value>Enumeration has either not started or has already finished.</value>
+  </data>
 </root>

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
@@ -419,7 +419,7 @@ namespace System.Collections.Concurrent
         /// <see cref="GetEnumerator"/> was called.  The enumerator is safe to use
         /// concurrently with reads from and writes to the bag.
         /// </remarks>
-        public IEnumerator<T> GetEnumerator() => ((IEnumerable<T>)ToArray()).GetEnumerator();
+        public IEnumerator<T> GetEnumerator() => new Enumerator(ToArray());
 
         /// <summary>
         /// Returns an enumerator that iterates through the <see
@@ -980,5 +980,62 @@ namespace System.Collections.Concurrent
             Add,
             Take
         };
+
+        /// <summary>Provides an enumerator for the bag.</summary>
+        /// <remarks>
+        /// The original implementation of ConcurrentBag used a <see cref="List{T}"/> as part of
+        /// the GetEnumerator implementation.  That list was then changed to be an array, but array's
+        /// GetEnumerator has different behavior than does list's, in particular for the case where
+        /// Current is used after MoveNext returns false.  To avoid any concerns around compatibility,
+        /// we use a custom enumerator rather than just returning array's. This enumerator provides
+        /// the essential elements of both list's and array's enumerators.
+        /// </remarks>
+        [Serializable]
+        private sealed class Enumerator : IEnumerator<T>
+        {
+            private readonly T[] _array;
+            private T _current;
+            private int _index;
+
+            public Enumerator(T[] array)
+            {
+                Debug.Assert(array != null);
+                _array = array;
+            }
+
+            public bool MoveNext()
+            {
+                if (_index < _array.Length)
+                {
+                    _current = _array[_index++];
+                    return true;
+                }
+
+                _index = _array.Length + 1;
+                return false;
+            }
+
+            public T Current => _current;
+
+            object IEnumerator.Current
+            {
+                get
+                {
+                    if (_index == 0 || _index == _array.Length + 1)
+                    {
+                        throw new InvalidOperationException(SR.ConcurrentBag_Enumerator_EnumerationNotStartedOrAlreadyFinished);
+                    }
+                    return Current;
+                }
+            }
+
+            public void Reset()
+            {
+                _index = 0;
+                _current = default(T);
+            }
+
+            public void Dispose() { }
+        }
     }
 }

--- a/src/System.Collections.Concurrent/tests/ConcurrentBagTests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentBagTests.cs
@@ -12,7 +12,6 @@ namespace System.Collections.Concurrent.Tests
 {
     public class ConcurrentBagTests : ProducerConsumerCollectionTests
     {
-        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
         protected override IProducerConsumerCollection<T> CreateProducerConsumerCollection<T>() => new ConcurrentBag<T>();
         protected override IProducerConsumerCollection<int> CreateProducerConsumerCollection(IEnumerable<int> collection) => new ConcurrentBag<int>(collection);
         protected override bool IsEmpty(IProducerConsumerCollection<int> pcc) => ((ConcurrentBag<int>)pcc).IsEmpty;


### PR DESCRIPTION
ConcurrentBag.GetEnumerator used to copy all of the contents into a List and then return that List's enumerator.  As part of some recent optimizations, I changed that to use an array instead of a list.  But array's enumerator has different semantics for the undefined case of accessing Current after MoveNext returns false.  Initially I thought we'd just accept the breaking change, but as it's simple to address and as the change does introduce an exception where there wasn't previously one, I've changed my mind and am just adding a simple enumerator to address the discrepancy.

Fixes https://github.com/dotnet/corefx/issues/14296
cc: @ianhays 