### PR TITLE
Support ISerializable in ReflectionOnly mode.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionClassWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionClassWriter.cs
@@ -21,7 +21,16 @@ namespace System.Runtime.Serialization
         {
             InvokeOnSerializing(obj, context, classContract);
             obj = ResolveAdapterType(obj, classContract);
-            ReflectionWriteMembers(xmlWriter, obj, context, classContract, classContract, 0 /*childElementIndex*/, memberNames);
+            var iSerializableObj = obj as ISerializable;
+            if (iSerializableObj != null)
+            {
+                context.WriteISerializable(xmlWriter, iSerializableObj);
+            }
+            else
+            {
+                ReflectionWriteMembers(xmlWriter, obj, context, classContract, classContract, 0 /*childElementIndex*/, memberNames);
+            }
+
             InvokeOnSerialized(obj, context, classContract);
         }
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionClassWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionClassWriter.cs
@@ -21,10 +21,9 @@ namespace System.Runtime.Serialization
         {
             InvokeOnSerializing(obj, context, classContract);
             obj = ResolveAdapterType(obj, classContract);
-            var iSerializableObj = obj as ISerializable;
-            if (iSerializableObj != null)
+            if (classContract.IsISerializable)
             {
-                context.WriteISerializable(xmlWriter, iSerializableObj);
+                context.WriteISerializable(xmlWriter, (ISerializable) obj);
             }
             else
             {

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2240,9 +2240,6 @@ public static partial class DataContractJsonSerializerTests
         }
     }
 
-#if ReflectionOnly
-    [ActiveIssue(13071)]
-#endif
     [Fact]
     public static void DCJS_MyISerializableType()
     {

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1431,9 +1431,6 @@ public static partial class DataContractSerializerTests
         Assert.StrictEqual(((SimpleKnownTypeValue)actual.SimpleTypeValue).StrProperty, "PropertyValue");
     }
 
-#if ReflectionOnly
-    [ActiveIssue(13071)]
-#endif
     [Fact]
     public static void DCS_ExceptionObject()
     {
@@ -1448,9 +1445,6 @@ public static partial class DataContractSerializerTests
         Assert.StrictEqual(value.HelpLink, actual.HelpLink);
     }
 
-#if ReflectionOnly
-    [ActiveIssue(13071)]
-#endif
     [Fact]
     public static void DCS_ArgumentExceptionObject()
     {
@@ -1465,9 +1459,6 @@ public static partial class DataContractSerializerTests
         Assert.StrictEqual(value.HelpLink, actual.HelpLink);
     }
 
-#if ReflectionOnly
-    [ActiveIssue(13071)]
-#endif
     [Fact]
     public static void DCS_ExceptionMesageWithSpecialChars()
     {
@@ -1482,9 +1473,6 @@ public static partial class DataContractSerializerTests
         Assert.StrictEqual(value.HelpLink, actual.HelpLink);
     }
 
-#if ReflectionOnly
-    [ActiveIssue(13071)]
-#endif
     [Fact]
     public static void DCS_InnerExceptionMesageWithSpecialChars()
     {
@@ -2756,9 +2744,6 @@ public static partial class DataContractSerializerTests
         Assert.Throws<PlatformNotSupportedException>(() => exporter.Export(typeof(Employee)));
     }
 
-#if ReflectionOnly
-    [ActiveIssue(13071)]
-#endif
     [Fact]
     public static void DCS_MyISerializableType()
     {


### PR DESCRIPTION
Enable DataContractSerializer and DataContractJsonSerializer to support ISerializable types in ReflectionOnly mode.

Fix #13071 
