### PR TITLE
Report publicly-accessible type as type of quote expressions.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -36,6 +36,8 @@ namespace System.Linq.Expressions
 
         internal abstract Type TypeCore { get; }
 
+        internal abstract Type PublicType { get; }
+
         /// <summary>
         /// Returns the node type of this <see cref="Expression"/>. (Inherited from <see cref="Expression"/>.)
         /// </summary>
@@ -167,6 +169,8 @@ namespace System.Linq.Expressions
         }
 
         internal sealed override Type TypeCore => typeof(TDelegate);
+
+        internal override Type PublicType => typeof(Expression<TDelegate>);
 
         /// <summary>
         /// Produces a delegate that represents the lambda expression.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -873,9 +873,13 @@ namespace System.Linq.Expressions
         public static UnaryExpression Quote(Expression expression)
         {
             RequiresCanRead(expression, nameof(expression));
-            bool validQuote = expression is LambdaExpression;
-            if (!validQuote) throw Error.QuotedExpressionMustBeLambda(nameof(expression));
-            return new UnaryExpression(ExpressionType.Quote, expression, expression.GetType(), null);
+            LambdaExpression lambda = expression as LambdaExpression;
+            if (lambda == null)
+            {
+                throw Error.QuotedExpressionMustBeLambda(nameof(expression));
+            }
+
+            return new UnaryExpression(ExpressionType.Quote, lambda, lambda.PublicType, null);
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/tests/Unary/UnaryQuoteTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryQuoteTests.cs
@@ -464,6 +464,38 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(4, vars[1]);
         }
 
+        [Fact]
+        public void NullLambda()
+        {
+            Assert.Throws<ArgumentNullException>("expression", () => Quote(null));
+        }
+
+        [Fact]
+        public void QuoteNonLamdba()
+        {
+            Func<int> zero = () => 0;
+            Expression funcConst = Constant(zero);
+            Assert.Throws<ArgumentException>("expression", () => Quote(funcConst));
+        }
+
+        [Fact]
+        public void CannotReduce()
+        {
+            Expression<Func<int>> exp = () => 2;
+            Expression q = Expression.Quote(exp);
+            Assert.False(q.CanReduce);
+            Assert.Same(q, q.Reduce());
+            Assert.Throws<ArgumentException>(() => q.ReduceAndCheck());
+        }
+
+        [Fact]
+        public void TypeExplicitWithGeneralLambdaArgument()
+        {
+            LambdaExpression lambda = Lambda(Constant(2));
+            Expression q = Quote(lambda);
+            Assert.Equal(typeof(Expression<Func<int>>), q.Type);
+        }
+
         private void AssertIsBox<T>(Expression expression, T value, bool isInterpreted)
         {
             if (isInterpreted)


### PR DESCRIPTION
E.g. return  `typeof(Expression<System.Func<int>>)` not `typeof(Expression0<System.Func<int>>)`

Fixes #14404