### PR TITLE
Update CoreRT targeting pack

### DIFF
--- a/src/System.Collections/src/System.Collections.csproj
+++ b/src/System.Collections/src/System.Collections.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == '' OR '$(TargetGroup)'=='netstandard1.7' OR '$(TargetGroup)'=='netcoreapp1.1'">
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj">
-      <TargetGroup>netstandard1.7</TargetGroup>
+      <UndefineProperties>%(ProjectReference.UndefineProperties);TargetGroup</UndefineProperties>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj">
       <UndefineProperties>%(ProjectReference.UndefineProperties);TargetGroup</UndefineProperties>

--- a/src/System.Private.Uri/pkg/unix/System.Private.Uri.pkgproj
+++ b/src/System.Private.Uri/pkg/unix/System.Private.Uri.pkgproj
@@ -10,7 +10,10 @@
     <ProjectReference Include="..\..\src\System.Private.Uri.csproj" >
       <OSGroup>Unix</OSGroup>
     </ProjectReference>
-
+    <ProjectReference Include="..\..\src\System.Private.Uri.csproj">
+      <TargetGroup>netcoreapp1.2corert</TargetGroup>
+      <OSGroup>Unix</OSGroup>
+    </ProjectReference>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Private.Uri/src/System.Private.Uri.builds
+++ b/src/System.Private.Uri/src/System.Private.Uri.builds
@@ -13,6 +13,10 @@
       <TargetGroup>uap101aot</TargetGroup>
     </Project>
     <Project Include="System.Private.Uri.csproj">
+      <OSGroup>Unix</OSGroup>
+      <TargetGroup>netcoreapp1.2corert</TargetGroup>
+    </Project>
+    <Project Include="System.Private.Uri.csproj">
       <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>netcoreapp1.2corert</TargetGroup>
     </Project>

--- a/src/System.Private.Uri/src/System.Private.Uri.csproj
+++ b/src/System.Private.Uri/src/System.Private.Uri.csproj
@@ -33,15 +33,6 @@
     <Compile Include="$(CommonPath)\System\Collections\Generic\LowLevelDictionary.cs">
       <Link>Common\System\Collections\Generic\LowLevelDictionary.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\StringNormalizationExtensions.cs" Condition="'$(TargetGroup)'=='uap101aot' or '$(TargetGroup)' == 'netcoreapp1.2corert'">
-      <Link>Common\System\StringNormalizationExtensions.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\Globalization\IdnMapping.cs" Condition="'$(TargetGroup)'=='uap101aot' or '$(TargetGroup)' == 'netcoreapp1.2corert'">
-      <Link>Common\System\Globalization\IdnMapping.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\Text\NormalizationForm.cs" Condition="'$(TargetGroup)'=='uap101aot' or '$(TargetGroup)' == 'netcoreapp1.2corert'">
-      <Link>Common\System\Text\NormalizationForm.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FxCopBaseline.cs" />
@@ -65,34 +56,54 @@
     <Compile Include="System\UriScheme.cs" />
     <Compile Include="System\UriSyntax.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(TargetGroup)'==''">
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.OutputDebugString.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.OutputDebugString.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\StringNormalizationExtensions.Windows.cs" Condition="'$(TargetGroup)'=='uap101aot' or '$(TargetGroup)' == 'netcoreapp1.2corert'">
+    <Compile Include="$(CommonPath)\System\Diagnostics\Debug.Windows.cs">
+      <Link>Common\System\Diagnostics\Debug.Windows.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(TargetGroup)'=='uap101aot'">
+    <Compile Include="$(CommonPath)\System\StringNormalizationExtensions.cs">
+      <Link>Common\System\StringNormalizationExtensions.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Globalization\IdnMapping.cs">
+      <Link>Common\System\Globalization\IdnMapping.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Text\NormalizationForm.cs">
+      <Link>Common\System\Text\NormalizationForm.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+      <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\StringNormalizationExtensions.Windows.cs">
       <Link>Common\System\StringNormalizationExtensions.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Globalization\IdnMapping.Windows.cs" Condition="'$(TargetGroup)'=='uap101aot' or '$(TargetGroup)' == 'netcoreapp1.2corert'">
+    <Compile Include="$(CommonPath)\System\Globalization\IdnMapping.Windows.cs">
       <Link>Common\System\Globalization\IdnMapping.Windows.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\Diagnostics\Debug.Windows.cs" Condition="'$(TargetGroup)'!='uap101aot' and '$(TargetGroup)' != 'netcoreapp1.2corert'">
-      <Link>Common\System\Diagnostics\Debug.Windows.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetLastError.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.SetLastError.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.Normalization.cs" Condition="'$(TargetGroup)'=='uap101aot' or '$(TargetGroup)' == 'netcoreapp1.2corert'">
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.Normalization.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.Normalization.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\normaliz\Interop.Idna.cs" Condition="'$(TargetGroup)'=='uap101aot' or '$(TargetGroup)' == 'netcoreapp1.2corert'">
+    <Compile Include="$(CommonPath)\Interop\Windows\normaliz\Interop.Idna.cs">
       <Link>Common\Interop\Windows\normaliz\Interop.Idna.cs</Link>
-  </Compile>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\Marshal.Win32.cs">
+      <Link>Common\System\Runtime\InteropServices\Marshal.Win32.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetLastError.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.GetLastError.cs</Link>
+    </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
-    <Compile Include="$(CommonPath)\System\Diagnostics\Debug.Unix.cs" Condition="'$(TargetGroup)'!='uap101aot' and '$(TargetGroup)' != 'netcoreapp1.2corert'">
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true' and '$(TargetGroup)' == ''">
+    <Compile Include="$(CommonPath)\System\Diagnostics\Debug.Unix.cs">
       <Link>Common\System\Diagnostics\Debug.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
@@ -142,15 +153,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\System\Resources\NeutralResourcesLanguageAttribute.cs">
       <Link>Common\System\Resources\NeutralResourcesLanguageAttribute.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\Marshal.Win32.cs" Condition="'$(TargetsWindows)'=='true'">
-      <Link>Common\System\Runtime\InteropServices\Marshal.Win32.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\Marshal.Unix.cs" Condition="'$(TargetsUnix)'=='true'">
-      <Link>Common\System\Runtime\InteropServices\Marshal.Unix.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetLastError.cs" Condition="'$(TargetsWindows)'=='true'">
-      <Link>Common\Interop\Windows\kernel32\Interop.GetLastError.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Private.Uri/src/project.json
+++ b/src/System.Private.Uri/src/project.json
@@ -12,7 +12,7 @@
     },
     "netcoreapp1.2": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreRT": "1.0.0-alpha-24806-1"
+        "Microsoft.TargetingPack.Private.CoreRT": "1.0.0-alpha-24815-0"
       }
     },
     "uap10.1": {

--- a/src/System.Runtime.Extensions/src/ApiCompatBaseline.netstandard15aot.txt
+++ b/src/System.Runtime.Extensions/src/ApiCompatBaseline.netstandard15aot.txt
@@ -1,4 +1,0 @@
-# API's don't exist in netcore50aot implementations yet. 
-MembersMustExist : Member 'System.Environment.Exit(System.Int32)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Environment.GetCommandLineArgs()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Environment.MachineName.get()' does not exist in the implementation but it does exist in the contract.

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -40,8 +40,7 @@
     </ContractProject>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net461'">
-    <!-- Temporarily skip AppDomain.cs for uap101aot -->
-    <Compile Include="System\AppDomain.cs" Condition="'$(TargetGroup)' != 'uap101aot'" />
+    <Compile Include="System\AppDomain.cs" Condition="'$(TargetGroup)' != 'uap101aot' and '$(TargetGroup)' != 'netcoreapp1.2corert'" />
     <Compile Include="System\Context.cs" />
     <Compile Include="System\AppDomainUnloadedException.cs" />
     <Compile Include="System\ApplicationId.cs" />

--- a/src/System.Runtime.Extensions/src/project.json
+++ b/src/System.Runtime.Extensions/src/project.json
@@ -5,9 +5,9 @@
         "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24814-02"
       }
     },
-    "netstandard1.5": {
+    "netcoreapp1.2": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24814-02"
+        "Microsoft.TargetingPack.Private.CoreRT": "1.0.0-alpha-24815-0"
       }
     },
     "net461": {

--- a/src/System.Runtime/pkg/any/System.Runtime.pkgproj
+++ b/src/System.Runtime/pkg/any/System.Runtime.pkgproj
@@ -11,7 +11,6 @@
       <TargetGroup>netstandard1.5</TargetGroup>
     </ProjectReference>
     <ProjectReference Include="..\..\src\System.Runtime.csproj">
-      <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>netcoreapp1.2corert</TargetGroup>
     </ProjectReference>
     <!-- AOT implementation comes from AOT package -->

--- a/src/System.Runtime/src/ApiCompatBaseline.netcoreapp1.2corert.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.netcoreapp1.2corert.txt
@@ -284,10 +284,6 @@ MembersMustExist : Member 'System.String.GetEnumerator()' does not exist in the 
 MembersMustExist : Member 'System.String.GetTypeCode()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.Intern(System.String)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.IsInterned(System.String)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.String.IsNormalized()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.String.IsNormalized(System.Text.NormalizationForm)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.String.Normalize()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.String.Normalize(System.Text.NormalizationForm)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.StartsWith(System.String, System.Boolean, System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.ToLower(System.Globalization.CultureInfo)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.ToString(System.IFormatProvider)' does not exist in the implementation but it does exist in the contract.
@@ -298,42 +294,7 @@ CannotRemoveBaseTypeOrInterface : Type 'System.TimeoutException' does not inheri
 MembersMustExist : Member 'System.TimeoutException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.TimeSpan.CompareTo(System.Object)' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.TimeZone' does not exist in the implementation but it does exist in the contract.
-CannotRemoveBaseTypeOrInterface : Type 'System.TimeZoneInfo' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.ClearCachedData()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.ConvertTimeBySystemTimeZoneId(System.DateTime, System.String)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.ConvertTimeBySystemTimeZoneId(System.DateTime, System.String, System.String)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.ConvertTimeBySystemTimeZoneId(System.DateTimeOffset, System.String)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.ConvertTimeFromUtc(System.DateTime, System.TimeZoneInfo)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.ConvertTimeToUtc(System.DateTime)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.ConvertTimeToUtc(System.DateTime, System.TimeZoneInfo)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.CreateCustomTimeZone(System.String, System.TimeSpan, System.String, System.String)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.CreateCustomTimeZone(System.String, System.TimeSpan, System.String, System.String, System.String, System.TimeZoneInfo.AdjustmentRule[])' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.CreateCustomTimeZone(System.String, System.TimeSpan, System.String, System.String, System.String, System.TimeZoneInfo.AdjustmentRule[], System.Boolean)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.FromSerializedString(System.String)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.GetAdjustmentRules()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.TimeZoneInfo.HasSameRules(System.TimeZoneInfo)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.ToSerializedString()' does not exist in the implementation but it does exist in the contract.
-CannotRemoveBaseTypeOrInterface : Type 'System.TimeZoneInfo.AdjustmentRule' does not implement interface 'System.Runtime.Serialization.IDeserializationCallback' in the implementation but it does in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(System.DateTime, System.DateTime, System.TimeSpan, System.TimeZoneInfo.TransitionTime, System.TimeZoneInfo.TransitionTime)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.AdjustmentRule.DateEnd.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.AdjustmentRule.DateStart.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.AdjustmentRule.DaylightDelta.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.AdjustmentRule.DaylightTransitionEnd.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.AdjustmentRule.DaylightTransitionStart.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.AdjustmentRule.Equals(System.TimeZoneInfo.AdjustmentRule)' does not exist in the implementation but it does exist in the contract.
-CannotRemoveBaseTypeOrInterface : Type 'System.TimeZoneInfo.TransitionTime' does not implement interface 'System.Runtime.Serialization.IDeserializationCallback' in the implementation but it does in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.TransitionTime.CreateFixedDateRule(System.DateTime, System.Int32, System.Int32)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.TransitionTime.CreateFloatingDateRule(System.DateTime, System.Int32, System.Int32, System.DayOfWeek)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.TransitionTime.Day.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.TransitionTime.DayOfWeek.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.TransitionTime.Equals(System.TimeZoneInfo.TransitionTime)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.TransitionTime.IsFixedDateRule.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.TransitionTime.Month.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.TransitionTime.op_Equality(System.TimeZoneInfo.TransitionTime, System.TimeZoneInfo.TransitionTime)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.TransitionTime.op_Inequality(System.TimeZoneInfo.TransitionTime, System.TimeZoneInfo.TransitionTime)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.TransitionTime.TimeOfDay.get()' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.TimeZoneInfo.TransitionTime.Week.get()' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.TimeZoneNotFoundException' does not exist in the implementation but it does exist in the contract.
 CannotMakeMemberNonVirtual : Member 'System.Type.IsEnum' is non-virtual in the implementation but is virtual in the contract.
 CannotMakeMemberNonVirtual : Member 'System.Type.Equals(System.Type)' is non-virtual in the implementation but is virtual in the contract.
 CannotMakeMemberNonVirtual : Member 'System.Type.IsEnum.get()' is non-virtual in the implementation but is virtual in the contract.
@@ -376,8 +337,6 @@ MembersMustExist : Member 'System.Diagnostics.DebuggableAttribute.IsJITTrackingE
 CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.CompareInfo' does not implement interface 'System.Runtime.Serialization.IDeserializationCallback' in the implementation but it does in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.CultureNotFoundException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
 MembersMustExist : Member 'System.Globalization.CultureNotFoundException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Globalization.DaylightTime' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Globalization.IdnMapping' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Globalization.TextInfo' does not implement interface 'System.Runtime.Serialization.IDeserializationCallback' in the implementation but it does in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.IO.DirectoryNotFoundException' does not inherit from base type 'System.SystemException' in the implementation but it does in the contract.
 MembersMustExist : Member 'System.IO.DirectoryNotFoundException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
@@ -539,7 +498,6 @@ MembersMustExist : Member 'System.Text.Encoding.IsMailNewsDisplay.get()' does no
 MembersMustExist : Member 'System.Text.Encoding.IsMailNewsSave.get()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Text.Encoding.WindowsCodePage.get()' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Text.EncodingInfo' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Text.NormalizationForm' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Text.StringBuilder' does not implement interface 'System.Runtime.Serialization.ISerializable' in the implementation but it does in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Threading.WaitHandle' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
 MembersMustExist : Member 'System.Threading.WaitHandle.Close()' does not exist in the implementation but it does exist in the contract.
@@ -558,4 +516,4 @@ CannotRemoveBaseTypeOrInterface : Type 'System.Threading.Tasks.Task' does not im
 MembersMustExist : Member 'System.Threading.Tasks.Task.Dispose()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Threading.Tasks.Task.Dispose(System.Boolean)' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.Threading.Tasks.Task<TResult>' does not implement interface 'System.IDisposable' in the implementation but it does in the contract.
-Total Issues: 559
+Total Issues: 517

--- a/src/System.Runtime/src/System.Runtime.builds
+++ b/src/System.Runtime/src/System.Runtime.builds
@@ -14,7 +14,6 @@
       <TargetGroup>uap101aot</TargetGroup>
     </Project>
     <Project Include="System.Runtime.csproj">
-      <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>netcoreapp1.2corert</TargetGroup>
     </Project>
   </ItemGroup>

--- a/src/System.Runtime/src/System.Runtime.csproj
+++ b/src/System.Runtime/src/System.Runtime.csproj
@@ -39,21 +39,21 @@
     <Compile Include="System\Runtime\CompilerServices\Attributes.cs" />
     <Compile Include="System\IO\FileAttributes.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == '' or '$(TargetGroup)' == 'netstandard1.7' or '$(TargetGroup)' == 'uap101aot' or '$(TargetGroup)' == 'netcoreapp1.2corert'">
+  <ItemGroup Condition="'$(TargetGroup)' != 'net461' and '$(TargetGroup)' != 'netstandard1.5'">
     <Compile Include="System\Runtime\NgenServicingAttributes.cs" />
     <Compile Include="System\IO\HandleInheritability.cs" />
     <Compile Include="System\Runtime\ConstrainedExecution\PrePrepareMethodAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\SpecialNameAttribute.cs" />
     <Compile Include="System\Threading\WaitHandleExtensions.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'!='uap101aot' and '$(TargetGroup)'!='net461' and '$(TargetGroup)' != 'netcoreapp1.2corert'">
+  <ItemGroup Condition="'$(TargetGroup)'=='' or '$(TargetGroup)' == 'netstandard1.5'">
     <Compile Include="System\ComponentModel\DefaultValueAttribute.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='uap101aot' or '$(TargetGroup)'=='uap101' or '$(TargetGroup)' == 'netcoreapp1.2corert'">
+  <ItemGroup Condition="'$(TargetGroup)'=='uap101aot' or '$(TargetGroup)' == 'netcoreapp1.2corert'">
     <Compile Include="$(CommonPath)\System\SystemException.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.csproj" Condition="'$(TargetGroup)' != 'net461' And '$(TargetGroup)' != 'uap101aot' And '$(TargetGroup)' != 'netcoreapp1.2corert'">
+    <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.csproj" Condition="'$(TargetGroup)' == '' or '$(TargetGroup)' == 'netstandard1.5'">
       <OSGroup>Windows_NT</OSGroup>
       <UndefineProperties>%(ProjectReference.UndefineProperties);TargetGroup</UndefineProperties>
     </ProjectReference>

--- a/src/System.Runtime/src/project.json
+++ b/src/System.Runtime/src/project.json
@@ -10,14 +10,9 @@
         "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24814-02"
       }
     },
-    "netcore50": {
-      "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.1.0-beta-24814-00"
-      }
-    },
     "netcoreapp1.2": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreRT": "1.0.0-alpha-24806-1"
+        "Microsoft.TargetingPack.Private.CoreRT": "1.0.0-alpha-24815-0"
       }
     },
     "net461": {


### PR DESCRIPTION
- Exclude string normalization APIs from System.Private.Uri builds. It makes System.Private.Uri platform neutral.
- Enable Unix builds of System.Private.Uri and System.Runtime
- Some prep work for enabling CoreRT build of System.Runtime.Extensions