### PR TITLE
Change error message for Expression.ArrayLength to be more accurate.

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -280,7 +280,7 @@
     <value>Argument for array index must be of type Int32</value>
   </data>
   <data name="ArgumentMustBeSingleDimensionalArrayType" xml:space="preserve">
-    <value>Argument must be single dimensional array type</value>
+    <value>Argument must be single-dimensional, zero-based array type</value>
   </data>
   <data name="ArgumentTypesMustMatch" xml:space="preserve">
     <value>Argument types do not match</value>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -562,7 +562,7 @@ namespace System.Linq.Expressions
             return ArgumentMustBeArrayIndexType(GetParamName(paramName, index));
         }
         /// <summary>
-        /// ArgumentException with message like "Argument must be single dimensional array type"
+        /// ArgumentException with message like "Argument must be single-dimensional, zero-based array type"
         /// </summary>
         internal static Exception ArgumentMustBeSingleDimensionalArrayType(string paramName)
         {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -365,7 +365,7 @@ namespace System.Linq.Expressions
         internal static string ArgumentMustBeArrayIndexType => SR.ArgumentMustBeArrayIndexType;
 
         /// <summary>
-        /// A string like "Argument must be single dimensional array type"
+        /// A string like "Argument must be single-dimensional, zero-based array type"
         /// </summary>
         internal static string ArgumentMustBeSingleDimensionalArrayType => SR.ArgumentMustBeSingleDimensionalArrayType;
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -844,13 +844,13 @@ namespace System.Linq.Expressions
             return GetMethodBasedCoercionOperator(ExpressionType.ConvertChecked, expression, type, method);
         }
 
-        /// <summary>Creates a <see cref="UnaryExpression"/> that represents getting the length of a one-dimensional array.</summary>
+        /// <summary>Creates a <see cref="UnaryExpression"/> that represents getting the length of a one-dimensional, zero-based array.</summary>
         /// <returns>A <see cref="UnaryExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.ArrayLength"/> and the <see cref="UnaryExpression.Operand"/> property equal to <paramref name="array"/>.</returns>
         /// <param name="array">An <see cref="Expression"/> to set the <see cref="UnaryExpression.Operand"/> property equal to.</param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="array"/> is null.</exception>
         /// <exception cref="ArgumentException">
-        /// <paramref name="array"/>.Type does not represent an array type.</exception>
+        /// <paramref name="array"/>.Type does not represent a single-dimensional, zero-based array type.</exception>
         public static UnaryExpression ArrayLength(Expression array)
         {
             ContractUtils.RequiresNotNull(array, nameof(array));


### PR DESCRIPTION
Update XML documentation as well.

Fixes #14406.