### PR TITLE
Remove test feed override of ToolPackageSource in checked-in build definitions

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -560,9 +560,6 @@
     "UseLegacyBuildScripts": {
       "value": "false",
       "allowOverride": true
-    },
-    "ToolPackageSource": {
-      "value": "https://www.myget.org/F/dagood-test-buildtools/api/v3/index.json"
     }
   },
   "retentionRules": [


### PR DESCRIPTION
Removing this environment variable allows the build to use the default feed defined in the Fetch-Tools.ps1 official build script, `https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json`, rather than overriding that to point at my test feed. (The package it's looking for is [EmbedIndex](https://dotnet.myget.org/feed/dotnet-buildtools/package/nuget/EmbedIndex).)

I made this change manually to the old shared publish def and the corefx 1.1.0 def.

@chcosta Does this look ok?
/cc @ericstj 