### PR TITLE
Add tests for XmlSerializationGeneratedCode and CodeIdentifier.

### DIFF
--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -2612,6 +2612,9 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
         cds.AddReserved(typeof(Employee).Name);
         cds.Add("test", new TestData());
         cds.AddUnique("test2", new TestData());
+        Assert.Equal("camelText", CodeIdentifier.MakeCamel("Camel Text"));
+        Assert.Equal("PascalText", CodeIdentifier.MakePascal("Pascal Text"));
+        Assert.Equal("ValidText", CodeIdentifier.MakeValid("Valid  Text!"));
     }
 
     [Fact]
@@ -2641,6 +2644,12 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
         Assert.Equal(1, mapping.Count);
     }
 
+    [Fact]
+    public static void XmlSerializationGeneratedCodeTest()
+    {
+        var cg = new MycodeGenerator();
+        Assert.NotNull(cg);
+    }
     private static Stream GenerateStreamFromString(string s)
     {
         var stream = new MemoryStream();

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -4155,3 +4155,8 @@ public class SampleTextWriter : IXmlTextWriterInitializer
         Stream = stream;
     }
 }
+
+public class MycodeGenerator : XmlSerializationGeneratedCode
+{
+
+}


### PR DESCRIPTION
Add test coverage for CodeIdentifier methods in existing test.
Add basic API test coverage for XmlSerializationGeneratedCode , which is for internal usage only.

#10581 #10577

@shmao @zhenlan @mconnew 