### PR TITLE
Fix XmlWriter Outerloop test failures

### DIFF
--- a/src/System.Private.Xml/tests/Writers/XmlWriterApi/CommonTests.cs
+++ b/src/System.Private.Xml/tests/Writers/XmlWriterApi/CommonTests.cs
@@ -7096,8 +7096,6 @@ namespace System.Xml.Tests
 
             public int writeValue_27()
             {
-                CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;  // So that the number format doesn't depend on the current culture
-
                 if (CurVariation.Desc.Equals("elem.WriteValue(new DateTimeOffset)"))
                 {
                     Console.WriteLine("elem.WriteValue(new DateTimeOffset)");
@@ -7110,6 +7108,7 @@ namespace System.Xml.Tests
                 Type dest = typeMapper[destStr];
                 bool isValid = (bool)CurVariation.Params[3];
                 object expVal = (object)CurVariation.Params[4];
+                CultureInfo origCulture = null;
 
                 if (expVal == null && destStr.Contains("DateTime"))
                     expVal = value[destStr];
@@ -7131,6 +7130,8 @@ namespace System.Xml.Tests
                 }
                 try
                 {
+                    origCulture = CultureInfo.CurrentCulture;
+                    CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;  // So that the number format doesn't depend on the current culture
                     VerifyValue(dest, expVal, param);
                 }
                 catch (XmlException)
@@ -7157,6 +7158,10 @@ namespace System.Xml.Tests
                 {
                     if (!isValid) return TEST_PASS;
                     CError.Compare(false, "ArgumentException");
+                }
+                finally
+                {
+                    CultureInfo.CurrentCulture = origCulture;
                 }
                 return (isValid) ? TEST_PASS : TEST_FAIL;
             }

--- a/src/System.Private.Xml/tests/Writers/XmlWriterApi/CommonTests.cs
+++ b/src/System.Private.Xml/tests/Writers/XmlWriterApi/CommonTests.cs
@@ -7096,6 +7096,8 @@ namespace System.Xml.Tests
 
             public int writeValue_27()
             {
+                CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;  // So that the number format doesn't depend on the current culture
+
                 if (CurVariation.Desc.Equals("elem.WriteValue(new DateTimeOffset)"))
                 {
                     Console.WriteLine("elem.WriteValue(new DateTimeOffset)");

--- a/src/System.Private.Xml/tests/Writers/XmlWriterApi/EndOfLineHandlingTests.cs
+++ b/src/System.Private.Xml/tests/Writers/XmlWriterApi/EndOfLineHandlingTests.cs
@@ -100,7 +100,7 @@ namespace System.Xml.Tests
                     {
                         output = output.Replace("\r\n", "\n");
                         output = output.Replace("\r", "\n");
-                        output = output.Replace("\n", "\r\n");
+                        output = output.Replace("\n", nl);
                     }
                     else
                     {
@@ -417,7 +417,7 @@ namespace System.Xml.Tests
             wSettings.Indent = true;
 
             XmlWriter w = CreateMemWriter(wSettings);
-            CError.Compare(w.Settings.NewLineChars, "\r\n", "Incorect default value for XmlWriter.Settings.NewLineChars");
+            CError.Compare(w.Settings.NewLineChars, nl, "Incorect default value for XmlWriter.Settings.NewLineChars");
             CError.Compare(w.Settings.IndentChars, "  ", "Incorect default value for XmlWriter.Settings.IndentChars");
 
             w.WriteStartElement("root");
@@ -427,7 +427,7 @@ namespace System.Xml.Tests
             w.WriteEndElement();
             w.Dispose();
 
-            VerifyOutput("<root>\r\n  <foo>\r\n    <bar />\r\n  </foo>\r\n</root>");
+            VerifyOutput(string.Format("<root>{0}  <foo>{0}    <bar />{0}  </foo>{0}</root>", nl));
 
             return TEST_PASS;
         }

--- a/src/System.Private.Xml/tests/Writers/XmlWriterApi/TCFullEndElement.cs
+++ b/src/System.Private.Xml/tests/Writers/XmlWriterApi/TCFullEndElement.cs
@@ -640,8 +640,8 @@ namespace System.Xml.Tests
                 // for function CData_13
                 {
                     this.AddChild(new CVariation(CData_13) { Attribute = new Variation("WriteCData with 0x0A with NewLineHandling.Entitize") { Params = new object[] { 10, NewLineHandling.Entitize, "<r><![CDATA[\n]]></r>" }, id = 18, Pri = 1 } });
-                    this.AddChild(new CVariation(CData_13) { Attribute = new Variation("WriteCData with 0x0D with NewLineHandling.Replace") { Params = new object[] { 13, NewLineHandling.Replace, "<r><![CDATA[\r\n]]></r>" }, id = 13, Pri = 1 } });
-                    this.AddChild(new CVariation(CData_13) { Attribute = new Variation("WriteCData with 0x0A with NewLineHandling.Replace") { Params = new object[] { 10, NewLineHandling.Replace, "<r><![CDATA[\r\n]]></r>" }, id = 16, Pri = 1 } });
+                    this.AddChild(new CVariation(CData_13) { Attribute = new Variation("WriteCData with 0x0D with NewLineHandling.Replace") { Params = new object[] { 13, NewLineHandling.Replace, string.Format("<r><![CDATA[{0}]]></r>", Environment.NewLine) }, id = 13, Pri = 1 } });
+                    this.AddChild(new CVariation(CData_13) { Attribute = new Variation("WriteCData with 0x0A with NewLineHandling.Replace") { Params = new object[] { 10, NewLineHandling.Replace, string.Format("<r><![CDATA[{0}]]></r>", Environment.NewLine) }, id = 16, Pri = 1 } });
                     this.AddChild(new CVariation(CData_13) { Attribute = new Variation("WriteCData with 0x0A with NewLineHandling.None") { Params = new object[] { 10, NewLineHandling.None, "<r><![CDATA[\n]]></r>" }, id = 17, Pri = 1 } });
                     this.AddChild(new CVariation(CData_13) { Attribute = new Variation("WriteCData with 0x0D with NewLineHandling.Entitize") { Params = new object[] { 13, NewLineHandling.Entitize, "<r><![CDATA[\r]]></r>" }, id = 15, Pri = 1 } });
                     this.AddChild(new CVariation(CData_13) { Attribute = new Variation("WriteCData with 0x0D with NewLineHandling.None") { Params = new object[] { 13, NewLineHandling.None, "<r><![CDATA[\r]]></r>" }, id = 14, Pri = 1 } });

--- a/src/System.Private.Xml/tests/Writers/XmlWriterApi/TCXmlWriterTestModule.cs
+++ b/src/System.Private.Xml/tests/Writers/XmlWriterApi/TCXmlWriterTestModule.cs
@@ -97,7 +97,6 @@ namespace System.Xml.Tests
 
         [Fact]
         [OuterLoop]
-        [ActiveIssue(1491)]
         public static void TCFullEndElement()
         {
             RunTest(() => new TCFullEndElement() { Attribute = new TestCase() { Name = "WriteFullEndElement" } });
@@ -105,7 +104,6 @@ namespace System.Xml.Tests
 
         [Fact]
         [OuterLoop]
-        [ActiveIssue(6331)]
         public static void TCEOFHandling()
         {
             RunTest(() => new TCEOFHandling() { Attribute = new TestCase() { Name = "XmlWriterSettings: NewLineHandling" } });


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/6331 and https://github.com/dotnet/corefx/issues/1491

These tests were failing due to: **1)** Newline differences on Unix and Windows, **2)** Decimal point differences in some cultures

cc: @danmosemsft @stephentoub @AlexGhiondea 