### PR TITLE
Pass toolSetDir to Windows native builds

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -157,7 +157,7 @@
       },
       "inputs": {
         "filename": "$(Build.SourcesDirectory)\\corefx\\build.cmd",
-        "arguments": "-buildArch=$(PB_Platform) -$(PB_ConfigurationGroup) -- toolsetDir=C:\\tools\\clr /p:SignType=$(PB_SignType)",
+        "arguments": "-buildArch=$(PB_Platform) -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType)",
         "workingFolder": "corefx",
         "failOnStandardError": "false"
       }

--- a/config.json
+++ b/config.json
@@ -186,6 +186,12 @@
       "values": [],
       "defaultValue": ""
     },
+    "ToolSetDir": {
+      "description": "Native toolset directory",
+      "valueType": "passThrough",
+      "values": [],
+      "defaultValue": "toolSetDir=c:\\tools\\clr"
+    },
     "Sync": {
       "description": "MsBuild target that restores the packages.",
       "valueType": "target",
@@ -351,7 +357,8 @@
            "BuildArchitecture": "default", 
            "CmakeBuildType": "default",           
            "HostOs": "default",
-           "ProcessorCount": "default"
+           "ProcessorCount": "default",
+           "ToolSetDir": "default"
          }
       }
     },


### PR DESCRIPTION
Windows native arm64 builds require toolSetDir variable - https://github.com/dotnet/corefx/blob/f47e50054279ee285fb8ae9ed85d2985b64bf553/src/Native/build-native.cmd#L159

We, previously, explicitly passed this in official builds to build-native.cmd.  Official builds are now using build.cmd, so we have to pass the variable to build-native.cmd, but not to build-managed.cmd.  

/cc @weshaggard 