### PR TITLE
Fix arm builds

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -157,7 +157,7 @@
       },
       "inputs": {
         "filename": "$(Build.SourcesDirectory)\\corefx\\build.cmd",
-        "arguments": "-buildArch=$(PB_Platform) -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType)",
+        "arguments": "-buildArch=$(PB_Platform) -$(PB_ConfigurationGroup) -- toolsetDir=C:\\tools\\clr /p:SignType=$(PB_SignType)",
         "workingFolder": "corefx",
         "failOnStandardError": "false"
       }


### PR DESCRIPTION
Arm builds are failing in official builds because I didn't propagate the toolsetdir property when creating the new definitions