### PR TITLE
Don't errorandcontinue for serialized projects

### DIFF
--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -48,8 +48,7 @@
     <MSBuild Targets="$(DefaultBuildAllTarget)"
              Projects="@(ProjectWithConfiguration)"
              Condition="'$(SerializeProjects)'=='true' AND '%(Identity)' != ''"
-             Properties="DefaultBuildAllTarget=$(DefaultBuildAllTarget);BuildAllProjects=true;BuildConfiguration=$(BuildConfiguration)"
-             ContinueOnError="ErrorAndContinue" />
+             Properties="DefaultBuildAllTarget=$(DefaultBuildAllTarget);BuildAllProjects=true;BuildConfiguration=$(BuildConfiguration)" />
 
     <MSBuild Targets="$(DefaultBuildAllTarget)"
              Projects="@(ProjectWithConfiguration)"


### PR DESCRIPTION
Failures are getting ignored in CI.  Turning off ErrorAndContinue for serialized projects.  I don't think that for serialized builds (ref.builds, src.builds, packages.builds) we want to error and continue because a ref build failure will always cause a src build failure which will always cause a packages build failure.  Regardless, I think this may only be part of the problem, I also think that the target ordering changes I've done may be causing MSBuildLastTaskResult to not be properly set which is hiding failures). I'm using this PR to test the CI and see if it catches anything with serialized builds.