### PR TITLE
Strip out SecurityCritical attributes

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Name.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Name.cs
@@ -90,7 +90,6 @@ namespace Microsoft.Win32.SafeHandles
         }
     }
 
-    [SecurityCritical]
     internal sealed class SafeX509NameStackHandle : SafeHandle
     {
         private SafeX509NameStackHandle() :

--- a/src/Common/src/Interop/Windows/kernel32/Interop.SafeCreateFile.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.SafeCreateFile.cs
@@ -18,7 +18,6 @@ internal partial class Interop
         /// "lpt1:", etc.  Use this to avoid security problems, like allowing a web client asking a server
         /// for "http://server/com1.aspx" and then causing a worker process to hang.
         /// </summary>
-        [System.Security.SecurityCritical]  // auto-generated
         internal static SafeFileHandle SafeCreateFile(
             String lpFileName,
             int dwDesiredAccess,

--- a/src/Common/src/Interop/Windows/kernel32/Interop.UnsafeCreateFile.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.UnsafeCreateFile.cs
@@ -10,7 +10,6 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [System.Security.SecurityCritical]  // auto-generated
         internal static SafeFileHandle UnsafeCreateFile(
             string lpFileName,
             int dwDesiredAccess,

--- a/src/Common/src/Microsoft/Win32/SafeHandles/Asn1SafeHandles.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/Asn1SafeHandles.Unix.cs
@@ -8,7 +8,6 @@ using System.Security;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [SecurityCritical]
     internal sealed class SafeAsn1ObjectHandle : SafeHandle
     {
         private SafeAsn1ObjectHandle() :
@@ -29,7 +28,6 @@ namespace Microsoft.Win32.SafeHandles
         }
     }
 
-    [SecurityCritical]
     internal sealed class SafeAsn1BitStringHandle : SafeHandle
     {
         private SafeAsn1BitStringHandle() :
@@ -50,7 +48,6 @@ namespace Microsoft.Win32.SafeHandles
         }
     }
 
-    [SecurityCritical]
     internal sealed class SafeAsn1OctetStringHandle : SafeHandle
     {
         private SafeAsn1OctetStringHandle() :
@@ -71,7 +68,6 @@ namespace Microsoft.Win32.SafeHandles
         }
     }
 
-    [SecurityCritical]
     internal sealed class SafeAsn1StringHandle : SafeHandle
     {
         private SafeAsn1StringHandle() :

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeBignumHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeBignumHandle.Unix.cs
@@ -8,7 +8,6 @@ using System.Security;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [SecurityCritical]
     internal sealed class SafeBignumHandle : SafeHandle
     {
         private SafeBignumHandle() :

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeBioHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeBioHandle.Unix.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [SecurityCritical]
     internal sealed class SafeBioHandle : SafeHandle
     {
         private SafeHandle _parent;

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeCreateHandle.OSX.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeCreateHandle.OSX.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Win32.SafeHandles
     /// if a Create* function is called, the caller must also CFRelease 
     /// on the same pointer in order to correctly free the memory.
     /// </summary>
-    [System.Security.SecurityCritical]
     internal sealed partial class SafeCreateHandle : SafeHandle
     {
         internal SafeCreateHandle() : base(IntPtr.Zero, true) { }
@@ -23,7 +22,6 @@ namespace Microsoft.Win32.SafeHandles
             this.SetHandle(ptr);
         }
 
-        [System.Security.SecurityCritical]
         protected override bool ReleaseHandle()
         {
             Interop.CoreFoundation.CFRelease(handle);
@@ -33,7 +31,6 @@ namespace Microsoft.Win32.SafeHandles
 
         public override bool IsInvalid
         {
-            [System.Security.SecurityCritical]
             get
             {
                 return handle == IntPtr.Zero;

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeDsaHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeDsaHandle.Unix.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [SecurityCritical]
     internal sealed class SafeDsaHandle : SafeHandle
     {
         private SafeDsaHandle() :

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeEcKeyHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeEcKeyHandle.Unix.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [SecurityCritical]
     internal sealed class SafeEcKeyHandle : SafeHandle
     {
         private SafeEcKeyHandle() :

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeEventStreamHandle.OSX.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeEventStreamHandle.OSX.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Win32.SafeHandles
     /// and CFRelease to free; however, FSEventStream has it's own release
     /// function, so we need to extend the pattern to account for that.
     /// </summary>
-    [System.Security.SecurityCritical]
     internal sealed partial class SafeEventStreamHandle : SafeHandle
     {
         internal SafeEventStreamHandle() : base(IntPtr.Zero, true) { }
@@ -24,7 +23,6 @@ namespace Microsoft.Win32.SafeHandles
             this.SetHandle(ptr);
         }
 
-        [System.Security.SecurityCritical]
         protected override bool ReleaseHandle()
         {
             Interop.EventStream.FSEventStreamStop(handle);
@@ -36,7 +34,6 @@ namespace Microsoft.Win32.SafeHandles
 
         public override bool IsInvalid
         {
-            [System.Security.SecurityCritical]
             get
             {
                 return handle == IntPtr.Zero;

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeEvpCipherCtxHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeEvpCipherCtxHandle.Unix.cs
@@ -8,7 +8,6 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [SecurityCritical]
     internal sealed class SafeEvpCipherCtxHandle : SafeHandle
     {
         private SafeEvpCipherCtxHandle() : 
@@ -16,7 +15,6 @@ namespace Microsoft.Win32.SafeHandles
         {
         }
 
-        [SecurityCritical]
         protected override bool ReleaseHandle()
         {
             Interop.Crypto.EvpCipherDestroy(handle);
@@ -26,7 +24,6 @@ namespace Microsoft.Win32.SafeHandles
 
         public override bool IsInvalid
         {
-            [SecurityCritical]
             get { return handle == IntPtr.Zero; }
         }
     }

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeEvpMdCtxHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeEvpMdCtxHandle.Unix.cs
@@ -8,7 +8,6 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [SecurityCritical]
     internal sealed class SafeEvpMdCtxHandle : SafeHandle
     {
         private SafeEvpMdCtxHandle() : 
@@ -16,7 +15,6 @@ namespace Microsoft.Win32.SafeHandles
         {
         }
 
-        [SecurityCritical]
         protected override bool ReleaseHandle()
         {
             Interop.Crypto.EvpMdCtxDestroy(handle);
@@ -25,7 +23,6 @@ namespace Microsoft.Win32.SafeHandles
 
         public override bool IsInvalid
         {
-            [SecurityCritical]
             get { return handle == IntPtr.Zero; }
         }
     }

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -8,7 +8,6 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [System.Security.SecurityCritical]
     sealed partial class SafeFileHandle : SafeHandle
     {
         /// <summary>A handle value of -1.</summary>
@@ -80,7 +79,6 @@ namespace Microsoft.Win32.SafeHandles
             return handle;
         }
 
-        [System.Security.SecurityCritical]
         protected override bool ReleaseHandle()
         {
             // When the SafeFileHandle was opened, we likely issued an flock on the created descriptor in order to add 
@@ -108,7 +106,6 @@ namespace Microsoft.Win32.SafeHandles
 
         public override bool IsInvalid
         {
-            [System.Security.SecurityCritical]
             get
             {
                 long h = (long)handle;

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeRsaHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeRsaHandle.Unix.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [SecurityCritical]
     internal sealed class SafeRsaHandle : SafeHandle
     {
         private SafeRsaHandle() :

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeX509Handles.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeX509Handles.Unix.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [SecurityCritical]
     internal sealed class SafeX509Handle : SafeHandle
     {
         internal static readonly SafeX509Handle InvalidHandle = new SafeX509Handle();
@@ -19,7 +18,6 @@ namespace Microsoft.Win32.SafeHandles
         {
         }
 
-        [SecurityCritical]
         protected override bool ReleaseHandle()
         {
             Interop.Crypto.X509Destroy(handle);
@@ -29,7 +27,6 @@ namespace Microsoft.Win32.SafeHandles
 
         public override bool IsInvalid
         {
-            [SecurityCritical]
             get { return handle == IntPtr.Zero; }
         }
     }
@@ -54,7 +51,6 @@ namespace Microsoft.Win32.SafeHandles
         }
     }
 
-    [SecurityCritical]
     internal sealed class SafeX509StoreHandle : SafeHandle
     {
         private SafeX509StoreHandle() :

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeX509NameHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeX509NameHandle.Unix.cs
@@ -8,7 +8,6 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [SecurityCritical]
     internal sealed class SafeX509NameHandle : SafeHandle
     {
         private SafeX509NameHandle() :

--- a/src/Common/src/Microsoft/Win32/SafeHandles/X509ExtensionSafeHandles.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/X509ExtensionSafeHandles.Unix.cs
@@ -8,7 +8,6 @@ using System.Security;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [SecurityCritical]
     internal sealed class SafeX509ExtensionHandle : SafeHandle
     {
         private SafeX509ExtensionHandle() :
@@ -29,7 +28,6 @@ namespace Microsoft.Win32.SafeHandles
         }
     }
 
-    [SecurityCritical]
     internal sealed class SafeEkuExtensionHandle : SafeHandle
     {
         private SafeEkuExtensionHandle() :

--- a/src/Common/src/System/Diagnostics/Debug.Windows.cs
+++ b/src/Common/src/System/Diagnostics/Debug.Windows.cs
@@ -20,7 +20,6 @@ namespace System.Diagnostics
 
         internal sealed class WindowsDebugLogger : IDebugLogger
         {
-            [SecuritySafeCritical]
             public void ShowAssertDialog(string stackTrace, string message, string detailMessage)
             {
                 if (Debugger.IsAttached)
@@ -60,7 +59,6 @@ namespace System.Diagnostics
                 }
             }
 
-            [System.Security.SecuritySafeCritical]
             private static void WriteToDebugger(string message)
             {
                 if (Debugger.IsLogging())

--- a/src/Common/src/System/Diagnostics/Debug.cs
+++ b/src/Common/src/System/Diagnostics/Debug.cs
@@ -88,7 +88,6 @@ namespace System.Diagnostics
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
-        [System.Security.SecuritySafeCritical]
         public static void Assert(bool condition, string message, string detailMessage)
         {
             if (!condition)

--- a/src/Common/src/System/StringNormalizationExtensions.Windows.cs
+++ b/src/Common/src/System/StringNormalizationExtensions.Windows.cs
@@ -12,7 +12,6 @@ namespace System
 {
     static partial class StringNormalizationExtensions
     {
-        [SecurityCritical]
         public static bool IsNormalized(this string strInput, NormalizationForm normalizationForm)
         {
             if (strInput == null)
@@ -46,7 +45,6 @@ namespace System
             return result;
         }
 
-        [SecurityCritical]
         public static string Normalize(this string strInput, NormalizationForm normalizationForm)
         {
             if (strInput == null)

--- a/src/Microsoft.VisualBasic/ref/Microsoft.VisualBasic.cs
+++ b/src/Microsoft.VisualBasic/ref/Microsoft.VisualBasic.cs
@@ -198,11 +198,8 @@ namespace Microsoft.VisualBasic.CompilerServices
     public sealed partial class ProjectData
     {
         internal ProjectData() { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public static void ClearProjectError() { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public static void SetProjectError(System.Exception ex) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public static void SetProjectError(System.Exception ex, int lErl) { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(4), Inherited = false, AllowMultiple = false)]

--- a/src/Microsoft.Win32.Registry.AccessControl/ref/Microsoft.Win32.Registry.AccessControl.cs
+++ b/src/Microsoft.Win32.Registry.AccessControl/ref/Microsoft.Win32.Registry.AccessControl.cs
@@ -8,7 +8,6 @@
 
 namespace Microsoft.Win32
 {
-    [System.Security.SecurityCriticalAttribute]
     public static partial class RegistryAclExtensions
     {
         public static System.Security.AccessControl.RegistrySecurity GetAccessControl(this Microsoft.Win32.RegistryKey key) { throw null; }
@@ -18,7 +17,6 @@ namespace Microsoft.Win32
 }
 namespace System.Security.AccessControl
 {
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class RegistryAccessRule : System.Security.AccessControl.AccessRule
     {
         public RegistryAccessRule(System.Security.Principal.IdentityReference identity, System.Security.AccessControl.RegistryRights registryRights, System.Security.AccessControl.AccessControlType type) : base(default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AccessControlType)) { }
@@ -27,14 +25,12 @@ namespace System.Security.AccessControl
         public RegistryAccessRule(string identity, System.Security.AccessControl.RegistryRights registryRights, System.Security.AccessControl.InheritanceFlags inheritanceFlags, System.Security.AccessControl.PropagationFlags propagationFlags, System.Security.AccessControl.AccessControlType type) : base(default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AccessControlType)) { }
         public System.Security.AccessControl.RegistryRights RegistryRights { get { throw null; } }
     }
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class RegistryAuditRule : System.Security.AccessControl.AuditRule
     {
         public RegistryAuditRule(System.Security.Principal.IdentityReference identity, System.Security.AccessControl.RegistryRights registryRights, System.Security.AccessControl.InheritanceFlags inheritanceFlags, System.Security.AccessControl.PropagationFlags propagationFlags, System.Security.AccessControl.AuditFlags flags) : base(default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AuditFlags)) { }
         public RegistryAuditRule(string identity, System.Security.AccessControl.RegistryRights registryRights, System.Security.AccessControl.InheritanceFlags inheritanceFlags, System.Security.AccessControl.PropagationFlags propagationFlags, System.Security.AccessControl.AuditFlags flags) : base(default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AuditFlags)) { }
         public System.Security.AccessControl.RegistryRights RegistryRights { get { throw null; } }
     }
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class RegistrySecurity : System.Security.AccessControl.NativeObjectSecurity
     {
         public RegistrySecurity() : base(default(bool), default(System.Security.AccessControl.ResourceType)) { }

--- a/src/Microsoft.Win32.Registry.AccessControl/src/Microsoft/Win32/RegistryAclExtensions.cs
+++ b/src/Microsoft.Win32.Registry.AccessControl/src/Microsoft/Win32/RegistryAclExtensions.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Win32
             return GetAccessControl(key, AccessControlSections.Access | AccessControlSections.Owner | AccessControlSections.Group);
         }
 
-        [SecuritySafeCritical]
         public static RegistrySecurity GetAccessControl(this RegistryKey key, AccessControlSections includeSections)
         {
             if (key.Handle == null)
@@ -26,7 +25,6 @@ namespace Microsoft.Win32
             return new RegistrySecurity(key.Handle, key.Name, includeSections);
         }
 
-        [SecuritySafeCritical]
         public static void SetAccessControl(this RegistryKey key, RegistrySecurity registrySecurity)
         {
             if (registrySecurity == null)

--- a/src/Microsoft.Win32.Registry.AccessControl/src/System/Security/AccessControl/RegistrySecurity.cs
+++ b/src/Microsoft.Win32.Registry.AccessControl/src/System/Security/AccessControl/RegistrySecurity.cs
@@ -91,13 +91,11 @@ namespace System.Security.AccessControl
         {
         }
 
-        [SecurityCritical]
         internal RegistrySecurity(SafeRegistryHandle hKey, string name, AccessControlSections includeSections)
             : base(true, ResourceType.RegistryKey, hKey, includeSections, _HandleErrorCode, null)
         {
         }
 
-        [SecurityCritical]
         private static Exception _HandleErrorCode(int errorCode, string name, SafeHandle handle, object context)
         {
             Exception exception = null;
@@ -159,7 +157,6 @@ namespace System.Security.AccessControl
             return persistRules;
         }
 
-        [SecurityCritical]
         internal void Persist(SafeRegistryHandle hKey, string keyName)
         {
             WriteLock();

--- a/src/Microsoft.Win32.Registry/ref/Microsoft.Win32.Registry.cs
+++ b/src/Microsoft.Win32.Registry/ref/Microsoft.Win32.Registry.cs
@@ -48,9 +48,7 @@ namespace Microsoft.Win32
         public void DeleteValue(string name, bool throwOnMissingValue) { }
         public void Dispose() { }
         public void Flush() { }
-        [System.Security.SecurityCriticalAttribute]
         public static Microsoft.Win32.RegistryKey FromHandle(Microsoft.Win32.SafeHandles.SafeRegistryHandle handle) { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         public static Microsoft.Win32.RegistryKey FromHandle(Microsoft.Win32.SafeHandles.SafeRegistryHandle handle, Microsoft.Win32.RegistryView view) { throw null; }
         public string[] GetSubKeyNames() { throw null; }
         public object GetValue(string name) { throw null; }
@@ -98,13 +96,10 @@ namespace Microsoft.Win32
 }
 namespace Microsoft.Win32.SafeHandles
 {
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class SafeRegistryHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
-        [System.Security.SecurityCriticalAttribute]
         public SafeRegistryHandle(System.IntPtr preexistingHandle, bool ownsHandle) : base(default(bool)) { }
         public override bool IsInvalid { [System.Security.SecurityCriticalAttribute]get { throw null; } }
-        [System.Security.SecurityCriticalAttribute]
         protected override bool ReleaseHandle() { throw null; }
     }
 }

--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -186,7 +186,6 @@ namespace System
         // we will lose repeated keystrokes when someone switches from
         // calling ReadKey to calling Read or ReadLine.  Those methods should 
         // ideally flush this cache as well.
-        [System.Security.SecurityCritical] // auto-generated
         private static Interop.InputRecord _cachedInputRecord;
 
         // Skip non key events. Generally we want to surface only KeyDown event 
@@ -194,13 +193,11 @@ namespace System
         // where the assumption of KeyDown-KeyUp pairing for a given key press 
         // is invalid. For example in IME Unicode keyboard input, we often see
         // only KeyUp until the key is released.  
-        [System.Security.SecurityCritical]  // auto-generated
         private static bool IsKeyDownEvent(Interop.InputRecord ir)
         {
             return (ir.eventType == Interop.KEY_EVENT && ir.keyEvent.keyDown);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         private static bool IsModKey(Interop.InputRecord ir)
         {
             // We should also skip over Shift, Control, and Alt, as well as caps lock.
@@ -230,7 +227,6 @@ namespace System
         // desired effect is to translate the sequence into one Unicode KeyPress. 
         // We need to keep track of the Alt+NumPad sequence and surface the final
         // unicode char alone when the Alt key is released. 
-        [System.Security.SecurityCritical]  // auto-generated
         private static bool IsAltKeyDown(Interop.InputRecord ir)
         {
             return (((ControlKeyState)ir.keyEvent.controlKeyState)
@@ -613,7 +609,6 @@ namespace System
 
         public static string Title
         {
-            [System.Security.SecuritySafeCritical]  // auto-generated
             get
             {
                 string title = null;
@@ -632,7 +627,6 @@ namespace System
                 return title;
             }
 
-            [System.Security.SecuritySafeCritical]  // auto-generated
             set
             {
                 if (value == null)
@@ -825,7 +819,6 @@ namespace System
 
         public static int BufferWidth
         {
-            [System.Security.SecuritySafeCritical]  // auto-generated
             get
             {
                 Interop.Kernel32.CONSOLE_SCREEN_BUFFER_INFO csbi = GetBufferInfo();
@@ -839,7 +832,6 @@ namespace System
 
         public static int BufferHeight
         {
-            [System.Security.SecuritySafeCritical]  // auto-generated
             get
             {
                 Interop.Kernel32.CONSOLE_SCREEN_BUFFER_INFO csbi = GetBufferInfo();
@@ -851,7 +843,6 @@ namespace System
             }
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static void SetBufferSize(int width, int height)
         {
             // Ensure the new size is not smaller than the console window
@@ -873,7 +864,6 @@ namespace System
 
         public static int LargestWindowWidth
         {
-            [System.Security.SecuritySafeCritical]  // auto-generated
             get
             {
                 // Note this varies based on current screen resolution and 
@@ -885,7 +875,6 @@ namespace System
 
         public static int LargestWindowHeight
         {
-            [System.Security.SecuritySafeCritical]  // auto-generated
             get
             {
                 // Note this varies based on current screen resolution and 

--- a/src/System.Diagnostics.Contracts/ref/System.Diagnostics.Contracts.cs
+++ b/src/System.Diagnostics.Contracts/ref/System.Diagnostics.Contracts.cs
@@ -87,9 +87,7 @@ namespace System.Diagnostics.Contracts
         public string Message { get { throw null; } }
         public System.Exception OriginalException { get { throw null; } }
         public bool Unwind { get { throw null; } }
-        [System.Security.SecurityCriticalAttribute]
         public void SetHandled() { }
-        [System.Security.SecurityCriticalAttribute]
         public void SetUnwind() { }
     }
     public enum ContractFailureKind

--- a/src/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.Unix.cs
+++ b/src/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.Unix.cs
@@ -28,11 +28,9 @@ namespace Microsoft.Win32.SafeHandles
 
         public override bool IsInvalid
         {
-            [SecurityCritical]
             get { return ((int)handle) < 0; } // Unix processes have non-negative ID values
         }
 
-        [SecurityCritical]
         protected override bool ReleaseHandle()
         {
             // Nop.  We don't actually hold handles to a process, as there's no equivalent

--- a/src/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.Windows.cs
+++ b/src/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.Windows.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Win32.SafeHandles
     {
         private const int DefaultInvalidHandleValue = 0;
 
-        [SecurityCritical]
         protected override bool ReleaseHandle()
         {
             return Interop.Kernel32.CloseHandle(handle);

--- a/src/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.cs
+++ b/src/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.cs
@@ -18,7 +18,6 @@ using System.Security;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [SecurityCritical]
     public sealed partial class SafeProcessHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         internal static readonly SafeProcessHandle InvalidHandle = new SafeProcessHandle();

--- a/src/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeThreadHandle.cs
+++ b/src/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeThreadHandle.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Win32.SafeHandles
 
         public override bool IsInvalid
         {
-            [SecurityCritical]
             get { return handle == IntPtr.Zero || handle == new IntPtr(-1); }
         }
 

--- a/src/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeTokenHandle.cs
+++ b/src/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeTokenHandle.cs
@@ -18,7 +18,6 @@ using System.Security;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [SecurityCritical]
     internal sealed class SafeTokenHandle : SafeHandle
     {
         private const int DefaultInvalidHandleValue = 0;
@@ -47,11 +46,9 @@ namespace Microsoft.Win32.SafeHandles
 
         public override bool IsInvalid
         {
-            [SecurityCritical]
             get { return handle == IntPtr.Zero || handle == new IntPtr(-1); }
         }
 
-        [SecurityCritical]
         protected override bool ReleaseHandle()
         {
             return Interop.Kernel32.CloseHandle(handle);

--- a/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
+++ b/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
@@ -206,11 +206,9 @@ namespace System.Diagnostics.Tracing
         protected void WriteEvent(int eventId, string arg1, string arg2) { }
         protected void WriteEvent(int eventId, string arg1, string arg2, string arg3) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         protected unsafe void WriteEventCore(int eventId, int eventDataCount, System.Diagnostics.Tracing.EventSource.EventData* data) { }
         protected void WriteEventWithRelatedActivityId(int eventId, System.Guid relatedActivityId, params object[] args) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         protected unsafe void WriteEventWithRelatedActivityIdCore(int eventId, System.Guid* relatedActivityId, int eventDataCount, System.Diagnostics.Tracing.EventSource.EventData* data) { }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         protected internal partial struct EventData

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/ActivityTracker.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/ActivityTracker.cs
@@ -221,7 +221,6 @@ namespace System.Diagnostics.Tracing
         /// <summary>
         /// Turns on activity tracking.    It is sticky, once on it stays on (race issues otherwise)
         /// </summary>
-        [System.Security.SecuritySafeCritical]
         public void Enable()
         {
             if (m_current == null)
@@ -366,7 +365,6 @@ namespace System.Diagnostics.Tracing
             /// byte (since the top nibble can't be zero you can determine if this is true by seeing if 
             /// this byte is nonZero.   This offset is needed to efficiently create the ID for child activities. 
             /// </summary>
-            [System.Security.SecuritySafeCritical]
             private unsafe void CreateActivityPathGuid(out Guid idRet, out int activityPathGuidOffset)
             {
                 fixed (Guid* outPtr = &idRet)
@@ -403,7 +401,6 @@ namespace System.Diagnostics.Tracing
             /// sufficient space for this ID.   By doing this, we preserve the fact that this activity
             /// is a child (of unknown depth) from that ancestor.
             /// </summary>
-            [System.Security.SecurityCritical]
             private unsafe void CreateOverflowGuid(Guid* outPtr)
             {
                 // Search backwards for an ancestor that has sufficient space to put the ID.  
@@ -452,7 +449,6 @@ namespace System.Diagnostics.Tracing
             /// is the maximum number of bytes that fit in a GUID) if the path did not fit.  
             /// If 'overflow' is true, then the number is encoded as an 'overflow number (which has a
             /// special (longer prefix) that indicates that this ID is allocated differently 
-            [System.Security.SecurityCritical]
             private static unsafe int AddIdToGuid(Guid* outPtr, int whereToAddId, uint id, bool overflow = false)
             {
                 byte* ptr = (byte*)outPtr;
@@ -526,7 +522,6 @@ namespace System.Diagnostics.Tracing
             /// Thus if it is non-zero it adds to the current byte, otherwise it advances and writes
             /// the new byte (in the high bits) of the next byte.  
             /// </summary>
-            [System.Security.SecurityCritical]
             private static unsafe void WriteNibble(ref byte* ptr, byte* endPtr, uint value)
             {
                 Contract.Assert(0 <= value && value < 16);

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -74,7 +74,6 @@ namespace System.Diagnostics.Tracing
 
         private static bool m_setInformationMissing;
 
-        [SecurityCritical]
         UnsafeNativeMethods.ManifestEtw.EtwEnableCallback m_etwCallback;     // Trace Callback function
         private long m_regHandle;                        // Trace Registration Handle
         private byte m_level;                            // Tracing Level
@@ -128,7 +127,6 @@ namespace System.Diagnostics.Tracing
         // <SatisfiesLinkDemand Name="Win32Exception..ctor(System.Int32)" />
         // <ReferencesCritical Name="Method: EtwEnableCallBack(Guid&, Int32, Byte, Int64, Int64, Void*, Void*):Void" Ring="1" />
         // </SecurityKernel>
-        [System.Security.SecurityCritical]
         internal unsafe void Register(Guid providerGuid)
         {
             m_providerId = providerGuid;
@@ -157,7 +155,6 @@ namespace System.Diagnostics.Tracing
         // <SecurityKernel Critical="True" TreatAsSafe="Does not expose critical resource" Ring="1">
         // <ReferencesCritical Name="Method: Deregister():Void" Ring="1" />
         // </SecurityKernel>
-        [System.Security.SecuritySafeCritical]
         protected virtual void Dispose(bool disposing)
         {
             //
@@ -227,7 +224,6 @@ namespace System.Diagnostics.Tracing
         // <UsesUnsafeCode Name="Parameter filterData of type: Void*" />
         // <UsesUnsafeCode Name="Parameter callbackContext of type: Void*" />
         // </SecurityKernel>
-        [System.Security.SecurityCritical]
         unsafe void EtwEnableCallBack(
                         [In] ref System.Guid sourceId,
                         [In] int controlCode,
@@ -348,7 +344,6 @@ namespace System.Diagnostics.Tracing
         /// ETW session that was added or remove, and the bool specifies whether the
         /// session was added or whether it was removed from the set.
         /// </summary>
-        [System.Security.SecuritySafeCritical]
         private List<Tuple<SessionInfo, bool>> GetSessions()
         {
             List<SessionInfo> liveSessionList = null;
@@ -424,7 +419,6 @@ namespace System.Diagnostics.Tracing
         /// for the current process ID, calling 'action' for each session, and passing it the
         /// ETW session and the 'AllKeywords' the session enabled for the current provider.
         /// </summary>
-        [System.Security.SecurityCritical]
         private unsafe void GetSessionInfo(Action<int, long> action)
         {
             // We wish the EventSource package to be legal for Windows Store applications.   
@@ -552,7 +546,6 @@ namespace System.Diagnostics.Tracing
         /// returns an array of bytes representing the data, the index into that byte array where the data
         /// starts, and the command being issued associated with that data.  
         /// </summary>
-        [System.Security.SecurityCritical]
         private unsafe bool GetDataFromController(int etwSessionId,
                 UnsafeNativeMethods.ManifestEtw.EVENT_FILTER_DESCRIPTOR* filterData, out ControllerCommand command, out byte[] data, out int dataStart)
         {
@@ -685,7 +678,6 @@ namespace System.Diagnostics.Tracing
         // <UsesUnsafeCode Name="Parameter dataDescriptor of type: EventData*" />
         // <UsesUnsafeCode Name="Parameter dataBuffer of type: Byte*" />
         // </SecurityKernel>
-        [System.Security.SecurityCritical]
         private static unsafe object EncodeObject(ref object data, ref EventData* dataDescriptor, ref byte* dataBuffer, ref uint totalEventSize)
         /*++
 
@@ -934,7 +926,6 @@ namespace System.Diagnostics.Tracing
         // </SecurityKernel>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Justification = "Performance-critical code")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference")]
-        [System.Security.SecurityCritical]
         internal unsafe bool WriteEvent(ref EventDescriptor eventDescriptor, Guid* activityID, Guid* childActivityID, params object[] eventPayload)
         {
             int status = 0;
@@ -1131,7 +1122,6 @@ namespace System.Diagnostics.Tracing
         // <CallsSuppressUnmanagedCode Name="UnsafeNativeMethods.ManifestEtw.EventWrite(System.Int64,EventDescriptor&,System.UInt32,System.Void*):System.UInt32" />
         // </SecurityKernel>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference")]
-        [System.Security.SecurityCritical]
         protected internal unsafe bool WriteEvent(ref EventDescriptor eventDescriptor, Guid* activityID, Guid* childActivityID, int dataCount, IntPtr data)
         {
             if (childActivityID != null)
@@ -1154,7 +1144,6 @@ namespace System.Diagnostics.Tracing
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference")]
-        [System.Security.SecurityCritical]
         internal unsafe bool WriteEventRaw(
             ref EventDescriptor eventDescriptor,
             Guid* activityID,
@@ -1183,7 +1172,6 @@ namespace System.Diagnostics.Tracing
 
         // These are look-alikes to the Manifest based ETW OS APIs that have been shimmed to work
         // either with Manifest ETW or Classic ETW (if Manifest based ETW is not available).  
-        [SecurityCritical]
         private unsafe uint EventRegister(ref Guid providerId, UnsafeNativeMethods.ManifestEtw.EtwEnableCallback enableCallback)
         {
             m_providerId = providerId;
@@ -1191,7 +1179,6 @@ namespace System.Diagnostics.Tracing
             return UnsafeNativeMethods.ManifestEtw.EventRegister(ref providerId, enableCallback, null, ref m_regHandle);
         }
 
-        [SecurityCritical]
         private uint EventUnregister()
         {
             uint status = UnsafeNativeMethods.ManifestEtw.EventUnregister(m_regHandle);

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSource.cs
@@ -529,7 +529,6 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         internal static Guid InternalCurrentThreadActivityId
         {
-            [System.Security.SecurityCritical]
             get
             {
                 Guid retval = CurrentThreadActivityId;
@@ -543,7 +542,6 @@ namespace System.Diagnostics.Tracing
 
         internal static Guid FallbackActivityId
         {
-            [System.Security.SecurityCritical]
             get
             {
 #pragma warning disable 612, 618
@@ -714,7 +712,6 @@ namespace System.Diagnostics.Tracing
 
 #pragma warning disable 1591
         // optimized for common signatures (no args)
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         protected unsafe void WriteEvent(int eventId)
         {
@@ -722,7 +719,6 @@ namespace System.Diagnostics.Tracing
         }
 
         // optimized for common signatures (ints)
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         protected unsafe void WriteEvent(int eventId, int arg1)
         {
@@ -735,7 +731,6 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         protected unsafe void WriteEvent(int eventId, int arg1, int arg2)
         {
@@ -750,7 +745,6 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         protected unsafe void WriteEvent(int eventId, int arg1, int arg2, int arg3)
         {
@@ -768,7 +762,6 @@ namespace System.Diagnostics.Tracing
         }
 
         // optimized for common signatures (longs)
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         protected unsafe void WriteEvent(int eventId, long arg1)
         {
@@ -781,7 +774,6 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         protected unsafe void WriteEvent(int eventId, long arg1, long arg2)
         {
@@ -796,7 +788,6 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         protected unsafe void WriteEvent(int eventId, long arg1, long arg2, long arg3)
         {
@@ -814,7 +805,6 @@ namespace System.Diagnostics.Tracing
         }
 
         // optimized for common signatures (strings)
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         protected unsafe void WriteEvent(int eventId, string arg1)
         {
@@ -831,7 +821,6 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         protected unsafe void WriteEvent(int eventId, string arg1, string arg2)
         {
@@ -852,7 +841,6 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         protected unsafe void WriteEvent(int eventId, string arg1, string arg2, string arg3)
         {
@@ -878,7 +866,6 @@ namespace System.Diagnostics.Tracing
         }
 
         // optimized for common signatures (string and ints)
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         protected unsafe void WriteEvent(int eventId, string arg1, int arg2)
         {
@@ -897,7 +884,6 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         protected unsafe void WriteEvent(int eventId, string arg1, int arg2, int arg3)
         {
@@ -919,7 +905,6 @@ namespace System.Diagnostics.Tracing
         }
 
         // optimized for common signatures (string and longs)
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         protected unsafe void WriteEvent(int eventId, string arg1, long arg2)
         {
@@ -939,7 +924,6 @@ namespace System.Diagnostics.Tracing
         }
 
         // optimized for common signatures (long and string)
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         protected unsafe void WriteEvent(int eventId, long arg1, string arg2)
         {
@@ -959,7 +943,6 @@ namespace System.Diagnostics.Tracing
         }
 
         // optimized for common signatures (int and string)
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         protected unsafe void WriteEvent(int eventId, int arg1, string arg2)
         {
@@ -978,7 +961,6 @@ namespace System.Diagnostics.Tracing
             }
         }
  
-         [SecuritySafeCritical] 
          [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")] 
          protected unsafe void WriteEvent(int eventId, byte[] arg1) 
          { 
@@ -1009,7 +991,6 @@ namespace System.Diagnostics.Tracing
              } 
          } 
 
-         [SecuritySafeCritical] 
          [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")] 
          protected unsafe void WriteEvent(int eventId, long arg1, byte[] arg2) 
          { 
@@ -1067,7 +1048,6 @@ namespace System.Diagnostics.Tracing
             /// <param name="pointer">Pinned tracelogging-compatible metadata blob.</param>
             /// <param name="size">The size of the metadata blob.</param>
             /// <param name="reserved">Value for reserved: 2 for per-provider metadata, 1 for per-event metadata</param>
-            [SecurityCritical]
             internal unsafe void SetMetadata(byte* pointer, int size, int reserved)
             {
                 this.m_Ptr = (long)(ulong)(UIntPtr)pointer;
@@ -1109,7 +1089,6 @@ namespace System.Diagnostics.Tracing
         ///    }
         /// </code>
         /// </remarks>
-        [SecurityCritical]
         [CLSCompliant(false)]
         protected unsafe void WriteEventCore(int eventId, int eventDataCount, EventSource.EventData* data)
         {
@@ -1141,7 +1120,6 @@ namespace System.Diagnostics.Tracing
         ///    }
         /// </code>
         /// </remarks>
-        [SecurityCritical]
         [CLSCompliant(false)]
         protected unsafe void WriteEventWithRelatedActivityIdCore(int eventId, Guid* relatedActivityId, int eventDataCount, EventSource.EventData* data)
         {
@@ -1298,7 +1276,6 @@ namespace System.Diagnostics.Tracing
         /// method signature. Even if you use this for rare events, this call should be guarded by an <see cref="IsEnabled()"/> 
         /// check so that the varargs call is not made when the EventSource is not active.  
         /// </summary>
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         protected unsafe void WriteEvent(int eventId, params object[] args)
         {
@@ -1313,7 +1290,6 @@ namespace System.Diagnostics.Tracing
         /// particular method signature. Even if you use this for rare events, this call should be guarded by an <see cref="IsEnabled()"/>
         /// check so that the varargs call is not made when the EventSource is not active.
         /// </summary>
-        [SecuritySafeCritical]
         protected unsafe void WriteEventWithRelatedActivityId(int eventId, Guid relatedActivityId, params object[] args)
         {
             WriteEventVarargs(eventId, &relatedActivityId, args);
@@ -1401,7 +1377,6 @@ namespace System.Diagnostics.Tracing
         }
 #endif
 
-        [SecurityCritical]
         private unsafe void WriteEventRaw(
             string eventName,
             ref EventDescriptor eventDescriptor,
@@ -1443,7 +1418,6 @@ namespace System.Diagnostics.Tracing
         /// member, and any future access to the "Log" would throw the cached exception).
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "guid")]
-        [SecuritySafeCritical]
         private unsafe void Initialize(Guid eventSourceGuid, string eventSourceName, string[] traits)
         {
             try
@@ -1742,7 +1716,6 @@ namespace System.Diagnostics.Tracing
             return new Guid(bytes);
         }
 
-        [SecurityCritical]
         private unsafe object DecodeObject(int eventId, int parameterId, ref EventSource.EventData* data)
         {
             // TODO FIX : We use reflection which in turn uses EventSource, right now we carefully avoid
@@ -1889,7 +1862,6 @@ namespace System.Diagnostics.Tracing
             return dispatcher;
         }
 
-        [SecurityCritical]
         private unsafe void WriteEventVarargs(int eventId, Guid* childActivityID, object[] args)
         {
             if (m_eventSourceEnabled)
@@ -2059,7 +2031,6 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        [SecurityCritical]
         private unsafe object[] SerializeEventArgs(int eventId, object[] args)
         {
             TraceLoggingEventTypes eventTypes = m_eventData[eventId].TraceLoggingEventTypes;
@@ -2135,7 +2106,6 @@ namespace System.Diagnostics.Tracing
             return sum;
         }
 
-        [SecurityCritical]
         private unsafe void WriteToAllListeners(int eventId, Guid* childActivityID, int eventDataCount, EventSource.EventData* data)
         {
             // We represent a byte[] as a integer denoting the length  and then a blob of bytes in the data pointer. This causes a spurious
@@ -2159,7 +2129,6 @@ namespace System.Diagnostics.Tracing
         }
 
         // helper for writing to all EventListeners attached the current eventSource.  
-        [SecurityCritical]
         private unsafe void WriteToAllListeners(int eventId, Guid* childActivityID, params object[] args)
         {
             EventWrittenEventArgs eventCallbackArgs = new EventWrittenEventArgs(this);
@@ -2173,7 +2142,6 @@ namespace System.Diagnostics.Tracing
             DispatchToAllListeners(eventId, childActivityID, eventCallbackArgs);
         }
 
-        [SecurityCritical]
         private unsafe void DispatchToAllListeners(int eventId, Guid* childActivityID, EventWrittenEventArgs eventCallbackArgs)
         {
             Exception lastThrownException = null;
@@ -2215,7 +2183,6 @@ namespace System.Diagnostics.Tracing
             }
         }
         
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         private unsafe void WriteEventString(EventLevel level, long keywords, string msgString)
         {
@@ -2310,7 +2277,6 @@ namespace System.Diagnostics.Tracing
         }
 
 #if FEATURE_ACTIVITYSAMPLING
-        [SecurityCritical]
         private unsafe SessionMask GetEtwSessionMask(int eventId, Guid* childActivityID)
         {
             SessionMask etwSessions = new SessionMask();
@@ -3022,7 +2988,6 @@ namespace System.Diagnostics.Tracing
             get { return m_eventSourceDisposed; }
         }
 
-        [SecuritySafeCritical]
         private void EnsureDescriptorsInitialized()
         {
 #if !ES_BUILD_STANDALONE
@@ -3089,7 +3054,6 @@ namespace System.Diagnostics.Tracing
 
         // Send out the ETW manifest XML out to ETW
         // Today, we only send the manifest to ETW, custom listeners don't get it. 
-        [SecuritySafeCritical]
         private unsafe bool SendManifest(byte[] rawManifest)
         {
             bool success = true;
@@ -3821,7 +3785,6 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         /// <param name="method">The method to probe.</param>
         /// <returns>The literal value or -1 if the value could not be determined. </returns>
-        [SecuritySafeCritical]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Justification = "Switch statement is clearer than alternatives")]
         private static int GetHelperCallFirstArg(MethodInfo method)
         {
@@ -4819,7 +4782,6 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         public Guid ActivityId
         {
-            [System.Security.SecurityCritical]
             get { return EventSource.CurrentThreadActivityId; }
         }
 
@@ -4828,7 +4790,6 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         public Guid RelatedActivityId
         {
-            [System.Security.SecurityCritical]
             get;
             internal set;
         }
@@ -5433,7 +5394,6 @@ namespace System.Diagnostics.Tracing
         /// If 'childActivityID' is present, it will be added to the active set if the 
         /// current activity is active.  
         /// </summary>
-        [SecurityCritical]
         public static unsafe bool PassesActivityFilter(
                                     ActivityFilter filterList,
                                     Guid* childActivityID,
@@ -5514,7 +5474,6 @@ namespace System.Diagnostics.Tracing
             return shouldBeLogged;
         }
 
-        [System.Security.SecuritySafeCritical]
         public static bool IsCurrentActivityActive(ActivityFilter filterList)
         {
             var activeActivities = GetActiveActivities(filterList);
@@ -5531,7 +5490,6 @@ namespace System.Diagnostics.Tracing
         /// value for  'currentActivityid' is an indication tha caller has already verified
         /// that the current activity is active.
         /// </summary>
-        [SecurityCritical]
         public static unsafe void FlowActivityIfNeeded(ActivityFilter filterList, Guid* currentActivityId, Guid* childActivityID)
         {
             Contract.Assert(childActivityID != null);

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSource_ProjectN.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSource_ProjectN.cs
@@ -29,7 +29,6 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         /// <param name="activityId">A Guid that represents the new activity with which to mark 
         /// the current thread</param>
-        [System.Security.SecuritySafeCritical]
         public static void SetCurrentThreadActivityId(Guid activityId)
         {
             if (TplEtwProvider.Log != null)
@@ -80,7 +79,6 @@ namespace System.Diagnostics.Tracing
         /// the current thread</param>
         /// <param name="oldActivityThatWillContinue">The Guid that represents the current activity  
         /// which will continue at some point in the future, on the current thread</param>
-        [System.Security.SecuritySafeCritical]
         public static void SetCurrentThreadActivityId(Guid activityId, out Guid oldActivityThatWillContinue)
         {
             oldActivityThatWillContinue = activityId;
@@ -104,7 +102,6 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         public static Guid CurrentThreadActivityId
         {
-            [System.Security.SecuritySafeCritical]
             get
             {
                 // We ignore errors to keep with the convention that EventSources do not throw 
@@ -288,7 +285,6 @@ namespace System.Diagnostics.Tracing
     
     internal partial class EventProvider
     {
-        [System.Security.SecurityCritical]
         internal unsafe int SetInformation(
             UnsafeNativeMethods.ManifestEtw.EVENT_INFO_CLASS eventInfoClass,
             IntPtr data,

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/DataCollector.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/DataCollector.cs
@@ -22,7 +22,6 @@ namespace System.Diagnostics.Tracing
     /// EventWrite. The instance must be Disabled before the arrays referenced
     /// by the pointers are freed or unpinned.
     /// </summary>
-    [SecurityCritical]
     internal unsafe struct DataCollector
     {
         [ThreadStatic]

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingDataCollector.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingDataCollector.cs
@@ -21,7 +21,6 @@ namespace System.Diagnostics.Tracing
     /// full-trust code, this abstraction is unnecessary (though it probably
     /// doesn't hurt anything).
     /// </summary>
-    [SecuritySafeCritical]
     internal unsafe class TraceLoggingDataCollector
     {
         internal static readonly TraceLoggingDataCollector Instance = new TraceLoggingDataCollector();

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
@@ -106,7 +106,6 @@ namespace System.Diagnostics.Tracing
         /// (Native API: EventWriteTransfer)
         /// </summary>
         /// <param name="eventName">The name of the event. Must not be null.</param>
-        [SecuritySafeCritical]
         public unsafe void Write(string eventName)
         {
             if (eventName == null)
@@ -134,7 +133,6 @@ namespace System.Diagnostics.Tracing
         /// Options for the event, such as the level, keywords, and opcode. Unset
         /// options will be set to default values.
         /// </param>
-        [SecuritySafeCritical]
         public unsafe void Write(string eventName, EventSourceOptions options)
         {
             if (eventName == null)
@@ -171,7 +169,6 @@ namespace System.Diagnostics.Tracing
         /// public instance properties of data will be written recursively to
         /// create the fields of the event.
         /// </param>
-        [SecuritySafeCritical]
         public unsafe void Write<T>(
             string eventName,
             T data)
@@ -208,7 +205,6 @@ namespace System.Diagnostics.Tracing
         /// public instance properties of data will be written recursively to
         /// create the fields of the event.
         /// </param>
-        [SecuritySafeCritical]
         public unsafe void Write<T>(
             string eventName,
             EventSourceOptions options,
@@ -247,7 +243,6 @@ namespace System.Diagnostics.Tracing
         /// public instance properties of data will be written recursively to
         /// create the fields of the event.
         /// </param>
-        [SecuritySafeCritical]
         public unsafe void Write<T>(
             string eventName,
             ref EventSourceOptions options,
@@ -293,7 +288,6 @@ namespace System.Diagnostics.Tracing
         /// public instance properties of data will be written recursively to
         /// create the fields of the event.
         /// </param>
-        [SecuritySafeCritical]
         public unsafe void Write<T>(
             string eventName,
             ref EventSourceOptions options,
@@ -350,7 +344,6 @@ namespace System.Diagnostics.Tracing
         /// the values must match the number and types of the fields described by the
         /// eventTypes parameter.
         /// </param>
-        [SecuritySafeCritical]
         private unsafe void WriteMultiMerge(
             string eventName,
             ref EventSourceOptions options,
@@ -411,7 +404,6 @@ namespace System.Diagnostics.Tracing
         /// the values must match the number and types of the fields described by the
         /// eventTypes parameter.
         /// </param>
-        [SecuritySafeCritical]
         private unsafe void WriteMultiMergeInner(
             string eventName,
             ref EventSourceOptions options,
@@ -521,7 +513,6 @@ namespace System.Diagnostics.Tracing
         /// The number and types of the values must match the number and types of the 
         /// fields described by the eventTypes parameter.
         /// </param>
-        [SecuritySafeCritical]
         internal unsafe void WriteMultiMerge(
             string eventName,
             ref EventSourceOptions options,
@@ -597,7 +588,6 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        [SecuritySafeCritical]
         private unsafe void WriteImpl(
             string eventName,
             ref EventSourceOptions options,
@@ -708,7 +698,6 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        [SecurityCritical]
         private unsafe void WriteToAllListeners(string eventName, ref EventDescriptor eventDescriptor, EventTags tags, Guid* pActivityId, EventPayload payload)
         {
             EventWrittenEventArgs eventCallbackArgs = new EventWrittenEventArgs(this);
@@ -737,7 +726,6 @@ namespace System.Diagnostics.Tracing
             System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState,
             System.Runtime.ConstrainedExecution.Cer.Success)]
 #endif
-        [SecurityCritical]
         [NonEvent]
         private unsafe void WriteCleanup(GCHandle* pPins, int cPins)
         {

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/UnsafeNativeMethods.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/UnsafeNativeMethods.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Win32
     [SuppressUnmanagedCodeSecurityAttribute()]
     internal static class UnsafeNativeMethods
     {
-        [SecurityCritical]
         [SuppressUnmanagedCodeSecurityAttribute()]
         internal static unsafe class ManifestEtw
         {
@@ -45,7 +44,6 @@ namespace Microsoft.Win32
             //
             // Callback
             //
-            [SecurityCritical]
             internal unsafe delegate void EtwEnableCallback(
                 [In] ref Guid sourceId,
                 [In] int isEnabled,
@@ -59,7 +57,6 @@ namespace Microsoft.Win32
             //
             // Registration APIs
             //
-            [SecurityCritical]
             internal static unsafe uint EventRegister(
                         [In] ref Guid providerId,
                         [In]EtwEnableCallback enableCallback,
@@ -91,7 +88,6 @@ namespace Microsoft.Win32
             }
 
 
-            [SecurityCritical]
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
             internal static uint EventUnregister([In] long registrationHandle)
             {
@@ -252,15 +248,12 @@ namespace Microsoft.Win32
         private const string CoreLocalizationApiSet = "kernel32.dll";
 #endif
 
-        [System.Security.SecuritySafeCritical]
-        // Gets an error message for a Win32 error code.
         internal static String GetMessage(int errorCode)
         {
             return Interop.Kernel32.GetMessage(errorCode);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1060:MovePInvokesToNativeMethodsClass")]
-        [System.Security.SecurityCritical]
         internal static uint GetCurrentProcessId()
         {
             return Interop.Kernel32.GetCurrentProcessId();

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Deflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Deflater.cs
@@ -77,7 +77,6 @@ namespace System.IO.Compression
             GC.SuppressFinalize(this);
         }
 
-        [SecuritySafeCritical]
         private void Dispose(bool disposing)
         {
             if (!_isDisposed)
@@ -203,7 +202,6 @@ namespace System.IO.Compression
             }
         }
 
-        [SecuritySafeCritical]
         private void DeflateInit(ZLibNative.CompressionLevel compressionLevel, int windowBits, int memLevel,
                                  ZLibNative.CompressionStrategy strategy)
         {
@@ -238,7 +236,6 @@ namespace System.IO.Compression
         }
 
 
-        [SecuritySafeCritical]
         private ZErrorCode Deflate(ZFlushCode flushCode)
         {
             ZErrorCode errC;

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
@@ -121,7 +121,6 @@ namespace System.IO.Compression
             }
         }
 
-        [SecuritySafeCritical]
         private void Dispose(bool disposing)
         {
             if (!_isDisposed)
@@ -154,7 +153,6 @@ namespace System.IO.Compression
         /// <summary>
         /// Creates the ZStream that will handle inflation
         /// </summary>
-        [SecuritySafeCritical]
         private void InflateInit(int windowBits)
         {
             ZLibNative.ErrorCode error;
@@ -206,7 +204,6 @@ namespace System.IO.Compression
         /// <summary>
         /// Wrapper around the ZLib inflate function
         /// </summary>
-        [SecuritySafeCritical]
         private ZLibNative.ErrorCode Inflate(ZLibNative.FlushCode flushCode)
         {
             ZLibNative.ErrorCode errC;

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/ZLibException.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/ZLibException.cs
@@ -87,19 +87,16 @@ namespace System.IO.Compression
 
         public string ZLibContext
         {
-            [SecurityCritical]
             get { return _zlibErrorContext; }
         }
 
         public int ZLibErrorCode
         {
-            [SecurityCritical]
             get { return (int)_zlibErrorCode; }
         }
 
         public string ZLibErrorMessage
         {
-            [SecurityCritical]
             get { return _zlibErrorMessage; }
         }
     }

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/ZLibNative.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/ZLibNative.cs
@@ -180,7 +180,6 @@ namespace System.IO.Compression
         /// <code>false</code>, which can for instance happen if the underlying ZLib <code>XxxxEnd</code>
         /// routines return an failure error code.
         /// </summary>
-        [SecurityCritical]
         public sealed class ZLibStreamHandle : SafeHandle
         {
             #region ZLibStream-SafeHandle-related routines
@@ -189,7 +188,6 @@ namespace System.IO.Compression
 
             private ZStream _zStream;
 
-            [SecurityCritical]
             private volatile State _initializationState;
 
 
@@ -205,19 +203,16 @@ namespace System.IO.Compression
 
             public override bool IsInvalid
             {
-                [SecurityCritical]
                 get { return handle == new IntPtr(-1); }
             }
 
             public State InitializationState
             {
                 [Pure]
-                [SecurityCritical]
                 get { return _initializationState; }
             }
 
 
-            [SecurityCritical]
             protected override bool ReleaseHandle()
             {
                 switch (InitializationState)
@@ -265,7 +260,6 @@ namespace System.IO.Compression
             #region Expose ZLib functions for use by user / Fx code (add more as required)
 
             [Pure]
-            [SecurityCritical]
             private void EnsureNotDisposed()
             {
                 if (InitializationState == State.Disposed)
@@ -274,7 +268,6 @@ namespace System.IO.Compression
 
 
             [Pure]
-            [SecurityCritical]
             private void EnsureState(State requiredState)
             {
                 if (InitializationState != requiredState)
@@ -282,7 +275,6 @@ namespace System.IO.Compression
             }
 
 
-            [SecurityCritical]
             public ErrorCode DeflateInit2_(CompressionLevel level, int windowBits, int memLevel, CompressionStrategy strategy)
             {
                 EnsureNotDisposed();
@@ -295,7 +287,6 @@ namespace System.IO.Compression
             }
 
 
-            [SecurityCritical]
             public ErrorCode Deflate(FlushCode flush)
             {
                 EnsureNotDisposed();
@@ -304,7 +295,6 @@ namespace System.IO.Compression
             }
 
 
-            [SecurityCritical]
             public ErrorCode DeflateEnd()
             {
                 EnsureNotDisposed();
@@ -317,7 +307,6 @@ namespace System.IO.Compression
             }
 
 
-            [SecurityCritical]
             public ErrorCode InflateInit2_(int windowBits)
             {
                 EnsureNotDisposed();
@@ -330,7 +319,6 @@ namespace System.IO.Compression
             }
 
 
-            [SecurityCritical]
             public ErrorCode Inflate(FlushCode flush)
             {
                 EnsureNotDisposed();
@@ -339,7 +327,6 @@ namespace System.IO.Compression
             }
 
 
-            [SecurityCritical]
             public ErrorCode InflateEnd()
             {
                 EnsureNotDisposed();
@@ -355,7 +342,6 @@ namespace System.IO.Compression
             /// This function is equivalent to inflateEnd followed by inflateInit.
             /// The stream will keep attributes that may have been set by inflateInit2.
             /// </summary>
-            [SecurityCritical]
             public ErrorCode InflateReset(int windowBits)
             {
                 EnsureNotDisposed();
@@ -375,7 +361,6 @@ namespace System.IO.Compression
             }
 
 
-            [SecurityCritical]
             public string GetErrorMessage()
             {
                 // This can work even after XxflateEnd().
@@ -392,7 +377,6 @@ namespace System.IO.Compression
         #region public factory methods for ZLibStreamHandle
 
 
-        [SecurityCritical]
         public static ErrorCode CreateZLibStreamForDeflate(out ZLibStreamHandle zLibStreamHandle,
                                                            CompressionLevel level, int windowBits, int memLevel, CompressionStrategy strategy)
         {
@@ -401,7 +385,6 @@ namespace System.IO.Compression
         }
 
 
-        [SecurityCritical]
         public static ErrorCode CreateZLibStreamForInflate(out ZLibStreamHandle zLibStreamHandle, int windowBits)
         {
             zLibStreamHandle = new ZLibStreamHandle();

--- a/src/System.IO.FileSystem.AccessControl/ref/System.IO.FileSystem.AccessControl.cs
+++ b/src/System.IO.FileSystem.AccessControl/ref/System.IO.FileSystem.AccessControl.cs
@@ -8,7 +8,6 @@
 
 namespace System.IO
 {
-    [System.Security.SecurityCriticalAttribute]
     public static partial class FileSystemAclExtensions
     {
         public static System.Security.AccessControl.DirectorySecurity GetAccessControl(this System.IO.DirectoryInfo directoryInfo) { throw null; }
@@ -23,7 +22,6 @@ namespace System.IO
 }
 namespace System.Security.AccessControl
 {
-    [System.Security.SecurityCriticalAttribute]
     public abstract partial class DirectoryObjectSecurity : System.Security.AccessControl.ObjectSecurity
     {
         protected DirectoryObjectSecurity() { }
@@ -46,19 +44,16 @@ namespace System.Security.AccessControl
         protected void SetAccessRule(System.Security.AccessControl.ObjectAccessRule rule) { }
         protected void SetAuditRule(System.Security.AccessControl.ObjectAuditRule rule) { }
     }
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class DirectorySecurity : System.Security.AccessControl.FileSystemSecurity
     {
         public DirectorySecurity() { }
         public DirectorySecurity(string name, System.Security.AccessControl.AccessControlSections includeSections) { }
     }
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class FileSecurity : System.Security.AccessControl.FileSystemSecurity
     {
         public FileSecurity() { }
         public FileSecurity(string fileName, System.Security.AccessControl.AccessControlSections includeSections) { }
     }
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class FileSystemAccessRule : System.Security.AccessControl.AccessRule
     {
         public FileSystemAccessRule(System.Security.Principal.IdentityReference identity, System.Security.AccessControl.FileSystemRights fileSystemRights, System.Security.AccessControl.AccessControlType type) : base(default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AccessControlType)) { }
@@ -67,7 +62,6 @@ namespace System.Security.AccessControl
         public FileSystemAccessRule(string identity, System.Security.AccessControl.FileSystemRights fileSystemRights, System.Security.AccessControl.InheritanceFlags inheritanceFlags, System.Security.AccessControl.PropagationFlags propagationFlags, System.Security.AccessControl.AccessControlType type) : base(default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AccessControlType)) { }
         public System.Security.AccessControl.FileSystemRights FileSystemRights { get { throw null; } }
     }
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class FileSystemAuditRule : System.Security.AccessControl.AuditRule
     {
         public FileSystemAuditRule(System.Security.Principal.IdentityReference identity, System.Security.AccessControl.FileSystemRights fileSystemRights, System.Security.AccessControl.AuditFlags flags) : base(default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AuditFlags)) { }
@@ -77,7 +71,6 @@ namespace System.Security.AccessControl
         public System.Security.AccessControl.FileSystemRights FileSystemRights { get { throw null; } }
     }
     [System.FlagsAttribute]
-    [System.Security.SecurityCriticalAttribute]
     public enum FileSystemRights
     {
         AppendData = 4,
@@ -104,7 +97,6 @@ namespace System.Security.AccessControl
         WriteData = 2,
         WriteExtendedAttributes = 16,
     }
-    [System.Security.SecurityCriticalAttribute]
     public abstract partial class FileSystemSecurity : System.Security.AccessControl.NativeObjectSecurity
     {
         internal FileSystemSecurity() : base(default(bool), default(System.Security.AccessControl.ResourceType)) { }

--- a/src/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
+++ b/src/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
@@ -62,7 +62,6 @@ namespace System.IO
             return new FileSecurity(handle, fileStream.Name, AccessControlSections.Access | AccessControlSections.Owner | AccessControlSections.Group);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static void SetAccessControl(this FileStream fileStream, FileSecurity fileSecurity)
         {
             SafeFileHandle handle = fileStream.SafeFileHandle;

--- a/src/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/FileSecurity.cs
+++ b/src/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/FileSecurity.cs
@@ -317,25 +317,21 @@ namespace System.Security.AccessControl
 
         #endregion
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal FileSystemSecurity(bool isContainer)
             : base(isContainer, s_ResourceType, _HandleErrorCode, isContainer)
         {
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal FileSystemSecurity(bool isContainer, String name, AccessControlSections includeSections, bool isDirectory)
             : base(isContainer, s_ResourceType, name, includeSections, _HandleErrorCode, isDirectory)
         {
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal FileSystemSecurity(bool isContainer, SafeFileHandle handle, AccessControlSections includeSections, bool isDirectory)
             : base(isContainer, s_ResourceType, handle, includeSections, _HandleErrorCode, isDirectory)
         {
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         private static Exception _HandleErrorCode(int errorCode, string name, SafeHandle handle, object context)
         {
             System.Exception exception = null;
@@ -428,7 +424,6 @@ namespace System.Security.AccessControl
             return persistRules;
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal void Persist(String fullPath)
         {
             WriteLock();
@@ -445,7 +440,6 @@ namespace System.Security.AccessControl
             }
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         internal void Persist(SafeFileHandle handle, String fullPath)
         {
             WriteLock();
@@ -618,13 +612,11 @@ namespace System.Security.AccessControl
     {
         #region Constructors
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public FileSecurity()
             : base(false)
         {
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public FileSecurity(String fileName, AccessControlSections includeSections)
             : base(false, fileName, includeSections, false)
         {
@@ -635,7 +627,6 @@ namespace System.Security.AccessControl
         // it public.  We don't want to get into a situation where someone can
         // pass in the string foo.txt and a handle to bar.exe, and we do a
         // demand on the wrong file name.
-        [System.Security.SecurityCritical]  // auto-generated
         internal FileSecurity(SafeFileHandle handle, String fullPath, AccessControlSections includeSections)
             : base(false, handle, includeSections, false)
         {
@@ -648,13 +639,11 @@ namespace System.Security.AccessControl
     {
         #region Constructors
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public DirectorySecurity()
             : base(true)
         {
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public DirectorySecurity(String name, AccessControlSections includeSections)
             : base(true, name, includeSections, true)
         {

--- a/src/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Unix.cs
+++ b/src/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Unix.cs
@@ -36,7 +36,6 @@ namespace System.IO
 
         public DriveType DriveType
         {
-            [SecuritySafeCritical]
             get
             {
                 DriveType type;
@@ -67,7 +66,6 @@ namespace System.IO
 
         public string DriveFormat
         {
-            [SecuritySafeCritical]
             get
             {
                 string format = string.Empty;
@@ -78,7 +76,6 @@ namespace System.IO
 
         public long AvailableFreeSpace
         {
-            [SecuritySafeCritical]
             get
             {
                 Interop.Sys.MountPointInformation mpi = default(Interop.Sys.MountPointInformation);
@@ -89,7 +86,6 @@ namespace System.IO
 
         public long TotalFreeSpace
         {
-            [SecuritySafeCritical]
             get
             {
                 Interop.Sys.MountPointInformation mpi = default(Interop.Sys.MountPointInformation);
@@ -100,7 +96,6 @@ namespace System.IO
 
         public long TotalSize
         {
-            [SecuritySafeCritical]
             get
             {
                 Interop.Sys.MountPointInformation mpi = default(Interop.Sys.MountPointInformation);
@@ -111,12 +106,10 @@ namespace System.IO
 
         public string VolumeLabel
         {
-            [SecuritySafeCritical]
             get
             {
                 return Name;
             }
-            [SecuritySafeCritical]
             set
             {
                 throw new PlatformNotSupportedException();

--- a/src/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Windows.cs
+++ b/src/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Windows.cs
@@ -48,7 +48,6 @@ namespace System.IO
 
         public DriveType DriveType
         {
-            [System.Security.SecuritySafeCritical]
             get
             {
                 // GetDriveType can't fail
@@ -58,7 +57,6 @@ namespace System.IO
 
         public String DriveFormat
         {
-            [System.Security.SecuritySafeCritical]  // auto-generated
             get
             {
                 const int volNameLen = 50;
@@ -86,7 +84,6 @@ namespace System.IO
 
         public long AvailableFreeSpace
         {
-            [System.Security.SecuritySafeCritical]
             get
             {
                 long userBytes, totalBytes, freeBytes;
@@ -107,7 +104,6 @@ namespace System.IO
 
         public long TotalFreeSpace
         {
-            [System.Security.SecuritySafeCritical]  // auto-generated
             get
             {
                 long userBytes, totalBytes, freeBytes;
@@ -128,7 +124,6 @@ namespace System.IO
 
         public long TotalSize
         {
-            [System.Security.SecuritySafeCritical]
             get
             {
                 // Don't cache this, to handle variable sized floppy drives
@@ -163,7 +158,6 @@ namespace System.IO
         // Null is a valid volume label.
         public String VolumeLabel
         {
-            [System.Security.SecuritySafeCritical]  // auto-generated
             get
             {
                 // NTFS uses a limit of 32 characters for the volume label,
@@ -194,7 +188,6 @@ namespace System.IO
                 }
                 return volumeName.ToString();
             }
-            [System.Security.SecuritySafeCritical]  // auto-generated
             set
             {
                 uint oldMode = Interop.Kernel32.SetErrorMode(Interop.Kernel32.SEM_FAILCRITICALERRORS);

--- a/src/System.IO.FileSystem.DriveInfo/src/System/IO/Error.cs
+++ b/src/System.IO.FileSystem.DriveInfo/src/System/IO/Error.cs
@@ -14,14 +14,12 @@ namespace System.IO
     internal static class Error
     {
         // An alternative to Win32Marshal with friendlier messages for drives
-        [System.Security.SecuritySafeCritical]  // auto-generated
         internal static Exception GetExceptionForLastWin32DriveError(String driveName)
         {
             int errorCode = Marshal.GetLastWin32Error();
             return GetExceptionForWin32DriveError(errorCode, driveName);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal static Exception GetExceptionForWin32DriveError(int errorCode, String driveName)
         {
             switch (errorCode)

--- a/src/System.IO.FileSystem/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/System.IO.FileSystem/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -8,7 +8,6 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [System.Security.SecurityCritical]
     public sealed class SafeFileHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         /// <summary>A handle value of -1.</summary>
@@ -83,7 +82,6 @@ namespace Microsoft.Win32.SafeHandles
             return handle;
         }
 
-        [System.Security.SecurityCritical]
         protected override bool ReleaseHandle()
         {
             // When the SafeFileHandle was opened, we likely issued an flock on the created descriptor in order to add 
@@ -111,7 +109,6 @@ namespace Microsoft.Win32.SafeHandles
 
         public override bool IsInvalid
         {
-            [System.Security.SecurityCritical]
             get
             {
                 long h = (long)handle;

--- a/src/System.IO.FileSystem/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
+++ b/src/System.IO.FileSystem/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
@@ -10,7 +10,6 @@ using Microsoft.Win32;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [System.Security.SecurityCritical]  // auto-generated_required
     public sealed class SafeFileHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         private bool? _isAsync;
@@ -42,7 +41,6 @@ namespace Microsoft.Win32.SafeHandles
 
         internal ThreadPoolBoundHandle ThreadPoolBinding { get; set; }
 
-        [System.Security.SecurityCritical]
         override protected bool ReleaseHandle()
         {
             return Interop.Kernel32.CloseHandle(handle);

--- a/src/System.IO.FileSystem/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.netstandard1.3.cs
+++ b/src/System.IO.FileSystem/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.netstandard1.3.cs
@@ -10,7 +10,6 @@ using Microsoft.Win32;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [System.Security.SecurityCritical]  // auto-generated_required
     public sealed class SafeFileHandle : SafeHandle
     {
         private bool? _isAsync;
@@ -42,7 +41,6 @@ namespace Microsoft.Win32.SafeHandles
 
         internal ThreadPoolBoundHandle ThreadPoolBinding { get; set; }
 
-        [System.Security.SecurityCritical]
         override protected bool ReleaseHandle()
         {
             return Interop.Kernel32.CloseHandle(handle);
@@ -50,7 +48,6 @@ namespace Microsoft.Win32.SafeHandles
 
         public override bool IsInvalid
         {
-            [System.Security.SecurityCritical]
             get
             {
                 return handle == IntPtr.Zero || handle == new IntPtr(-1);

--- a/src/System.IO.FileSystem/src/Microsoft/Win32/SafeHandles/SafeFindHandle.Windows.cs
+++ b/src/System.IO.FileSystem/src/Microsoft/Win32/SafeHandles/SafeFindHandle.Windows.cs
@@ -10,13 +10,10 @@ using Microsoft.Win32;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [System.Security.SecurityCritical]  // auto-generated
     internal sealed class SafeFindHandle : SafeHandle
     {
-        [System.Security.SecurityCritical]  // auto-generated_required
         internal SafeFindHandle() : base(IntPtr.Zero, true) { }
 
-        [System.Security.SecurityCritical]
         override protected bool ReleaseHandle()
         {
             return Interop.Kernel32.FindClose(handle);
@@ -24,7 +21,6 @@ namespace Microsoft.Win32.SafeHandles
 
         public override bool IsInvalid
         {
-            [System.Security.SecurityCritical]
             get
             {
                 return handle == IntPtr.Zero || handle == new IntPtr(-1);

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -37,7 +37,6 @@ namespace System.IO
             return new DirectoryInfo(s);
         }
 
-        [System.Security.SecuritySafeCritical]
         public static DirectoryInfo CreateDirectory(String path)
         {
             if (path == null)
@@ -73,7 +72,6 @@ namespace System.IO
         // Your application must have Read permission to the directory's
         // contents.
         //
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static bool Exists(String path)
         {
             try
@@ -480,7 +478,6 @@ namespace System.IO
                 (includeFiles ? SearchTarget.Files : 0) | (includeDirs ? SearchTarget.Directories : 0));
         }
 
-        [System.Security.SecuritySafeCritical]
         public static String GetDirectoryRoot(String path)
         {
             if (path == null)
@@ -506,14 +503,12 @@ namespace System.IO
        **Arguments: The current DirectoryInfo to which to switch to the setter.
        **Exceptions: 
        ==============================================================================*/
-        [System.Security.SecuritySafeCritical]
         public static String GetCurrentDirectory()
         {
             return FileSystem.Current.GetCurrentDirectory();
         }
 
 
-        [System.Security.SecurityCritical] // auto-generated
         public static void SetCurrentDirectory(String path)
         {
             if (path == null)
@@ -529,7 +524,6 @@ namespace System.IO
             FileSystem.Current.SetCurrentDirectory(fulldestDirName);
         }
 
-        [System.Security.SecuritySafeCritical]
         public static void Move(String sourceDirName, String destDirName)
         {
             if (sourceDirName == null)
@@ -567,14 +561,12 @@ namespace System.IO
             FileSystem.Current.MoveDirectory(fullsourceDirName, fulldestDirName);
         }
 
-        [System.Security.SecuritySafeCritical]
         public static void Delete(String path)
         {
             String fullPath = Path.GetFullPath(path);
             FileSystem.Current.RemoveDirectory(fullPath, false);
         }
 
-        [System.Security.SecuritySafeCritical]
         public static void Delete(String path, bool recursive)
         {
             String fullPath = Path.GetFullPath(path);

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.Windows.cs
@@ -9,7 +9,6 @@ namespace System.IO
 {
     partial class DirectoryInfo
     {
-        [SecurityCritical]
         internal DirectoryInfo(string fullPath, ref Interop.Kernel32.WIN32_FIND_DATA findData)
             : this(fullPath, findData.cFileName)
         {

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -13,7 +13,6 @@ namespace System.IO
     [Serializable]
     public sealed partial class DirectoryInfo : FileSystemInfo
     {
-        [System.Security.SecuritySafeCritical]
         public DirectoryInfo(String path)
         {
             if (path == null)
@@ -25,7 +24,6 @@ namespace System.IO
             DisplayPath = GetDisplayName(OriginalPath);
         }
 
-        [System.Security.SecuritySafeCritical]
         internal DirectoryInfo(String fullPath, String originalPath)
         {
             Debug.Assert(Path.IsPathRooted(fullPath), "fullPath must be fully qualified!");
@@ -51,7 +49,6 @@ namespace System.IO
 
         public DirectoryInfo Parent
         {
-            [System.Security.SecuritySafeCritical]
             get
             {
                 string s = FullPath;
@@ -72,7 +69,6 @@ namespace System.IO
         }
 
 
-        [System.Security.SecuritySafeCritical]
         public DirectoryInfo CreateSubdirectory(String path)
         {
             if (path == null)
@@ -82,7 +78,6 @@ namespace System.IO
             return CreateSubdirectoryHelper(path);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         private DirectoryInfo CreateSubdirectoryHelper(String path)
         {
             Debug.Assert(path != null);
@@ -103,7 +98,6 @@ namespace System.IO
             return new DirectoryInfo(fullPath);
         }
 
-        [System.Security.SecurityCritical]
         public void Create()
         {
             FileSystem.Current.CreateDirectory(FullPath);
@@ -116,7 +110,6 @@ namespace System.IO
         //
         public override bool Exists
         {
-            [System.Security.SecuritySafeCritical]  // auto-generated
             get
             {
                 try
@@ -132,7 +125,6 @@ namespace System.IO
 
         // Returns an array of Files in the current DirectoryInfo matching the 
         // given search criteria (i.e. "*.txt").
-        [SecurityCritical]
         public FileInfo[] GetFiles(String searchPattern)
         {
             if (searchPattern == null)
@@ -369,7 +361,6 @@ namespace System.IO
 
         public DirectoryInfo Root
         {
-            [System.Security.SecuritySafeCritical]
             get
             {
                 String rootPath = Path.GetPathRoot(FullPath);
@@ -378,7 +369,6 @@ namespace System.IO
             }
         }
 
-        [System.Security.SecuritySafeCritical]
         public void MoveTo(String destDirName)
         {
             if (destDirName == null)
@@ -423,13 +413,11 @@ namespace System.IO
             Invalidate();
         }
 
-        [System.Security.SecuritySafeCritical]
         public override void Delete()
         {
             FileSystem.Current.RemoveDirectory(FullPath, false);
         }
 
-        [System.Security.SecuritySafeCritical]
         public void Delete(bool recursive)
         {
             FileSystem.Current.RemoveDirectory(FullPath, recursive);

--- a/src/System.IO.FileSystem/src/System/IO/File.cs
+++ b/src/System.IO.FileSystem/src/System/IO/File.cs
@@ -102,7 +102,6 @@ namespace System.IO
         /// <devdoc>
         ///    Note: This returns the fully qualified name of the destination file.
         /// </devdoc>
-        [System.Security.SecuritySafeCritical]
         internal static String InternalCopy(String sourceFileName, String destFileName, bool overwrite)
         {
             Debug.Assert(sourceFileName != null);
@@ -160,7 +159,6 @@ namespace System.IO
         // 
         // Your application must have Delete permission to the target file.
         // 
-        [System.Security.SecuritySafeCritical]
         public static void Delete(String path)
         {
             if (path == null)
@@ -180,7 +178,6 @@ namespace System.IO
         //
         // Your application must have Read permission for the target directory.
         // 
-        [System.Security.SecuritySafeCritical]
         public static bool Exists(String path)
         {
             try
@@ -211,7 +208,6 @@ namespace System.IO
             return false;
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal static bool InternalExists(String path)
         {
             return FileSystem.Current.FileExists(path);
@@ -256,14 +252,12 @@ namespace System.IO
             FileSystem.Current.SetCreationTime(fullPath, GetUtcDateTimeOffset(creationTimeUtc), asDirectory: false);
         }
 
-        [System.Security.SecuritySafeCritical]
         public static DateTime GetCreationTime(String path)
         {
             String fullPath = Path.GetFullPath(path);
             return FileSystem.Current.GetCreationTime(fullPath).LocalDateTime;
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static DateTime GetCreationTimeUtc(String path)
         {
             String fullPath = Path.GetFullPath(path);
@@ -282,14 +276,12 @@ namespace System.IO
             FileSystem.Current.SetLastAccessTime(fullPath, GetUtcDateTimeOffset(lastAccessTimeUtc), asDirectory: false);
         }
 
-        [System.Security.SecuritySafeCritical]
         public static DateTime GetLastAccessTime(String path)
         {
             String fullPath = Path.GetFullPath(path);
             return FileSystem.Current.GetLastAccessTime(fullPath).LocalDateTime;
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static DateTime GetLastAccessTimeUtc(String path)
         {
             String fullPath = Path.GetFullPath(path);
@@ -308,35 +300,30 @@ namespace System.IO
             FileSystem.Current.SetLastWriteTime(fullPath, GetUtcDateTimeOffset(lastWriteTimeUtc), asDirectory: false);
         }
 
-        [System.Security.SecuritySafeCritical]
         public static DateTime GetLastWriteTime(String path)
         {
             String fullPath = Path.GetFullPath(path);
             return FileSystem.Current.GetLastWriteTime(fullPath).LocalDateTime;
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static DateTime GetLastWriteTimeUtc(String path)
         {
             String fullPath = Path.GetFullPath(path);
             return FileSystem.Current.GetLastWriteTime(fullPath).UtcDateTime;
         }
 
-        [System.Security.SecuritySafeCritical]
         public static FileAttributes GetAttributes(String path)
         {
             String fullPath = Path.GetFullPath(path);
             return FileSystem.Current.GetAttributes(fullPath);
         }
 
-        [System.Security.SecurityCritical]
         public static void SetAttributes(String path, FileAttributes fileAttributes)
         {
             String fullPath = Path.GetFullPath(path);
             FileSystem.Current.SetAttributes(fullPath, fileAttributes);
         }
 
-        [System.Security.SecuritySafeCritical]
         public static FileStream OpenRead(String path)
         {
             return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
@@ -349,7 +336,6 @@ namespace System.IO
                                   FileAccess.Write, FileShare.None);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static String ReadAllText(String path)
         {
             if (path == null)
@@ -361,7 +347,6 @@ namespace System.IO
             return InternalReadAllText(path, Encoding.UTF8);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static String ReadAllText(String path, Encoding encoding)
         {
             if (path == null)
@@ -375,7 +360,6 @@ namespace System.IO
             return InternalReadAllText(path, encoding);
         }
 
-        [System.Security.SecurityCritical]
         private static String InternalReadAllText(String path, Encoding encoding)
         {
             Debug.Assert(path != null);
@@ -386,7 +370,6 @@ namespace System.IO
                 return sr.ReadToEnd();
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static void WriteAllText(String path, String contents)
         {
             if (path == null)
@@ -401,7 +384,6 @@ namespace System.IO
             }
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static void WriteAllText(String path, String contents, Encoding encoding)
         {
             if (path == null)
@@ -418,13 +400,11 @@ namespace System.IO
             }
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static byte[] ReadAllBytes(String path)
         {
             return InternalReadAllBytes(path);
         }
 
-        [System.Security.SecurityCritical]
         private static byte[] InternalReadAllBytes(String path)
         {
             // bufferSize == 1 used to avoid unnecessary buffer in FileStream
@@ -449,7 +429,6 @@ namespace System.IO
             }
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static void WriteAllBytes(String path, byte[] bytes)
         {
             if (path == null)
@@ -463,7 +442,6 @@ namespace System.IO
             InternalWriteAllBytes(path, bytes);
         }
 
-        [System.Security.SecurityCritical]
         private static void InternalWriteAllBytes(String path, byte[] bytes)
         {
             Debug.Assert(path != null);
@@ -676,7 +654,6 @@ namespace System.IO
         // sourceFileName and Write 
         // permissions to destFileName.
         // 
-        [System.Security.SecuritySafeCritical]
         public static void Move(String sourceFileName, String destFileName)
         {
             if (sourceFileName == null)

--- a/src/System.IO.FileSystem/src/System/IO/FileInfo.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileInfo.Windows.cs
@@ -9,7 +9,6 @@ namespace System.IO
 {
     partial class FileInfo
     {
-        [SecurityCritical]
         internal FileInfo(string fullPath, ref Interop.Kernel32.WIN32_FIND_DATA findData)
             : this(fullPath, findData.cFileName)
         {

--- a/src/System.IO.FileSystem/src/System/IO/FileInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileInfo.cs
@@ -20,10 +20,8 @@ namespace System.IO
     {
         private String _name;
 
-        [System.Security.SecurityCritical]
         private FileInfo() { }
 
-        [System.Security.SecuritySafeCritical]
         public FileInfo(String fileName)
         {
             if (fileName == null)
@@ -39,7 +37,6 @@ namespace System.IO
             DisplayPath = GetDisplayPath(OriginalPath);
         }
 
-        [System.Security.SecurityCritical]
         private void Init(String fileName)
         {
             OriginalPath = fileName;
@@ -56,7 +53,6 @@ namespace System.IO
             return originalPath;
         }
 
-        [System.Security.SecuritySafeCritical]
         internal FileInfo(String fullPath, String originalPath)
         {
             Debug.Assert(Path.IsPathRooted(fullPath), "fullPath must be fully qualified!");
@@ -74,7 +70,6 @@ namespace System.IO
 
         public long Length
         {
-            [System.Security.SecuritySafeCritical]  // auto-generated
             get
             {
                 if ((FileSystemObject.Attributes & FileAttributes.Directory) == FileAttributes.Directory)
@@ -88,7 +83,6 @@ namespace System.IO
         /* Returns the name of the directory that the file is in */
         public String DirectoryName
         {
-            [System.Security.SecuritySafeCritical]
             get
             {
                 return Path.GetDirectoryName(FullPath);
@@ -122,7 +116,6 @@ namespace System.IO
             }
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public StreamReader OpenText()
         {
             return new StreamReader(FullPath, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
@@ -197,7 +190,6 @@ namespace System.IO
         // 
         // Your application must have Delete permission to the target file.
         // 
-        [System.Security.SecuritySafeCritical]
         public override void Delete()
         {
             FileSystem.Current.DeleteFile(FullPath);
@@ -210,7 +202,6 @@ namespace System.IO
         // Your application must have Read permission for the target directory.
         public override bool Exists
         {
-            [System.Security.SecuritySafeCritical]  // auto-generated
             get
             {
                 try
@@ -241,7 +232,6 @@ namespace System.IO
         }
 
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public FileStream OpenRead()
         {
             return new FileStream(FullPath, FileMode.Open, FileAccess.Read,
@@ -263,7 +253,6 @@ namespace System.IO
         // sourceFileName and Write 
         // permissions to destFileName.
         // 
-        [System.Security.SecuritySafeCritical]
         public void MoveTo(String destFileName)
         {
             if (destFileName == null)

--- a/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Windows.cs
@@ -17,7 +17,6 @@ namespace System.IO
         // throw an appropriate error when attempting to access the cached info.
         private int _dataInitialized = -1;
 
-        [SecurityCritical]
         internal void Init(ref Interop.Kernel32.WIN32_FIND_DATA findData)
         {
             // Copy the information to data

--- a/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.cs
@@ -20,7 +20,6 @@ namespace System.IO
         protected String OriginalPath;      // path passed in by the user
         private String _displayPath = "";   // path that can be displayed to the user
 
-        [System.Security.SecurityCritical]
         protected FileSystemInfo()
         {
         }
@@ -45,7 +44,6 @@ namespace System.IO
         // Full path of the directory/file
         public virtual String FullName
         {
-            [System.Security.SecuritySafeCritical]
             get
             {
                 return FullPath;
@@ -101,7 +99,6 @@ namespace System.IO
 
         public DateTime CreationTimeUtc
         {
-            [System.Security.SecuritySafeCritical]
             get
             {
                 return FileSystemObject.CreationTime.UtcDateTime;
@@ -129,7 +126,6 @@ namespace System.IO
 
         public DateTime LastAccessTimeUtc
         {
-            [System.Security.SecuritySafeCritical]
             get
             {
                 return FileSystemObject.LastAccessTime.UtcDateTime;
@@ -157,7 +153,6 @@ namespace System.IO
 
         public DateTime LastWriteTimeUtc
         {
-            [System.Security.SecuritySafeCritical]
             get
             {
                 return FileSystemObject.LastWriteTime.UtcDateTime;
@@ -176,12 +171,10 @@ namespace System.IO
 
         public FileAttributes Attributes
         {
-            [System.Security.SecuritySafeCritical]
             get
             {
                 return FileSystemObject.Attributes;
             }
-            [System.Security.SecurityCritical] // auto-generated
             set
             {
                 FileSystemObject.Attributes = value;

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystem.cs
@@ -61,7 +61,6 @@ namespace System.IO
             }
         }
 
-        [System.Security.SecuritySafeCritical]
         public override void CreateDirectory(string fullPath)
         {
             if (PathInternal.IsDirectoryTooLong(fullPath))
@@ -222,7 +221,6 @@ namespace System.IO
 
         // Returns 0 on success, otherwise a Win32 error code.  Note that
         // classes should use -1 as the uninitialized state for dataInitialized.
-        [System.Security.SecurityCritical]  // auto-generated
         internal static int FillAttributeInfo(String path, ref Interop.Kernel32.WIN32_FILE_ATTRIBUTE_DATA data, bool tryagain, bool returnErrorOnNotFound)
         {
             int errorCode = 0;
@@ -450,7 +448,6 @@ namespace System.IO
             return new FileStream(fullPath, mode, access, share, bufferSize, options);
         }
 
-        [System.Security.SecurityCritical]
         private static SafeFileHandle OpenHandle(string fullPath, bool asDirectory)
         {
             String root = fullPath.Substring(0, PathInternal.GetRootLength(fullPath));
@@ -509,7 +506,6 @@ namespace System.IO
             RemoveDirectoryHelper(PathInternal.EnsureExtendedPrefix(fullPath), recursive, true);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         private static void RemoveDirectoryHelper(string fullPath, bool recursive, bool throwOnTopLevelDirectoryNotFound)
         {
             bool r;

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
@@ -96,7 +96,6 @@ namespace System.IO
         private List<PathPair> _searchList;
         private PathPair _searchData;
         private readonly string _searchCriteria;
-        [SecurityCritical]
         private SafeFindHandle _hnd = null;
 
         // empty means we know in advance that we won?t find any search results, which can happen if:
@@ -113,7 +112,6 @@ namespace System.IO
         private readonly string _normalizedSearchPath;
         private readonly uint _oldMode;
 
-        [SecuritySafeCritical]
         internal Win32FileSystemEnumerableIterator(string path, string originalUserPath, string searchPattern, SearchOption searchOption, SearchResultHandler<TSource> resultHandler)
         {
             Debug.Assert(path != null);
@@ -154,7 +152,6 @@ namespace System.IO
             }
         }
 
-        [SecurityCritical]
         private void CommonInit()
         {
             Debug.Assert(_searchCriteria != null, "searchCriteria should be initialized");
@@ -209,7 +206,6 @@ namespace System.IO
             }
         }
 
-        [SecuritySafeCritical]
         private Win32FileSystemEnumerableIterator(string fullPath, string normalizedSearchPath, string searchCriteria, string userPath, SearchOption searchOption, SearchResultHandler<TSource> resultHandler)
         {
             _fullPath = fullPath;
@@ -239,7 +235,6 @@ namespace System.IO
             return new Win32FileSystemEnumerableIterator<TSource>(_fullPath, _normalizedSearchPath, _searchCriteria, _userPath, _searchOption, _resultHandler);
         }
 
-        [SecuritySafeCritical]
         protected override void Dispose(bool disposing)
         {
             try
@@ -256,7 +251,6 @@ namespace System.IO
             }
         }
 
-        [SecuritySafeCritical]
         public override bool MoveNext()
         {
             Interop.Kernel32.WIN32_FIND_DATA data = new Interop.Kernel32.WIN32_FIND_DATA();
@@ -383,7 +377,6 @@ namespace System.IO
             return false;
         }
 
-        [SecurityCritical]
         private bool IsResultIncluded(ref Interop.Kernel32.WIN32_FIND_DATA findData, out TSource result)
         {
             Debug.Assert(findData.cFileName.Length != 0 && !Path.IsPathRooted(findData.cFileName),
@@ -392,14 +385,12 @@ namespace System.IO
             return _resultHandler.IsResultIncluded(_searchData.FullPath, _searchData.UserPath, ref findData, out result);
         }
 
-        [SecurityCritical]
         private void HandleError(int errorCode, string path)
         {
             Dispose();
             throw Win32Marshal.GetExceptionForWin32Error(errorCode, path);
         }
 
-        [SecurityCritical]  // auto-generated
         private void AddSearchableDirsToList(PathPair localSearchData)
         {
             string searchPath = Path.Combine(localSearchData.FullPath, "*");
@@ -486,7 +477,6 @@ namespace System.IO
         /// Returns true if the result should be included. If true, the <paramref name="result"/> parameter
         /// is set to the created result object, otherwise it is set to null.
         /// </summary>
-        [SecurityCritical]
         internal abstract bool IsResultIncluded(string fullPath, string userPath, ref Interop.Kernel32.WIN32_FIND_DATA findData, out TSource result);
     }
 
@@ -540,7 +530,6 @@ namespace System.IO
                 _includeDirs = includeDirs;
             }
 
-            [SecurityCritical]
             internal override bool IsResultIncluded(string fullPath, string userPath, ref Interop.Kernel32.WIN32_FIND_DATA findData, out string result)
             {
                 if ((_includeFiles && Win32FileSystemEnumerableHelpers.IsFile(ref findData)) ||
@@ -557,7 +546,6 @@ namespace System.IO
 
         private sealed class FileInfoResultHandler : SearchResultHandler<FileInfo>
         {
-            [SecurityCritical]
             internal override bool IsResultIncluded(string fullPath, string userPath, ref Interop.Kernel32.WIN32_FIND_DATA findData, out FileInfo result)
             {
                 if (Win32FileSystemEnumerableHelpers.IsFile(ref findData))
@@ -574,7 +562,6 @@ namespace System.IO
 
         private sealed class DirectoryInfoResultHandler : SearchResultHandler<DirectoryInfo>
         {
-            [SecurityCritical]
             internal override bool IsResultIncluded(string fullPath, string userPath, ref Interop.Kernel32.WIN32_FIND_DATA findData, out DirectoryInfo result)
             {
                 if (Win32FileSystemEnumerableHelpers.IsDir(ref findData))
@@ -591,7 +578,6 @@ namespace System.IO
 
         private sealed class FileSystemInfoResultHandler : SearchResultHandler<FileSystemInfo>
         {
-            [SecurityCritical]
             internal override bool IsResultIncluded(string fullPath, string userPath, ref Interop.Kernel32.WIN32_FIND_DATA findData, out FileSystemInfo result)
             {
                 if (Win32FileSystemEnumerableHelpers.IsFile(ref findData))
@@ -615,7 +601,6 @@ namespace System.IO
 
     internal static class Win32FileSystemEnumerableHelpers
     {
-        [SecurityCritical]  // auto-generated
         internal static bool IsDir(ref Interop.Kernel32.WIN32_FIND_DATA data)
         {
             // Don't add "." nor ".."
@@ -623,7 +608,6 @@ namespace System.IO
                                                 && !data.cFileName.Equals(".") && !data.cFileName.Equals("..");
         }
 
-        [SecurityCritical]  // auto-generated
         internal static bool IsFile(ref Interop.Kernel32.WIN32_FIND_DATA data)
         {
             return 0 == (data.dwFileAttributes & Interop.Kernel32.FileAttributes.FILE_ATTRIBUTE_DIRECTORY);

--- a/src/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
+++ b/src/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
@@ -85,7 +85,6 @@ namespace Microsoft.Win32.SafeHandles
 
         public override bool IsInvalid
         {
-            [SecurityCritical]
             get { return (long)handle <= 0; }
         }
     }

--- a/src/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedViewHandle.cs
+++ b/src/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedViewHandle.cs
@@ -8,7 +8,6 @@ using System.Security;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [SecurityCritical]
 #pragma warning disable 0618    // SafeBuffer is obsolete
     public sealed partial class SafeMemoryMappedViewHandle : SafeBuffer
 #pragma warning restore

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
@@ -14,7 +14,6 @@ namespace System.IO.MemoryMappedFiles
         /// memory mapped file should not be associated with an existing file on disk (i.e. start
         /// out empty).
         /// </summary>
-        [SecurityCritical]
         private static unsafe SafeMemoryMappedFileHandle CreateCore(
             FileStream fileStream, string mapName, 
             HandleInheritability inheritability, MemoryMappedFileAccess access, 
@@ -85,7 +84,6 @@ namespace System.IO.MemoryMappedFiles
         /// <summary>
         /// Used by the CreateOrOpen factory method groups.
         /// </summary>
-        [SecurityCritical]
         private static SafeMemoryMappedFileHandle CreateOrOpenCore(
             string mapName, 
             HandleInheritability inheritability, MemoryMappedFileAccess access,
@@ -101,7 +99,6 @@ namespace System.IO.MemoryMappedFiles
         /// We'll throw an ArgumentException if the file mapping object didn't exist and the
         /// caller used CreateOrOpen since Create isn't valid with Write access
         /// </summary>
-        [SecurityCritical]
         private static SafeMemoryMappedFileHandle OpenCore(
             string mapName, HandleInheritability inheritability, MemoryMappedFileAccess access, bool createOrOpen)
         {
@@ -113,7 +110,6 @@ namespace System.IO.MemoryMappedFiles
         /// We'll throw an ArgumentException if the file mapping object didn't exist and the
         /// caller used CreateOrOpen since Create isn't valid with Write access
         /// </summary>
-        [SecurityCritical]
         private static SafeMemoryMappedFileHandle OpenCore(
             string mapName, HandleInheritability inheritability, MemoryMappedFileRights rights, bool createOrOpen)
         {

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Windows.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Windows.cs
@@ -19,7 +19,6 @@ namespace System.IO.MemoryMappedFiles
         /// </summary>
 
         private static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
-        [SecurityCritical]
         private static SafeMemoryMappedFileHandle CreateCore(
             FileStream fileStream, string mapName, HandleInheritability inheritability,
             MemoryMappedFileAccess access, MemoryMappedFileOptions options, long capacity)
@@ -75,7 +74,6 @@ namespace System.IO.MemoryMappedFiles
         /// <summary>
         /// Used by the CreateOrOpen factory method groups.
         /// </summary>
-        [SecurityCritical]
         private static SafeMemoryMappedFileHandle CreateOrOpenCore(
             string mapName, HandleInheritability inheritability, MemoryMappedFileAccess access, 
             MemoryMappedFileOptions options, long capacity)
@@ -217,7 +215,6 @@ namespace System.IO.MemoryMappedFiles
         /// We'll throw an ArgumentException if the file mapping object didn't exist and the
         /// caller used CreateOrOpen since Create isn't valid with Write access
         /// </summary>
-        [SecurityCritical]
         private static SafeMemoryMappedFileHandle OpenCore(
             string mapName, HandleInheritability inheritability, int desiredAccessRights, bool createOrOpen)
         {
@@ -244,7 +241,6 @@ namespace System.IO.MemoryMappedFiles
         /// Helper method used to extract the native binary security descriptor from the MemoryMappedFileSecurity
         /// type. If pinningHandle is not null, caller must free it AFTER the call to CreateFile has returned.
         /// </summary>
-        [SecurityCritical]
         private static unsafe Interop.Kernel32.SECURITY_ATTRIBUTES GetSecAttrs(HandleInheritability inheritability)
         {
             Interop.Kernel32.SECURITY_ATTRIBUTES secAttrs = default(Interop.Kernel32.SECURITY_ATTRIBUTES);

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs
@@ -16,7 +16,6 @@ namespace System.IO.MemoryMappedFiles
         internal const int DefaultSize = 0;
 
         // Private constructors to be used by the factory methods.
-        [SecurityCritical]
         private MemoryMappedFile(SafeMemoryMappedFileHandle handle)
         {
             Debug.Assert(handle != null);
@@ -27,7 +26,6 @@ namespace System.IO.MemoryMappedFiles
             _leaveOpen = true; // No FileStream to dispose of in this case.
         }
 
-        [SecurityCritical]
         private MemoryMappedFile(SafeMemoryMappedFileHandle handle, FileStream fileStream, bool leaveOpen)
         {
             Debug.Assert(handle != null);
@@ -57,7 +55,6 @@ namespace System.IO.MemoryMappedFiles
             return OpenExisting(mapName, desiredAccessRights, HandleInheritability.None);
         }
 
-        [SecurityCritical]
         public static MemoryMappedFile OpenExisting(string mapName, MemoryMappedFileRights desiredAccessRights,
                                                                     HandleInheritability inheritability)
         {
@@ -112,7 +109,6 @@ namespace System.IO.MemoryMappedFiles
             return CreateFromFile(path, mode, mapName, capacity, MemoryMappedFileAccess.ReadWrite);
         }
 
-        [SecurityCritical]
         public static MemoryMappedFile CreateFromFile(string path, FileMode mode, string mapName, long capacity,
                                                                         MemoryMappedFileAccess access)
         {
@@ -190,7 +186,6 @@ namespace System.IO.MemoryMappedFiles
             return new MemoryMappedFile(handle, fileStream, false);
         }
 
-        [SecurityCritical]
         public static MemoryMappedFile CreateFromFile(FileStream fileStream, string mapName, long capacity,
                                                         MemoryMappedFileAccess access,
                                                         HandleInheritability inheritability, bool leaveOpen)
@@ -270,7 +265,6 @@ namespace System.IO.MemoryMappedFiles
                    HandleInheritability.None);
         }
 
-        [SecurityCritical]
         public static MemoryMappedFile CreateNew(string mapName, long capacity, MemoryMappedFileAccess access,
                                                     MemoryMappedFileOptions options,
                                                     HandleInheritability inheritability)
@@ -331,7 +325,6 @@ namespace System.IO.MemoryMappedFiles
             return CreateOrOpen(mapName, capacity, access, MemoryMappedFileOptions.None, HandleInheritability.None);
         }
 
-        [SecurityCritical]
         public static MemoryMappedFile CreateOrOpen(string mapName, long capacity,
                                                     MemoryMappedFileAccess access, MemoryMappedFileOptions options,
                                                     HandleInheritability inheritability)
@@ -396,7 +389,6 @@ namespace System.IO.MemoryMappedFiles
             return CreateViewStream(offset, size, MemoryMappedFileAccess.ReadWrite);
         }
 
-        [SecurityCritical]
         public MemoryMappedViewStream CreateViewStream(long offset, long size, MemoryMappedFileAccess access)
         {
             if (offset < 0)
@@ -434,7 +426,6 @@ namespace System.IO.MemoryMappedFiles
             return CreateViewAccessor(offset, size, MemoryMappedFileAccess.ReadWrite);
         }
 
-        [SecurityCritical]
         public MemoryMappedViewAccessor CreateViewAccessor(long offset, long size, MemoryMappedFileAccess access)
         {
             if (offset < 0)
@@ -467,7 +458,6 @@ namespace System.IO.MemoryMappedFiles
             GC.SuppressFinalize(this);
         }
 
-        [SecuritySafeCritical]
         protected virtual void Dispose(bool disposing)
         {
             try
@@ -488,7 +478,6 @@ namespace System.IO.MemoryMappedFiles
 
         public SafeMemoryMappedFileHandle SafeMemoryMappedFileHandle
         {
-            [SecurityCritical]
             get { return _handle; }
         }
 

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Unix.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Unix.cs
@@ -11,7 +11,6 @@ namespace System.IO.MemoryMappedFiles
 {
     internal partial class MemoryMappedView
     {
-        [SecurityCritical]
         public static unsafe MemoryMappedView CreateView(
             SafeMemoryMappedFileHandle memMappedFileHandle, MemoryMappedFileAccess access,
             long requestedOffset, long requestedSize)
@@ -137,7 +136,6 @@ namespace System.IO.MemoryMappedFiles
                 access);
         }
 
-        [SecurityCritical]
         public unsafe void Flush(UIntPtr capacity)
         {
             if (capacity == UIntPtr.Zero)

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
@@ -17,7 +17,6 @@ namespace System.IO.MemoryMappedFiles
         private const int MaxFlushWaits = 15;  // must be <=30
         private const int MaxFlushRetriesPerWait = 20;
 
-        [SecurityCritical]
         public static unsafe MemoryMappedView CreateView(SafeMemoryMappedFileHandle memMappedFileHandle,
                                             MemoryMappedFileAccess access, long offset, long size)
         {
@@ -97,7 +96,6 @@ namespace System.IO.MemoryMappedFiles
         // flush to the disk.
         // NOTE: This will flush all bytes before and after the view up until an offset that is a multiple
         //       of SystemPageSize.
-        [SecurityCritical]
         public void Flush(UIntPtr capacity)
         {
             unsafe
@@ -157,7 +155,6 @@ namespace System.IO.MemoryMappedFiles
         // ---- PAL layer ends here ----
         // -----------------------------
 
-        [SecurityCritical]
         private static int GetSystemPageAllocationGranularity()
         {
             Interop.Kernel32.SYSTEM_INFO info;

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.cs
@@ -15,7 +15,6 @@ namespace System.IO.MemoryMappedFiles
         private readonly long _size;
         private readonly MemoryMappedFileAccess _access;
 
-        [SecurityCritical]
         private unsafe MemoryMappedView(SafeMemoryMappedViewHandle viewHandle, long pointerOffset,
                                         long size, MemoryMappedFileAccess access)
         {
@@ -29,7 +28,6 @@ namespace System.IO.MemoryMappedFiles
 
         public SafeMemoryMappedViewHandle ViewHandle
         {
-            [SecurityCritical]
             get { return _viewHandle; }
         }
 
@@ -48,7 +46,6 @@ namespace System.IO.MemoryMappedFiles
             get { return _access; }
         }
 
-        [SecurityCritical]
         protected virtual void Dispose(bool disposing)
         {
             if (!_viewHandle.IsClosed)
@@ -57,7 +54,6 @@ namespace System.IO.MemoryMappedFiles
             }
         }
 
-        [SecurityCritical]
         public void Dispose()
         {
             Dispose(true);
@@ -66,7 +62,6 @@ namespace System.IO.MemoryMappedFiles
 
         public bool IsClosed
         {
-            [SecuritySafeCritical]
             get { return _viewHandle.IsClosed; }
         }
 

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewAccessor.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewAccessor.cs
@@ -12,7 +12,6 @@ namespace System.IO.MemoryMappedFiles
     {
         private readonly MemoryMappedView _view;
 
-        [SecurityCritical]
         internal MemoryMappedViewAccessor(MemoryMappedView view)
         {
             Debug.Assert(view != null, "view is null");
@@ -23,7 +22,6 @@ namespace System.IO.MemoryMappedFiles
 
         public SafeMemoryMappedViewHandle SafeMemoryMappedViewHandle
         {
-            [SecurityCritical]
             get { return _view.ViewHandle; }
         }
 
@@ -32,7 +30,6 @@ namespace System.IO.MemoryMappedFiles
             get { return _view.PointerOffset; }
         }
 
-        [SecuritySafeCritical]
         protected override void Dispose(bool disposing)
         {
             try
@@ -62,7 +59,6 @@ namespace System.IO.MemoryMappedFiles
         // flush to the disk.
         // NOTE: This will flush all bytes before and after the view up until an offset that is a
         // multiple of SystemPageSize.
-        [SecurityCritical]
         public void Flush()
         {
             if (!IsOpen)

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewStream.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewStream.cs
@@ -12,7 +12,6 @@ namespace System.IO.MemoryMappedFiles
     {
         private readonly MemoryMappedView _view;
 
-        [SecurityCritical]
         internal unsafe MemoryMappedViewStream(MemoryMappedView view)
         {
             Debug.Assert(view != null, "view is null");
@@ -23,7 +22,6 @@ namespace System.IO.MemoryMappedFiles
 
         public SafeMemoryMappedViewHandle SafeMemoryMappedViewHandle
         {
-            [SecurityCritical]
             get { return _view.ViewHandle; }
         }
 
@@ -37,7 +35,6 @@ namespace System.IO.MemoryMappedFiles
             get { return _view.PointerOffset; }
         }
 
-        [SecuritySafeCritical]
         protected override void Dispose(bool disposing)
         {
             try
@@ -65,7 +62,6 @@ namespace System.IO.MemoryMappedFiles
         // flush to the disk.
         // NOTE: This will flush all bytes before and after the view up until an offset that is a 
         // multiple of SystemPageSize.
-        [SecurityCritical]
         public override void Flush()
         {
             if (!CanSeek)

--- a/src/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.cs
+++ b/src/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.cs
@@ -41,9 +41,7 @@ namespace System.IO.Pipes
         public System.IO.Pipes.PipeAccessRights PipeAccessRights { get { throw null; } }
     }
     public static partial class PipesAclExtensions {
-        [System.Security.SecurityCriticalAttribute]
         public static System.IO.Pipes.PipeSecurity GetAccessControl(this System.IO.Pipes.PipeStream stream) { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         public static void SetAccessControl(this System.IO.Pipes.PipeStream stream, System.IO.Pipes.PipeSecurity pipeSecurity) { }
     }
     public partial class PipeSecurity : System.Security.AccessControl.NativeObjectSecurity
@@ -56,9 +54,7 @@ namespace System.IO.Pipes
         public void AddAccessRule(System.IO.Pipes.PipeAccessRule rule) { }
         public void AddAuditRule(System.IO.Pipes.PipeAuditRule rule) { }
         public sealed override System.Security.AccessControl.AuditRule AuditRuleFactory(System.Security.Principal.IdentityReference identityReference, int accessMask, bool isInherited, System.Security.AccessControl.InheritanceFlags inheritanceFlags, System.Security.AccessControl.PropagationFlags propagationFlags, System.Security.AccessControl.AuditFlags flags) { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         protected internal void Persist(System.Runtime.InteropServices.SafeHandle handle) { }
-        [System.Security.SecurityCriticalAttribute]
         protected internal void Persist(string name) { }
         public bool RemoveAccessRule(System.IO.Pipes.PipeAccessRule rule) { throw null; }
         public void RemoveAccessRuleSpecific(System.IO.Pipes.PipeAccessRule rule) { }

--- a/src/System.IO.Pipes.AccessControl/src/System/IO/PipeSecurity.cs
+++ b/src/System.IO.Pipes.AccessControl/src/System/IO/PipeSecurity.cs
@@ -16,7 +16,6 @@ namespace System.IO.Pipes
             : base(false, ResourceType.KernelObject) { }
 
         // Used by PipeStream.GetAccessControl
-        [System.Security.SecuritySafeCritical]
         internal PipeSecurity(SafePipeHandle safeHandle, AccessControlSections includeSections)
             : base(false, ResourceType.KernelObject, safeHandle, includeSections) { }
 
@@ -219,8 +218,6 @@ namespace System.IO.Pipes
 
         // Use this in your own Persist after you have demanded any appropriate CAS permissions.
         // Note that you will want your version to be internal and use a specialized Safe Handle. 
-        [System.Security.SecurityCritical]
-        //[SecurityPermission(SecurityAction.Assert, UnmanagedCode = true)]
         protected internal void Persist(SafeHandle handle)
         {
             WriteLock();
@@ -239,8 +236,6 @@ namespace System.IO.Pipes
 
         // Use this in your own Persist after you have demanded any appropriate CAS permissions.
         // Note that you will want your version to be internal. 
-        [System.Security.SecurityCritical]
-        //[SecurityPermission(SecurityAction.Assert, UnmanagedCode = true)]
         protected internal void Persist(String name)
         {
             WriteLock();

--- a/src/System.IO.Pipes.AccessControl/src/System/IO/PipesAclExtensions.cs
+++ b/src/System.IO.Pipes.AccessControl/src/System/IO/PipesAclExtensions.cs
@@ -9,7 +9,6 @@ namespace System.IO.Pipes
 {
     public static class PipesAclExtensions
     {
-        [System.Security.SecurityCritical]
         public static PipeSecurity GetAccessControl(this PipeStream stream)
         {
             // PipeState can not be Closed and the Handle can not be null or closed
@@ -17,7 +16,6 @@ namespace System.IO.Pipes
             return new PipeSecurity(handle, AccessControlSections.Access | AccessControlSections.Owner | AccessControlSections.Group);
         }
 
-        [System.Security.SecurityCritical]
         public static void SetAccessControl(this PipeStream stream, PipeSecurity pipeSecurity)
         {
             // PipeState can not be Closed and the Handle can not be null or closed

--- a/src/System.IO.Pipes.AccessControl/src/System/IO/PipesAclExtensions.net46.cs
+++ b/src/System.IO.Pipes.AccessControl/src/System/IO/PipesAclExtensions.net46.cs
@@ -9,13 +9,11 @@ namespace System.IO.Pipes
 {
     public static class PipesAclExtensions
     {
-        [System.Security.SecurityCritical]
         public static PipeSecurity GetAccessControl(PipeStream stream)
         {
             return stream.GetAccessControl();
         }
 
-        [System.Security.SecurityCritical]
         public static void SetAccessControl(PipeStream stream, PipeSecurity pipeSecurity)
         {
             stream.SetAccessControl(pipeSecurity);

--- a/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.Unix.cs
+++ b/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.Unix.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Win32.SafeHandles
 
         public override bool IsInvalid
         {
-            [SecurityCritical]
             get { return (long)handle < 0 && _namedPipeSocket == null; }
         }
     }

--- a/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.cs
+++ b/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.cs
@@ -8,7 +8,6 @@ using System.Security;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [SecurityCritical]
     public sealed partial class SafePipeHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         internal SafePipeHandle()

--- a/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeClientStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeClientStream.cs
@@ -14,14 +14,12 @@ namespace System.IO.Pipes
     /// </summary>
     public sealed partial class AnonymousPipeClientStream : PipeStream
     {
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "string", Justification = "By design")]
         public AnonymousPipeClientStream(String pipeHandleAsString)
             : this(PipeDirection.In, pipeHandleAsString)
         {
         }
 
-        [SecurityCritical]
         [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "string", Justification = "By design")]
         public AnonymousPipeClientStream(PipeDirection direction, String pipeHandleAsString)
             : base(direction, 0)
@@ -53,7 +51,6 @@ namespace System.IO.Pipes
             Init(direction, safePipeHandle);
         }
 
-        [SecurityCritical]
         public AnonymousPipeClientStream(PipeDirection direction, SafePipeHandle safePipeHandle)
             : base(direction, 0)
         {
@@ -73,7 +70,6 @@ namespace System.IO.Pipes
             Init(direction, safePipeHandle);
         }
 
-        [SecuritySafeCritical]
         private void Init(PipeDirection direction, SafePipeHandle safePipeHandle)
         {
             Debug.Assert(direction != PipeDirection.InOut, "anonymous pipes are unidirectional, caller should have verified before calling Init");
@@ -93,13 +89,11 @@ namespace System.IO.Pipes
         // which P/Invokes (and sometimes fails).
         public override PipeTransmissionMode TransmissionMode
         {
-            [SecurityCritical]
             get { return PipeTransmissionMode.Byte; }
         }
 
         public override PipeTransmissionMode ReadMode
         {
-            [SecurityCritical]
             set
             {
                 CheckPipePropertyOperations();

--- a/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Unix.cs
@@ -14,7 +14,6 @@ namespace System.IO.Pipes
     public sealed partial class AnonymousPipeServerStream : PipeStream
     {
         // Creates the anonymous pipe.
-        [SecurityCritical]
         private unsafe void Create(PipeDirection direction, HandleInheritability inheritability, int bufferSize)
         {
             Debug.Assert(direction != PipeDirection.InOut, "Anonymous pipe direction shouldn't be InOut");

--- a/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Windows.cs
@@ -15,7 +15,6 @@ namespace System.IO.Pipes
     public sealed partial class AnonymousPipeServerStream : PipeStream
     {
         // Creates the anonymous pipe.
-        [SecurityCritical]
         private void Create(PipeDirection direction, HandleInheritability inheritability, int bufferSize)
         {
             Debug.Assert(direction != PipeDirection.InOut, "Anonymous pipe direction shouldn't be InOut");

--- a/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.cs
@@ -16,26 +16,22 @@ namespace System.IO.Pipes
         private SafePipeHandle _clientHandle;
         private bool _clientHandleExposed;
 
-        [SecuritySafeCritical]
         public AnonymousPipeServerStream()
             : this(PipeDirection.Out, HandleInheritability.None, 0)
         {
         }
 
-        [SecuritySafeCritical]
         public AnonymousPipeServerStream(PipeDirection direction)
             : this(direction, HandleInheritability.None, 0)
         {
         }
 
-        [SecuritySafeCritical]
         public AnonymousPipeServerStream(PipeDirection direction, HandleInheritability inheritability)
             : this(direction, inheritability, 0)
         { 
         }
 
         // Create an AnonymousPipeServerStream from two existing pipe handles.
-        [SecuritySafeCritical]
         public AnonymousPipeServerStream(PipeDirection direction, SafePipeHandle serverSafePipeHandle, SafePipeHandle clientSafePipeHandle)
             : base(direction, 0)
         {
@@ -71,7 +67,6 @@ namespace System.IO.Pipes
 
         // bufferSize is used as a suggestion; specify 0 to let OS decide
         // This constructor instantiates the PipeSecurity using just the inheritability flag
-        [SecuritySafeCritical]
         public AnonymousPipeServerStream(PipeDirection direction, HandleInheritability inheritability, int bufferSize)
             : base(direction, bufferSize)
         {
@@ -94,7 +89,6 @@ namespace System.IO.Pipes
 
         // This method should exist until we add a first class way of passing handles between parent and child
         // processes. For now, people do it via command line arguments. 
-        [SecurityCritical]
         [SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Runtime.InteropServices.SafeHandle.DangerousGetHandle", Justification = "By design")]
         public String GetClientHandleAsString()
         {
@@ -105,7 +99,6 @@ namespace System.IO.Pipes
 
         public SafePipeHandle ClientSafePipeHandle
         {
-            [SecurityCritical]
             get
             {
                 _clientHandleExposed = true;
@@ -124,7 +117,6 @@ namespace System.IO.Pipes
         // 
         // Right now, this is the best signal to set the anonymous pipe as connected; if this is called, we
         // know the client has been passed the handle and so the connection is live.
-        [SecurityCritical]
         public void DisposeLocalCopyOfClientHandle()
         {
             if (_clientHandle != null && !_clientHandle.IsClosed)
@@ -133,7 +125,6 @@ namespace System.IO.Pipes
             }
         }
 
-        [SecurityCritical]
         protected override void Dispose(bool disposing)
         {
             try
@@ -153,13 +144,11 @@ namespace System.IO.Pipes
         // Anonymous pipes do not support message mode so there is no need to use the base version that P/Invokes here.
         public override PipeTransmissionMode TransmissionMode
         {
-            [SecurityCritical]
             get { return PipeTransmissionMode.Byte; }
         }
 
         public override PipeTransmissionMode ReadMode
         {
-            [SecurityCritical]
             set
             {
                 CheckPipePropertyOperations();

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Unix.cs
@@ -16,7 +16,6 @@ namespace System.IO.Pipes
     /// </summary>
     public sealed partial class NamedPipeClientStream : PipeStream
     {
-        [SecurityCritical]
         private bool TryConnect(int timeout, CancellationToken cancellationToken)
         {
             // timeout and cancellationToken aren't used as Connect will be very fast,
@@ -60,7 +59,6 @@ namespace System.IO.Pipes
 
         public int NumberOfServerInstances
         {
-            [SecurityCritical]
             [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Justification = "Security model of pipes: demand at creation but no subsequent demands")]
             get
             {

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
@@ -21,7 +21,6 @@ namespace System.IO.Pipes
         // on the server end, but WaitForConnection will not return until we have returned.  Any data written to the
         // pipe by us after we have connected but before the server has called WaitForConnection will be available
         // to the server after it calls WaitForConnection. 
-        [SecurityCritical]
         private bool TryConnect(int timeout, CancellationToken cancellationToken)
         {
             Interop.Kernel32.SECURITY_ATTRIBUTES secAttrs = PipeStream.GetSecAttrs(_inheritability);
@@ -98,7 +97,6 @@ namespace System.IO.Pipes
 
         public int NumberOfServerInstances
         {
-            [SecurityCritical]
             [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Justification = "Security model of pipes: demand at creation but no subsequent demands")]
             get
             {

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
@@ -26,38 +26,32 @@ namespace System.IO.Pipes
         private readonly PipeDirection _direction;
 
         // Creates a named pipe client using default server (same machine, or "."), and PipeDirection.InOut 
-        [SecuritySafeCritical]
         public NamedPipeClientStream(String pipeName)
             : this(".", pipeName, PipeDirection.InOut, PipeOptions.None, TokenImpersonationLevel.None, HandleInheritability.None)
         { 
         }
 
-        [SecuritySafeCritical]
         public NamedPipeClientStream(String serverName, String pipeName)
             : this(serverName, pipeName, PipeDirection.InOut, PipeOptions.None, TokenImpersonationLevel.None, HandleInheritability.None)
         {
         }
 
-        [SecuritySafeCritical]
         public NamedPipeClientStream(String serverName, String pipeName, PipeDirection direction)
             : this(serverName, pipeName, direction, PipeOptions.None, TokenImpersonationLevel.None, HandleInheritability.None)
         {
         }
 
-        [SecuritySafeCritical]
         public NamedPipeClientStream(String serverName, String pipeName, PipeDirection direction, PipeOptions options)
             : this(serverName, pipeName, direction, options, TokenImpersonationLevel.None, HandleInheritability.None)
         {
         }
 
-        [SecuritySafeCritical]
         public NamedPipeClientStream(String serverName, String pipeName, PipeDirection direction,
             PipeOptions options, TokenImpersonationLevel impersonationLevel)
             : this(serverName, pipeName, direction, options, impersonationLevel, HandleInheritability.None)
         {
         }
 
-        [SecuritySafeCritical]
         public NamedPipeClientStream(String serverName, String pipeName, PipeDirection direction,
             PipeOptions options, TokenImpersonationLevel impersonationLevel, HandleInheritability inheritability)
             : base(direction, 0)
@@ -99,7 +93,6 @@ namespace System.IO.Pipes
         }
 
         // Create a NamedPipeClientStream from an existing server pipe handle.
-        [SecuritySafeCritical]
         public NamedPipeClientStream(PipeDirection direction, bool isAsync, bool isConnected, SafePipeHandle safePipeHandle)
             : base(direction, 0)
         {
@@ -142,7 +135,6 @@ namespace System.IO.Pipes
             ConnectInternal(timeout, CancellationToken.None, Environment.TickCount);
         }
 
-        [SecurityCritical]
         private void ConnectInternal(int timeout, CancellationToken cancellationToken, int startTime)
         {
             // This is the main connection loop. It will loop until the timeout expires.  
@@ -213,7 +205,6 @@ namespace System.IO.Pipes
 
         // override because named pipe clients can't get/set properties when waiting to connect
         // or broken
-        [SecurityCritical]
         protected internal override void CheckPipePropertyOperations()
         {
             base.CheckPipePropertyOperations();

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
@@ -26,7 +26,6 @@ namespace System.IO.Pipes
         private int _outBufferSize;
         private HandleInheritability _inheritability;
 
-        [SecurityCritical]
         private void Create(string pipeName, PipeDirection direction, int maxNumberOfServerInstances,
                 PipeTransmissionMode transmissionMode, PipeOptions options, int inBufferSize, int outBufferSize,
                 HandleInheritability inheritability)
@@ -54,7 +53,6 @@ namespace System.IO.Pipes
             _inheritability = inheritability;
         }
 
-        [SecurityCritical]
         [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Justification = "Security model of pipes: demand at creation but no subsequent demands")]
         public void WaitForConnection()
         {
@@ -145,7 +143,6 @@ namespace System.IO.Pipes
             }
         }
 
-        [SecurityCritical]
         public void Disconnect()
         {
             CheckDisconnectOperations();
@@ -157,7 +154,6 @@ namespace System.IO.Pipes
         // Gets the username of the connected client.  Not that we will not have access to the client's 
         // username until it has written at least once to the pipe (and has set its impersonationLevel 
         // argument appropriately). 
-        [SecurityCritical]
         public string GetImpersonationUserName()
         {
             CheckWriteOperations();

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
@@ -20,7 +20,6 @@ namespace System.IO.Pipes
     /// </summary>
     public sealed partial class NamedPipeServerStream : PipeStream
     {
-        [SecurityCritical]
         private void Create(string pipeName, PipeDirection direction, int maxNumberOfServerInstances,
                 PipeTransmissionMode transmissionMode, PipeOptions options, int inBufferSize, int outBufferSize,
                 HandleInheritability inheritability)
@@ -71,7 +70,6 @@ namespace System.IO.Pipes
         // was called (but not before this server is been created, or, if we were servicing another client, 
         // not before we called Disconnect), in which case, there may be some buffer already in the pipe waiting
         // for us to read.  See NamedPipeClientStream.Connect for more information.
-        [SecurityCritical]
         [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Justification = "Security model of pipes: demand at creation but no subsequent demands")]
         public void WaitForConnection()
         {
@@ -122,7 +120,6 @@ namespace System.IO.Pipes
             return WaitForConnectionCoreAsync(cancellationToken);
         }
 
-        [SecurityCritical]
         public void Disconnect()
         {
             CheckDisconnectOperations();
@@ -139,7 +136,6 @@ namespace System.IO.Pipes
         // Gets the username of the connected client.  Not that we will not have access to the client's 
         // username until it has written at least once to the pipe (and has set its impersonationLevel 
         // argument appropriately). 
-        [SecurityCritical]
         public String GetImpersonationUserName()
         {
             CheckWriteOperations();
@@ -230,7 +226,6 @@ namespace System.IO.Pipes
             internal int _impersonateErrorCode;
             internal int _revertImpersonateErrorCode;
 
-            [SecurityCritical]
             internal ExecuteHelper(PipeStreamImpersonationWorker userCode, SafePipeHandle handle)
             {
                 _userCode = userCode;

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
@@ -18,37 +18,31 @@ namespace System.IO.Pipes
         // Use the maximum number of server instances that the system resources allow
         public const int MaxAllowedServerInstances = -1;
 
-        [SecuritySafeCritical]
         public NamedPipeServerStream(String pipeName)
             : this(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0, HandleInheritability.None)
         {
         }
 
-        [SecuritySafeCritical]
         public NamedPipeServerStream(String pipeName, PipeDirection direction)
             : this(pipeName, direction, 1, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0, HandleInheritability.None)
         {
         }
 
-        [SecuritySafeCritical]
         public NamedPipeServerStream(String pipeName, PipeDirection direction, int maxNumberOfServerInstances)
             : this(pipeName, direction, maxNumberOfServerInstances, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0, HandleInheritability.None)
         {
         }
 
-        [SecuritySafeCritical]
         public NamedPipeServerStream(String pipeName, PipeDirection direction, int maxNumberOfServerInstances, PipeTransmissionMode transmissionMode)
             : this(pipeName, direction, maxNumberOfServerInstances, transmissionMode, PipeOptions.None, 0, 0, HandleInheritability.None)
         {
         }
 
-        [SecuritySafeCritical]
         public NamedPipeServerStream(String pipeName, PipeDirection direction, int maxNumberOfServerInstances, PipeTransmissionMode transmissionMode, PipeOptions options)
             : this(pipeName, direction, maxNumberOfServerInstances, transmissionMode, options, 0, 0, HandleInheritability.None)
         {
         }
 
-        [SecuritySafeCritical]
         public NamedPipeServerStream(String pipeName, PipeDirection direction, int maxNumberOfServerInstances, PipeTransmissionMode transmissionMode, PipeOptions options, int inBufferSize, int outBufferSize)
             : this(pipeName, direction, maxNumberOfServerInstances, transmissionMode, options, inBufferSize, outBufferSize, HandleInheritability.None)
         {
@@ -81,7 +75,6 @@ namespace System.IO.Pipes
         /// <param name="inheritability">Whether handle is inheritable</param>
         /// <param name="additionalAccessRights">Combination (logical OR) of PipeAccessRights.TakeOwnership, 
         /// PipeAccessRights.AccessSystemSecurity, and PipeAccessRights.ChangePermissions</param>
-        [SecuritySafeCritical]
         private NamedPipeServerStream(String pipeName, PipeDirection direction, int maxNumberOfServerInstances,
                 PipeTransmissionMode transmissionMode, PipeOptions options, int inBufferSize, int outBufferSize,
                 HandleInheritability inheritability)
@@ -124,7 +117,6 @@ namespace System.IO.Pipes
         }
 
         // Create a NamedPipeServerStream from an existing server pipe handle.
-        [SecuritySafeCritical]
         public NamedPipeServerStream(PipeDirection direction, bool isAsync, bool isConnected, SafePipeHandle safePipeHandle)
             : base(direction, PipeTransmissionMode.Byte, 0)
         {
@@ -163,7 +155,6 @@ namespace System.IO.Pipes
             TaskToApm.End(asyncResult);
 
         // Server can only connect from Disconnected state
-        [SecurityCritical]
         [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Justification = "Consistent with security model")]
         private void CheckConnectOperationsServer()
         {
@@ -186,7 +177,6 @@ namespace System.IO.Pipes
         }
 
         // Server is allowed to disconnect from connected and broken states
-        [SecurityCritical]
         private void CheckDisconnectOperations()
         {
             if (State == PipeState.WaitingToConnect)

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -77,7 +77,6 @@ namespace System.IO.Pipes
 
         /// <summary>Initializes the handle to be used asynchronously.</summary>
         /// <param name="handle">The handle.</param>
-        [SecurityCritical]
         private void InitializeAsyncHandle(SafePipeHandle handle)
         {
             // nop
@@ -235,7 +234,6 @@ namespace System.IO.Pipes
         }
 
         // Blocks until the other end of the pipe has read in all written buffer.
-        [SecurityCritical]
         public void WaitForPipeDrain()
         {
             CheckWriteOperations();
@@ -255,7 +253,6 @@ namespace System.IO.Pipes
         // override this in cases where only one mode is legal (such as anonymous pipes)
         public virtual PipeTransmissionMode TransmissionMode
         {
-            [SecurityCritical]
             [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Justification = "Security model of pipes: demand at creation but no subsequent demands")]
             get
             {
@@ -268,7 +265,6 @@ namespace System.IO.Pipes
         // access. If that passes, call to GetNamedPipeInfo will succeed.
         public virtual int InBufferSize
         {
-            [SecurityCritical]
             [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
             get
             {
@@ -287,7 +283,6 @@ namespace System.IO.Pipes
         // the ctor.
         public virtual int OutBufferSize
         {
-            [SecurityCritical]
             [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Justification = "Security model of pipes: demand at creation but no subsequent demands")]
             get
             {
@@ -302,13 +297,11 @@ namespace System.IO.Pipes
 
         public virtual PipeTransmissionMode ReadMode
         {
-            [SecurityCritical]
             get
             {
                 CheckPipePropertyOperations();
                 return PipeTransmissionMode.Byte; // Unix pipes are only byte-based, not message-based
             }
-            [SecurityCritical]
             [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Justification = "Security model of pipes: demand at creation but no subsequent demands")]
             set
             {

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
@@ -53,7 +53,6 @@ namespace System.IO.Pipes
                 _threadPoolBinding.Dispose();
         }
 
-        [SecurityCritical]
         private unsafe int ReadCore(byte[] buffer, int offset, int count)
         {
             int errorCode = 0;
@@ -80,7 +79,6 @@ namespace System.IO.Pipes
             return r;
         }
 
-        [SecuritySafeCritical]
         private Task<int> ReadAsyncCore(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             var completionSource = new ReadWriteCompletionSource(this, buffer, cancellationToken, isWrite: false);
@@ -135,7 +133,6 @@ namespace System.IO.Pipes
             return completionSource.Task;
         }
 
-        [SecurityCritical]
         private unsafe void WriteCore(byte[] buffer, int offset, int count)
         {
             int errorCode = 0;
@@ -148,7 +145,6 @@ namespace System.IO.Pipes
             Debug.Assert(r >= 0, "PipeStream's WriteCore is likely broken.");
         }
 
-        [SecuritySafeCritical]
         private Task WriteAsyncCore(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             var completionSource = new ReadWriteCompletionSource(this, buffer, cancellationToken, isWrite: true);
@@ -182,7 +178,6 @@ namespace System.IO.Pipes
         }
 
         // Blocks until the other end of the pipe has read in all written buffer.
-        [SecurityCritical]
         public void WaitForPipeDrain()
         {
             CheckWriteOperations();
@@ -202,7 +197,6 @@ namespace System.IO.Pipes
         // override this in cases where only one mode is legal (such as anonymous pipes)
         public virtual PipeTransmissionMode TransmissionMode
         {
-            [SecurityCritical]
             [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Justification = "Security model of pipes: demand at creation but no subsequent demands")]
             get
             {
@@ -236,7 +230,6 @@ namespace System.IO.Pipes
         // access. If that passes, call to GetNamedPipeInfo will succeed.
         public virtual int InBufferSize
         {
-            [SecurityCritical]
             [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
             get
             {
@@ -262,7 +255,6 @@ namespace System.IO.Pipes
         // the ctor.
         public virtual int OutBufferSize
         {
-            [SecurityCritical]
             [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Justification = "Security model of pipes: demand at creation but no subsequent demands")]
             get
             {
@@ -291,7 +283,6 @@ namespace System.IO.Pipes
 
         public virtual PipeTransmissionMode ReadMode
         {
-            [SecurityCritical]
             get
             {
                 CheckPipePropertyOperations();
@@ -303,7 +294,6 @@ namespace System.IO.Pipes
                 }
                 return _readMode;
             }
-            [SecurityCritical]
             [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Justification = "Security model of pipes: demand at creation but no subsequent demands")]
             set
             {
@@ -335,7 +325,6 @@ namespace System.IO.Pipes
         // ---- PAL layer ends here ----
         // -----------------------------
 
-        [SecurityCritical]
         private unsafe int ReadFileNative(SafePipeHandle handle, byte[] buffer, int offset, int count,
                 NativeOverlapped* overlapped, out int errorCode)
         {
@@ -385,7 +374,6 @@ namespace System.IO.Pipes
             return numBytesRead;
         }
 
-        [SecurityCritical]
         private unsafe int WriteFileNative(SafePipeHandle handle, byte[] buffer, int offset, int count,
                 NativeOverlapped* overlapped, out int errorCode)
         {
@@ -428,7 +416,6 @@ namespace System.IO.Pipes
             return numBytesWritten;
         }
 
-        [SecurityCritical]
         internal static unsafe Interop.Kernel32.SECURITY_ATTRIBUTES GetSecAttrs(HandleInheritability inheritability)
         {
             Interop.Kernel32.SECURITY_ATTRIBUTES secAttrs = default(Interop.Kernel32.SECURITY_ATTRIBUTES);
@@ -444,7 +431,6 @@ namespace System.IO.Pipes
         /// <summary>
         /// Determine pipe read mode from Win32 
         /// </summary>
-        [SecurityCritical]
         private void UpdateReadMode()
         {
             int flags;
@@ -468,7 +454,6 @@ namespace System.IO.Pipes
         /// Filter out all pipe related errors and do some cleanup before calling Error.WinIOError.
         /// </summary>
         /// <param name="errorCode"></param>
-        [SecurityCritical]
         internal Exception WinIOError(int errorCode)
         {
             switch (errorCode)

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
@@ -95,7 +95,6 @@ namespace System.IO.Pipes
         // Once a PipeStream has a handle ready, it should call this method to set up the PipeStream.  If
         // the pipe is in a connected state already, it should also set the IsConnected (protected) property.
         // This method may also be called to uninitialize a handle, setting it to null.
-        [SecuritySafeCritical]
         protected void InitializeHandle(SafePipeHandle handle, bool isExposed, bool isAsync)
         {
             if (isAsync && handle != null)
@@ -111,7 +110,6 @@ namespace System.IO.Pipes
             _isFromExistingHandle = isExposed;
         }
 
-        [SecurityCritical]
         public override int Read(byte[] buffer, int offset, int count)
         {
             if (_isAsync)
@@ -129,7 +127,6 @@ namespace System.IO.Pipes
             return ReadCore(buffer, offset, count);
         }
 
-        [SecuritySafeCritical]
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             CheckReadWriteArgs(buffer, offset, count);
@@ -175,7 +172,6 @@ namespace System.IO.Pipes
                 return base.EndRead(asyncResult);
         }
 
-        [SecurityCritical]
         public override void Write(byte[] buffer, int offset, int count)
         {
             if (_isAsync)
@@ -194,7 +190,6 @@ namespace System.IO.Pipes
             WriteCore(buffer, offset, count);
         }
 
-        [SecuritySafeCritical]
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             CheckReadWriteArgs(buffer, offset, count);
@@ -272,7 +267,6 @@ namespace System.IO.Pipes
 
         // Reads a byte from the pipe stream.  Returns the byte cast to an int
         // or -1 if the connection has been broken.
-        [SecurityCritical]
         public override int ReadByte()
         {
             byte[] buffer = SingleByteArray;
@@ -281,7 +275,6 @@ namespace System.IO.Pipes
                 -1;
         }
 
-        [SecurityCritical]
         public override void WriteByte(byte value)
         {
             byte[] buffer = SingleByteArray;
@@ -291,7 +284,6 @@ namespace System.IO.Pipes
 
         // Does nothing on PipeStreams.  We cannot call Interop.FlushFileBuffers here because we can deadlock
         // if the other end of the pipe is no longer interested in reading from the pipe. 
-        [SecurityCritical]
         public override void Flush()
         {
             CheckWriteOperations();
@@ -301,7 +293,6 @@ namespace System.IO.Pipes
             }
         }
 
-        [SecurityCritical]
         protected override void Dispose(bool disposing)
         {
             try
@@ -349,7 +340,6 @@ namespace System.IO.Pipes
         // message, otherwise it is set to true. 
         public bool IsMessageComplete
         {
-            [SecurityCritical]
             [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Justification = "Security model of pipes: demand at creation but no subsequent demands")]
             get
             {
@@ -391,7 +381,6 @@ namespace System.IO.Pipes
 
         public SafePipeHandle SafePipeHandle
         {
-            [SecurityCritical]
             [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands", Justification = "Security model of pipes: demand at creation but no subsequent demands")]
             get
             {
@@ -411,7 +400,6 @@ namespace System.IO.Pipes
 
         internal SafePipeHandle InternalHandle
         {
-            [SecurityCritical]
             get
             {
                 return _handle;

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
@@ -329,7 +329,6 @@ namespace System.Runtime.CompilerServices
         //      but it's unclear because we have tests passing without RMA.
         //
         // When Silverlight gets RMA we may be able to remove this.
-        [System.Security.SecuritySafeCritical]
         private static Delegate CreateDelegateHelper(Type delegateType, MethodInfo method)
         {
             return method.CreateDelegate(delegateType);

--- a/src/System.Net.HttpListener/src/System/Net/WebSockets/WebSocketProtocolComponent.cs
+++ b/src/System.Net.HttpListener/src/System/Net/WebSockets/WebSocketProtocolComponent.cs
@@ -72,7 +72,6 @@ namespace System.Net.WebSockets
             Receive = 2,
         }
 
-        [SecuritySafeCritical]
         static WebSocketProtocolComponent()
         {
             s_webSocketDllHandle = Interop.Kernel32.LoadLibraryExW(Interop.Libraries.WebSocket, IntPtr.Zero, 0);

--- a/src/System.Net.Security/src/System/PinnableBufferCache.cs
+++ b/src/System.Net.Security/src/System/PinnableBufferCache.cs
@@ -44,7 +44,6 @@ namespace System
         /// <summary>
         /// Get a object from the buffer manager.  If no buffers exist, allocate a new one.
         /// </summary>
-        [System.Security.SecuritySafeCritical]
         internal object Allocate()
         {
             // Fast path, get it from our Gen2 aged _freeList.  
@@ -87,7 +86,6 @@ namespace System
         /// <summary>
         /// Return a buffer back to the buffer manager.
         /// </summary>
-        [System.Security.SecuritySafeCritical]
         internal void Free(object buffer)
         {
             if (PinnableBufferCacheEventSource.Log.IsEnabled())
@@ -123,7 +121,6 @@ namespace System
         /// Called when we don't have any buffers in our free list to give out.    
         /// </summary>
         /// <returns></returns>
-        [System.Security.SecuritySafeCritical]
         private void Restock(out object returnBuffer)
         {
             lock (this)
@@ -184,7 +181,6 @@ namespace System
         /// <summary>
         /// See if we can promote the buffers to the free list.  Returns true if successful. 
         /// </summary>
-        [System.Security.SecuritySafeCritical]
         private bool AgePendingBuffers()
         {
             if (_gen1CountAtLastRestock < GC.CollectionCount(GC.MaxGeneration - 1))
@@ -270,7 +266,6 @@ namespace System
         /// otherwise, we root the cache to the Gen2GcCallback object, and leak the cache even when
         /// the application no longer needs it.
         /// </summary>
-        [System.Security.SecuritySafeCritical]
         private static bool Gen2GcCallbackFunc(object targetObj)
         {
             return ((PinnableBufferCache)(targetObj)).TrimFreeListIfNeeded();
@@ -281,7 +276,6 @@ namespace System
         /// NOTE: DO NOT CALL THIS DIRECTLY FROM THE GEN2GCCALLBACK.  INSTEAD CALL IT VIA A STATIC FUNCTION (SEE ABOVE).
         /// If you register a non-static function as a callback, then this object will be leaked.
         /// </summary>
-        [System.Security.SecuritySafeCritical]
         private bool TrimFreeListIfNeeded()
         {
             int curMSec = Environment.TickCount;
@@ -439,7 +433,6 @@ namespace System
     /// </summary>
     internal sealed class Gen2GcCallback //: CriticalFinalizerObject
     {
-        [System.Security.SecuritySafeCritical]
         public Gen2GcCallback()
             : base()
         {
@@ -464,14 +457,12 @@ namespace System
         private Func<object, bool> _callback;
         private GCHandle _weakTargetObj;
 
-        [System.Security.SecuritySafeCritical]
         private void Setup(Func<object, bool> callback, object targetObj)
         {
             _callback = callback;
             _weakTargetObj = GCHandle.Alloc(targetObj, GCHandleType.Weak);
         }
 
-        [System.Security.SecuritySafeCritical]
         ~Gen2GcCallback()
         {
             // Check to see if the target object is still alive.
@@ -572,7 +563,6 @@ namespace System
             return 0;
         }
 
-        [System.Security.SecuritySafeCritical]
         internal static unsafe long AddressOfByteArray(byte[] array)
         {
             if (array == null)

--- a/src/System.Private.Xml/src/System/Xml/Base64Decoder.cs
+++ b/src/System.Private.Xml/src/System/Xml/Base64Decoder.cs
@@ -44,7 +44,6 @@ namespace System.Xml
             }
         }
 
-        [System.Security.SecuritySafeCritical]
         internal override unsafe int Decode(char[] chars, int startPos, int len)
         {
             if (chars == null)
@@ -80,7 +79,6 @@ namespace System.Xml
             return charsDecoded;
         }
 
-        [System.Security.SecuritySafeCritical]
         internal override unsafe int Decode(string str, int startPos, int len)
         {
             if (str == null)
@@ -153,7 +151,6 @@ namespace System.Xml
             return mapBase64;
         }
 
-        [System.Security.SecurityCritical]
         private unsafe void Decode(char* pChars, char* pCharsEndPos,
                              byte* pBytes, byte* pBytesEndPos,
                              out int charsDecoded, out int bytesDecoded)

--- a/src/System.Private.Xml/src/System/Xml/BinHexDecoder.cs
+++ b/src/System.Private.Xml/src/System/Xml/BinHexDecoder.cs
@@ -38,7 +38,6 @@ namespace System.Xml
             }
         }
 
-        [System.Security.SecuritySafeCritical]
         internal override unsafe int Decode(char[] chars, int startPos, int len)
         {
             if (chars == null)
@@ -75,7 +74,6 @@ namespace System.Xml
             return charsDecoded;
         }
 
-        [System.Security.SecuritySafeCritical]
         internal override unsafe int Decode(string str, int startPos, int len)
         {
             if (str == null)
@@ -135,7 +133,6 @@ namespace System.Xml
         //
         // Static methods
         //
-        [System.Security.SecuritySafeCritical]
         public static unsafe byte[] Decode(char[] chars, bool allowOddChars)
         {
             if (chars == null)
@@ -181,7 +178,6 @@ namespace System.Xml
         // Private methods
         //
 
-        [System.Security.SecurityCritical]
         private static unsafe void Decode(char* pChars, char* pCharsEndPos,
                                     byte* pBytes, byte* pBytesEndPos,
                                     ref bool hasHalfByteCached, ref byte cachedHalfByte,

--- a/src/System.Private.Xml/src/System/Xml/Core/BinaryCompatibility.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/BinaryCompatibility.cs
@@ -14,7 +14,6 @@ namespace System.Xml
 
         private static bool s_targetsAtLeast_Desktop_V4_5_2 = RunningOnCheck("TargetsAtLeast_Desktop_V4_5_2");
 
-        [SecuritySafeCritical]
         private static bool RunningOnCheck(string propertyName)
         {
             Type binaryCompatabilityType;

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.cs
@@ -656,7 +656,6 @@ namespace System.Xml
 
         // Serialize text that is part of an attribute value.  The '&', '<', '>', and '"' characters
         // are entitized.
-        [SecuritySafeCritical]
         protected unsafe int WriteAttributeTextBlockNoFlush(char* pSrc, char* pSrcEnd)
         {
             char* pRaw = pSrc;
@@ -762,7 +761,6 @@ namespace System.Xml
             return -1;
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteAttributeTextBlockNoFlush(char[] chars, int index, int count)
         {
             if (count == 0)
@@ -777,7 +775,6 @@ namespace System.Xml
             }
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteAttributeTextBlockNoFlush(string text, int index, int count)
         {
             if (count == 0)
@@ -845,7 +842,6 @@ namespace System.Xml
 
         // Serialize text that is part of element content.  The '&', '<', and '>' characters
         // are entitized.
-        [SecuritySafeCritical]
         protected unsafe int WriteElementTextBlockNoFlush(char* pSrc, char* pSrcEnd, out bool needWriteNewLine)
         {
             needWriteNewLine = false;
@@ -954,7 +950,6 @@ namespace System.Xml
             return -1;
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteElementTextBlockNoFlush(char[] chars, int index, int count, out bool needWriteNewLine)
         {
             needWriteNewLine = false;
@@ -971,7 +966,6 @@ namespace System.Xml
             }
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteElementTextBlockNoFlush(string text, int index, int count, out bool needWriteNewLine)
         {
             needWriteNewLine = false;
@@ -1070,7 +1064,6 @@ namespace System.Xml
             } while (writeLen >= 0 || needWriteNewLine);
         }
 
-        [SecuritySafeCritical]
         protected unsafe int RawTextNoFlush(char* pSrcBegin, char* pSrcEnd)
         {
             char* pRaw = pSrcBegin;
@@ -1119,7 +1112,6 @@ namespace System.Xml
             return -1;
         }
 
-        [SecuritySafeCritical]
         protected unsafe int RawTextNoFlush(string text, int index, int count)
         {
             if (count == 0)
@@ -1228,7 +1220,6 @@ namespace System.Xml
             }
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteRawWithCharCheckingNoFlush(char* pSrcBegin, char* pSrcEnd, out bool needWriteNewLine)
         {
             needWriteNewLine = false;
@@ -1324,7 +1315,6 @@ namespace System.Xml
             return -1;
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteRawWithCharCheckingNoFlush(char[] chars, int index, int count, out bool needWriteNewLine)
         {
             needWriteNewLine = false;
@@ -1340,7 +1330,6 @@ namespace System.Xml
             }
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteRawWithCharCheckingNoFlush(string text, int index, int count, out bool needWriteNewLine)
         {
             needWriteNewLine = false;
@@ -1404,7 +1393,6 @@ namespace System.Xml
             } while (writeLen >= 0 || needWriteNewLine);
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteCommentOrPiNoFlush(string text, int index, int count, int stopChar, out bool needWriteNewLine)
         {
             needWriteNewLine = false;
@@ -1574,7 +1562,6 @@ namespace System.Xml
             } while (writeLen >= 0 || needWriteNewLine);
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteCDataSectionNoFlush(string text, int index, int count, out bool needWriteNewLine)
         {
             needWriteNewLine = false;

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlReaderSettings.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlReaderSettings.cs
@@ -775,7 +775,6 @@ namespace System.Xml
             return s_enableLegacyXmlSettings.Value;
         }
 
-        [SecuritySafeCritical]
         private static bool ReadSettingsFromRegistry(RegistryKey hive, ref bool value)
         {
             const string regValueName = "EnableLegacyXmlSettings";

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextEncoder.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextEncoder.cs
@@ -110,7 +110,6 @@ namespace System.Xml
             _textWriter.Write(lowChar);
         }
 
-        [System.Security.SecurityCritical]
         internal void Write(char[] array, int offset, int count)
         {
             if (null == array)
@@ -254,7 +253,6 @@ namespace System.Xml
             _textWriter.Write(';');
         }
 
-        [System.Security.SecurityCritical]
         internal void Write(string text)
         {
             if (text == null)
@@ -399,7 +397,6 @@ namespace System.Xml
             }
         }
 
-        [System.Security.SecurityCritical]
         internal void WriteRawWithSurrogateChecking(string text)
         {
             if (text == null)

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
@@ -9644,7 +9644,6 @@ namespace System.Xml
             }
         }
 
-        [System.Security.SecuritySafeCritical]
         internal static unsafe void AdjustLineInfo(char[] chars, int startPos, int endPos, bool isNormalized, ref LineInfo lineInfo)
         {
             Debug.Assert(startPos >= 0);
@@ -9657,7 +9656,6 @@ namespace System.Xml
             }
         }
 
-        [System.Security.SecuritySafeCritical]
         internal static unsafe void AdjustLineInfo(string str, int startPos, int endPos, bool isNormalized, ref LineInfo lineInfo)
         {
             Debug.Assert(startPos >= 0);
@@ -9670,7 +9668,6 @@ namespace System.Xml
             }
         }
 
-        [System.Security.SecurityCritical]
         internal static unsafe void AdjustLineInfo(char* pChars, int length, bool isNormalized, ref LineInfo lineInfo)
         {
             int lastNewLinePos = -1;

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.cs
@@ -554,7 +554,6 @@ namespace System.Xml
 
         // Serialize text that is part of an attribute value.  The '&', '<', '>', and '"' characters
         // are entitized.
-        [SecuritySafeCritical]
         protected unsafe int WriteAttributeTextBlockNoFlush(char* pSrc, char* pSrcEnd)
         {
             char* pRaw = pSrc;
@@ -660,7 +659,6 @@ namespace System.Xml
             return -1;
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteAttributeTextBlockNoFlush(char[] chars, int index, int count)
         {
             if (count == 0)
@@ -675,7 +673,6 @@ namespace System.Xml
             }
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteAttributeTextBlockNoFlush(string text, int index, int count)
         {
             if (count == 0)
@@ -742,7 +739,6 @@ namespace System.Xml
 
         // Serialize text that is part of element content.  The '&', '<', and '>' characters
         // are entitized.
-        [SecuritySafeCritical]
         protected unsafe int WriteElementTextBlockNoFlush(char* pSrc, char* pSrcEnd, out bool needWriteNewLine)
         {
             needWriteNewLine = false;
@@ -851,7 +847,6 @@ namespace System.Xml
             return -1;
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteElementTextBlockNoFlush(char[] chars, int index, int count, out bool needWriteNewLine)
         {
             needWriteNewLine = false;
@@ -868,7 +863,6 @@ namespace System.Xml
             }
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteElementTextBlockNoFlush(string text, int index, int count, out bool needWriteNewLine)
         {
             needWriteNewLine = false;
@@ -967,7 +961,6 @@ namespace System.Xml
             } while (writeLen >= 0 || needWriteNewLine);
         }
 
-        [SecuritySafeCritical]
         protected unsafe int RawTextNoFlush(char* pSrcBegin, char* pSrcEnd)
         {
             char* pRaw = pSrcBegin;
@@ -1016,7 +1009,6 @@ namespace System.Xml
             return -1;
         }
 
-        [SecuritySafeCritical]
         protected unsafe int RawTextNoFlush(string text, int index, int count)
         {
             if (count == 0)
@@ -1125,7 +1117,6 @@ namespace System.Xml
             }
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteRawWithCharCheckingNoFlush(char* pSrcBegin, char* pSrcEnd, out bool needWriteNewLine)
         {
             needWriteNewLine = false;
@@ -1221,7 +1212,6 @@ namespace System.Xml
             return -1;
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteRawWithCharCheckingNoFlush(char[] chars, int index, int count, out bool needWriteNewLine)
         {
             needWriteNewLine = false;
@@ -1237,7 +1227,6 @@ namespace System.Xml
             }
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteRawWithCharCheckingNoFlush(string text, int index, int count, out bool needWriteNewLine)
         {
             needWriteNewLine = false;
@@ -1301,7 +1290,6 @@ namespace System.Xml
             } while (writeLen >= 0 || needWriteNewLine);
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteCommentOrPiNoFlush(string text, int index, int count, int stopChar, out bool needWriteNewLine)
         {
             needWriteNewLine = false;
@@ -1471,7 +1459,6 @@ namespace System.Xml
             } while (writeLen >= 0 || needWriteNewLine);
         }
 
-        [SecuritySafeCritical]
         protected unsafe int WriteCDataSectionNoFlush(string text, int index, int count, out bool needWriteNewLine)
         {
             needWriteNewLine = false;

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriter.cs
@@ -2133,7 +2133,6 @@ namespace System.Xml
             return s;
         }
 
-        [System.Security.SecuritySafeCritical]
         private unsafe void CheckNCName(string ncname)
         {
             Debug.Assert(ncname != null && ncname.Length > 0);

--- a/src/System.Private.Xml/src/System/Xml/Serialization/Globals.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/Globals.cs
@@ -11,11 +11,9 @@ namespace System.Xml.Serialization
 {
     internal static class Globals
     {
-        [SecurityCritical]
         private static Type s_typeOfDBNull;
         internal static Type TypeOfDBNull
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_typeOfDBNull == null)
@@ -24,11 +22,9 @@ namespace System.Xml.Serialization
             }
         }
 
-        [SecurityCritical]
         private static object s_valueOfDBNull;
         internal static object ValueOfDBNull
         {
-            [SecuritySafeCritical]
             get
             {
                 if (s_valueOfDBNull == null && TypeOfDBNull != null)

--- a/src/System.Private.Xml/src/System/Xml/ValidateNames.cs
+++ b/src/System.Private.Xml/src/System/Xml/ValidateNames.cs
@@ -72,7 +72,6 @@ namespace System.Xml
         /// Quits parsing when an invalid Nmtoken char is reached or the end of string is reached.
         /// Returns the number of valid Nmtoken chars that were parsed.
         /// </summary>
-        [System.Security.SecuritySafeCritical]
         internal static unsafe int ParseNmtokenNoNamespaces(string s, int offset)
         {
             Debug.Assert(s != null && offset <= s.Length);
@@ -117,7 +116,6 @@ namespace System.Xml
         /// Quits parsing when an invalid Name char is reached or the end of string is reached.
         /// Returns the number of valid Name chars that were parsed.
         /// </summary>
-        [System.Security.SecuritySafeCritical]
         internal static unsafe int ParseNameNoNamespaces(string s, int offset)
         {
             Debug.Assert(s != null && offset <= s.Length);
@@ -180,7 +178,6 @@ namespace System.Xml
         /// Quits parsing when an invalid NCName char is reached or the end of string is reached.
         /// Returns the number of valid NCName chars that were parsed.
         /// </summary>
-        [System.Security.SecuritySafeCritical]
         internal static unsafe int ParseNCName(string s, int offset)
         {
             Debug.Assert(s != null && offset <= s.Length);

--- a/src/System.Private.Xml/src/System/Xml/XmlConvert.cs
+++ b/src/System.Private.Xml/src/System/Xml/XmlConvert.cs
@@ -1600,7 +1600,6 @@ namespace System.Xml
             return false;
         }
 
-        [System.Security.SecuritySafeCritical]
         private static unsafe long DoubleToInt64Bits(double value)
         {
             // NOTE: BitConverter.DoubleToInt64Bits is missing in Silverlight

--- a/src/System.Reflection.Emit.ILGeneration/ref/System.Reflection.Emit.ILGeneration.cs
+++ b/src/System.Reflection.Emit.ILGeneration/ref/System.Reflection.Emit.ILGeneration.cs
@@ -30,30 +30,23 @@ namespace System.Reflection.Emit
         public virtual System.Reflection.Emit.Label DefineLabel() { throw null; }
         public virtual void Emit(System.Reflection.Emit.OpCode opcode) { }
         public virtual void Emit(System.Reflection.Emit.OpCode opcode, byte arg) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public virtual void Emit(System.Reflection.Emit.OpCode opcode, double arg) { }
         public virtual void Emit(System.Reflection.Emit.OpCode opcode, short arg) { }
         public virtual void Emit(System.Reflection.Emit.OpCode opcode, int arg) { }
         public virtual void Emit(System.Reflection.Emit.OpCode opcode, long arg) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public virtual void Emit(System.Reflection.Emit.OpCode opcode, System.Reflection.ConstructorInfo con) { }
         public virtual void Emit(System.Reflection.Emit.OpCode opcode, System.Reflection.Emit.Label label) { }
         public virtual void Emit(System.Reflection.Emit.OpCode opcode, System.Reflection.Emit.Label[] labels) { }
         public virtual void Emit(System.Reflection.Emit.OpCode opcode, System.Reflection.Emit.LocalBuilder local) { }
         public virtual void Emit(System.Reflection.Emit.OpCode opcode, System.Reflection.Emit.SignatureHelper signature) { }
         public virtual void Emit(System.Reflection.Emit.OpCode opcode, System.Reflection.FieldInfo field) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public virtual void Emit(System.Reflection.Emit.OpCode opcode, System.Reflection.MethodInfo meth) { }
         [System.CLSCompliantAttribute(false)]
         public void Emit(System.Reflection.Emit.OpCode opcode, sbyte arg) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public virtual void Emit(System.Reflection.Emit.OpCode opcode, float arg) { }
         public virtual void Emit(System.Reflection.Emit.OpCode opcode, string str) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public virtual void Emit(System.Reflection.Emit.OpCode opcode, System.Type cls) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public virtual void EmitCall(System.Reflection.Emit.OpCode opcode, System.Reflection.MethodInfo methodInfo, System.Type[] optionalParameterTypes) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public virtual void EmitCalli(System.Reflection.Emit.OpCode opcode, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Type[] optionalParameterTypes) { }
         public virtual void EmitWriteLine(System.Reflection.Emit.LocalBuilder localBuilder) { }
         public virtual void EmitWriteLine(System.Reflection.FieldInfo fld) { }
@@ -89,20 +82,15 @@ namespace System.Reflection.Emit
         public bool IsOut { get { throw null; } }
         public virtual string Name { get { throw null; } }
         public virtual int Position { get { throw null; } }
-        [System.Security.SecuritySafeCriticalAttribute]
         public virtual void SetConstant(object defaultValue) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) { }
     }
     public sealed partial class SignatureHelper
     {
         internal SignatureHelper() { }
         public void AddArgument(System.Type clsArgument) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public void AddArgument(System.Type argument, bool pinned) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public void AddArgument(System.Type argument, System.Type[] requiredCustomModifiers, System.Type[] optionalCustomModifiers) { }
         public void AddArguments(System.Type[] arguments, System.Type[][] requiredCustomModifiers, System.Type[][] optionalCustomModifiers) { }
         public void AddSentinel() { }
@@ -112,11 +100,8 @@ namespace System.Reflection.Emit
         public static System.Reflection.Emit.SignatureHelper GetLocalVarSigHelper() { throw null; }
         public static System.Reflection.Emit.SignatureHelper GetLocalVarSigHelper(System.Reflection.Module mod) { throw null; }
         public static System.Reflection.Emit.SignatureHelper GetMethodSigHelper(System.Reflection.CallingConventions callingConvention, System.Type returnType) { throw null; }
-        [System.Security.SecuritySafeCriticalAttribute]
         public static System.Reflection.Emit.SignatureHelper GetMethodSigHelper(System.Reflection.Module mod, System.Reflection.CallingConventions callingConvention, System.Type returnType) { throw null; }
-        [System.Security.SecuritySafeCriticalAttribute]
         public static System.Reflection.Emit.SignatureHelper GetMethodSigHelper(System.Reflection.Module mod, System.Type returnType, System.Type[] parameterTypes) { throw null; }
-        [System.Security.SecuritySafeCriticalAttribute]
         public static System.Reflection.Emit.SignatureHelper GetPropertySigHelper(System.Reflection.Module mod, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] requiredReturnTypeCustomModifiers, System.Type[] optionalReturnTypeCustomModifiers, System.Type[] parameterTypes, System.Type[][] requiredParameterTypeCustomModifiers, System.Type[][] optionalParameterTypeCustomModifiers) { throw null; }
         public static System.Reflection.Emit.SignatureHelper GetPropertySigHelper(System.Reflection.Module mod, System.Type returnType, System.Type[] parameterTypes) { throw null; }
         public static System.Reflection.Emit.SignatureHelper GetPropertySigHelper(System.Reflection.Module mod, System.Type returnType, System.Type[] requiredReturnTypeCustomModifiers, System.Type[] optionalReturnTypeCustomModifiers, System.Type[] parameterTypes, System.Type[][] requiredParameterTypeCustomModifiers, System.Type[][] optionalParameterTypeCustomModifiers) { throw null; }

--- a/src/System.Reflection.Emit.Lightweight/ref/System.Reflection.Emit.Lightweight.cs
+++ b/src/System.Reflection.Emit.Lightweight/ref/System.Reflection.Emit.Lightweight.cs
@@ -10,21 +10,13 @@ namespace System.Reflection.Emit
 {
     public sealed partial class DynamicMethod : System.Reflection.MethodInfo
     {
-        [System.Security.SecuritySafeCriticalAttribute]
         public DynamicMethod(string name, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Reflection.Module m, bool skipVisibility) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public DynamicMethod(string name, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Type owner, bool skipVisibility) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public DynamicMethod(string name, System.Type returnType, System.Type[] parameterTypes) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public DynamicMethod(string name, System.Type returnType, System.Type[] parameterTypes, bool restrictedSkipVisibility) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public DynamicMethod(string name, System.Type returnType, System.Type[] parameterTypes, System.Reflection.Module m) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public DynamicMethod(string name, System.Type returnType, System.Type[] parameterTypes, System.Reflection.Module m, bool skipVisibility) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public DynamicMethod(string name, System.Type returnType, System.Type[] parameterTypes, System.Type owner) { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public DynamicMethod(string name, System.Type returnType, System.Type[] parameterTypes, System.Type owner, bool skipVisibility) { }
         public override System.Reflection.MethodAttributes Attributes { get { throw null; } }
         public override System.Reflection.CallingConventions CallingConvention { get { throw null; } }
@@ -33,12 +25,9 @@ namespace System.Reflection.Emit
         public override string Name { get { throw null; } }
         public override System.Reflection.ParameterInfo ReturnParameter { get { throw null; } }
         public override System.Type ReturnType { get { throw null; } }
-        [System.Security.SecuritySafeCriticalAttribute]
         public sealed override System.Delegate CreateDelegate(System.Type delegateType) { throw null; }
-        [System.Security.SecuritySafeCriticalAttribute]
         public sealed override System.Delegate CreateDelegate(System.Type delegateType, object target) { throw null; }
         public System.Reflection.Emit.ILGenerator GetILGenerator() { throw null; }
-        [System.Security.SecuritySafeCriticalAttribute]
         public System.Reflection.Emit.ILGenerator GetILGenerator(int streamSize) { throw null; }
         public override System.Reflection.ParameterInfo[] GetParameters() { throw null; }
         public override string ToString() { throw null; }

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -623,9 +623,7 @@ namespace System
         public static long WorkingSet { get { throw null; } }
         public static string ExpandEnvironmentVariables(string name) { throw null; }
         public static void Exit(int exitCode) { }
-        [System.Security.SecurityCriticalAttribute]
         public static void FailFast(string message) { }
-        [System.Security.SecurityCriticalAttribute]
         public static void FailFast(string message, System.Exception exception) { }
         public static string[] GetCommandLineArgs() { throw null; }
         public static string GetEnvironmentVariable(string variable) { throw null; }
@@ -951,10 +949,8 @@ namespace System
     public static class StringNormalizationExtensions
     {
         public static bool IsNormalized(this string value) { throw null; }
-        [System.Security.SecurityCritical]
         public static bool IsNormalized(this string value, System.Text.NormalizationForm normalizationForm) { throw null; }
         public static String Normalize(this string value) { throw null; }
-        [System.Security.SecurityCritical]
         public static String Normalize(this string value, System.Text.NormalizationForm normalizationForm) { throw null; }
     }
 }

--- a/src/System.Runtime.Extensions/src/System/BitConverter.cs
+++ b/src/System.Runtime.Extensions/src/System/BitConverter.cs
@@ -44,7 +44,6 @@ namespace System
 
         // Converts a short into an array of bytes with length
         // two.
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static unsafe byte[] GetBytes(short value)
         {
             Contract.Ensures(Contract.Result<byte[]>() != null);
@@ -58,7 +57,6 @@ namespace System
 
         // Converts an int into an array of bytes with length 
         // four.
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static unsafe byte[] GetBytes(int value)
         {
             Contract.Ensures(Contract.Result<byte[]>() != null);
@@ -72,7 +70,6 @@ namespace System
 
         // Converts a long into an array of bytes with length 
         // eight.
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static unsafe byte[] GetBytes(long value)
         {
             Contract.Ensures(Contract.Result<byte[]>() != null);
@@ -119,7 +116,6 @@ namespace System
 
         // Converts a float into an array of bytes with length 
         // four.
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static unsafe byte[] GetBytes(float value)
         {
             Contract.Ensures(Contract.Result<byte[]>() != null);
@@ -130,7 +126,6 @@ namespace System
 
         // Converts a double into an array of bytes with length 
         // eight.
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static unsafe byte[] GetBytes(double value)
         {
             Contract.Ensures(Contract.Result<byte[]>() != null);
@@ -154,7 +149,6 @@ namespace System
         }
 
         // Converts an array of bytes into a short.  
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static unsafe short ToInt16(byte[] value, int startIndex)
         {
             if (value == null)
@@ -184,7 +178,6 @@ namespace System
         }
 
         // Converts an array of bytes into an int.  
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static unsafe int ToInt32(byte[] value, int startIndex)
         {
             if (value == null)
@@ -214,7 +207,6 @@ namespace System
         }
 
         // Converts an array of bytes into a long.  
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static unsafe long ToInt64(byte[] value, int startIndex)
         {
             if (value == null)
@@ -297,7 +289,6 @@ namespace System
         }
 
         // Converts an array of bytes into a float.  
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static unsafe float ToSingle(byte[] value, int startIndex)
         {
             if (value == null)
@@ -313,7 +304,6 @@ namespace System
         }
 
         // Converts an array of bytes into a double.  
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static unsafe double ToDouble(byte[] value, int startIndex)
         {
             if (value == null)
@@ -441,25 +431,21 @@ namespace System
             return value[startIndex] != 0;
         }
 
-        [SecuritySafeCritical]
         public static unsafe long DoubleToInt64Bits(double value)
         {
             return *((long*)&value);
         }
 
-        [SecuritySafeCritical]
         public static unsafe double Int64BitsToDouble(long value)
         {
             return *((double*)&value);
         }
 
-        [SecuritySafeCritical]
         public static unsafe int SingleToInt32Bits(float value)
         {
             return *((int*)&value);
         }
 
-        [SecuritySafeCritical]
         public static unsafe float Int32BitsToSingle(int value)
         {
             return *((float*)&value);

--- a/src/System.Runtime.Extensions/src/System/Collections/ArrayList.cs
+++ b/src/System.Runtime.Extensions/src/System/Collections/ArrayList.cs
@@ -830,7 +830,6 @@ namespace System.Collections
         // downcasting all elements.  This copy may fail and is an O(n) operation.
         // Internally, this implementation calls Array.Copy.
         //
-        [SecuritySafeCritical]
         public virtual Array ToArray(Type type)
         {
             if (type == null)
@@ -1246,7 +1245,6 @@ namespace System.Collections
                 return array;
             }
 
-            [SecuritySafeCritical]
             public override Array ToArray(Type type)
             {
                 if (type == null)
@@ -2924,7 +2922,6 @@ namespace System.Collections
                 return array;
             }
 
-            [SecuritySafeCritical]
             public override Array ToArray(Type type)
             {
                 if (type == null)

--- a/src/System.Runtime.Extensions/src/System/Runtime/Versioning/VersioningHelper.cs
+++ b/src/System.Runtime.Extensions/src/System/Runtime/Versioning/VersioningHelper.cs
@@ -30,7 +30,6 @@ namespace System.Runtime.Versioning
             return MakeVersionSafeName(name, from, to, null);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         [ResourceExposure(ResourceScope.None)]
         [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
         public static string MakeVersionSafeName(String name, ResourceScope from, ResourceScope to, Type type)

--- a/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/ComAwareEventInfo.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/ComAwareEventInfo.cs
@@ -4,7 +4,6 @@
 
 namespace System.Runtime.InteropServices
 {
-    [System.Security.SecuritySafeCritical]
     public class ComAwareEventInfo : System.Reflection.EventInfo
     {
         private System.Reflection.EventInfo _innerEventInfo;
@@ -14,7 +13,6 @@ namespace System.Runtime.InteropServices
             _innerEventInfo = type.GetEvent(eventName);
         }
 
-        [System.Security.SecuritySafeCritical]
         public override void AddEventHandler(object target, Delegate handler)
         {
             if (Marshal.IsComObject(target))
@@ -32,7 +30,6 @@ namespace System.Runtime.InteropServices
             }
         }
 
-        [System.Security.SecuritySafeCritical]
         public override void RemoveEventHandler(object target, Delegate handler)
         {
             if (Marshal.IsComObject(target))

--- a/src/System.Runtime.Numerics/src/System/Globalization/FormatProvider.BigInteger.cs
+++ b/src/System.Runtime.Numerics/src/System/Globalization/FormatProvider.BigInteger.cs
@@ -9,7 +9,6 @@ namespace System.Globalization
 {
     internal partial class FormatProvider
     {
-        [SecurityCritical]
         internal static string FormatBigInteger(int precision, int scale, bool sign, string format, NumberFormatInfo numberFormatInfo, char[] digits, int startIndex)
         {
             unsafe
@@ -31,7 +30,6 @@ namespace System.Globalization
             }
         }
 
-        [SecurityCritical]
         internal static bool TryStringToBigInteger(
             string s,
             NumberStyles styles,

--- a/src/System.Runtime.Numerics/src/System/Globalization/FormatProvider.NumberBuffer.cs
+++ b/src/System.Runtime.Numerics/src/System/Globalization/FormatProvider.NumberBuffer.cs
@@ -20,14 +20,12 @@ namespace System.Globalization
 
                 public char* digits
                 {
-                    [SecurityCritical]
                     get
                     {
                         return overrideDigits;
                     }
                 }
 
-                [SecurityCritical]
                 public char* overrideDigits; // Used for BigNumber support which can't be limited to 32 characters.
             }
         }

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.AddSub.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.AddSub.cs
@@ -35,7 +35,6 @@ namespace System.Numerics
             return bits;
         }
 
-        [SecuritySafeCritical]
         public static unsafe uint[] Add(uint[] left, uint[] right)
         {
             Debug.Assert(left != null);
@@ -57,7 +56,6 @@ namespace System.Numerics
             return bits;
         }
 
-        [SecuritySafeCritical]
         private static unsafe void Add(uint* left, int leftLength,
                                        uint* right, int rightLength,
                                        uint* bits, int bitsLength)
@@ -90,7 +88,6 @@ namespace System.Numerics
             bits[i] = (uint)carry;
         }
 
-        [SecuritySafeCritical]
         private static unsafe void AddSelf(uint* left, int leftLength,
                                            uint* right, int rightLength)
         {
@@ -147,7 +144,6 @@ namespace System.Numerics
             return bits;
         }
 
-        [SecuritySafeCritical]
         public static unsafe uint[] Subtract(uint[] left, uint[] right)
         {
             Debug.Assert(left != null);
@@ -170,7 +166,6 @@ namespace System.Numerics
             return bits;
         }
 
-        [SecuritySafeCritical]
         private static unsafe void Subtract(uint* left, int leftLength, 
                                             uint* right, int rightLength,
                                             uint* bits, int bitsLength)
@@ -205,7 +200,6 @@ namespace System.Numerics
             Debug.Assert(carry == 0);
         }
 
-        [SecuritySafeCritical]
         private static unsafe void SubtractSelf(uint* left, int leftLength,
                                                 uint* right, int rightLength)
         {
@@ -258,7 +252,6 @@ namespace System.Numerics
             return 0;
         }
 
-        [SecuritySafeCritical]
         private static unsafe int Compare(uint* left, int leftLength,
                                           uint* right, int rightLength)
         {

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.BitsBuffer.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.BitsBuffer.cs
@@ -41,7 +41,6 @@ namespace System.Numerics
                 Array.Copy(value, 0, _bits, 0, _length);
             }
 
-            [SecuritySafeCritical]
             public unsafe void MultiplySelf(ref BitsBuffer value,
                                             ref BitsBuffer temp)
             {
@@ -70,7 +69,6 @@ namespace System.Numerics
                 Apply(ref temp, _length + value._length);
             }
 
-            [SecuritySafeCritical]
             public unsafe void SquareSelf(ref BitsBuffer temp)
             {
                 Debug.Assert(temp._length == 0);
@@ -95,7 +93,6 @@ namespace System.Numerics
                 _length = reducer.Reduce(_bits, _length);
             }
 
-            [SecuritySafeCritical]
             public unsafe void Reduce(uint[] modulus)
             {
                 Debug.Assert(modulus != null);
@@ -116,7 +113,6 @@ namespace System.Numerics
                 }
             }
 
-            [SecuritySafeCritical]
             public unsafe void Reduce(ref BitsBuffer modulus)
             {
                 // Executes a modulo operation using the divide operation.

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.DivRem.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.DivRem.cs
@@ -70,7 +70,6 @@ namespace System.Numerics
             return (uint)carry;
         }
 
-        [SecuritySafeCritical]
         public static unsafe uint[] Divide(uint[] left, uint[] right,
                                            out uint[] remainder)
         {
@@ -100,7 +99,6 @@ namespace System.Numerics
             return bits;
         }
 
-        [SecuritySafeCritical]
         public static unsafe uint[] Divide(uint[] left, uint[] right)
         {
             Debug.Assert(left != null);
@@ -124,7 +122,6 @@ namespace System.Numerics
             return bits;
         }
 
-        [SecuritySafeCritical]
         public static unsafe uint[] Remainder(uint[] left, uint[] right)
         {
             Debug.Assert(left != null);
@@ -147,7 +144,6 @@ namespace System.Numerics
             return localLeft;
         }
 
-        [SecuritySafeCritical]
         private static unsafe void Divide(uint* left, int leftLength,
                                           uint* right, int rightLength,
                                           uint* bits, int bitsLength)
@@ -234,7 +230,6 @@ namespace System.Numerics
             }
         }
 
-        [SecuritySafeCritical]
         private static unsafe uint AddDivisor(uint* left, int leftLength,
                                               uint* right, int rightLength)
         {
@@ -255,7 +250,6 @@ namespace System.Numerics
             return (uint)carry;
         }
 
-        [SecuritySafeCritical]
         private static unsafe uint SubtractDivisor(uint* left, int leftLength,
                                                    uint* right, int rightLength,
                                                    ulong q)

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs
@@ -66,7 +66,6 @@ namespace System.Numerics
                               _modulus, _modulus.Length + 1);
             }
 
-            [SecuritySafeCritical]
             private static unsafe int DivMul(uint[] left, int leftLength,
                                              uint[] right, int rightLength,
                                              uint[] bits, int k)
@@ -111,7 +110,6 @@ namespace System.Numerics
                 return 0;
             }
 
-            [SecuritySafeCritical]
             private static unsafe int SubMod(uint[] left, int leftLength,
                                              uint[] right, int rightLength,
                                              uint[] modulus, int k)

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.SquMul.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.SquMul.cs
@@ -9,7 +9,6 @@ namespace System.Numerics
 {
     internal static partial class BigIntegerCalculator
     {
-        [SecuritySafeCritical]
         public static unsafe uint[] Square(uint[] value)
         {
             Debug.Assert(value != null);
@@ -32,7 +31,6 @@ namespace System.Numerics
         private static int SquareThreshold = 32;
         private static int AllocationThreshold = 256;
 
-        [SecuritySafeCritical]
         private static unsafe void Square(uint* value, int valueLength,
                                           uint* bits, int bitsLength)
         {
@@ -185,7 +183,6 @@ namespace System.Numerics
             return bits;
         }
 
-        [SecuritySafeCritical]
         public static unsafe uint[] Multiply(uint[] left, uint[] right)
         {
             Debug.Assert(left != null);
@@ -210,7 +207,6 @@ namespace System.Numerics
         // Mutable for unit testing...
         private static int MultiplyThreshold = 32;
 
-        [SecuritySafeCritical]
         private static unsafe void Multiply(uint* left, int leftLength,
                                             uint* right, int rightLength,
                                             uint* bits, int bitsLength)
@@ -358,7 +354,6 @@ namespace System.Numerics
             }
         }
 
-        [SecuritySafeCritical]
         private static unsafe void SubtractCore(uint* left, int leftLength,
                                                 uint* right, int rightLength,
                                                 uint* core, int coreLength)

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
@@ -322,7 +322,6 @@ namespace System.Numerics
             return true;
         }
 
-        [SecuritySafeCritical]
         internal static bool TryParseBigInteger(string value, NumberStyles style, NumberFormatInfo info, out BigInteger result)
         {
             unsafe
@@ -530,7 +529,6 @@ namespace System.Numerics
             return sb.ToString();
         }
 
-        [SecuritySafeCritical]
         internal static string FormatBigInteger(BigInteger value, string format, NumberFormatInfo info)
         {
             int digits = 0;

--- a/src/System.Runtime.WindowsRuntime/ref/System.Runtime.WindowsRuntime.Manual.cs
+++ b/src/System.Runtime.WindowsRuntime/ref/System.Runtime.WindowsRuntime.Manual.cs
@@ -18,12 +18,10 @@ namespace Windows.Foundation
 {
     public partial struct Point : IFormattable
     {
-        [SecuritySafeCriticalAttribute]
         string IFormattable.ToString(string format, IFormatProvider provider) { throw null; }
     }
     public partial struct Rect : IFormattable
     {
-        [SecuritySafeCriticalAttribute]
         string IFormattable.ToString(string format, IFormatProvider provider) { throw null; }
     }
 }
@@ -31,7 +29,6 @@ namespace Windows.UI
 {
     public partial struct Color : IFormattable
     {
-        [SecuritySafeCriticalAttribute]
         string IFormattable.ToString(string format, IFormatProvider provider) { throw null; }
     }
 }

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/UnmanagedMemoryStreamInternal.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/UnmanagedMemoryStreamInternal.cs
@@ -143,7 +143,6 @@ namespace System.IO
             { return _isOpen && (_access & FileAccess.Write) != 0; }
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         protected override void Dispose(bool disposing)
         {
             _isOpen = false;
@@ -186,7 +185,6 @@ namespace System.IO
                 Contract.EndContractBlock();
                 return Interlocked.Read(ref _position);
             }
-            [System.Security.SecuritySafeCritical]  // auto-generated
             set
             {
                 if (value < 0)
@@ -237,7 +235,6 @@ namespace System.IO
             }
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int Read([In, Out] byte[] buffer, int offset, int count)
         {
             if (buffer == null)
@@ -274,7 +271,6 @@ namespace System.IO
             return nInt;
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int ReadByte()
         {
             if (!_isOpen) throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
@@ -327,7 +323,6 @@ namespace System.IO
             return finalPos;
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override void SetLength(long value)
         {
             if (value < 0)
@@ -355,7 +350,6 @@ namespace System.IO
             }
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override void Write(byte[] buffer, int offset, int count)
         {
             if (buffer == null)
@@ -408,7 +402,6 @@ namespace System.IO
             return;
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override void WriteByte(byte value)
         {
             if (!_isOpen) throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);

--- a/src/System.Runtime.WindowsRuntime/src/System/Threading/WindowsRuntimeSynchronizationContext.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Threading/WindowsRuntimeSynchronizationContext.cs
@@ -192,7 +192,6 @@ namespace System.Threading
 
         #endregion class WinRTSynchronizationContext.Invoker
 
-        [SecuritySafeCritical]
         public override void Post(SendOrPostCallback d, object state)
         {
             if (d == null)
@@ -202,7 +201,6 @@ namespace System.Threading
             var ignored = _dispatcher.RunAsync(CoreDispatcherPriority.Normal, new Invoker(d, state).Invoke);
         }
 
-        [SecuritySafeCritical]
         public override void Send(SendOrPostCallback d, object state)
         {
             throw new NotSupportedException(SR.InvalidOperation_SendNotSupportedOnWindowsRTSynchronizationContext);

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -7,43 +7,35 @@
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [System.Security.SecurityCriticalAttribute]
     public abstract partial class CriticalHandleMinusOneIsInvalid : System.Runtime.InteropServices.CriticalHandle
     {
         protected CriticalHandleMinusOneIsInvalid() : base(System.IntPtr.Zero) { }
         public override bool IsInvalid { [System.Security.SecurityCriticalAttribute]get { throw null; } }
     }
-    [System.Security.SecurityCriticalAttribute]
     public abstract partial class CriticalHandleZeroOrMinusOneIsInvalid : System.Runtime.InteropServices.CriticalHandle
     {
         protected CriticalHandleZeroOrMinusOneIsInvalid() : base(System.IntPtr.Zero) { }
         public override bool IsInvalid { [System.Security.SecurityCriticalAttribute]get { throw null; } }
     }
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class SafeFileHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         public SafeFileHandle(System.IntPtr preexistingHandle, bool ownsHandle) : base(default(bool)) { }
         public override bool IsInvalid { [System.Security.SecurityCriticalAttribute]get { throw null; } }
-        [System.Security.SecurityCriticalAttribute]
         protected override bool ReleaseHandle() { throw null; }
     }
-    [System.Security.SecurityCriticalAttribute]
     public abstract partial class SafeHandleMinusOneIsInvalid : System.Runtime.InteropServices.SafeHandle
     {
         protected SafeHandleMinusOneIsInvalid(bool ownsHandle) : base(System.IntPtr.Zero, ownsHandle) { }
         public override bool IsInvalid { [System.Security.SecurityCriticalAttribute]get { throw null; } }
     }
-    [System.Security.SecurityCriticalAttribute]
     public abstract partial class SafeHandleZeroOrMinusOneIsInvalid : System.Runtime.InteropServices.SafeHandle
     {
         protected SafeHandleZeroOrMinusOneIsInvalid(bool ownsHandle) : base(System.IntPtr.Zero, ownsHandle) { }
         public override bool IsInvalid { [System.Security.SecurityCriticalAttribute]get { throw null; } }
     }
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class SafeWaitHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         public SafeWaitHandle(System.IntPtr existingHandle, bool ownsHandle) : base(ownsHandle) { }
-        [System.Security.SecurityCriticalAttribute]
         protected override bool ReleaseHandle() { throw null; }
     }
 }
@@ -481,10 +473,8 @@ namespace System
         public static int ByteLength(System.Array array) { throw null; }
         public static byte GetByte(System.Array array, int index) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public static unsafe void MemoryCopy(void* source, void* destination, long destinationSizeInBytes, long sourceBytesToCopy) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public static unsafe void MemoryCopy(void* source, void* destination, ulong destinationSizeInBytes, ulong sourceBytesToCopy) { }
         public static void SetByte(System.Array array, int index, byte value) { }
     }
@@ -806,7 +796,6 @@ namespace System
         public System.DateTimeOffset Subtract(System.TimeSpan value) { throw null; }
         int System.IComparable.CompareTo(object obj) { throw null; }
         void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
-        [System.Security.SecurityCriticalAttribute]
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public long ToFileTime() { throw null; }
         public System.DateTimeOffset ToLocalTime() { throw null; }
@@ -1224,7 +1213,6 @@ namespace System
     public static partial class GC
     {
         public static int MaxGeneration { get { throw null; } }
-        [System.Security.SecurityCriticalAttribute]
         public static void AddMemoryPressure(long bytesAllocated) { }
         public static void CancelFullGCNotification() { }
         public static void Collect() { }
@@ -1239,7 +1227,6 @@ namespace System
         public static long GetTotalMemory(bool forceFullCollection) { throw null; }
         public static void KeepAlive(object obj) { }
         public static void RegisterForFullGCNotification(int maxGenerationThreshold, int largeObjectHeapThreshold) { }
-        [System.Security.SecurityCriticalAttribute]
         public static void RemoveMemoryPressure(long bytesAllocated) { }
         public static void ReRegisterForFinalize(object obj) { }
         public static void SuppressFinalize(object obj) { }
@@ -1496,7 +1483,6 @@ namespace System
         public IntPtr(int value) { throw null; }
         public IntPtr(long value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe IntPtr(void* value) { throw null; }
         public static int Size { get { throw null; } }
         public static System.IntPtr Add(System.IntPtr pointer, int offset) { throw null; }
@@ -1515,7 +1501,6 @@ namespace System
         [System.CLSCompliantAttribute(false)]
         public static unsafe explicit operator void* (System.IntPtr value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public static unsafe explicit operator System.IntPtr(void* value) { throw null; }
         public static bool operator !=(System.IntPtr value1, System.IntPtr value2) { throw null; }
         public static System.IntPtr operator -(System.IntPtr pointer, int offset) { throw null; }
@@ -1958,10 +1943,8 @@ namespace System
     {
         public static readonly string Empty;
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe String(char* value) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe String(char* value, int startIndex, int length) { }
         public String(char c, int count) { }
         public String(char[] value) { }
@@ -2273,7 +2256,6 @@ namespace System
         public string ToSerializedString() { throw null; }
         public override string ToString() { throw null; }
         void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
-        [System.Security.SecurityCriticalAttribute]
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public sealed partial class AdjustmentRule : System.IEquatable<System.TimeZoneInfo.AdjustmentRule>, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
         {
@@ -2287,7 +2269,6 @@ namespace System
             public bool Equals(System.TimeZoneInfo.AdjustmentRule other) { throw null; }
             public override int GetHashCode() { throw null; }
             void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
-            [System.Security.SecurityCriticalAttribute]
             void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -2307,7 +2288,6 @@ namespace System
             public static bool operator ==(System.TimeZoneInfo.TransitionTime t1, System.TimeZoneInfo.TransitionTime t2) { throw null; }
             public static bool operator !=(System.TimeZoneInfo.TransitionTime t1, System.TimeZoneInfo.TransitionTime t2) { throw null; }
             void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object sender) { }
-            [System.Security.SecurityCriticalAttribute]
             void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         }
     }
@@ -2462,9 +2442,7 @@ namespace System
         public static readonly System.Reflection.MemberFilter FilterNameIgnoreCase;
         public static readonly object Missing;
         protected Type() { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public static bool operator ==(System.Type left, System.Type right) { throw null; }
-        [System.Security.SecuritySafeCriticalAttribute]
         public static bool operator !=(System.Type left, System.Type right) { throw null; }
         public abstract System.Reflection.Assembly Assembly { get; }
         public abstract string AssemblyQualifiedName { get; }
@@ -2828,7 +2806,6 @@ namespace System
         public UIntPtr(uint value) { throw null; }
         public UIntPtr(ulong value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe UIntPtr(void* value) { throw null; }
         public static int Size { get { throw null; } }
         public static System.UIntPtr Add(System.UIntPtr pointer, int offset) { throw null; }
@@ -2845,10 +2822,8 @@ namespace System
         public static explicit operator uint (System.UIntPtr value) { throw null; }
         public static explicit operator ulong (System.UIntPtr value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public static unsafe explicit operator void* (System.UIntPtr value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public static unsafe explicit operator System.UIntPtr(void* value) { throw null; }
         public static bool operator !=(System.UIntPtr value1, System.UIntPtr value2) { throw null; }
         public static System.UIntPtr operator -(System.UIntPtr pointer, int offset) { throw null; }
@@ -3155,7 +3130,6 @@ namespace System.Runtime.ConstrainedExecution
 {
     public abstract partial class CriticalFinalizerObject
     {
-        [System.Security.SecuritySafeCriticalAttribute]
         protected CriticalFinalizerObject() { }
         ~CriticalFinalizerObject() { }
     }
@@ -3213,28 +3187,21 @@ namespace System.Runtime.InteropServices
         public virtual int ErrorCode { get; }
         public override string ToString() { throw null; }
     }
-    [System.Security.SecurityCriticalAttribute]
     public abstract partial class SafeHandle : System.Runtime.ConstrainedExecution.CriticalFinalizerObject, System.IDisposable
     {
         protected System.IntPtr handle;
         protected SafeHandle(System.IntPtr invalidHandleValue, bool ownsHandle) { }
         public bool IsClosed { get { throw null; } }
         public abstract bool IsInvalid { get; }
-        [System.Security.SecurityCriticalAttribute]
         public void Close() { }
-        [System.Security.SecurityCriticalAttribute]
         public void DangerousAddRef(ref bool success) { }
         public System.IntPtr DangerousGetHandle() { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         public void DangerousRelease() { }
-        [System.Security.SecuritySafeCriticalAttribute]
         public void Dispose() { }
-        [System.Security.SecurityCriticalAttribute]
         protected virtual void Dispose(bool disposing) { }
         ~SafeHandle() { }
         protected abstract bool ReleaseHandle();
         protected void SetHandle(System.IntPtr handle) { }
-        [System.Security.SecurityCriticalAttribute]
         public void SetHandleAsInvalid() { }
     }
 }
@@ -3251,7 +3218,6 @@ namespace System.Runtime.CompilerServices
             public bool IsCompleted { get { throw null; } }
             public void GetResult() { }
             public void OnCompleted(System.Action continuation) { }
-            [System.Security.SecurityCriticalAttribute]
             public void UnsafeOnCompleted(System.Action continuation) { }
         }
     }
@@ -3265,13 +3231,11 @@ namespace System.Runtime.CompilerServices
             public bool IsCompleted { get { throw null; } }
             public TResult GetResult() { throw null; }
             public void OnCompleted(System.Action continuation) { }
-            [System.Security.SecurityCriticalAttribute]
             public void UnsafeOnCompleted(System.Action continuation) { }
         }
     }
     public partial interface ICriticalNotifyCompletion : System.Runtime.CompilerServices.INotifyCompletion
     {
-        [System.Security.SecurityCriticalAttribute]
         void UnsafeOnCompleted(System.Action continuation);
     }
     public partial interface INotifyCompletion
@@ -3284,7 +3248,6 @@ namespace System.Runtime.CompilerServices
         public bool IsCompleted { get { throw null; } }
         public void GetResult() { }
         public void OnCompleted(System.Action continuation) { }
-        [System.Security.SecurityCriticalAttribute]
         public void UnsafeOnCompleted(System.Action continuation) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -3293,7 +3256,6 @@ namespace System.Runtime.CompilerServices
         public bool IsCompleted { get { throw null; } }
         public TResult GetResult() { throw null; }
         public void OnCompleted(System.Action continuation) { }
-        [System.Security.SecurityCriticalAttribute]
         public void UnsafeOnCompleted(System.Action continuation) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size = 1)]
@@ -3306,7 +3268,6 @@ namespace System.Runtime.CompilerServices
             public bool IsCompleted { get { throw null; } }
             public void GetResult() { }
             public void OnCompleted(System.Action continuation) { }
-            [System.Security.SecurityCriticalAttribute]
             public void UnsafeOnCompleted(System.Action continuation) { }
         }
     }
@@ -4919,7 +4880,6 @@ namespace System.Reflection
         public void SetPublicKeyToken(byte[] publicKeyToken) { }
         public override string ToString() { throw null; }
         public static bool ReferenceMatchesDefinition(System.Reflection.AssemblyName reference, System.Reflection.AssemblyName definition) { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { throw null; }
         public void OnDeserialization(Object sender) { throw null; }
     }
@@ -5397,7 +5357,6 @@ namespace System.Reflection
         public static System.Reflection.MethodBase GetCurrentMethod() { throw null; }
         public virtual System.Type[] GetGenericArguments() { throw null; }
         public override int GetHashCode() { throw null; }
-        [System.Security.SecuritySafeCriticalAttribute]
         public virtual System.Reflection.MethodBody GetMethodBody() { throw null; }
         public static System.Reflection.MethodBase GetMethodFromHandle(System.RuntimeMethodHandle handle) { throw null; }
         public static System.Reflection.MethodBase GetMethodFromHandle(System.RuntimeMethodHandle handle, System.RuntimeTypeHandle declaringType) { throw null; }
@@ -5489,7 +5448,6 @@ namespace System.Reflection
         protected virtual System.Reflection.MethodInfo GetMethodImpl(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
         public MethodInfo[] GetMethods() { throw null; }
         public virtual MethodInfo[] GetMethods(BindingFlags bindingFlags) { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public virtual void GetPEKind(out System.Reflection.PortableExecutableKinds peKind, out System.Reflection.ImageFileMachine machine) { throw null; }
         public virtual Type GetType(string className) { throw null; }
@@ -5584,11 +5542,8 @@ namespace System.Reflection
     public sealed class Pointer : System.Runtime.Serialization.ISerializable
     {
         private Pointer() { }    
-        [System.Security.SecurityCriticalAttribute]
         public static unsafe object Box(void* ptr, System.Type type) { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         public static unsafe void* Unbox(object ptr) { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         unsafe void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     [System.FlagsAttribute]
@@ -5755,7 +5710,6 @@ namespace System.Reflection
     {
         protected System.Type typeImpl;
         public override bool IsAssignableFrom(System.Reflection.TypeInfo typeInfo) { throw null; }
-        [System.Security.SecuritySafeCriticalAttribute]
         protected TypeDelegator() { }
         public TypeDelegator(System.Type delegatingType) { }
         public override System.Guid GUID { get { throw null; } }
@@ -6059,23 +6013,16 @@ namespace System.Runtime.CompilerServices
         public static void RunClassConstructor(System.RuntimeTypeHandle type) { }
         public static void RunModuleConstructor(System.ModuleHandle module) { }
         public static void ExecuteCodeWithGuaranteedCleanup(System.Runtime.CompilerServices.RuntimeHelpers.TryCode code, System.Runtime.CompilerServices.RuntimeHelpers.CleanupCode backoutCode, object userData) { }
-        [System.Security.SecurityCriticalAttribute]
         public delegate void CleanupCode(object userData, bool exceptionThrown);
-        [System.Security.SecurityCriticalAttribute]
         public delegate void TryCode(object userData);
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute((System.Runtime.ConstrainedExecution.Consistency)(3), (System.Runtime.ConstrainedExecution.Cer)(1))]
-        [System.Security.SecurityCriticalAttribute]
         public static void PrepareConstrainedRegions() { }
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute((System.Runtime.ConstrainedExecution.Consistency)(3), (System.Runtime.ConstrainedExecution.Cer)(1))]
-        [System.Security.SecurityCriticalAttribute]
         public static void PrepareConstrainedRegionsNoOP() { }
         public static void PrepareContractedDelegate(System.Delegate d) { }
         public static void PrepareDelegate(System.Delegate d) { }
-        [System.Security.SecurityCriticalAttribute]
         public static void PrepareMethod(System.RuntimeMethodHandle method) { }
-        [System.Security.SecurityCriticalAttribute]
         public static void PrepareMethod(System.RuntimeMethodHandle method, System.RuntimeTypeHandle[] instantiation) { }
-        [System.Security.SecurityCriticalAttribute]
         public static void ProbeForSufficientStack() { }
 #if netcoreapp11
         public static bool TryEnsureSufficientExecutionStack() { return default(bool); }
@@ -6150,7 +6097,6 @@ namespace System.Runtime.CompilerServices
     {
         internal RuntimeWrappedException() { }
         public object WrappedException { get { throw null; } }
-        [System.Security.SecurityCriticalAttribute]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
@@ -6545,7 +6491,6 @@ namespace System.Text
         public System.Text.StringBuilder Append(byte value) { throw null; }
         public System.Text.StringBuilder Append(char value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe System.Text.StringBuilder Append(char* value, int valueCount) { throw null; }
         public System.Text.StringBuilder Append(char value, int repeatCount) { throw null; }
         public System.Text.StringBuilder Append(char[] value) { throw null; }
@@ -6689,7 +6634,6 @@ namespace System.Text
         public override bool Fallback(byte[] bytesUnknown, int index) { throw null; }
         public override char GetNextChar() { throw null; }
         public override bool MovePrevious() { throw null; }
-        [System.Security.SecuritySafeCriticalAttribute]
         public override void Reset() { }
     }
     public abstract partial class Encoder
@@ -6772,7 +6716,6 @@ namespace System.Text
         public override bool Fallback(char charUnknown, int index) { throw null; }
         public override char GetNextChar() { throw null; }
         public override bool MovePrevious() { throw null; }
-        [System.Security.SecuritySafeCriticalAttribute]
         public override void Reset() { }
     }
     public abstract partial class Encoding : System.ICloneable
@@ -6806,13 +6749,11 @@ namespace System.Text
         public static byte[] Convert(System.Text.Encoding srcEncoding, System.Text.Encoding dstEncoding, byte[] bytes, int index, int count) { throw null; }
         public override bool Equals(object value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe virtual int GetByteCount(char* chars, int count) { throw null; }
         public virtual int GetByteCount(char[] chars) { throw null; }
         public abstract int GetByteCount(char[] chars, int index, int count);
         public virtual int GetByteCount(string s) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe virtual int GetBytes(char* chars, int charCount, byte* bytes, int byteCount) { throw null; }
         public virtual byte[] GetBytes(char[] chars) { throw null; }
         public virtual byte[] GetBytes(char[] chars, int index, int count) { throw null; }
@@ -6820,12 +6761,10 @@ namespace System.Text
         public virtual byte[] GetBytes(string s) { throw null; }
         public virtual int GetBytes(string s, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe virtual int GetCharCount(byte* bytes, int count) { throw null; }
         public virtual int GetCharCount(byte[] bytes) { throw null; }
         public abstract int GetCharCount(byte[] bytes, int index, int count);
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe virtual int GetChars(byte* bytes, int byteCount, char* chars, int charCount) { throw null; }
         public virtual char[] GetChars(byte[] bytes) { throw null; }
         public virtual char[] GetChars(byte[] bytes, int index, int count) { throw null; }
@@ -6842,13 +6781,11 @@ namespace System.Text
         public abstract int GetMaxCharCount(int byteCount);
         public virtual byte[] GetPreamble() { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe string GetString(byte* bytes, int byteCount) { throw null; }
         public virtual string GetString(byte[] bytes) { throw null; }
         public virtual string GetString(byte[] bytes, int index, int count) { throw null; }
         public bool IsAlwaysNormalized() { throw null; }
         public virtual bool IsAlwaysNormalized(System.Text.NormalizationForm form) { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         public static void RegisterProvider(System.Text.EncodingProvider provider) { }
     }
     public sealed partial class EncodingInfo
@@ -6951,9 +6888,7 @@ namespace System.Threading
     }
     public static partial class WaitHandleExtensions
     {
-        [System.Security.SecurityCriticalAttribute]
         public static Microsoft.Win32.SafeHandles.SafeWaitHandle GetSafeWaitHandle(this System.Threading.WaitHandle waitHandle) { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         public static void SetSafeWaitHandle(this System.Threading.WaitHandle waitHandle, Microsoft.Win32.SafeHandles.SafeWaitHandle value) { }
     }
 }
@@ -7255,15 +7190,10 @@ namespace System.Threading.Tasks
         public virtual int MaximumConcurrencyLevel { get { throw null; } }
         public static event System.EventHandler<System.Threading.Tasks.UnobservedTaskExceptionEventArgs> UnobservedTaskException { add { } remove { } }
         public static System.Threading.Tasks.TaskScheduler FromCurrentSynchronizationContext() { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         protected abstract System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task> GetScheduledTasks();
-        [System.Security.SecurityCriticalAttribute]
         protected internal abstract void QueueTask(System.Threading.Tasks.Task task);
-        [System.Security.SecurityCriticalAttribute]
         protected internal virtual bool TryDequeue(System.Threading.Tasks.Task task) { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         protected bool TryExecuteTask(System.Threading.Tasks.Task task) { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         protected abstract bool TryExecuteTaskInline(System.Threading.Tasks.Task task, bool taskWasPreviouslyQueued);
     }
     public enum TaskStatus

--- a/src/System.Runtime/src/System/Threading/WaitHandleExtensions.cs
+++ b/src/System.Runtime/src/System/Threading/WaitHandleExtensions.cs
@@ -14,7 +14,6 @@ namespace System.Threading
         /// </summary>
         /// <param name="waitHandle">The <see cref="System.Threading.WaitHandle"/> to operate on.</param>
         /// <returns>A <see cref="System.Runtime.InteropServices.SafeHandle"/> representing the native operating system handle.</returns>
-        [SecurityCritical]
         public static SafeWaitHandle GetSafeWaitHandle(this WaitHandle waitHandle)
         {
             if (waitHandle == null)
@@ -30,7 +29,6 @@ namespace System.Threading
         /// </summary>
         /// <param name="waitHandle">The <see cref="System.Threading.WaitHandle"/> to operate on.</param>
         /// <param name="value">A <see cref="System.Runtime.InteropServices.SafeHandle"/> representing the native operating system handle.</param>
-        [SecurityCritical]
         public static void SetSafeWaitHandle(this WaitHandle waitHandle, SafeWaitHandle value)
         {
             if (waitHandle == null)

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
@@ -366,7 +366,6 @@ namespace System.Security.AccessControl
 
             public SafeTokenHandle ThreadHandle
             {
-                [System.Security.SecurityCritical]  // auto-generated
                 get
                 { return this.threadHandle; }
             }

--- a/src/System.Security.Claims/ref/System.Security.Claims.cs
+++ b/src/System.Security.Claims/ref/System.Security.Claims.cs
@@ -61,9 +61,7 @@ namespace System.Security.Claims
         public virtual string Name { get { throw null; } }
         public string NameClaimType { get { throw null; } }
         public string RoleClaimType { get { throw null; } }
-        [System.Security.SecurityCriticalAttribute]
         public virtual void AddClaim(System.Security.Claims.Claim claim) { }
-        [System.Security.SecurityCriticalAttribute]
         public virtual void AddClaims(System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> claims) { }
         public virtual System.Security.Claims.ClaimsIdentity Clone() { throw null; }
         protected virtual System.Security.Claims.Claim CreateClaim(System.IO.BinaryReader reader) { throw null; }
@@ -74,9 +72,7 @@ namespace System.Security.Claims
         protected virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public virtual bool HasClaim(System.Predicate<System.Security.Claims.Claim> match) { throw null; }
         public virtual bool HasClaim(string type, string value) { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         public virtual void RemoveClaim(System.Security.Claims.Claim claim) { }
-        [System.Security.SecurityCriticalAttribute]
         public virtual bool TryRemoveClaim(System.Security.Claims.Claim claim) { throw null; }
         public virtual void WriteTo(System.IO.BinaryWriter writer) { }
         protected virtual void WriteTo(System.IO.BinaryWriter writer, byte[] userData) { }
@@ -96,9 +92,7 @@ namespace System.Security.Claims
         public virtual System.Collections.Generic.IEnumerable<System.Security.Claims.ClaimsIdentity> Identities { get { throw null; } }
         public virtual System.Security.Principal.IIdentity Identity { get { throw null; } }
         public static System.Func<System.Collections.Generic.IEnumerable<System.Security.Claims.ClaimsIdentity>, System.Security.Claims.ClaimsIdentity> PrimaryIdentitySelector { get { throw null; }[System.Security.SecurityCriticalAttribute]set { } }
-        [System.Security.SecurityCriticalAttribute]
         public virtual void AddIdentities(System.Collections.Generic.IEnumerable<System.Security.Claims.ClaimsIdentity> identities) { }
-        [System.Security.SecurityCriticalAttribute]
         public virtual void AddIdentity(System.Security.Claims.ClaimsIdentity identity) { }
         public virtual System.Security.Claims.ClaimsPrincipal Clone() { throw null; }
         protected virtual System.Security.Claims.ClaimsIdentity CreateClaimsIdentity(System.IO.BinaryReader reader) { throw null; }

--- a/src/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -276,7 +276,6 @@ namespace System.Security.Claims
         /// The <see cref="SerializationInfo"/> to read from.
         /// </param>
         /// <exception cref="ArgumentNullException">Thrown is the <paramref name="info"/> is null.</exception>
-        [SecurityCritical]
         protected ClaimsIdentity(SerializationInfo info)
         {
             if (null == info)

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SafeCryptoHandles.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SafeCryptoHandles.cs
@@ -12,7 +12,6 @@ namespace System.Security.Cryptography
     /// <summary>
     /// Safehandle representing HCRYPTPROV
     /// </summary>
-    [SecurityCritical]
     internal sealed class SafeProvHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         private string _containerName;
@@ -137,7 +136,6 @@ namespace System.Security.Cryptography
     ///     of the key handle and provider handle. This also applies to hash handles, which point to a 
     ///     CRYPT_HASH_CTX. Those structures are defined in COMCryptography.h
     /// </summary>
-    [SecurityCritical]  // auto-generated
     internal sealed class SafeKeyHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         private int _keySpec;
@@ -205,7 +203,6 @@ namespace System.Security.Cryptography
             }
         }
 
-        [SecurityCritical]
         protected override bool ReleaseHandle()
         {
             bool successfullyFreed = CapiHelper.CryptDestroyKey(handle);
@@ -222,7 +219,6 @@ namespace System.Security.Cryptography
     /// <summary>
     /// SafeHandle representing HCRYPTHASH handle
     /// </summary>
-    [SecurityCritical]
     internal sealed class SafeHashHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         private SafeProvHandle _parent;
@@ -262,7 +258,6 @@ namespace System.Security.Cryptography
             }
         }
 
-        [SecurityCritical]
         protected override bool ReleaseHandle()
         {
             bool successfullyFreed = CapiHelper.CryptDestroyHash(handle);

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/ECDsaCertificateExtensions.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/ECDsaCertificateExtensions.cs
@@ -16,7 +16,6 @@ namespace System.Security.Cryptography.X509Certificates
         /// <summary>
         /// Gets the <see cref="ECDsa" /> public key from the certificate or null if the certificate does not have an ECDsa public key.
         /// </summary>
-        [SecuritySafeCritical]
         public static ECDsa GetECDsaPublicKey(this X509Certificate2 certificate)
         {
             return certificate.GetPublicKey<ECDsa>(cert => HasECDsaKeyUsage(cert));
@@ -25,7 +24,6 @@ namespace System.Security.Cryptography.X509Certificates
         /// <summary>
         /// Gets the <see cref="ECDsa" /> private key from the certificate or null if the certificate does not have an ECDsa private key.
         /// </summary>
-        [SecuritySafeCritical]
         public static ECDsa GetECDsaPrivateKey(this X509Certificate2 certificate)
         {
             return certificate.GetPrivateKey<ECDsa>(cert => HasECDsaKeyUsage(cert));

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/RSACertificateExtensions.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/RSACertificateExtensions.cs
@@ -16,7 +16,6 @@ namespace System.Security.Cryptography.X509Certificates
         /// <summary>
         /// Gets the <see cref="RSA" /> public key from the certificate or null if the certificate does not have an RSA public key.
         /// </summary>
-        [SecuritySafeCritical]
         public static RSA GetRSAPublicKey(this X509Certificate2 certificate)
         {
             return certificate.GetPublicKey<RSA>();
@@ -25,7 +24,6 @@ namespace System.Security.Cryptography.X509Certificates
         /// <summary>
         /// Gets the <see cref="RSA" /> private key from the certificate or null if the certificate does not have an RSA private key.
         /// </summary>
-        [SecuritySafeCritical]
         public static RSA GetRSAPrivateKey(this X509Certificate2 certificate)
         {
             return certificate.GetPrivateKey<RSA>();

--- a/src/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.cs
+++ b/src/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.cs
@@ -8,13 +8,11 @@
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class SafeAccessTokenHandle : System.Runtime.InteropServices.SafeHandle
     {
         public SafeAccessTokenHandle(System.IntPtr handle) : base(default(System.IntPtr), default(bool)) { }
         public static Microsoft.Win32.SafeHandles.SafeAccessTokenHandle InvalidHandle {[System.Security.SecurityCriticalAttribute]get { throw null; } }
         public override bool IsInvalid {[System.Security.SecurityCriticalAttribute]get { throw null; } }
-        [System.Security.SecurityCriticalAttribute]
         protected override bool ReleaseHandle() { throw null; }
     }
 }

--- a/src/System.Text.Encoding.CodePages/ref/System.Text.Encoding.CodePages.cs
+++ b/src/System.Text.Encoding.CodePages/ref/System.Text.Encoding.CodePages.cs
@@ -8,7 +8,6 @@
 
 namespace System.Text
 {
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class CodePagesEncodingProvider
     {
         internal CodePagesEncodingProvider() { }

--- a/src/System.Text.Encoding.CodePages/src/Microsoft/Win32/SafeHandles/SafeAllocHHandle.cs
+++ b/src/System.Text.Encoding.CodePages/src/Microsoft/Win32/SafeHandles/SafeAllocHHandle.cs
@@ -8,7 +8,6 @@ using System.Security;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    [SecurityCritical]
     internal sealed class SafeAllocHHandle : SafeBuffer
     {
         private SafeAllocHHandle() : base(true) { }
@@ -23,7 +22,6 @@ namespace Microsoft.Win32.SafeHandles
             get { return new SafeAllocHHandle(IntPtr.Zero); }
         }
 
-        [System.Security.SecurityCritical]
         override protected bool ReleaseHandle()
         {
             if (handle != IntPtr.Zero)

--- a/src/System.Text.Encoding.CodePages/src/System/Text/BaseCodePageEncoding.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/BaseCodePageEncoding.cs
@@ -55,13 +55,11 @@ namespace System.Text
         protected char[] arrayUnicodeBestFit = null;
         protected char[] arrayBytesBestFit = null;
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal BaseCodePageEncoding(int codepage)
             : this(codepage, codepage)
         {
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal BaseCodePageEncoding(int codepage, int dataCodePage)
             : base(codepage, new InternalEncoderBestFitFallback(null), new InternalDecoderBestFitFallback(null))
         {
@@ -158,7 +156,6 @@ namespace System.Text
         protected int m_dataSize;
 
         // Safe handle wrapper around section map view
-        [System.Security.SecurityCritical] // auto-generated
         protected SafeAllocHHandle safeNativeMemoryHandle = null;
 
         internal static Stream GetEncodingDataStream(String tableName)
@@ -183,7 +180,6 @@ namespace System.Text
         }
 
         // We need to load tables for our code page
-        [System.Security.SecurityCritical]  // auto-generated
         private unsafe void LoadCodePageTables()
         {
             if (!FindCodePage(dataTableCodePage))
@@ -197,7 +193,6 @@ namespace System.Text
         }
 
         // Look up the code page pointer
-        [System.Security.SecurityCritical]  // auto-generated
         private unsafe bool FindCodePage(int codePage)
         {
             Debug.Assert(m_codePageHeader != null && m_codePageHeader.Length == CODEPAGE_HEADER_SIZE, "m_codePageHeader expected to match in size the struct CodePageHeader");
@@ -256,7 +251,6 @@ namespace System.Text
         }
 
         // Get our code page byte count
-        [System.Security.SecurityCritical]  // auto-generated
         internal static unsafe int GetCodePageByteSize(int codePage)
         {
             // Loop through all of the m_pCodePageIndex[] items to find our code page
@@ -297,11 +291,9 @@ namespace System.Text
         }
 
         // We have a managed code page entry, so load our tables
-        [System.Security.SecurityCritical]
         protected abstract unsafe void LoadManagedCodePage();
 
         // Allocate memory to load our code page
-        [System.Security.SecurityCritical]  // auto-generated
         protected unsafe byte* GetNativeMemory(int iSize)
         {
             if (safeNativeMemoryHandle == null)
@@ -315,10 +307,8 @@ namespace System.Text
             return (byte*)safeNativeMemoryHandle.DangerousGetHandle();
         }
 
-        [System.Security.SecurityCritical]
         protected abstract unsafe void ReadBestFitTable();
 
-        [System.Security.SecuritySafeCritical]
         internal char[] GetBestFitUnicodeToBytesData()
         {
             // Read in our best fit table if necessary
@@ -330,7 +320,6 @@ namespace System.Text
             return arrayUnicodeBestFit;
         }
 
-        [System.Security.SecuritySafeCritical]
         internal char[] GetBestFitBytesToUnicodeData()
         {
             // Read in our best fit table if necessary
@@ -346,7 +335,6 @@ namespace System.Text
         // invalid. We detect that by validating the memory section handle then re-initializing the memory 
         // section by calling LoadManagedCodePage() method and eventually the mapped file handle and
         // the memory section pointer will get finalized one more time.
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe void CheckMemorySection()
         {
             if (safeNativeMemoryHandle != null && safeNativeMemoryHandle.DangerousGetHandle() == IntPtr.Zero)

--- a/src/System.Text.Encoding.CodePages/src/System/Text/DBCSCodePageEncoding.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/DBCSCodePageEncoding.cs
@@ -18,9 +18,7 @@ namespace System.Text
     internal class DBCSCodePageEncoding : BaseCodePageEncoding
     {
         // Pointers to our memory section parts
-        [SecurityCritical]
         protected unsafe char* mapBytesToUnicode = null;      // char 65536
-        [SecurityCritical]
         protected unsafe ushort* mapUnicodeToBytes = null;      // byte 65536
 
         protected const char UNKNOWN_CHAR_FLAG = (char)0x0;
@@ -33,17 +31,14 @@ namespace System.Text
         private int _byteCountUnknown;
         protected char charUnknown = (char)0;
 
-        [System.Security.SecurityCritical]  // auto-generated
         public DBCSCodePageEncoding(int codePage) : this(codePage, codePage)
         {
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal DBCSCodePageEncoding(int codePage, int dataCodePage) : base(codePage, dataCodePage)
         {
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal DBCSCodePageEncoding(int codePage, int dataCodePage, EncoderFallback enc, DecoderFallback dec) : base(codePage, dataCodePage, enc, dec)
         {
         }
@@ -76,7 +71,6 @@ namespace System.Text
         //               correspond to those unicode code points.
         // We have a managed code page entry, so load our tables
         //
-        [System.Security.SecurityCritical]  // auto-generated
         protected override unsafe void LoadManagedCodePage()
         {
             fixed (byte* pBytes = m_codePageHeader)
@@ -210,7 +204,6 @@ namespace System.Text
         }
 
         // Any special processing for this code page
-        [System.Security.SecurityCritical]  // auto-generated
         protected virtual unsafe void CleanUpEndBytes(char* chars)
         {
         }
@@ -231,7 +224,6 @@ namespace System.Text
         }
 
         // Read in our best fit table
-        [System.Security.SecurityCritical]  // auto-generated
         protected unsafe override void ReadBestFitTable()
         {
             // Lock so we don't confuse ourselves.
@@ -510,7 +502,6 @@ namespace System.Text
         // GetByteCount
         // Note: We start by assuming that the output will be the same as count.  Having
         // an encoder or fallback may change that assumption
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetByteCount(char* chars, int count, EncoderNLS encoder)
         {
             // Just need to ASSERT, this is called by something else internal that checked parameters already
@@ -606,7 +597,6 @@ namespace System.Text
             return (int)byteCount;
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetBytes(char* chars, int charCount,
                                                 byte* bytes, int byteCount, EncoderNLS encoder)
         {
@@ -757,7 +747,6 @@ namespace System.Text
         }
 
         // This is internal and called by something else,
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetCharCount(byte* bytes, int count, DecoderNLS baseDecoder)
         {
             // Just assert, we're called internally so these should be safe, checked already
@@ -908,7 +897,6 @@ namespace System.Text
             return charCount;
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetChars(byte* bytes, int byteCount,
                                                 char* chars, int charCount, DecoderNLS baseDecoder)
         {

--- a/src/System.Text.Encoding.CodePages/src/System/Text/DecoderBestFitFallback.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/DecoderBestFitFallback.cs
@@ -155,14 +155,12 @@ namespace System.Text
         }
 
         // Clear the buffer
-        [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override unsafe void Reset()
         {
             iCount = -1;
         }
 
         // This version just counts the fallback and doesn't actually copy anything.
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe int InternalFallback(byte[] bytes, byte* pBytes)
         // Right now this has both bytes and bytes[], since we might have extra bytes, hence the
         // array, and we might need the index, hence the byte*

--- a/src/System.Text.Encoding.CodePages/src/System/Text/DecoderFallbackBufferHelper.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/DecoderFallbackBufferHelper.cs
@@ -94,7 +94,6 @@ namespace System.Text
         }
 
         // This version just counts the fallback and doesn't actually copy anything.
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe int InternalFallback(byte[] bytes, byte* pBytes)
         // Right now this has both bytes and bytes[], since we might have extra bytes, hence the
         // array, and we might need the index, hence the byte*

--- a/src/System.Text.Encoding.CodePages/src/System/Text/DecoderNLS.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/DecoderNLS.cs
@@ -129,7 +129,6 @@ namespace System.Text
             return GetCharCount(bytes, index, count, false);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override unsafe int GetCharCount(byte[] bytes, int index, int count, bool flush)
         {
             // Validate Parameters
@@ -153,7 +152,6 @@ namespace System.Text
                 return GetCharCount(pBytes + index, count, flush);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetCharCount(byte* bytes, int count, bool flush)
         {
             // Validate parameters
@@ -178,7 +176,6 @@ namespace System.Text
             return GetChars(bytes, byteIndex, byteCount, chars, charIndex, false);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override unsafe int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                              char[] chars, int charIndex, bool flush)
         {
@@ -213,7 +210,6 @@ namespace System.Text
                                     pChars + charIndex, charCount, flush);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetChars(byte* bytes, int byteCount,
                                               char* chars, int charCount, bool flush)
         {
@@ -235,7 +231,6 @@ namespace System.Text
 
         // This method is used when the output buffer might not be big enough.
         // Just call the pointer version.  (This gets chars)
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override unsafe void Convert(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex, int charCount, bool flush,
                                               out int bytesUsed, out int charsUsed, out bool completed)
@@ -277,7 +272,6 @@ namespace System.Text
 
         // This is the version that used pointers.  We call the base encoding worker function
         // after setting our appropriate internal variables.  This is getting chars
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe void Convert(byte* bytes, int byteCount,
                                               char* chars, int charCount, bool flush,
                                               out int bytesUsed, out int charsUsed, out bool completed)

--- a/src/System.Text.Encoding.CodePages/src/System/Text/EUCJPEncoding.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/EUCJPEncoding.cs
@@ -49,7 +49,6 @@ namespace System.Text
     internal class EUCJPEncoding : DBCSCodePageEncoding
     {
         // This pretends to be CP 932 as far as memory tables are concerned.
-        [System.Security.SecurityCritical]  // auto-generated
         public EUCJPEncoding() : base(51932, 932)
         {
         }
@@ -146,7 +145,6 @@ namespace System.Text
             return true;
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         protected override unsafe void CleanUpEndBytes(char* chars)
         {
             // Need to special case CP 51932

--- a/src/System.Text.Encoding.CodePages/src/System/Text/EncoderBestFitFallback.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/EncoderBestFitFallback.cs
@@ -180,7 +180,6 @@ namespace System.Text
         }
 
         // Clear the buffer
-        [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override unsafe void Reset()
         {
             _iCount = -1;

--- a/src/System.Text.Encoding.CodePages/src/System/Text/EncoderFallbackBufferHelper.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/EncoderFallbackBufferHelper.cs
@@ -30,7 +30,6 @@ namespace System.Text
 
         // Internal Reset
         // For example, what if someone fails a conversion and wants to reset one of our fallback buffers?
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe void InternalReset()
         {
             charStart = null;
@@ -41,7 +40,6 @@ namespace System.Text
 
         // Set the above values
         // This can't be part of the constructor because EncoderFallbacks would have to know how to implement these.
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe void InternalInitialize(char* _charStart, char* _charEnd, EncoderNLS _encoder, bool _setEncoder)
         {
             charStart = _charStart;
@@ -69,7 +67,6 @@ namespace System.Text
         // Note that this could also change the contents of encoder, which is the same
         // object that the caller is using, so the caller could mess up the encoder for us
         // if they aren't careful.
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe bool InternalFallback(char ch, ref char* chars)
         {
             // Shouldn't have null charStart

--- a/src/System.Text.Encoding.CodePages/src/System/Text/EncoderNLS.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/EncoderNLS.cs
@@ -139,7 +139,6 @@ namespace System.Text
                 m_fallbackBuffer.Reset();
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override unsafe int GetByteCount(char[] chars, int index, int count, bool flush)
         {
             // Validate input parameters
@@ -166,7 +165,6 @@ namespace System.Text
             return result;
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetByteCount(char* chars, int count, bool flush)
         {
             // Validate input parameters
@@ -182,7 +180,6 @@ namespace System.Text
             return m_encoding.GetByteCount(chars, count, this);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override unsafe int GetBytes(char[] chars, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex, bool flush)
         {
@@ -216,7 +213,6 @@ namespace System.Text
                                     pBytes + byteIndex, byteCount, flush);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount, bool flush)
         {
             // Validate parameters
@@ -234,7 +230,6 @@ namespace System.Text
 
         // This method is used when your output buffer might not be large enough for the entire result.
         // Just call the pointer version.  (This gets bytes)
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override unsafe void Convert(char[] chars, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex, int byteCount, bool flush,
                                               out int charsUsed, out int bytesUsed, out bool completed)
@@ -276,7 +271,6 @@ namespace System.Text
 
         // This is the version that uses pointers.  We call the base encoding worker function
         // after setting our appropriate internal variables.  This is getting bytes
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe void Convert(char* chars, int charCount,
                                               byte* bytes, int byteCount, bool flush,
                                               out int charsUsed, out int bytesUsed, out bool completed)

--- a/src/System.Text.Encoding.CodePages/src/System/Text/EncodingCharBuffer.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/EncodingCharBuffer.cs
@@ -20,7 +20,6 @@ namespace System.Text
         private DecoderFallbackBuffer _fallbackBuffer;
         private DecoderFallbackBufferHelper _fallbackBufferHelper;
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe EncodingCharBuffer(EncodingNLS enc, DecoderNLS decoder, char* charStart, int charCount, byte* byteStart, int byteCount)
         {
             _enc = enc;
@@ -47,7 +46,6 @@ namespace System.Text
             _fallbackBufferHelper.InternalInitialize(_bytes, _charEnd);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe bool AddChar(char ch, int numBytes)
         {
             if (_chars != null)
@@ -66,14 +64,12 @@ namespace System.Text
             return true;
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe bool AddChar(char ch)
         {
             return AddChar(ch, 1);
         }
 
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe bool AddChar(char ch1, char ch2, int numBytes)
         {
             // Need room for 2 chars
@@ -87,7 +83,6 @@ namespace System.Text
             return AddChar(ch1, numBytes) && AddChar(ch2, numBytes);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe void AdjustBytes(int count)
         {
             _bytes += count;
@@ -95,7 +90,6 @@ namespace System.Text
 
         internal unsafe bool MoreData
         {
-            [System.Security.SecurityCritical]  // auto-generated
             get
             {
                 return _bytes < _byteEnd;
@@ -103,7 +97,6 @@ namespace System.Text
         }
 
         // Do we have count more bytes?
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe bool EvenMoreData(int count)
         {
             return (_bytes <= _byteEnd - count);
@@ -111,7 +104,6 @@ namespace System.Text
 
         // GetNextByte shouldn't be called unless the caller's already checked more data or even more data,
         // but we'll double check just to make sure.
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe byte GetNextByte()
         {
             Debug.Assert(_bytes < _byteEnd, "[EncodingCharBuffer.GetNextByte]Expected more date");
@@ -122,14 +114,12 @@ namespace System.Text
 
         internal unsafe int BytesUsed
         {
-            [System.Security.SecurityCritical]  // auto-generated
             get
             {
                 return (int)(_bytes - _byteStart);
             }
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe bool Fallback(byte fallbackByte)
         {
             // Build our buffer
@@ -139,7 +129,6 @@ namespace System.Text
             return Fallback(byteBuffer);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe bool Fallback(byte byte1, byte byte2)
         {
             // Build our buffer
@@ -149,7 +138,6 @@ namespace System.Text
             return Fallback(byteBuffer);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe bool Fallback(byte byte1, byte byte2, byte byte3, byte byte4)
         {
             // Build our buffer
@@ -159,7 +147,6 @@ namespace System.Text
             return Fallback(byteBuffer);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe bool Fallback(byte[] byteBuffer)
         {
             // Do the fallback and add the data.

--- a/src/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
@@ -47,7 +47,6 @@ namespace System.Text
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
         // So if you fix this, fix the others. 
         // parent method is safe
-        [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override unsafe int GetByteCount(char[] chars, int index, int count)
         {
             // Validate input parameters
@@ -73,7 +72,6 @@ namespace System.Text
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
         // So if you fix this, fix the others. 
         // parent method is safe
-        [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override unsafe int GetByteCount(String s)
         {
             // Validate input
@@ -87,7 +85,6 @@ namespace System.Text
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
         // So if you fix this, fix the others.
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetByteCount(char* chars, int count)
         {
             // Validate Parameters
@@ -106,7 +103,6 @@ namespace System.Text
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
         // So if you fix this, fix the others.
 
-        [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override unsafe int GetBytes(String s, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
         {
@@ -147,7 +143,6 @@ namespace System.Text
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
         // So if you fix this, fix the others.  
         // parent method is safe
-        [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override unsafe int GetBytes(char[] chars, int charIndex, int charCount,
                                                byte[] bytes, int byteIndex)
         {
@@ -185,7 +180,6 @@ namespace System.Text
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
         // So if you fix this, fix the others. 
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
             // Validate Parameters
@@ -205,7 +199,6 @@ namespace System.Text
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
         // So if you fix this, fix the others.  
         // parent method is safe
-        [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override unsafe int GetCharCount(byte[] bytes, int index, int count)
         {
             // Validate Parameters
@@ -230,7 +223,6 @@ namespace System.Text
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
         // So if you fix this, fix the others.  
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
             // Validate Parameters
@@ -247,7 +239,6 @@ namespace System.Text
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
         // So if you fix this, fix the others.  
         // parent method is safe
-        [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override unsafe int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
@@ -285,7 +276,6 @@ namespace System.Text
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
         // So if you fix this, fix the others.  
-        [System.Security.SecurityCritical]  // auto-generated
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
             // Validate Parameters
@@ -305,7 +295,6 @@ namespace System.Text
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
         // So if you fix this, fix the others.
         // parent method is safe
-        [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override unsafe String GetString(byte[] bytes, int index, int count)
         {
             // Validate Parameters

--- a/src/System.Text.Encoding.CodePages/src/System/Text/GB18030Encoding.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/GB18030Encoding.cs
@@ -116,7 +116,6 @@ namespace System.Text
         private const int GBLastSurrogateOffset = 0x12E247; // GBE3329A35
 
         // We have to load the 936 code page tables, so impersonate 936 as our base
-        [System.Security.SecurityCritical]  // auto-generated
         internal GB18030Encoding()
             // For GB18030Encoding just use default replacement fallbacks because its only for bad surrogates
             : base(GB18030, 936, EncoderFallback.ReplacementFallback, DecoderFallback.ReplacementFallback)
@@ -125,7 +124,6 @@ namespace System.Text
 
         // This loads our base 936 code page and then applies the changes from the tableUnicodeToGBDiffs table.
         // See table comments for table format.
-        [System.Security.SecurityCritical]  // auto-generated
         protected override unsafe void LoadManagedCodePage()
         {
             // Use base code page loading algorithm.
@@ -196,7 +194,6 @@ namespace System.Text
         // Is4Byte
         // Checks the 4 byte table and returns true if this is a 4 byte code.
         // Its a 4 byte code if the flag is set in mapUnicodeTo4BytesFlags
-        [System.Security.SecurityCritical]  // auto-generated
         internal unsafe bool Is4Byte(char charTest)
         {
             // See what kind it is
@@ -205,14 +202,12 @@ namespace System.Text
         }
 
         // GetByteCount
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetByteCount(char* chars, int count, EncoderNLS encoder)
         {
             // Just call GetBytes() with null bytes
             return GetBytes(chars, count, null, 0, encoder);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetBytes(char* chars, int charCount,
                                                 byte* bytes, int byteCount, EncoderNLS encoder)
         {
@@ -393,14 +388,12 @@ namespace System.Text
         }
 
         // This is internal and called by something else,
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetCharCount(byte* bytes, int count, DecoderNLS baseDecoder)
         {
             // Just call GetChars() with null chars to count
             return GetChars(bytes, count, null, 0, baseDecoder);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetChars(byte* bytes, int byteCount,
                                                 char* chars, int charCount, DecoderNLS baseDecoder)
         {

--- a/src/System.Text.Encoding.CodePages/src/System/Text/ISCIIEncoding.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/ISCIIEncoding.cs
@@ -134,7 +134,6 @@ namespace System.Text
         }
 
         // Our workhorse version
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetByteCount(char* chars, int count, EncoderNLS baseEncoder)
         {
             // Use null pointer to ask GetBytes for count
@@ -142,7 +141,6 @@ namespace System.Text
         }
 
         // Workhorse
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount, EncoderNLS baseEncoder)
         {
             // Allow null bytes for counting
@@ -318,7 +316,6 @@ namespace System.Text
         }
 
         // Workhorse
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetCharCount(byte* bytes, int count, DecoderNLS baseDecoder)
         {
             // Just call GetChars with null chars saying we want count
@@ -331,7 +328,6 @@ namespace System.Text
         // Devenagari F0, B8 -> \u0952
         // Devenagari F0, BF -> \u0970
         // Some characters followed by E9 become a different character instead.
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetChars(byte* bytes, int byteCount,
                                                 char* chars, int charCount, DecoderNLS baseDecoder)
         {

--- a/src/System.Text.Encoding.CodePages/src/System/Text/ISO2022Encoding.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/ISO2022Encoding.cs
@@ -59,7 +59,6 @@ namespace System.Text
 
         // We have to load the 936 code page tables, so impersonate 936 as our base
         // This pretends to be other code pages as far as memory sections are concerned.
-        [System.Security.SecurityCritical]  // auto-generated
         internal ISO2022Encoding(int codePage) : base(codePage, s_tableBaseCodePages[codePage % 10])
         {
         }
@@ -224,7 +223,6 @@ namespace System.Text
         }
 
         // GetByteCount
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetByteCount(char* chars, int count, EncoderNLS baseEncoder)
         {
             // Just need to ASSERT, this is called by something else internal that checked parameters already
@@ -235,7 +233,6 @@ namespace System.Text
             return GetBytes(chars, count, null, 0, baseEncoder);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetBytes(char* chars, int charCount,
                                                 byte* bytes, int byteCount, EncoderNLS baseEncoder)
         {
@@ -277,7 +274,6 @@ namespace System.Text
         }
 
         // This is internal and called by something else,
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetCharCount(byte* bytes, int count, DecoderNLS baseDecoder)
         {
             // Just assert, we're called internally so these should be safe, checked already
@@ -288,7 +284,6 @@ namespace System.Text
             return GetChars(bytes, count, null, 0, baseDecoder);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetChars(byte* bytes, int byteCount,
                                                 char* chars, int charCount, DecoderNLS baseDecoder)
         {
@@ -360,7 +355,6 @@ namespace System.Text
         // undefined, so we maintain that behavior when decoding.  We will never generate characters using
         // that technique, but the decoder will process them.
         //
-        [System.Security.SecurityCritical]  // auto-generated
         private unsafe int GetBytesCP5022xJP(char* chars, int charCount,
                                                   byte* bytes, int byteCount, ISO2022Encoder encoder)
         {
@@ -602,7 +596,6 @@ namespace System.Text
         // Also Mlang always assumed KR mode, even if the designator wasn't found yet, so we do that as
         // well.  So basically we just ignore <ESC>$)C when decoding.
         //
-        [System.Security.SecurityCritical]  // auto-generated
         private unsafe int GetBytesCP50225KR(char* chars, int charCount,
                                                     byte* bytes, int byteCount, ISO2022Encoder encoder)
         {
@@ -752,7 +745,6 @@ namespace System.Text
         //
         // This encoding is designed for transmission by e-mail and news.  No bytes should have high bit set.
         // (all bytes <= 0x7f)
-        [System.Security.SecurityCritical]  // auto-generated
         private unsafe int GetBytesCP52936(char* chars, int charCount,
                                            byte* bytes, int byteCount, ISO2022Encoder encoder)
         {
@@ -886,7 +878,6 @@ namespace System.Text
             return buffer.Count;
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         private unsafe int GetCharsCP5022xJP(byte* bytes, int byteCount,
                                                   char* chars, int charCount, ISO2022Decoder decoder)
         {
@@ -1212,7 +1203,6 @@ namespace System.Text
 
         // Note that in DBCS mode mlang passed through ' ', '\t' and '\n' as SBCS characters
         // probably to allow mailer formatting without too much extra work.
-        [System.Security.SecurityCritical]  // auto-generated
         private unsafe int GetCharsCP50225KR(byte* bytes, int byteCount,
                                                    char* chars, int charCount, ISO2022Decoder decoder)
         {
@@ -1450,7 +1440,6 @@ namespace System.Text
         //
         // This encoding is designed for transmission by e-mail and news.  No bytes should have high bit set.
         // (all bytes <= 0x7f)
-        [System.Security.SecurityCritical]  // auto-generated
         private unsafe int GetCharsCP52936(byte* bytes, int byteCount,
                                                 char* chars, int charCount, ISO2022Decoder decoder)
         {

--- a/src/System.Text.Encoding.CodePages/src/System/Text/SBCSCodePageEncoding.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/SBCSCodePageEncoding.cs
@@ -17,9 +17,7 @@ namespace System.Text
     internal class SBCSCodePageEncoding : BaseCodePageEncoding
     {
         // Pointers to our memory section parts
-        [SecurityCritical]
         private unsafe char* _mapBytesToUnicode = null;      // char 256
-        [SecurityCritical]
         private unsafe byte* _mapUnicodeToBytes = null;      // byte 65536
 
         private const char UNKNOWN_CHAR = (char)0xFFFD;
@@ -28,12 +26,10 @@ namespace System.Text
         private byte _byteUnknown;
         private char _charUnknown;
 
-        [System.Security.SecurityCritical]  // auto-generated
         public SBCSCodePageEncoding(int codePage) : this(codePage, codePage)
         {
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         public SBCSCodePageEncoding(int codePage, int dataCodePage) : base(codePage, dataCodePage)
         {
         }
@@ -72,7 +68,6 @@ namespace System.Text
         //              byte < 0x20 means skip the next n positions.  (Where n is the byte #)
         //              byte == 1 means that next word is another unicode code point #
         //              byte == 0 is unknown.  (doesn't override initial WCHAR[256] table!
-        [System.Security.SecurityCritical]  // auto-generated
         protected override unsafe void LoadManagedCodePage()
         {
             fixed (byte* pBytes = m_codePageHeader)
@@ -157,7 +152,6 @@ namespace System.Text
         }
 
         // Read in our best fit table
-        [System.Security.SecurityCritical]  // auto-generated
         protected unsafe override void ReadBestFitTable()
         {
             // Lock so we don't confuse ourselves.
@@ -312,7 +306,6 @@ namespace System.Text
         // GetByteCount
         // Note: We start by assuming that the output will be the same as count.  Having
         // an encoder or fallback may change that assumption
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetByteCount(char* chars, int count, EncoderNLS encoder)
         {
             // Just need to ASSERT, this is called by something else internal that checked parameters already
@@ -437,7 +430,6 @@ namespace System.Text
             return (int)byteCount;
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetBytes(char* chars, int charCount,
                                                 byte* bytes, int byteCount, EncoderNLS encoder)
         {
@@ -673,7 +665,6 @@ namespace System.Text
         }
 
         // This is internal and called by something else,
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetCharCount(byte* bytes, int count, DecoderNLS decoder)
         {
             // Just assert, we're called internally so these should be safe, checked already
@@ -761,7 +752,6 @@ namespace System.Text
             return charCount;
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetChars(byte* bytes, int byteCount,
                                                 char* chars, int charCount, DecoderNLS decoder)
         {

--- a/src/System.Text.Encoding.Extensions/ref/System.Text.Encoding.Extensions.cs
+++ b/src/System.Text.Encoding.Extensions/ref/System.Text.Encoding.Extensions.cs
@@ -13,21 +13,17 @@ namespace System.Text
         public ASCIIEncoding() { }
         public override bool IsSingleByte { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetByteCount(char* chars, int count) { throw null; }
         public override int GetByteCount(char[] chars, int index, int count) { throw null; }
         public override int GetByteCount(string chars) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetBytes(char* chars, int charCount, byte* bytes, int byteCount) { throw null; }
         public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         public override int GetBytes(string chars, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetCharCount(byte* bytes, int count) { throw null; }
         public override int GetCharCount(byte[] bytes, int index, int count) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount) { throw null; }
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex) { throw null; }
         public override System.Text.Decoder GetDecoder() { throw null; }
@@ -45,20 +41,16 @@ namespace System.Text
         public override bool Equals(object value) { throw null; }
         public override int GetByteCount(char[] chars, int index, int count) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetByteCount(char* chars, int count) { throw null; }
         public override int GetByteCount(string s) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetBytes(char* chars, int charCount, byte* bytes, int byteCount) { throw null; }
         public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         public override int GetBytes(string s, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetCharCount(byte* bytes, int count) { throw null; }
         public override int GetCharCount(byte[] bytes, int index, int count) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount) { throw null; }
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex) { throw null; }
         public override System.Text.Decoder GetDecoder() { throw null; }
@@ -76,21 +68,17 @@ namespace System.Text
         public UTF32Encoding(bool bigEndian, bool byteOrderMark, bool throwOnInvalidCharacters) { }
         public override bool Equals(object value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetByteCount(char* chars, int count) { throw null; }
         public override int GetByteCount(char[] chars, int index, int count) { throw null; }
         public override int GetByteCount(string s) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetBytes(char* chars, int charCount, byte* bytes, int byteCount) { throw null; }
         public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         public override int GetBytes(string s, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetCharCount(byte* bytes, int count) { throw null; }
         public override int GetCharCount(byte[] bytes, int index, int count) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount) { throw null; }
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex) { throw null; }
         public override System.Text.Decoder GetDecoder() { throw null; }
@@ -107,21 +95,17 @@ namespace System.Text
         public UTF7Encoding(bool allowOptionals) { }
         public override bool Equals(object value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetByteCount(char* chars, int count) { throw null; }
         public override int GetByteCount(char[] chars, int index, int count) { throw null; }
         public override int GetByteCount(string s) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetBytes(char* chars, int charCount, byte* bytes, int byteCount) { throw null; }
         public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         public override int GetBytes(string s, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetCharCount(byte* bytes, int count) { throw null; }
         public override int GetCharCount(byte[] bytes, int index, int count) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount) { throw null; }
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex) { throw null; }
         public override System.Text.Decoder GetDecoder() { throw null; }
@@ -138,21 +122,17 @@ namespace System.Text
         public UTF8Encoding(bool encoderShouldEmitUTF8Identifier, bool throwOnInvalidBytes) { }
         public override bool Equals(object value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetByteCount(char* chars, int count) { throw null; }
         public override int GetByteCount(char[] chars, int index, int count) { throw null; }
         public override int GetByteCount(string chars) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetBytes(char* chars, int charCount, byte* bytes, int byteCount) { throw null; }
         public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         public override int GetBytes(string s, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetCharCount(byte* bytes, int count) { throw null; }
         public override int GetCharCount(byte[] bytes, int index, int count) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Security.SecurityCriticalAttribute]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount) { throw null; }
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex) { throw null; }
         public override System.Text.Decoder GetDecoder() { throw null; }

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/BufferInternal.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/BufferInternal.cs
@@ -14,7 +14,6 @@ namespace System {
     static class BufferInternal
     {       
         // This method has different signature for x64 and other platforms and is done for performance reasons.
-        [System.Security.SecurityCritical]
         private static unsafe void Memmove(byte* dest, byte* src, uint len)
         {
             if (AreOverlapping(dest, src, len))
@@ -187,7 +186,6 @@ namespace System {
 
         // The attributes on this method are chosen for best JIT performance. 
         // Please do not edit unless intentional.
-        [System.Security.SecurityCritical]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void MemoryCopy(void* source, void* destination, int destinationSizeInBytes, int sourceBytesToCopy)
         {

--- a/src/System.Threading.AccessControl/ref/System.Threading.AccessControl.Manual.cs
+++ b/src/System.Threading.AccessControl/ref/System.Threading.AccessControl.Manual.cs
@@ -9,7 +9,6 @@
 namespace System.Security.AccessControl
 {
     [System.FlagsAttribute]
-    [System.Security.SecurityCriticalAttribute]
     public enum EventWaitHandleRights
     {
         ChangePermissions = 262144,
@@ -21,7 +20,6 @@ namespace System.Security.AccessControl
         TakeOwnership = 524288,
     }
 
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class EventWaitHandleSecurity : System.Security.AccessControl.NativeObjectSecurity
     {
         public EventWaitHandleSecurity() : base(default(bool), default(System.Security.AccessControl.ResourceType)) { }

--- a/src/System.Threading.AccessControl/ref/System.Threading.AccessControl.cs
+++ b/src/System.Threading.AccessControl/ref/System.Threading.AccessControl.cs
@@ -8,34 +8,29 @@
 
 namespace System.Security.AccessControl
 {
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class EventWaitHandleAccessRule : System.Security.AccessControl.AccessRule
     {
         public EventWaitHandleAccessRule(System.Security.Principal.IdentityReference identity, System.Security.AccessControl.EventWaitHandleRights eventRights, System.Security.AccessControl.AccessControlType type) : base(default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AccessControlType)) { }
         public EventWaitHandleAccessRule(string identity, System.Security.AccessControl.EventWaitHandleRights eventRights, System.Security.AccessControl.AccessControlType type) : base(default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AccessControlType)) { }
         public System.Security.AccessControl.EventWaitHandleRights EventWaitHandleRights { get { throw null; } }
     }
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class EventWaitHandleAuditRule : System.Security.AccessControl.AuditRule
     {
         public EventWaitHandleAuditRule(System.Security.Principal.IdentityReference identity, System.Security.AccessControl.EventWaitHandleRights eventRights, System.Security.AccessControl.AuditFlags flags) : base(default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AuditFlags)) { }
         public System.Security.AccessControl.EventWaitHandleRights EventWaitHandleRights { get { throw null; } }
     }
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class MutexAccessRule : System.Security.AccessControl.AccessRule
     {
         public MutexAccessRule(System.Security.Principal.IdentityReference identity, System.Security.AccessControl.MutexRights eventRights, System.Security.AccessControl.AccessControlType type) : base(default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AccessControlType)) { }
         public MutexAccessRule(string identity, System.Security.AccessControl.MutexRights eventRights, System.Security.AccessControl.AccessControlType type) : base(default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AccessControlType)) { }
         public System.Security.AccessControl.MutexRights MutexRights { get { throw null; } }
     }
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class MutexAuditRule : System.Security.AccessControl.AuditRule
     {
         public MutexAuditRule(System.Security.Principal.IdentityReference identity, System.Security.AccessControl.MutexRights eventRights, System.Security.AccessControl.AuditFlags flags) : base(default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AuditFlags)) { }
         public System.Security.AccessControl.MutexRights MutexRights { get { throw null; } }
     }
     [System.FlagsAttribute]
-    [System.Security.SecurityCriticalAttribute]
     public enum MutexRights
     {
         ChangePermissions = 262144,
@@ -46,7 +41,6 @@ namespace System.Security.AccessControl
         Synchronize = 1048576,
         TakeOwnership = 524288,
     }
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class MutexSecurity : System.Security.AccessControl.NativeObjectSecurity
     {
         public MutexSecurity() : base(default(bool), default(System.Security.AccessControl.ResourceType)) { }
@@ -68,21 +62,18 @@ namespace System.Security.AccessControl
         public void SetAccessRule(System.Security.AccessControl.MutexAccessRule rule) { }
         public void SetAuditRule(System.Security.AccessControl.MutexAuditRule rule) { }
     }
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class SemaphoreAccessRule : System.Security.AccessControl.AccessRule
     {
         public SemaphoreAccessRule(System.Security.Principal.IdentityReference identity, System.Security.AccessControl.SemaphoreRights eventRights, System.Security.AccessControl.AccessControlType type) : base(default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AccessControlType)) { }
         public SemaphoreAccessRule(string identity, System.Security.AccessControl.SemaphoreRights eventRights, System.Security.AccessControl.AccessControlType type) : base(default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AccessControlType)) { }
         public System.Security.AccessControl.SemaphoreRights SemaphoreRights { get { throw null; } }
     }
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class SemaphoreAuditRule : System.Security.AccessControl.AuditRule
     {
         public SemaphoreAuditRule(System.Security.Principal.IdentityReference identity, System.Security.AccessControl.SemaphoreRights eventRights, System.Security.AccessControl.AuditFlags flags) : base(default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AuditFlags)) { }
         public System.Security.AccessControl.SemaphoreRights SemaphoreRights { get { throw null; } }
     }
     [System.FlagsAttribute]
-    [System.Security.SecurityCriticalAttribute]
     public enum SemaphoreRights
     {
         ChangePermissions = 262144,
@@ -93,7 +84,6 @@ namespace System.Security.AccessControl
         Synchronize = 1048576,
         TakeOwnership = 524288,
     }
-    [System.Security.SecurityCriticalAttribute]
     public sealed partial class SemaphoreSecurity : System.Security.AccessControl.NativeObjectSecurity
     {
         public SemaphoreSecurity() : base(default(bool), default(System.Security.AccessControl.ResourceType)) { }
@@ -118,7 +108,6 @@ namespace System.Security.AccessControl
 }
 namespace System.Threading
 {
-    [System.Security.SecurityCriticalAttribute]
     public static partial class ThreadingAclExtensions
     {
         public static System.Security.AccessControl.EventWaitHandleSecurity GetAccessControl(this System.Threading.EventWaitHandle handle) { throw null; }

--- a/src/System.Threading.AccessControl/src/System/Security/AccessControl/EventWaitHandleSecurity.cs
+++ b/src/System.Threading.AccessControl/src/System/Security/AccessControl/EventWaitHandleSecurity.cs
@@ -115,21 +115,18 @@ namespace System.Security.AccessControl
         {
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal EventWaitHandleSecurity(String name, AccessControlSections includeSections)
             : base(true, ResourceType.KernelObject, name, includeSections, _HandleErrorCode, null)
         {
             // Let the underlying ACL API's demand unmanaged code permission.
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal EventWaitHandleSecurity(SafeWaitHandle handle, AccessControlSections includeSections)
             : base(true, ResourceType.KernelObject, handle, includeSections, _HandleErrorCode, null)
         {
             // Let the underlying ACL API's demand unmanaged code permission.
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         private static Exception _HandleErrorCode(int errorCode, string name, SafeHandle handle, object context)
         {
             System.Exception exception = null;
@@ -176,7 +173,6 @@ namespace System.Security.AccessControl
             return persistRules;
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal void Persist(SafeWaitHandle handle)
         {
             //

--- a/src/System.Threading.AccessControl/src/System/Security/AccessControl/MutexSecurity.cs
+++ b/src/System.Threading.AccessControl/src/System/Security/AccessControl/MutexSecurity.cs
@@ -116,21 +116,18 @@ namespace System.Security.AccessControl
         {
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public MutexSecurity(String name, AccessControlSections includeSections)
             : base(true, ResourceType.KernelObject, name, includeSections, _HandleErrorCode, null)
         {
             // Let the underlying ACL API's demand unmanaged code permission.
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal MutexSecurity(SafeWaitHandle handle, AccessControlSections includeSections)
             : base(true, ResourceType.KernelObject, handle, includeSections, _HandleErrorCode, null)
         {
             // Let the underlying ACL API's demand unmanaged code permission.
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         private static Exception _HandleErrorCode(int errorCode, string name, SafeHandle handle, object context)
         {
             System.Exception exception = null;
@@ -177,7 +174,6 @@ namespace System.Security.AccessControl
             return persistRules;
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         internal void Persist(SafeWaitHandle handle)
         {
             // Let the underlying ACL API's demand unmanaged code.

--- a/src/System.Threading.AccessControl/src/System/Threading/ThreadingAclExtensions.cs
+++ b/src/System.Threading.AccessControl/src/System/Threading/ThreadingAclExtensions.cs
@@ -15,13 +15,11 @@ namespace System.Threading
 {
     public static class ThreadingAclExtensions
     {
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static EventWaitHandleSecurity GetAccessControl(this EventWaitHandle handle)
         {
             return new EventWaitHandleSecurity(handle.GetSafeWaitHandle(), AccessControlSections.Access | AccessControlSections.Owner | AccessControlSections.Group);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static void SetAccessControl(this EventWaitHandle handle, EventWaitHandleSecurity eventSecurity)
         {
             if (eventSecurity == null)
@@ -31,13 +29,11 @@ namespace System.Threading
             eventSecurity.Persist(handle.GetSafeWaitHandle());
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static MutexSecurity GetAccessControl(this Mutex mutex)
         {
             return new MutexSecurity(mutex.GetSafeWaitHandle(), AccessControlSections.Access | AccessControlSections.Owner | AccessControlSections.Group);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static void SetAccessControl(this Mutex mutex, MutexSecurity mutexSecurity)
         {
             if (mutexSecurity == null)

--- a/src/System.Threading.Overlapped/ref/System.Threading.Overlapped.cs
+++ b/src/System.Threading.Overlapped/ref/System.Threading.Overlapped.cs
@@ -9,7 +9,6 @@
 namespace System.Threading
 {
     [System.CLSCompliantAttribute(false)]
-    [System.Security.SecurityCriticalAttribute]
     public unsafe delegate void IOCompletionCallback(uint errorCode, uint numBytes, System.Threading.NativeOverlapped* pOVERLAP);
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct NativeOverlapped

--- a/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilder.cs
+++ b/src/System.Threading.Tasks.Extensions/src/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilder.cs
@@ -93,7 +93,6 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="TStateMachine">The type of the state machine.</typeparam>
         /// <param name="awaiter">the awaiter</param>
         /// <param name="stateMachine">The state machine.</param>
-        [SecuritySafeCritical]
         public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
             where TAwaiter : ICriticalNotifyCompletion 
             where TStateMachine : IAsyncStateMachine

--- a/src/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelETWProvider.cs
+++ b/src/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelETWProvider.cs
@@ -98,7 +98,6 @@ namespace System.Threading.Tasks
         /// <param name="OperationType">The kind of fork/join operation.</param>
         /// <param name="InclusiveFrom">The lower bound of the loop.</param>
         /// <param name="ExclusiveTo">The upper bound of the loop.</param>
-        [SecuritySafeCritical]
         [Event(PARALLELLOOPBEGIN_ID, Level = EventLevel.Informational, Task = ParallelEtwProvider.Tasks.Loop, Opcode = EventOpcode.Start)]
         public void ParallelLoopBegin(Int32 OriginatingTaskSchedulerID, Int32 OriginatingTaskID,      // PFX_COMMON_EVENT_HEADER
                                       Int32 ForkJoinContextID, ForkJoinOperationType OperationType, // PFX_FORKJOIN_COMMON_EVENT_HEADER
@@ -141,7 +140,6 @@ namespace System.Threading.Tasks
         /// <param name="OriginatingTaskID">The task ID.</param>
         /// <param name="ForkJoinContextID">The loop ID.</param>
         /// <param name="TotalIterations">the total number of iterations processed.</param>
-        [SecuritySafeCritical]
         [Event(PARALLELLOOPEND_ID, Level = EventLevel.Informational, Task = ParallelEtwProvider.Tasks.Loop, Opcode = EventOpcode.Stop)]
         public void ParallelLoopEnd(Int32 OriginatingTaskSchedulerID, Int32 OriginatingTaskID,  // PFX_COMMON_EVENT_HEADER
                                     Int32 ForkJoinContextID, Int64 TotalIterations)
@@ -177,7 +175,6 @@ namespace System.Threading.Tasks
         /// <param name="ForkJoinContextID">The invoke ID.</param>
         /// <param name="OperationType">The kind of fork/join operation.</param>
         /// <param name="ActionCount">The number of actions being invoked.</param>
-        [SecuritySafeCritical]
         [Event(PARALLELINVOKEBEGIN_ID, Level = EventLevel.Informational, Task = ParallelEtwProvider.Tasks.Invoke, Opcode = EventOpcode.Start)]
         public void ParallelInvokeBegin(Int32 OriginatingTaskSchedulerID, Int32 OriginatingTaskID,      // PFX_COMMON_EVENT_HEADER
                                         Int32 ForkJoinContextID, ForkJoinOperationType OperationType, // PFX_FORKJOIN_COMMON_EVENT_HEADER

--- a/src/System.Threading.Tasks.Parallel/tests/ParallelForTests.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/ParallelForTests.cs
@@ -1250,25 +1250,21 @@ namespace System.Threading.Tasks.Tests
         // Used for parallel scheduler tests
         public class ParallelTestsScheduler : TaskScheduler
         {
-            [SecurityCritical]
             protected override void QueueTask(Task task)
             {
                 Task.Run(() => TryExecuteTaskWrapper(task));
             }
 
-            [SecuritySafeCritical]
             private void TryExecuteTaskWrapper(Task task)
             {
                 TryExecuteTask(task);
             }
 
-            [SecurityCritical]
             protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
             {
                 return TryExecuteTask(task);
             }
 
-            [SecurityCritical]
             protected override IEnumerable<Task> GetScheduledTasks()
             {
                 return null;

--- a/src/System.Threading.Tasks/tests/CESchedulerPairTests.cs
+++ b/src/System.Threading.Tasks/tests/CESchedulerPairTests.cs
@@ -36,7 +36,6 @@ namespace System.Threading.Tasks.Tests
         }
 
 
-        [SecurityCritical]
         protected override void QueueTask(Task task)
         {
             if (task == null) throw new ArgumentNullException("When reqeusting to QueueTask, the input task can not be null");
@@ -52,13 +51,11 @@ namespace System.Threading.Tasks.Tests
             }, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
         }
 
-        [SecuritySafeCritical] //This has to be SecuritySafeCritical since its accesses TaskScheduler.TryExecuteTask (which is safecritical)
         private void ExecuteTask(Task task)
         {
             base.TryExecuteTask(task);
         }
 
-        [SecurityCritical]
         protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
         {
             if (taskWasPreviouslyQueued) return false;
@@ -72,7 +69,6 @@ namespace System.Threading.Tasks.Tests
         //	set;
         //}
 
-        [SecurityCritical]
         protected override IEnumerable<Task> GetScheduledTasks() { return null; }
         private Object _lockObj = new Object();
         private int _counter = 1; //This is used ot keep track of how many scheduler tasks were created

--- a/src/System.Threading.Tasks/tests/Task/TaskRunSyncTests.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskRunSyncTests.cs
@@ -89,13 +89,11 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [SecuritySafeCritical]
         private bool ExecuteTask(Task task)
         {
             return TryExecuteTask(task);
         }
 
-        [SecurityCritical]
         protected override void QueueTask(Task task)
         {
             _tasks.Add(task);
@@ -109,7 +107,6 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [SecurityCritical]
         protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
         {
             RunSyncCalledCount++;
@@ -128,7 +125,6 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [SecurityCritical]
         protected override IEnumerable<Task> GetScheduledTasks()
         {
             return _tasks;

--- a/src/System.Threading.Tasks/tests/TaskScheduler/TaskSchedulerTests.cs
+++ b/src/System.Threading.Tasks/tests/TaskScheduler/TaskSchedulerTests.cs
@@ -336,13 +336,11 @@ namespace System.Threading.Tasks.Tests
 
         // Buggy task scheduler to make sure that we handle QueueTask()/TryExecuteTaskInline()
         // exceptions correctly.  Used in RunBuggySchedulerTests() below.
-        [SecuritySafeCritical]
         public class BuggyTaskScheduler : TaskScheduler
         {
             private readonly ConcurrentQueue<Task> _tasks = new ConcurrentQueue<Task>();
 
             private bool _faultQueues;
-            [SecurityCritical]
             protected override void QueueTask(Task task)
             {
                 if (_faultQueues)
@@ -351,13 +349,11 @@ namespace System.Threading.Tasks.Tests
                 _tasks.Enqueue(task);
             }
 
-            [SecurityCritical]
             protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
             {
                 throw new ArgumentException("I am your worst nightmare!");
             }
 
-            [SecurityCritical]
             protected override IEnumerable<Task> GetScheduledTasks()
             {
                 return _tasks;

--- a/src/System.Threading.ThreadPool/ref/System.Threading.ThreadPool.cs
+++ b/src/System.Threading.ThreadPool/ref/System.Threading.ThreadPool.cs
@@ -17,7 +17,6 @@ namespace System.Threading
     {
         [System.ObsoleteAttribute("ThreadPool.BindHandle(IntPtr) has been deprecated.  Please use ThreadPool.BindHandle(SafeHandle) instead.", false)]
         public static bool BindHandle(System.IntPtr osHandle) { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         public static bool BindHandle(System.Runtime.InteropServices.SafeHandle osHandle) { throw null; }
         public static void GetAvailableThreads(out int workerThreads, out int completionPortThreads) { throw null; }
         public static void GetMaxThreads(out int workerThreads, out int completionPortThreads) { throw null; }

--- a/src/System.Threading/ref/System.Threading.cs
+++ b/src/System.Threading/ref/System.Threading.cs
@@ -33,7 +33,6 @@ namespace System.Threading
     public sealed partial class AsyncLocal<T>
     {
         public AsyncLocal() { }
-        [System.Security.SecurityCriticalAttribute]
         public AsyncLocal(System.Action<System.Threading.AsyncLocalValueChangedArgs<T>> valueChangedHandler) { }
         public T Value { get { throw null; } set { } }
     }
@@ -109,15 +108,11 @@ namespace System.Threading
     public partial class EventWaitHandle : System.Threading.WaitHandle
     {
         public EventWaitHandle(bool initialState, System.Threading.EventResetMode mode) { }
-        [System.Security.SecurityCriticalAttribute]
         public EventWaitHandle(bool initialState, System.Threading.EventResetMode mode, string name) { }
-        [System.Security.SecurityCriticalAttribute]
         public EventWaitHandle(bool initialState, System.Threading.EventResetMode mode, string name, out bool createdNew) { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         public static System.Threading.EventWaitHandle OpenExisting(string name) { throw null; }
         public bool Reset() { throw null; }
         public bool Set() { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         public static bool TryOpenExisting(string name, out System.Threading.EventWaitHandle result) { throw null; }
     }
     public sealed partial class ExecutionContext : System.IDisposable, System.Runtime.Serialization.ISerializable
@@ -247,14 +242,10 @@ namespace System.Threading
     {
         public Mutex() { }
         public Mutex(bool initiallyOwned) { }
-        [System.Security.SecurityCriticalAttribute]
         public Mutex(bool initiallyOwned, string name) { }
-        [System.Security.SecurityCriticalAttribute]
         public Mutex(bool initiallyOwned, string name, out bool createdNew) { throw null; }
-        [System.Security.SecurityCriticalAttribute]
         public static System.Threading.Mutex OpenExisting(string name) { throw null; }
         public void ReleaseMutex() { }
-        [System.Security.SecurityCriticalAttribute]
         public static bool TryOpenExisting(string name, out System.Threading.Mutex result) { throw null; }
     }
     public sealed partial class ReaderWriterLock : System.Runtime.ConstrainedExecution.CriticalFinalizerObject

--- a/src/System.Threading/src/System/Threading/Barrier.cs
+++ b/src/System.Threading/src/System/Threading/Barrier.cs
@@ -132,7 +132,6 @@ namespace System.Threading
         private ExecutionContext _ownerThreadContext;
 
         // The EC callback that invokes the post phase action
-        [SecurityCritical]
         private static ContextCallback s_invokePostPhaseAction;
 
         // Post phase action after each phase
@@ -755,7 +754,6 @@ namespace System.Threading
         /// last arrival thread
         /// </summary>
         /// <param name="observedSense">The current phase sense</param>
-        [SecuritySafeCritical]
         private void FinishPhase(bool observedSense)
         {
             // Execute the PHA in try/finally block to reset the variables back in case of it threw an exception
@@ -805,7 +803,6 @@ namespace System.Threading
         /// Helper method to call the post phase action
         /// </summary>
         /// <param name="obj"></param>
-        [SecurityCritical]
         private static void InvokePostPhaseAction(object obj)
         {
             var thisBarrier = (Barrier)obj;

--- a/src/System.Threading/src/System/Threading/CDSsyncETWBCLProvider.cs
+++ b/src/System.Threading/src/System/Threading/CDSsyncETWBCLProvider.cs
@@ -87,7 +87,6 @@ namespace System.Threading
         // Barrier Events
         //
 
-        [SecuritySafeCritical]
         [Event(BARRIER_PHASEFINISHED_ID, Level = EventLevel.Verbose, Version = 1)]
         public void Barrier_PhaseFinished(bool currentSense, long phaseNum)
         {


### PR DESCRIPTION
They don't have any function in Core.

Stripped via regex:

```
^.*\[(System\.Security\.)?Security(Safe)?Critical(Attribute)?\](\s*//.*|\s*)$[\r\n]*
```

related to https://github.com/dotnet/coreclr/pull/8571