### PR TITLE
Improving System.Linq.Intersect with no comparer.

### DIFF
--- a/src/System.Linq/src/System/Linq/Intersect.cs
+++ b/src/System.Linq/src/System/Linq/Intersect.cs
@@ -19,7 +19,12 @@ namespace System.Linq
             {
                 throw Error.ArgumentNull(nameof(second));
             }
-           
+            
+            return IntersectIteratorNoComparer(first, second);          
+        }
+        
+        private static IEnumerable<TSource> IntersectIteratorNoComparer<TSource>(IEnumerable<TSource> first, IEnumerable<TSource> second)
+        {
             IEnumerable<TSource> first2 = first.Distinct();
             IEnumerable<TSource> second2 = second.Distinct();
             
@@ -29,9 +34,9 @@ namespace System.Linq
                 {
                     yield return element;
                 }
-            }
+            }            
         }
-
+        
         public static IEnumerable<TSource> Intersect<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource> comparer)
         {
             if (first == null)

--- a/src/System.Linq/src/System/Linq/Intersect.cs
+++ b/src/System.Linq/src/System/Linq/Intersect.cs
@@ -20,23 +20,12 @@ namespace System.Linq
                 throw Error.ArgumentNull(nameof(second));
             }
            
-            IEnumerable<TSource> big = null;
-            IEnumerable<TSource> small = null;
-
-            if (first.Count() > second.Count())
+            IEnumerable<TSource> first2 = first.Distinct();
+            IEnumerable<TSource> second2 = second.Distinct();
+            
+            foreach (TSource element in first2)
             {
-                big = first.Distinct();
-                small = second.Distinct();
-            }
-            else
-            {
-                big = second.Distinct();
-                small = first.Distinct();
-            }
-
-            foreach (TSource element in big)
-            {
-                if (small.Contains(element))
+                if (second2.Contains(element))
                 {
                     yield return element;
                 }

--- a/src/System.Linq/src/System/Linq/Intersect.cs
+++ b/src/System.Linq/src/System/Linq/Intersect.cs
@@ -19,8 +19,14 @@ namespace System.Linq
             {
                 throw Error.ArgumentNull(nameof(second));
             }
-
-            return IntersectIterator(first, second, null);
+           
+            foreach (TSource element in first)
+            {
+                if (second.Contains(element))
+                {
+                    yield return element;
+                }
+            }
         }
 
         public static IEnumerable<TSource> Intersect<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource> comparer)

--- a/src/System.Linq/src/System/Linq/Intersect.cs
+++ b/src/System.Linq/src/System/Linq/Intersect.cs
@@ -20,9 +20,12 @@ namespace System.Linq
                 throw Error.ArgumentNull(nameof(second));
             }
            
-            foreach (TSource element in first)
+            var first2 = first.Distinct();
+            var second2 = second.Distinct();
+
+            foreach (TSource element in first2)
             {
-                if (second.Contains(element))
+                if (second2.Contains(element))
                 {
                     yield return element;
                 }

--- a/src/System.Linq/src/System/Linq/Intersect.cs
+++ b/src/System.Linq/src/System/Linq/Intersect.cs
@@ -20,12 +20,23 @@ namespace System.Linq
                 throw Error.ArgumentNull(nameof(second));
             }
            
-            var first2 = first.Distinct();
-            var second2 = second.Distinct();
+            IEnumerable<TSource> big = null;
+            IEnumerable<TSource> small = null;
 
-            foreach (TSource element in first2)
+            if (first.Count() > second.Count())
             {
-                if (second2.Contains(element))
+                big = first.Distinct();
+                small = second.Distinct();
+            }
+            else
+            {
+                big = second.Distinct();
+                small = first.Distinct();
+            }
+
+            foreach (TSource element in big)
+            {
+                if (small.Contains(element))
                 {
                     yield return element;
                 }


### PR DESCRIPTION
The `Intersect` overload not taking a `IEqualityComparer<TSource> comparer` argument is unnecessarily slow because of calling `IntersectIterator`, whose algorithm is mostly meant to deal with a non-null `comparer`. 

The proposed modification relies on `Contains` and shows a noticeable performance improvement. Below these lines I am including a simplistic testing code where, under my specific conditions, `Intersect2` (i.e., the proposed modification) is systematically 40% quicker.

UPDATE: as rightly pointed out via comments, the original test didn't account for the iterator peculiarities (e.g., being called from a `forearch` loop) where the new approach doesn't perform too well (some times better, even notably better; but not always as shown in the updated code below these lines).

```C#
using System;
using System.Collections.Generic;
using System.Diagnostics;
using System.Linq;

namespace TestIntersect
{
    static class Program
    {
        public delegate IEnumerable<TSource> target<TSource>(IEnumerable<TSource> first, IEnumerable<TSource> second);
        public static void Main(string[] args)
        {
            int count = 0;
            int maxCount = 1000;
            int maxItems = 50000;

            List<string> first = new List<string>()
            {
                "abcd", "mdddfg", "bbbbbbb", "999999999", "identical"
            };

            List<string> second = new List<string>()
            {
                "abcd", "123456789", "bbbbbbb", "1255555", "identical"
            };

            while (count < maxItems)
            {
                count++;
                first.Add("13456");
                first.Add("dd");
                first.Add("abceeee");
                first.Add("99999");
                second.Add("93456");
                second.Add("a");
                second.Add("abceeee");
                second.Add("5555");
            };

            target<string>[] targets = new target<string>[] { Intersect, Intersect2 };
            string[] captions = new string[]{ "Original", "New" };
            bool[] iteratorNots = new bool[] { false, true, true, false };

            foreach (bool iteratorNot in iteratorNots)
            {
                for (int i = 0; i < captions.Length; i++)
                {
                    Test(maxCount, targets[i], first, second, captions[i], iteratorNot);
                }
            }

            Console.ReadLine();
        }

        public static void Test(int maxCount, target<string> target, IEnumerable<string> first, IEnumerable<string> second, string caption, bool testIterator)
        {
            Stopwatch sw = new Stopwatch();
            sw.Start();
            if (testIterator) TestIterator(maxCount, target, first, second);
            else TestReturnedCollection(maxCount, target, first, second);
            sw.Stop();

            caption += " " + (testIterator ? "Iterator" : "ReturnedCollection") + " ";

            Console.WriteLine(caption + sw.ElapsedMilliseconds.ToString());
        }

        public static void TestIterator(int maxCount, target<string> target, IEnumerable<string> first, IEnumerable<string> second)
        {
            int count = 0;
            while (count < maxCount)
            {
                count++;
                foreach (var item in target(first, second)) { }
            }
        }

        public static void TestReturnedCollection(int maxCount, target<string> target, IEnumerable<string> first, IEnumerable<string> second)
        {
            int count = 0;
            while (count < maxCount)
            {
                count++;
                target(first, second);
            }
        }

        public static IEnumerable<TSource> Intersect<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second)
        {
            if (first == null)
            {
                throw new Exception();
            }

            if (second == null)
            {
                throw new Exception();
            }

            return IntersectIterator(first, second, null);
        }

        public static IEnumerable<TSource> Intersect2<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second)
        {
            if (first == null)
            {
                throw new Exception();
            }

            if (second == null)
            {
                throw new Exception();
            }

            IEnumerable<TSource> first2 = first.Distinct();
            IEnumerable<TSource> second2 = second.Distinct();

            foreach (TSource element in first2)
            {
                if (second2.Contains(element))
                {
                    yield return element;
                }
            }
        }

        private static IEnumerable<TSource> IntersectIterator<TSource>(IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource> comparer)
        {
            Set<TSource> set = new Set<TSource>(comparer);
            foreach (TSource element in second)
            {
                set.Add(element);
            }

            foreach (TSource element in first)
            {
                if (set.Remove(element))
                {
                    yield return element;
                }
            }
        }
    }

    internal sealed class Set<TElement>
    {
        private readonly IEqualityComparer<TElement> _comparer;
        private int[] _buckets;
        private Slot[] _slots;
        private int _count;

        public Set(IEqualityComparer<TElement> comparer)
        {
            _comparer = comparer ?? EqualityComparer<TElement>.Default;
            _buckets = new int[7];
            _slots = new Slot[7];
        }

        // If value is not in set, add it and return true; otherwise return false
        public bool Add(TElement value)
        {
            int hashCode = InternalGetHashCode(value);
            for (int i = _buckets[hashCode % _buckets.Length] - 1; i >= 0; i = _slots[i]._next)
            {
                if (_slots[i]._hashCode == hashCode && _comparer.Equals(_slots[i]._value, value))
                {
                    return false;
                }
            }

            if (_count == _slots.Length)
            {
                Resize();
            }

            int index = _count;
            _count++;
            int bucket = hashCode % _buckets.Length;
            _slots[index]._hashCode = hashCode;
            _slots[index]._value = value;
            _slots[index]._next = _buckets[bucket] - 1;
            _buckets[bucket] = index + 1;
            return true;
        }

        // If value is in set, remove it and return true; otherwise return false
        public bool Remove(TElement value)
        {
            int hashCode = InternalGetHashCode(value);
            int bucket = hashCode % _buckets.Length;
            int last = -1;
            for (int i = _buckets[bucket] - 1; i >= 0; last = i, i = _slots[i]._next)
            {
                if (_slots[i]._hashCode == hashCode && _comparer.Equals(_slots[i]._value, value))
                {
                    if (last < 0)
                    {
                        _buckets[bucket] = _slots[i]._next + 1;
                    }
                    else
                    {
                        _slots[last]._next = _slots[i]._next;
                    }

                    _slots[i]._hashCode = -1;
                    _slots[i]._value = default(TElement);
                    _slots[i]._next = -1;
                    return true;
                }
            }

            return false;
        }

        private void Resize()
        {
            int newSize = checked((_count * 2) + 1);
            int[] newBuckets = new int[newSize];
            Slot[] newSlots = new Slot[newSize];
            Array.Copy(_slots, 0, newSlots, 0, _count);
            for (int i = 0; i < _count; i++)
            {
                int bucket = newSlots[i]._hashCode % newSize;
                newSlots[i]._next = newBuckets[bucket] - 1;
                newBuckets[bucket] = i + 1;
            }

            _buckets = newBuckets;
            _slots = newSlots;
        }

        internal TElement[] ToArray()
        {
            TElement[] array = new TElement[_count];
            for (int i = 0; i != array.Length; ++i)
            {
                array[i] = _slots[i]._value;
            }

            return array;
        }

        internal List<TElement> ToList()
        {
            int count = _count;
            List<TElement> list = new List<TElement>(count);
            for (int i = 0; i != count; ++i)
            {
                list.Add(_slots[i]._value);
            }

            return list;
        }

        internal int Count
        {
            get { return _count; }
        }

        internal int InternalGetHashCode(TElement value)
        {
            // Handle comparer implementations that throw when passed null
            return (value == null) ? 0 : _comparer.GetHashCode(value) & 0x7FFFFFFF;
        }

        internal struct Slot
        {
            internal int _hashCode;
            internal int _next;
            internal TElement _value;
        }
    }
}
```
