### PR TITLE
Validate CopyTo calls on collections with S.L.Expressions.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/ListArgumentProvider.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/ListArgumentProvider.cs
@@ -4,7 +4,10 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
+using LinqError = System.Linq.Expressions.Error;
 
 namespace System.Dynamic.Utils
 {
@@ -35,11 +38,13 @@ namespace System.Dynamic.Utils
             return -1;
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         public void Insert(int index, T item)
         {
             throw ContractUtils.Unreachable;
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         public void RemoveAt(int index)
         {
             throw ContractUtils.Unreachable;
@@ -56,6 +61,7 @@ namespace System.Dynamic.Utils
 
                 return GetElement(index);
             }
+            [ExcludeFromCodeCoverage] // Unreachable
             set
             {
                 throw ContractUtils.Unreachable;
@@ -66,11 +72,13 @@ namespace System.Dynamic.Utils
 
         #region ICollection<T> Members
 
+        [ExcludeFromCodeCoverage] // Unreachable
         public void Add(T item)
         {
             throw ContractUtils.Unreachable;
         }
 
+        [ExcludeFromCodeCoverage] // Unreachable
         public void Clear()
         {
             throw ContractUtils.Unreachable;
@@ -78,19 +86,34 @@ namespace System.Dynamic.Utils
 
         public bool Contains(T item) => IndexOf(item) != -1;
 
-        public void CopyTo(T[] array, int arrayIndex)
+        public void CopyTo(T[] array, int index)
         {
-            array[arrayIndex++] = First;
-            for (int i = 1, n = ElementCount; i < n; i++)
+            ContractUtils.RequiresNotNull(array, nameof(array));
+            if (index < 0)
             {
-                array[arrayIndex++] = GetElement(i);
+                throw LinqError.ArgumentOutOfRange(nameof(index));
+            }
+
+            int n = ElementCount;
+            Debug.Assert(n > 0);
+            if (index + n > array.Length)
+            {
+                throw new ArgumentException();
+            }
+
+            array[index++] = First;
+            for (int i = 1; i < n; i++)
+            {
+                array[index++] = GetElement(i);
             }
         }
 
         public int Count => ElementCount;
 
+        [ExcludeFromCodeCoverage] // Unreachable
         public bool IsReadOnly => true;
 
+        [ExcludeFromCodeCoverage] // Unreachable
         public bool Remove(T item)
         {
             throw ContractUtils.Unreachable;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -583,12 +583,25 @@ namespace System.Linq.Expressions
             return IndexOf(item) != -1;
         }
 
-        public void CopyTo(Expression[] array, int arrayIndex)
+        public void CopyTo(Expression[] array, int index)
         {
-            array[arrayIndex++] = _arg0;
-            for (int i = 1; i < _block.ExpressionCount; i++)
+            ContractUtils.RequiresNotNull(array, nameof(array));
+            if (index < 0)
             {
-                array[arrayIndex++] = _block.GetExpression(i);
+                throw Error.ArgumentOutOfRange(nameof(index));
+            }
+
+            int n = _block.ExpressionCount;
+            Debug.Assert(n > 0);
+            if (index + n > array.Length)
+            {
+                throw new ArgumentException();
+            }
+
+            array[index++] = _arg0;
+            for (int i = 1; i < n; i++)
+            {
+                array[index++] = _block.GetExpression(i);
             }
         }
 

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Reflection;
 using Xunit;
 
@@ -647,6 +649,55 @@ namespace System.Linq.Expressions.Tests
 
             Assert.Equal(42, i());
             Assert.Equal(84, i());
+        }
+
+        private static IEnumerable<object[]> LambdaTypes() =>
+            from parCount in Enumerable.Range(0, 6)
+            from name in new[] {null, "Lambda"}
+            from tailCall in new[] {false, true}
+            select new object[] {parCount, name, tailCall};
+
+        [Theory, MemberData(nameof(LambdaTypes))]
+        public void ParameterListBehavior(int parCount, string name, bool tailCall)
+        {
+            // This method contains a lot of assertions, which amount to one large assertion that
+            // the result of the Parameters property behaves correctly.
+            ParameterExpression[] pars =
+                Enumerable.Range(0, parCount).Select(_ => Expression.Parameter(typeof(int))).ToArray();
+            LambdaExpression lamda = Expression.Lambda(Expression.Empty(), name, tailCall, pars);
+            ReadOnlyCollection<ParameterExpression> parameters = lamda.Parameters;
+            Assert.Equal(parCount, parameters.Count);
+            using (var en = parameters.GetEnumerator())
+            {
+                IEnumerator nonGenEn = ((IEnumerable)parameters).GetEnumerator();
+                for (int i = 0; i != parCount; ++i)
+                {
+                    Assert.True(en.MoveNext());
+                    Assert.True(nonGenEn.MoveNext());
+                    Assert.Same(pars[i], parameters[i]);
+                    Assert.Same(pars[i], en.Current);
+                    Assert.Same(pars[i], nonGenEn.Current);
+                    Assert.Equal(i, parameters.IndexOf(pars[i]));
+                    Assert.True(parameters.Contains(pars[i]));
+                }
+
+                Assert.False(en.MoveNext());
+                Assert.False(nonGenEn.MoveNext());
+                (nonGenEn as IDisposable)?.Dispose();
+            }
+
+            ParameterExpression[] copyToTest = new ParameterExpression[parCount + 1];
+            Assert.Throws<ArgumentNullException>(() => parameters.CopyTo(null, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => parameters.CopyTo(copyToTest, -1));
+            Assert.All(copyToTest, Assert.Null); // assert partial copy didn't happen before exception
+            Assert.Throws<ArgumentException>(() => parameters.CopyTo(copyToTest, 2));
+            Assert.All(copyToTest, Assert.Null);
+            parameters.CopyTo(copyToTest, 1);
+            Assert.Equal(copyToTest, pars.Prepend(null));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => parameters[-1]);
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => parameters[parCount]);
+            Assert.Equal(-1, parameters.IndexOf(Expression.Parameter(typeof(int))));
+            Assert.False(parameters.Contains(Expression.Parameter(typeof(int))));
         }
 
         private static int Add(ref int var, int val)


### PR DESCRIPTION
Fixes #14439