### PR TITLE
Catch failures in dev/eng branch

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -21,8 +21,7 @@
 
   <ItemGroup>
     <Project Include="external\dir.proj" />
-    <Project Include="src\ref.builds" />
-    <Project Include="src\src.builds" />
+    <Project Include="src\dirs.proj" />
     <!--
     <Project Include="src\tests.builds" Condition="$(BuildTests)=='true'">
       <InputOSGroup>$(InputOSGroup)</InputOSGroup>

--- a/buildvertical.targets
+++ b/buildvertical.targets
@@ -8,6 +8,22 @@
  <!-- Required for FindBestConfiguration task -->
  <Import Project="$(MSBuildThisFileDirectory)src/Tools/GenerateProps/properties.props" />
 
+ <Target Name="AnnotateProjects"
+         BeforeTargets="BuildAllProjects"
+         Condition="!$(MSBuildProjectFullPath.EndsWith('.proj'))">
+   <!-- Clear ProjectWithConfiguration to prevent circular dependency -->
+   <ItemGroup><ProjectWithConfiguration Remove="@(ProjectWithConfiguration)" /></ItemGroup>
+   <MSBuild Targets="AnnotateProjectsWithConfiguration" 
+            Projects="@(Project)"> 
+     <Output TaskParameter="TargetOutputs" 
+             ItemName="ProjectWithConfiguration" /> 
+   </MSBuild> 
+   <ItemGroup>
+     <Project Remove="@(Project)" />
+     <Project Include="@(ProjectWithConfiguration)" />
+   </ItemGroup>
+ </Target>
+
  <Target Name="AnnotateProjectsWithConfiguration" 
          Returns="@(ProjectWithConfiguration)"> 
     <ItemGroup> 

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -35,28 +35,20 @@
       <DefaultBuildAllTarget Condition="'$(DefaultBuildAllTarget)'==''">$(MSBuildProjectDefaultTargets)</DefaultBuildAllTarget>
     </PropertyGroup>
 
-   <!-- Clear ProjectWithConfiguration to prevent circular dependency -->
-   <ItemGroup><ProjectWithConfiguration Remove="@(ProjectWithConfiguration)" /></ItemGroup>
-   <MSBuild Targets="AnnotateProjectsWithConfiguration" 
-            Projects="@(Project)"> 
-     <Output TaskParameter="TargetOutputs" 
-             ItemName="ProjectWithConfiguration" /> 
-   </MSBuild> 
-
     <!-- To Serialize we use msbuild's batching functionality '%' to force it to batch all similar projects with the same identity
          however since the project names are unique it will essentially force each to run in its own batch -->
     <MSBuild Targets="$(DefaultBuildAllTarget)"
-             Projects="@(ProjectWithConfiguration)"
+             Projects="@(Project)"
              Condition="'$(SerializeProjects)'=='true' AND '%(Identity)' != ''"
              Properties="DefaultBuildAllTarget=$(DefaultBuildAllTarget);BuildAllProjects=true;BuildConfiguration=$(BuildConfiguration)"
-             ContinueOnError="ErrorAndContinue" />
+             ContinueOnError="ErrorAndStop" />
 
     <MSBuild Targets="$(DefaultBuildAllTarget)"
-             Projects="@(ProjectWithConfiguration)"
+             Projects="@(Project)"
              Condition="'$(SerializeProjects)'!='true'"
-             Properties="DefaultBuildAllTarget=$(DefaultBuildAllTarget);BuildAllProjects=true;BuildConfiguration=$(BuildConfiguration);%(ProjectWithConfiguration.AdditionalProperties)"
+             Properties="DefaultBuildAllTarget=$(DefaultBuildAllTarget);BuildAllProjects=true;BuildConfiguration=$(BuildConfiguration);%(Project.AdditionalProperties)"
              BuildInParallel="true"
-             ContinueOnError="ErrorAndContinue" />
+             ContinueOnError="ErrorAndStop" />
 
     <!-- Given we ErrorAndContinue we need to propagate the error if the overall task failed -->
     <Error Condition="'$(MSBuildLastTaskResult)'=='false'" />

--- a/netci.groovy
+++ b/netci.groovy
@@ -315,7 +315,7 @@ def testNugetRuntimeIdConfiguration = ['Debug': 'win7-x86',
                 // On Windows we use the packer to put together everything. On *nix we use tar
                 steps {
                     if (osName == 'Windows 10' || osName == 'Windows 7' || osName == 'Windows_NT') {
-                        batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd -${configurationGroup} -os:${osGroup} -buildArch:${buildArchConfiguration[configurationGroup]} -TestNugetRuntimeId:${testNugetRuntimeIdConfiguration[configurationGroup]} -- /p:WithoutCategories=IgnoreForCI")
+                        batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd -${configurationGroup} -os:${osGroup} -buildArch:${buildArchConfiguration[configurationGroup]} -TestNugetRuntimeId:${testNugetRuntimeIdConfiguration[configurationGroup]} -- /p:WithoutCategories=IgnoreForCI /p:ArchGroup=${buildArchConfiguration[configurationGroup]}")
                         batchFile("C:\\Packer\\Packer.exe .\\bin\\build.pack .\\bin")
                     }
                     else {

--- a/netci.groovy
+++ b/netci.groovy
@@ -306,67 +306,69 @@ def testNugetRuntimeIdConfiguration = ['Debug': 'win7-x86',
 // that don't run per PR can be requested via a magic phrase.
 // **************************
 [true, false].each { isPR ->
-    ['Debug', 'Release'].each { configurationGroup ->
-        ['Windows_NT', 'Ubuntu14.04', 'Ubuntu16.04', 'Ubuntu16.10', 'Debian8.4', 'CentOS7.1', 'OpenSUSE13.2', 'OpenSUSE42.1', 'Fedora23', 'Fedora24', 'RHEL7.2', 'OSX'].each { osName ->
-            def osGroup = osGroupMap[osName]
-            def newJobName = "${osName.toLowerCase()}_${configurationGroup.toLowerCase()}"
+    ['netcoreapp'].each { targetGroup ->
+        ['Debug', 'Release'].each { configurationGroup ->
+            ['Windows_NT', 'Ubuntu14.04', 'Ubuntu16.04', 'Ubuntu16.10', 'Debian8.4', 'CentOS7.1', 'OpenSUSE13.2', 'OpenSUSE42.1', 'Fedora23', 'Fedora24', 'RHEL7.2', 'OSX'].each { osName ->
+                def osGroup = osGroupMap[osName]
+                def newJobName = "${osName.toLowerCase()}_${configurationGroup.toLowerCase()}"
 
-            def newJob = job(Utilities.getFullJobName(project, newJobName, isPR)) {
-                // On Windows we use the packer to put together everything. On *nix we use tar
-                steps {
-                    if (osName == 'Windows 10' || osName == 'Windows 7' || osName == 'Windows_NT') {
-                        batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd -${configurationGroup} -os:${osGroup} -buildArch:${buildArchConfiguration[configurationGroup]} -TestNugetRuntimeId:${testNugetRuntimeIdConfiguration[configurationGroup]} -- /p:WithoutCategories=IgnoreForCI /p:ArchGroup=${buildArchConfiguration[configurationGroup]}")
-                        batchFile("C:\\Packer\\Packer.exe .\\bin\\build.pack .\\bin")
-                    }
-                    else {
-                        // Use Server GC for Ubuntu/OSX Debug PR build & test
-                        def useServerGC = (configurationGroup == 'Release' && isPR) ? 'useServerGC' : ''
-                        shell("HOME=\$WORKSPACE/tempHome ./build.sh -${configurationGroup.toLowerCase()} -- ${useServerGC} /p:TestWithLocalNativeLibraries=true /p:TestNugetRuntimeId=${targetNugetRuntimeMap[osName]} /p:WithoutCategories=IgnoreForCI")
-                        // Tar up the appropriate bits.  On OSX the tarring is a different syntax for exclusion.
-                        if (osName == 'OSX') {
-                            // TODO: Re-enable package archival when the build refactoring work allows it.
-                            // shell("tar -czf bin/build.tar.gz --exclude *.Tests bin/*.${configurationGroup} bin/ref bin/packages")
-                            shell("tar -czf bin/build.tar.gz --exclude *.Tests bin/*.${configurationGroup} bin/ref")
+                def newJob = job(Utilities.getFullJobName(project, newJobName, isPR)) {
+                    // On Windows we use the packer to put together everything. On *nix we use tar
+                    steps {
+                        if (osName == 'Windows 10' || osName == 'Windows 7' || osName == 'Windows_NT') {
+                            batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd -${configurationGroup} -os:${osGroup} -buildArch:${buildArchConfiguration[configurationGroup]} -TestNugetRuntimeId:${testNugetRuntimeIdConfiguration[configurationGroup]} -- /p:WithoutCategories=IgnoreForCI /p:BuildConfiguration=${targetGroup}-${osName}-${configurationGroup}-${buildArchConfiguration[configurationGroup]}")
+                            batchFile("C:\\Packer\\Packer.exe .\\bin\\build.pack .\\bin")
                         }
                         else {
-                            // TODO: Re-enable package archival when the build refactoring work allows it.
-                            // shell("tar -czf bin/build.tar.gz bin/*.${configurationGroup} bin/ref bin/packages --exclude=*.Tests")
-                            shell("tar -czf bin/build.tar.gz bin/*.${configurationGroup} bin/ref --exclude=*.Tests")
+                            // Use Server GC for Ubuntu/OSX Debug PR build & test
+                            def useServerGC = (configurationGroup == 'Release' && isPR) ? 'useServerGC' : ''
+                            shell("HOME=\$WORKSPACE/tempHome ./build.sh -${configurationGroup.toLowerCase()} -- ${useServerGC} /p:TestWithLocalNativeLibraries=true /p:TestNugetRuntimeId=${targetNugetRuntimeMap[osName]} /p:WithoutCategories=IgnoreForCI /p:BuildConfiguration=${targetGroup}-${osName}-${configurationGroup}-${buildArchConfiguration[configurationGroup]}")
+                            // Tar up the appropriate bits.  On OSX the tarring is a different syntax for exclusion.
+                            if (osName == 'OSX') {
+                                // TODO: Re-enable package archival when the build refactoring work allows it.
+                                // shell("tar -czf bin/build.tar.gz --exclude *.Tests bin/*.${configurationGroup} bin/ref bin/packages")
+                                shell("tar -czf bin/build.tar.gz --exclude *.Tests bin/*.${configurationGroup} bin/ref")
+                            }
+                            else {
+                                // TODO: Re-enable package archival when the build refactoring work allows it.
+                                // shell("tar -czf bin/build.tar.gz bin/*.${configurationGroup} bin/ref bin/packages --exclude=*.Tests")
+                                shell("tar -czf bin/build.tar.gz bin/*.${configurationGroup} bin/ref --exclude=*.Tests")
+                            }
                         }
                     }
                 }
-            }
 
-            // Set the affinity.
-            Utilities.setMachineAffinity(newJob, osName, 'latest-or-auto')
-            // Set up standard options.
-            Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
-            // Add the unit test results
-            // TODO: Re-enable test analysis when the build refactoring work allows it.
-            // Utilities.addXUnitDotNETResults(newJob, 'bin/tests/**/testResults.xml')
-            def archiveContents = "msbuild.log"
-            if (osName.contains('Windows')) {
-                // Packer.exe is a .NET Framework application. When we can use it from the tool-runtime, we can archive the ".pack" file here.
-                archiveContents += ",bin/build.pack"
-            }
-            else {
-                archiveContents += ",bin/build.tar.gz"
-            }
-            // Add archival for the built data.
-            Utilities.addArchival(newJob, archiveContents, '', doNotFailIfNothingArchived=true, archiveOnlyIfSuccessful=false)
-            // Set up triggers
-            if (isPR) {
-                // Set PR trigger, we run Windows_NT, Ubuntu 14.04, CentOS 7.1 and OSX on every PR.
-                if ( osName == 'Windows_NT' || osName == 'Ubuntu14.04' || osName == 'CentOS7.1' || osName == 'OSX' ) {
-                    Utilities.addGithubPRTriggerForBranch(newJob, branch, "Innerloop ${osName} ${configurationGroup} Build and Test")
+                // Set the affinity.
+                Utilities.setMachineAffinity(newJob, osName, 'latest-or-auto')
+                // Set up standard options.
+                Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
+                // Add the unit test results
+                // TODO: Re-enable test analysis when the build refactoring work allows it.
+                // Utilities.addXUnitDotNETResults(newJob, 'bin/tests/**/testResults.xml')
+                def archiveContents = "msbuild.log"
+                if (osName.contains('Windows')) {
+                    // Packer.exe is a .NET Framework application. When we can use it from the tool-runtime, we can archive the ".pack" file here.
+                    archiveContents += ",bin/build.pack"
                 }
                 else {
-                    Utilities.addGithubPRTriggerForBranch(newJob, branch, "Innerloop ${osName} ${configurationGroup} Build and Test", "(?i).*test\\W+innerloop\\W+${osName}\\W+${configurationGroup}.*")
+                    archiveContents += ",bin/build.tar.gz"
                 }
-            }
-            else {
-                // Set a push trigger
-                Utilities.addGithubPushTrigger(newJob)
+                // Add archival for the built data.
+                Utilities.addArchival(newJob, archiveContents, '', doNotFailIfNothingArchived=true, archiveOnlyIfSuccessful=false)
+                // Set up triggers
+                if (isPR) {
+                    // Set PR trigger, we run Windows_NT, Ubuntu 14.04, CentOS 7.1 and OSX on every PR.
+                    if ( osName == 'Windows_NT' || osName == 'Ubuntu14.04' || osName == 'CentOS7.1' || osName == 'OSX' ) {
+                        Utilities.addGithubPRTriggerForBranch(newJob, branch, "Innerloop ${osName} ${configurationGroup} Build and Test")
+                    }
+                    else {
+                        Utilities.addGithubPRTriggerForBranch(newJob, branch, "Innerloop ${osName} ${configurationGroup} Build and Test", "(?i).*test\\W+innerloop\\W+${osName}\\W+${configurationGroup}.*")
+                    }
+                }
+                else {
+                    // Set a push trigger
+                    Utilities.addGithubPushTrigger(newJob)
+                }
             }
         }
     }

--- a/src/System.Memory/src/Configurations.props
+++ b/src/System.Memory/src/Configurations.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard1.0;
+      netstandard1.0-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/src.builds
+++ b/src/src.builds
@@ -2,9 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <ProjectExclusions Condition="'$(OS)' != 'Windows_NT'" Include="$(MSBuildThisFileDirectory)**\src\System.Memory.csproj" />
-  </ItemGroup>
-  <ItemGroup>
     <Project Include="$(MSBuildThisFileDirectory)*/src/*.csproj" Exclude="@(ProjectExclusions)">
       <AdditionalMetadata>ConfigurationGroup=$(ConfigurationGroup)</AdditionalMetadata>
     </Project>


### PR DESCRIPTION
Traversal has changed.  ErrorAndContinue was hiding build failures. - https://github.com/dotnet/corefx/issues/14581

Move project annotation into buildvertical.targets, should be easier to move this code around with parts of it not in build.proj.

Update system.memory configuration

/cc @ericstj @weshaggard @mellinoe 