### PR TITLE
Prohibit pointer and byref types in TypeAs expressions.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -714,11 +714,21 @@ namespace System.Linq.Expressions
             RequiresCanRead(expression, nameof(expression));
             ContractUtils.RequiresNotNull(type, nameof(type));
             TypeUtils.ValidateType(type, nameof(type));
+            if (type.IsByRef)
+            {
+                throw Error.TypeMustNotBeByRef(nameof(type));
+            }
+
+            if (type.IsPointer)
+            {
+                throw Error.TypeMustNotBePointer(nameof(type));
+            }
 
             if (type.GetTypeInfo().IsValueType && !type.IsNullableType())
             {
                 throw Error.IncorrectTypeForTypeAs(type, nameof(type));
             }
+
             return new UnaryExpression(ExpressionType.TypeAs, expression, type, null);
         }
 

--- a/src/System.Linq.Expressions/tests/Cast/AsTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/AsTests.cs
@@ -846,6 +846,51 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal("(o As String)", e.ToString());
         }
 
+        [Fact]
+        public static void NonNullableValueType()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.TypeAs(Expression.Constant(0), typeof(int)));
+            Assert.Throws<ArgumentException>("type", () => Expression.TypeAs(Expression.Constant(null), typeof(DateTime)));
+            Assert.Throws<ArgumentException>("type", () => Expression.TypeAs(Expression.Constant(DateTime.MinValue), typeof(DateTime)));
+        }
+
+        [Fact]
+        public static void NullType() =>
+            Assert.Throws<ArgumentNullException>("type", () => Expression.TypeAs(Expression.Constant(""), null));
+
+        [Fact]
+        public static void NullExpression() =>
+            Assert.Throws<ArgumentNullException>("expression", () => Expression.TypeAs(null, typeof(string)));
+
+        [Fact]
+        public static void AsOpenGeneric()
+        {
+            Assert.Throws<ArgumentException>("type", () => Expression.TypeAs(Expression.Constant(""), typeof(List<>)));
+            Assert.Throws<ArgumentException>("type", () => Expression.TypeAs(Expression.Constant(""), typeof(List<>).MakeGenericType(typeof(List<>))));
+        }
+
+        [Fact]
+        public static void PointerType()
+        {
+            Assert.Throws<ArgumentException>(
+                "type", () => Expression.TypeAs(Expression.Constant(""), typeof(int).MakePointerType()));
+        }
+
+        [Fact]
+        public static void ByRefType()
+        {
+            Assert.Throws<ArgumentException>(
+                "type", () => Expression.TypeAs(Expression.Constant(""), typeof(string).MakeByRefType()));
+        }
+
+        [Fact]
+        public static void UnreadableTypeAs()
+        {
+            MemberExpression unreadable = Expression.Property(
+                null, typeof(Unreadable<string>), nameof(Unreadable<string>.WriteOnly));
+            Assert.Throws<ArgumentException>("expression", () => Expression.TypeAs(unreadable, typeof(string)));
+        }
+
         #endregion
 
         #region Generic helpers


### PR DESCRIPTION
Contributes to #8081

Further test `TypeAs` validation.