### PR TITLE
Fill some gaps in S.L.Expression testing

### DIFF
--- a/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
@@ -2769,5 +2769,57 @@ namespace System.Linq.Expressions.Tests
             Expression index = Expression.Property(null, typeof(Unreadable<int>), nameof(Unreadable<int>.WriteOnly));
             Assert.Throws<ArgumentException>("index", () => Expression.ArrayIndex(array, index));
         }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void NonZeroBasedOneDimensionalArrayIndex(bool useInterpreter)
+        {
+            Array arrayObj = Array.CreateInstance(typeof(int), new[] { 3 }, new[] { -1 });
+            arrayObj.SetValue(5, -1);
+            arrayObj.SetValue(6, 0);
+            arrayObj.SetValue(7, 1);
+            ConstantExpression array = Expression.Constant(arrayObj);
+            BinaryExpression indexM1 = Expression.ArrayIndex(array, Expression.Constant(-1));
+            BinaryExpression index0 = Expression.ArrayIndex(array, Expression.Constant(0));
+            BinaryExpression index1 = Expression.ArrayIndex(array, Expression.Constant(1));
+            Func<bool> testValues = Expression.Lambda<Func<bool>>(
+                Expression.And(
+                    Expression.Equal(indexM1, Expression.Constant(5)),
+                    Expression.And(
+                        Expression.Equal(index0, Expression.Constant(6)),
+                        Expression.Equal(index1, Expression.Constant(7))))).Compile(useInterpreter);
+            Assert.True(testValues());
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void NonZeroBasedOneDimensionalArrayIndexMethod(bool useInterpreter)
+        {
+            Array arrayObj = Array.CreateInstance(typeof(int), new[] { 3 }, new[] { -1 });
+            arrayObj.SetValue(5, -1);
+            arrayObj.SetValue(6, 0);
+            arrayObj.SetValue(7, 1);
+            ConstantExpression array = Expression.Constant(arrayObj);
+            MethodCallExpression indexM1 = Expression.ArrayIndex(array, new [] { Expression.Constant(-1)});
+            MethodCallExpression index0 = Expression.ArrayIndex(array, new[] { Expression.Constant(0)});
+            MethodCallExpression index1 = Expression.ArrayIndex(array, new[] { Expression.Constant(1)});
+            Func<bool> testValues = Expression.Lambda<Func<bool>>(
+                Expression.And(
+                    Expression.Equal(indexM1, Expression.Constant(5)),
+                    Expression.And(
+                        Expression.Equal(index0, Expression.Constant(6)),
+                        Expression.Equal(index1, Expression.Constant(7))))).Compile(useInterpreter);
+            Assert.True(testValues());
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void HighRankArrayIndex(bool useInterpreter)
+        {
+            string[,,,,,,,,,] arrayObj = {{{{{{{{{{"hugz"}}}}}}}}}};
+            ConstantExpression array = Expression.Constant(arrayObj);
+            Func<string> func = Expression.Lambda<Func<string>>(
+                Expression.ArrayIndex(array, Enumerable.Repeat(Expression.Constant(0), 10))).Compile(useInterpreter);
+            Assert.Equal("hugz", func());
+        }
+
+
     }
 }

--- a/src/System.Linq.Expressions/tests/Cast/AsNullable.cs
+++ b/src/System.Linq.Expressions/tests/Cast/AsNullable.cs
@@ -28,6 +28,46 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckEnumAsNullableEnumTypeTest(bool useInterpreter)
+        {
+            E[] array = { 0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifyEnumAsNullableEnumType(array[i], useInterpreter);
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableEnumAsNullableEnumTypeTest(bool useInterpreter)
+        {
+            E?[] array = { null, 0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue };
+            for (int i = 0; i < array.Length; i++)
+            {
+                VerifyNullableEnumAsNullableEnumType(array[i], useInterpreter);
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckLongAsNullableEnumTypeTest(bool useInterpreter)
+        {
+            long[] array = { 0, 1, long.MinValue, long.MaxValue };
+            foreach (long value in array)
+            {
+                VerifyLongAsNullableEnumType(value, useInterpreter);
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void CheckNullableLongAsNullableEnumTypeTest(bool useInterpreter)
+        {
+            long?[] array = { null, 0, 1, long.MinValue, long.MaxValue };
+            foreach (long? value in array)
+            {
+                VerifyNullableLongAsNullableEnumType(value, useInterpreter);
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckNullableEnumAsObjectTest(bool useInterpreter)
         {
             E?[] array = new E?[] { null, (E)0, E.A, E.B, (E)int.MaxValue, (E)int.MinValue };
@@ -158,6 +198,38 @@ namespace System.Linq.Expressions.Tests
             Func<Enum> f = e.Compile(useInterpreter);
 
             Assert.Equal(value as ValueType, f());
+        }
+
+        private static void VerifyEnumAsNullableEnumType(E value, bool useInterpreter)
+        {
+            Expression<Func<E?>> e = Expression.Lambda<Func<E?>>(
+                Expression.TypeAs(Expression.Constant(value), typeof(E?)));
+            Func<E?> f = e.Compile(useInterpreter);
+            Assert.Equal(value, f());
+        }
+
+        private static void VerifyNullableEnumAsNullableEnumType(E? value, bool useInterpreter)
+        {
+            Expression<Func<E?>> e = Expression.Lambda<Func<E?>>(
+                Expression.TypeAs(Expression.Constant(value, typeof(E?)), typeof(E?)));
+            Func<E?> f = e.Compile(useInterpreter);
+            Assert.Equal(value, f());
+        }
+
+        private static void VerifyLongAsNullableEnumType(long value, bool useInterpreter)
+        {
+            Expression<Func<E?>> e = Expression.Lambda<Func<E?>>(
+                Expression.TypeAs(Expression.Constant(value), typeof(E?)));
+            Func<E?> f = e.Compile(useInterpreter);
+            Assert.False(f().HasValue);
+        }
+
+        private static void VerifyNullableLongAsNullableEnumType(long? value, bool useInterpreter)
+        {
+            Expression<Func<E?>> e = Expression.Lambda<Func<E?>>(
+                Expression.TypeAs(Expression.Constant(value, typeof(long?)), typeof(E?)));
+            Func<E?> f = e.Compile(useInterpreter);
+            Assert.False(f().HasValue);
         }
 
         private static void VerifyNullableEnumAsObject(E? value, bool useInterpreter)


### PR DESCRIPTION
A few small bits that won't fall under a focus on any other section.

Some array-expressions tests, mostly on aspects of non-szarrays.

Test `TypeAs` expressions between nullables.

Test fault and finally after many such blocks (catch regressions in a non-optimised path hit in this case).