### PR TITLE
Fix casing for native binaries

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
@@ -35,7 +35,7 @@
 
     <RefBinDir>$(BinDir)$(TargetFrameworkName)/pkg/ref</RefBinDir>
     <LibBinDir>$(BinDir)$(TargetFrameworkName)/pkg/lib</LibBinDir>
-    <NativeBinDir>$(BinDir)$(OSGroup).$(PackagePlatform).$(ConfigurationGroup)/Native</NativeBinDir>
+    <NativeBinDir>$(BinDir)$(OSGroup).$(PackagePlatform).$(ConfigurationGroup)/native</NativeBinDir>
 
     <NETStandardLibraryPackage>NETStandard.Library2</NETStandardLibraryPackage>
     <NETStandardLibraryPackageVersion>2.0.0-beta-24709-0</NETStandardLibraryPackageVersion>

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
@@ -35,7 +35,7 @@
 
     <RefBinDir>$(BinDir)$(TargetFrameworkName)/pkg/ref</RefBinDir>
     <LibBinDir>$(BinDir)$(TargetFrameworkName)/pkg/lib</LibBinDir>
-    <NativeBinDir>$(BinDir)$(OSGroup).$(PackagePlatform).$(ConfigurationGroup)/native</NativeBinDir>
+    <NativeBinDir>$(BinDir)$(OSGroup).$(PackagePlatform).$(ConfigurationGroup)/Native</NativeBinDir>
 
     <NETStandardLibraryPackage>NETStandard.Library2</NETStandardLibraryPackage>
     <NETStandardLibraryPackageVersion>2.0.0-beta-24709-0</NETStandardLibraryPackageVersion>

--- a/run-test.sh
+++ b/run-test.sh
@@ -386,7 +386,7 @@ fi
 
 if [ "$CoreFxNativeBins" == "" ]
 then
-    CoreFxNativeBins="$ProjectRoot/bin/$OS.x64.$ConfigurationGroup/Native"
+    CoreFxNativeBins="$ProjectRoot/bin/$OS.x64.$ConfigurationGroup/native"
 fi
 
 if [ "$CoreFxPackages" == "" ]

--- a/src/Native/build-native.cmd
+++ b/src/Native/build-native.cmd
@@ -71,10 +71,10 @@ echo Commencing build of native components
 echo.
 
 if %__CMakeBinDir% == "" (
-    set "__CMakeBinDir=%__binDir%\Windows_NT.%__BuildArch%.%CMAKE_BUILD_TYPE%\Native"
+    set "__CMakeBinDir=%__binDir%\Windows_NT.%__BuildArch%.%CMAKE_BUILD_TYPE%\native"
 )
 if %__IntermediatesDir% == "" (
-    set "__IntermediatesDir=%__binDir%\obj\Windows_NT.%__BuildArch%.%CMAKE_BUILD_TYPE%\Native"
+    set "__IntermediatesDir=%__binDir%\obj\Windows_NT.%__BuildArch%.%CMAKE_BUILD_TYPE%\native"
 )
 set "__CMakeBinDir=%__CMakeBinDir:\=/%"
 set "__IntermediatesDir=%__IntermediatesDir:\=/%"
@@ -127,13 +127,13 @@ IF ERRORLEVEL 1 (
 )
 
 :: Copy to vertical runtime directory
-xcopy /yqs "%__binDir%\Windows_NT.%__BuildArch%.%CMAKE_BUILD_TYPE%\Native\*" "%__RuntimePath%"
+xcopy /yqs "%__binDir%\Windows_NT.%__BuildArch%.%CMAKE_BUILD_TYPE%\native\*" "%__RuntimePath%"
 
 echo Done building Native components
 
 :BuildNativeAOT
-set "__CMakeBinDir=%__binDir%\Windows_NT.%__BuildArch%.%CMAKE_BUILD_TYPE%\Native_aot"
-set "__IntermediatesDir=%__binDir%\obj\Windows_NT.%__BuildArch%.%CMAKE_BUILD_TYPE%\Native_aot"
+set "__CMakeBinDir=%__binDir%\Windows_NT.%__BuildArch%.%CMAKE_BUILD_TYPE%\native_aot"
+set "__IntermediatesDir=%__binDir%\obj\Windows_NT.%__BuildArch%.%CMAKE_BUILD_TYPE%\native_aot"
 set "__CMakeBinDir=%__CMakeBinDir:\=/%"
 set "__IntermediatesDir=%__IntermediatesDir:\=/%"
 if exist "%__IntermediatesDir%" rd /s /q "%__IntermediatesDir%"

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -256,8 +256,8 @@ case $CPUName in
 esac
 
 # Set the remaining variables based upon the determined build configuration
-__IntermediatesDir="$__rootbinpath/obj/$__BuildOS.$__BuildArch.$__BuildType/Native"
-__BinDir="$__rootbinpath/$__BuildOS.$__BuildArch.$__BuildType/Native"
+__IntermediatesDir="$__rootbinpath/obj/$__BuildOS.$__BuildArch.$__BuildType/native"
+__BinDir="$__rootbinpath/$__BuildOS.$__BuildArch.$__BuildType/native"
 __RuntimePath="$__rootbinpath/runtime/$__TargetGroup-$__BuildOS-$__BuildType-$__BuildArch"
 
 # Make the directories necessary for build if they don't exist

--- a/src/Native/pkg/dir.props
+++ b/src/Native/pkg/dir.props
@@ -4,14 +4,14 @@
   <PropertyGroup>
     <!-- common properties that point to output of native build.  Can be overriden in case of 
          a coordinating build that produces all packages from OS-specific native builds -->
-    <LinuxNativePath Condition="'$(LinuxNativePath)' == ''">$(BinDir)Linux.$(PackagePlatform).$(ConfigurationGroup)\Native\</LinuxNativePath>
-    <WinNativeAOTPath Condition="'$(WinNativeAOTPath)' == ''">$(BinDir)Windows_NT.$(PackagePlatform).$(ConfigurationGroup)\Native_aot\</WinNativeAOTPath>
-    <WinNativePath Condition="'$(WinNativePath)' == ''">$(BinDir)Windows_NT.$(PackagePlatform).$(ConfigurationGroup)\Native\</WinNativePath>
+    <LinuxNativePath Condition="'$(LinuxNativePath)' == ''">$(BinDir)Linux.$(PackagePlatform).$(ConfigurationGroup)\native\</LinuxNativePath>
+    <WinNativeAOTPath Condition="'$(WinNativeAOTPath)' == ''">$(BinDir)Windows_NT.$(PackagePlatform).$(ConfigurationGroup)\native_aot\</WinNativeAOTPath>
+    <WinNativePath Condition="'$(WinNativePath)' == ''">$(BinDir)Windows_NT.$(PackagePlatform).$(ConfigurationGroup)\native\</WinNativePath>
     <RHELNativePath Condition="'$(RHELNativePath)' == ''">$(LinuxNativePath)</RHELNativePath>
     <DebianNativePath Condition="'$(DebianNativePath)' == ''">$(LinuxNativePath)</DebianNativePath>
     <Fedora23NativePath Condition="'$(Fedora23NativePath)' == ''">$(LinuxNativePath)</Fedora23NativePath>
     <Fedora24NativePath Condition="'$(Fedora24NativePath)' == ''">$(LinuxNativePath)</Fedora24NativePath>
-    <OSXNativePath Condition="'$(OSXNativePath)' == ''">$(BinDir)OSX.$(PackagePlatform).$(ConfigurationGroup)\Native\</OSXNativePath>
+    <OSXNativePath Condition="'$(OSXNativePath)' == ''">$(BinDir)OSX.$(PackagePlatform).$(ConfigurationGroup)\native\</OSXNativePath>
     <OpenSuse132NativePath Condition="'$(OpenSuse132NativePath)' == ''">$(LinuxNativePath)</OpenSuse132NativePath>
     <OpenSuse421NativePath Condition="'$(OpenSuse421NativePath)' == ''">$(LinuxNativePath)</OpenSuse421NativePath>
     <Ubuntu1404NativePath Condition="'$(Ubuntu1404NativePath)' == ''">$(LinuxNativePath)</Ubuntu1404NativePath>


### PR DESCRIPTION
Native binary path is in 'Native'.  https://github.com/dotnet/corefx/blob/dev/eng/src/Native/build-native.sh#L260

This is causing package builds to fail on Unix