### PR TITLE
Add TestNugetRuntimeId to OuterLoop OSX runs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -232,7 +232,7 @@ def testNugetRuntimeIdConfiguration = ['Debug': 'win7-x86',
                         batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd -${configurationGroup} -outerloop -- /p:WithoutCategories=IgnoreForCI")
                     }
                     else if (osName == 'OSX') {
-                        shell("HOME=\$WORKSPACE/tempHome ./build.sh -${configurationGroup.toLowerCase()} -outerloop -- /p:TestWithLocalNativeLibraries=true /p:WithoutCategories=IgnoreForCI")
+                        shell("HOME=\$WORKSPACE/tempHome ./build.sh -${configurationGroup.toLowerCase()} -outerloop -- /p:TestWithLocalNativeLibraries=true /p:TestNugetRuntimeId=${targetNugetRuntimeMap[osName]} /p:WithoutCategories=IgnoreForCI")
                     }
                     else {
                         shell("sudo HOME=\$WORKSPACE/tempHome ./build.sh -${configurationGroup.toLowerCase()} -outerloop -- /p:TestWithLocalNativeLibraries=true /p:TestNugetRuntimeId=${targetNugetRuntimeMap[osName]} /p:WithoutCategories=IgnoreForCI")


### PR DESCRIPTION
The most recent OuterLoop OSX runs have been failing on CI: https://ci.dot.net/job/dotnet_corefx/job/master/job/outerloop_osx_debug/.

Looks like the issue is  "Outerloop OSX is using ` [23:21:21.05] Using RuntimeIdentifier = 'osx.10.11-x64' ` which tries to restore for the wrong rid."
Relevant thread: https://github.com/dotnet/corefx/pull/14462

cc: @karajas @weshaggard @joperezr @danmosemsft 