### PR TITLE
Make the Crypto.Encoding library work on macOS without OpenSSL

### DIFF
--- a/src/Common/src/System/Security/Cryptography/DerSequenceReader.cs
+++ b/src/Common/src/System/Security/Cryptography/DerSequenceReader.cs
@@ -16,6 +16,7 @@ namespace System.Security.Cryptography
     {
         internal const byte ContextSpecificTagFlag = 0x80;
         internal const byte ConstructedFlag = 0x20;
+        internal const byte TagNumberMask = 0x1F;
 
         private readonly byte[] _data;
         private readonly int _end;
@@ -232,7 +233,7 @@ namespace System.Security.Cryptography
                 return;
             }
 
-            byte relevant = (byte)(actual & 0x1F);
+            byte relevant = (byte)(actual & TagNumberMask);
             byte expectedByte = (byte)expected;
 
             if (expectedByte != relevant)

--- a/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/AsnFormatter.OSX.cs
+++ b/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/AsnFormatter.OSX.cs
@@ -1,0 +1,217 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Internal.Cryptography
+{
+    internal abstract partial class AsnFormatter
+    {
+        private static readonly AsnFormatter s_instance = new AppleAsnFormatter();
+
+        // -----------------------------
+        // ---- PAL layer ends here ----
+        // -----------------------------
+    }
+
+    internal class AppleAsnFormatter : AsnFormatter
+    {
+        protected override string FormatNative(Oid oid, byte[] rawData, bool multiLine)
+        {
+            if (oid == null || string.IsNullOrEmpty(oid.Value))
+            {
+                return EncodeHexString(rawData, true);
+            }
+
+            switch (oid.Value)
+            {
+                case "2.5.29.17":
+                    return FormatSubjectAlternativeName(rawData);
+            }
+
+            return null;
+        }
+
+        private const string CommaSpace = ", ";
+
+        internal enum GeneralNameType
+        {
+            OtherName = 0,
+            Rfc822Name = 1,
+            // RFC 822: Standard for the format of ARPA Internet Text Messages.
+            // That means "email", and an RFC 822 Name: "Email address"
+            Email = Rfc822Name,
+            DnsName = 2,
+            X400Address = 3,
+            DirectoryName = 4,
+            EdiPartyName = 5,
+            UniformResourceIdentifier = 6,
+            IPAddress = 7,
+            RegisteredId = 8,
+        }
+
+        private string FormatSubjectAlternativeName(byte[] rawData)
+        {
+            // Because SubjectAlternativeName is a commonly parsed structure, we'll
+            // specifically format this one.  And we'll match the OpenSSL format, which
+            // includes not localizing any of the values (or respecting the multiLine boolean)
+            //
+            // The intent here is to be functionally equivalent to OpenSSL GENERAL_NAME_print.
+
+            // The end size of this string is hard to predict.
+            // * dNSName values have a tag that takes four characters to represent ("DNS:")
+            //   and then their payload is ASCII encoded (so one byte -> one char), so they
+            //   work out to be about equal (in chars) to their DER encoded length (in bytes).
+            // * iPAddress values have a tag that takes 11 characters ("IP Address:") and then
+            //   grow from 4 bytes to up to 15 characters for IPv4, or 16 bytes to 47 characters
+            //   for IPv6
+            //
+            // So use a List<string> and just Concat them all when we're done, and we reduce the
+            // number of times we copy the header values (vs pointers to the header values).
+            List<string> segments = new List<string>();
+
+            try
+            {
+                // SubjectAltName ::= GeneralNames
+                //
+                // GeneralNames ::= SEQUENCE SIZE (1..MAX) OF GeneralName
+                //
+                // GeneralName ::= CHOICE {
+                //   otherName                       [0]     OtherName,
+                //   rfc822Name                      [1]     IA5String,
+                //   dNSName                         [2]     IA5String,
+                //   x400Address                     [3]     ORAddress,
+                //   directoryName                   [4]     Name,
+                //   ediPartyName                    [5]     EDIPartyName,
+                //   uniformResourceIdentifier       [6]     IA5String,
+                //   iPAddress                       [7]     OCTET STRING,
+                //   registeredID                    [8]     OBJECT IDENTIFIER }
+                //
+                // OtherName::= SEQUENCE {
+                //   type - id    OBJECT IDENTIFIER,
+                //   value[0] EXPLICIT ANY DEFINED BY type - id }
+                DerSequenceReader altNameReader = new DerSequenceReader(rawData);
+
+                while (altNameReader.HasData)
+                {
+                    if (segments.Count != 0)
+                    {
+                        segments.Add(CommaSpace);
+                    }
+
+                    byte tag = altNameReader.PeekTag();
+
+                    if ((tag & DerSequenceReader.ContextSpecificTagFlag) == 0)
+                    {
+                        // All GeneralName values need the ContextSpecific flag.
+                        return null;
+                    }
+
+                    GeneralNameType nameType = (GeneralNameType)(tag & DerSequenceReader.TagNumberMask);
+
+                    bool needsConstructedFlag = false;
+
+                    switch (nameType)
+                    {
+                        case GeneralNameType.OtherName:
+                        case GeneralNameType.X400Address:
+                        case GeneralNameType.DirectoryName:
+                        case GeneralNameType.EdiPartyName:
+                            needsConstructedFlag = true;
+                            break;
+                    }
+
+                    if (needsConstructedFlag &&
+                        (tag & DerSequenceReader.ConstructedFlag) == 0)
+                    {
+                        // All of the SEQUENCE types require the constructed bit,
+                        // or OpenSSL will have refused to print it.
+                        return null;
+                    }
+
+                    switch (nameType)
+                    {
+                        case GeneralNameType.OtherName:
+                            segments.Add("othername:<unsupported>");
+                            altNameReader.SkipValue();
+                            break;
+                        case GeneralNameType.Rfc822Name:
+                            segments.Add("email:");
+                            segments.Add(altNameReader.ReadIA5String());
+                            break;
+                        case GeneralNameType.DnsName:
+                            segments.Add("DNS:");
+                            segments.Add(altNameReader.ReadIA5String());
+                            break;
+                        case GeneralNameType.X400Address:
+                            segments.Add("X400Name:<unsupported>");
+                            altNameReader.SkipValue();
+                            break;
+                        case GeneralNameType.DirectoryName:
+                            // OpenSSL supports printing one of these, but the logic lives in X509Certificates,
+                            // and it isn't very common.  So we'll skip this one until someone asks for it.
+                            segments.Add("DirName:<unsupported>");
+                            altNameReader.SkipValue();
+                            break;
+                        case GeneralNameType.EdiPartyName:
+                            segments.Add("EdiPartyName:<unsupported>");
+                            altNameReader.SkipValue();
+                            break;
+                        case GeneralNameType.UniformResourceIdentifier:
+                            segments.Add("URI:");
+                            segments.Add(altNameReader.ReadIA5String());
+                            break;
+                        case GeneralNameType.IPAddress:
+                            segments.Add("IP Address");
+
+                            byte[] ipAddressBytes = altNameReader.ReadOctetString();
+
+                            if (ipAddressBytes.Length == 4)
+                            {
+                                // Add the colon and dotted-decimal representation of IPv4.
+                                segments.Add(
+                                    $":{ipAddressBytes[0]}.{ipAddressBytes[1]}.{ipAddressBytes[2]}.{ipAddressBytes[3]}");
+                            }
+                            else if (ipAddressBytes.Length == 16)
+                            {
+                                // Print the IP Address value as colon separated UInt16 hex values without leading zeroes.
+                                // 20 01 0D B8 AC 10 FE 01 00 00 00 00 00 00 00 00
+                                //
+                                // IP Address:2001:DB8:AC10:FE01:0:0:0:0
+                                for (int i = 0; i < ipAddressBytes.Length; i += 2)
+                                {
+                                    segments.Add($":{ipAddressBytes[i] << 8 | ipAddressBytes[i + 1]:X}");
+                                }
+                            }
+                            else
+                            {
+                                segments.Add(":<invalid>");
+                            }
+
+                            break;
+                        case GeneralNameType.RegisteredId:
+                            segments.Add("Registered ID:");
+                            segments.Add(altNameReader.ReadOidAsString());
+                            break;
+                        default:
+                            // A new extension to GeneralName could legitimately hit this,
+                            // but it's correct to say that until we know what that is that
+                            // the pretty-print has failed, and we should fall back to hex.
+                            //
+                            // But it could also simply be poorly encoded user data.
+                            return null;
+                    }
+                }
+
+                return string.Concat(segments);
+            }
+            catch (CryptographicException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.OSX.cs
+++ b/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.OSX.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    internal static partial class OidLookup
+    {
+        private static bool ShouldUseCache(OidGroup oidGroup)
+        {
+            return true;
+        }
+
+        private static string NativeOidToFriendlyName(string oid, OidGroup oidGroup, bool fallBackToAllGroups)
+        {
+            return null;
+        }
+
+        private static string NativeFriendlyNameToOid(string friendlyName, OidGroup oidGroup, bool fallBackToAllGroups)
+        {
+            return null;
+        }
+
+        // -----------------------------
+        // ---- PAL layer ends here ----
+        // -----------------------------
+    }
+}

--- a/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.builds
+++ b/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.builds
@@ -3,6 +3,9 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Security.Cryptography.Encoding.csproj">
+      <OSGroup>OSX</OSGroup>
+    </Project>
+    <Project Include="System.Security.Cryptography.Encoding.csproj">
       <OSGroup>Unix</OSGroup>
     </Project>
     <Project Include="System.Security.Cryptography.Encoding.csproj">

--- a/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
+++ b/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
@@ -54,7 +54,7 @@
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
+  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' AND '$(TargetsOSX)' != 'true' ">
     <Compile Include="Internal\Cryptography\AsnFormatter.Unix.cs" />
     <Compile Include="Internal\Cryptography\OidLookup.Unix.cs" />
     <Compile Include="Internal\Cryptography\OpenSslAsnFormatter.cs" />
@@ -91,6 +91,13 @@
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
+    <Compile Include="$(CommonPath)\System\Security\Cryptography\DerSequenceReader.cs">
+      <Link>Common\System\Security\Cryptography\DerSequenceReader.cs</Link>
+    </Compile>
+    <Compile Include="Internal\Cryptography\AsnFormatter.OSX.cs" />
+    <Compile Include="Internal\Cryptography\OidLookup.OSX.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net463'">
     <TargetingPackReference Include="mscorlib" />

--- a/src/System.Security.Cryptography.Encoding/src/project.json
+++ b/src/System.Security.Cryptography.Encoding/src/project.json
@@ -12,6 +12,7 @@
         "System.Runtime": "4.4.0-beta-24709-02",
         "System.Runtime.Extensions": "4.4.0-beta-24709-02",
         "System.Runtime.InteropServices": "4.4.0-beta-24709-02",
+        "System.Runtime.Numerics": "4.4.0-beta-24709-02",
         "System.Text.Encoding": "4.4.0-beta-24709-02",
         "System.Security.Cryptography.Primitives": "4.4.0-beta-24709-02"
       }

--- a/src/System.Security.Cryptography.Encoding/tests/Oid.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Oid.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Security.Cryptography.Encoding.Tests
@@ -265,8 +266,28 @@ namespace System.Security.Cryptography.Encoding.Tests
             // This needs to be an OID not in the static lookup table.  The purpose is to verify the
             // NativeOidToFriendlyName fallback for Unix.  For Windows this is accomplished by
             // using FromOidValue with an OidGroup other than OidGroup.All.
-            
-            Oid oid = Oid.FromOidValue(ObsoleteSmime3desWrap_Oid, OidGroup.All);
+
+            Oid oid;
+
+            try
+            {
+                oid = Oid.FromOidValue(ObsoleteSmime3desWrap_Oid, OidGroup.All);
+            }
+            catch (CryptographicException)
+            {
+                bool isMac = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
+                Assert.True(isMac, "Exception is only raised on macOS");
+
+                if (isMac)
+                {
+                    return;
+                }
+                else
+                {
+                    throw;
+                }
+            }
 
             Assert.Equal(ObsoleteSmime3desWrap_Oid, oid.Value);
             Assert.Equal(ObsoleteSmime3desWrap_Name, oid.FriendlyName);
@@ -279,7 +300,27 @@ namespace System.Security.Cryptography.Encoding.Tests
             // This needs to be a name not in the static lookup table.  The purpose is to verify the
             // NativeFriendlyNameToOid fallback for Unix.  For Windows this is accomplished by
             // using FromOidValue with an OidGroup other than OidGroup.All.
-            Oid oid = Oid.FromFriendlyName(ObsoleteSmime3desWrap_Name, OidGroup.All);
+            Oid oid;
+
+            try
+            {
+                oid = Oid.FromFriendlyName(ObsoleteSmime3desWrap_Name, OidGroup.All);
+            }
+            catch (CryptographicException)
+            {
+                bool isMac = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
+                Assert.True(isMac, "Exception is only raised on macOS");
+
+                if (isMac)
+                {
+                    return;
+                }
+                else
+                {
+                    throw;
+                }
+            }
 
             Assert.Equal(ObsoleteSmime3desWrap_Oid, oid.Value);
             Assert.Equal(ObsoleteSmime3desWrap_Name, oid.FriendlyName);


### PR DESCRIPTION
Apple's Security framework doesn't seem to expose any OID resolution or
ASN.1/DER pretty-printing, so the "make a native call here" functions just
always report that they have failed.

The pretty-printing of SubjectAlternativeName was manually written into this
library to retain support for libraries which are parsing the ToString output.

Part of #9394.