### PR TITLE
Re-enable building System.Runtime.Serialization.Formatters 

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
@@ -89,7 +89,6 @@
   <ItemGroup>
     <IgnoredReference Include="System.Private.CoreLib" />
     <IgnoredReference Include="System.Threading.Overlapped" />
-    <IgnoredReference Include="System.Runtime.Serialization.Formatters" />
   </ItemGroup>
 
   <Target Name="VerifyClosure" AfterTargets="Build">

--- a/src/src.builds
+++ b/src/src.builds
@@ -4,8 +4,6 @@
   <ItemGroup>
     <ProjectExclusions Condition="'$(OS)' != 'Windows_NT'" Include="$(MSBuildThisFileDirectory)**\src\System.Memory.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)**\src\System.Threading.Overlapped.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)**\src\System.Runtime.Serialization.Formatters.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)**\src\System.Runtime.CompilerServices.Unsafe.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Project Include="$(MSBuildThisFileDirectory)*/src/*.csproj" Exclude="@(ProjectExclusions)">


### PR DESCRIPTION
Also removes entry for System.Runtime.CompilerServices.Unsafe.  This project was already building via System.Memory but there was an additional entry for csproj (the project is an ilproj). 

System.Runtime.Serialization.Formatters now builds because its references are all present or built properly.

This does not re-enable System.Threading.Overlapped, that one is a bit trickier..

/cc @weshaggard @ericstj 