### PR TITLE
Extend the implicit machine.config

### DIFF
--- a/src/System.Configuration/src/System.Configuration.csproj
+++ b/src/System.Configuration/src/System.Configuration.csproj
@@ -106,6 +106,7 @@
     <Compile Include="System\Configuration\Internal\IInternalConfigClientHost.cs" />
     <Compile Include="System\Configuration\Internal\IInternalConfigConfigurationFactory.cs" />
     <Compile Include="System\Configuration\Internal\IInternalConfigHost.cs" />
+    <Compile Include="System\Configuration\Internal\IInternalConfigHostPaths.cs" />
     <Compile Include="System\Configuration\Internal\IInternalConfigRecord.cs" />
     <Compile Include="System\Configuration\Internal\IInternalConfigRoot.cs" />
     <Compile Include="System\Configuration\Internal\IInternalConfigSettingsFactory.cs" />

--- a/src/System.Configuration/src/System/Configuration/ClientConfigurationHost.cs
+++ b/src/System.Configuration/src/System/Configuration/ClientConfigurationHost.cs
@@ -55,7 +55,7 @@ namespace System.Configuration
             }
         }
 
-        internal bool HasRoamingConfig
+        public override bool HasRoamingConfig
         {
             get
             {
@@ -64,7 +64,7 @@ namespace System.Configuration
             }
         }
 
-        internal bool HasLocalConfig
+        public override bool HasLocalConfig
         {
             get
             {
@@ -73,7 +73,7 @@ namespace System.Configuration
             }
         }
 
-        internal bool IsAppConfigHttp => !IsFile(GetStreamName(ExeConfigPath));
+        public override bool IsAppConfigHttp => !IsFile(GetStreamName(ExeConfigPath));
 
         public override bool SupportsRefresh => true;
 
@@ -112,7 +112,7 @@ namespace System.Configuration
             return LocalUserConfigPath;
         }
 
-        internal void RefreshConfigPaths()
+        public override void RefreshConfigPaths()
         {
             // Refresh current config paths.
             if ((_configPaths != null) && !_configPaths.HasEntryAssembly && (_exePath == null))

--- a/src/System.Configuration/src/System/Configuration/ClientConfigurationSystem.cs
+++ b/src/System.Configuration/src/System/Configuration/ClientConfigurationSystem.cs
@@ -11,7 +11,7 @@ namespace System.Configuration
     {
         private const string SystemDiagnosticsConfigKey = "system.diagnostics";
         private const string SystemNetGroupKey = "system.net/";
-        private readonly ClientConfigurationHost _configHost;
+        private readonly IInternalConfigHost _configHost;
         private readonly IInternalConfigRoot _configRoot;
         private readonly bool _isAppConfigHttp;
         private IInternalConfigRecord _completeConfigRecord;
@@ -27,12 +27,12 @@ namespace System.Configuration
             IConfigSystem configSystem = new ConfigSystem();
             configSystem.Init(typeof(ClientConfigurationHost), null, null);
 
-            _configHost = (ClientConfigurationHost)configSystem.Host;
+            _configHost = configSystem.Host;
             _configRoot = configSystem.Root;
 
             _configRoot.ConfigRemoved += OnConfigRemoved;
 
-            _isAppConfigHttp = _configHost.IsAppConfigHttp;
+            _isAppConfigHttp = ((IInternalConfigHostPaths)_configHost).IsAppConfigHttp;
         }
 
         object IInternalConfigSystem.GetSection(string sectionName)
@@ -138,12 +138,17 @@ namespace System.Configuration
                     //}
 
                     // Now load the rest of configuration
-                    _configHost.RefreshConfigPaths();
+                    var configHostPaths = (IInternalConfigHostPaths)_configHost;
+                    configHostPaths.RefreshConfigPaths();
+
                     string configPath;
-                    if (_configHost.HasLocalConfig) configPath = ClientConfigurationHost.LocalUserConfigPath;
+                    if (configHostPaths.HasLocalConfig)
+                    {
+                        configPath = ClientConfigurationHost.LocalUserConfigPath;
+                    }
                     else
                     {
-                        configPath = _configHost.HasRoamingConfig
+                        configPath = configHostPaths.HasRoamingConfig
                             ? ClientConfigurationHost.RoamingUserConfigPath
                             : ClientConfigurationHost.ExeConfigPath;
                     }

--- a/src/System.Configuration/src/System/Configuration/ConfigurationManager.cs
+++ b/src/System.Configuration/src/System/Configuration/ConfigurationManager.cs
@@ -99,12 +99,12 @@ namespace System.Configuration
                 {
                     try
                     {
-                        // Create the system, but let it initialize itself
-                        // when GetConfig is called, so that it can handle its
-                        // own re-entrancy issues during initialization.
-                        // When initialization is complete, the DefaultConfigurationSystem
-                        // will call CompleteConfigInit to mark initialization as
-                        // having completed.
+                        // Create the system, but let it initialize itself when GetConfig is called,
+                        // so that it can handle its own re-entrancy issues during initialization.
+                        //
+                        // When initialization is complete, the DefaultConfigurationSystem will call
+                        // CompleteConfigInit to mark initialization as having completed.
+                        //
                         // Note: the ClientConfigurationSystem has a 2-stage initialization,
                         // and that's why s_initState isn't set to InitState.Completed yet.
                         s_configSystem = new ClientConfigurationSystem();

--- a/src/System.Configuration/src/System/Configuration/ImplicitMachineConfigHost.cs
+++ b/src/System.Configuration/src/System/Configuration/ImplicitMachineConfigHost.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Configuration.Internal;
-using System.Diagnostics;
 using System.IO;
 using System.Text;
 
@@ -12,9 +11,9 @@ namespace System.Configuration
     internal class ImplicitMachineConfigHost : DelegatingConfigHost
     {
         private string _machineStreamName;
-        ConfigurationFileMap _fileMap;
+        private ConfigurationFileMap _fileMap;
 
-        internal ImplicitMachineConfigHost(UpdateConfigHost host)
+        internal ImplicitMachineConfigHost(IInternalConfigHost host)
         {
             // Delegate to the host provided.
             Host = host;

--- a/src/System.Configuration/src/System/Configuration/Internal/ConfigSystem.cs
+++ b/src/System.Configuration/src/System/Configuration/Internal/ConfigSystem.cs
@@ -13,9 +13,13 @@ namespace System.Configuration.Internal
         void IConfigSystem.Init(Type typeConfigHost, params object[] hostInitParams)
         {
             _configRoot = new InternalConfigRoot();
-            _configHost = (IInternalConfigHost)TypeUtil.CreateInstance(typeConfigHost);
 
-            _configRoot.Init(_configHost, false);
+            // Create the requested host and wrap in ImplicitMachineConfigHost so we can
+            // stub in a simple machine.config if needed.
+            IInternalConfigHost host = (IInternalConfigHost)TypeUtil.CreateInstance(typeConfigHost);
+            _configHost = new ImplicitMachineConfigHost(host);
+
+            _configRoot.Init(_configHost, isDesignTime: false);
             _configHost.Init(_configRoot, hostInitParams);
         }
 

--- a/src/System.Configuration/src/System/Configuration/Internal/DelegatingConfigHost.cs
+++ b/src/System.Configuration/src/System/Configuration/Internal/DelegatingConfigHost.cs
@@ -21,7 +21,7 @@ namespace System.Configuration.Internal
     //    implementation can remain internal.
     //  * It allows straightforward chaining of host functionality,
     //    see UpdateConfigHost as an example.
-    public class DelegatingConfigHost : IInternalConfigHost
+    public class DelegatingConfigHost : IInternalConfigHost, IInternalConfigHostPaths
     {
         protected DelegatingConfigHost() { }
 
@@ -210,5 +210,19 @@ namespace System.Configuration.Internal
         }
 
         public virtual bool IsRemote => Host.IsRemote;
+
+        // Want this to fail hard if we actually try and call where there is no implementation
+        private IInternalConfigHostPaths HostPaths => (IInternalConfigHostPaths)Host;
+
+        public virtual void RefreshConfigPaths()
+        {
+            HostPaths.RefreshConfigPaths();
+        }
+
+        public virtual bool HasLocalConfig => HostPaths.HasLocalConfig;
+
+        public virtual bool HasRoamingConfig => HostPaths.HasRoamingConfig;
+
+        public virtual bool IsAppConfigHttp => HostPaths.IsAppConfigHttp;
     }
 }

--- a/src/System.Configuration/src/System/Configuration/Internal/IInternalConfigHostPaths.cs
+++ b/src/System.Configuration/src/System/Configuration/Internal/IInternalConfigHostPaths.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Configuration.Internal
+{
+    [ComVisible(false)]
+    public interface IInternalConfigHostPaths
+    {
+        void RefreshConfigPaths();
+        bool HasLocalConfig { get; }
+        bool HasRoamingConfig { get; }
+        bool IsAppConfigHttp { get; }
+    }
+}

--- a/src/System.Configuration/src/System/Configuration/Internal/WriteFileContext.cs
+++ b/src/System.Configuration/src/System/Configuration/Internal/WriteFileContext.cs
@@ -163,9 +163,7 @@ namespace System.Configuration.Internal
                 !FileIsWriteLocked(target))
             {
                 Thread.Sleep(SavingRetryInterval);
-
                 duration += SavingRetryInterval;
-
                 writeSucceeded = AttemptMove(source, target);
             }
 
@@ -180,7 +178,7 @@ namespace System.Configuration.Internal
         {
             try
             {
-                File.Move(source, target);
+                File.Replace(source, target, null);
                 return true;
             }
             catch

--- a/src/System.Configuration/tests/System.Configuration.Tests.csproj
+++ b/src/System.Configuration/tests/System.Configuration.Tests.csproj
@@ -50,11 +50,14 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Strings.resx</DependentUpon>
     </Compile>
+    <Compile Include="System\Configuration\AppSettingsTests.cs" />
     <Compile Include="System\Configuration\ConfigPathUtilityTests.cs" />
     <Compile Include="System\Configuration\ExceptionUtilTests.cs" />
+    <Compile Include="System\Configuration\ImplicitMachineConfigTests.cs" />
     <Compile Include="System\Configuration\SmokeTest.cs" />
     <Compile Include="System\Configuration\StringUtilTests.cs" />
     <Compile Include="System\Configuration\TempConfig.cs" />
+    <Compile Include="System\Configuration\TestData.cs" />
     <Compile Include="System\Configuration\TypeUtilTests.cs" />
     <Compile Include="System\Configuration\ValidatiorUtilsTests.cs" />
   </ItemGroup>

--- a/src/System.Configuration/tests/System/Configuration/AppSettingsTests.cs
+++ b/src/System.Configuration/tests/System/Configuration/AppSettingsTests.cs
@@ -1,0 +1,87 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Configuration;
+using System.IO;
+using Xunit;
+
+namespace System.ConfigurationTests
+{
+    public class AppSettingsTests
+    {
+        [Fact]
+        public void EmptyRuntimeAppSettings()
+        {
+            var appSettings = ConfigurationManager.AppSettings;
+            Assert.NotNull(appSettings);
+            Assert.Empty(appSettings);
+        }
+
+        [Fact]
+        public void EmptyDesignTimeAppSettings()
+        {
+            using (var temp = new TempConfig(TestData.EmptyConfig))
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                Assert.NotNull(config.AppSettings);
+                Assert.Empty(config.AppSettings.Settings);
+            }
+        }
+
+        [Fact]
+        public void SimpleAppSettings()
+        {
+            using (var temp = new TempConfig(TestData.SimpleConfig))
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                Assert.NotNull(config.AppSettings);
+                Assert.Equal(2, config.AppSettings.Settings.Count);
+                Assert.Equal("FooValue", config.AppSettings.Settings["FooKey"].Value);
+                Assert.Equal("BarValue", config.AppSettings.Settings["BarKey"].Value);
+            }
+        }
+
+        [Fact]
+        public void AddToAppSettings_NoSave()
+        {
+            using (var temp = new TempConfig(TestData.EmptyConfig))
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                Assert.NotNull(config.AppSettings);
+                Assert.Empty(config.AppSettings.Settings);
+
+                config.AppSettings.Settings.Add("NewKey", "NewValue");
+                Assert.NotEmpty(config.AppSettings.Settings);
+                Assert.Equal("NewValue", config.AppSettings.Settings["NewKey"].Value);
+
+                config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                Assert.Empty(config.AppSettings.Settings);
+            }
+        }
+
+        [Fact]
+        public void AddToAppSettings_Save()
+        {
+            using (var temp = new TempConfig(TestData.EmptyConfig))
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                Assert.NotNull(config.AppSettings);
+                Assert.Empty(config.AppSettings.Settings);
+
+                config.AppSettings.Settings.Add("NewKey", "NewValue");
+                Assert.NotEmpty(config.AppSettings.Settings);
+                Assert.Equal("NewValue", config.AppSettings.Settings["NewKey"].Value);
+
+                config.Save();
+
+                // Make sure we didn't serialize the implicit machine.config
+                Assert.False(File.Exists(new ConfigurationFileMap().MachineConfigFilename));
+
+                config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                Assert.NotEmpty(config.AppSettings.Settings);
+                Assert.Equal("NewValue", config.AppSettings.Settings["NewKey"].Value);
+            }
+        }
+    }
+}

--- a/src/System.Configuration/tests/System/Configuration/ConfigPathUtilityTests.cs
+++ b/src/System.Configuration/tests/System/Configuration/ConfigPathUtilityTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Configuration;
-using System.IO;
 using Xunit;
 
 namespace System.ConfigurationTests

--- a/src/System.Configuration/tests/System/Configuration/ImplicitMachineConfigTests.cs
+++ b/src/System.Configuration/tests/System/Configuration/ImplicitMachineConfigTests.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Configuration;
+using System.IO;
+using Xunit;
+
+namespace System.ConfigurationTests
+{
+    public class ImplicitMachineConfigTests
+    {
+        [Fact]
+        public void RuntimeAppSettingsAccessible()
+        {
+            var appSettings = ConfigurationManager.AppSettings;
+            Assert.NotNull(appSettings);
+        }
+
+        [Fact]
+        public void DesignTimeAppSettingsAccessible()
+        {
+            using (var temp = new TempConfig(TestData.EmptyConfig))
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                Assert.NotNull(config);
+                Assert.NotNull(config.AppSettings);
+            }
+        }
+
+        [Fact]
+        public void DesignTimeAppSettingsFailWithMissingMachineConfig_1()
+        {
+            // ConfigurationFileMap checks for existence in the constructor
+            string missingFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".config");
+            Assert.Throws<ArgumentException>(() => new ConfigurationFileMap(missingFile));
+        }
+
+        [Fact]
+        public void DesignTimeAppSettingsFailWithMissingMachineConfig_2()
+        {
+            // Get around the existence check by using the default constructor
+            string missingFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".config");
+            ConfigurationFileMap map = new ConfigurationFileMap();
+            map.MachineConfigFilename = missingFile;
+            var config = ConfigurationManager.OpenMappedMachineConfiguration(map);
+            Assert.NotNull(config);
+            Assert.Null(config.AppSettings);
+        }
+
+        [Fact]
+        public void DesignTimeAppSettingsFailWithEmptyMachineConfig()
+        {
+            // If we've explicitly specified a machine config and it doesn't define the AppSettingsType we shouldn't be able
+            // to get it (e.g. we haven't stubbed in overtop).
+            using (var temp = new TempConfig(TestData.EmptyConfig))
+            {
+                var config = ConfigurationManager.OpenMappedMachineConfiguration(new ConfigurationFileMap(temp.ConfigPath));
+                Assert.NotNull(config);
+
+                Assert.Null(config.AppSettings);
+            }
+        }
+    }
+}

--- a/src/System.Configuration/tests/System/Configuration/SmokeTest.cs
+++ b/src/System.Configuration/tests/System/Configuration/SmokeTest.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Configuration;
-using System.IO;
 using Xunit;
 
 namespace System.ConfigurationTests
@@ -13,18 +12,7 @@ namespace System.ConfigurationTests
         [Fact]
         public void CreateExe()
         {
-            // Normally the "built-in" configuration section types come from the machine wide config.
-            // Core doesn't have one that it installs, adding appSettings explicitly for now.
-            const string SimpleConfig =
-@"<?xml version='1.0' encoding='utf-8' ?>
-<configuration>
-  <appSettings>
-    <add key='Setting1' value='May 5, 2014'/>
-    <add key='Setting2' value='May 6, 2014'/>
-  </appSettings>
-</configuration>";
-
-            using (var temp = new TempConfig(SimpleConfig))
+            using (var temp = new TempConfig(TestData.SimpleConfig))
             {
                 var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
                 Assert.NotNull(config);

--- a/src/System.Configuration/tests/System/Configuration/TestData.cs
+++ b/src/System.Configuration/tests/System/Configuration/TestData.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ConfigurationTests
+{
+    public static class TestData
+    {
+        public static string EmptyConfig =
+@"<?xml version='1.0' encoding='utf-8' ?>
+<configuration>
+</configuration>";
+
+        public static string SimpleConfig =
+@"<?xml version='1.0' encoding='utf-8' ?>
+<configuration>
+  <appSettings>
+    <add key='FooKey' value='FooValue'/>
+    <add key='BarKey' value='BarValue'/>
+  </appSettings>
+</configuration>";
+    }
+}

--- a/src/System.Configuration/tests/System/Configuration/ValidatiorUtilsTests.cs
+++ b/src/System.Configuration/tests/System/Configuration/ValidatiorUtilsTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Configuration;
-using System.IO;
 using Xunit;
 
 namespace System.ConfigurationTests


### PR DESCRIPTION
Shim the implicit machine.config into the runtime configuration.
It is a little ugly, but I don't want to change existing public
interfaces.

This starts adding a few tests and fixes a Save problem.