### PR TITLE
Change expected behavior for reported parameter names.

### DIFF
--- a/src/Common/tests/System/RuntimeDetection.cs
+++ b/src/Common/tests/System/RuntimeDetection.cs
@@ -12,7 +12,7 @@ namespace System
         private static readonly string s_frameworkDescription = RuntimeInformation.FrameworkDescription;
 
         // public static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
-         public static bool IsNetFramework { get; } = s_frameworkDescription.StartsWith(".NET Framework");
+        public static bool IsNetFramework { get; } = s_frameworkDescription.StartsWith(".NET Framework");
         // public static bool IsCoreclr { get; } = s_frameworkDescription.StartsWith(".NET Core");
         public static bool IsNetNative { get; } = s_frameworkDescription.StartsWith(".NET Native");
     }

--- a/src/Common/tests/System/RuntimeDetection.cs
+++ b/src/Common/tests/System/RuntimeDetection.cs
@@ -12,7 +12,7 @@ namespace System
         private static readonly string s_frameworkDescription = RuntimeInformation.FrameworkDescription;
 
         // public static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
-        // public static bool IsNetFramework { get; } = s_frameworkDescription.StartsWith(".NET Framework");
+         public static bool IsNetFramework { get; } = s_frameworkDescription.StartsWith(".NET Framework");
         // public static bool IsCoreclr { get; } = s_frameworkDescription.StartsWith(".NET Core");
         public static bool IsNetNative { get; } = s_frameworkDescription.StartsWith(".NET Native");
     }

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -124,6 +124,9 @@
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\RuntimeDetection.cs">
+      <Link>Common\System\RuntimeDetection.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp1.1'">
     <Compile Include="System\ArrayTests.netcoreapp1.1.cs" />

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
@@ -629,34 +629,23 @@ namespace System.Text.Tests
 
             Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => builder.Append(new char[0], -1, 0)); // Start index < 0
 
+            if (RuntimeDetection.IsNetFramework)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => builder.Append(new char[0], 0, -1)); // Count < 0
+
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => builder.Append(new char[5], 6, 0)); // Start index + count > value.Length
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => builder.Append(new char[5], 5, 1)); // Start index + count > value.Length
+            }
+            else
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("charCount", () => builder.Append(new char[0], 0, -1)); // Count < 0
+
+                Assert.Throws<ArgumentOutOfRangeException>("charCount", () => builder.Append(new char[5], 6, 0)); // Start index + count > value.Length
+                Assert.Throws<ArgumentOutOfRangeException>("charCount", () => builder.Append(new char[5], 5, 1)); // Start index + count > value.Length
+            }
+
             Assert.Throws<ArgumentOutOfRangeException>("valueCount", () => builder.Append(new char[] { 'a' })); // New length > builder.MaxCapacity
             Assert.Throws<ArgumentOutOfRangeException>("valueCount", () => builder.Append(new char[] { 'a' }, 0, 1)); // New length > builder.MaxCapacity
-        }
-
-        [Fact]
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
-        public static void Append_CharArray_Count_Invalid()
-        {
-            var builder = new StringBuilder(0, 5);
-            builder.Append("Hello");
-
-            Assert.Throws<ArgumentOutOfRangeException>("count", () => builder.Append(new char[0], 0, -1)); // Count < 0
-
-            Assert.Throws<ArgumentOutOfRangeException>("count", () => builder.Append(new char[5], 6, 0)); // Start index + count > value.Length
-            Assert.Throws<ArgumentOutOfRangeException>("count", () => builder.Append(new char[5], 5, 1)); // Start index + count > value.Length
-        }
-
-        [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
-        public static void Append_CharArray_CharCount_Invalid()
-        {
-            var builder = new StringBuilder(0, 5);
-            builder.Append("Hello");
-
-            Assert.Throws<ArgumentOutOfRangeException>("charCount", () => builder.Append(new char[0], 0, -1)); // Count < 0
-
-            Assert.Throws<ArgumentOutOfRangeException>("charCount", () => builder.Append(new char[5], 6, 0)); // Start index + count > value.Length
-            Assert.Throws<ArgumentOutOfRangeException>("charCount", () => builder.Append(new char[5], 5, 1)); // Start index + count > value.Length
         }
 
         public static IEnumerable<object[]> AppendFormat_TestData()
@@ -1415,6 +1404,15 @@ namespace System.Text.Tests
 
             Assert.Throws<ArgumentNullException>(() => builder.Insert(0, null, 1, 1)); // Value is null (startIndex and count are not zero)
 
+            if (RuntimeDetection.IsNetFramework)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("count", () => builder.Insert(0, new char[0], 0, -1)); // Char count < 0
+            }
+            else
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("charCount", () => builder.Insert(0, new char[0], 0, -1)); // Char count < 0
+            }
+
             Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => builder.Insert(0, new char[0], -1, 0)); // Start index < 0
 
             Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => builder.Insert(0, new char[3], 4, 0)); // Start index + char count > value.Length
@@ -1423,22 +1421,6 @@ namespace System.Text.Tests
 
             Assert.Throws<ArgumentOutOfRangeException>("requiredLength", () => builder.Insert(builder.Length, new char[1])); // New length > builder.MaxCapacity
             Assert.Throws<ArgumentOutOfRangeException>("requiredLength", () => builder.Insert(builder.Length, new char[] { 'a' }, 0, 1)); // New length > builder.MaxCapacity
-        }
-        [Fact]
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
-        public static void Insert_CharArray_Count_Invalid()
-        {
-            var builder = new StringBuilder(0, 5);
-            builder.Append("Hello");
-            Assert.Throws<ArgumentOutOfRangeException>("count", () => builder.Insert(0, new char[0], 0, -1)); // Char count < 0
-        }
-        [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
-        public static void Insert_CharArray_CharCount_Invalid()
-        {
-            var builder = new StringBuilder(0, 5);
-            builder.Append("Hello");
-            Assert.Throws<ArgumentOutOfRangeException>("charCount", () => builder.Insert(0, new char[0], 0, -1)); // Char count < 0
         }
 
         [Theory]
@@ -1473,28 +1455,19 @@ namespace System.Text.Tests
             var builder = new StringBuilder("Hello");
             Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => builder.Remove(-1, 0)); // Start index < 0
             Assert.Throws<ArgumentOutOfRangeException>("length", () => builder.Remove(0, -1)); // Length < 0
-        }
 
-        [Fact]
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
-        public static void Remove_Index_Invalid()
-        {
-            var builder = new StringBuilder("Hello");
-
-            Assert.Throws<ArgumentOutOfRangeException>("index", () => builder.Remove(6, 0)); // Start index + length > 0
-            Assert.Throws<ArgumentOutOfRangeException>("index", () => builder.Remove(5, 1)); // Start index + length > 0
-            Assert.Throws<ArgumentOutOfRangeException>("index", () => builder.Remove(4, 2)); // Start index + length > 0
-        }
-
-        [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
-        public static void Remove_Length_Invalid()
-        {
-            var builder = new StringBuilder("Hello");
-
-            Assert.Throws<ArgumentOutOfRangeException>("length", () => builder.Remove(6, 0)); // Start index + length > 0
-            Assert.Throws<ArgumentOutOfRangeException>("length", () => builder.Remove(5, 1)); // Start index + length > 0
-            Assert.Throws<ArgumentOutOfRangeException>("length", () => builder.Remove(4, 2)); // Start index + length > 0
+            if (RuntimeDetection.IsNetFramework)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => builder.Remove(6, 0)); // Start index + length > 0
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => builder.Remove(5, 1)); // Start index + length > 0
+                Assert.Throws<ArgumentOutOfRangeException>("index", () => builder.Remove(4, 2)); // Start index + length > 0
+            }
+            else
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("length", () => builder.Remove(6, 0)); // Start index + length > 0
+                Assert.Throws<ArgumentOutOfRangeException>("length", () => builder.Remove(5, 1)); // Start index + length > 0
+                Assert.Throws<ArgumentOutOfRangeException>("length", () => builder.Remove(4, 2)); // Start index + length > 0
+            }
         }
 
         [Theory]

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
@@ -628,13 +628,35 @@ namespace System.Text.Tests
             Assert.Throws<ArgumentNullException>("value", () => builder.Append((char[])null, 1, 1)); // Value is null, startIndex > 0 and count > 0
 
             Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => builder.Append(new char[0], -1, 0)); // Start index < 0
+
+            Assert.Throws<ArgumentOutOfRangeException>("valueCount", () => builder.Append(new char[] { 'a' })); // New length > builder.MaxCapacity
+            Assert.Throws<ArgumentOutOfRangeException>("valueCount", () => builder.Append(new char[] { 'a' }, 0, 1)); // New length > builder.MaxCapacity
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
+        public static void Append_CharArray_Count_Invalid()
+        {
+            var builder = new StringBuilder(0, 5);
+            builder.Append("Hello");
+
             Assert.Throws<ArgumentOutOfRangeException>("count", () => builder.Append(new char[0], 0, -1)); // Count < 0
 
             Assert.Throws<ArgumentOutOfRangeException>("count", () => builder.Append(new char[5], 6, 0)); // Start index + count > value.Length
             Assert.Throws<ArgumentOutOfRangeException>("count", () => builder.Append(new char[5], 5, 1)); // Start index + count > value.Length
+        }
 
-            Assert.Throws<ArgumentOutOfRangeException>("valueCount", () => builder.Append(new char[] { 'a' })); // New length > builder.MaxCapacity
-            Assert.Throws<ArgumentOutOfRangeException>("valueCount", () => builder.Append(new char[] { 'a' }, 0, 1)); // New length > builder.MaxCapacity
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
+        public static void Append_CharArray_CharCount_Invalid()
+        {
+            var builder = new StringBuilder(0, 5);
+            builder.Append("Hello");
+
+            Assert.Throws<ArgumentOutOfRangeException>("charCount", () => builder.Append(new char[0], 0, -1)); // Count < 0
+
+            Assert.Throws<ArgumentOutOfRangeException>("charCount", () => builder.Append(new char[5], 6, 0)); // Start index + count > value.Length
+            Assert.Throws<ArgumentOutOfRangeException>("charCount", () => builder.Append(new char[5], 5, 1)); // Start index + count > value.Length
         }
 
         public static IEnumerable<object[]> AppendFormat_TestData()
@@ -1394,7 +1416,6 @@ namespace System.Text.Tests
             Assert.Throws<ArgumentNullException>(() => builder.Insert(0, null, 1, 1)); // Value is null (startIndex and count are not zero)
 
             Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => builder.Insert(0, new char[0], -1, 0)); // Start index < 0
-            Assert.Throws<ArgumentOutOfRangeException>("count", () => builder.Insert(0, new char[0], 0, -1)); // Char count < 0
 
             Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => builder.Insert(0, new char[3], 4, 0)); // Start index + char count > value.Length
             Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => builder.Insert(0, new char[3], 3, 1)); // Start index + char count > value.Length
@@ -1402,6 +1423,22 @@ namespace System.Text.Tests
 
             Assert.Throws<ArgumentOutOfRangeException>("requiredLength", () => builder.Insert(builder.Length, new char[1])); // New length > builder.MaxCapacity
             Assert.Throws<ArgumentOutOfRangeException>("requiredLength", () => builder.Insert(builder.Length, new char[] { 'a' }, 0, 1)); // New length > builder.MaxCapacity
+        }
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
+        public static void Insert_CharArray_Count_Invalid()
+        {
+            var builder = new StringBuilder(0, 5);
+            builder.Append("Hello");
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => builder.Insert(0, new char[0], 0, -1)); // Char count < 0
+        }
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
+        public static void Insert_CharArray_CharCount_Invalid()
+        {
+            var builder = new StringBuilder(0, 5);
+            builder.Append("Hello");
+            Assert.Throws<ArgumentOutOfRangeException>("charCount", () => builder.Insert(0, new char[0], 0, -1)); // Char count < 0
         }
 
         [Theory]
@@ -1436,10 +1473,28 @@ namespace System.Text.Tests
             var builder = new StringBuilder("Hello");
             Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => builder.Remove(-1, 0)); // Start index < 0
             Assert.Throws<ArgumentOutOfRangeException>("length", () => builder.Remove(0, -1)); // Length < 0
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
+        public static void Remove_Index_Invalid()
+        {
+            var builder = new StringBuilder("Hello");
 
             Assert.Throws<ArgumentOutOfRangeException>("index", () => builder.Remove(6, 0)); // Start index + length > 0
             Assert.Throws<ArgumentOutOfRangeException>("index", () => builder.Remove(5, 1)); // Start index + length > 0
             Assert.Throws<ArgumentOutOfRangeException>("index", () => builder.Remove(4, 2)); // Start index + length > 0
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
+        public static void Remove_Length_Invalid()
+        {
+            var builder = new StringBuilder("Hello");
+
+            Assert.Throws<ArgumentOutOfRangeException>("length", () => builder.Remove(6, 0)); // Start index + length > 0
+            Assert.Throws<ArgumentOutOfRangeException>("length", () => builder.Remove(5, 1)); // Start index + length > 0
+            Assert.Throws<ArgumentOutOfRangeException>("length", () => builder.Remove(4, 2)); // Start index + length > 0
         }
 
         [Theory]

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
@@ -628,21 +628,13 @@ namespace System.Text.Tests
             Assert.Throws<ArgumentNullException>("value", () => builder.Append((char[])null, 1, 1)); // Value is null, startIndex > 0 and count > 0
 
             Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => builder.Append(new char[0], -1, 0)); // Start index < 0
+            Assert.Throws<ArgumentOutOfRangeException>(
+                RuntimeDetection.IsNetFramework ? "count" : "charCount", () => builder.Append(new char[0], 0, -1)); // Count < 0
 
-            if (RuntimeDetection.IsNetFramework)
-            {
-                Assert.Throws<ArgumentOutOfRangeException>("count", () => builder.Append(new char[0], 0, -1)); // Count < 0
-
-                Assert.Throws<ArgumentOutOfRangeException>("count", () => builder.Append(new char[5], 6, 0)); // Start index + count > value.Length
-                Assert.Throws<ArgumentOutOfRangeException>("count", () => builder.Append(new char[5], 5, 1)); // Start index + count > value.Length
-            }
-            else
-            {
-                Assert.Throws<ArgumentOutOfRangeException>("charCount", () => builder.Append(new char[0], 0, -1)); // Count < 0
-
-                Assert.Throws<ArgumentOutOfRangeException>("charCount", () => builder.Append(new char[5], 6, 0)); // Start index + count > value.Length
-                Assert.Throws<ArgumentOutOfRangeException>("charCount", () => builder.Append(new char[5], 5, 1)); // Start index + count > value.Length
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(
+                RuntimeDetection.IsNetFramework ? "count" : "charCount", () => builder.Append(new char[5], 6, 0)); // Start index + count > value.Length
+            Assert.Throws<ArgumentOutOfRangeException>(
+                RuntimeDetection.IsNetFramework ? "count" : "charCount", () => builder.Append(new char[5], 5, 1)); // Start index + count > value.Length
 
             Assert.Throws<ArgumentOutOfRangeException>("valueCount", () => builder.Append(new char[] { 'a' })); // New length > builder.MaxCapacity
             Assert.Throws<ArgumentOutOfRangeException>("valueCount", () => builder.Append(new char[] { 'a' }, 0, 1)); // New length > builder.MaxCapacity
@@ -1403,15 +1395,7 @@ namespace System.Text.Tests
             Assert.Throws<ArgumentOutOfRangeException>("index", () => builder.Insert(builder.Length + 1, new char[0], 0, 0)); // Index > builder.Length
 
             Assert.Throws<ArgumentNullException>(() => builder.Insert(0, null, 1, 1)); // Value is null (startIndex and count are not zero)
-
-            if (RuntimeDetection.IsNetFramework)
-            {
-                Assert.Throws<ArgumentOutOfRangeException>("count", () => builder.Insert(0, new char[0], 0, -1)); // Char count < 0
-            }
-            else
-            {
-                Assert.Throws<ArgumentOutOfRangeException>("charCount", () => builder.Insert(0, new char[0], 0, -1)); // Char count < 0
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(RuntimeDetection.IsNetFramework ? "count" : "charCount", () => builder.Insert(0, new char[0], 0, -1)); // Char count < 0
 
             Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => builder.Insert(0, new char[0], -1, 0)); // Start index < 0
 
@@ -1455,19 +1439,12 @@ namespace System.Text.Tests
             var builder = new StringBuilder("Hello");
             Assert.Throws<ArgumentOutOfRangeException>("startIndex", () => builder.Remove(-1, 0)); // Start index < 0
             Assert.Throws<ArgumentOutOfRangeException>("length", () => builder.Remove(0, -1)); // Length < 0
-
-            if (RuntimeDetection.IsNetFramework)
-            {
-                Assert.Throws<ArgumentOutOfRangeException>("index", () => builder.Remove(6, 0)); // Start index + length > 0
-                Assert.Throws<ArgumentOutOfRangeException>("index", () => builder.Remove(5, 1)); // Start index + length > 0
-                Assert.Throws<ArgumentOutOfRangeException>("index", () => builder.Remove(4, 2)); // Start index + length > 0
-            }
-            else
-            {
-                Assert.Throws<ArgumentOutOfRangeException>("length", () => builder.Remove(6, 0)); // Start index + length > 0
-                Assert.Throws<ArgumentOutOfRangeException>("length", () => builder.Remove(5, 1)); // Start index + length > 0
-                Assert.Throws<ArgumentOutOfRangeException>("length", () => builder.Remove(4, 2)); // Start index + length > 0
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(
+                RuntimeDetection.IsNetFramework ? "index" : "length", () => builder.Remove(6, 0)); // Start index + length > 0
+            Assert.Throws<ArgumentOutOfRangeException>(
+                RuntimeDetection.IsNetFramework ? "index" : "length", () => builder.Remove(5, 1)); // Start index + length > 0
+            Assert.Throws<ArgumentOutOfRangeException>(
+                RuntimeDetection.IsNetFramework ? "index" : "length",, () => builder.Remove(4, 2)); // Start index + length > 0
         }
 
         [Theory]

--- a/src/System.Text.Encoding/tests/Fallback/EncoderExceptionFallbackTests.cs
+++ b/src/System.Text.Encoding/tests/Fallback/EncoderExceptionFallbackTests.cs
@@ -54,14 +54,8 @@ namespace System.Text.Tests
             EncoderFallbackBuffer buffer = new EncoderExceptionFallback().CreateFallbackBuffer();
 
             Assert.Throws<ArgumentOutOfRangeException>("charUnknownHigh", () => buffer.Fallback('a', '\uDC00', 0));
-            if (RuntimeDetection.IsNetFramework)
-            {
-                Assert.Throws<ArgumentOutOfRangeException>("CharUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
-            }
-            else
-            {
-                Assert.Throws<ArgumentOutOfRangeException>("charUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(
+                RuntimeDetection.IsNetFramework ? "CharUnknownLow" : "charUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
         }
     }
 }

--- a/src/System.Text.Encoding/tests/Fallback/EncoderExceptionFallbackTests.cs
+++ b/src/System.Text.Encoding/tests/Fallback/EncoderExceptionFallbackTests.cs
@@ -49,23 +49,19 @@ namespace System.Text.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
-        public void CreateFallbackBuffer_Fallback_InvalidSurrogateChars_Original_ThrowsArgumentOutOfRangeException()
-        {
-            EncoderFallbackBuffer buffer = new EncoderExceptionFallback().CreateFallbackBuffer();
-
-            Assert.Throws<ArgumentOutOfRangeException>("charUnknownHigh", () => buffer.Fallback('a', '\uDC00', 0));
-            Assert.Throws<ArgumentOutOfRangeException>("CharUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
-        }
-
-        [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
         public void CreateFallbackBuffer_Fallback_InvalidSurrogateChars_ThrowsArgumentOutOfRangeException()
         {
             EncoderFallbackBuffer buffer = new EncoderExceptionFallback().CreateFallbackBuffer();
 
             Assert.Throws<ArgumentOutOfRangeException>("charUnknownHigh", () => buffer.Fallback('a', '\uDC00', 0));
-            Assert.Throws<ArgumentOutOfRangeException>("charUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
+            if (RuntimeDetection.IsNetFramework)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("CharUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
+            }
+            else
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("charUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
+            }
         }
     }
 }

--- a/src/System.Text.Encoding/tests/Fallback/EncoderExceptionFallbackTests.cs
+++ b/src/System.Text.Encoding/tests/Fallback/EncoderExceptionFallbackTests.cs
@@ -49,12 +49,23 @@ namespace System.Text.Tests
         }
 
         [Fact]
-        public void CreateFallbackBuffer_Fallback_InvalidSurrogateChars_ThrowsArgumentOutOfRangeException()
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
+        public void CreateFallbackBuffer_Fallback_InvalidSurrogateChars_Original_ThrowsArgumentOutOfRangeException()
         {
             EncoderFallbackBuffer buffer = new EncoderExceptionFallback().CreateFallbackBuffer();
 
             Assert.Throws<ArgumentOutOfRangeException>("charUnknownHigh", () => buffer.Fallback('a', '\uDC00', 0));
             Assert.Throws<ArgumentOutOfRangeException>("CharUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
+        public void CreateFallbackBuffer_Fallback_InvalidSurrogateChars_ThrowsArgumentOutOfRangeException()
+        {
+            EncoderFallbackBuffer buffer = new EncoderExceptionFallback().CreateFallbackBuffer();
+
+            Assert.Throws<ArgumentOutOfRangeException>("charUnknownHigh", () => buffer.Fallback('a', '\uDC00', 0));
+            Assert.Throws<ArgumentOutOfRangeException>("charUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
         }
     }
 }

--- a/src/System.Text.Encoding/tests/Fallback/EncoderReplacementFallbackTests.cs
+++ b/src/System.Text.Encoding/tests/Fallback/EncoderReplacementFallbackTests.cs
@@ -109,14 +109,8 @@ namespace System.Text.Tests
             EncoderFallbackBuffer buffer = new EncoderReplacementFallback().CreateFallbackBuffer();
 
             Assert.Throws<ArgumentOutOfRangeException>("charUnknownHigh", () => buffer.Fallback('a', '\uDC00', 0));
-            if (RuntimeDetection.IsNetFramework)
-            {
-                Assert.Throws<ArgumentOutOfRangeException>("CharUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
-            }
-            else
-            {
-                Assert.Throws<ArgumentOutOfRangeException>("charUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(
+                RuntimeDetection.IsNetFramework ? "CharUnknownLow" : "charUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
         }
     }
 }

--- a/src/System.Text.Encoding/tests/Fallback/EncoderReplacementFallbackTests.cs
+++ b/src/System.Text.Encoding/tests/Fallback/EncoderReplacementFallbackTests.cs
@@ -104,23 +104,19 @@ namespace System.Text.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
-        public void CreateFallbackBuffer_Fallback_InvalidSurrogateChars_Original_ThrowsArgumentOutOfRangeException()
-        {
-            EncoderFallbackBuffer buffer = new EncoderReplacementFallback().CreateFallbackBuffer();
-
-            Assert.Throws<ArgumentOutOfRangeException>("charUnknownHigh", () => buffer.Fallback('a', '\uDC00', 0));
-            Assert.Throws<ArgumentOutOfRangeException>("CharUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
-        }
-
-        [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
         public void CreateFallbackBuffer_Fallback_InvalidSurrogateChars_ThrowsArgumentOutOfRangeException()
         {
             EncoderFallbackBuffer buffer = new EncoderReplacementFallback().CreateFallbackBuffer();
 
             Assert.Throws<ArgumentOutOfRangeException>("charUnknownHigh", () => buffer.Fallback('a', '\uDC00', 0));
-            Assert.Throws<ArgumentOutOfRangeException>("charUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
+            if (RuntimeDetection.IsNetFramework)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("CharUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
+            }
+            else
+            {
+                Assert.Throws<ArgumentOutOfRangeException>("charUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
+            }
         }
     }
 }

--- a/src/System.Text.Encoding/tests/Fallback/EncoderReplacementFallbackTests.cs
+++ b/src/System.Text.Encoding/tests/Fallback/EncoderReplacementFallbackTests.cs
@@ -104,12 +104,23 @@ namespace System.Text.Tests
         }
 
         [Fact]
-        public void CreateFallbackBuffer_Fallback_InvalidSurrogateChars_ThrowsArgumentOutOfRangeException()
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
+        public void CreateFallbackBuffer_Fallback_InvalidSurrogateChars_Original_ThrowsArgumentOutOfRangeException()
         {
             EncoderFallbackBuffer buffer = new EncoderReplacementFallback().CreateFallbackBuffer();
 
             Assert.Throws<ArgumentOutOfRangeException>("charUnknownHigh", () => buffer.Fallback('a', '\uDC00', 0));
             Assert.Throws<ArgumentOutOfRangeException>("CharUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Parameter name changes in error messages are breaking, not currently backported.")]
+        public void CreateFallbackBuffer_Fallback_InvalidSurrogateChars_ThrowsArgumentOutOfRangeException()
+        {
+            EncoderFallbackBuffer buffer = new EncoderReplacementFallback().CreateFallbackBuffer();
+
+            Assert.Throws<ArgumentOutOfRangeException>("charUnknownHigh", () => buffer.Fallback('a', '\uDC00', 0));
+            Assert.Throws<ArgumentOutOfRangeException>("charUnknownLow", () => buffer.Fallback('\uD800', 'a', 0));
         }
     }
 }

--- a/src/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
+++ b/src/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
@@ -93,5 +93,10 @@
       <Name>System.Runtime</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\RuntimeDetection.cs">
+      <Link>Common\System\RuntimeDetection.cs</Link>
+    </Compile>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Companion to dotnet/coreclr#8727

Fixes those tests that were failing due to changes in coreclr argument names.  Desktop skips added.  
Will fail until the clr used for testing changes, which would cause _other_ PRs to fail.

(I dunno, should we make this sort of thing a two-step process in the future?  Disable the tests in one, update the clr used, _then_ correct the tests?  Or would a more elegant solution be to add a line in the comments for the bot to parse and pass to the build system...?)

cc @jkotas , @AlexGhiondea 