### PR TITLE
Use "OSGroup", not OS Name, to construct BuildConfiguration in netci.groovy

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -316,13 +316,13 @@ def testNugetRuntimeIdConfiguration = ['Debug': 'win7-x86',
                     // On Windows we use the packer to put together everything. On *nix we use tar
                     steps {
                         if (osName == 'Windows 10' || osName == 'Windows 7' || osName == 'Windows_NT') {
-                            batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd -${configurationGroup} -os:${osGroup} -buildArch:${buildArchConfiguration[configurationGroup]} -TestNugetRuntimeId:${testNugetRuntimeIdConfiguration[configurationGroup]} -- /p:WithoutCategories=IgnoreForCI /p:BuildConfiguration=${targetGroup}-${osName}-${configurationGroup}-${buildArchConfiguration[configurationGroup]}")
+                            batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd -${configurationGroup} -os:${osGroup} -buildArch:${buildArchConfiguration[configurationGroup]} -TestNugetRuntimeId:${testNugetRuntimeIdConfiguration[configurationGroup]} -- /p:WithoutCategories=IgnoreForCI /p:BuildConfiguration=${targetGroup}-${osGroup}-${configurationGroup}-${buildArchConfiguration[configurationGroup]}")
                             batchFile("C:\\Packer\\Packer.exe .\\bin\\build.pack .\\bin")
                         }
                         else {
                             // Use Server GC for Ubuntu/OSX Debug PR build & test
                             def useServerGC = (configurationGroup == 'Release' && isPR) ? 'useServerGC' : ''
-                            shell("HOME=\$WORKSPACE/tempHome ./build.sh -${configurationGroup.toLowerCase()} -- ${useServerGC} /p:TestWithLocalNativeLibraries=true /p:TestNugetRuntimeId=${targetNugetRuntimeMap[osName]} /p:WithoutCategories=IgnoreForCI /p:BuildConfiguration=${targetGroup}-${osName}-${configurationGroup}-x64")
+                            shell("HOME=\$WORKSPACE/tempHome ./build.sh -${configurationGroup.toLowerCase()} -- ${useServerGC} /p:TestWithLocalNativeLibraries=true /p:TestNugetRuntimeId=${targetNugetRuntimeMap[osName]} /p:WithoutCategories=IgnoreForCI /p:BuildConfiguration=${targetGroup}-${osGroup}-${configurationGroup}-x64")
                             // Tar up the appropriate bits.  On OSX the tarring is a different syntax for exclusion.
                             if (osName == 'OSX') {
                                 // TODO: Re-enable package archival when the build refactoring work allows it.


### PR DESCRIPTION
`BuildConfiguration` should include an `OSGroup`, not the name of a particular OS. On Windows, these happened to be the same ("`Windows_NT`"), but it was broken for everything else.

@chcosta 