### PR TITLE
use SocketPal.GetLastSocketError instead of calling Marshal.GetLastWin32Error directly

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Windows.cs
@@ -62,7 +62,7 @@ namespace System.Net.Sockets
 
                     if (errorCode == SocketError.SocketError)
                     {
-                        errorCode = (SocketError)Marshal.GetLastWin32Error();
+                        errorCode = SocketPal.GetLastSocketError();
                     }
 
                     if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"setsockopt handle:{handle}, AcceptSocket:{_acceptSocket}, returns:{errorCode}");

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
@@ -111,7 +111,7 @@ namespace System.Net.Sockets
                         try
                         {
                             // The async IO completed with a failure.
-                            // Here we need to call WSAGetOverlappedResult() just so Marshal.GetLastWin32Error() will return the correct error.
+                            // Here we need to call WSAGetOverlappedResult() just so GetLastSocketError() will return the correct error.
                             SocketFlags ignore;
                             bool success = Interop.Winsock.WSAGetOverlappedResult(
                                 socket.SafeHandle,
@@ -121,11 +121,7 @@ namespace System.Net.Sockets
                                 out ignore);
                             if (!success)
                             {
-                                socketError = (SocketError)Marshal.GetLastWin32Error();
-                                if (socketError == 0)
-                                {
-                                    NetEventSource.Fail(asyncResult, $"socketError:0 numBytes:{numBytes}");
-                                }
+                                socketError = SocketPal.GetLastSocketError();
                             }
                             if (success)
                             {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/ConnectOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/ConnectOverlappedAsyncResult.Windows.cs
@@ -32,7 +32,7 @@ namespace System.Net.Sockets
                         0);
                     if (errorCode == SocketError.SocketError)
                     {
-                        errorCode = (SocketError)Marshal.GetLastWin32Error();
+                        errorCode = SocketPal.GetLastSocketError();
                     }
                 }
                 catch (ObjectDisposedException)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3233,9 +3233,6 @@ namespace System.Net.Sockets
             // Throw an appropriate SocketException if the native call fails synchronously.
             if (errorCode != SocketError.Success)
             {
-                // TODO: https://github.com/dotnet/corefx/issues/5426
-                // NetEventSource.Fail(this, "GetLastWin32Error() returned zero.");
-
                 // Update the internal state of this socket according to the error before throwing.
                 UpdateStatusAfterSocketError(errorCode);
                 var socketException = new SocketException((int)errorCode);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -251,7 +251,7 @@ namespace System.Net.Sockets
                     (int)(DisconnectReuseSocket ? TransmitFileOptions.ReuseSocket : 0),
                     0))
             {
-                socketError = (SocketError)Marshal.GetLastWin32Error();
+                socketError = SocketPal.GetLastSocketError();
             }
 
             return socketError;
@@ -1244,7 +1244,7 @@ namespace System.Net.Sockets
                             try
                             {
                                 // The Async IO completed with a failure.
-                                // here we need to call WSAGetOverlappedResult() just so Marshal.GetLastWin32Error() will return the correct error.
+                                // here we need to call WSAGetOverlappedResult() just so GetLastSocketError() will return the correct error.
                                 bool success = Interop.Winsock.WSAGetOverlappedResult(
                                     _currentSocket.SafeHandle,
                                     _ptrNativeOverlapped,

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -41,7 +41,14 @@ namespace System.Net.Sockets
 
         public static SocketError GetLastSocketError()
         {
-            return (SocketError)Marshal.GetLastWin32Error();
+            int win32Error = Marshal.GetLastWin32Error();
+
+            if (win32Error == 0)
+            {
+                NetEventSource.Fail(null, "GetLastWin32Error() returned zero.");
+            }
+
+            return (SocketError)win32Error;
         }
 
         public static SocketError CreateSocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, out SafeCloseSocket socket)
@@ -62,7 +69,7 @@ namespace System.Net.Sockets
 
             if (errorCode == SocketError.SocketError)
             {
-                errorCode = (SocketError)Marshal.GetLastWin32Error();
+                errorCode = GetLastSocketError();
             }
 
             willBlock = intBlocking == 0;
@@ -153,7 +160,7 @@ namespace System.Net.Sockets
 
                 if ((SocketError)errorCode == SocketError.SocketError)
                 {
-                    errorCode = (SocketError)Marshal.GetLastWin32Error();
+                    errorCode = GetLastSocketError();
                 }
 
                 return errorCode;
@@ -278,7 +285,7 @@ namespace System.Net.Sockets
 
                 if ((SocketError)errorCode == SocketError.SocketError)
                 {
-                    errorCode = (SocketError)Marshal.GetLastWin32Error();
+                    errorCode = GetLastSocketError();
                 }
 
                 return errorCode;
@@ -341,7 +348,7 @@ namespace System.Net.Sockets
                     IntPtr.Zero,
                     IntPtr.Zero) == SocketError.SocketError)
                 {
-                    errorCode = (SocketError)Marshal.GetLastWin32Error();
+                    errorCode = GetLastSocketError();
                 }
             }
             finally
@@ -1018,7 +1025,7 @@ namespace System.Net.Sockets
             // This can throw ObjectDisposedException (handle, and retrieving the delegate).
             if (!socket.DisconnectExBlocking(handle, IntPtr.Zero, (int)(reuseSocket ? TransmitFileOptions.ReuseSocket : 0), 0))
             {
-                errorCode = (SocketError)Marshal.GetLastWin32Error();
+                errorCode = GetLastSocketError();
             }
 
             return errorCode;


### PR DESCRIPTION
Add logic to SocketPal.GetLastSocketError to detect and fail if Marshal.GetLastWin32Error returns 0.
Make sure the rest of the code uses GetLastSocketError instead of GetLastWin32Error directly.

Addresses #5426.
