### PR TITLE
Remove enum → underlying unwrapping in expression instruction ctors

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
@@ -176,10 +176,7 @@ namespace System.Linq.Expressions.Interpreter
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         public static Instruction Create(Type type)
         {
-            // Boxed enums can be unboxed as their underlying types:
-            Type underlyingType = type.GetTypeInfo().IsEnum ? Enum.GetUnderlyingType(type) : type.GetNonNullableType();
-
-            switch (underlyingType.GetTypeCode())
+            switch (type.GetNonNullableType().GetTypeCode())
             {
                 case TypeCode.SByte: return s_SByte ?? (s_SByte = new AndSByte());
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new AndInt16());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
@@ -512,12 +512,9 @@ namespace System.Linq.Expressions.Interpreter
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         public static Instruction Create(Type type, bool liftedToNull)
         {
-            // Boxed enums can be unboxed as their underlying types:
-            Type underlyingType = type.GetTypeInfo().IsEnum ? Enum.GetUnderlyingType(type) : type.GetNonNullableType();
-
             if (liftedToNull)
             {
-                switch (underlyingType.GetTypeCode())
+                switch (type.GetNonNullableType().GetTypeCode())
                 {
                     case TypeCode.Boolean: return s_BooleanLiftedToNull ?? (s_BooleanLiftedToNull = new EqualBooleanLiftedToNull());
                     case TypeCode.SByte: return s_SByteLiftedToNull ?? (s_SByteLiftedToNull = new EqualSByteLiftedToNull());
@@ -531,13 +528,13 @@ namespace System.Linq.Expressions.Interpreter
                     case TypeCode.UInt64: return s_UInt64LiftedToNull ?? (s_UInt64LiftedToNull = new EqualUInt64LiftedToNull());
                     case TypeCode.Single: return s_SingleLiftedToNull ?? (s_SingleLiftedToNull = new EqualSingleLiftedToNull());
                     default:
-                        Debug.Assert(underlyingType.GetTypeCode() == TypeCode.Double);
+                        Debug.Assert(type.GetNonNullableType().GetTypeCode() == TypeCode.Double);
                         return s_DoubleLiftedToNull ?? (s_DoubleLiftedToNull = new EqualDoubleLiftedToNull());
                 }
             }
             else
             {
-                switch (underlyingType.GetTypeCode())
+                switch (type.GetNonNullableType().GetTypeCode())
                 {
                     case TypeCode.Boolean: return s_Boolean ?? (s_Boolean = new EqualBoolean());
                     case TypeCode.SByte: return s_SByte ?? (s_SByte = new EqualSByte());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ExclusiveOrInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ExclusiveOrInstruction.cs
@@ -164,10 +164,7 @@ namespace System.Linq.Expressions.Interpreter
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         public static Instruction Create(Type type)
         {
-            // Boxed enums can be unboxed as their underlying types:
-            Type underlyingType = type.GetTypeInfo().IsEnum ? Enum.GetUnderlyingType(type) : type.GetNonNullableType();
-
-            switch (underlyingType.GetTypeCode())
+            switch (type.GetNonNullableType().GetTypeCode())
             {
                 case TypeCode.SByte: return s_SByte ?? (s_SByte = new ExclusiveOrSByte());
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new ExclusiveOrInt16());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LeftShiftInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LeftShiftInstruction.cs
@@ -164,10 +164,7 @@ namespace System.Linq.Expressions.Interpreter
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         public static Instruction Create(Type type)
         {
-            // Boxed enums can be unboxed as their underlying types:
-            Type underlyingType = type.GetTypeInfo().IsEnum ? Enum.GetUnderlyingType(type) : type.GetNonNullableType();
-
-            switch (underlyingType.GetTypeCode())
+            switch (type.GetNonNullableType().GetTypeCode())
             {
                 case TypeCode.SByte: return s_SByte ?? (s_SByte = new LeftShiftSByte());
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new LeftShiftInt16());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
@@ -512,12 +512,9 @@ namespace System.Linq.Expressions.Interpreter
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         public static Instruction Create(Type type, bool liftedToNull)
         {
-            // Boxed enums can be unboxed as their underlying types:
-            Type underlyingType = type.GetTypeInfo().IsEnum ? Enum.GetUnderlyingType(type) : type.GetNonNullableType();
-
             if (liftedToNull)
             {
-                switch (underlyingType.GetTypeCode())
+                switch (type.GetNonNullableType().GetTypeCode())
                 {
                     case TypeCode.Boolean: return s_BooleanLiftedToNull ?? (s_BooleanLiftedToNull = new NotEqualBooleanLiftedToNull());
                     case TypeCode.SByte: return s_SByteLiftedToNull ?? (s_SByteLiftedToNull = new NotEqualSByteLiftedToNull());
@@ -531,13 +528,13 @@ namespace System.Linq.Expressions.Interpreter
                     case TypeCode.UInt64: return s_UInt64LiftedToNull ?? (s_UInt64LiftedToNull = new NotEqualUInt64LiftedToNull());
                     case TypeCode.Single: return s_SingleLiftedToNull ?? (s_SingleLiftedToNull = new NotEqualSingleLiftedToNull());
                     default:
-                        Debug.Assert(underlyingType.GetTypeCode() == TypeCode.Double);
+                        Debug.Assert(type.GetNonNullableType().GetTypeCode() == TypeCode.Double);
                         return s_DoubleLiftedToNull ?? (s_DoubleLiftedToNull = new NotEqualDoubleLiftedToNull());
                 }
             }
             else
             {
-                switch (underlyingType.GetTypeCode())
+                switch (type.GetNonNullableType().GetTypeCode())
                 {
                     case TypeCode.Boolean: return s_Boolean ?? (s_Boolean = new NotEqualBoolean());
                     case TypeCode.SByte: return s_SByte ?? (s_SByte = new NotEqualSByte());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
@@ -178,10 +178,7 @@ namespace System.Linq.Expressions.Interpreter
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         public static Instruction Create(Type type)
         {
-            // Boxed enums can be unboxed as their underlying types:
-            Type underlyingType = type.GetTypeInfo().IsEnum ? Enum.GetUnderlyingType(type) : type.GetNonNullableType();
-
-            switch (underlyingType.GetTypeCode())
+            switch (type.GetNonNullableType().GetTypeCode())
             {
                 case TypeCode.SByte: return s_SByte ?? (s_SByte = new OrSByte());
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new OrInt16());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RightShiftInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RightShiftInstruction.cs
@@ -164,10 +164,7 @@ namespace System.Linq.Expressions.Interpreter
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         public static Instruction Create(Type type)
         {
-            // Boxed enums can be unboxed as their underlying types:
-            Type underlyingType = type.GetTypeInfo().IsEnum ? Enum.GetUnderlyingType(type) : type.GetNonNullableType();
-
-            switch (underlyingType.GetTypeCode())
+            switch (type.GetNonNullableType().GetTypeCode())
             {
                 case TypeCode.SByte: return s_SByte ?? (s_SByte = new RightShiftSByte());
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new RightShiftInt16());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -449,13 +449,12 @@ namespace System.Linq.Expressions.Interpreter
         {
             object from = frame.Pop();
             Debug.Assert(from != null);
-            Type underlying = Enum.GetUnderlyingType(_t);
 
             // If from is neither a T nor a type assignable to T (viz. an T-backed enum)
             // this will cause an InvalidCastException, which is what this operation should
             // throw in this case.
 
-            switch (underlying.GetTypeCode())
+            switch (_t.GetTypeCode())
             {
                 case TypeCode.Int32:
                     frame.Push(Enum.ToObject(_t, (int)from));
@@ -488,7 +487,7 @@ namespace System.Linq.Expressions.Interpreter
                 default:
                     // Only remaining possible type.
                     // Disallowed in C#, but allowed in CIL
-                    Debug.Assert(underlying == typeof(bool));
+                    Debug.Assert(_t.GetTypeCode() == TypeCode.Boolean);
                     frame.Push(Enum.ToObject(_t, (bool)from));
                     break;
             }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/EqualNotEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/EqualNotEqualTests.cs
@@ -28,6 +28,7 @@ namespace System.Linq.Expressions.Tests
                 yield return new object[] { new ushort[] { 0, 1, ushort.MaxValue }, useInterpreter };
                 yield return new object[] { new TestClass[] { new TestClass(), new TestClass() }, useInterpreter };
                 yield return new object[] { new TestEnum[] { new TestEnum(), new TestEnum() }, useInterpreter };
+                yield return new object[] { new E[] {E.A, E.B, (E)int.MinValue}, useInterpreter };
 
                 yield return new object[] { new bool?[] { null, true, false }, useInterpreter };
                 yield return new object[] { new byte?[] { null, 0, 1, byte.MaxValue }, useInterpreter };
@@ -42,6 +43,7 @@ namespace System.Linq.Expressions.Tests
                 yield return new object[] { new uint?[] { null, 0, 1, uint.MaxValue }, useInterpreter };
                 yield return new object[] { new ulong?[] { null, 0, 1, ulong.MaxValue }, useInterpreter };
                 yield return new object[] { new ushort?[] { null, 0, 1, ushort.MaxValue }, useInterpreter };
+                yield return new object[] { new E?[] {null, E.A, E.B, (E)int.MaxValue, (E)int.MinValue}, useInterpreter };
             }
         }
 


### PR DESCRIPTION
Incorrect (should be `type.GetNonNullableType().GetTypeInfo().IsEnum ? Enum.GetUnderlyingType(type.GetNonNullableType()) …` to work consistently), unreachable in most cases, and has no effect on the subsequent calls `GetTypeCode()` anyway (as shown by it not being an error when it hits that incorrect point).

@bartdesmet I'm generally keeping away from the `Instruction` classes while you do your templating, but I think this case might help, as there's a bit less difference between different instruction types after it, but if it's conflicting with you I can hold back on it.