### PR TITLE
Fix Newline bug in Xsl tests

### DIFF
--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltApiV2.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltApiV2.cs
@@ -601,7 +601,7 @@ namespace System.Xml.Tests
         public void VerifyResult(string expectedValue)
         {
             XmlDiff.XmlDiff xmldiff = new XmlDiff.XmlDiff();
-            xmldiff.Option = XmlDiffOption.InfosetComparison | XmlDiffOption.IgnoreEmptyElement;
+            xmldiff.Option = XmlDiffOption.InfosetComparison | XmlDiffOption.IgnoreEmptyElement | XmlDiffOption.NormalizeNewline;
 
             StreamReader sr = new StreamReader(new FileStream("out.xml", FileMode.Open, FileAccess.Read));
             string actualValue = sr.ReadToEnd();
@@ -633,7 +633,7 @@ namespace System.Xml.Tests
             baseline = FullFilePath(baseline);
 
             XmlDiff.XmlDiff diff = new XmlDiff.XmlDiff();
-            diff.Option = XmlDiffOption.IgnoreEmptyElement | XmlDiffOption.IgnoreAttributeOrder | XmlDiffOption.InfosetComparison | XmlDiffOption.IgnoreWhitespace;
+            diff.Option = XmlDiffOption.IgnoreEmptyElement | XmlDiffOption.IgnoreAttributeOrder | XmlDiffOption.InfosetComparison | XmlDiffOption.IgnoreWhitespace | XmlDiffOption.NormalizeNewline;
             XmlParserContext context = new XmlParserContext(new NameTable(), null, "", XmlSpace.None);
 
             fsExpected = new FileStream(baseline, FileMode.Open, FileAccess.Read, FileShare.Read);


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/14146, https://github.com/dotnet/corefx/issues/14148, and https://github.com/dotnet/corefx/issues/14147

I was not able to repro the failures locally even after building against local packages (as instructed [here](https://github.com/dotnet/corefx/blob/master/Documentation/building/build-tests-against-packages.md)). But after looking at the helix test result xml output I'm pretty sure these are caused by new line differences on unix and windows (`\r\n` vs. `\n`)

cc: @danmosemsft @stephentoub @joperezr 