### PR TITLE
Add ubuntu.XX-arm to runtime.native.XX.pkgproj

### DIFF
--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
@@ -34,8 +34,14 @@
     <ProjectReference Include="ubuntu\14.04\runtime.native.System.IO.Compression.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="ubuntu\14.04\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>arm</Platform>
+    </ProjectReference>
     <ProjectReference Include="ubuntu\16.04\runtime.native.System.IO.Compression.pkgproj">
       <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\16.04\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>arm</Platform>
     </ProjectReference>
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.IO.Compression.pkgproj">
       <Platform>amd64</Platform>

--- a/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.pkgproj
@@ -34,8 +34,14 @@
     <ProjectReference Include="ubuntu\14.04\runtime.native.System.Net.Http.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="ubuntu\14.04\runtime.native.System.Net.Http.pkgproj">
+      <Platform>arm</Platform>
+    </ProjectReference>
     <ProjectReference Include="ubuntu\16.04\runtime.native.System.Net.Http.pkgproj">
       <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\16.04\runtime.native.System.Net.Http.pkgproj">
+      <Platform>arm</Platform>
     </ProjectReference>
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.Net.Http.pkgproj">
       <Platform>amd64</Platform>

--- a/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Security/runtime.native.System.Net.Security.pkgproj
@@ -34,8 +34,14 @@
     <ProjectReference Include="ubuntu\14.04\runtime.native.System.Net.Security.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="ubuntu\14.04\runtime.native.System.Net.Security.pkgproj">
+      <Platform>arm</Platform>
+    </ProjectReference>
     <ProjectReference Include="ubuntu\16.04\runtime.native.System.Net.Security.pkgproj">
       <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\16.04\runtime.native.System.Net.Security.pkgproj">
+      <Platform>arm</Platform>
     </ProjectReference>
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.Net.Security.pkgproj">
       <Platform>amd64</Platform>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography.OpenSsl/runtime.native.System.Security.Cryptography.OpenSsl.pkgproj
@@ -34,8 +34,14 @@
     <ProjectReference Include="ubuntu\14.04\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="ubuntu\14.04\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <Platform>arm</Platform>
+    </ProjectReference>
     <ProjectReference Include="ubuntu\16.04\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
       <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\16.04\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
+      <Platform>arm</Platform>
     </ProjectReference>
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.Security.Cryptography.OpenSsl.pkgproj">
       <Platform>amd64</Platform>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.pkgproj
@@ -34,8 +34,14 @@
     <ProjectReference Include="ubuntu\14.04\runtime.native.System.Security.Cryptography.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="ubuntu\14.04\runtime.native.System.Security.Cryptography.pkgproj">
+      <Platform>arm</Platform>
+    </ProjectReference>
     <ProjectReference Include="ubuntu\16.04\runtime.native.System.Security.Cryptography.pkgproj">
       <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\16.04\runtime.native.System.Security.Cryptography.pkgproj">
+      <Platform>arm</Platform>
     </ProjectReference>
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.Security.Cryptography.pkgproj">
       <Platform>amd64</Platform>

--- a/src/Native/pkg/runtime.native.System/runtime.native.System.pkgproj
+++ b/src/Native/pkg/runtime.native.System/runtime.native.System.pkgproj
@@ -34,8 +34,14 @@
     <ProjectReference Include="ubuntu\14.04\runtime.native.System.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="ubuntu\14.04\runtime.native.System.pkgproj">
+      <Platform>arm</Platform>
+    </ProjectReference>
     <ProjectReference Include="ubuntu\16.04\runtime.native.System.pkgproj">
       <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\16.04\runtime.native.System.pkgproj">
+      <Platform>arm</Platform>
     </ProjectReference>
     <ProjectReference Include="ubuntu\16.10\runtime.native.System.pkgproj">
       <Platform>amd64</Platform>


### PR DESCRIPTION
This patch adds ubuntu.14.04-arm and ubuntu.16.04-arm into
runtime.native.XX.pkgproj

Signed-off-by: chunseoklee chunseok.lee@samsung.com

Related PR : #14655 
(@chunseoklee is on vacation, so I revised it and made another PR.)