### PR TITLE
ExcludeFromCodeCoverageAssemblyAttribute for excluding assemblies

### DIFF
--- a/src/Common/src/System/Diagnostics/CodeAnalysis/ExcludeFromCodeCoverageAssemblyAttribute.cs
+++ b/src/Common/src/System/Diagnostics/CodeAnalysis/ExcludeFromCodeCoverageAssemblyAttribute.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    // Matches the *.ExcludeFromCodeCoverage* filter passed to OpenCover but
+    // unlike ExcludeFromCodeCoverageAttribute can be applied to assemblies.
+    [Conditional("DEBUG")] // don't bloat release assemblies
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = false)]
+    internal sealed class ExcludeFromCodeCoverageAssemblyAttribute : Attribute
+    {
+    }
+}

--- a/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/AssemblyAttributes.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/AssemblyAttributes.cs
@@ -2,4 +2,4 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAssembly]

--- a/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/RemoteExecutorConsoleApp.csproj
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/RemoteExecutorConsoleApp.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
     <Compile Include="AssemblyAttributes.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
-      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/Common/tests/System/Xml/BaseLibManaged/BaseLibManaged.csproj
+++ b/src/Common/tests/System/Xml/BaseLibManaged/BaseLibManaged.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Globalization.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
-      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Common/tests/System/Xml/BaseLibManaged/Globalization.cs
+++ b/src/Common/tests/System/Xml/BaseLibManaged/Globalization.cs
@@ -4,7 +4,7 @@
 
 using System;
 
-[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAssembly]
 
 namespace WebData.BaseLib
 {

--- a/src/Common/tests/System/Xml/ModuleCore/ModuleCore.csproj
+++ b/src/Common/tests/System/Xml/ModuleCore/ModuleCore.csproj
@@ -22,8 +22,8 @@
     <Compile Include="ctestmodule.cs" />
     <Compile Include="cvariation.cs" />
     <Compile Include="interop.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
-      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Common/tests/System/Xml/ModuleCore/ccommon.cs
+++ b/src/Common/tests/System/Xml/ModuleCore/ccommon.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Diagnostics;		//Assert
 
-[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAssembly]
 
 namespace OLEDB.Test.ModuleCore
 {

--- a/src/Common/tests/System/Xml/XmlCoreTest/MiscUtil.cs
+++ b/src/Common/tests/System/Xml/XmlCoreTest/MiscUtil.cs
@@ -4,7 +4,7 @@
 
 using System;
 
-[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAssembly]
 
 namespace XmlCoreTest.Common
 {

--- a/src/Common/tests/System/Xml/XmlCoreTest/XmlCoreTest.csproj
+++ b/src/Common/tests/System/Xml/XmlCoreTest/XmlCoreTest.csproj
@@ -22,8 +22,8 @@
     <Compile Include="UnicodeCharHelper.cs" />
     <Compile Include="WriterFactory.cs" />
     <Compile Include="TestData.g.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
-      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/Common/tests/System/Xml/XmlDiff/XmlDiff.cs
+++ b/src/Common/tests/System/Xml/XmlDiff/XmlDiff.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.IO;
 using System.Diagnostics;
 
-[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAssembly]
 
 namespace System.Xml.XmlDiff
 {

--- a/src/Common/tests/System/Xml/XmlDiff/XmlDiff.csproj
+++ b/src/Common/tests/System/Xml/XmlDiff/XmlDiff.csproj
@@ -15,8 +15,8 @@
     <Compile Include="XmlDiff.cs" />
     <Compile Include="XmlDiffDocument.cs" />
     <Compile Include="XmlDiffOption.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
-      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/AssemblyInfo.cs
+++ b/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/AssemblyInfo.cs
@@ -2,4 +2,4 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAssembly]

--- a/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/Microsoft.Composition.Demos.ExtendedCollectionImports.csproj
+++ b/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/Microsoft.Composition.Demos.ExtendedCollectionImports.csproj
@@ -15,8 +15,8 @@
     <Compile Include="OrderedImportManyAttribute.cs" />
     <Compile Include="OrderedCollections\OrderedImportManyExportDescriptorProvider.cs" />
     <Compile Include="KeyByMetadataAttribute.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
-      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Composition/scenarios/TestLibrary/TestClass.cs
+++ b/src/System.Composition/scenarios/TestLibrary/TestClass.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Composition;
 
-[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAssembly]
 
 namespace TestLibrary
 {

--- a/src/System.Composition/scenarios/TestLibrary/TestLibrary.csproj
+++ b/src/System.Composition/scenarios/TestLibrary/TestLibrary.csproj
@@ -10,8 +10,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="TestClass.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
-      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Private.Xml/tests/XmlReaderLib/CommonTest.cs
+++ b/src/System.Private.Xml/tests/XmlReaderLib/CommonTest.cs
@@ -6,7 +6,7 @@ using OLEDB.Test.ModuleCore;
 using System.IO;
 using XmlCoreTest.Common;
 
-[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAssembly]
 
 namespace System.Xml.Tests
 {

--- a/src/System.Private.Xml/tests/XmlReaderLib/System.Xml.RW.XmlReaderLib.csproj
+++ b/src/System.Private.Xml/tests/XmlReaderLib/System.Xml.RW.XmlReaderLib.csproj
@@ -79,8 +79,8 @@
     <Compile Include="TCXmlSpace.cs" />
     <Compile Include="TestFiles.cs" />
     <Compile Include="XmlException.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
-      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Reflection/tests/TestExe/Program.cs
+++ b/src/System.Reflection/tests/TestExe/Program.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAssembly]
 
 namespace System.Reflection.Tests
 {

--- a/src/System.Reflection/tests/TestExe/System.Reflection.TestExe.csproj
+++ b/src/System.Reflection/tests/TestExe/System.Reflection.TestExe.csproj
@@ -11,8 +11,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="Program.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
-      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Runtime.Extensions/tests/AssemblyResolveTests/AssemblyAttributes.cs
+++ b/src/System.Runtime.Extensions/tests/AssemblyResolveTests/AssemblyAttributes.cs
@@ -2,4 +2,4 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAssembly]

--- a/src/System.Runtime.Extensions/tests/AssemblyResolveTests/AssemblyResolveTests.csproj
+++ b/src/System.Runtime.Extensions/tests/AssemblyResolveTests/AssemblyResolveTests.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
     <Compile Include="AssemblyAttributes.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
-      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">

--- a/src/System.Runtime.Extensions/tests/TestApp/AssemblyAttributes.cs
+++ b/src/System.Runtime.Extensions/tests/TestApp/AssemblyAttributes.cs
@@ -2,4 +2,4 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAssembly]

--- a/src/System.Runtime.Extensions/tests/TestApp/TestApp.csproj
+++ b/src/System.Runtime.Extensions/tests/TestApp/TestApp.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
     <Compile Include="AssemblyAttributes.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
-      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">

--- a/src/System.Runtime.Extensions/tests/TestAppOutsideOfTPA/AssemblyAttributes.cs
+++ b/src/System.Runtime.Extensions/tests/TestAppOutsideOfTPA/AssemblyAttributes.cs
@@ -2,4 +2,4 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAssembly]

--- a/src/System.Runtime.Extensions/tests/TestAppOutsideOfTPA/TestAppOutsideOfTPA.csproj
+++ b/src/System.Runtime.Extensions/tests/TestAppOutsideOfTPA/TestAppOutsideOfTPA.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
     <Compile Include="AssemblyAttributes.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
-      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">

--- a/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/AssemblyAttributes.cs
+++ b/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/AssemblyAttributes.cs
@@ -2,4 +2,4 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAssembly]

--- a/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.csproj
+++ b/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
     <Compile Include="AssemblyAttributes.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
-      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">

--- a/src/System.Runtime/tests/TestAssembly/AssemblyAttributes.cs
+++ b/src/System.Runtime/tests/TestAssembly/AssemblyAttributes.cs
@@ -2,4 +2,4 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAssembly]

--- a/src/System.Runtime/tests/TestAssembly/TestAssembly.csproj
+++ b/src/System.Runtime/tests/TestAssembly/TestAssembly.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
     <Compile Include="AssemblyAttributes.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
-      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
+    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">


### PR DESCRIPTION
Treated like ExcludeFromCodeCoverageAttribute by OpenCover but doesn't
clash with the public form of that attribute in being allowed on
assemblies.

Fixes #14488

CC @mellinoe 

@dotnet-bot test code coverage