### PR TITLE
Ensure the selector gets run during Count.

### DIFF
--- a/src/System.Linq/src/System/Linq/Select.cs
+++ b/src/System.Linq/src/System/Linq/Select.cs
@@ -155,9 +155,38 @@ namespace System.Linq
                 return builder.ToArray();
             }
 
-            public List<TResult> ToList() => new List<TResult>(this);
+            public List<TResult> ToList()
+            {
+                var list = new List<TResult>();
 
-            public int GetCount(bool onlyIfCheap) => onlyIfCheap ? -1 : _source.Count();
+                foreach (TSource item in _source)
+                {
+                    list.Add(_selector(item));
+                }
+
+                return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                if (onlyIfCheap)
+                {
+                    return -1;
+                }
+
+                int count = 0;
+
+                foreach (TSource item in _source)
+                {
+                    _selector(item);
+                    checked
+                    {
+                        count++;
+                    }
+                }
+
+                return count;
+            }
         }
 
         internal sealed class SelectArrayIterator<TSource, TResult> : Iterator<TResult>, IPartition<TResult>
@@ -226,6 +255,14 @@ namespace System.Linq
 
             public int GetCount(bool onlyIfCheap)
             {
+                if (!onlyIfCheap)
+                {
+                    foreach (TSource item in _source)
+                    {
+                        _selector(item);
+                    }
+                }
+
                 return _source.Length;
             }
 
@@ -351,7 +388,17 @@ namespace System.Linq
 
             public int GetCount(bool onlyIfCheap)
             {
-                return _source.Count;
+                int count = _source.Count;
+
+                if (!onlyIfCheap)
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        _selector(_source[i]);
+                    }
+                }
+
+                return count;
             }
 
             public IPartition<TResult> Skip(int count)
@@ -491,7 +538,17 @@ namespace System.Linq
 
             public int GetCount(bool onlyIfCheap)
             {
-                return _source.Count;
+                int count = _source.Count;
+
+                if (!onlyIfCheap)
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        _selector(_source[i]);
+                    }
+                }
+
+                return count;
             }
 
             public IPartition<TResult> Skip(int count)
@@ -703,6 +760,14 @@ namespace System.Linq
 
             public int GetCount(bool onlyIfCheap)
             {
+                if (!onlyIfCheap)
+                {
+                    foreach (TSource item in _source)
+                    {
+                        _selector(item);
+                    }
+                }
+
                 return _source.GetCount(onlyIfCheap);
             }
         }
@@ -852,7 +917,18 @@ namespace System.Linq
 
             public int GetCount(bool onlyIfCheap)
             {
-                return Count;
+                int count = Count;
+
+                if (!onlyIfCheap)
+                {
+                    int end = _minIndexInclusive + count;
+                    for (int i = _minIndexInclusive; i != end; ++i)
+                    {
+                        _selector(_source[i]);
+                    }
+                }
+
+                return count;
             }
         }
     }

--- a/src/System.Linq/src/System/Linq/Select.cs
+++ b/src/System.Linq/src/System/Linq/Select.cs
@@ -169,6 +169,9 @@ namespace System.Linq
 
             public int GetCount(bool onlyIfCheap)
             {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+
                 if (onlyIfCheap)
                 {
                     return -1;
@@ -255,6 +258,9 @@ namespace System.Linq
 
             public int GetCount(bool onlyIfCheap)
             {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+
                 if (!onlyIfCheap)
                 {
                     foreach (TSource item in _source)
@@ -388,6 +394,9 @@ namespace System.Linq
 
             public int GetCount(bool onlyIfCheap)
             {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+
                 int count = _source.Count;
 
                 if (!onlyIfCheap)
@@ -538,6 +547,9 @@ namespace System.Linq
 
             public int GetCount(bool onlyIfCheap)
             {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+
                 int count = _source.Count;
 
                 if (!onlyIfCheap)
@@ -760,6 +772,9 @@ namespace System.Linq
 
             public int GetCount(bool onlyIfCheap)
             {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+
                 if (!onlyIfCheap)
                 {
                     foreach (TSource item in _source)
@@ -917,6 +932,9 @@ namespace System.Linq
 
             public int GetCount(bool onlyIfCheap)
             {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+
                 int count = Count;
 
                 if (!onlyIfCheap)

--- a/src/System.Linq/src/System/Linq/Where.cs
+++ b/src/System.Linq/src/System/Linq/Where.cs
@@ -434,6 +434,9 @@ namespace System.Linq
 
             public int GetCount(bool onlyIfCheap)
             {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+
                 if (onlyIfCheap)
                 {
                     return -1;
@@ -536,6 +539,9 @@ namespace System.Linq
 
             public int GetCount(bool onlyIfCheap)
             {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+
                 if (onlyIfCheap)
                 {
                     return -1;
@@ -658,6 +664,9 @@ namespace System.Linq
 
             public int GetCount(bool onlyIfCheap)
             {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+
                 if (onlyIfCheap)
                 {
                     return -1;


### PR DESCRIPTION
`Select` does not change the count of an enumerable, so previously we made an optimization where if `Count()` was called we would bypass running the selector altogether and iterate directly through the source. This commit undoes that and makes sure we always run the selector if `onlyIfCheap` is false.

Fixes #13910

cc @JonHanna, @stephentoub, @VSadov 