### PR TITLE
[dev/eng] Use lower-case 'native' in Microsoft.Private.CoreFx.NETCoreApp.pkgproj

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
@@ -35,7 +35,7 @@
 
     <RefBinDir>$(BinDir)$(TargetFrameworkName)/pkg/ref</RefBinDir>
     <LibBinDir>$(BinDir)$(TargetFrameworkName)/pkg/lib</LibBinDir>
-    <NativeBinDir>$(BinDir)$(OSGroup).$(PackagePlatform).$(ConfigurationGroup)/Native</NativeBinDir>
+    <NativeBinDir>$(BinDir)$(OSGroup).$(PackagePlatform).$(ConfigurationGroup)/native</NativeBinDir>
 
     <NETStandardLibraryPackage>NETStandard.Library2</NETStandardLibraryPackage>
     <NETStandardLibraryPackageVersion>2.0.0-beta-24709-0</NETStandardLibraryPackageVersion>


### PR DESCRIPTION
@chcosta I had changed this in my giant PR and forgotten that it would conflict with the change from #14822 . This just reverts the change that I made so that it lines up with the rest of the casing changes you made.