### PR TITLE
Generate packages for portable native build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,7 +59,6 @@ if [ $? -ne 0 ];then
    exit 1
 fi
 
-
 if [ $__IsCentos -eq 1 ] ; then
    "$__scriptpath/build-packages.sh" -DisableManagedPackage -FilterToOSGroup=rhel.7 $__UnprocessedBuildArgs
 elif [ $__IsOSX -eq 1 ] ; then

--- a/config.json
+++ b/config.json
@@ -266,6 +266,12 @@
             "MsBuildLogging":"/flp:v=normal;LogFile=build-packages.log"
           }
         },
+        "portableLinux":{
+          "description": "Make the build-native script generate binaries that are portable over glibc based Linux distros.",
+          "settings": {
+            "FilterToOSGroup":"linux"
+          }
+        },
         "tests": {
           "description": "Builds the tests that are in the repository, doesn't restore packages.",
           "settings": {

--- a/src/Native/pkg/runtime.native.System.IO.Compression/linux/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/linux/runtime.native.System.IO.Compression.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>linux-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(LinuxNativePath)System.IO.Compression.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
@@ -3,6 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="runtime.native.System.IO.Compression.pkgproj"/>
+    <Project Include="linux\runtime.native.System.IO.Compression.pkgproj">
+      <OSGroup>linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="rhel\runtime.native.System.IO.Compression.pkgproj">
       <OSGroup>rhel.7</OSGroup>
       <Platform>amd64</Platform>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
@@ -10,6 +10,9 @@
     <File Include="$(PlaceHolderFile)">
       <TargetPath>lib/netstandard1.0</TargetPath>
     </File>
+    <ProjectReference Include="linux\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="rhel\runtime.native.System.IO.Compression.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/Native/pkg/runtime.native.System.Net.Http/linux/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/linux/runtime.native.System.Net.Http.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>linux-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(LinuxNativePath)System.Net.Http.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.builds
+++ b/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.builds
@@ -3,6 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="runtime.native.System.Net.Http.pkgproj"/>
+    <Project Include="linux\runtime.native.System.Net.Http.pkgproj">
+      <OSGroup>linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="rhel\runtime.native.System.Net.Http.pkgproj">
       <OSGroup>rhel.7</OSGroup>
       <Platform>amd64</Platform>

--- a/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.pkgproj
@@ -10,6 +10,9 @@
     <File Include="$(PlaceHolderFile)">
       <TargetPath>lib/netstandard1.0</TargetPath>
     </File>
+    <ProjectReference Include="linux\runtime.native.System.Net.Http.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="rhel\runtime.native.System.Net.Http.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/Native/pkg/runtime.native.System.Net.Security/linux/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/linux/runtime.native.System.Net.Security.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>linux-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(LinuxNativePath)\System.Net.Security.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.builds
+++ b/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.builds
@@ -3,6 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="runtime.native.System.Net.Security.pkgproj"/>
+    <Project Include="linux\runtime.native.System.Net.Security.pkgproj">
+      <OSGroup>linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="rhel\runtime.native.System.Net.Security.pkgproj">
       <OSGroup>rhel.7</OSGroup>
       <Platform>amd64</Platform>

--- a/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.pkgproj
@@ -10,6 +10,9 @@
     <File Include="$(PlaceHolderFile)">
       <TargetPath>lib/netstandard1.0</TargetPath>
     </File>
+    <ProjectReference Include="linux\runtime.native.System.Net.Security.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="rhel\runtime.native.System.Net.Security.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/linux/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/linux/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>linux-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(LinuxNativePath)System.Security.Cryptography.Native.OpenSsl.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.builds
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.builds
@@ -3,6 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="runtime.native.System.Security.Cryptography.OpenSsl.pkgproj"/>
+    <Project Include="linux\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <OSGroup>linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="rhel\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
       <OSGroup>rhel.7</OSGroup>
       <Platform>amd64</Platform>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -10,6 +10,9 @@
     <File Include="$(PlaceHolderFile)">
       <TargetPath>lib/netstandard1.0</TargetPath>
     </File>
+    <ProjectReference Include="linux\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="rhel\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/linux/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/linux/runtime.native.System.Security.Cryptography.pkgproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>linux-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(LinuxNativePath)System.Security.Cryptography.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.builds
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.builds
@@ -3,6 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="runtime.native.System.Security.Cryptography.pkgproj"/>
+    <Project Include="linux\runtime.native.System.Security.Cryptography.pkgproj">
+      <OSGroup>linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="rhel\runtime.native.System.Security.Cryptography.pkgproj">
       <OSGroup>rhel.7</OSGroup>
       <Platform>amd64</Platform>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.pkgproj
@@ -10,6 +10,9 @@
     <File Include="$(PlaceHolderFile)">
       <TargetPath>lib/netstandard1.0</TargetPath>
     </File>
+    <ProjectReference Include="linux\runtime.native.System.Security.Cryptography.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="rhel\runtime.native.System.Security.Cryptography.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/Native/pkg/runtime.native.System/linux/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/linux/runtime.native.System.pkgproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>linux-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeFile Include="$(LinuxNativePath)System.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeFile>
+    <File Include="$(LinuxNativePath)System.Native.a">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System/runtime.native.System.builds
+++ b/src/Native/pkg/runtime.native.System/runtime.native.System.builds
@@ -3,6 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="runtime.native.System.pkgproj"/>
+    <Project Include="linux\runtime.native.System.pkgproj">
+      <OSGroup>linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Include="rhel\runtime.native.System.pkgproj">
       <OSGroup>rhel.7</OSGroup>
       <Platform>amd64</Platform>

--- a/src/Native/pkg/runtime.native.System/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/runtime.native.System.pkgproj
@@ -10,6 +10,9 @@
     <File Include="$(PlaceHolderFile)">
       <TargetPath>lib/netstandard1.0</TargetPath>
     </File>
+    <ProjectReference Include="linux\runtime.native.System.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="rhel\runtime.native.System.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>


### PR DESCRIPTION
This enables generating "Linux-{arch}" packages for Portable Native build of CoreFX.

@weshaggard @ellismg @janvorli PTAL.