### PR TITLE
EnsureValidDataType reject whitespaces

### DIFF
--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DataTypeAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DataTypeAttribute.cs
@@ -114,7 +114,7 @@ namespace System.ComponentModel.DataAnnotations
         /// <exception cref="InvalidOperationException"> is thrown if the current attribute is ill-formed.</exception>
         private void EnsureValidDataType()
         {
-            if (DataType == DataType.Custom && string.IsNullOrEmpty(CustomDataType))
+            if (DataType == DataType.Custom && string.IsNullOrWhiteSpace(CustomDataType))
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
                     SR.DataTypeAttribute_EmptyDataTypeString));

--- a/src/System.ComponentModel.Annotations/tests/DataTypeAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/DataTypeAttributeTests.cs
@@ -67,10 +67,12 @@ namespace System.ComponentModel.DataAnnotations
             Assert.Throws<InvalidOperationException>(() => attribute.Validate(new object(), s_testValidationContext));
         }
 
-        [Fact]
-        public static void GetDataTypeName_and_IsValid_on_whitespace_custom_DataTypeAttribute_throws_exception()
+        [Theory]
+        [InlineData(" ")]
+        [InlineData("     ")]
+        public static void GetDataTypeName_and_IsValid_on_whitespace_custom_DataTypeAttribute_throws_exception(string value)
         {
-            var attribute = new DataTypeAttribute(new String(' ', 5)); // Create a string with five whitespaces
+            var attribute = new DataTypeAttribute(value);
             Assert.Equal(DataType.Custom, attribute.DataType); // Only throw when call GetDataTypeName() or Validate()
             AssertEx.Empty(attribute.CustomDataType); // Only throw when call GetDataTypeName() or Validate()
             Assert.Throws<InvalidOperationException>(() => attribute.GetDataTypeName());

--- a/src/System.ComponentModel.Annotations/tests/DataTypeAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/DataTypeAttributeTests.cs
@@ -68,6 +68,16 @@ namespace System.ComponentModel.DataAnnotations
         }
 
         [Fact]
+        public static void GetDataTypeName_and_IsValid_on_whitespace_custom_DataTypeAttribute_throws_exception()
+        {
+            var attribute = new DataTypeAttribute(new String(' ', 5)); // Create a string with five whitespaces
+            Assert.Equal(DataType.Custom, attribute.DataType); // Only throw when call GetDataTypeName() or Validate()
+            AssertEx.Empty(attribute.CustomDataType); // Only throw when call GetDataTypeName() or Validate()
+            Assert.Throws<InvalidOperationException>(() => attribute.GetDataTypeName());
+            Assert.Throws<InvalidOperationException>(() => attribute.Validate(new object(), s_testValidationContext));
+        }
+
+        [Fact]
         public static void GetDataTypeName_and_IsValid_on_non_null_custom_DataTypeAttribute_is_successful()
         {
             var attribute = new DataTypeAttribute("TestCustomDataType");
@@ -108,6 +118,6 @@ namespace System.ComponentModel.DataAnnotations
                     Assert.Null(attribute.DisplayFormat);
                 }
             }
-        }
+        }        
     }
 }


### PR DESCRIPTION
EnsureValidDataType should reject whitespaces in DataTypeAttribute.CustomDataType property because it is mandatory and it does not make sense that the property is whitespaces.

Fix #4465