### PR TITLE
Dictionary.GetValueOrDefault

### DIFF
--- a/src/System.Collections/ref/System.Collections.cs
+++ b/src/System.Collections/ref/System.Collections.cs
@@ -40,6 +40,15 @@ namespace System.Collections
 }
 namespace System.Collections.Generic
 {
+#if netcoreapp11
+    public static class CollectionExtensions
+    {
+        public static TValue GetValueOrDefault<TKey, TValue>(System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
+        public static TValue GetValueOrDefault<TKey, TValue>(System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
+        public static TValue GetValueOrDefault<TKey, TValue>(System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
+        public static TValue GetValueOrDefault<TKey, TValue>(System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
+    }
+#endif
     public abstract partial class Comparer<T> : System.Collections.Generic.IComparer<T>, System.Collections.IComparer
     {
         protected Comparer() { }
@@ -80,6 +89,10 @@ namespace System.Collections.Generic
         public bool ContainsValue(TValue value) { throw null; }
         public System.Collections.Generic.Dictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#if netcoreapp11
+        public TValue GetValueOrDefault(TKey key) { throw null; }
+        public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
+#endif
         public virtual void OnDeserialization(object sender) { }
         public bool Remove(TKey key) { throw null; }
         void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }

--- a/src/System.Collections/src/System.Collections.csproj
+++ b/src/System.Collections/src/System.Collections.csproj
@@ -86,5 +86,8 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="System\Collections\Generic\CollectionExtensions.cs" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
+++ b/src/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
@@ -1,0 +1,33 @@
+﻿namespace System.Collections.Generic
+{
+    public static class CollectionExtensions
+    {
+        public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
+        {
+            TValue value;
+            dictionary.TryGetValue(key, out value);
+            return value;
+        }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)
+        {
+            if (dictionary.ContainsKey(key))
+                return dictionary[key];
+            return defaultValue;
+        }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)
+        {
+            TValue value;
+            dictionary.TryGetValue(key, out value);
+            return value;
+        }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)
+        {
+            if (dictionary.ContainsKey(key))
+                return dictionary[key];
+            return defaultValue;
+        }
+    }
+}

--- a/src/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
+++ b/src/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
@@ -21,8 +21,9 @@
                 throw new ArgumentNullException(nameof(dictionary));
             }
 
-            if (dictionary.ContainsKey(key))
-                return dictionary[key];
+            TValue value;
+            if (dictionary.TryGetValue(key, out value))
+                return value;
             return defaultValue;
         }
 
@@ -45,8 +46,9 @@
                 throw new ArgumentNullException(nameof(dictionary));
             }
 
-            if (dictionary.ContainsKey(key))
-                return dictionary[key];
+            TValue value;
+            if (dictionary.TryGetValue(key, out value))
+                return value;
             return defaultValue;
         }
     }

--- a/src/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
+++ b/src/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
@@ -4,6 +4,11 @@
     {
         public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
         {
+            if (dictionary == null)
+            {
+                throw new ArgumentNullException(nameof(dictionary));
+            }
+
             TValue value;
             dictionary.TryGetValue(key, out value);
             return value;
@@ -11,6 +16,11 @@
 
         public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)
         {
+            if (dictionary == null)
+            {
+                throw new ArgumentNullException(nameof(dictionary));
+            }
+
             if (dictionary.ContainsKey(key))
                 return dictionary[key];
             return defaultValue;
@@ -18,6 +28,11 @@
 
         public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)
         {
+            if (dictionary == null)
+            {
+                throw new ArgumentNullException(nameof(dictionary));
+            }
+
             TValue value;
             dictionary.TryGetValue(key, out value);
             return value;
@@ -25,6 +40,11 @@
 
         public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)
         {
+            if (dictionary == null)
+            {
+                throw new ArgumentNullException(nameof(dictionary));
+            }
+
             if (dictionary.ContainsKey(key))
                 return dictionary[key];
             return defaultValue;

--- a/src/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
+++ b/src/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
@@ -2,18 +2,11 @@
 {
     public static class CollectionExtensions
     {
-        public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
-        {
-            if (dictionary == null)
-            {
-                throw new ArgumentNullException(nameof(dictionary));
-            }
+        // Method similar to TryGetValue that returns the value instead of putting it in an out param.
+        public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key) => dictionary.GetValueOrDefault(key, default(TValue));
 
-            TValue value;
-            dictionary.TryGetValue(key, out value);
-            return value;
-        }
-
+        // Method similar to TryGetValue that returns the value instead of putting it in an out param. If the entry
+        // doesn't exist, returns the defaultValue instead.
         public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)
         {
             if (dictionary == null)
@@ -27,18 +20,11 @@
             return defaultValue;
         }
 
-        public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)
-        {
-            if (dictionary == null)
-            {
-                throw new ArgumentNullException(nameof(dictionary));
-            }
+        // Method similar to TryGetValue that returns the value instead of putting it in an out param.
+        public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key) => dictionary.GetValueOrDefault(key, default(TValue));
 
-            TValue value;
-            dictionary.TryGetValue(key, out value);
-            return value;
-        }
-
+        // Method similar to TryGetValue that returns the value instead of putting it in an out param. If the entry
+        // doesn't exist, returns the defaultValue instead.
         public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)
         {
             if (dictionary == null)

--- a/src/System.Collections/src/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Dictionary.cs
@@ -537,24 +537,11 @@ namespace System.Collections.Generic
             return false;
         }
 
-        // This is a convenience method that were converted from using Hashtable.
-        // Many were combining key doesn't exist and key exists but null value (for non-value types) checks.
-        // This allows them to continue getting that behavior with minimal code delta. This is basically
-        // TryGetValue without the out param
-        public TValue GetValueOrDefault(TKey key)
-        {
-            int i = FindEntry(key);
-            if (i >= 0)
-            {
-                return entries[i].value;
-            }
-            return default(TValue);
-        }
+        // Method similar to TryGetValue that returns the value instead of putting it in an out param.
+        public TValue GetValueOrDefault(TKey key) => GetValueOrDefault(key, default(TValue));
 
-        // This is a convenience method that were converted from using Hashtable.
-        // Many were combining key doesn't exist and key exists but null value (for non-value types) checks.
-        // This allows them to continue getting that behavior with minimal code delta. This is basically
-        // TryGetValue without the out param
+        // Method similar to TryGetValue that returns the value instead of putting it in an out param. If the entry
+        // doesn't exist, returns the defaultValue instead.
         public TValue GetValueOrDefault(TKey key, TValue defaultValue)
         {
             int i = FindEntry(key);

--- a/src/System.Collections/src/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Dictionary.cs
@@ -537,11 +537,11 @@ namespace System.Collections.Generic
             return false;
         }
 
-        // This is a convenience method for the internal callers that were converted from using Hashtable.
+        // This is a convenience method that were converted from using Hashtable.
         // Many were combining key doesn't exist and key exists but null value (for non-value types) checks.
         // This allows them to continue getting that behavior with minimal code delta. This is basically
         // TryGetValue without the out param
-        internal TValue GetValueOrDefault(TKey key)
+        public TValue GetValueOrDefault(TKey key)
         {
             int i = FindEntry(key);
             if (i >= 0)
@@ -549,6 +549,20 @@ namespace System.Collections.Generic
                 return entries[i].value;
             }
             return default(TValue);
+        }
+
+        // This is a convenience method that were converted from using Hashtable.
+        // Many were combining key doesn't exist and key exists but null value (for non-value types) checks.
+        // This allows them to continue getting that behavior with minimal code delta. This is basically
+        // TryGetValue without the out param
+        public TValue GetValueOrDefault(TKey key, TValue defaultValue)
+        {
+            int i = FindEntry(key);
+            if (i >= 0)
+            {
+                return entries[i].value;
+            }
+            return defaultValue;
         }
 
         bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly


### PR DESCRIPTION
With dictionaries of class-types it is often desirable and expected to return null for a non-existent key.
Close https://github.com/dotnet/corefx/issues/3482