### PR TITLE
Supporting C# 7 deconstruction of certain types

### DIFF
--- a/src/Common/tests/System/Collections/IDictionary.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/IDictionary.Generic.Tests.cs
@@ -12,7 +12,7 @@ namespace System.Collections.Tests
     /// Contains tests that ensure the correctness of any class that implements the generic
     /// IDictionary interface
     /// </summary>
-    public abstract class IDictionary_Generic_Tests<TKey, TValue> : ICollection_Generic_Tests<KeyValuePair<TKey, TValue>>
+    public abstract partial class IDictionary_Generic_Tests<TKey, TValue> : ICollection_Generic_Tests<KeyValuePair<TKey, TValue>>
     {
         #region IDictionary<TKey, TValue> Helper Methods
 
@@ -218,6 +218,44 @@ namespace System.Collections.Tests
         /// in the parent dictionary. However, some collections (e.g. ConcurrentDictionary) don't.
         /// </summary>
         protected virtual bool IDictionary_Generic_Keys_Values_Enumeration_ResetImplemented => ResetImplemented;
+
+        #endregion
+
+        #region KeyValuePair
+
+        [Fact]
+        public void KeyValuePair_Empty()
+        {
+            KeyValuePair<TKey, TValue> pair = new KeyValuePair<TKey, TValue>();
+
+            TKey key = default(TKey);
+            TValue value = default(TValue);
+
+            Assert.Equal(key, pair.Key);
+            Assert.Equal(value, pair.Value);
+
+            KeyValuePair_ToString(pair);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void KeyValuePair_ToString(int count)
+        {
+            IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
+
+            Assert.All(dictionary, KeyValuePair_ToString);
+        }
+
+        protected void KeyValuePair_ToString(KeyValuePair<TKey, TValue> pair)
+        {
+            TKey key = pair.Key;
+            string keyStr = key == null ? string.Empty : key.ToString();
+
+            TValue value = pair.Value;
+            string valueStr = value == null ? string.Empty : value.ToString();
+
+            Assert.Equal($"[{keyStr}, {valueStr}]", pair.ToString());
+        }
 
         #endregion
 

--- a/src/Common/tests/System/Collections/IDictionary.Generic.Tests.netcoreapp1.1.cs
+++ b/src/Common/tests/System/Collections/IDictionary.Generic.Tests.netcoreapp1.1.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    /// <summary>
+    /// Contains tests that ensure the correctness of any class that implements the generic
+    /// IDictionary interface
+    /// </summary>
+    public abstract partial class IDictionary_Generic_Tests<TKey, TValue> : ICollection_Generic_Tests<KeyValuePair<TKey, TValue>>
+    {
+        #region KeyValuePair
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void KeyValuePair_Deconstruct(int count)
+        {
+            IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
+
+            Assert.All(dictionary, KeyValuePair_Deconstruct);
+            Assert.True(false);
+        }
+
+        public void KeyValuePair_Deconstruct(KeyValuePair<TKey, TValue> pair)
+        {
+            TKey key;
+            TValue value;
+            pair.Deconstruct(out key, out value);
+
+            Assert.Equal(pair.Key, key);
+            Assert.Equal(pair.Value, value);
+        }
+
+        #endregion
+    }
+}

--- a/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.cs
@@ -12,7 +12,7 @@ namespace System.Collections.Tests
     /// Contains tests that ensure the correctness of any class that implements the nongeneric
     /// IDictionary interface
     /// </summary>
-    public abstract class IDictionary_NonGeneric_Tests : ICollection_NonGeneric_Tests
+    public abstract partial class IDictionary_NonGeneric_Tests : ICollection_NonGeneric_Tests
     {
         #region IDictionary Helper Methods
 

--- a/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.netcoreapp1.1.cs
+++ b/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.netcoreapp1.1.cs
@@ -22,7 +22,10 @@ namespace System.Collections.Tests
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
 
-            Assert.All<DictionaryEntry>(dictionary, DictionaryEntry_Deconstruct);
+            foreach (DictionaryEntry entry in dictionary)
+            {
+                DictionaryEntry_Deconstruct(entry);
+            }
             Assert.True(false);
         }
 

--- a/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.netcoreapp1.1.cs
+++ b/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.netcoreapp1.1.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    /// <summary>
+    /// Contains tests that ensure the correctness of any class that implements the nongeneric
+    /// IDictionary interface
+    /// </summary>
+    public abstract partial class IDictionary_NonGeneric_Tests : ICollection_NonGeneric_Tests
+    {
+        #region DictionaryEntry
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void DictionaryEntry_Deconstruct(int count)
+        {
+            IDictionary dictionary = NonGenericIDictionaryFactory(count);
+
+            Assert.All(dictionary, DictionaryEntry_Deconstruct);
+            Assert.True(false);
+        }
+
+        public void DictionaryEntry_Deconstruct(DictionaryEntry entry)
+        {
+            object key;
+            object value;
+            entry.Deconstruct(out key, out value);
+
+            Assert.Equal(entry.Key, key);
+            Assert.Equal(entry.Value, value);
+        }
+
+        #endregion
+    }
+}

--- a/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.netcoreapp1.1.cs
+++ b/src/Common/tests/System/Collections/IDictionary.NonGeneric.Tests.netcoreapp1.1.cs
@@ -22,7 +22,7 @@ namespace System.Collections.Tests
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
 
-            Assert.All(dictionary, DictionaryEntry_Deconstruct);
+            Assert.All<DictionaryEntry>(dictionary, DictionaryEntry_Deconstruct);
             Assert.True(false);
         }
 

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -76,6 +76,12 @@
     <Compile Include="$(CommonTestPath)\System\RuntimeDetection.cs" >
       <Link>Common\System\RuntimeDetection.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Collections\IDictionary.Generic.Tests.netcoreapp1.1.cs" Condition="'$(TargetGroup)'=='netcoreapp1.1'" >
+      <Link>Common\System\Collections\IDictionary.Generic.Tests.netcoreapp1.1.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Collections\IDictionary.NonGeneric.Tests.netcoreapp1.1.cs" Condition="'$(TargetGroup)'=='netcoreapp1.1'" >
+      <Link>Common\System\Collections\IDictionary.NonGeneric.Tests.netcoreapp1.1.cs</Link>
+    </Compile>
     <!-- Generic tests -->
     <Compile Include="StructuralComparisonsTests.cs" />
     <Compile Include="BitArray\BitArray_CtorTests.cs" />


### PR DESCRIPTION
C# 7 added support for deconstruction of user-defined types via a Deconstruct(out ...) method. It would make sense to be able to use this feature with tuple-like types such as KeyValuePair and DictionaryEntry.
Close https://github.com/dotnet/corefx/issues/13746