### PR TITLE
Initial set of work for building external dependencies

### DIFF
--- a/Tools-Override/FrameworkTargeting.targets
+++ b/Tools-Override/FrameworkTargeting.targets
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <ItemGroup>
+    <TargetingPackDirs Include="$(RefPath)" />
+    <AdditionalReferencePaths Include="@(TargetingPackDirs)" />
+  </ItemGroup>
+
+  <PropertyGroup >
+    <!-- TODO: This will begin depending on a target once we start computing RefPath -->
+    <ContractOutputPath>$(RefPath)</ContractOutputPath>
+    <FrameworkPathOverride>$(ContractOutputPath)</FrameworkPathOverride>
+    <AssemblySearchPaths>$(AssemblySearchPaths);$(ContractOutputPath);{RawFileName}</AssemblySearchPaths>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == ''
                          and '$(TargetFrameworkVersion)'    == ''
                          and '$(TargetFrameworkProfile)'    == '' ">

--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TestRuntimeDir>$(RuntimeDir)</TestRuntimeDir>
+    <TestRuntimeDir>$(RuntimePath)</TestRuntimeDir>
     <TestHostExecutable Condition="'$(TestHostExecutable)' == ''">$(TestRuntimeDir)\corerun.exe</TestHostExecutable>
     <XunitExecutable Condition="'$(XunitExecutable)' == ''">$(TestRuntimeDir)/xunit.console.netcore.exe</XunitExecutable>
   </PropertyGroup>

--- a/binplace.targets
+++ b/binplace.targets
@@ -32,11 +32,8 @@
 
   <Target Name="GetTargetingPackDir">
     <ItemGroup Condition="'$(NuGetTargetMoniker)' == '' Or $(NuGetTargetMoniker.Contains('NETCoreApp')) Or $(NuGetTargetMoniker.Contains('NETStandard'))">
-      <TargetingPackDir Include="$(BinDir)netcoreapp\TargetingPack" />
+      <TargetingPackDir Include="$(RefPath)" />
       <TargetingPackDir Condition="'$(IsNETCoreAppRef)' == 'true'" Include="$(BinDir)netcoreapp\pkg\ref" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(NuGetTargetMoniker)' == '' Or $(NuGetTargetMoniker.Contains('NETStandard'))">
-      <TargetingPackDir  Include="$(BinDir)netstandard\TargetingPack" />
     </ItemGroup>
     <Error Condition="'@(TargetingPackDir)' == ''" Text="No targeting pack directory could be determined for NuGetTargetMoniker:$(NuGetTargetMoniker)" />
     <Message Text="Got TargetingPackDir:@(TargetingPackDir) from NuGetTargetMoniker:$(NuGetTargetMoniker)" Importance="Low" />
@@ -44,11 +41,8 @@
 
   <Target Name="GetRuntimeDir">
     <ItemGroup Condition="'$(NuGetTargetMoniker)' == '' Or $(NuGetTargetMoniker.Contains('NETCoreApp')) Or $(NuGetTargetMoniker.Contains('NETStandard'))">
-      <RuntimeDir Include="$(BinDir)netcoreapp\Runtime" />
+      <RuntimeDir Include="$(RuntimePath)" />
       <RuntimeDir Condition="'$(IsNETCoreApp)' == 'true'" Include="$(BinDir)netcoreapp\pkg\lib" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(NuGetTargetMoniker)' == '' Or $(NuGetTargetMoniker.Contains('NETStandard'))">
-      <RuntimeDir Include="$(BinDir)netstandard\Runtime" />
     </ItemGroup>
     <Error Condition="'@(RuntimeDir)' == ''" Text="No Runtime directory could be determined for NuGetTargetMoniker:$(NuGetTargetMoniker)" />
     <Message Text="Got RuntimeDir:@(RuntimeDir) from NuGetTargetMoniker:$(NuGetTargetMoniker)" Importance="Low" />
@@ -56,7 +50,6 @@
 
   <ItemGroup>
     <AdditionalCleanDirectories Include="$(BinDir)netcoreapp" />
-    <AdditionalCleanDirectories Include="$(BinDir)netstandard" />
   </ItemGroup>
 
   <!-- Incremental clean only cleans paths under Intermediate or OutDir, handle additional paths -->
@@ -66,7 +59,7 @@
       <Output TaskParameter="InPath" ItemName="_CleanCurrentFileWrites" />
     </FindUnderPath>
   </Target>
-  
+
   <Target Name="IncrementalCleanAdditionalDirectories" BeforeTargets="IncrementalClean">
     <ItemGroup>
       <_CleanOrphanAdditionalFileWrites Include="@(_CleanPriorFileWrites)" Exclude="@(_CleanCurrentFileWrites)" />
@@ -74,7 +67,7 @@
     <FindUnderPath Path="%(AdditionalCleanDirectories.Identity)" Files="@(_CleanOrphanAdditionalFileWrites)">
       <Output TaskParameter="InPath" ItemName="_CleanOrphanFileWritesInAdditionalDirectories" />
     </FindUnderPath>
-    
+
     <!-- Delete the orphaned files.  IncrementalClean will remove these from the file list -->
     <Delete Files="@(_CleanOrphanFileWritesInAdditionalDirectories)" TreatErrorsAsWarnings="true">
       <Output TaskParameter="DeletedFiles" ItemName="_CleanOrphanFilesDeleted" />

--- a/build.proj
+++ b/build.proj
@@ -20,6 +20,7 @@
   <Import Project="$(ToolsDir)VersionTools.targets" Condition="Exists('$(ToolsDir)VersionTools.targets')" />
 
   <ItemGroup>
+    <Project Include="external\dir.proj" />
     <Project Include="src\ref.builds" />
     <Project Include="src\src.builds" />
     <!--

--- a/dir.props
+++ b/dir.props
@@ -154,34 +154,25 @@
     <RunApiCompat>true</RunApiCompat>
   </PropertyGroup>
 
-
   <PropertyGroup>
     <ArchGroup Condition="'$(ArchGroup)'==''">x64</ArchGroup>
     <BuildConfiguration_OSGroup>$(OS)</BuildConfiguration_OSGroup>
     <BuildConfiguration_OSGroup Condition="'$(OSGroup)' != ''">$(OSGroup)</BuildConfiguration_OSGroup>
     <BuildConfiguration Condition="'$(BuildConfiguration)' == ''">netcoreapp1.1-$(BuildConfiguration_OSGroup)-Debug-$(ArchGroup)</BuildConfiguration>
 
-    <BuildConfigurationImportFile>$(BinDir)tools/configuration/configuration.props</BuildConfigurationImportFile>
+    <BuildConfigurationImportFile>$(ToolsDir)/configuration/configuration.props</BuildConfigurationImportFile>
   </PropertyGroup>
 
-  <Import Project="$(BuildConfigurationImportFile)" Condition="Exists('$(BuildConfigurationImportFile)') and '$(BuildConfigurations)' != ''" /> 
+  <Import Project="$(BuildConfigurationImportFile)" Condition="Exists('$(BuildConfigurationImportFile)')" />
 
-  <!-- Set up Default symbol and optimization for Configuration --> 
-  <Choose> 
-    <When Condition="'$(ConfigurationGroup)'=='Debug'"> 
-      <PropertyGroup> 
-        <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols> 
-        <Optimize Condition="'$(Optimize)' == ''">false</Optimize> 
-        <DebugType Condition="'$(DebugType)' == ''">full</DebugType> 
-        <DefineConstants>$(DefineConstants),DEBUG,TRACE</DefineConstants> 
-      </PropertyGroup> 
-    </When> 
-    <When Condition="'$(ConfigurationGroup)' == 'Release'"> 
-      <PropertyGroup> 
-        <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols> 
-        <Optimize Condition="'$(Optimize)' == ''">true</Optimize> 
-        <DebugType Condition="'$(DebugType)' == ''">pdbonly</DebugType> 
-        <DefineConstants>$(DefineConstants),TRACE</DefineConstants> 
+  <!-- Set up Default symbol and optimization for Configuration -->
+  <Choose>
+    <When Condition="'$(ConfigurationGroup)'=='Debug'">
+      <PropertyGroup>
+        <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
+        <Optimize Condition="'$(Optimize)' == ''">false</Optimize>
+        <DebugType Condition="'$(DebugType)' == ''">full</DebugType>
+        <DefineConstants>$(DefineConstants),DEBUG,TRACE</DefineConstants>
       </PropertyGroup>
     </When>
     <When Condition="'$(ConfigurationGroup)' == 'Release'">
@@ -192,61 +183,12 @@
         <DefineConstants>$(DefineConstants),TRACE</DefineConstants>
       </PropertyGroup>
     </When>
-  </Choose>
-
-  <!-- initialize all the targets variables to false as they should only be set below -->
-  <PropertyGroup>
-    <TargetsWindows>false</TargetsWindows>
-    <TargetsUnix>false</TargetsUnix>
-    <TargetsLinux>false</TargetsLinux>
-    <TargetsOSX>false</TargetsOSX>
-    <TargetsFreeBSD>false</TargetsFreeBSD>
-    <TargetsNetBSD>false</TargetsNetBSD>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(BuildConfigurations)' == '' or '$(OSGroup)' == 'AnyOS'">
-    <TargetsWindows>true</TargetsWindows>
-    <TargetsUnix>true</TargetsUnix>
-    <TargetsLinux>true</TargetsLinux>
-    <TargetsOSX>true</TargetsOSX>
-    <TargetsFreeBSD>true</TargetsFreeBSD>
-    <TargetsNetBSD>true</TargetsNetBSD>
-  </PropertyGroup>
-
-<!-- Probably want to make these be generated into configurations.props -->
-  <Choose>
-    <When Condition="'$(OSGroup)'=='Windows_NT'">
+    <When Condition="'$(ConfigurationGroup)' == 'Release'">
       <PropertyGroup>
-        <TargetsWindows>true</TargetsWindows>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(OSGroup)'=='Unix'">
-      <PropertyGroup>
-        <TargetsUnix>true</TargetsUnix>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(OSGroup)'=='Linux'">
-      <PropertyGroup>
-        <TargetsUnix>true</TargetsUnix>
-        <TargetsLinux>true</TargetsLinux>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(OSGroup)'=='OSX'">
-      <PropertyGroup>
-        <TargetsUnix>true</TargetsUnix>
-        <TargetsOSX>true</TargetsOSX>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(OSGroup)'=='FreeBSD'">
-      <PropertyGroup>
-        <TargetsUnix>true</TargetsUnix>
-        <TargetsFreeBSD>true</TargetsFreeBSD>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(OSGroup)'=='NetBSD'">
-      <PropertyGroup>
-        <TargetsUnix>true</TargetsUnix>
-        <TargetsNetBSD>true</TargetsNetBSD>
+        <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
+        <Optimize Condition="'$(Optimize)' == ''">true</Optimize>
+        <DebugType Condition="'$(DebugType)' == ''">pdbonly</DebugType>
+        <DefineConstants>$(DefineConstants),TRACE</DefineConstants>
       </PropertyGroup>
     </When>
   </Choose>
@@ -313,7 +255,11 @@
     <IntermediateOutputRootPath Condition="'$(IntermediateOutputRootPath)' == ''">$(BaseIntermediateOutputPath)$(OSPlatformConfig)/</IntermediateOutputRootPath>
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(IntermediateOutputRootPath)$(MSBuildProjectName)/$(TargetOutputRelPath)</IntermediateOutputPath>
 
-    <RuntimeDir Condition="'$(RuntimeDir)'==''">$(BinDir)netcoreapp\Runtime</RuntimeDir>
+    <RuntimePath Condition="'$(RuntimePath)' == ''">$(BinDir)runtime/$(BuildConfiguration)/</RuntimePath>
+    <RefRootPath>$(BinDir)ref/</RefRootPath>
+    <!-- TODO: We need to compute this based on the TargetGroup of the BuildConfiguration -->
+    <RefPath>$(RefRootPath)netcoreapp/</RefPath>
+    <NetStandardRefPath>$(RefRootPath)netstandard/</NetStandardRefPath>
 
     <PackagesBasePath Condition="'$(PackagesBasePath)'==''">$(BinDir)$(OSPlatformConfig)</PackagesBasePath>
     <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(PackageOutputRoot)$(ConfigurationGroup)/</PackageOutputPath>

--- a/external/coreclr/coreclr.depproj
+++ b/external/coreclr/coreclr.depproj
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <OutputPath>$(RuntimePath)</OutputPath>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/external/coreclr/project.json.template
+++ b/external/coreclr/project.json.template
@@ -1,0 +1,13 @@
+﻿{
+  "frameworks": {
+    "{TFM}": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.2.0-beta-24721-02",
+        "Microsoft.NETCore.Runtime.CoreCLR": "1.2.0-beta-24728-02"
+      }
+    }
+  },
+  "runtimes": {
+    "{RID}": { },
+  }
+}

--- a/external/dir.proj
+++ b/external/dir.proj
@@ -1,0 +1,11 @@
+<Project ToolsVersion="14.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="../dir.props" />
+
+  <!-- Build for all configurations -->
+  <ItemGroup>
+    <Project Include="coreclr/coreclr.depproj" />
+    <Project Include="netstandard20/netstandard20.depproj" />
+  </ItemGroup>
+
+  <Import Project="../dir.traversal.targets" />
+</Project>

--- a/external/dir.props
+++ b/external/dir.props
@@ -1,0 +1,13 @@
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\dir.props" />
+  <PropertyGroup>
+    <!-- HACK to work around binplacing issue right now for depproj's -->
+    <IsRuntimeAssembly>false</IsRuntimeAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ProjectJsonTemplate>$(MSBuildThisProjectDirectory)project.json.template</ProjectJsonTemplate>
+    <ProjectJson Condition="Exists('$(ProjectJsonTemplate)')">$(IntermediateOutputPath)project.json</ProjectJson>
+    <ProjectLockJson Condition="Exists('$(ProjectJsonTemplate)')">$(IntermediateOutputPath)project.lock.json</ProjectLockJson>
+    <NugetRuntimeIdentifier>$(RuntimeOS)-$(ArchGroup)</NugetRuntimeIdentifier>
+  </PropertyGroup>
+</Project>

--- a/external/dir.targets
+++ b/external/dir.targets
@@ -1,0 +1,28 @@
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\dir.targets" />
+
+  <PropertyGroup>
+    <RestorePackages>true</RestorePackages>
+    <PrereleaseResolveNuGetPackages>true</PrereleaseResolveNuGetPackages>
+  </PropertyGroup>
+
+  <Target
+    Name="GenerateProjectJsonFromTemplates"
+    BeforeTargets="RestorePackages"
+    Inputs="$(ProjectJsonTemplate)"
+    Outputs="$(ProjectJson)"
+    Condition="Exists('$(ProjectJsonTemplate)')"
+    >
+    <!-- Update project.json template -->
+    <WriteLinesToFile
+      File="$(ProjectJson)"
+      Lines="$([System.IO.File]::ReadAllText('project.json.template').Replace('{RID}', $(NuGetRuntimeIdentifier)).Replace('{TFM}', $(NuGetTargetMoniker)))"
+      Overwrite="true"
+                      />
+    <ItemGroup>
+      <FileWrites Include="$(ProjectJson)" />
+    </ItemGroup>
+
+  </Target>
+
+</Project>

--- a/external/netstandard20/netstandard20.depproj
+++ b/external/netstandard20/netstandard20.depproj
@@ -4,16 +4,8 @@
   <PropertyGroup>
     <NuGetDeploySourceItem>Reference</NuGetDeploySourceItem>
     <NuGetTargetMoniker>.NETStandard,Version=v1.7</NuGetTargetMoniker>
-    <OutputPath>$(RestoredRefRootPath)netstandard20</OutputPath>
+    <NugetRuntimeIdentifier>None</NugetRuntimeIdentifier>
+    <OutputPath>$(NetStandardRefPath)</OutputPath>
   </PropertyGroup>
-  <ItemGroup>
-    <None Include="project.json" />
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-  <Target Name="FilterNugetPackage" AfterTargets="ResolveNuGetPackages">
-    <!-- Filter down to just netstandard ref -->
-    <ItemGroup>
-      <Reference Remove="@(Reference)" Condition="'%(Filename)' != 'netstandard'" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/external/netstandard20/project.json.template
+++ b/external/netstandard20/project.json.template
@@ -1,0 +1,9 @@
+﻿{
+  "frameworks": {
+    "{TFM}": {
+      "dependencies": {
+        "NETStandard.Library2": "2.0.0-beta-24815-05"
+      }
+    }
+  }
+}

--- a/layout/netstandard20/project.json
+++ b/layout/netstandard20/project.json
@@ -1,9 +1,0 @@
-﻿{
-  "frameworks": {
-    "netstandard1.7": {
-      "dependencies": {
-        "NETStandard.Library2": "2.0.0-beta-24709-0"
-      }
-    }
-  }
-}

--- a/src/System.Runtime/ref/System.Runtime.csproj
+++ b/src/System.Runtime/ref/System.Runtime.csproj
@@ -5,7 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsCoreAssembly>true</IsCoreAssembly>
     <ProjectGuid>{ADBCF120-3454-4A3C-9D1D-AC4293E795D6}</ProjectGuid>
-    <DefineConstants Condition="'$(TargetGroup)' == ''">$(DefineConstants);netcoreapp11</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp1.1'">$(DefineConstants);netcoreapp11</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Runtime.cs" />

--- a/src/Tools/CoreFx.Tools/Configuration/Configuration.cs
+++ b/src/Tools/CoreFx.Tools/Configuration/Configuration.cs
@@ -40,9 +40,9 @@ namespace Microsoft.DotNet.Build.Tasks
             var configurationBuilder = new StringBuilder();
             foreach (var value in Values)
             {
-                if (value.Property.Ignored)
+                if (value.Property.Independent)
                 {
-                    // skip ignored properties
+                    // skip independent properties
                     continue;
                 }
 

--- a/src/Tools/CoreFx.Tools/Configuration/PropertyInfo.cs
+++ b/src/Tools/CoreFx.Tools/Configuration/PropertyInfo.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public bool Insignificant { get; }
 
-        public bool Ignored { get; }
+        public bool Independent { get; }
 
         public PropertyInfo(ITaskItem propertyItem)
         {
@@ -41,9 +41,9 @@ namespace Microsoft.DotNet.Build.Tasks
 
             Precedence = int.MaxValue;
             var precedence = propertyItem.GetMetadata(nameof(Precedence));
-            if (precedence.Equals(nameof(Ignored), StringComparison.OrdinalIgnoreCase))
+            if (precedence.Equals(nameof(Independent), StringComparison.OrdinalIgnoreCase))
             {
-                Ignored = Insignificant = true;
+                Independent = Insignificant = true;
             }
             else if (precedence.Equals(nameof(Insignificant), StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Tools/CoreFx.Tools/project.json
+++ b/src/Tools/CoreFx.Tools/project.json
@@ -1,5 +1,6 @@
 ﻿{
   "dependencies": {
+    "Microsoft.DotNet.PlatformAbstractions": "1.2.0-beta-001090",
     "NETStandard.Library": "1.6.0"
   },
   "frameworks": {

--- a/src/Tools/GenerateProps/GenerateProps.proj
+++ b/src/Tools/GenerateProps/GenerateProps.proj
@@ -9,7 +9,7 @@
 
   <Target Name="Build">
     <PropertyGroup>
-      <ConfigurationPropsFolder>$(CoreFxToolsDir)configuration</ConfigurationPropsFolder>
+      <ConfigurationPropsFolder>$(ToolsDir)configuration</ConfigurationPropsFolder>
     </PropertyGroup>
 
     <GenerateConfigurationProps Properties="@(Property)" PropertyValues="@(PropertyValue)" PropsFolder="$(ConfigurationPropsFolder)" />

--- a/src/Tools/GenerateProps/archgroups.props
+++ b/src/Tools/GenerateProps/archgroups.props
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ArchGroups Include="AnyCPU" />
     <ArchGroups Include="x86" />
     <ArchGroups Include="x64" />
     <ArchGroups Include="ARM" />

--- a/src/Tools/GenerateProps/osgroups.props
+++ b/src/Tools/GenerateProps/osgroups.props
@@ -2,16 +2,33 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <OSGroups Include="Windows_NT">
-        <Imports>AnyOS</Imports>
+      <Imports>AnyOS</Imports>
+      <TargetsWindows>true</TargetsWindows>
     </OSGroups>
     <OSGroups Include="Unix">
-        <Imports>AnyOS</Imports>
+      <Imports>AnyOS</Imports>
+      <TargetsUnix>true</TargetsUnix>
+      <TargetsLinux>true</TargetsLinux>
     </OSGroups>
     <OSGroups Include="Linux">
-        <Imports>Unix</Imports>
+      <Imports>Unix</Imports>
+      <TargetsUnix>true</TargetsUnix>
+      <TargetsLinux>true</TargetsLinux>
     </OSGroups>
     <OSGroups Include="OSX">
-        <Imports>Unix</Imports>
+      <Imports>Unix</Imports>
+      <TargetsUnix>true</TargetsUnix>
+      <TargetsOSX>true</TargetsOSX>
+    </OSGroups>
+    <OSGroups Include="FreeBSD">
+      <Imports>Unix</Imports>
+      <TargetsUnix>true</TargetsUnix>
+      <TargetsFreeBSD>true</TargetsFreeBSD>
+    </OSGroups>
+    <OSGroups Include="NetBSD">
+      <Imports>Unix</Imports>
+      <TargetsUnix>true</TargetsUnix>
+      <TargetsNetBSD>true</TargetsNetBSD>
     </OSGroups>
     <OSGroups Include="AnyOS" />
   </ItemGroup>

--- a/src/Tools/GenerateProps/properties.props
+++ b/src/Tools/GenerateProps/properties.props
@@ -4,7 +4,7 @@
   <Import Project="targetgroups.props"/>
   <Import Project="configurationgroups.props"/>
   <Import Project="archgroups.props"/>
-  
+
   <ItemGroup>
     <Property Include="OSGroup">
       <DefaultValue>AnyOS</DefaultValue>
@@ -28,9 +28,9 @@
       <Order>3</Order>
     </Property>
     <Property Include="ArchGroup">
-      <DefaultValue>AnyCPU</DefaultValue>
-      <!-- Property is insignificant to compatibility decisions, and ignored from configuration strings -->
-      <Precedence>Ignored</Precedence>
+      <DefaultValue>x64</DefaultValue>
+      <!-- Property is insignificant to compatibility decisions, and independent from the configuration strings -->
+      <Precedence>Independent</Precedence>
       <Order>4</Order>
     </Property>
 

--- a/src/Tools/GenerateProps/targetgroups.props
+++ b/src/Tools/GenerateProps/targetgroups.props
@@ -74,7 +74,7 @@
       <PackageTargetFramework>netcoreapp1.1</PackageTargetFramework>
       <NuGetTargetMoniker>.NETCoreApp,Version=v1.1</NuGetTargetMoniker>
       <Imports>netcoreapp1.1</Imports>
-      <CompatibleWith>netstandard1.7</CompatibleWith>
+      <CompatibleWith>netstandard</CompatibleWith>
     </TargetGroups>
     <TargetGroups Include="net45">
       <PackageTargetFramework>net45</PackageTargetFramework>

--- a/src/Tools/corefxTools.props
+++ b/src/Tools/corefxTools.props
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+
     <!-- Temporarily enable local build of tools -->
-    <CoreFxToolsDir Condition="'$(CoreFxToolsDir)' == ''">$(BinDir)/tools/</CoreFxToolsDir>
-    <CoreFxDesktopToolsDir Condition="'$(CoreFxDesktopToolsDir)' == ''">$(BinDir)/tools/net45/</CoreFxDesktopToolsDir>
+    <CoreFxToolsDir Condition="'$(CoreFxToolsDir)' == ''">$(ToolsDir)</CoreFxToolsDir>
+    <CoreFxDesktopToolsDir Condition="'$(CoreFxDesktopToolsDir)' == ''">$(ToolsDir)net45/</CoreFxDesktopToolsDir>
     <CoreFxToolsTaskDir Condition="'$(CoreFxToolsTaskDir)' == '' AND '$(BuildToolsTargets45)' != 'true'">$(CoreFxToolsDir)</CoreFxToolsTaskDir>
     <CoreFxToolsTaskDir Condition="'$(CoreFxToolsTaskDir)' == '' AND '$(BuildToolsTargets45)' == 'true'">$(CoreFxDesktopToolsDir)</CoreFxToolsTaskDir>
   </PropertyGroup>

--- a/targetingpacks.props
+++ b/targetingpacks.props
@@ -1,17 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <ItemGroup>
-    <TargetingPackDirs Include="$(BinDir)netcoreapp/TargetingPack" />
-    <AdditionalReferencePaths Include="@(TargetingPackDirs)" />
-  </ItemGroup>
-
-  <PropertyGroup>
-    <ContractOutputPath>$(BinDir)netcoreapp/TargetingPack</ContractOutputPath>
-    <FrameworkPathOverride>$(ContractOutputPath)</FrameworkPathOverride>
-    <AssemblySearchPaths>$(AssemblySearchPaths);$(ContractOutputPath);{RawFileName}</AssemblySearchPaths>
-  </PropertyGroup>
-
   <!-- Adds test references to the targeting pack and runtime assemblies. -->
   <Target Name="AddTestTargetingPackReferences" BeforeTargets="ResolveAssemblyReferences" Condition="'$(IsTestProject)' == 'true'">
     <ItemGroup>


### PR DESCRIPTION
This adds an external folder with some basic infrastructure to
template project.json files by TFM and RID so that we can only
restore the set that we actually need.

Updates our configuration generation to add RuntimeOS and ArchGroup
so we can use those to build up a NugetRuntimeIdentifier for using
to restore the builds.

cc @ericstj @mellinoe @joperezr @chcosta