### PR TITLE
Add several LINQ tests related to comparers

### DIFF
--- a/src/System.Linq/tests/ExceptTests.cs
+++ b/src/System.Linq/tests/ExceptTests.cs
@@ -125,5 +125,22 @@ namespace System.Linq.Tests
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }
+
+        [Fact]
+        public void HashSetWithBuiltInComparer_HashSetContainsNotUsed()
+        {
+            IEnumerable<string> input1 = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "a" };
+            IEnumerable<string> input2 = new[] { "A" };
+
+            Assert.Equal(new[] { "a" }, input1.Except(input2));
+            Assert.Equal(new[] { "a" }, input1.Except(input2, null));
+            Assert.Equal(new[] { "a" }, input1.Except(input2, EqualityComparer<string>.Default));
+            Assert.Equal(Enumerable.Empty<string>(), input1.Except(input2, StringComparer.OrdinalIgnoreCase));
+
+            Assert.Equal(new[] { "A" }, input2.Except(input1));
+            Assert.Equal(new[] { "A" }, input2.Except(input1, null));
+            Assert.Equal(new[] { "A" }, input2.Except(input1, EqualityComparer<string>.Default));
+            Assert.Equal(Enumerable.Empty<string>(), input2.Except(input1, StringComparer.OrdinalIgnoreCase));
+        }
     }
 }

--- a/src/System.Linq/tests/IntersectTests.cs
+++ b/src/System.Linq/tests/IntersectTests.cs
@@ -119,5 +119,22 @@ namespace System.Linq.Tests
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }
+
+        [Fact]
+        public void HashSetWithBuiltInComparer_HashSetContainsNotUsed()
+        {
+            IEnumerable<string> input1 = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "a" };
+            IEnumerable<string> input2 = new[] { "A" };
+
+            Assert.Equal(Enumerable.Empty<string>(), input1.Intersect(input2));
+            Assert.Equal(Enumerable.Empty<string>(), input1.Intersect(input2, null));
+            Assert.Equal(Enumerable.Empty<string>(), input1.Intersect(input2, EqualityComparer<string>.Default));
+            Assert.Equal(new[] { "a" }, input1.Intersect(input2, StringComparer.OrdinalIgnoreCase));
+
+            Assert.Equal(Enumerable.Empty<string>(), input2.Intersect(input1));
+            Assert.Equal(Enumerable.Empty<string>(), input2.Intersect(input1, null));
+            Assert.Equal(Enumerable.Empty<string>(), input2.Intersect(input1, EqualityComparer<string>.Default));
+            Assert.Equal(new[] { "A" }, input2.Intersect(input1, StringComparer.OrdinalIgnoreCase));
+        }
     }
 }

--- a/src/System.Linq/tests/UnionTests.cs
+++ b/src/System.Linq/tests/UnionTests.cs
@@ -396,5 +396,22 @@ namespace System.Linq.Tests
 
             Assert.Equal(result, result);
         }
+
+        [Fact]
+        public void HashSetWithBuiltInComparer_HashSetContainsNotUsed()
+        {
+            IEnumerable<string> input1 = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "a" };
+            IEnumerable<string> input2 = new[] { "A" };
+
+            Assert.Equal(new[] { "a", "A" }, input1.Union(input2));
+            Assert.Equal(new[] { "a", "A" }, input1.Union(input2, null));
+            Assert.Equal(new[] { "a", "A" }, input1.Union(input2, EqualityComparer<string>.Default));
+            Assert.Equal(new[] { "a" }, input1.Union(input2, StringComparer.OrdinalIgnoreCase));
+
+            Assert.Equal(new[] { "A", "a" }, input2.Union(input1));
+            Assert.Equal(new[] { "A", "a" }, input2.Union(input1, null));
+            Assert.Equal(new[] { "A", "a" }, input2.Union(input1, EqualityComparer<string>.Default));
+            Assert.Equal(new[] { "A" }, input2.Union(input1, StringComparer.OrdinalIgnoreCase));
+        }
     }
 }


### PR DESCRIPTION
To help make sure we don't take breaking changes related to making assumptions about the behavior of a collection's Contains implementation and what comparer it uses.

cc: @JonHanna 