### PR TITLE
Make GetEnvironmentVariables more compatible

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Environment.Win32.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Win32.Unix.cs
@@ -4,6 +4,7 @@
 
 using Internal.Runtime.Augments;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace System
 {
@@ -21,12 +22,19 @@ namespace System
 
         public static IDictionary GetEnvironmentVariables()
         {
-            return EnvironmentAugments.GetEnvironmentVariables();
+            // To maintain complete compatibility with prior versions we need to return a Hashtable.
+            // We did ship a prior version of Core with LowLevelDictionary, which does iterate the
+            // same (e.g. yields DictionaryEntry), but it is not a public type.
+            //
+            // While we could pass Hashtable back from CoreCLR the type is also defined here. We only
+            // want to surface the local Hashtable.
+            return new Hashtable(EnvironmentAugments.GetEnvironmentVariables());
         }
 
         public static IDictionary GetEnvironmentVariables(EnvironmentVariableTarget target)
         {
-            return EnvironmentAugments.GetEnvironmentVariables(target);
+            // See comments in GetEnvironmentVariables()
+            return new Hashtable(EnvironmentAugments.GetEnvironmentVariables(target));
         }
 
         public static void SetEnvironmentVariable(string variable, string value)

--- a/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
@@ -136,7 +136,7 @@ namespace System.Tests
 
         public void EnumerateYieldsDictionaryEntryFromIEnumerable()
         {
-            // GetEnvrionmentVariables has always yielded DictionaryEntry from IEnumerable
+            // GetEnvironmentVariables has always yielded DictionaryEntry from IEnumerable
             IDictionary vars = Environment.GetEnvironmentVariables();
             IEnumerator enumerator = ((IEnumerable)vars).GetEnumerator();
             if (enumerator.MoveNext())
@@ -170,7 +170,7 @@ namespace System.Tests
         [InlineData(EnvironmentVariableTarget.User)]
         public void EnumerateYieldsDictionaryEntryFromIEnumerable(EnvironmentVariableTarget target)
         {
-            // GetEnvrionmentVariables has always yielded DictionaryEntry from IEnumerable
+            // GetEnvironmentVariables has always yielded DictionaryEntry from IEnumerable
             IDictionary vars = Environment.GetEnvironmentVariables(target);
             IEnumerator enumerator = ((IEnumerable)vars).GetEnumerator();
             if (enumerator.MoveNext())

--- a/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
@@ -134,8 +134,55 @@ namespace System.Tests
             }
         }
 
+        public void EnumerateYieldsDictionaryEntryFromIEnumerable()
+        {
+            // GetEnvrionmentVariables has always yielded DictionaryEntry from IEnumerable
+            IDictionary vars = Environment.GetEnvironmentVariables();
+            IEnumerator enumerator = ((IEnumerable)vars).GetEnumerator();
+            if (enumerator.MoveNext())
+            {
+                Assert.IsType<DictionaryEntry>(enumerator.Current);
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+            }
+        }
+
 #if netstandard17
-        [ActiveIssue(14417)]
+        public void EnvironmentVariablesAreHashtable()
+        {
+            // On NetFX, the type returned was always Hashtable
+            Assert.IsType<Hashtable>(Environment.GetEnvironmentVariables());
+        }
+
+        [InlineData(EnvironmentVariableTarget.Process)]
+        [InlineData(EnvironmentVariableTarget.Machine)]
+        [InlineData(EnvironmentVariableTarget.User)]
+        public void EnvironmentVariablesAreHashtable(EnvironmentVariableTarget target)
+        {
+            // On NetFX, the type returned was always Hashtable
+            Assert.IsType<Hashtable>(Environment.GetEnvironmentVariables(target));
+        }
+
+        [InlineData(EnvironmentVariableTarget.Process)]
+        [InlineData(EnvironmentVariableTarget.Machine)]
+        [InlineData(EnvironmentVariableTarget.User)]
+        public void EnumerateYieldsDictionaryEntryFromIEnumerable(EnvironmentVariableTarget target)
+        {
+            // GetEnvrionmentVariables has always yielded DictionaryEntry from IEnumerable
+            IDictionary vars = Environment.GetEnvironmentVariables(target);
+            IEnumerator enumerator = ((IEnumerable)vars).GetEnumerator();
+            if (enumerator.MoveNext())
+            {
+                Assert.IsType<DictionaryEntry>(enumerator.Current);
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+            }
+        }
+
         [OuterLoop] // manipulating environment variables broader in scope than the process
         [Theory]
         [InlineData(EnvironmentVariableTarget.Process)]


### PR DESCRIPTION
The legacy APIs returned Hashtable and could only
iterate as DictionaryEntry.

Fixes #14417 

As we're going for compatible it seemed more appropriate to return Hashtable than
low-level dictionary.