### PR TITLE
SqlConnection.RetrieveStatistics should always return DictionaryEntry

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlStatistics.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlStatistics.cs
@@ -222,8 +222,11 @@ namespace System.Data.SqlClient
             }
         }
 
-        // We subclass Dictionary to provide our own implementation of CopyTo, Keys.CopyTo, and
-        // Values.CopyTo to match the behavior of Hashtable, which is used in the full framework:
+        // We subclass Dictionary to provide our own implementation of GetEnumerator, CopyTo, Keys.CopyTo,
+        // and Values.CopyTo to match the behavior of Hashtable, which is used in the full framework:
+        //
+        //  - Hashtable's IEnumerator.GetEnumerator enumerator yields DictionaryEntry entries whereas
+        //    Dictionary's yields KeyValuePair entries.
         //
         //  - When arrayIndex > array.Length, Hashtable throws ArgumentException whereas Dictionary
         //    throws ArgumentOutOfRangeException.
@@ -240,7 +243,7 @@ namespace System.Data.SqlClient
         //
         // Ideally this would derive from Dictionary<string, long>, but that would break compatibility
         // with the full framework, which allows adding keys/values of any type.
-        private sealed class StatisticsDictionary : Dictionary<object, object>, IDictionary
+        private sealed class StatisticsDictionary : Dictionary<object, object>, IDictionary, IEnumerable
         {
             private Collection _keys;
             private Collection _values;
@@ -250,6 +253,9 @@ namespace System.Data.SqlClient
             ICollection IDictionary.Keys => _keys ?? (_keys = new Collection(this, Keys));
 
             ICollection IDictionary.Values => _values ?? (_values = new Collection(this, Values));
+
+            // Return a DictionaryEntry enumerator instead of a KeyValuePair enumerator.
+            IEnumerator IEnumerable.GetEnumerator() => ((IDictionary)this).GetEnumerator();
 
             void ICollection.CopyTo(Array array, int arrayIndex)
             {

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.RetrieveStatistics.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.RetrieveStatistics.cs
@@ -278,7 +278,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        public void RetrieveStatistics_GetEnumerator_Success()
+        public void RetrieveStatistics_IDictionary_GetEnumerator_Success()
         {
             IDictionary d = new SqlConnection().RetrieveStatistics();
 
@@ -296,12 +296,63 @@ namespace System.Data.SqlClient.Tests
                     Assert.True(e.MoveNext());
 
                     Assert.NotNull(e.Current);
+                    Assert.IsType<DictionaryEntry>(e.Current);
+
                     Assert.NotNull(e.Entry.Key);
+                    Assert.IsType<string>(e.Entry.Key);
                     Assert.NotNull(e.Entry.Value);
+                    Assert.IsType<long>(e.Entry.Value);
 
                     Assert.Equal(e.Current, e.Entry);
                     Assert.Same(e.Key, e.Entry.Key);
                     Assert.Same(e.Value, e.Entry.Value);
+
+                    Assert.True(s_retrieveStatisticsKeys.Contains(e.Entry.Key));
+                }
+
+                Assert.False(e.MoveNext());
+                Assert.False(e.MoveNext());
+                Assert.False(e.MoveNext());
+
+                Assert.Throws<InvalidOperationException>(() => e.Current);
+
+                e.Reset();
+            }
+        }
+
+        [Fact]
+        public void RetrieveStatistics_IEnumerable_GetEnumerator_Success()
+        {
+            // Treat the result as IEnumerable instead of IDictionary.
+            IEnumerable d = new SqlConnection().RetrieveStatistics();
+
+            IEnumerator e = d.GetEnumerator();
+
+            Assert.NotNull(e);
+            Assert.NotSame(e, d.GetEnumerator());
+
+            for (int i = 0; i < 2; i++)
+            {
+                Assert.Throws<InvalidOperationException>(() => e.Current);
+
+                foreach (string ignored in s_retrieveStatisticsKeys)
+                {
+                    Assert.True(e.MoveNext());
+
+                    Assert.NotNull(e.Current);
+
+                    // Verify the IEnumerable.GetEnumerator enumerator is yielding DictionaryEntry entries,
+                    // not KeyValuePair entries.
+                    Assert.IsType<DictionaryEntry>(e.Current);
+
+                    DictionaryEntry entry = (DictionaryEntry)e.Current;
+
+                    Assert.NotNull(entry.Key);
+                    Assert.IsType<string>(entry.Key);
+                    Assert.NotNull(entry.Value);
+                    Assert.IsType<long>(entry.Value);
+
+                    Assert.True(s_retrieveStatisticsKeys.Contains(entry.Key));
                 }
 
                 Assert.False(e.MoveNext());


### PR DESCRIPTION
### Summary

If the `IDictionary` returned from `SqlConnection.RetrieveStatistics()` is cast to `IEnumerable`, its enumerator will yield `KeyValuePair` items instead of `DictionaryEntry` items, which is a behavior difference from the full framework. This PR addresses the behavior difference by changing `IEnumerable.GetEnumerator` to return a `DictionaryEntry` enumerator to match the behavior of the full framework.

### Details

To break the dependency on the non-generic collections, `SqlConnection.RetrieveStatistics()` was changed to return an instance of a `Hashtable`-compatible subclass of `Dictionary<object, object>` instead of returning a `Hashtable` instance (#7691). However, a subtle behavior difference was missed (see #14417 for a similar issue).

 - `Dictionary<TKey, TValue>`'s implementation of [`IDictionary.GetEnumerator`](https://github.com/dotnet/coreclr/blob/04d6bd105ade5f6189a15a6dbb59b082613429a1/src/mscorlib/src/System/Collections/Generic/Dictionary.cs#L703-L705) returns a `DictionaryEntry` enumerator, which matches `Hashtable`. Since the return type of `RetrieveStatistics` is `IDictionary`, the default behavior of enumerating the result as-is (without casting away from `IDictionary`) is the same as `Hashtable`.

 - However, if the result is cast from `IDictionary` to `IEnumerable`, `Dictionary<TKey, TValue>`'s [`IEnumerable.GetEnumerator`](https://github.com/dotnet/coreclr/blob/04d6bd105ade5f6189a15a6dbb59b082613429a1/src/mscorlib/src/System/Collections/Generic/Dictionary.cs#L601-L603) implementation will return a `KeyValuePair<TKey, TValue>` enumerator, which does not match `Hashtable`'s behavior of returning a `DictionaryEntry` enumerator.

This PR changes the `Hashtable`-compatible subclass's `IEnumerable.GetEnumerator` implementation to return a `DictionaryEntry` enumerator to match `Hashtable`.

Updated tests pass on the full framework, fail before the src changes, and pass after the src changes.

Note that this is technically a breaking change from .NET Core 1.0/1.1. However, publicly available [telemetry](https://apisof.net/catalog/System.Data.SqlClient.SqlConnection.RetrieveStatistics()) shows 0% usage of this API, and the default behavior of enumerating the resulting `IDictionary` as-is without casting to `IEnumerable` isn't changing, which makes me think this is a fairly low-risk change that's worth making to be more compatible with the full framework.

An alternative fix would be to just re-establish the direct dependency on `System.Collections.NonGeneric` and change this back to returning `Hashtable` for the next version of .NET Core since some of `System.Data.SqlClient`'s dependencies now depend on `System.Collections.NonGeneric` (due to the .NET Standard 2.0 effort), which would allow deleting the private `StatisticsDictionary` subclass. If this is preferred, I can update the PR.

cc: @saurabh500, @stephentoub