### PR TITLE
Update LocalAppContext DisableCaching and XmlSchemaSet Tests to fix failure

### DIFF
--- a/src/Common/src/System/LocalAppContext.cs
+++ b/src/Common/src/System/LocalAppContext.cs
@@ -8,12 +8,12 @@ namespace System
 {
     internal partial class LocalAppContext
     {
-        private static bool m_isDisableCachingInitialized;
+        private static bool s_isDisableCachingInitialized;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool GetCachedSwitchValue(string switchName, ref int switchValue)
         {
-            if (!m_isDisableCachingInitialized)
+            if (!s_isDisableCachingInitialized)
             {
                 InitDisableCaching();
             }
@@ -46,7 +46,7 @@ namespace System
                 DisableCaching = isEnabled;
             }
             
-            m_isDisableCachingInitialized = true;            
+            s_isDisableCachingInitialized = true;            
         }
 
         private static bool DisableCaching { get; set; }

--- a/src/Common/src/System/LocalAppContext.cs
+++ b/src/Common/src/System/LocalAppContext.cs
@@ -9,15 +9,11 @@ namespace System
     internal partial class LocalAppContext
     {
         private static bool s_isDisableCachingInitialized;
+        private static bool s_disableCaching;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool GetCachedSwitchValue(string switchName, ref int switchValue)
         {
-            if (!s_isDisableCachingInitialized)
-            {
-                InitDisableCaching();
-            }
-
             if (switchValue < 0) return false;
             if (switchValue > 0) return true;
 
@@ -38,17 +34,23 @@ namespace System
             return isSwitchEnabled;
         }
 
-        private static void InitDisableCaching()
-        {
-            bool isEnabled;
-            if (AppContext.TryGetSwitch(@"TestSwitch.LocalAppContext.DisableCaching", out isEnabled))
+        private static bool DisableCaching 
+        { 
+            get 
             {
-                DisableCaching = isEnabled;
-            }
-            
-            s_isDisableCachingInitialized = true;            
-        }
+                if (!s_isDisableCachingInitialized)
+                {
+                    bool isEnabled;
+                    if (AppContext.TryGetSwitch(@"TestSwitch.LocalAppContext.DisableCaching", out isEnabled))
+                    {
+                        s_disableCaching = isEnabled;
+                    }
 
-        private static bool DisableCaching { get; set; }
+                    s_isDisableCachingInitialized = true;
+                }
+
+                return s_disableCaching;
+            }
+        }
     }
 }

--- a/src/Common/src/System/LocalAppContext.cs
+++ b/src/Common/src/System/LocalAppContext.cs
@@ -8,18 +8,16 @@ namespace System
 {
     internal partial class LocalAppContext
     {
-        static LocalAppContext()
-        {
-            bool isEnabled;
-            if (AppContext.TryGetSwitch(@"TestSwitch.LocalAppContext.DisableCaching", out isEnabled))
-            {
-                DisableCaching = isEnabled;
-            }
-        }
+        private static bool m_isDisableCachingInitialized;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool GetCachedSwitchValue(string switchName, ref int switchValue)
         {
+            if (!m_isDisableCachingInitialized)
+            {
+                InitDisableCaching();
+            }
+
             if (switchValue < 0) return false;
             if (switchValue > 0) return true;
 
@@ -38,6 +36,17 @@ namespace System
 
             switchValue = isSwitchEnabled ? 1 /*true*/ : -1 /*false*/;
             return isSwitchEnabled;
+        }
+
+        private static void InitDisableCaching()
+        {
+            bool isEnabled;
+            if (AppContext.TryGetSwitch(@"TestSwitch.LocalAppContext.DisableCaching", out isEnabled))
+            {
+                DisableCaching = isEnabled;
+            }
+            
+            m_isDisableCachingInitialized = true;            
         }
 
         private static bool DisableCaching { get; set; }

--- a/src/Common/src/System/LocalAppContext.cs
+++ b/src/Common/src/System/LocalAppContext.cs
@@ -10,6 +10,7 @@ namespace System
     {
         private static bool s_isDisableCachingInitialized;
         private static bool s_disableCaching;
+        private static readonly object s_syncObject = new object();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool GetCachedSwitchValue(string switchName, ref int switchValue)
@@ -40,13 +41,19 @@ namespace System
             {
                 if (!s_isDisableCachingInitialized)
                 {
-                    bool isEnabled;
-                    if (AppContext.TryGetSwitch(@"TestSwitch.LocalAppContext.DisableCaching", out isEnabled))
+                    lock (s_syncObject)
                     {
-                        s_disableCaching = isEnabled;
-                    }
+                        if (!s_isDisableCachingInitialized)
+                        {
+                            bool isEnabled;
+                            if (AppContext.TryGetSwitch(@"TestSwitch.LocalAppContext.DisableCaching", out isEnabled))
+                            {
+                                s_disableCaching = isEnabled;
+                            }
 
-                    s_isDisableCachingInitialized = true;
+                            s_isDisableCachingInitialized = true;
+                        }
+                    }
                 }
 
                 return s_disableCaching;

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet.cs
@@ -8,6 +8,11 @@ namespace System.Xml.Tests
 {
     public class TestData
     {
+        static TestData()
+        {
+            AppContext.SetSwitch("TestSwitch.LocalAppContext.DisableCaching", true);
+        }
+        
         internal static string _Root = Path.Combine("TestFiles", "TestData");
         internal static string StandardPath = Path.Combine("TestFiles", "StandardTests");
         internal static string _FileXSD1 = Path.Combine(_Root, "schema1.xsd");

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlResolver.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlResolver.cs
@@ -16,9 +16,6 @@ namespace System.Xml.Tests
 
         public TC_SchemaSet_XmlResolver(ITestOutputHelper output)
         {
-            // Make sure that we don't cache the value of the switch to enable testing
-            AppContext.SetSwitch("TestSwitch.LocalAppContext.DisableCaching", true);
-
             _output = output;
         }
 
@@ -97,7 +94,6 @@ namespace System.Xml.Tests
         }
 
         //[Variation(Desc = "v4 - schema(Local)->schema(Local)", Priority = 1)]
-        [ActiveIssue(14064)]
         [Fact]
         public void v4()
         {

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlResolver.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlResolver.cs
@@ -109,7 +109,6 @@ namespace System.Xml.Tests
         }
 
         //[Variation(Desc = "v5 - schema(Local)->schema(Local)->schema(Local)", Priority = 1)]
-        [ActiveIssue(14064)]
         [Fact]
         public void v5()
         {


### PR DESCRIPTION
Fixes #14064

I updated `LocalAppContext` to get `DisableCaching` switch's value on the first call to `GetCachedSwitchValue` instead of doing it on an static constructor. 

The tests were failing because the `LocalAppContext` was trying to get `DisableCaching` switch value before it was set to true because other tests that didn't needed `DisableCaching` set to true where calling `LocalAppContext.GetCachedSwitchValue` first and when the tests that needed no caching were trying to get switches values they would get the previously cached value so that would cause the failure.

In order to fix this I added an static constructor to `Xml.Tests.TestData` and in that constructor I set the `DisableCaching` switch value to true before `LocalAppContext` tries to get it. The static constructor is the first thing that will be called because `TestData` is referenced from all the tests so when a test is executed the constructor is being called.

/cc @AlexGhiondea @sepidehMS 