### PR TITLE
Start running tests against the built runtime folder.

### DIFF
--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -5,8 +5,8 @@
 
   <PropertyGroup>
     <TestRuntimeDir>$(RuntimeDir)</TestRuntimeDir>
-    <TestHostExecutable>$(TestRuntimeDir)/corerun</TestHostExecutable>
-    <XunitExecutable>$(TestRuntimeDir)/xunit.console.netcore.exe</XunitExecutable>
+    <TestHostExecutable Condition="'$(TestHostExecutable)' == ''">$(TestRuntimeDir)/corerun</TestHostExecutable>
+    <XunitExecutable Condition="'$(XunitExecutable)' == ''">$(TestRuntimeDir)/xunit.console.netcore.exe</XunitExecutable>
   </PropertyGroup>
 
     <!-- Which categories of tests to run by default -->

--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- This is the target that copies the test assets to the test output -->
+  <Import Project="$(MSBuildThisFileDirectory)publishtest.targets" />
+  <UsingTask TaskName="GetTargetMachineInfo" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="GenerateTestExecutionScripts" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <!-- Which categories of tests to run by default -->
+  <PropertyGroup>
+    <TestDisabled>false</TestDisabled>
+    <TestDisabled Condition="'$(IsTestProject)'!='true' Or '$(SkipTests)'=='true' Or '$(RunTestsForProject)'=='false'">true</TestDisabled>
+    <TestsSuccessfulSemaphore>tests.passed</TestsSuccessfulSemaphore>
+  </PropertyGroup>
+
+  <!-- In case that TestPath is not yet set, default it here -->
+  <PropertyGroup>
+    <TestTargetOutputRelPath Condition="'$(TestTargetOutputRelPath)'=='' And '$(TargetGroup)'!='' And '$(TestTFM)'!=''">$(TargetGroup).$(TestTFM)/</TestTargetOutputRelPath>
+    <TestTargetOutputRelPath Condition="'$(TestTargetOutputRelPath)'=='' And '$(TargetGroup)'=='' And '$(TestTFM)'!=''">default.$(TestTFM)/</TestTargetOutputRelPath>
+    <TestPath Condition="'$(TestPath)'==''">$(TestWorkingDir)$(OSPlatformConfig)/$(MSBuildProjectName)/$(TestTargetOutputRelPath)</TestPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Split semicolon separated lists -->
+    <WithCategoriesItems Include="$(WithCategories)" />
+    <WithoutCategoriesItems Include="$(WithoutCategories)" />
+    <DefaultNoCategories Include="$(DefaultNoCategories)" />
+    <UnsupportedPlatformsItems Include="$(UnsupportedPlatforms)"/>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TestWithCore Condition="'$(TestWithCore)' == '' And !$(TestTFM.StartsWith('netcoreapp', StringComparison.OrdinalIgnoreCase))">false</TestWithCore>
+    <!-- TestAppX is true only for debug scenario which runs on non-aot runtime ids -->
+    <TestAppX Condition="'$(TestWithCore)' == 'false' And '$(TestTFM)' == 'netcore50' And !$(TestNugetRuntimeId.Contains('aot'))">true</TestAppX>
+    <TestWithCore Condition="'$(TestWithCore)' == '' ">true</TestWithCore>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TestWithCore)' == 'true' And '$(TestAppX)' != 'true'">
+    <TestHostExecutable>CoreRun.exe</TestHostExecutable>
+    <XunitExecutable Condition="'$(XunitExecutable)' == ''">xunit.console.netcore.exe</XunitExecutable>
+    <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UseDotNetNativeToolchain)' == 'true'">
+    <TestILCVersion>1.4.24208-prerelease</TestILCVersion>
+    <!-- Workaround:  On .NET execution, these paths will hit 263 characters during unzipping and fail
+         Unfortunately this means slightly different content of Runtests.cmd local vs Helix, but without lots of
+         long-path trickery this is the only current options.
+    -->
+    <TestILCFolder Condition="'$(EnableCloudTest)' != 'true'">%PACKAGE_DIR%\Microsoft.DotNet.TestILC\$(TestILCVersion)\contentFiles\any\any\TestILC</TestILCFolder>
+    <!-- CloudTest.targets will zip up the TestILC folder from within the package path above to this folder.-->
+    <TestILCFolder Condition="'$(EnableCloudTest)' == 'true'">%PACKAGE_DIR%\TestILC</TestILCFolder>
+    <TestHostExecutable></TestHostExecutable>
+    <XunitExecutable>xunit.console.netcore.exe</XunitExecutable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TestWithCore)' != 'true' And '$(TestAppX)' != 'true'">
+    <XunitExecutable Condition="'$(XunitExecutable)' == ''">xunit.console.exe</XunitExecutable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TestAppX)' == 'true'">
+    <TestHostExecutable></TestHostExecutable>
+    <XunitExecutable Condition="'$(XunitExecutable)' == ''">xunit.console.uwp.exe</XunitExecutable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Table to track mapping between TestNugetTargetMoniker and the corresponding TestTFM -->
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'netcoreapp1.0'">.NETCoreApp,Version=v1.0</TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'netcoreapp1.1'">.NETCoreApp,Version=v1.1</TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net463'">.NETFramework,Version=v4.6.3</TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net462'">.NETFramework,Version=v4.6.2</TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net461'">.NETFramework,Version=v4.6.1</TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net46'">.NETFramework,Version=v4.6</TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net45'">.NETFramework,Version=v4.5</TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net451'">.NETFramework,Version=v4.5.1</TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net452'">.NETFramework,Version=v4.5.2</TestNugetTargetMoniker>
+    <!-- Project template for UWP Apps uses uap10.0, this mapping allows support for the Debug and Release scenarios -->
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'netcore50aot' Or '$(TestTFM)' == 'netcore50'">UAP,Version=v10.0</TestNugetTargetMoniker>
+  </PropertyGroup>
+
+  <!-- General xunit options -->
+  <PropertyGroup>
+    <XunitResultsFileName>testResults.xml</XunitResultsFileName>
+
+    <XunitOptions Condition="'$(TestWithCore)' != 'true'">$(XunitOptions) -noshadow </XunitOptions>
+    <XunitOptions>$(XunitOptions) -xml $(XunitResultsFileName)</XunitOptions>
+
+    <XunitOptions Condition="'$(Performance)'!='true'">$(XunitOptions) -notrait Benchmark=true</XunitOptions>
+
+    <XunitOptions Condition="'$(UseDotNetNativeToolchain)'=='true'">$(XunitOptions) -redirectoutput</XunitOptions>
+
+    <XunitOptions Condition="'$(TestTFM)'!=''">$(XunitOptions) -notrait category=non$(TestTFM)tests</XunitOptions>
+    <XunitOptions Condition="'$(XunitMaxThreads)'!=''">$(XunitOptions) -maxthreads $(XunitMaxThreads)</XunitOptions>
+    <XunitTestAssembly Condition="'$(XunitTestAssembly)' == ''">$(TargetFileName)</XunitTestAssembly>
+    <XunitArguments>$(XunitTestAssembly) $(XunitOptions)</XunitArguments>
+
+    <TestProgram Condition="'$(TestHostExecutable)'!=''">$(TestHostExecutable)</TestProgram>
+    <TestArguments Condition="'$(TestHostExecutable)'!=''">$(XunitExecutable) $(XunitArguments)</TestArguments>
+
+    <TestProgram Condition="'$(TestHostExecutable)'==''">$(XunitExecutable)</TestProgram>
+    <TestArguments Condition="'$(TestHostExecutable)'==''">$(XunitArguments)</TestArguments>
+
+    <TestCommandLine Condition="'$(Performance)'!='true'">$(TestProgram) $(TestArguments) {XunitTraitOptions}</TestCommandLine>
+  </PropertyGroup>
+
+  <!-- The Code Coverage targets will override TestHost and TestCommandLine if coverage is enabled -->
+  <Import Project="$(MSBuildThisFileDirectory)CodeCoverage.targets" />
+
+  <!-- import settings for perf testing -->
+  <Import Project="$(MSBuildThisFileDirectory)PerfTesting.targets" Condition="'$(Performance)'=='true'"/>
+
+  <!-- In VS (2015 Preview or later currently required): Debug to run unit tests on CoreCLR. -->
+  <PropertyGroup Condition="'$(IsTestProject)'=='true'">
+    <StartWorkingDirectory Condition="'$(StartWorkingDirectory)'==''">$(TestPath)</StartWorkingDirectory>
+    <StartAction Condition="'$(StartAction)'==''">Program</StartAction>
+    <StartProgram Condition="'$(StartProgram)'==''">$(TestPath)$(TestProgram)</StartProgram>
+    <StartArguments Condition="'$(StartArguments)'==''">$(TestArguments) -wait -parallel none</StartArguments>
+  </PropertyGroup>
+
+  <Target Name="DiscoverTestInputs" DependsOnTargets="ResolveReferences;GetCopyToOutputDirectoryItems">
+    <ItemGroup>
+      <RunTestsForProjectInputs Include="@(ReferenceCopyLocalPaths)" />
+      <RunTestsForProjectInputs Include="@(Content)" />
+      <RunTestsForProjectInputs Include="@(IntermediateAssembly)" />
+      <RunTestsForProjectInputs Include="@(_DebugSymbolsIntermediatePath)" />
+      <RunTestsForProjectInputs Include="@(AllItemsFullPathWithTargetPath)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    On command line run unit tests on CoreCLR after the Test target.
+    Set ForceRunTests to true to run tests even if there have been no changes since the last successful run.
+  -->
+  <Target Name="RunTestsForProject"
+          DependsOnTargets="DiscoverTestInputs;CheckTestCategories"
+          Inputs="@(RunTestsForProjectInputs)"
+          Outputs="$(TestsSuccessfulSemaphore);$(TestPath)/$(XunitResultsFileName);$(CoverageOutputFilePath)"
+          >
+
+    <ItemGroup>
+      <RunWithoutTraits Condition="'$(TargetOS)'=='Windows_NT'" Include="nonwindowstests" />
+      <RunWithoutTraits Condition="'$(TargetOS)'=='Linux'" Include="nonlinuxtests" />
+      <RunWithoutTraits Condition="'$(TargetOS)'=='OSX'" Include="nonosxtests"/>
+      <RunWithoutTraits Condition="'$(TargetOS)'=='FreeBSD'" Include="nonfreebsdtests"/>
+      <RunWithoutTraits Condition="'$(TargetOS)'=='NetBSD'" Include="nonnetbsdtests"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <RunnerScriptName Condition="'$(TargetOS)'=='Windows_NT'" >RunTests.cmd</RunnerScriptName>
+      <RunnerTemplateName Condition="'$(TargetOS)'=='Windows_NT'" >RunnerTemplate.Windows.txt</RunnerTemplateName>
+      <RunnerScriptName Condition="'$(TargetOS)'!='Windows_NT'" >RunTests.sh</RunnerScriptName>
+      <RunnerTemplateName Condition="'$(TargetOS)'!='Windows_NT'" >RunnerTemplate.Unix.txt</RunnerTemplateName>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <XunitTraitOptions Condition="'@(RunWithTraits)'!=''">$(XunitTraitOptions) -trait category=@(RunWithTraits, ' -trait category=') </XunitTraitOptions>
+      <XunitTraitOptions Condition="'@(RunWithoutTraits)'!=''">$(XunitTraitOptions) -notrait category=@(RunWithoutTraits, ' -notrait category=') </XunitTraitOptions>
+    </PropertyGroup>
+
+    <!-- Replace the {XunitTraitOptions} place holder with the actual traits.  We use the place holder
+         because code coverage needs to have a bit of the test command line after the traits (it adds ending quotes
+         to one of its options).  Simply appending the traits would break code coverage.
+         Additionally, replace CoreRun.exe with ./corerun on Non-Windows OSes (this is the only difference in the command)
+         Future refactoring will allow us to construct this correctly initially, but we don't always know the TargetOS
+         when the properties are set currently.
+         -->
+
+    <PropertyGroup>
+      <TestCommandLine Condition="'$(TargetOS)'!='Windows_NT'" >$(TestCommandLine.Replace('$(TestHostExecutable)', './corerun'))</TestCommandLine>
+      <TestCommandLine>$(TestCommandLine.Replace('{XunitTraitOptions}', '$(XunitTraitOptions)'))</TestCommandLine>
+      <OutputFolderForScriptGenerator>$(TestPath)</OutputFolderForScriptGenerator>
+      <OutputPathForScriptGenerator>$(OutputFolderForScriptGenerator)/$(RunnerScriptName)</OutputPathForScriptGenerator>
+      <OutputFolderForTestDependencies>$(BinDir)/TestDependencies</OutputFolderForTestDependencies>
+    </PropertyGroup>
+
+    <MakeDir Condition="'$(CoverageEnabledForProject)'=='true'" Directories="$(CoverageReportDir)" />
+
+    <ItemGroup>
+      <!-- Not all platforms can use the .ni.dlls that come from packages.  If TestWithoutNativeImages is specified, we'll exclude them from copy generation.
+           If we end up needing this for any other sorts of filtering, we'll want to add a list of filtered extensions to be matched on EndsWith.  -->
+      <IncludedFileForRunnerScript Include="@(_TestCopyLocalByFileNameWithoutDuplicates)"
+                                   Condition="'$(TestWithoutNativeImages)' != 'true' Or !$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').EndsWith('.ni.dll'))" >
+        <PackageRelativePath Condition="'%(_TestCopyLocalByFileNameWithoutDuplicates.NugetPackageId)' != ''">$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').Replace('$(PackagesDir)',''))</PackageRelativePath>
+        <UseAbsolutePath Condition="'$(TestWithLocalLibraries)'=='true' Or '$(TestWithLocalNativeLibraries)'=='true'">$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').StartsWith('$(BinDir)'))</UseAbsolutePath>
+      </IncludedFileForRunnerScript>
+    </ItemGroup>
+
+    <MakeDir Directories="$(OutputFolderForTestDependencies)" />
+    <PropertyGroup>
+      <_TestDependencyListRoot>$(AssemblyName)-$(OSGroup).$(Platform).$(ConfigurationGroup)</_TestDependencyListRoot>
+      <_TestDependencyListRoot Condition="'$(TargetGroup)' != ''">$(_TestDependencyListRoot).$(TargetGroup)</_TestDependencyListRoot>
+      <_TestDependencyListRoot Condition="'$(TargetGroup)' == ''">$(_TestDependencyListRoot).default</_TestDependencyListRoot>
+      <_TestDependencyListRoot Condition="'$(TestTFM)' != ''">$(_TestDependencyListRoot).$(TestTFM)</_TestDependencyListRoot>
+      <_TestDependencyListFileName>$(_TestDependencyListRoot).dependencylist.txt</_TestDependencyListFileName>
+      <TestDependencyListFilePath>$(OutputFolderForTestDependencies)/$(_TestDependencyListFileName)</TestDependencyListFilePath>
+    </PropertyGroup>
+    <Message Text="Generating $(TestDependencyListFilePath)" />
+    <WriteLinesToFile
+      File="$(TestDependencyListFilePath)"
+      Lines="@(IncludedFileForRunnerScript -> '%(PackageRelativePath)')"
+      Overwrite="true"
+      Encoding="Ascii" />
+
+    <Message Text="Generating JSON-Processed $(OutDir)assemblylist.txt for legacy execution" Condition="'$(UseLegacyXunitPerfRunner)'=='true'" />
+    <GenerateAssemblyList
+      InputListLocation="$(TestDependencyListFilePath)"
+      OutputListLocation="$(OutDir)assemblylist.txt"
+      Condition="'$(UseLegacyXunitPerfRunner)'=='true'"
+     />
+
+    <!-- For .NET Native compilation, we first need to generate a native executable if possible. -->
+    <ItemGroup Condition="'$(UseDotNetNativeToolchain)' == 'true' AND '$(Performance)'!='true'" >
+      <TestCommandLines Include="copy /y $(TestILCFolder)\default.rd.xml  %EXECUTION_DIR%" />
+      <TestCommandLines Include="$(TestILCFolder)\ilc.exe -usecustomframework -ExeName xunit.console.netcore.exe -in %EXECUTION_DIR% -out %EXECUTION_DIR%\native -usedefaultpinvoke -buildtype ret -v diag || exit /b %ERRORLEVEL%"/>
+      <TestCommandLines Include="copy /y $(TestILCFolder)\CRT\vcruntime140_app.dll %EXECUTION_DIR%\native" />
+      <TestCommandLines Include="echo > %EXECUTION_DIR%\native\$(XunitTestAssembly)"/>
+      <TestCommandLines Include="cd native"/>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(Performance)'!='true'">
+      <!-- On Windows, call prevents the test command from making execution end prematurely -->
+      <TestCommandLines  Condition="'$(TargetOS)'=='Windows_NT'" Include="call $(TestCommandLine)"/>
+      <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT'" Include="$(TestCommandLine)"/>
+    </ItemGroup>
+
+    <!-- Currently all netcore50 implementations of System.Console actually write to a noop stream -->
+    <!-- Workaround is to have the exe detect this and use Console.SetOut to write to a text file. -->
+    <ItemGroup Condition="'$(UseDotNetNativeToolchain)' == 'true' AND '$(Performance)'!='true'" >
+      <TestCommandLines Include="type Xunit.Console.Output.txt" />
+      <TestCommandLines Include="copy /y testResults.xml %EXECUTION_DIR%\" />
+    </ItemGroup>
+
+    <!-- Do not put anything between this Item Group and the GenerateTestExecutionScripts invocation -->
+    <ItemGroup>
+      <TestCommandLines Include="@(PostExecutionTestCommandLines)" />
+    </ItemGroup>
+    <GenerateTestExecutionScripts
+      TestCommands="@(TestCommandLines)"
+      TestDependencies="@(IncludedFileForRunnerScript)"
+      RunnerScriptTemplate="$(MSBuildThisFileDirectory)/$(RunnerTemplateName)"
+      ScriptOutputPath ="$(OutputPathForScriptGenerator)"
+    />
+
+    <Exec Command="$(TestPath)/$(RunnerScriptName) $(PackagesDir)"
+          Condition="'$(TestDisabled)' != 'true'"
+          WorkingDirectory="$(TestPath)"
+          CustomErrorRegularExpression="Failed: [^0]"
+          ContinueOnError="true"
+          IgnoreStandardErrorWarningFormat="true"
+          >
+      <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />
+    </Exec>
+
+    <Delete Condition="'$(DeletePerfDataFile)' == 'true'" Files="$(TestPath)/$(EventTracerDataFile)" />
+    <Error Condition="'$(TestDisabled)'!='true' And '$(TestRunExitCode)' != '0'" Text="One or more tests failed while running tests from '$(MSBuildProjectName)' please check log for details!" />
+    <Touch Condition="'$(TestRunExitCode)' == '0'" Files="$(TestsSuccessfulSemaphore)" AlwaysCreate="true" />
+  </Target>
+
+  <!-- Needs to run before RunTestsForProject target as it computes categories and set TestDisabled -->
+  <Target Name="CheckTestCategories">
+
+    <!-- Default behavior is to disable OuterLoop and failing tests if not specified in WithCategories. -->
+    <ItemGroup>
+      <DefaultNoCategories Condition="'$(Outerloop)'!='true'" Include="OuterLoop" />
+      <DefaultNoCategories Include="failing" />
+      <WithoutCategoriesItems Include="@(DefaultNoCategories)" Exclude="@(WithCategoriesItems)" />
+      <WithoutCategoriesItemsDistinct Include="@(WithoutCategoriesItems->Distinct())" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <RunWithTraits Condition="'@(WithCategoriesItems)'!=''" Include="@(WithCategoriesItems)" />
+      <RunWithoutTraits Condition="'@(WithoutCategoriesItemsDistinct)'!=''" Include="@(WithoutCategoriesItemsDistinct)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <TestsSuccessfulSemaphore Condition="'@(RunWithTraits)' != ''">$(TestsSuccessfulSemaphore).with.@(RunWithTraits, '.')</TestsSuccessfulSemaphore>
+      <TestsSuccessfulSemaphore Condition="'@(RunWithoutTraits)' != ''">$(TestsSuccessfulSemaphore).without.@(RunWithoutTraits, '.')</TestsSuccessfulSemaphore>
+      <TestsSuccessfulSemaphore>$(TestPath)/$(TestsSuccessfulSemaphore)</TestsSuccessfulSemaphore>
+    </PropertyGroup>
+
+    <Delete Condition="'$(ForceRunTests)'=='true' And Exists($(TestsSuccessfulSemaphore))"
+            Files="$(TestsSuccessfulSemaphore)" />
+  </Target>
+
+  <Target Name="GetDefaultTestRid">
+    <GetTargetMachineInfo>
+      <Output TaskParameter="RuntimeIdentifier" PropertyName="DefaultTestNugetRuntimeId" />
+    </GetTargetMachineInfo>
+    <!-- On Windows, we always use win7-x64 as the default test RID because the build context,
+         usually 32-bit full-framework MSBuild, is not a good default test context. -->
+    <PropertyGroup>
+      <DefaultTestNugetRuntimeId Condition="$(DefaultTestNugetRuntimeId.StartsWith('win'))">win7-x64</DefaultTestNugetRuntimeId>
+      <TestArchitecture Condition="'$(TestArchitecture)' == ''">x64</TestArchitecture>
+      <TestNugetRuntimeId Condition="'$(TestNugetRuntimeId)' == ''">$(DefaultTestNugetRuntimeId)</TestNugetRuntimeId>
+    </PropertyGroup>
+  </Target>
+
+  <PropertyGroup>
+    <ResolvePkgProjReferencesDependsOn>GetDefaultTestRid;$(ResolvePkgProjReferencesDependsOn)</ResolvePkgProjReferencesDependsOn>
+  </PropertyGroup>
+
+  <Target Name="CheckTestPlatforms">
+    <GetTargetMachineInfo Condition="'$(TargetOS)' == ''">
+      <Output TaskParameter="TargetOS" PropertyName="TargetOS" />
+    </GetTargetMachineInfo>
+    <PropertyGroup>
+      <TestDisabled Condition="'%(UnsupportedPlatformsItems.Identity)' == '$(TargetOS)'">true</TestDisabled>
+    </PropertyGroup>
+    <Message Condition="'%(UnsupportedPlatformsItems.Identity)' == '$(TargetOS)'"
+      Text="Skipping tests in $(AssemblyName) because it is not supported on $(TargetOS)" />
+  </Target>
+
+  <Target Name="SetupTestProperties" DependsOnTargets="GetDefaultTestRid;CheckTestPlatforms;CheckTestCategories" />
+
+  <PropertyGroup>
+    <TestDependsOn>
+      $(TestDependsOn);
+      DiscoverTestInputs;
+      SetupTestProperties;
+      CopyTestToTestDirectory;
+      RunTestsForProject;
+      ArchiveTestBuild
+    </TestDependsOn>
+  </PropertyGroup>
+
+  <Target Name="Test"
+          DependsOnTargets="$(TestDependsOn)">
+  </Target>
+
+</Project>

--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -1,22 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- This is the target that copies the test assets to the test output -->
-  <Import Project="$(MSBuildThisFileDirectory)publishtest.targets" />
   <UsingTask TaskName="GetTargetMachineInfo" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <UsingTask TaskName="GenerateTestExecutionScripts" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <!-- Which categories of tests to run by default -->
+
+  <PropertyGroup>
+    <TestRuntimeDir>$(RuntimeDir)</TestRuntimeDir>
+    <TestHostExecutable>$(TestRuntimeDir)/corerun</TestHostExecutable>
+    <XunitExecutable>$(TestRuntimeDir)/xunit.console.netcore.exe</XunitExecutable>
+  </PropertyGroup>
+
+    <!-- Which categories of tests to run by default -->
   <PropertyGroup>
     <TestDisabled>false</TestDisabled>
     <TestDisabled Condition="'$(IsTestProject)'!='true' Or '$(SkipTests)'=='true' Or '$(RunTestsForProject)'=='false'">true</TestDisabled>
     <TestsSuccessfulSemaphore>tests.passed</TestsSuccessfulSemaphore>
-  </PropertyGroup>
-
-  <!-- In case that TestPath is not yet set, default it here -->
-  <PropertyGroup>
-    <TestTargetOutputRelPath Condition="'$(TestTargetOutputRelPath)'=='' And '$(TargetGroup)'!='' And '$(TestTFM)'!=''">$(TargetGroup).$(TestTFM)/</TestTargetOutputRelPath>
-    <TestTargetOutputRelPath Condition="'$(TestTargetOutputRelPath)'=='' And '$(TargetGroup)'=='' And '$(TestTFM)'!=''">default.$(TestTFM)/</TestTargetOutputRelPath>
-    <TestPath Condition="'$(TestPath)'==''">$(TestWorkingDir)$(OSPlatformConfig)/$(MSBuildProjectName)/$(TestTargetOutputRelPath)</TestPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,56 +23,6 @@
     <DefaultNoCategories Include="$(DefaultNoCategories)" />
     <UnsupportedPlatformsItems Include="$(UnsupportedPlatforms)"/>
   </ItemGroup>
-
-  <PropertyGroup>
-    <TestWithCore Condition="'$(TestWithCore)' == '' And !$(TestTFM.StartsWith('netcoreapp', StringComparison.OrdinalIgnoreCase))">false</TestWithCore>
-    <!-- TestAppX is true only for debug scenario which runs on non-aot runtime ids -->
-    <TestAppX Condition="'$(TestWithCore)' == 'false' And '$(TestTFM)' == 'netcore50' And !$(TestNugetRuntimeId.Contains('aot'))">true</TestAppX>
-    <TestWithCore Condition="'$(TestWithCore)' == '' ">true</TestWithCore>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TestWithCore)' == 'true' And '$(TestAppX)' != 'true'">
-    <TestHostExecutable>CoreRun.exe</TestHostExecutable>
-    <XunitExecutable Condition="'$(XunitExecutable)' == ''">xunit.console.netcore.exe</XunitExecutable>
-    <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(UseDotNetNativeToolchain)' == 'true'">
-    <TestILCVersion>1.4.24208-prerelease</TestILCVersion>
-    <!-- Workaround:  On .NET execution, these paths will hit 263 characters during unzipping and fail
-         Unfortunately this means slightly different content of Runtests.cmd local vs Helix, but without lots of
-         long-path trickery this is the only current options.
-    -->
-    <TestILCFolder Condition="'$(EnableCloudTest)' != 'true'">%PACKAGE_DIR%\Microsoft.DotNet.TestILC\$(TestILCVersion)\contentFiles\any\any\TestILC</TestILCFolder>
-    <!-- CloudTest.targets will zip up the TestILC folder from within the package path above to this folder.-->
-    <TestILCFolder Condition="'$(EnableCloudTest)' == 'true'">%PACKAGE_DIR%\TestILC</TestILCFolder>
-    <TestHostExecutable></TestHostExecutable>
-    <XunitExecutable>xunit.console.netcore.exe</XunitExecutable>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TestWithCore)' != 'true' And '$(TestAppX)' != 'true'">
-    <XunitExecutable Condition="'$(XunitExecutable)' == ''">xunit.console.exe</XunitExecutable>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TestAppX)' == 'true'">
-    <TestHostExecutable></TestHostExecutable>
-    <XunitExecutable Condition="'$(XunitExecutable)' == ''">xunit.console.uwp.exe</XunitExecutable>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <!-- Table to track mapping between TestNugetTargetMoniker and the corresponding TestTFM -->
-    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'netcoreapp1.0'">.NETCoreApp,Version=v1.0</TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'netcoreapp1.1'">.NETCoreApp,Version=v1.1</TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net463'">.NETFramework,Version=v4.6.3</TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net462'">.NETFramework,Version=v4.6.2</TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net461'">.NETFramework,Version=v4.6.1</TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net46'">.NETFramework,Version=v4.6</TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net45'">.NETFramework,Version=v4.5</TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net451'">.NETFramework,Version=v4.5.1</TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net452'">.NETFramework,Version=v4.5.2</TestNugetTargetMoniker>
-    <!-- Project template for UWP Apps uses uap10.0, this mapping allows support for the Debug and Release scenarios -->
-    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'netcore50aot' Or '$(TestTFM)' == 'netcore50'">UAP,Version=v10.0</TestNugetTargetMoniker>
-  </PropertyGroup>
 
   <!-- General xunit options -->
   <PropertyGroup>
@@ -90,7 +37,7 @@
 
     <XunitOptions Condition="'$(TestTFM)'!=''">$(XunitOptions) -notrait category=non$(TestTFM)tests</XunitOptions>
     <XunitOptions Condition="'$(XunitMaxThreads)'!=''">$(XunitOptions) -maxthreads $(XunitMaxThreads)</XunitOptions>
-    <XunitTestAssembly Condition="'$(XunitTestAssembly)' == ''">$(TargetFileName)</XunitTestAssembly>
+    <XunitTestAssembly Condition="'$(XunitTestAssembly)' == ''">$(TargetPath)</XunitTestAssembly>
     <XunitArguments>$(XunitTestAssembly) $(XunitOptions)</XunitArguments>
 
     <TestProgram Condition="'$(TestHostExecutable)'!=''">$(TestHostExecutable)</TestProgram>
@@ -101,159 +48,6 @@
 
     <TestCommandLine Condition="'$(Performance)'!='true'">$(TestProgram) $(TestArguments) {XunitTraitOptions}</TestCommandLine>
   </PropertyGroup>
-
-  <!-- The Code Coverage targets will override TestHost and TestCommandLine if coverage is enabled -->
-  <Import Project="$(MSBuildThisFileDirectory)CodeCoverage.targets" />
-
-  <!-- import settings for perf testing -->
-  <Import Project="$(MSBuildThisFileDirectory)PerfTesting.targets" Condition="'$(Performance)'=='true'"/>
-
-  <!-- In VS (2015 Preview or later currently required): Debug to run unit tests on CoreCLR. -->
-  <PropertyGroup Condition="'$(IsTestProject)'=='true'">
-    <StartWorkingDirectory Condition="'$(StartWorkingDirectory)'==''">$(TestPath)</StartWorkingDirectory>
-    <StartAction Condition="'$(StartAction)'==''">Program</StartAction>
-    <StartProgram Condition="'$(StartProgram)'==''">$(TestPath)$(TestProgram)</StartProgram>
-    <StartArguments Condition="'$(StartArguments)'==''">$(TestArguments) -wait -parallel none</StartArguments>
-  </PropertyGroup>
-
-  <Target Name="DiscoverTestInputs" DependsOnTargets="ResolveReferences;GetCopyToOutputDirectoryItems">
-    <ItemGroup>
-      <RunTestsForProjectInputs Include="@(ReferenceCopyLocalPaths)" />
-      <RunTestsForProjectInputs Include="@(Content)" />
-      <RunTestsForProjectInputs Include="@(IntermediateAssembly)" />
-      <RunTestsForProjectInputs Include="@(_DebugSymbolsIntermediatePath)" />
-      <RunTestsForProjectInputs Include="@(AllItemsFullPathWithTargetPath)" />
-    </ItemGroup>
-  </Target>
-
-  <!--
-    On command line run unit tests on CoreCLR after the Test target.
-    Set ForceRunTests to true to run tests even if there have been no changes since the last successful run.
-  -->
-  <Target Name="RunTestsForProject"
-          DependsOnTargets="DiscoverTestInputs;CheckTestCategories"
-          Inputs="@(RunTestsForProjectInputs)"
-          Outputs="$(TestsSuccessfulSemaphore);$(TestPath)/$(XunitResultsFileName);$(CoverageOutputFilePath)"
-          >
-
-    <ItemGroup>
-      <RunWithoutTraits Condition="'$(TargetOS)'=='Windows_NT'" Include="nonwindowstests" />
-      <RunWithoutTraits Condition="'$(TargetOS)'=='Linux'" Include="nonlinuxtests" />
-      <RunWithoutTraits Condition="'$(TargetOS)'=='OSX'" Include="nonosxtests"/>
-      <RunWithoutTraits Condition="'$(TargetOS)'=='FreeBSD'" Include="nonfreebsdtests"/>
-      <RunWithoutTraits Condition="'$(TargetOS)'=='NetBSD'" Include="nonnetbsdtests"/>
-    </ItemGroup>
-
-    <PropertyGroup>
-      <RunnerScriptName Condition="'$(TargetOS)'=='Windows_NT'" >RunTests.cmd</RunnerScriptName>
-      <RunnerTemplateName Condition="'$(TargetOS)'=='Windows_NT'" >RunnerTemplate.Windows.txt</RunnerTemplateName>
-      <RunnerScriptName Condition="'$(TargetOS)'!='Windows_NT'" >RunTests.sh</RunnerScriptName>
-      <RunnerTemplateName Condition="'$(TargetOS)'!='Windows_NT'" >RunnerTemplate.Unix.txt</RunnerTemplateName>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <XunitTraitOptions Condition="'@(RunWithTraits)'!=''">$(XunitTraitOptions) -trait category=@(RunWithTraits, ' -trait category=') </XunitTraitOptions>
-      <XunitTraitOptions Condition="'@(RunWithoutTraits)'!=''">$(XunitTraitOptions) -notrait category=@(RunWithoutTraits, ' -notrait category=') </XunitTraitOptions>
-    </PropertyGroup>
-
-    <!-- Replace the {XunitTraitOptions} place holder with the actual traits.  We use the place holder
-         because code coverage needs to have a bit of the test command line after the traits (it adds ending quotes
-         to one of its options).  Simply appending the traits would break code coverage.
-         Additionally, replace CoreRun.exe with ./corerun on Non-Windows OSes (this is the only difference in the command)
-         Future refactoring will allow us to construct this correctly initially, but we don't always know the TargetOS
-         when the properties are set currently.
-         -->
-
-    <PropertyGroup>
-      <TestCommandLine Condition="'$(TargetOS)'!='Windows_NT'" >$(TestCommandLine.Replace('$(TestHostExecutable)', './corerun'))</TestCommandLine>
-      <TestCommandLine>$(TestCommandLine.Replace('{XunitTraitOptions}', '$(XunitTraitOptions)'))</TestCommandLine>
-      <OutputFolderForScriptGenerator>$(TestPath)</OutputFolderForScriptGenerator>
-      <OutputPathForScriptGenerator>$(OutputFolderForScriptGenerator)/$(RunnerScriptName)</OutputPathForScriptGenerator>
-      <OutputFolderForTestDependencies>$(BinDir)/TestDependencies</OutputFolderForTestDependencies>
-    </PropertyGroup>
-
-    <MakeDir Condition="'$(CoverageEnabledForProject)'=='true'" Directories="$(CoverageReportDir)" />
-
-    <ItemGroup>
-      <!-- Not all platforms can use the .ni.dlls that come from packages.  If TestWithoutNativeImages is specified, we'll exclude them from copy generation.
-           If we end up needing this for any other sorts of filtering, we'll want to add a list of filtered extensions to be matched on EndsWith.  -->
-      <IncludedFileForRunnerScript Include="@(_TestCopyLocalByFileNameWithoutDuplicates)"
-                                   Condition="'$(TestWithoutNativeImages)' != 'true' Or !$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').EndsWith('.ni.dll'))" >
-        <PackageRelativePath Condition="'%(_TestCopyLocalByFileNameWithoutDuplicates.NugetPackageId)' != ''">$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').Replace('$(PackagesDir)',''))</PackageRelativePath>
-        <UseAbsolutePath Condition="'$(TestWithLocalLibraries)'=='true' Or '$(TestWithLocalNativeLibraries)'=='true'">$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').StartsWith('$(BinDir)'))</UseAbsolutePath>
-      </IncludedFileForRunnerScript>
-    </ItemGroup>
-
-    <MakeDir Directories="$(OutputFolderForTestDependencies)" />
-    <PropertyGroup>
-      <_TestDependencyListRoot>$(AssemblyName)-$(OSGroup).$(Platform).$(ConfigurationGroup)</_TestDependencyListRoot>
-      <_TestDependencyListRoot Condition="'$(TargetGroup)' != ''">$(_TestDependencyListRoot).$(TargetGroup)</_TestDependencyListRoot>
-      <_TestDependencyListRoot Condition="'$(TargetGroup)' == ''">$(_TestDependencyListRoot).default</_TestDependencyListRoot>
-      <_TestDependencyListRoot Condition="'$(TestTFM)' != ''">$(_TestDependencyListRoot).$(TestTFM)</_TestDependencyListRoot>
-      <_TestDependencyListFileName>$(_TestDependencyListRoot).dependencylist.txt</_TestDependencyListFileName>
-      <TestDependencyListFilePath>$(OutputFolderForTestDependencies)/$(_TestDependencyListFileName)</TestDependencyListFilePath>
-    </PropertyGroup>
-    <Message Text="Generating $(TestDependencyListFilePath)" />
-    <WriteLinesToFile
-      File="$(TestDependencyListFilePath)"
-      Lines="@(IncludedFileForRunnerScript -> '%(PackageRelativePath)')"
-      Overwrite="true"
-      Encoding="Ascii" />
-
-    <Message Text="Generating JSON-Processed $(OutDir)assemblylist.txt for legacy execution" Condition="'$(UseLegacyXunitPerfRunner)'=='true'" />
-    <GenerateAssemblyList
-      InputListLocation="$(TestDependencyListFilePath)"
-      OutputListLocation="$(OutDir)assemblylist.txt"
-      Condition="'$(UseLegacyXunitPerfRunner)'=='true'"
-     />
-
-    <!-- For .NET Native compilation, we first need to generate a native executable if possible. -->
-    <ItemGroup Condition="'$(UseDotNetNativeToolchain)' == 'true' AND '$(Performance)'!='true'" >
-      <TestCommandLines Include="copy /y $(TestILCFolder)\default.rd.xml  %EXECUTION_DIR%" />
-      <TestCommandLines Include="$(TestILCFolder)\ilc.exe -usecustomframework -ExeName xunit.console.netcore.exe -in %EXECUTION_DIR% -out %EXECUTION_DIR%\native -usedefaultpinvoke -buildtype ret -v diag || exit /b %ERRORLEVEL%"/>
-      <TestCommandLines Include="copy /y $(TestILCFolder)\CRT\vcruntime140_app.dll %EXECUTION_DIR%\native" />
-      <TestCommandLines Include="echo > %EXECUTION_DIR%\native\$(XunitTestAssembly)"/>
-      <TestCommandLines Include="cd native"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(Performance)'!='true'">
-      <!-- On Windows, call prevents the test command from making execution end prematurely -->
-      <TestCommandLines  Condition="'$(TargetOS)'=='Windows_NT'" Include="call $(TestCommandLine)"/>
-      <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT'" Include="$(TestCommandLine)"/>
-    </ItemGroup>
-
-    <!-- Currently all netcore50 implementations of System.Console actually write to a noop stream -->
-    <!-- Workaround is to have the exe detect this and use Console.SetOut to write to a text file. -->
-    <ItemGroup Condition="'$(UseDotNetNativeToolchain)' == 'true' AND '$(Performance)'!='true'" >
-      <TestCommandLines Include="type Xunit.Console.Output.txt" />
-      <TestCommandLines Include="copy /y testResults.xml %EXECUTION_DIR%\" />
-    </ItemGroup>
-
-    <!-- Do not put anything between this Item Group and the GenerateTestExecutionScripts invocation -->
-    <ItemGroup>
-      <TestCommandLines Include="@(PostExecutionTestCommandLines)" />
-    </ItemGroup>
-    <GenerateTestExecutionScripts
-      TestCommands="@(TestCommandLines)"
-      TestDependencies="@(IncludedFileForRunnerScript)"
-      RunnerScriptTemplate="$(MSBuildThisFileDirectory)/$(RunnerTemplateName)"
-      ScriptOutputPath ="$(OutputPathForScriptGenerator)"
-    />
-
-    <Exec Command="$(TestPath)/$(RunnerScriptName) $(PackagesDir)"
-          Condition="'$(TestDisabled)' != 'true'"
-          WorkingDirectory="$(TestPath)"
-          CustomErrorRegularExpression="Failed: [^0]"
-          ContinueOnError="true"
-          IgnoreStandardErrorWarningFormat="true"
-          >
-      <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />
-    </Exec>
-
-    <Delete Condition="'$(DeletePerfDataFile)' == 'true'" Files="$(TestPath)/$(EventTracerDataFile)" />
-    <Error Condition="'$(TestDisabled)'!='true' And '$(TestRunExitCode)' != '0'" Text="One or more tests failed while running tests from '$(MSBuildProjectName)' please check log for details!" />
-    <Touch Condition="'$(TestRunExitCode)' == '0'" Files="$(TestsSuccessfulSemaphore)" AlwaysCreate="true" />
-  </Target>
 
   <!-- Needs to run before RunTestsForProject target as it computes categories and set TestDisabled -->
   <Target Name="CheckTestCategories">
@@ -281,17 +75,59 @@
             Files="$(TestsSuccessfulSemaphore)" />
   </Target>
 
-  <Target Name="GetDefaultTestRid">
-    <GetTargetMachineInfo>
-      <Output TaskParameter="RuntimeIdentifier" PropertyName="DefaultTestNugetRuntimeId" />
-    </GetTargetMachineInfo>
-    <!-- On Windows, we always use win7-x64 as the default test RID because the build context,
-         usually 32-bit full-framework MSBuild, is not a good default test context. -->
+  <Target Name="RunTestsForProject">
+
+    <ItemGroup>
+      <RunWithoutTraits Condition="'$(TargetOS)'=='Windows_NT'" Include="nonwindowstests" />
+      <RunWithoutTraits Condition="'$(TargetOS)'=='Linux'" Include="nonlinuxtests" />
+      <RunWithoutTraits Condition="'$(TargetOS)'=='OSX'" Include="nonosxtests"/>
+      <RunWithoutTraits Condition="'$(TargetOS)'=='FreeBSD'" Include="nonfreebsdtests"/>
+      <RunWithoutTraits Condition="'$(TargetOS)'=='NetBSD'" Include="nonnetbsdtests"/>
+    </ItemGroup>
+
     <PropertyGroup>
-      <DefaultTestNugetRuntimeId Condition="$(DefaultTestNugetRuntimeId.StartsWith('win'))">win7-x64</DefaultTestNugetRuntimeId>
-      <TestArchitecture Condition="'$(TestArchitecture)' == ''">x64</TestArchitecture>
-      <TestNugetRuntimeId Condition="'$(TestNugetRuntimeId)' == ''">$(DefaultTestNugetRuntimeId)</TestNugetRuntimeId>
+      <XunitTraitOptions Condition="'@(RunWithTraits)'!=''">$(XunitTraitOptions) -trait category=@(RunWithTraits, ' -trait category=') </XunitTraitOptions>
+      <XunitTraitOptions Condition="'@(RunWithoutTraits)'!=''">$(XunitTraitOptions) -notrait category=@(RunWithoutTraits, ' -notrait category=') </XunitTraitOptions>
+      <TestCommandLine>$(TestCommandLine.Replace('{XunitTraitOptions}', '$(XunitTraitOptions)'))</TestCommandLine>
     </PropertyGroup>
+
+    <Exec Command="$(TestCommandLine)"
+          Condition="'$(TestDisabled)' != 'true'"
+          WorkingDirectory="$(OutDir)"
+          CustomErrorRegularExpression="Failed: [^0]"
+          ContinueOnError="true"
+          IgnoreStandardErrorWarningFormat="true"
+          EnvironmentVariables="CORE_LIBRARIES=$(OutDir)"
+          >
+      <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />
+    </Exec>
+  </Target>
+
+
+  <!-- Needs to run before RunTestsForProject target as it computes categories and set TestDisabled -->
+  <Target Name="CheckTestCategories">
+
+    <!-- Default behavior is to disable OuterLoop and failing tests if not specified in WithCategories. -->
+    <ItemGroup>
+      <DefaultNoCategories Condition="'$(Outerloop)'!='true'" Include="OuterLoop" />
+      <DefaultNoCategories Include="failing" />
+      <WithoutCategoriesItems Include="@(DefaultNoCategories)" Exclude="@(WithCategoriesItems)" />
+      <WithoutCategoriesItemsDistinct Include="@(WithoutCategoriesItems->Distinct())" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <RunWithTraits Condition="'@(WithCategoriesItems)'!=''" Include="@(WithCategoriesItems)" />
+      <RunWithoutTraits Condition="'@(WithoutCategoriesItemsDistinct)'!=''" Include="@(WithoutCategoriesItemsDistinct)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <TestsSuccessfulSemaphore Condition="'@(RunWithTraits)' != ''">$(TestsSuccessfulSemaphore).with.@(RunWithTraits, '.')</TestsSuccessfulSemaphore>
+      <TestsSuccessfulSemaphore Condition="'@(RunWithoutTraits)' != ''">$(TestsSuccessfulSemaphore).without.@(RunWithoutTraits, '.')</TestsSuccessfulSemaphore>
+      <TestsSuccessfulSemaphore>$(TestPath)/$(TestsSuccessfulSemaphore)</TestsSuccessfulSemaphore>
+    </PropertyGroup>
+
+    <Delete Condition="'$(ForceRunTests)'=='true' And Exists($(TestsSuccessfulSemaphore))"
+            Files="$(TestsSuccessfulSemaphore)" />
   </Target>
 
   <PropertyGroup>
@@ -309,21 +145,18 @@
       Text="Skipping tests in $(AssemblyName) because it is not supported on $(TargetOS)" />
   </Target>
 
-  <Target Name="SetupTestProperties" DependsOnTargets="GetDefaultTestRid;CheckTestPlatforms;CheckTestCategories" />
+  <Target Name="SetupTestProperties" DependsOnTargets="CheckTestPlatforms;CheckTestCategories" />
 
   <PropertyGroup>
     <TestDependsOn>
       $(TestDependsOn);
-      DiscoverTestInputs;
       SetupTestProperties;
-      CopyTestToTestDirectory;
       RunTestsForProject;
-      ArchiveTestBuild
     </TestDependsOn>
   </PropertyGroup>
 
-  <Target Name="Test"
-          DependsOnTargets="$(TestDependsOn)">
-  </Target>
+  <Target Name="Test" DependsOnTargets="$(TestDependsOn)" />
+  <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />
+  <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" />
 
 </Project>

--- a/dir.props
+++ b/dir.props
@@ -287,6 +287,7 @@
     <NoExplicitReferenceToStdLib>true</NoExplicitReferenceToStdLib>
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <CopyNuGetImplementations>false</CopyNuGetImplementations>
   </PropertyGroup>
 
   <!-- Set up handling of build warnings -->

--- a/src/Common/test-runtime/XUnit.Runtime.depproj
+++ b/src/Common/test-runtime/XUnit.Runtime.depproj
@@ -24,7 +24,12 @@
                                                                               '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='xunit.console.netcore' And 
                                                                               '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='xunit.runner.utility' And 
                                                                               '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='Microsoft.xunit.netcore.extensions' And
-                                                                              '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='Microsoft.DotNet.xunit.performance.run.core'" />
+                                                                              '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='Microsoft.DotNet.xunit.performance.run.core' And
+                                                                              '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR' And
+                                                                              '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='runtime.win7-x64.Microsoft.NETCore.TestHost' And
+                                                                              '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets' And
+                                                                              '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='runtime.win7-x64.Microsoft.NETCore.Jit'
+                                                                              " />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Common/test-runtime/XUnit.Runtime.depproj
+++ b/src/Common/test-runtime/XUnit.Runtime.depproj
@@ -27,7 +27,6 @@
                                                                               '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='Microsoft.DotNet.xunit.performance.run.core' And
                                                                               '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR' And
                                                                               '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='runtime.win7-x64.Microsoft.NETCore.TestHost' And
-                                                                              '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets' And
                                                                               '%(ReferenceCopyLocalPaths.NuGetPackageId)'!='runtime.win7-x64.Microsoft.NETCore.Jit'
                                                                               " />
     </ItemGroup>

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -9,7 +9,6 @@
       "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0040",
       "Microsoft.NETCore.Runtime.CoreCLR": "1.2.0-beta-24728-02",
       "Microsoft.NETCore.TestHost": "1.2.0-beta-24728-02",
-      "Microsoft.NETCore.Windows.ApiSets": "1.0.2-beta-24727-00",
    },
    "frameworks": {
       "netstandard1.7": {}

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -3,10 +3,13 @@
       "xunit.console.netcore": "1.0.3-prerelease-00921-01",
       "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04",
       "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01001-04",
-       "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0040",
-       "Microsoft.DotNet.xunit.performance.analysis.cli": "1.0.0-alpha-build0040",
-       "Microsoft.DotNet.xunit.performance.runner.cli": "1.0.0-alpha-build0040",
-       "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0040"
+      "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0040",
+      "Microsoft.DotNet.xunit.performance.analysis.cli": "1.0.0-alpha-build0040",
+      "Microsoft.DotNet.xunit.performance.runner.cli": "1.0.0-alpha-build0040",
+      "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0040",
+      "Microsoft.NETCore.Runtime.CoreCLR": "1.2.0-beta-24728-02",
+      "Microsoft.NETCore.TestHost": "1.2.0-beta-24728-02",
+      "Microsoft.NETCore.Windows.ApiSets": "1.0.2-beta-24727-00",
    },
    "frameworks": {
       "netstandard1.7": {}

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -2,11 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>{8CBA022C-635F-4C8D-9D29-CD8AAC68C8E6}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <NugetTargetMoniker Condition="'$(NugetTargetMoniker)' == ''">.NETStandard,Version=v1.7</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -107,11 +103,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\System.Security.Principal.Windows\pkg\System.Security.Principal.Windows.pkgproj" />
-    <ProjectReference Include="..\..\pkg\System.Net.Sockets.pkgproj">
-      <Project>{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}</Project>
-      <Name>System.Net.Sockets</Name>
-    </ProjectReference>
 	<ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
       <Name>RemoteExecutorConsoleApp</Name>

--- a/src/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
+++ b/src/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
@@ -2,23 +2,12 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{A7074928-82C3-4739-88FE-9B528977950C}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>System.Numerics.Tests</RootNamespace>
-    <AssemblyName>System.Numerics.Vectors.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NuGetPackageImportStamp>11f13d9c</NuGetPackageImportStamp>
-    <NugetTargetMoniker>.NETStandard,Version=v1.3</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Compile Include="..\src\System\Numerics\ConstantHelper.cs">
       <AutoGen>True</AutoGen>
@@ -42,16 +31,6 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\pkg\System.Numerics.Vectors.pkgproj">
-      <Project>{53134b0c-0d57-481b-b84e-d1991e8d54ff}</Project>
-      <Name>System.Numerics.Vectors</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\src\System\Numerics\ConstantHelper.tt">

--- a/src/System.Runtime.Extensions/tests/AssemblyResolveTests/AssemblyResolveTests.csproj
+++ b/src/System.Runtime.Extensions/tests/AssemblyResolveTests/AssemblyResolveTests.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <ProjectGuid>ad83807c-8be5-4f27-85df-9793613233e1</ProjectGuid>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <CopyNuGetImplementations>false</CopyNuGetImplementations>
     <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>
@@ -28,4 +27,4 @@
     <TargetingPackReference Include="System.Runtime" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
- </Project>
+</Project>

--- a/src/System.Runtime.Extensions/tests/AssemblyResolveTests/AssemblyResolveTests.csproj
+++ b/src/System.Runtime.Extensions/tests/AssemblyResolveTests/AssemblyResolveTests.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>ad83807c-8be5-4f27-85df-9793613233e1</ProjectGuid>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <CopyNuGetImplementations>false</CopyNuGetImplementations>
     <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -5,15 +5,9 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>System.Runtime.Extensions.Tests</RootNamespace>
-    <AssemblyName>System.Runtime.Extensions.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants Condition="'$(TargetGroup)'=='netstandard1.7'">$(DefineConstants);netstandard17</DefineConstants>
-    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.5</NugetTargetMoniker>
   </PropertyGroup>
   <!-- Folder logic needs moved into common targets: https://github.com/dotnet/corefx/issues/11468 -->
   <ItemGroup Condition="'$(TargetGroup)'=='netstandard1.7'">
@@ -120,16 +114,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\System.Diagnostics.Debug\pkg\System.Diagnostics.Debug.pkgproj" />
-    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
-    <ProjectReference Include="..\..\System.IO.FileSystem.Primitives\pkg\System.IO.FileSystem.Primitives.pkgproj" />
-    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
-    <ProjectReference Include="..\..\System.IO.FileSystem\pkg\System.IO.FileSystem.pkgproj" />
-    <ProjectReference Include="..\pkg\System.Runtime.Extensions.pkgproj">
-      <Project>{1e689c1b-690c-4799-bde9-6e7990585894}</Project>
-      <Name>System.Runtime.Extensions.CoreCLR</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\System.Private.Uri\pkg\System.Private.Uri.pkgproj" />
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
       <Name>RemoteExecutorConsoleApp</Name>
@@ -152,8 +136,6 @@
       <Name>TestApp</Name>
       <UndefineProperties>TargetGroup;OSGroup</UndefineProperties>
     </ProjectReference>
-    <!-- ToDo: Remove this P2P reference once new packages are produced and updated -->
-    <ProjectReference Include="..\..\System.IO\pkg\System.IO.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.Extensions/tests/TestApp/TestApp.csproj
+++ b/src/System.Runtime.Extensions/tests/TestApp/TestApp.csproj
@@ -4,11 +4,10 @@
   <PropertyGroup>
     <ProjectGuid>{24BCEC6B-B9D2-47BC-9D66-725BD6B526FA}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>TestApp</RootNamespace>
-    <AssemblyName>TestApp</AssemblyName>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <CopyNuGetImplementations>false</CopyNuGetImplementations>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Runtime.Extensions/tests/TestAppOutsideOfTPA/TestAppOutsideOfTPA.csproj
+++ b/src/System.Runtime.Extensions/tests/TestAppOutsideOfTPA/TestAppOutsideOfTPA.csproj
@@ -4,11 +4,9 @@
   <PropertyGroup>
     <ProjectGuid>{C44B33E3-F89F-40B9-B353-D380C1524988}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>TestAppOutsideOfTPA</RootNamespace>
-    <AssemblyName>TestAppOutsideOfTPA</AssemblyName>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <CopyNuGetImplementations>false</CopyNuGetImplementations>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -28,9 +26,6 @@
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="System.Core" />
     <TargetingPackReference Include="System.Runtime" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AssemblyResolveTests\AssemblyResolveTests.csproj">

--- a/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.csproj
+++ b/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.csproj
@@ -4,11 +4,9 @@
   <PropertyGroup>
     <ProjectGuid>{9F312D76-9AF1-4E90-B3B0-815A1EC6C346}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>VoidMainWithExitCodeApp</RootNamespace>
-    <AssemblyName>VoidMainWithExitCodeApp</AssemblyName>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <CopyNuGetImplementations>false</CopyNuGetImplementations>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -28,9 +26,6 @@
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="System.Core" />
     <TargetingPackReference Include="System.Runtime" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/targetingpacks.props
+++ b/targetingpacks.props
@@ -27,7 +27,7 @@
 
       <!-- Add Reference's to all files in the targeting pack folder, and to whitelisted items from the group above in the runtime folder. -->
       <TargetingPackItems Include="%(TargetingPackDirs.Identity)/*" />
-      <Reference Include="%(TargetingPackItems.Filename)" Exclude="@(TargetingPackExclusions)" Condition="'$(NoTargetingPackReferences)' != 'true'"> <!-- TODO: System.Private.CoreLib shouldn't even be in the targeting pack. -->
+      <Reference Include="%(TargetingPackItems.Filename)" Exclude="@(TargetingPackExclusions)"> <!-- TODO: System.Private.CoreLib shouldn't even be in the targeting pack. -->
         <Private>false</Private>
       </Reference>
       <Reference Include="@(RuntimeReferencedAssemblyNames)" />


### PR DESCRIPTION
@joperezr @karajas 

This is an initial version of tests.targets that runs tests using corerun.exe and the live-built runtime. I also converted a handful of tests around the repo to make sure things were working with a few different random projects.