### PR TITLE
Validate against unreadable arrays in Expression.ArrayLength

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -853,7 +853,7 @@ namespace System.Linq.Expressions
         /// <paramref name="array"/>.Type does not represent an array type.</exception>
         public static UnaryExpression ArrayLength(Expression array)
         {
-            ContractUtils.RequiresNotNull(array, nameof(array));
+            RequiresCanRead(array, nameof(array));
             if (!array.Type.IsArray || !typeof(Array).IsAssignableFrom(array.Type))
             {
                 throw Error.ArgumentMustBeArray(nameof(array));

--- a/src/System.Linq.Expressions/tests/Array/ArrayArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayArrayIndexTests.cs
@@ -2669,5 +2669,61 @@ namespace System.Linq.Expressions.Tests
         }
 
         #endregion
+
+        [Fact]
+        public static void ArrayIndexNotArray()
+        {
+            Expression intExp = Expression.Constant(1);
+            Assert.Throws<ArgumentException>("array", () => Expression.ArrayIndex(intExp, intExp, intExp));
+            Assert.Throws<ArgumentException>("array", () => Expression.ArrayIndex(intExp, Enumerable.Repeat(intExp, 1)));
+        }
+
+        [Fact]
+        public static void ArrayIndexNullArray()
+        {
+            Assert.Throws<ArgumentNullException>("array", () => Expression.ArrayIndex(null));
+            Assert.Throws<ArgumentNullException>(
+                "array", () => Expression.ArrayIndex(null, Enumerable.Empty<Expression>()));
+        }
+
+        [Fact]
+        public static void ArrayIndexNullIndices()
+        {
+            Expression array = Expression.Constant(new[,] { { 1, 2 }, { 2, 1 } });
+            Assert.Throws<ArgumentNullException>("indexes", () => Expression.ArrayIndex(array, default(Expression[])));
+            Assert.Throws<ArgumentNullException>("indexes[1]",
+                () => Expression.ArrayIndex(array, Expression.Constant(1), null));
+        }
+
+        [Fact]
+        public static void ArrayIndexWrongRank()
+        {
+            Expression array = Expression.Constant(new[,] { { 1, 2 }, { 2, 1 } });
+            Assert.Throws<ArgumentException>(null, () => Expression.ArrayIndex(array, new[] { Expression.Constant(2) }));
+            Assert.Throws<ArgumentException>(null, () =>
+                Expression.ArrayIndex(array, Expression.Constant(2), Expression.Constant(1), Expression.Constant(2)));
+        }
+
+        [Fact]
+        public static void ArrayIndexWrongType()
+        {
+            Expression array = Expression.Constant(new[,] { { 1, 2 }, { 2, 1 } });
+            Assert.Throws<ArgumentException>("indexes[0]", () => Expression.ArrayIndex(array, Expression.Constant(2L), Expression.Constant(1)));
+        }
+
+        [Fact]
+        public static void UnreadableArray()
+        {
+            Expression array = Expression.Property(null, typeof(Unreadable<int[,]>), nameof(Unreadable<int[,]>.WriteOnly));
+            Assert.Throws<ArgumentException>("array", () => Expression.ArrayIndex(array, Expression.Constant(0), Expression.Constant(0)));
+        }
+
+        [Fact]
+        public static void UnreadableIndex()
+        {
+            Expression array = Expression.Constant(new[,] { { 1, 2 }, { 2, 1 } });
+            Expression index = Expression.Property(null, typeof(Unreadable<int>), nameof(Unreadable<int>.WriteOnly));
+            Assert.Throws<ArgumentException>("indexes[0]", () => Expression.ArrayIndex(array, index, index));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
@@ -2720,5 +2720,54 @@ namespace System.Linq.Expressions.Tests
         }
 
         #endregion
+
+        [Fact]
+        public static void ArrayIndexNotArray()
+        {
+            Expression intExp = Expression.Constant(1);
+            Assert.Throws<ArgumentException>("array", () => Expression.ArrayIndex(intExp, intExp));
+        }
+
+        [Fact]
+        public static void ArrayIndexNullArray()
+        {
+            Assert.Throws<ArgumentNullException>("array", () => Expression.ArrayIndex(null, Expression.Constant(0)));
+        }
+
+        [Fact]
+        public static void ArrayIndexNullIndices()
+        {
+            Expression array = Expression.Constant(new[] {1, 2});
+            Assert.Throws<ArgumentNullException>("index", () => Expression.ArrayIndex(array, default(Expression)));
+        }
+
+        [Fact]
+        public static void ArrayIndexWrongRank()
+        {
+            Expression array = Expression.Constant(new[,] { { 1, 2 }, { 2, 1 } });
+            Assert.Throws<ArgumentException>(null, () => Expression.ArrayIndex(array, Expression.Constant(2)));
+        }
+
+        [Fact]
+        public static void ArrayIndexWrongType()
+        {
+            Expression array = Expression.Constant(new[] {1, 2});
+            Assert.Throws<ArgumentException>("index", () => Expression.ArrayIndex(array, Expression.Constant(2L)));
+        }
+
+        [Fact]
+        public static void UnreadableArray()
+        {
+            Expression array = Expression.Property(null, typeof(Unreadable<int[]>), nameof(Unreadable<int>.WriteOnly));
+            Assert.Throws<ArgumentException>(() => Expression.ArrayIndex(array, Expression.Constant(0)));
+        }
+
+        [Fact]
+        public static void UnreadableIndex()
+        {
+            Expression array = Expression.Constant(new[]  { 1, 2 });
+            Expression index = Expression.Property(null, typeof(Unreadable<int>), nameof(Unreadable<int>.WriteOnly));
+            Assert.Throws<ArgumentException>("index", () => Expression.ArrayIndex(array, index));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
@@ -1566,5 +1566,34 @@ namespace System.Linq.Expressions.Tests
         }
 
         #endregion
+
+        [Fact]
+        public static void NullArray()
+        {
+            Assert.Throws<ArgumentNullException>("array", () => Expression.ArrayLength(null));
+        }
+
+        [Fact]
+        public static void IsNotArray()
+        {
+            Expression notArray = Expression.Constant(8);
+            Assert.Throws<ArgumentException>("array", () => Expression.ArrayLength(notArray));
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ArrayTypeArrayAllowed(bool useInterpreter)
+        {
+            Array arr = new[] {1, 2, 3};
+            Func<int> func =
+                Expression.Lambda<Func<int>>(Expression.ArrayLength(Expression.Constant(arr))).Compile(useInterpreter);
+            Assert.Equal(3, func());
+        }
+
+        [Fact]
+        public static void UnreadableArray()
+        {
+            Expression array = Expression.Property(null, typeof(Unreadable<int[]>), nameof(Unreadable<int>.WriteOnly));
+            Assert.Throws<ArgumentException>(() => Expression.ArrayLength(array));
+        }
     }
 }


### PR DESCRIPTION
Fixes #14399 

(Further array-expression–related tests too, as that's how this was found).