### PR TITLE
Build each configuration of corefx tools

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -97,8 +97,17 @@
   </ItemGroup>
 
   <Target Name="BuildCoreFxTools">
-    <MSBuild Projects="src\Tools\tools.builds"
-             ContinueOnError="ErrorAndContinue" />
+    <ItemGroup>
+      <BuildToolsProject Include="src\Tools\CoreFx.Tools\CoreFx.Tools.csproj" />
+      <BuildToolsProject Include="src\Tools\CoreFx.Tools\CoreFx.Tools.csproj">
+        <TargetGroup>net45</TargetGroup>
+      </BuildToolsProject>
+      <BuildToolsProject Include="src\Tools\GenerateProps\GenerateProps.proj" />
+    </ItemGroup>
+    <MSBuild Projects="@(BuildToolsProject)"
+             ContinueOnError="ErrorAndContinue"
+             Condition="'%(Identity)' != ''" 
+             Properties="TargetGroup=%(BuildToolsProject.TargetGroup)" />
   </Target>
 
   <Target Name="BatchRestorePackages" DependsOnTargets="AddGeneratedProjectJsons;VerifyDependencies">


### PR DESCRIPTION
Vertical build breaks ".builds" file traversal.  Explicitly build CoreFx tools projects.

This will resume building the configurations which can be used statically during the build to determine configuration groups rather than using the dynamic groups.  The work to actually transition to using the static configurations is up next..