### PR TITLE
Use win10-arm64 for NETCore.App package

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.props
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.props
@@ -21,7 +21,7 @@
     <BuildRID Include="win7-x64">
       <OSGroup>Windows_NT</OSGroup>
     </BuildRID>
-    <BuildRID Include="win-arm64">
+    <BuildRID Include="win10-arm64">
       <Platform>arm64</Platform>
       <OSGroup>Windows_NT</OSGroup>
     </BuildRID>


### PR DESCRIPTION
win-arm64 was a typo.

/cc @weshaggard @mellinoe @chcosta 