### PR TITLE
[Linq] Lower LargeArrayBuilder's ResizeLimit

### DIFF
--- a/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
@@ -13,7 +13,7 @@ namespace System.Collections.Generic
     internal struct LargeArrayBuilder<T>
     {
         private const int StartingCapacity = 4;
-        private const int ResizeLimit = 32;
+        private const int ResizeLimit = 8;
 
         private readonly int _maxCapacity;  // The maximum capacity this builder can have.
         private T[] _first;                 // The first buffer we store items in. Resized until ResizeLimit.
@@ -210,11 +210,11 @@ namespace System.Collections.Generic
                 }
                 else
                 {
-                    // Example scenario: Let's say _count == 256.
-                    // Then our buffers look like this: | 32 | 32 | 64 | 128 |
+                    // Example scenario: Let's say _count == 64.
+                    // Then our buffers look like this: | 8 | 8 | 16 | 32 |
                     // As you can see, our count will be just double the last buffer.
-                    // Now, say _maxCapacity is 500. We will find the right amount to allocate by
-                    // doing min(256, 500 - 256). The lhs represents double the last buffer,
+                    // Now, say _maxCapacity is 100. We will find the right amount to allocate by
+                    // doing min(64, 100 - 64). The lhs represents double the last buffer,
                     // the rhs the limit minus the amount we've already allocated.
 
                     Debug.Assert(_count >= ResizeLimit * 2);


### PR DESCRIPTION
**Background:** `LargeArrayBuilder` has a "resize limit" after which it stops resizing its buffer and switches to using chunked arrays. I initially chose this limit to be 32 elements, because I didn't want it to be too small in case `sizeof(T)` was small, but also didn't want it to be too large in case `sizeof(T)` was large.

**Description:** Since writing https://github.com/dotnet/corefx/pull/14020, I've come to realize that the 90% use case for Linq is with business objects / classes, and not with low-level stuff like bytes. Since reference types are 4/8 bytes wide, it makes sense to optimize for `T` being wider. This PR lowers the resize limit of `LargeArrayBuilder` from 32 -> 8 elements.

**Performance improvements:** [gist](https://gist.github.com/jamesqo/641ab9dc63f5abcade39cd7453106afa) For reference types, there is a decrease of ~5 GCs for sizes 9-15, and ~10 GCs from 17-31 and 33+. Sizes 16 and 32 regress, which is expected since the array is now chunked at those sizes and the builder can't directly return it.

cc @stephentoub, @JonHanna, @VSadov 