### PR TITLE
Modify RemoteExecutorTestBase to handle new test structure.

### DIFF
--- a/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -15,8 +15,10 @@ namespace System.Diagnostics
     {
         /// <summary>The name of the test console app.</summary>
         protected const string TestConsoleApp = "RemoteExecutorConsoleApp.exe";
-        /// <summary>The CoreCLR host used to host the test console app.</summary>
-        protected static readonly string HostRunner = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "CoreRun.exe" : "corerun";
+        /// <summary>The name of the CoreCLR host used to host the test console app.</summary>
+        protected static readonly string HostRunnerName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "CoreRun.exe" : "corerun";
+        /// <summary>The absolute path to the host runner executable.</summary>
+        protected static string HostRunner => Path.Combine(AppContext.BaseDirectory, HostRunnerName);
 
         /// <summary>A timeout (milliseconds) after which a wait on a remote operation should be considered a failure.</summary>
         public const int FailWaitTimeoutMilliseconds = 30 * 1000;


### PR DESCRIPTION
Instead of using "CoreRun.exe" as the process's name in `RemoteExecutorTestBase`, we now pass the absolute path to the host executable. I am making the assumption that the host is located in `AppContext.BaseDirectory` (next to xunit.console.netcore.exe, essentially), which is true in our current test plans.

Fixes #14375 

@joperezr 