### PR TITLE
Make EncodingStreamWrapper Flush Only When Inner Stream CanWrite

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Xml/EncodingStreamWrapper.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/EncodingStreamWrapper.cs
@@ -596,7 +596,11 @@ namespace System.Xml
 
         protected override void Dispose(bool disposing)
         {
-            Flush();
+            if (_stream.CanWrite)
+            {
+                Flush();
+            }
+
             _stream.Dispose();
             base.Dispose(disposing);
         }


### PR DESCRIPTION
Make EncodingStreamWrapper.Dispose flushes the underlying stream only when the stream.CanWrite is true.

Fix #14454

cc: @mconnew @zhenlan 