### PR TITLE
Restore original shim output paths, copy to vertical runtime folder as a post-step

### DIFF
--- a/src/Native/build-native.cmd
+++ b/src/Native/build-native.cmd
@@ -71,10 +71,10 @@ echo Commencing build of native components
 echo.
 
 if %__CMakeBinDir% == "" (
-    set "__CMakeBinDir=%__binDir%\runtime\%__TargetGroup%-Windows_NT-%CMAKE_BUILD_TYPE%-%__BuildArch%"
+    set "__CMakeBinDir=%__binDir%\Windows_NT.%__BuildArch%.%CMAKE_BUILD_TYPE%\Native"
 )
 if %__IntermediatesDir% == "" (
-    set "__IntermediatesDir=%__binDir%\obj\runtime\%__TargetGroup%-Windows_NT-%CMAKE_BUILD_TYPE%-%__BuildArch%"
+    set "__IntermediatesDir=%__binDir%\obj\Windows_NT.%__BuildArch%.%CMAKE_BUILD_TYPE%\Native"
 )
 set "__CMakeBinDir=%__CMakeBinDir:\=/%"
 set "__IntermediatesDir=%__IntermediatesDir:\=/%"
@@ -124,6 +124,10 @@ call %__rootDir%/run.cmd build-managed -project="%__IntermediatesDir%\install.vc
 IF ERRORLEVEL 1 (
     goto :Failure
 )
+
+:: Copy to vertical runtime directory
+xcopy "%__binDir%\Windows_NT.%__BuildArch%.%CMAKE_BUILD_TYPE%\Native\*" "%__binDir%\runtime\%__TargetGroup%-Windows_NT-%CMAKE_BUILD_TYPE%-%__BuildArch%"\ 
+
 echo Done building Native components
 
 :BuildNativeAOT

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -25,6 +25,7 @@ setup_dirs()
 
     mkdir -p "$__BinDir"
     mkdir -p "$__IntermediatesDir"
+    mkdir -p "$__VerticalRuntimeDir"
 }
 
 # Check the system to ensure the right pre-reqs are in place
@@ -90,6 +91,12 @@ build_native()
         echo "Failed to build corefx native components."
         exit 1
     fi
+}
+
+copy_to_vertical_runtime()
+{
+    echo "Copying native shims to vertical runtime folder."
+    cp $__BinDir/* "$__VerticalRuntimeDir"
 }
 
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
@@ -249,8 +256,9 @@ case $CPUName in
 esac
 
 # Set the remaining variables based upon the determined build configuration
-__IntermediatesDir="$__rootbinpath/obj/runtime/$__TargetGroup-$__BuildOS-$__BuildType-$__BuildArch"
-__BinDir="$__rootbinpath/runtime/$__TargetGroup-$__BuildOS-$__BuildType-$__BuildArch"
+__IntermediatesDir="$__rootbinpath/obj/$__BuildOS.$__BuildArch.$__BuildType/Native"
+__BinDir="$__rootbinpath/$__BuildOS.$__BuildArch.$__BuildType/Native"
+__VerticalRuntimeDir="$__rootbinpath/runtime/$__TargetGroup-$__BuildOS-$__BuildType-$__BuildArch"
 
 # Make the directories necessary for build if they don't exist
 setup_dirs
@@ -274,3 +282,7 @@ fi
     # Build the corefx native components.
 
     build_native
+
+    # Copy files to vertical runtime folder
+
+    copy_to_vertical_runtime


### PR DESCRIPTION
@ericstj 

This changes the CMake output path back to the paths we were originally using, and then adds another step that copies that folder to the vertical group's runtime folder.