### PR TITLE
Fix line ending bug in XSLT test

### DIFF
--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompiledTransform.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompiledTransform.cs
@@ -3866,7 +3866,7 @@ param2 (correct answer is 'local-param2-arg'): local-param2-arg
 
             if ((LoadXSL("Bug109644.xsl") == 1) && (Transform("foo.xml") == 1))
             {
-                Assert.Equal(expected, File.ReadAllText("out.xml"));
+                Assert.Equal(expected, File.ReadAllText("out.xml"), ignoreLineEndingDifferences:true);
             }
             else
                 Assert.True(false);


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/14148. The test failed because of whitespace differences between two strings on some platforms.

cc: @danmosemsft @stephentoub 