### PR TITLE
Clean-up batch restoring of packages.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <!-- Capture OSGroup passed to command line for setting default FilterToOSGroup value below -->
-    <_OriginalOSGroup>$(OSGroup)</_OriginalOSGroup>
-  </PropertyGroup>
-  <PropertyGroup>
-    <InputOSGroup>$(OSGroup)</InputOSGroup>
-    <InputOSGroup Condition="'$(InputOSGroup)'==''">$(FilterToOSGroup)</InputOSGroup>
-  </PropertyGroup>
   <Import Project="dir.props" />
 
   <!-- required to build the projects in their specified order -->
@@ -15,19 +7,14 @@
     <SerializeProjects>true</SerializeProjects>
   </PropertyGroup>
 
-  <!-- The following properties are in place to keep the behavior of build.cmd while we work on the dev workflow steps. -->
-  <PropertyGroup>
-    <!-- To disable the restoration of packages, set RestoreDuringBuild=false or pass /p:RestoreDuringBuild=false.-->
-    <RestoreDuringBuild Condition="'$(RestoreDuringBuild)'==''">true</RestoreDuringBuild>
-    <!-- To disable building packages, set BuildPackages=false or pass /p:BuildPackages=false.-->
-    <BuildPackages Condition="'$(BuildPackages)'==''">true</BuildPackages>
-    <!-- To disable building tests, set BuildTests=false or pass /p:BuildTests=false.-->
-    <BuildTests Condition="'$(BuildTests)'==''">true</BuildTests>
-  </PropertyGroup>
-
   <PropertyGroup>
     <GenerateCodeCoverageReportForAll>true</GenerateCodeCoverageReportForAll>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <BuildPackages Condition="'$(BuildPackages)'==''">true</BuildPackages>
+  </PropertyGroup>
+
   <Import Project="$(ToolsDir)CodeCoverage.targets" Condition="Exists('$(ToolsDir)CodeCoverage.targets')" />
   <Import Project="$(ToolsDir)PerfTesting.targets" Condition="Exists('$(ToolsDir)PerfTesting.targets') and '$(Performance)' == 'true'"/>
   <Import Project="$(ToolsDir)VersionTools.targets" Condition="Exists('$(ToolsDir)VersionTools.targets')" />
@@ -62,40 +49,10 @@
   <PropertyGroup>
     <TraversalBuildDependsOn>
       BuildCoreFxTools;
-      $(TraversalBuildDependsOn);
-    </TraversalBuildDependsOn>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(RestoreDuringBuild)'=='true'">
-    <TraversalBuildDependsOn>
-      BatchRestorePackages;
-      ValidateExactRestore;
       CreateOrUpdateCurrentVersionFile;
       $(TraversalBuildDependsOn);
     </TraversalBuildDependsOn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(BuildTestsAgainstPackages)' == 'true'">
-    <TraversalBuildDependsOn>
-      UpdateVersionsOnTestProjectJson;
-      BatchGenerateTestProjectJsons;
-      $(TraversalBuildDependsOn);
-    </TraversalBuildDependsOn>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <TestProjectJsons Include="$(MSBuildThisFileDirectory)src/Common/test-runtime/project.json" />
-    <TestProjectJsons Include="$(MSBuildThisFileDirectory)external/supplemental-test-data/project.json" />
-  </ItemGroup>
-
-  <UsingTask TaskName="GatherDirectoriesToRestore" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
-
-  <!-- Create a collection of all project.json files for dependency updates. -->
-  <ItemGroup>
-    <ProjectJsonFiles Include="$(SourceDir)**/project.json" />
-    <ProjectJsonFiles Include="$(MSBuildThisFileDirectory)pkg/**/project.json" />
-    <ProjectJsonFiles Include="$(MSBuildThisFileDirectory)layout/**/project.json" />
-    <ProjectJsonFiles Condition="'$(BuildTestsAgainstPackages)' == 'true'" Include="$(GeneratedProjectJsonDir)/**/project.json" />
-  </ItemGroup>
 
   <Target Name="BuildCoreFxTools">
     <ItemGroup>
@@ -107,97 +64,11 @@
     </ItemGroup>
     <MSBuild Projects="@(BuildToolsProject)"
              ContinueOnError="ErrorAndContinue"
-             Condition="'%(Identity)' != ''" 
+             Condition="'%(Identity)' != ''"
              Properties="TargetGroup=%(BuildToolsProject.TargetGroup)" />
   </Target>
 
-  <Target Name="BatchRestorePackages" DependsOnTargets="AddGeneratedProjectJsons;VerifyDependencies">
-    <MakeDir Directories="$(PackagesDir)" Condition="!Exists('$(PackagesDir)')" />
-
-    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring all packages..." />
-
-    <IsRestoreRequired ProjectJsons="@(ProjectJsonFiles)" PackagesFolder="$(PackagesDir)">
-      <Output TaskParameter="RestoreRequired" PropertyName="RestoreRequired" />
-    </IsRestoreRequired>
-
-    <!-- This is to restore the test-runtime project.json up front which contains the latest packages to be tested to avoid download contention within nuget. -->
-    <Exec Command="$(DnuRestoreCommand) @(TestProjectJsons->'&quot;%(Identity)&quot;', ' ')"
-          Condition="'$(RestoreRequired)' == 'true'"
-          StandardOutputImportance="Low"
-          CustomErrorRegularExpression="(^Unable to locate .*)|(^Updating the invalid lock file with .*)"
-          ContinueOnError="ErrorAndContinue" />
-
-    <Exec Command="$(DnuRestoreCommand) @(DnuRestoreDir->'&quot;%(Identity)&quot;', ' ')"
-          Condition="'$(RestoreRequired)' == 'true'"
-          StandardOutputImportance="Low"
-          CustomErrorRegularExpression="(^Unable to locate .*)|(^Updating the invalid lock file with .*)"
-          ContinueOnError="ErrorAndContinue" />
-
-    <!-- Given we ErrorAndContinue we need to propagate the error if the overall task failed -->
-    <Error Condition="'$(MSBuildLastTaskResult)'=='false'" />
-
-    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring all packages...Done." />
-  </Target>
-
-  <!-- Generated project.json's may not exist when the "ProjectJsonFiles"" item group is defined (in dir.props), This target
-       ensures those files are added to the itemgroup. -->
-  <Target Name="AddGeneratedProjectJsons">
-    <ItemGroup>
-      <ProjectJsonFiles Condition="'$(BuildTestsAgainstPackages)' == 'true'" Include="$(GeneratedProjectJsonDir)/**/project.json" />
-    </ItemGroup>
-  </Target>
-
-  <UsingTask TaskName="AddDependenciesToProjectJson" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <Target Name="UpdateVersionsOnTestProjectJson" >
-
-  <!-- Duplicate properties to be removed in future -->
-    <PropertyGroup>
-        <PackageNameRegex Condition="'$(PackageNameRegex)' == ''">(?%3Cname%3E.*)\.(?%3Cversion%3E\d+\.\d+\.\d+)(-(?%3Cprerelease%3E.*)?)?</PackageNameRegex>
-    </PropertyGroup>
-    <ItemGroup>
-      <_PackagesDropsForCommonProjectJson Include="$(PackagesDrops)" />
-    </ItemGroup>
-
-    <AddDependenciesToProjectJson AdditionalDependencies="@(ExternalDependencies)"
-                                  PackagesDrops="@(_PackagesDropsForCommonProjectJson)"
-                                  PackageNameRegex="$(PackageNameRegex)"
-                                  VersionsFiles="@(_VersionsFiles)"
-                                  ProjectJson="$(CommonTestProjectJson)"
-                                  OutputProjectJson="$(CommonOutputTestProjectJson)"
-                                  UseNewestAvailablePackages="$(UseNewestAvailablePackages)"
-                                   />
-  </Target>
-
-  <!-- Evaluate our test projects (in src\tests.builds) -->
-  <Target Name="BatchGenerateTestProjectJsons"
-          Condition="'$(BuildTestsAgainstPackages)' == 'true'"
-          DependsOnTargets="FilterProjects;UpdateVersionsOnTestProjectJson"
-          BeforeTargets="RestorePackages">
-      <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Generating Test project.json's..." />
-      <MSBuild Targets="GenerateAllTestProjectJsons"
-               Projects="src\tests.builds" />
-      <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Generating Test project.json's...done" />
-  </Target>
-
-  <!-- Task from buildtools that uses lockfiles to validate that packages restored are exactly what were specified. -->
-  <UsingTask TaskName="ValidateExactRestore" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
-
-  <Target Name="ValidateExactRestore"
-          Condition="'$(AllowInexactRestore)'!='true'">
-    <ValidateExactRestore ProjectLockJsons="@(ProjectJsonFiles->'%(RootDir)%(Directory)%(Filename).lock.json')" />
-  </Target>
-
-  <!-- Tasks from buildtools for easy project.json dependency updates -->
-  <UsingTask TaskName="UpdatePackageDependencyVersion" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
-
-  <Target Name="UpdatePackageDependencyVersion">
-    <UpdatePackageDependencyVersion ProjectJsons="@(ProjectJsonFiles)"
-                                    PackageId="$(PackageId)"
-                                    OldVersion="$(OldVersion)"
-                                    NewVersion="$(NewVersion)" />
-  </Target>
-
-  <!-- Packages.zip creation -->
+  <!-- TODO: Can we move this archive test build to BuildTools -->
   <UsingTask TaskName="ZipFileCreateFromDependencyLists" Condition="'$(ArchiveTests)' == 'true'" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <Target Name="ArchiveTestBuild" Condition="'$(ArchiveTests)' == 'true'" AfterTargets="Build" >
     <ItemGroup>
@@ -218,9 +89,6 @@
       RelativePathBaseDirectory="$(PackagesDir)"
       OverwriteDestination="true" />
   </Target>
-
-  <!-- Override RestorePackages from dir.traversal.targets and do a batch restore -->
-  <Target Name="RestorePackages" DependsOnTargets="BatchRestorePackages" />
 
   <!-- Override CleanAllProjects from dir.traversal.targets and just remove the full BinDir -->
   <Target Name="CleanAllProjects">

--- a/dir.props
+++ b/dir.props
@@ -24,7 +24,7 @@
     <!-- Hacky BuildConfiguration -->
     <BuildConfiguration Condition="'$(BuildConfiguration)' == ''">netcoreapp1.1-$(OSEnvironment)</BuildConfiguration>
   </PropertyGroup>
-  
+
   <Import Condition="Exists('$(MSBuildProjectDirectory)/Configurations.props')" Project="$(MSBuildProjectDirectory)/Configurations.props" />
 
   <PropertyGroup>
@@ -149,11 +149,6 @@
     <DnuRestoreCommand Condition="'$(NuGetConfigPath)'!=''">$(DnuRestoreCommand) --configfile $(NuGetConfigPath)</DnuRestoreCommand>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(BuildAllProjects)'=='true'">
-    <!-- When we do a traversal build we get all packages up front, don't restore them again -->
-    <RestorePackages>false</RestorePackages>
-  </PropertyGroup>
-
   <PropertyGroup>
     <!-- By default make all libraries to be AnyCPU but individual projects can override it if they need to -->
     <Platform>AnyCPU</Platform>
@@ -177,30 +172,30 @@
     <ConfigurationGroup Condition="'$(ConfigurationGroup)'==''">Debug</ConfigurationGroup>
 <!-->    <TargetGroup Condition="'$(TargetGroup)' == ''">netcoreapp1.1</TargetGroup>
     <OSGroup Condition="'$(OSGroup)' == ''">$(OSEnvironment)</OSGroup>
--->    
+-->
     <Configuration Condition="'$(OSGroup)' != 'AnyOS'">$(TargetGroup)-$(OSGroup)</Configuration>
     <Configuration Condition="'$(OSGroup)' == 'AnyOS'">$(TargetGroup)</Configuration>
   </PropertyGroup>
 
-  <!-- Set up Default symbol and optimization for Configuration --> 
-  <Choose> 
-    <When Condition="'$(ConfigurationGroup)'=='Debug'"> 
-      <PropertyGroup> 
-        <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols> 
-        <Optimize Condition="'$(Optimize)' == ''">false</Optimize> 
-        <DebugType Condition="'$(DebugType)' == ''">full</DebugType> 
-        <DefineConstants>$(DefineConstants),DEBUG,TRACE</DefineConstants> 
-      </PropertyGroup> 
-    </When> 
-    <When Condition="'$(ConfigurationGroup)' == 'Release'"> 
-      <PropertyGroup> 
-        <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols> 
-        <Optimize Condition="'$(Optimize)' == ''">true</Optimize> 
-        <DebugType Condition="'$(DebugType)' == ''">pdbonly</DebugType> 
-        <DefineConstants>$(DefineConstants),TRACE</DefineConstants> 
+  <!-- Set up Default symbol and optimization for Configuration -->
+  <Choose>
+    <When Condition="'$(ConfigurationGroup)'=='Debug'">
+      <PropertyGroup>
+        <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
+        <Optimize Condition="'$(Optimize)' == ''">false</Optimize>
+        <DebugType Condition="'$(DebugType)' == ''">full</DebugType>
+        <DefineConstants>$(DefineConstants),DEBUG,TRACE</DefineConstants>
       </PropertyGroup>
-    </When> 
-  </Choose> 
+    </When>
+    <When Condition="'$(ConfigurationGroup)' == 'Release'">
+      <PropertyGroup>
+        <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
+        <Optimize Condition="'$(Optimize)' == ''">true</Optimize>
+        <DebugType Condition="'$(DebugType)' == ''">pdbonly</DebugType>
+        <DefineConstants>$(DefineConstants),TRACE</DefineConstants>
+      </PropertyGroup>
+    </When>
+  </Choose>
 
   <!-- initialize all the targets variables to false as they should only be set below -->
   <PropertyGroup>
@@ -212,48 +207,48 @@
     <TargetsNetBSD>false</TargetsNetBSD>
   </PropertyGroup>
 
-<!-- Probably want to make these be generated into configurations.props --> 
-  <Choose> 
-    <When Condition="'$(OSGroup)'=='Windows_NT'"> 
-      <PropertyGroup> 
-        <TargetsWindows>true</TargetsWindows> 
-      </PropertyGroup> 
-    </When> 
-    <When Condition="'$(OSGroup)'=='Unix'"> 
-      <PropertyGroup> 
-        <TargetsUnix>true</TargetsUnix> 
-      </PropertyGroup> 
-    </When> 
-    <When Condition="'$(OSGroup)'=='Linux'"> 
-      <PropertyGroup> 
-        <TargetsUnix>true</TargetsUnix> 
-        <TargetsLinux>true</TargetsLinux> 
-      </PropertyGroup> 
-    </When> 
-    <When Condition="'$(OSGroup)'=='OSX'"> 
-      <PropertyGroup> 
-        <TargetsUnix>true</TargetsUnix> 
-        <TargetsOSX>true</TargetsOSX> 
-      </PropertyGroup> 
-    </When> 
-    <When Condition="'$(OSGroup)'=='FreeBSD'"> 
-      <PropertyGroup> 
-        <TargetsUnix>true</TargetsUnix> 
-        <TargetsFreeBSD>true</TargetsFreeBSD> 
-      </PropertyGroup> 
-    </When> 
-    <When Condition="'$(OSGroup)'=='NetBSD'"> 
-      <PropertyGroup> 
-        <TargetsUnix>true</TargetsUnix> 
-        <TargetsNetBSD>true</TargetsNetBSD> 
-      </PropertyGroup> 
-    </When> 
-  </Choose> 
+<!-- Probably want to make these be generated into configurations.props -->
+  <Choose>
+    <When Condition="'$(OSGroup)'=='Windows_NT'">
+      <PropertyGroup>
+        <TargetsWindows>true</TargetsWindows>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(OSGroup)'=='Unix'">
+      <PropertyGroup>
+        <TargetsUnix>true</TargetsUnix>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(OSGroup)'=='Linux'">
+      <PropertyGroup>
+        <TargetsUnix>true</TargetsUnix>
+        <TargetsLinux>true</TargetsLinux>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(OSGroup)'=='OSX'">
+      <PropertyGroup>
+        <TargetsUnix>true</TargetsUnix>
+        <TargetsOSX>true</TargetsOSX>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(OSGroup)'=='FreeBSD'">
+      <PropertyGroup>
+        <TargetsUnix>true</TargetsUnix>
+        <TargetsFreeBSD>true</TargetsFreeBSD>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(OSGroup)'=='NetBSD'">
+      <PropertyGroup>
+        <TargetsUnix>true</TargetsUnix>
+        <TargetsNetBSD>true</TargetsNetBSD>
+      </PropertyGroup>
+    </When>
+  </Choose>
 
   <PropertyGroup>
     <BuildConfigurationImportFile>$(BinDir)tools/configuration/configuration.props</BuildConfigurationImportFile>
   </PropertyGroup>
-  <Import Project="$(BuildConfigurationImportFile)" Condition="Exists('$(BuildConfigurationImportFile)')" /> 
+  <Import Project="$(BuildConfigurationImportFile)" Condition="Exists('$(BuildConfigurationImportFile)')" />
 
   <!-- Default Test platform to deploy the netstandard compiled tests to -->
   <PropertyGroup>
@@ -309,7 +304,7 @@
     <TestTargetOutputRelPath Condition="'$(TestTargetOutputRelPath)'=='' And '$(TargetGroup)'=='' And '$(TestTFM)'!=''">default.$(TestTFM)/</TestTargetOutputRelPath>
 
     <BaseOutputPath Condition="'$(BaseOutputPath)'==''">$(BinDir)</BaseOutputPath>
-    
+
     <OutputPathSubfolder Condition="'$(IsCompatAssembly)'=='true'">/Compat</OutputPathSubfolder>
     <OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)$(OSPlatformConfig)/$(MSBuildProjectName)/$(TargetOutputRelPath)$(OutputPathSubfolder)</OutputPath>
 

--- a/dir.targets
+++ b/dir.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" InitialTargets="CheckForBuildTools" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  
+
   <Target Name="CheckForBuildTools">
     <Error Condition="!Exists('$(ToolsDir)') and '$(OverrideToolsDir)'=='true'"
            Text="The tools directory [$(ToolsDir)] does not exist. Please run sync in your enlistment to ensure the tools are installed before attempting to build an individual project." />
@@ -12,10 +12,6 @@
   <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />
   <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" />
   <Target Name="Test" />
-  
-  <!-- Targets will be overridden if buildagainstpackages.targets is imported. -->
-  <Target Name="GenerateTestProjectJson" />
-  <Target Name="GenerateAllTestProjectJsons" />
 
   <Target Name="AnnotateProjectsWithConfiguration"
           Returns="@(ProjectWithConfiguration)" >
@@ -31,7 +27,7 @@
   <Target Name="UndefineTestTFM" BeforeTargets="AssignProjectConfiguration">
     <ItemGroup>
       <ProjectReference>
-        <!-- 
+        <!--
         Always undefine TestTFM and FilterToTestTFM for all project reference as not needed for compilation and
         avoid bin clash tool to fail
         -->
@@ -39,21 +35,6 @@
       </ProjectReference>
     </ItemGroup>
   </Target>
-  
-  <PropertyGroup>
-    <CommonTestProjectJson>$(MSBuildThisFileDirectory)src/Common/test-runtime/project.json</CommonTestProjectJson>
-    <CommonTestProjectLockJson>$(MSBuildThisFileDirectory)src/Common/test-runtime/project.lock.json</CommonTestProjectLockJson>
-    <CommonOutputTestProjectJson>$(GeneratedProjectJsonDir)/project.json</CommonOutputTestProjectJson>
-    <CommonOutputTestProjectLockJson>$(GeneratedProjectJsonDir)/project.lock.json</CommonOutputTestProjectLockJson>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
-    <CommonTestProjectJson Condition="'$(BuildTestsAgainstPackages)'=='true'">$(CommonOutputTestProjectJson)</CommonTestProjectJson>
-    <CommonTestProjectLockJson Condition="'$(BuildTestsAgainstPackages)'=='true'">$(CommonOutputTestProjectLockJson)</CommonTestProjectLockJson>
-    <ProjectJson Condition="'$(ProjectJson)'=='' and Exists('$(MSBuildProjectDirectory)/project.json')">$(MSBuildProjectDirectory)/project.json</ProjectJson>
-    <!-- If project specific project.json exists then don't skip generating test project.json files -->
-    <SkipGenerateTestProjectJson Condition="'$(ProjectJson)'==''" >true</SkipGenerateTestProjectJson>
-  </PropertyGroup>
 
   <Import Project="$(ToolsDir)/Build.Common.targets" Condition="Exists('$(ToolsDir)/Build.Common.targets')" />
 
@@ -97,7 +78,7 @@
     <ValidPinvokeMappings Condition="'$(TargetGroup)'=='netcore50' or '$(TargetGroup)'=='netcore50aot' or '$(SupportsUWP)'=='true'">$(MSBuildThisFileDirectory)PinvokeAnalyzer_UWPApis.txt</ValidPinvokeMappings>
   </PropertyGroup>
 
-  <Target Name="ProducesPackageId" 
+  <Target Name="ProducesPackageId"
           Returns="@(PackageIds)">
     <ItemGroup>
       <PackageIds Include="$(Id)" />


### PR DESCRIPTION
This cleans out a lot of the project.json batch restoring, validation,
and generation from the build.proj. Also enables restoring of packages
for individual projects again. We well eventually move all projects that
need restoring under external so we can keep them isolated from the rest
of the build.

cc @ericstj @mellinoe @joperezr @chcosta @karajas 

This gets build.cmd call down to only a couple minutes now on my machine.