### PR TITLE
Add skip for BitArray.CopyTo bug test on desktop.

### DIFF
--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -359,6 +359,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Desktop Framework hasn't received the fix yet.")]
         [MemberData(nameof(CopyTo_Hidden_Data))]
         public static void CopyTo_Int_Hidden(string label, BitArray bits)
         {
@@ -379,6 +380,24 @@ namespace System.Collections.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop Framework hasn't received the fix yet.")]
+        [MemberData(nameof(CopyTo_Hidden_Data))]
+        public static void CopyTo_Int_Hidden_Desktop(string label, BitArray bits)
+        {
+            int allBitsSet = unchecked((int)0xffffffff); // 32 bits set to 1 = -1
+            int fullInts = bits.Length / BitsPerInt32;
+            int remainder = bits.Length % BitsPerInt32;
+            int arrayLength = fullInts + (remainder > 0 ? 1 : 0);
+
+            int[] data = new int[arrayLength];
+            ((ICollection)bits).CopyTo(data, 0);
+
+            Assert.All(data, d => Assert.Equal(allBitsSet, d));
+            
+        }
+
+        [Theory]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Desktop Framework hasn't received the fix yet.")]
         [MemberData(nameof(CopyTo_Hidden_Data))]
         public static void CopyTo_Byte_Hidden(string label, BitArray bits)
         {
@@ -397,6 +416,24 @@ namespace System.Collections.Tests
             {
                 Assert.Equal((byte)((1 << remainder) - 1), data[fullBytes]);
             }
+        }
+
+        [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop Framework hasn't received the fix yet.")]
+        [MemberData(nameof(CopyTo_Hidden_Data))]
+        public static void CopyTo_Byte_Hidden_Desktop(string label, BitArray bits)
+        {
+            byte allBitsSet = (1 << BitsPerByte) - 1; // 8 bits set to 1 = 255
+
+            int fullBytes = bits.Length / BitsPerByte;
+            int remainder = bits.Length % BitsPerByte;
+            int arrayLength = fullBytes + (remainder > 0 ? 1 : 0);
+
+            byte[] data = new byte[arrayLength];
+            ((ICollection)bits).CopyTo(data, 0);
+
+            Assert.All(data, d => Assert.Equal(allBitsSet, d));
+            
         }
     }
 }

--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -359,7 +359,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Desktop Framework hasn't received the fix yet.")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop Framework hasn't received the fix for #9838 yet.")]
         [MemberData(nameof(CopyTo_Hidden_Data))]
         public static void CopyTo_Int_Hidden(string label, BitArray bits)
         {
@@ -380,7 +380,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop Framework hasn't received the fix yet.")]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Desktop Framework hasn't received the fix for #9838 yet.")]
         [MemberData(nameof(CopyTo_Hidden_Data))]
         public static void CopyTo_Int_Hidden_Desktop(string label, BitArray bits)
         {
@@ -397,7 +397,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Desktop Framework hasn't received the fix yet.")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop Framework hasn't received the fix for #9838 yet.")]
         [MemberData(nameof(CopyTo_Hidden_Data))]
         public static void CopyTo_Byte_Hidden(string label, BitArray bits)
         {
@@ -419,7 +419,7 @@ namespace System.Collections.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop Framework hasn't received the fix yet.")]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Desktop Framework hasn't received the fix for #9838 yet.")]
         [MemberData(nameof(CopyTo_Hidden_Data))]
         public static void CopyTo_Byte_Hidden_Desktop(string label, BitArray bits)
         {


### PR DESCRIPTION
Fixes #13241 

Adds Skip for test on desktop framework.

cc @danmosemsft , @ianhays 