### PR TITLE
Deprecate sync.cmd

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -69,6 +69,15 @@
              Properties="TargetGroup=%(BuildToolsProject.TargetGroup)" />
   </Target>
 
+  <Target Name="Sync" DependsOnTargets="BuildCoreFxTools">
+    <ItemGroup>
+      <ExternalProject Include="external\dir.proj" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(ExternalProject)"
+             ContinueOnError="ErrorAndContinue" />
+  </Target>
+
   <!-- TODO: Can we move this archive test build to BuildTools -->
   <UsingTask TaskName="ZipFileCreateFromDependencyLists" Condition="'$(ArchiveTests)' == 'true'" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <Target Name="ArchiveTestBuild" Condition="'$(ArchiveTests)' == 'true'" AfterTargets="Build" >

--- a/config.json
+++ b/config.json
@@ -78,12 +78,6 @@
       "values": ["True", "False"],
       "defaultValue": true
     },
-    "BuildTestsAgainstPackages": {
-      "description": "Allows building tests against product packages.",
-      "valueType": "property",
-      "values": ["True", "False"],
-      "defaultValue": true
-    },
     "Coverage": {
       "description": "Enables code coverage runs.",
       "valueType": "property",
@@ -192,13 +186,7 @@
       "values": [],
       "defaultValue": ""
     },
-    "BatchGenerateTestProjectJsons": {
-      "description": "MsBuild target that generates the project.json files to build tests against packages.",
-      "valueType": "target",
-      "values": [],
-      "defaultValue": ""
-    },
-    "BatchRestorePackages": {
+    "Sync": {
       "description": "MsBuild target that restores the packages.",
       "valueType": "target",
       "values": [],
@@ -447,7 +435,7 @@
           "description": "Restores all NuGet packages for repository.",
           "settings": {
             "RestoreDuringBuild":  true,
-            "BatchRestorePackages": "default"
+            "Sync": "default"
           }
         },
         "ab": {
@@ -457,12 +445,10 @@
           }
         },
         "t": {
-          "description": "Generates project.jsons for test projects, restores packages, builds product and then builds tests against the generated project.json files.",
+          "description": "Deprecated, use sync /p instead.",
           "settings": {
             "RestoreDuringBuild":  true,
-            "BuildTestsAgainstPackages": true,
-            "BatchGenerateTestProjectJsons":  "default",
-            "BatchRestorePackages": "default"
+            "Sync": "default"
           }
         },
         "AzureAccount": {

--- a/src/Tools/CoreFx.Tools/CoreFx.Tools.csproj
+++ b/src/Tools/CoreFx.Tools/CoreFx.Tools.csproj
@@ -3,12 +3,14 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.5</NuGetTargetMoniker>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == 'net45'">.NETFramework,Version=v4.5</NuGetTargetMoniker>
     <CLSCompliant>false</CLSCompliant>
     <ProjectGuid>{360F25FA-3CD9-4338-B961-A4F3122B88B2}</ProjectGuid>
     <OutputPath Condition="'$(TargetGroup)' != 'net45'">$(CoreFxToolsDir)</OutputPath>
     <OutputPath Condition="'$(TargetGroup)' == 'net45'">$(CoreFxDesktopToolsDir)</OutputPath>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'netstandard1.5_Debug'" />
   <PropertyGroup Condition="'$(Configuration)' == 'net45_Debug'" />
   <ItemGroup>
     <Compile Include="ConfigurationTask.cs" />


### PR DESCRIPTION
This is follow-up for https://github.com/dotnet/corefx/commit/2d3e555196bfa5c9d2156a9adcabf9ef902b1ba0.

It may make sense to bring back some form of sync.cmd, but right now
that needs to do a bit more than just restore.

/cc @weshaggard @mellinoe @chcosta 

This is needed to get the official builds working.