### PR TITLE
Remove VSTS Symbol publish step from checked in definitions

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows-Native.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows-Native.json
@@ -278,28 +278,6 @@
     {
       "enabled": true,
       "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Publish to Symbols to Artifact Services",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "29827cd1-5c33-4ff0-a817-abd46970ffc4",
-        "versionSpec": "0.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "symbolServiceURI": "https://devdiv.artifacts.visualstudio.com/DefaultCollection",
-        "requestName": "$(system.teamProject)/$(Build.BuildNumber)/$(Build.BuildId)",
-        "sourcePath": "$(Build.SourcesDirectory)\\corefx\\bin",
-        "assemblyPath": "",
-        "toLowerCase": "true",
-        "detailedLog": "true",
-        "expirationInDays": "",
-        "usePat": "true"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
       "alwaysRun": true,
       "displayName": "Execute cleanup tasks",
       "timeoutInMinutes": 0,

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -314,28 +314,6 @@
     {
       "enabled": true,
       "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Publish to Symbols to Artifact Services",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "29827cd1-5c33-4ff0-a817-abd46970ffc4",
-        "versionSpec": "0.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "symbolServiceURI": "https://devdiv.artifacts.visualstudio.com/DefaultCollection",
-        "requestName": "$(system.teamProject)/$(Build.BuildNumber)/$(Build.BuildId)",
-        "sourcePath": "$(Build.SourcesDirectory)\\corefx\\bin",
-        "assemblyPath": "",
-        "toLowerCase": "true",
-        "detailedLog": "true",
-        "expirationInDays": "",
-        "usePat": "true"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
       "alwaysRun": true,
       "displayName": "Execute cleanup tasks",
       "timeoutInMinutes": 0,


### PR DESCRIPTION
Removes an unnecessary step from the build, decoupling a dependency that has caused build failures.

When we add this back in, I think we should try to run it in the publish build to isolate it better.

@chcosta