### PR TITLE
Revert "Use ArrayPool for multiple buffers in CurlHandler"

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -215,9 +214,6 @@ namespace System.Net.Http
 
                 // Dispose native callback resources
                 _callbackHandle?.Dispose();
-
-                // Release any send transfer state, which will return its buffer to the pool
-                _sendTransferState?.Dispose();
             }
 
             private void SetUrl()
@@ -795,30 +791,20 @@ namespace System.Net.Http
                 throw CreateHttpRequestException(new CurlException((int)CURLcode.CURLE_OUT_OF_MEMORY, isMulti: false));
             }
 
-            internal sealed class SendTransferState : IDisposable
+            internal sealed class SendTransferState
             {
-                internal byte[] _buffer;
+                internal readonly byte[] _buffer;
                 internal int _offset;
                 internal int _count;
                 internal Task<int> _task;
 
-                public SendTransferState(int bufferLength)
+                internal SendTransferState(int bufferLength)
                 {
                     Debug.Assert(bufferLength > 0 && bufferLength <= MaxRequestBufferSize, $"Expected 0 < bufferLength <= {MaxRequestBufferSize}, got {bufferLength}");
-                    _buffer = ArrayPool<byte>.Shared.Rent(bufferLength);
+                    _buffer = new byte[bufferLength];
                 }
 
-                public void Dispose()
-                {
-                    byte[] buffer = _buffer;
-                    if (buffer != null)
-                    {
-                        _buffer = null;
-                        ArrayPool<byte>.Shared.Return(buffer);
-                    }
-                }
-
-                public void SetTaskOffsetCount(Task<int> task, int offset, int count)
+                internal void SetTaskOffsetCount(Task<int> task, int offset, int count)
                 {
                     Debug.Assert(offset >= 0, "Offset should never be negative");
                     Debug.Assert(count >= 0, "Count should never be negative");


### PR DESCRIPTION
Reverts dotnet/corefx#14363

This may be contributing to the PostLongerContentLengths_UsesChunkedSemantics test failing in outerloop on some Linux distros/versions.  Will need to investigate if that's actually the case, why, and fix it later; for now, I'm reverting the change.