### PR TITLE
Avoid unintended test runs and errors

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -221,6 +221,12 @@ run_test()
   fi
 
   dirName="$1/$TestRelPath"
+
+  if [ ! -d "$dirName" ]; then
+    echo "Nothing to test in $testProject"
+    exit 0
+  fi
+
   copy_test_overlay $dirName
 
   pushd $dirName > /dev/null


### PR DESCRIPTION
* Skip test runs where doesn`t have test cases for certain target, and generate errors with exit code 127.