### PR TITLE
Add Xenial (Ubuntu 16.04) rootfs support for cross build

### DIFF
--- a/cross/arm/sources.list.xenial
+++ b/cross/arm/sources.list.xenial
@@ -1,0 +1,11 @@
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial-updates main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial-updates main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial-backports main restricted
+deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial-backports main restricted
+
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial-security main restricted universe multiverse
+deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial-security main restricted universe multiverse

--- a/cross/arm64/sources.list.xenial
+++ b/cross/arm64/sources.list.xenial
@@ -1,0 +1,11 @@
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial-updates main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial-updates main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial-backports main restricted
+deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial-backports main restricted
+
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial-security main restricted universe multiverse
+deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial-security main restricted universe multiverse

--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -4,7 +4,7 @@ usage()
 {
     echo "Usage: $0 [BuildArch] [UbuntuCodeName]"
     echo "BuildArch can be: arm, arm-softfp, arm64"
-    echo "UbuntuCodeName - optional, Code name for Ubuntu, can be: trusty(default), vivid, wily. If BuildArch is arm-softfp, UbuntuCodeName is ignored."
+    echo "UbuntuCodeName - optional, Code name for Ubuntu, can be: trusty(default), vivid, wily, xenial. If BuildArch is arm-softfp, UbuntuCodeName is ignored."
 
     exit 1
 }
@@ -72,6 +72,11 @@ for i in "$@" ; do
         wily)
             if [ "$__UbuntuCodeName" != "jessie" ]; then
                 __UbuntuCodeName=wily
+            fi
+            ;;
+        xenial)
+            if [ "$__UbuntuCodeName" != "jessie" ]; then
+                __UbuntuCodeName=xenial
             fi
             ;;
         *)


### PR DESCRIPTION
Add Xenial (Ubuntu 16.04) rootfs to keep consistency with CoreCLR and Core-Setup.

Related issue: #14538 

CC @gkhanna79  @janvorli @kouvel PTAL