### PR TITLE
Never skip building RID-specific  NETCoreApp pkg

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.builds
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.builds
@@ -1,33 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
+
   <Import Project="$(MSBuildProjectName).props" />
-  
+
   <ItemGroup>
     <!-- identity project, runtime specific projects are included by props above -->
     <Project Include="$(MSBuildProjectName).pkgproj" />
   </ItemGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 
-  <UsingTask TaskName="GetTargetMachineInfo" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <Target Name="FilterPackageProjects" AfterTargets="FilterProjects">
-    <!-- If we're not on Windows, and RID wasn't specified, get native RID -->
-    <GetTargetMachineInfo Condition="'$(OS)' != 'Windows_NT' AND '$(TestNugetRuntimeId)' == ''">
-      <Output TaskParameter="RuntimeIdentifier" PropertyName="TestNugetRuntimeId" />
-    </GetTargetMachineInfo>
-    
-    <!-- If on Windows and RID isn't specified, filter by OSGroup --> 
-    <ItemGroup Condition="'$(OS)' == 'Windows_NT' AND '$(TestNugetRuntimeId)' == ''">
-      <_projectsToBuild Include="@(Project)" Condition="'%(Project.OSGroup)' == '' OR '%(Project.OSGroup)' == 'Windows_NT'" />
-    </ItemGroup>
-    
-    <!-- If RID is specified, use it -->
-    <ItemGroup Condition="'$(TestNugetRuntimeId)' != ''">
-      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '$(TestNugetRuntimeId)' OR '%(Project.PackageTargetRuntime)' == ''" />
+  <PropertyGroup>
+    <TraversalBuildDependsOn>
+      FilterProjects;
+      $(TraversalBuildDependsOn);
+    </TraversalBuildDependsOn>
+  </PropertyGroup>
+
+  <Target Name="FilterProjects">
+    <Error Condition="'$(PackageRID)' == ''" Text="'PackageRID' property must be specified."/>
+
+    <!-- Only build packages for current RID -->
+    <ItemGroup>
+      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '$(PackageRID)' OR '%(Project.PackageTargetRuntime)' == ''" />
     </ItemGroup>
 
-    <ItemGroup Condition="'@(_projectsToBuild)' != ''">
+    <ItemGroup>
       <Project Remove="@(Project)" />
       <Project Include="@(_projectsToBuild)" />
     </ItemGroup>

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
@@ -32,8 +32,6 @@
     <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>
-    <!-- don't build if we're missing files, we'll intentionally add a missing file if native build is missing -->
-    <SkipCreatePackageOnMissingFiles>true</SkipCreatePackageOnMissingFiles>
 
     <RefBinDir>$(BinDir)$(TargetFrameworkName)/pkg/ref</RefBinDir>
     <LibBinDir>$(BinDir)$(TargetFrameworkName)/pkg/lib</LibBinDir>
@@ -61,9 +59,12 @@
     <ProjectReference Include="@(Project)" />
     
     <!-- Include refs -->
-    <File Include="$(RefBinDir)/*.*">
+    <RefFile Include="$(RefBinDir)/*.*">
       <TargetPath>ref/$(TargetFramework)</TargetPath>
-    </File>
+    </RefFile>
+    <File Include="@(RefFile)" />
+    <!-- force a missing file if ref build is absent -->
+    <File Include="$(RefBinDir)/MISSING_REF_BUILD" Condition="'@(RefFile)' == ''" />
 
     <FilePackageDependency Include="Microsoft.NETCore.Platforms">
       <Version>$(PlatformPackageVersion)</Version>
@@ -72,9 +73,12 @@
 
   <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
     <!-- Include lib -->
-    <File Include="$(LibBinDir)/*.*">
+    <LibFile Include="$(LibBinDir)/*.*">
       <TargetPath>runtimes/$(PackageTargetRuntime)/lib/$(TargetFramework)</TargetPath>
-    </File>
+    </LibFile>
+    <File Include="@(LibFile)" />
+    <!-- force a missing file if lib build is absent -->
+    <File Include="$(LibBinDir)/MISSING_LIB_BUILD" Condition="'@(LibFile)' == ''" />
 
     <!-- Include native -->
     <ExcludeNative Include="$(NativeBinDir)/*.lib" />

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.props
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.props
@@ -7,33 +7,34 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <BuildRID Include="alpine.3.4.3-x64" />
-    <BuildRID Include="debian.8-x64" />
-    <BuildRID Include="fedora.23-x64" />
-    <BuildRID Include="fedora.24-x64" />
-    <BuildRID Include="opensuse.13.2-x64" />
-    <BuildRID Include="opensuse.42.1-x64" />
-    <BuildRID Include="osx.10.10-x64">
+    <OfficialBuildRID Include="alpine.3.4.3-x64" />
+    <OfficialBuildRID Include="debian.8-x64" />
+    <OfficialBuildRID Include="fedora.23-x64" />
+    <OfficialBuildRID Include="fedora.24-x64" />
+    <OfficialBuildRID Include="opensuse.13.2-x64" />
+    <OfficialBuildRID Include="opensuse.42.1-x64" />
+    <OfficialBuildRID Include="osx.10.10-x64">
       <OSGroup>OSX</OSGroup>
-    </BuildRID>
-    <BuildRID Include="rhel.7-x64" />
-    <BuildRID Include="ubuntu.14.04-x64" />
-    <BuildRID Include="ubuntu.16.04-x64" />
-    <BuildRID Include="ubuntu.16.10-x64" />
-    <BuildRID Include="win7-x86">
+    </OfficialBuildRID>
+    <OfficialBuildRID Include="rhel.7-x64" />
+    <OfficialBuildRID Include="ubuntu.14.04-x64" />
+    <OfficialBuildRID Include="ubuntu.16.04-x64" />
+    <OfficialBuildRID Include="ubuntu.16.10-x64" />
+    <OfficialBuildRID Include="win7-x86">
       <Platform>x86</Platform>
       <OSGroup>Windows_NT</OSGroup>
-    </BuildRID>
-    <BuildRID Include="win7-x64">
+    </OfficialBuildRID>
+    <OfficialBuildRID Include="win7-x64">
       <OSGroup>Windows_NT</OSGroup>
-    </BuildRID>
-    <BuildRID Include="win10-arm64">
+    </OfficialBuildRID>
+    <OfficialBuildRID Include="win10-arm64">
       <Platform>arm64</Platform>
       <OSGroup>Windows_NT</OSGroup>
-    </BuildRID>
+    </OfficialBuildRID>
 
     <!-- Ensure we have a RID-specific package for the current build, even if it isn't in our official set -->
-    <BuildRID Include="$(PackageRID)" Condition="!@(BuildRID->AnyHaveMetadataValue('Identity', '$(PackageRID)'))">
+    <BuildRID Include="@(OfficialBuildRID)" Exclude="$(PackageRID)"/>
+    <BuildRID Include="$(PackageRID)">
       <Platform Condition="'$(ArchGroup)' == 'x64'">amd64</Platform>
       <Platform Condition="'$(ArchGroup)' != 'x64'">$(ArchGroup)</Platform>
       <OSGroup>$(BuildConfiguration_OSGroup)</OSGroup>

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.props
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.props
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(PackageRID)' == ''">
+    <PackageRID>$(RuntimeOS)-$(ArchGroup)</PackageRID>
+    <!-- On Windows x86/x64 use Win7 regardless of current RuntimeOS -->
+    <PackageRID Condition="$(RuntimeOS.StartsWith('win')) AND ('$(ArchGroup)' == 'x86' OR '$(ArchGroup)' == 'x64')">win7-$(ArchGroup)</PackageRID>
+  </PropertyGroup>
+
   <ItemGroup>
     <BuildRID Include="alpine.3.4.3-x64" />
     <BuildRID Include="debian.8-x64" />
@@ -25,6 +31,13 @@
       <Platform>arm64</Platform>
       <OSGroup>Windows_NT</OSGroup>
     </BuildRID>
+
+    <!-- Ensure we have a RID-specific package for the current build, even if it isn't in our official set -->
+    <BuildRID Include="$(PackageRID)" Condition="!@(BuildRID->AnyHaveMetadataValue('Identity', '$(PackageRID)'))">
+      <Platform Condition="'$(ArchGroup)' == 'x64'">amd64</Platform>
+      <Platform Condition="'$(ArchGroup)' != 'x64'">$(ArchGroup)</Platform>
+      <OSGroup>$(BuildConfiguration_OSGroup)</OSGroup>
+    </BuildRID>
   </ItemGroup>
 
   <ItemGroup>
@@ -32,7 +45,7 @@
       <OSGroup Condition="'%(OSGroup)' == ''">Linux</OSGroup>
       <Platform Condition="'%(Platform)' == ''">amd64</Platform>
       <PackageTargetRuntime>%(Identity)</PackageTargetRuntime>
-      <AdditionalProperties>PackageTargetRuntime=%(Identity)</AdditionalProperties>
+      <AdditionalProperties>PackageTargetRuntime=%(Identity);OSGroup=%(OSGroup);Platform=%(Platform)</AdditionalProperties>
     </_project>
     
     <Project Include="@(_project->'$(MSBuildProjectName).pkgproj')" />


### PR DESCRIPTION
Previously I'd skip building the package if I couldn't find the native
bits.  Now we'll always try to build the "right" package.  If any files
are missing the build will fail.

To determine "right" package I do the following:
1. Always build the identity package (refs, runtime.json).
2. Build the runtime package that matches the current PackageRID,
    where PackageRID is either specified or derived from the environment
    using the RuntimeOS & ArchGroup properties.

If the runtime package we decide to build isn't one in our official list
we will still build it.  This enables folks to do specific builds of new
RIDs (eg: a vertical build) without necessarily updating the list that
drives the packages produced by the official builds.

In the case that we are only doing a vertical build the list of
BuildRIDs is irrelevant since we never need to publish the output,
but in the case of independent repo builds we need to publish
the identity package with the correct set of RIDs that we actually
build for.

/cc @weshaggard @chcosta @ellismg 

@mellinoe this will cause the build to break should we stop 
dropping native bits where I expect them to be.  So we won't
issues like https://github.com/dotnet/corefx/pull/14643 in the
future.