### PR TITLE
add SimpleContextAwareResult and use it instead of ContextAwareResult

### DIFF
--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -53,6 +53,7 @@
     <Compile Include="System\Net\Sockets\NetworkStream.cs" />
     <Compile Include="System\Net\Sockets\SelectMode.cs" />
     <Compile Include="System\Net\Sockets\SendPacketsElement.cs" />
+    <Compile Include="System\Net\Sockets\SimpleContextAwareResult.cs" />
     <Compile Include="System\Net\Sockets\Socket.cs" />
     <Compile Include="System\Net\Sockets\SocketAsyncEventArgs.cs" />
     <Compile Include="System\Net\Sockets\SocketAsyncOperation.cs" />
@@ -97,9 +98,6 @@
       <Link>Common\System\Net\DebugSafeHandleMinusOneIsInvalid.cs</Link>
     </Compile>
     <!-- System.Net common -->
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.cs">
-      <Link>Common\System\Net\ContextAwareResult.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\Net\LazyAsyncResult.cs">
       <Link>Common\System\Net\LazyAsyncResult.cs</Link>
     </Compile>
@@ -290,16 +288,8 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.LocalFree.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.LocalFree.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Windows.cs">
-      <Link>Common\System\Net\ContextAwareResult.Windows.cs</Link>
-    </Compile>
   </ItemGroup>
   <!-- Windows : Win32 + WinRT -->
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(EnableWinRT)' == 'true'">
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Uap.cs">
-      <Link>Common\System\Net\ContextAwareResult.Uap.cs</Link>
-    </Compile>
-  </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="System\Net\Sockets\AcceptOverlappedAsyncResult.Unix.cs" />
     <Compile Include="System\Net\Sockets\BaseOverlappedAsyncResult.Unix.cs" />
@@ -314,9 +304,6 @@
     <Compile Include="System\Net\Sockets\SocketPal.Unix.cs" />
     <Compile Include="System\Net\Sockets\TCPClient.Unix.cs" />
     <Compile Condition="'$(TargetGroup)' != 'netcore50'" Include="System\Net\Sockets\TCPClient.Unix.netstandard17.cs" />
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Unix.cs">
-      <Link>Common\System\Net\ContextAwareResult.Unix.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\Net\InteropIPAddressExtensions.Unix.cs">
       <Link>Common\System\Net\InteropIPAddressExtensions.Unix.cs</Link>
     </Compile>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Unix.cs
@@ -15,7 +15,7 @@ namespace System.Net.Sockets
     //
     // This class is used to track state for async Socket operations such as the BeginSend, BeginSendTo,
     // BeginReceive, BeginReceiveFrom, BeginSendFile, and BeginAccept calls.
-    internal partial class BaseOverlappedAsyncResult : ContextAwareResult
+    internal partial class BaseOverlappedAsyncResult : SimpleContextAwareResult
     {
         public BaseOverlappedAsyncResult(Socket socket, Object asyncState, AsyncCallback asyncCallback)
             : base(socket, asyncState, asyncCallback)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
@@ -15,7 +15,7 @@ namespace System.Net.Sockets
     //
     // This class is used to track state for async Socket operations such as the BeginSend, BeginSendTo,
     // BeginReceive, BeginReceiveFrom, BeginSendFile, and BeginAccept calls.
-    internal partial class BaseOverlappedAsyncResult : ContextAwareResult
+    internal partial class BaseOverlappedAsyncResult : SimpleContextAwareResult
     {
         private int _cleanupCount;
         private SafeNativeOverlapped _nativeOverlapped;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.cs
@@ -15,7 +15,7 @@ namespace System.Net.Sockets
     //
     // This class is used to track state for async Socket operations such as the BeginSend, BeginSendTo,
     // BeginReceive, BeginReceiveFrom, BeginSendFile, and BeginAccept calls.
-    internal partial class BaseOverlappedAsyncResult : ContextAwareResult
+    internal partial class BaseOverlappedAsyncResult : SimpleContextAwareResult
     {
         // Sentinel object passed to callers of PostCompletion to use as the
         // "result" of this operation, in order to avoid boxing the actual result.

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SimpleContextAwareResult.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SimpleContextAwareResult.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Threading;
+
+namespace System.Net
+{
+    // This class ensures that the user callback runs in the caller's ExecutionContext.
+    internal partial class SimpleContextAwareResult : LazyAsyncResult
+    {
+        private ExecutionContext _context;
+
+        internal SimpleContextAwareResult(object myObject, object myState, AsyncCallback myCallBack)
+            : base(myObject, myState, myCallBack)
+        {
+            _context = ExecutionContext.Capture();
+        }
+
+        // This method is guaranteed to be called only once.
+        protected override void Complete(IntPtr userToken)
+        {
+            if (CompletedSynchronously)
+            {
+                Debug.Assert(ExecutionContext.Capture() == _context);
+
+                CompleteCallback();
+            }
+            else
+            {
+                ExecutionContext.Run(_context, s => ((SimpleContextAwareResult)s).CompleteCallback(), this);
+            }
+        }
+
+        private void CompleteCallback()
+        {
+            base.Complete(IntPtr.Zero);
+        }
+    }
+}

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SimpleContextAwareResult.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SimpleContextAwareResult.cs
@@ -10,7 +10,7 @@ namespace System.Net
     // This class ensures that the user callback runs in the caller's ExecutionContext.
     internal partial class SimpleContextAwareResult : LazyAsyncResult
     {
-        private ExecutionContext _context;
+        private readonly ExecutionContext _context;
 
         internal SimpleContextAwareResult(object myObject, object myState, AsyncCallback myCallBack)
             : base(myObject, myState, myCallBack)
@@ -25,6 +25,11 @@ namespace System.Net
             {
                 Debug.Assert(ExecutionContext.Capture() == _context);
 
+                CompleteCallback();
+            }
+            else if (_context == null)
+            {
+                // EC flow was suppressed.
                 CompleteCallback();
             }
             else

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -241,7 +241,6 @@ namespace System.Net.Sockets
             FileStream fileStream = OpenFile(fileName);
 
             TransmitFileAsyncResult asyncResult = new TransmitFileAsyncResult(this, state, callback);
-            asyncResult.StartPostingAsyncOp(false);
 
             SocketError errorCode = SocketPal.SendFileAsync(_handle, fileStream, preBuffer, postBuffer, flags, asyncResult);
 
@@ -253,8 +252,6 @@ namespace System.Net.Sockets
                 if (NetEventSource.IsEnabled) NetEventSource.Error(this, socketException);
                 throw socketException;
             }
-
-            asyncResult.FinishPostingAsyncOp(ref Caches.SendClosureCache);
 
             return asyncResult;
         }

--- a/src/System.Net.Sockets/tests/FunctionalTests/ContextFlowTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ContextFlowTest.cs
@@ -1,0 +1,142 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Sockets.Tests
+{
+    public class ContextFlowTest
+    {
+        private static class ECHelper
+        {
+            private static readonly AsyncLocal<string> s_asyncLocal = new AsyncLocal<string>();
+
+            public static void RunInCustomEC(string name, Action action)
+            {
+                var ec = ExecutionContext.Capture();
+
+                // We never modify the existing EC, instead we do the following
+                // to create a custom EC and run the action in it
+                ExecutionContext.Run(ec, (_) =>
+                {
+                    s_asyncLocal.Value = name;
+                    action();
+                }, null);
+            }
+
+            // Note, null == default EC
+            public static string GetCurrentECName()
+            {
+                return s_asyncLocal.Value;
+            }
+
+        }
+
+        public void DoAPMContextFlow(Socket listenSocket)
+        {
+            string ecName = ECHelper.GetCurrentECName();
+
+            AutoResetEvent completed = new AutoResetEvent(false);
+
+            // Start async operation
+            var asyncResult = listenSocket.BeginAccept(ar =>
+            {
+                var acceptSocket = listenSocket.EndAccept(ar);
+                Assert.NotNull(acceptSocket);
+                acceptSocket.Close();
+
+                // Same EC as caller
+                Assert.Equal(ecName, ECHelper.GetCurrentECName());
+
+                completed.Set();
+            }, null);
+
+            Assert.False(asyncResult.CompletedSynchronously);
+
+            // Connect, causing the async op above to complete
+            using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                client.Connect(listenSocket.LocalEndPoint);
+
+                // Wait for the completion routine to finish
+                completed.WaitOne();
+            }
+        }
+
+        [OuterLoop] // TODO: Issue #11345
+        [Fact]
+        public void ContextFlow_APM_Success()
+        {
+            using (Socket listenSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                int port = listenSocket.BindToAnonymousPort(IPAddress.Loopback);
+                listenSocket.Listen(1);
+
+                ECHelper.RunInCustomEC("ec1", () => DoAPMContextFlow(listenSocket));
+                ECHelper.RunInCustomEC("ec2", () => DoAPMContextFlow(listenSocket));
+                ECHelper.RunInCustomEC("ec3", () => DoAPMContextFlow(listenSocket));
+            }
+        }
+
+        public void DoSAEAContextFlow(Socket listenSocket, SocketAsyncEventArgs e)
+        {
+            string ecName = ECHelper.GetCurrentECName();
+
+            AutoResetEvent completed = new AutoResetEvent(false);
+
+            EventHandler<SocketAsyncEventArgs> handler = null;
+            handler = (_, args) =>
+            {
+                Assert.Equal(SocketError.Success, args.SocketError);
+                Assert.NotNull(args.AcceptSocket);
+                args.AcceptSocket.Close();
+                args.AcceptSocket = null;
+                args.Completed -= handler;
+
+                // Same EC as caller
+                Assert.Equal(ecName, ECHelper.GetCurrentECName());
+
+                completed.Set();
+            };
+
+            e.Completed += handler;
+            bool pending = listenSocket.AcceptAsync(e);
+
+            Assert.True(pending);
+
+            // Connect, causing the async op above to complete
+            using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                client.Connect(listenSocket.LocalEndPoint);
+
+                // Wait for the completion routine to finish
+                completed.WaitOne();
+            }
+        }
+
+        [OuterLoop] // TODO: Issue #11345
+        [Fact]
+        public void ContextFlow_SAEA_Success()
+        {
+            using (Socket listenSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                int port = listenSocket.BindToAnonymousPort(IPAddress.Loopback);
+                listenSocket.Listen(1);
+
+                SocketAsyncEventArgs e1 = new SocketAsyncEventArgs();
+                ECHelper.RunInCustomEC("ec1", () => DoSAEAContextFlow(listenSocket, e1));
+                ECHelper.RunInCustomEC("ec2", () => DoSAEAContextFlow(listenSocket, e1));
+
+                SocketAsyncEventArgs e2 = new SocketAsyncEventArgs();
+                ECHelper.RunInCustomEC("ec3", () => DoSAEAContextFlow(listenSocket, e2));
+                ECHelper.RunInCustomEC("ec4", () => DoSAEAContextFlow(listenSocket, e2));
+
+                ECHelper.RunInCustomEC("ec5", () => DoSAEAContextFlow(listenSocket, e1));
+                ECHelper.RunInCustomEC("ec6", () => DoSAEAContextFlow(listenSocket, e2));
+            }
+        }
+    }
+}

--- a/src/System.Net.Sockets/tests/FunctionalTests/ContextFlowTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ContextFlowTest.cs
@@ -42,9 +42,9 @@ namespace System.Net.Sockets.Tests
             AutoResetEvent completed = new AutoResetEvent(false);
 
             // Start async operation
-            var asyncResult = listenSocket.BeginAccept(ar =>
+            IAsyncResult asyncResult = listenSocket.BeginAccept(ar =>
             {
-                var acceptSocket = listenSocket.EndAccept(ar);
+                Socket acceptSocket = listenSocket.EndAccept(ar);
                 Assert.NotNull(acceptSocket);
                 acceptSocket.Close();
 
@@ -63,6 +63,8 @@ namespace System.Net.Sockets.Tests
 
                 // Wait for the completion routine to finish
                 completed.WaitOne();
+
+                Assert.True(asyncResult.IsCompleted);
             }
         }
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -12,6 +12,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="ContextFlowTest.cs" />
     <Compile Include="AcceptAsync.cs" />
     <Compile Include="AgnosticListenerTest.cs" />
     <Compile Include="ArgumentValidationTests.cs" />


### PR DESCRIPTION
The existing ContextAwareResult is doing a bunch of things we don't need for System.Net.Sockets.  In particular:

(1) Trying to optimize ExecutionContext flow with closure caches.  This is unnecessary now because EC flow is cheap.
(2) Providing some locking and identity capture functionality, none of which is used in System.Net.Sockets.

Replace this with SimpleContextAwareResult, simplifying the code and saving a few cycles/bytes here and there.

Also add some tests for EC flow.

@stephentoub @CIPop 