### PR TITLE
Test StringComparer.FromComparison

### DIFF
--- a/src/System.Runtime.Extensions/System.Runtime.Extensions.sln
+++ b/src/System.Runtime.Extensions/System.Runtime.Extensions.sln
@@ -40,14 +40,14 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
-		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Debug|Any CPU.ActiveCfg = net462_Release|Any CPU
-		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Debug|Any CPU.Build.0 = net462_Release|Any CPU
-		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Release|Any CPU.ActiveCfg = net462_Release|Any CPU
-		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Release|Any CPU.Build.0 = net462_Release|Any CPU
-		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.netstandard1.7_Debug|Any CPU.ActiveCfg = net463_Release|Any CPU
-		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.netstandard1.7_Debug|Any CPU.Build.0 = net463_Release|Any CPU
-		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.netstandard1.7_Release|Any CPU.ActiveCfg = net463_Debug|Any CPU
-		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.netstandard1.7_Release|Any CPU.Build.0 = net463_Debug|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Debug|Any CPU.ActiveCfg = net461_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Debug|Any CPU.Build.0 = net461_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Release|Any CPU.ActiveCfg = net461_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Release|Any CPU.Build.0 = net461_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.netstandard1.7_Debug|Any CPU.ActiveCfg = net461_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.netstandard1.7_Debug|Any CPU.Build.0 = net461_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.netstandard1.7_Release|Any CPU.ActiveCfg = net461_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.netstandard1.7_Release|Any CPU.Build.0 = net461_Release|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Unix_Debug|Any CPU.ActiveCfg = Unix_Debug|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Unix_Debug|Any CPU.Build.0 = Unix_Debug|Any CPU

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -902,7 +902,7 @@ namespace System
         public static System.StringComparer Ordinal { get { throw null; } }
         public static System.StringComparer OrdinalIgnoreCase { get { throw null; } }
 #if netcoreapp11
-        public static System.StringComparer FromComparison(System.StringComparison comparison) { throw null; }
+        public static System.StringComparer FromComparison(System.StringComparison comparisonType) { throw null; }
 #endif
         public abstract int Compare(string x, string y);
         public static System.StringComparer Create(System.Globalization.CultureInfo culture, bool ignoreCase) { throw null; }

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -901,6 +901,9 @@ namespace System
         public static System.StringComparer InvariantCultureIgnoreCase { get { throw null; } }
         public static System.StringComparer Ordinal { get { throw null; } }
         public static System.StringComparer OrdinalIgnoreCase { get { throw null; } }
+#if netcoreapp11
+        public static System.StringComparer FromComparison(System.StringComparison comparison) { throw null; }
+#endif
         public abstract int Compare(string x, string y);
         public static System.StringComparer Create(System.Globalization.CultureInfo culture, bool ignoreCase) { throw null; }
         public new bool Equals(object x, object y) { throw null; }

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="System\IO\Path.GetRelativePath.cs" />
     <Compile Include="System\MathTests.netcoreapp1.1.cs" />
     <Compile Include="System\MathF.netcoreapp1.1.cs" />
+    <Compile Include="System\StringComparer.netcoreapp1.1.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="System\Diagnostics\Stopwatch.cs" />

--- a/src/System.Runtime.Extensions/tests/System/StringComparer.netcoreapp1.1.cs
+++ b/src/System.Runtime.Extensions/tests/System/StringComparer.netcoreapp1.1.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Globalization;
+using Xunit;
+
+namespace System.Tests
+{
+    public static partial class MiscStringComparerTests
+    {
+        public static object[][] FromComparison_TestData()
+        {
+            return new object[][] {
+            //                  StringComparison                StringComparer
+                new object[] { StringComparison.CurrentCulture, StringComparer.CurrentCulture },
+                new object[] { StringComparison.CurrentCultureIgnoreCase, StringComparer.CurrentCultureIgnoreCase },
+                new object[] { StringComparison.InvariantCulture, StringComparer.InvariantCulture },
+                new object[] { StringComparison.InvariantCultureIgnoreCase, StringComparer.InvariantCultureIgnoreCase },
+                new object[] { StringComparison.Ordinal, StringComparer.Ordinal },
+                new object[] { StringComparison.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase },
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(FromComparison_TestData))]
+        public static void FromComparisonTest(StringComparison comparison, StringComparer comparer)
+        {
+            Assert.Equal(comparer, StringComparer.FromComparison(comparison));
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/tests/System/StringComparer.netcoreapp1.1.cs
+++ b/src/System.Runtime.Extensions/tests/System/StringComparer.netcoreapp1.1.cs
@@ -35,8 +35,8 @@ namespace System.Tests
             StringComparison minInvalid = Enum.GetValues(typeof(StringComparison)).Cast<StringComparison>().Min() - 1;
             StringComparison maxInvalid = Enum.GetValues(typeof(StringComparison)).Cast<StringComparison>().Max() + 1;
 
-            Assert.Throw<ArgumentException>(() => { StringComparer.FromComparison(minInvalid); });
-            Assert.Throw<ArgumentException>(() => { StringComparer.FromComparison(maxInvalid); });
+            Assert.Throw<ArgumentException>(() => StringComparer.FromComparison(minInvalid));
+            Assert.Throw<ArgumentException>(() => StringComparer.FromComparison(maxInvalid));
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/StringComparer.netcoreapp1.1.cs
+++ b/src/System.Runtime.Extensions/tests/System/StringComparer.netcoreapp1.1.cs
@@ -11,18 +11,15 @@ namespace System.Tests
 {
     public static partial class MiscStringComparerTests
     {
-        public static object[][] FromComparison_TestData()
-        {
-            return new object[][] {
-            //                  StringComparison                StringComparer
-                new object[] { StringComparison.CurrentCulture, StringComparer.CurrentCulture },
-                new object[] { StringComparison.CurrentCultureIgnoreCase, StringComparer.CurrentCultureIgnoreCase },
-                new object[] { StringComparison.InvariantCulture, StringComparer.InvariantCulture },
-                new object[] { StringComparison.InvariantCultureIgnoreCase, StringComparer.InvariantCultureIgnoreCase },
-                new object[] { StringComparison.Ordinal, StringComparer.Ordinal },
-                new object[] { StringComparison.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase },
-            };
-        }
+        public static object[][] FromComparison_TestData = new object[][] {
+            //              StringComparison                StringComparer
+            new object[] { StringComparison.CurrentCulture, StringComparer.CurrentCulture },
+            new object[] { StringComparison.CurrentCultureIgnoreCase, StringComparer.CurrentCultureIgnoreCase },
+            new object[] { StringComparison.InvariantCulture, StringComparer.InvariantCulture },
+            new object[] { StringComparison.InvariantCultureIgnoreCase, StringComparer.InvariantCultureIgnoreCase },
+            new object[] { StringComparison.Ordinal, StringComparer.Ordinal },
+            new object[] { StringComparison.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase },
+        };
 
         [Theory]
         [MemberData(nameof(FromComparison_TestData))]

--- a/src/System.Runtime.Extensions/tests/System/StringComparer.netcoreapp1.1.cs
+++ b/src/System.Runtime.Extensions/tests/System/StringComparer.netcoreapp1.1.cs
@@ -35,8 +35,8 @@ namespace System.Tests
             StringComparison minInvalid = Enum.GetValues(typeof(StringComparison)).Cast<StringComparison>().Min() - 1;
             StringComparison maxInvalid = Enum.GetValues(typeof(StringComparison)).Cast<StringComparison>().Max() + 1;
 
-            Assert.Throw<ArgumentException>(() => StringComparer.FromComparison(minInvalid));
-            Assert.Throw<ArgumentException>(() => StringComparer.FromComparison(maxInvalid));
+            Assert.Throws<ArgumentException>(() => StringComparer.FromComparison(minInvalid));
+            Assert.Throws<ArgumentException>(() => StringComparer.FromComparison(maxInvalid));
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/StringComparer.netcoreapp1.1.cs
+++ b/src/System.Runtime.Extensions/tests/System/StringComparer.netcoreapp1.1.cs
@@ -11,7 +11,8 @@ namespace System.Tests
 {
     public static partial class MiscStringComparerTests
     {
-        public static object[][] FromComparison_TestData = new object[][] {
+        public static readonly object[][] FromComparison_TestData =
+        {
             //              StringComparison                StringComparer
             new object[] { StringComparison.CurrentCulture, StringComparer.CurrentCulture },
             new object[] { StringComparison.CurrentCultureIgnoreCase, StringComparer.CurrentCultureIgnoreCase },

--- a/src/System.Runtime.Extensions/tests/System/StringComparer.netcoreapp1.1.cs
+++ b/src/System.Runtime.Extensions/tests/System/StringComparer.netcoreapp1.1.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Xunit;
 
 namespace System.Tests
@@ -28,6 +29,16 @@ namespace System.Tests
         public static void FromComparisonTest(StringComparison comparison, StringComparer comparer)
         {
             Assert.Equal(comparer, StringComparer.FromComparison(comparison));
+        }
+
+        [Fact]
+        public static void FromComparisonInvalidTest()
+        {
+            StringComparison minInvalid = Enum.GetValues(typeof(StringComparison)).Cast<StringComparison>().Min() - 1;
+            StringComparison maxInvalid = Enum.GetValues(typeof(StringComparison)).Cast<StringComparison>().Max() + 1;
+
+            Assert.Throw<ArgumentException>(() => { StringComparer.FromComparison(minInvalid); });
+            Assert.Throw<ArgumentException>(() => { StringComparer.FromComparison(maxInvalid); });
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/StringComparer.netstandard1.7.cs
+++ b/src/System.Runtime.Extensions/tests/System/StringComparer.netstandard1.7.cs
@@ -67,9 +67,9 @@ namespace System.Tests
         [InlineData(StringComparison.InvariantCultureIgnoreCase, StringComparer.InvariantCultureIgnoreCase)]
         [InlineData(StringComparison.Ordinal, StringComparer.Ordinal)]
         [InlineData(StringComparison.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase)]
-        public static void FromComparisonTest(StringComparison ñomparison, StringComparer comparer)
+        public static void FromComparisonTest(StringComparison comparison, StringComparer comparer)
         {
-            Assert.Equal(comparer, StringComparer.FromComparison(ñomparison));
+            Assert.Equal(comparer, StringComparer.FromComparison(comparison));
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/StringComparer.netstandard1.7.cs
+++ b/src/System.Runtime.Extensions/tests/System/StringComparer.netstandard1.7.cs
@@ -59,5 +59,17 @@ namespace System.Tests
             Assert.Equal(StringComparer.InvariantCultureIgnoreCase.GetHashCode("test"), StringComparer.InvariantCultureIgnoreCase.GetHashCode("TEST"));
             Assert.Equal(0, StringComparer.InvariantCultureIgnoreCase.Compare("test", "TEST"));
         }
+
+        [Theory]
+        [InlineData(StringComparison.CurrentCulture, StringComparer.CurrentCulture)]
+        [InlineData(StringComparison.CurrentCultureIgnoreCase, StringComparer.CurrentCultureIgnoreCase)]
+        [InlineData(StringComparison.InvariantCulture, StringComparer.InvariantCulture)]
+        [InlineData(StringComparison.InvariantCultureIgnoreCase, StringComparer.InvariantCultureIgnoreCase)]
+        [InlineData(StringComparison.Ordinal, StringComparer.Ordinal)]
+        [InlineData(StringComparison.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase)]
+        public static void FromComparisonTest(StringComparison ñomparison, StringComparer comparer)
+        {
+            Assert.Equal(comparer, StringComparer.FromComparison(ñomparison));
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/StringComparer.netstandard1.7.cs
+++ b/src/System.Runtime.Extensions/tests/System/StringComparer.netstandard1.7.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Tests
 {
-    public static class MiscStringComparerTests
+    public static partial class MiscStringComparerTests
     {
         public static IEnumerable<object[]> UpperLowerCasing_TestData()
         {
@@ -58,24 +58,6 @@ namespace System.Tests
             Assert.True(StringComparer.InvariantCultureIgnoreCase.Equals((object) "test", (object) "TEST"), "same objects with different casing with StringComparer.InvariantCultureIgnoreCase should be equal");
             Assert.Equal(StringComparer.InvariantCultureIgnoreCase.GetHashCode("test"), StringComparer.InvariantCultureIgnoreCase.GetHashCode("TEST"));
             Assert.Equal(0, StringComparer.InvariantCultureIgnoreCase.Compare("test", "TEST"));
-        }
-
-        public static IEnumerable<object[]> FromComparison_TestData()
-        {
-            //                          StringComparison                StringComparer
-            yield return new object[] { StringComparison.CurrentCulture, StringComparer.CurrentCulture };
-            yield return new object[] { StringComparison.CurrentCultureIgnoreCase, StringComparer.CurrentCultureIgnoreCase };
-            yield return new object[] { StringComparison.InvariantCulture, StringComparer.InvariantCulture };
-            yield return new object[] { StringComparison.InvariantCultureIgnoreCase, StringComparer.InvariantCultureIgnoreCase };
-            yield return new object[] { StringComparison.Ordinal, StringComparer.Ordinal };
-            yield return new object[] { StringComparison.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase };
-        }
-
-        [Theory]
-        [MemberData(nameof(FromComparison_TestData))]
-        public static void FromComparisonTest(StringComparison comparison, StringComparer comparer)
-        {
-            Assert.Equal(comparer, StringComparer.FromComparison(comparison));
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/StringComparer.netstandard1.7.cs
+++ b/src/System.Runtime.Extensions/tests/System/StringComparer.netstandard1.7.cs
@@ -60,13 +60,19 @@ namespace System.Tests
             Assert.Equal(0, StringComparer.InvariantCultureIgnoreCase.Compare("test", "TEST"));
         }
 
+        public static IEnumerable<object[]> FromComparison_TestData()
+        {
+            //                          StringComparison                StringComparer
+            yield return new object[] { StringComparison.CurrentCulture, StringComparer.CurrentCulture };
+            yield return new object[] { StringComparison.CurrentCultureIgnoreCase, StringComparer.CurrentCultureIgnoreCase };
+            yield return new object[] { StringComparison.InvariantCulture, StringComparer.InvariantCulture };
+            yield return new object[] { StringComparison.InvariantCultureIgnoreCase, StringComparer.InvariantCultureIgnoreCase };
+            yield return new object[] { StringComparison.Ordinal, StringComparer.Ordinal };
+            yield return new object[] { StringComparison.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase };
+        }
+
         [Theory]
-        [InlineData(StringComparison.CurrentCulture, StringComparer.CurrentCulture)]
-        [InlineData(StringComparison.CurrentCultureIgnoreCase, StringComparer.CurrentCultureIgnoreCase)]
-        [InlineData(StringComparison.InvariantCulture, StringComparer.InvariantCulture)]
-        [InlineData(StringComparison.InvariantCultureIgnoreCase, StringComparer.InvariantCultureIgnoreCase)]
-        [InlineData(StringComparison.Ordinal, StringComparer.Ordinal)]
-        [InlineData(StringComparison.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase)]
+        [MemberData(nameof(FromComparison_TestData))]
         public static void FromComparisonTest(StringComparison comparison, StringComparer comparer)
         {
             Assert.Equal(comparer, StringComparer.FromComparison(comparison));


### PR DESCRIPTION
Add API to convert a StringComparison to a StringComparer, to avoid bunch of switch-statements in user code (see 'Motivation' section below).
See https://github.com/dotnet/corefx/issues/13800 and https://github.com/dotnet/coreclr/pull/8633