### PR TITLE
[RFC] [No merge] Remove a field from most Select iterators

### DIFF
--- a/src/System.Linq/src/System/Linq/Select.cs
+++ b/src/System.Linq/src/System/Linq/Select.cs
@@ -86,7 +86,7 @@ namespace System.Linq
             }
         }
 
-        internal sealed class SelectEnumerableIterator<TSource, TResult> : Iterator<TResult>, IIListProvider<TResult>
+        internal sealed class SelectEnumerableIterator<TSource, TResult> : ManualIterator<TResult>, IIListProvider<TResult>
         {
             private readonly IEnumerable<TSource> _source;
             private readonly Func<TSource, TResult> _selector;
@@ -100,7 +100,9 @@ namespace System.Linq
                 _selector = selector;
             }
 
-            public override Iterator<TResult> Clone()
+            public override TResult Current => _selector(_enumerator.Current);
+
+            public override ManualIterator<TResult> Clone()
             {
                 return new SelectEnumerableIterator<TSource, TResult>(_source, _selector);
             }
@@ -127,7 +129,6 @@ namespace System.Linq
                     case 2:
                         if (_enumerator.MoveNext())
                         {
-                            _current = _selector(_enumerator.Current);
                             return true;
                         }
 
@@ -160,7 +161,7 @@ namespace System.Linq
             public int GetCount(bool onlyIfCheap) => onlyIfCheap ? -1 : _source.Count();
         }
 
-        internal sealed class SelectArrayIterator<TSource, TResult> : Iterator<TResult>, IPartition<TResult>
+        internal sealed class SelectArrayIterator<TSource, TResult> : ManualIterator<TResult>, IPartition<TResult>
         {
             private readonly TSource[] _source;
             private readonly Func<TSource, TResult> _selector;
@@ -174,7 +175,9 @@ namespace System.Linq
                 _selector = selector;
             }
 
-            public override Iterator<TResult> Clone()
+            public override TResult Current => _selector(_source[_state - 2]);
+
+            public override ManualIterator<TResult> Clone()
             {
                 return new SelectArrayIterator<TSource, TResult>(_source, _selector);
             }
@@ -187,8 +190,7 @@ namespace System.Linq
                     return false;
                 }
 
-                int index = _state++ - 1;
-                _current = _selector(_source[index]);
+                _state++;
                 return true;
             }
 
@@ -274,7 +276,7 @@ namespace System.Linq
             }
         }
 
-        internal sealed class SelectListIterator<TSource, TResult> : Iterator<TResult>, IPartition<TResult>
+        internal sealed class SelectListIterator<TSource, TResult> : ManualIterator<TResult>, IPartition<TResult>
         {
             private readonly List<TSource> _source;
             private readonly Func<TSource, TResult> _selector;
@@ -288,7 +290,9 @@ namespace System.Linq
                 _selector = selector;
             }
 
-            public override Iterator<TResult> Clone()
+            public override TResult Current => _selector(_enumerator.Current);
+
+            public override ManualIterator<TResult> Clone()
             {
                 return new SelectListIterator<TSource, TResult>(_source, _selector);
             }
@@ -304,7 +308,6 @@ namespace System.Linq
                     case 2:
                         if (_enumerator.MoveNext())
                         {
-                            _current = _selector(_enumerator.Current);
                             return true;
                         }
 
@@ -403,7 +406,7 @@ namespace System.Linq
             }
         }
 
-        internal sealed class SelectIListIterator<TSource, TResult> : Iterator<TResult>, IPartition<TResult>
+        internal sealed class SelectIListIterator<TSource, TResult> : ManualIterator<TResult>, IPartition<TResult>
         {
             private readonly IList<TSource> _source;
             private readonly Func<TSource, TResult> _selector;
@@ -417,7 +420,9 @@ namespace System.Linq
                 _selector = selector;
             }
 
-            public override Iterator<TResult> Clone()
+            public override TResult Current => _selector(_enumerator.Current);
+
+            public override ManualIterator<TResult> Clone()
             {
                 return new SelectIListIterator<TSource, TResult>(_source, _selector);
             }
@@ -433,7 +438,6 @@ namespace System.Linq
                     case 2:
                         if (_enumerator.MoveNext())
                         {
-                            _current = _selector(_enumerator.Current);
                             return true;
                         }
 
@@ -543,7 +547,7 @@ namespace System.Linq
             }
         }
 
-        internal sealed class SelectIPartitionIterator<TSource, TResult> : Iterator<TResult>, IPartition<TResult>
+        internal sealed class SelectIPartitionIterator<TSource, TResult> : ManualIterator<TResult>, IPartition<TResult>
         {
             private readonly IPartition<TSource> _source;
             private readonly Func<TSource, TResult> _selector;
@@ -557,7 +561,9 @@ namespace System.Linq
                 _selector = selector;
             }
 
-            public override Iterator<TResult> Clone()
+            public override TResult Current => _selector(_enumerator.Current);
+
+            public override ManualIterator<TResult> Clone()
             {
                 return new SelectIPartitionIterator<TSource, TResult>(_source, _selector);
             }
@@ -573,7 +579,6 @@ namespace System.Linq
                     case 2:
                         if (_enumerator.MoveNext())
                         {
-                            _current = _selector(_enumerator.Current);
                             return true;
                         }
 
@@ -707,7 +712,7 @@ namespace System.Linq
             }
         }
 
-        private sealed class SelectListPartitionIterator<TSource, TResult> : Iterator<TResult>, IPartition<TResult>
+        private sealed class SelectListPartitionIterator<TSource, TResult> : ManualIterator<TResult>, IPartition<TResult>
         {
             private readonly IList<TSource> _source;
             private readonly Func<TSource, TResult> _selector;
@@ -728,7 +733,9 @@ namespace System.Linq
                 _index = minIndexInclusive;
             }
 
-            public override Iterator<TResult> Clone()
+            public override TResult Current => _selector(_source[_index - 1]);
+
+            public override ManualIterator<TResult> Clone()
             {
                 return new SelectListPartitionIterator<TSource, TResult>(_source, _selector, _minIndexInclusive, _maxIndexInclusive);
             }
@@ -737,7 +744,6 @@ namespace System.Linq
             {
                 if ((_state == 1 & _index <= _maxIndexInclusive) && _index < _source.Count)
                 {
-                    _current = _selector(_source[_index]);
                     ++_index;
                     return true;
                 }

--- a/src/System.Linq/src/System/Linq/Where.cs
+++ b/src/System.Linq/src/System/Linq/Where.cs
@@ -197,7 +197,7 @@ namespace System.Linq
             }
         }
 
-        internal sealed class WhereArrayIterator<TSource> : Iterator<TSource>, IIListProvider<TSource>
+        internal sealed class WhereArrayIterator<TSource> : ManualIterator<TSource>, IIListProvider<TSource>
         {
             private readonly TSource[] _source;
             private readonly Func<TSource, bool> _predicate;
@@ -210,7 +210,9 @@ namespace System.Linq
                 _predicate = predicate;
             }
 
-            public override Iterator<TSource> Clone()
+            public override TSource Current => _source[_state - 2];
+
+            public override ManualIterator<TSource> Clone()
             {
                 return new WhereArrayIterator<TSource>(_source, _predicate);
             }
@@ -249,7 +251,6 @@ namespace System.Linq
                     index = _state++;
                     if (_predicate(item))
                     {
-                        _current = item;
                         return true;
                     }
                 }
@@ -299,7 +300,7 @@ namespace System.Linq
             }
         }
 
-        internal sealed class WhereListIterator<TSource> : Iterator<TSource>, IIListProvider<TSource>
+        internal sealed class WhereListIterator<TSource> : ManualIterator<TSource>, IIListProvider<TSource>
         {
             private readonly List<TSource> _source;
             private readonly Func<TSource, bool> _predicate;
@@ -313,7 +314,9 @@ namespace System.Linq
                 _predicate = predicate;
             }
 
-            public override Iterator<TSource> Clone()
+            public override TSource Current => _enumerator.Current;
+
+            public override ManualIterator<TSource> Clone()
             {
                 return new WhereListIterator<TSource>(_source, _predicate);
             }
@@ -356,7 +359,6 @@ namespace System.Linq
                             TSource item = _enumerator.Current;
                             if (_predicate(item))
                             {
-                                _current = item;
                                 return true;
                             }
                         }

--- a/src/System.Linq/src/System/Linq/Where.cs
+++ b/src/System.Linq/src/System/Linq/Where.cs
@@ -411,7 +411,7 @@ namespace System.Linq
             }
         }
 
-        internal sealed class WhereSelectArrayIterator<TSource, TResult> : Iterator<TResult>, IIListProvider<TResult>
+        internal sealed class WhereSelectArrayIterator<TSource, TResult> : ManualIterator<TResult>, IIListProvider<TResult>
         {
             private readonly TSource[] _source;
             private readonly Func<TSource, bool> _predicate;
@@ -427,7 +427,9 @@ namespace System.Linq
                 _selector = selector;
             }
 
-            public override Iterator<TResult> Clone()
+            public override TResult Current => _selector(_source[_state - 2]);
+
+            public override ManualIterator<TResult> Clone()
             {
                 return new WhereSelectArrayIterator<TSource, TResult>(_source, _predicate, _selector);
             }
@@ -467,7 +469,6 @@ namespace System.Linq
                     index = _state++;
                     if (_predicate(item))
                     {
-                        _current = _selector(item);
                         return true;
                     }
                 }
@@ -512,7 +513,7 @@ namespace System.Linq
             }
         }
 
-        internal sealed class WhereSelectListIterator<TSource, TResult> : Iterator<TResult>, IIListProvider<TResult>
+        internal sealed class WhereSelectListIterator<TSource, TResult> : ManualIterator<TResult>, IIListProvider<TResult>
         {
             private readonly List<TSource> _source;
             private readonly Func<TSource, bool> _predicate;
@@ -529,7 +530,9 @@ namespace System.Linq
                 _selector = selector;
             }
 
-            public override Iterator<TResult> Clone()
+            public override TResult Current => _selector(_enumerator.Current);
+
+            public override ManualIterator<TResult> Clone()
             {
                 return new WhereSelectListIterator<TSource, TResult>(_source, _predicate, _selector);
             }
@@ -573,7 +576,6 @@ namespace System.Linq
                             TSource item = _enumerator.Current;
                             if (_predicate(item))
                             {
-                                _current = _selector(item);
                                 return true;
                             }
                         }

--- a/src/System.Linq/tests/SelectTests.cs
+++ b/src/System.Linq/tests/SelectTests.cs
@@ -370,76 +370,6 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void Select_SourceIsAnArray_CurrentIsDefaultOfTAfterEnumeration()
-        {
-            int[] source = new[] { 1 };
-            Func<int, int> selector = i => i + 1;
-
-            IEnumerable<int> query = source.Select(selector);
-
-            var enumerator = query.GetEnumerator();
-            while (enumerator.MoveNext()) ;
-
-            Assert.Equal(default(int), enumerator.Current);
-        }
-
-        [Fact]
-        public void Select_SourceIsAList_CurrentIsDefaultOfTAfterEnumeration()
-        {
-            List<int> source = new List<int>() { 1 };
-            Func<int, int> selector = i => i + 1;
-
-            IEnumerable<int> query = source.Select(selector);
-
-            var enumerator = query.GetEnumerator();
-            while (enumerator.MoveNext()) ;
-
-            Assert.Equal(default(int), enumerator.Current);
-        }
-
-        [Fact]
-        public void Select_SourceIsIReadOnlyCollection_CurrentIsDefaultOfTAfterEnumeration()
-        {
-            IReadOnlyCollection<int> source = new ReadOnlyCollection<int>(new List<int>() { 1 });
-            Func<int, int> selector = i => i + 1;
-
-            IEnumerable<int> query = source.Select(selector);
-
-            var enumerator = query.GetEnumerator();
-            while (enumerator.MoveNext()) ;
-
-            Assert.Equal(default(int), enumerator.Current);
-        }
-
-        [Fact]
-        public void Select_SourceIsICollection_CurrentIsDefaultOfTAfterEnumeration()
-        {
-            ICollection<int> source = new LinkedList<int>(new List<int>() { 1 });
-            Func<int, int> selector = i => i + 1;
-
-            IEnumerable<int> query = source.Select(selector);
-
-            var enumerator = query.GetEnumerator();
-            while (enumerator.MoveNext()) ;
-
-            Assert.Equal(default(int), enumerator.Current);
-        }
-
-        [Fact]
-        public void Select_SourceIsIEnumerable_CurrentIsDefaultOfTAfterEnumeration()
-        {
-            IEnumerable<int> source = Enumerable.Repeat(1, 1);
-            Func<int, int> selector = i => i + 1;
-
-            IEnumerable<int> query = source.Select(selector);
-
-            var enumerator = query.GetEnumerator();
-            while (enumerator.MoveNext()) ;
-
-            Assert.Equal(default(int), enumerator.Current);
-        }
-
-        [Fact]
         public void SelectSelect_SourceIsAnArray_ReturnsExpectedValues()
         {
             Func<int, int> selector = i => i + 1;
@@ -561,8 +491,9 @@ namespace System.Linq.Tests
 
             var result = source.Select(selector);
             var enumerator = result.GetEnumerator();
+            enumerator.MoveNext();
 
-            Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
         }
 
         [Fact]
@@ -578,8 +509,9 @@ namespace System.Linq.Tests
 
             var result = source.Select(selector);
             var enumerator = result.GetEnumerator();
+            enumerator.MoveNext();
 
-            Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
             enumerator.MoveNext();
             Assert.Equal(3 /* 2 + 1 */, enumerator.Current);
         }
@@ -592,8 +524,9 @@ namespace System.Linq.Tests
 
             var result = source.Select(selector);
             var enumerator = result.GetEnumerator();
+            enumerator.MoveNext();
 
-            Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
         }
 
         [Fact]
@@ -604,8 +537,9 @@ namespace System.Linq.Tests
 
             var result = source.Select(selector);
             var enumerator = result.GetEnumerator();
+            enumerator.MoveNext();
 
-            Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
             enumerator.MoveNext();
             Assert.Equal(3 /* 2 + 1 */, enumerator.Current);
         }
@@ -666,7 +600,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void Select_ExceptionThrownFromGetEnumeratorOnSource_CurrentIsSetToDefaultOfItemTypeAndIteratorCanBeUsedAfterExceptionIsCaught()
+        public void Select_ExceptionThrownFromGetEnumeratorOnSource_IteratorCanBeUsedAfterExceptionIsCaught()
         {
             IEnumerable<int> source = new ThrowsOnGetEnumerator();
             Func<int, string> selector = i => i.ToString();
@@ -675,8 +609,6 @@ namespace System.Linq.Tests
             var enumerator = result.GetEnumerator();
 
             Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
-            string currentValue = enumerator.Current;
-            Assert.Equal(default(string), currentValue);
 
             Assert.True(enumerator.MoveNext());
             Assert.Equal("1", enumerator.Current);

--- a/src/System.Linq/tests/SkipWhileTests.cs
+++ b/src/System.Linq/tests/SkipWhileTests.cs
@@ -54,8 +54,8 @@ namespace System.Linq.Tests
         [Fact]
         public void SkipErrorWhenSourceErrors()
         {
-            var source = NumberRangeGuaranteedNotCollectionType(-2, 5).Select(i => (decimal)i).Select(m => 1 / m).Skip(4);
-            using(var en = source.GetEnumerator())
+            var source = ForceNotCollection(NumberRangeGuaranteedNotCollectionType(-2, 5).Select(i => (decimal)i).Select(m => 1 / m)).Skip(4);
+            using (var en = source.GetEnumerator())
             {
                 Assert.Throws<DivideByZeroException>(() => en.MoveNext());
             }

--- a/src/System.Linq/tests/WhereTests.cs
+++ b/src/System.Linq/tests/WhereTests.cs
@@ -1078,11 +1078,8 @@ namespace System.Linq.Tests
                         Assert.True(en.MoveNext());
                     }
 
-                    Assert.False(en.MoveNext()); // No more items, this should dispose.
-                    Assert.Equal(0, en.Current); // Reset to default value
-
-                    Assert.False(en.MoveNext()); // Want to be sure MoveNext after disposing still works.
-                    Assert.Equal(0, en.Current);
+                    Assert.False(en.MoveNext()); // There are no more items, so this should call Dispose.
+                    Assert.False(en.MoveNext()); // Be sure that calling MoveNext after Dispose still works.
                 }
             }
         }


### PR DESCRIPTION
**Description:** Instead of running the selector and storing the result in a field during `MoveNext`, we can just run the selector during `Current` and remove that field.

**Breaking changes:** `MoveNext` by itself will no longer run the selector. If someone calls `Current` twice, the selector will be evaluated twice. Repro:

```cs
int selectorRuns = 0;
var it = new[] { 0xff }.Select(i => selectorRuns++);
using (var en = it.GetEnumerator())
{
    en.MoveNext(); // Before ran the selector, now doesn't
    int unused = en.Current; // Before didn't run the selector, now does
    unused = en.Current; // Now runs the selector again

    // Before, `selectorRuns` would be 1. Now, it's 2.
}
```

**Why they're acceptable:** Enumerables are used mainly in two contexts: `foreach` and Linq. `foreach` handles this correctly by caching `Current` into a local at the beginning of the loop, so it can only be evaluated once. Linq handles things correctly and does not run `Current` more than once.

Therefore, this change should break only fringe cases where 1) someone manually calls `GetEnumerator` on an enumerable and invokes `Current` more than once per `MoveNext` (a bug in their code) and 2) `e.Select` with an impure selector is passed to that function.

**Performance results:** Not posted yet. I am wondering if maintainers think this is an acceptable change.

I have marked this [No merge] temporarily because this is going to degrade perf in a few places where we check for `Iterator` for optimizations; [here](https://github.com/dotnet/corefx/blob/master/src/System.Linq/src/System/Linq/Select.cs#L25) is one of them. This can be easily worked around by using interfaces. Also, I need to add more comprehensive tests for these changes.

@JonHanna @VSadov @stephentoub PTAL