### PR TITLE
Change how test references are resolved.

### DIFF
--- a/src/System.Diagnostics.Debug/tests/System.Diagnostics.Debug.Tests.csproj
+++ b/src/System.Diagnostics.Debug/tests/System.Diagnostics.Debug.Tests.csproj
@@ -9,7 +9,6 @@
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <NoWarn>1685</NoWarn>
     <NoTargetingPackReferences>true</NoTargetingPackReferences>
-    <WindowsAppContainer>false</WindowsAppContainer>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
@@ -17,16 +16,16 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <ItemGroup>
-    <Reference Include="System.Diagnostics.Debug" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.Extensions" />
-    <Reference Include="System.Private.CoreLib" />
-    <Reference Include="System.Threading.Tasks" />
-    <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />
+    <RuntimeReferencedAssemblyNames Include="System.Diagnostics.Debug" />
+    <RuntimeReferencedAssemblyNames Include="System.Runtime" />
+    <RuntimeReferencedAssemblyNames Include="System.Runtime.Extensions" />
+    <RuntimeReferencedAssemblyNames Include="System.Private.CoreLib" />
+    <RuntimeReferencedAssemblyNames Include="System.Threading.Tasks" />
+    <RuntimeReferencedAssemblyNames Include="System.Runtime.InteropServices.RuntimeInformation" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AttributeTests.cs" />
-    <Compile Include="DebuggerTests.cs" Condition="'$(TargetGroup)'==''"/>
+    <Compile Include="DebuggerTests.cs" Condition="'$(TargetGroup)'=='netstandard1.7'"/>
     <Compile Include="DebugTests.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
   </ItemGroup>

--- a/src/System.Diagnostics.Debug/tests/System.Diagnostics.Debug.Tests.csproj
+++ b/src/System.Diagnostics.Debug/tests/System.Diagnostics.Debug.Tests.csproj
@@ -16,12 +16,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <ItemGroup>
-    <RuntimeReferencedAssemblyNames Include="System.Diagnostics.Debug" />
-    <RuntimeReferencedAssemblyNames Include="System.Runtime" />
-    <RuntimeReferencedAssemblyNames Include="System.Runtime.Extensions" />
-    <RuntimeReferencedAssemblyNames Include="System.Private.CoreLib" />
-    <RuntimeReferencedAssemblyNames Include="System.Threading.Tasks" />
-    <RuntimeReferencedAssemblyNames Include="System.Runtime.InteropServices.RuntimeInformation" />
+    <ReferenceFromRuntime Include="System.Diagnostics.Debug" />
+    <ReferenceFromRuntime Include="System.Runtime" />
+    <ReferenceFromRuntime Include="System.Runtime.Extensions" />
+    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ReferenceFromRuntime Include="System.Threading.Tasks" />
+    <ReferenceFromRuntime Include="System.Runtime.InteropServices.RuntimeInformation" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AttributeTests.cs" />

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -16,7 +16,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <TargetingPackExclusions Include="System.Linq.Expressions" />
-    <ProjectReference Include="..\src\System.Linq.Expressions.csproj" />
+    <RuntimeReferencedAssemblyNames Include="System.Linq.Expressions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -16,7 +16,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <TargetingPackExclusions Include="System.Linq.Expressions" />
-    <RuntimeReferencedAssemblyNames Include="System.Linq.Expressions" />
+    <ReferenceFromRuntime Include="System.Linq.Expressions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/targetingpacks.props
+++ b/targetingpacks.props
@@ -17,18 +17,12 @@
       <RuntimeReferencedAssemblyNames Include="Newtonsoft.Json" Condition="'$(SkipIncludeNewtonsoftJson)'!='true'" />
 
       <!-- Add Reference's to all files in the targeting pack folder, and to whitelisted items from the group above in the runtime folder. -->
-      <TargetingPackItems Include="%(TargetingPackDirs.Identity)/*" />
+      <TargetingPackItems Include="%(TargetingPackDirs.Identity)/*" Condition="'$(NoTargetingPackReferences)' != 'true'" />
       <Reference Include="%(TargetingPackItems.Filename)" Exclude="@(TargetingPackExclusions)"> <!-- TODO: System.Private.CoreLib shouldn't even be in the targeting pack. -->
         <Private>false</Private>
       </Reference>
-      <Reference Include="@(RuntimeReferencedAssemblyNames)" />
+      <ReferencePath Include="@(RuntimeReferencedAssemblyNames->'$(RuntimePath)%(Identity).dll')" />
     </ItemGroup>
-
-    <!-- Allow tests to reference items from the runtime directory -->
-    <PropertyGroup>
-      <AssemblySearchPaths Condition="'$(NoTargetingPackReferences)' == 'true'">$(RuntimePath);$(AssemblySearchPaths)</AssemblySearchPaths>
-      <AssemblySearchPaths Condition="'$(NoTargetingPackReferences)' != 'true'">$(AssemblySearchPaths);$(RuntimePath)</AssemblySearchPaths>
-    </PropertyGroup>
   </Target>
 
 </Project>

--- a/targetingpacks.props
+++ b/targetingpacks.props
@@ -8,20 +8,20 @@
       <TargetingPackExclusions Include="System.Runtime.WindowsRuntime.UI.Xaml" /> <!-- Harmless, but causes PRI targets to run -->
 
       <!-- Whitelisted runtime assemblies that are OK to reference. -->
-      <RuntimeReferencedAssemblyNames Include="xunit.core" />
-      <RuntimeReferencedAssemblyNames Include="Xunit.NetCore.Extensions" />
-      <RuntimeReferencedAssemblyNames Include="xunit.assert" />
-      <RuntimeReferencedAssemblyNames Include="xunit.abstractions" />
-      <RuntimeReferencedAssemblyNames Include="xunit.performance.core" />
-      <RuntimeReferencedAssemblyNames Include="xunit.execution.dotnet" />
-      <RuntimeReferencedAssemblyNames Include="Newtonsoft.Json" Condition="'$(SkipIncludeNewtonsoftJson)'!='true'" />
+      <ReferenceFromRuntime Include="xunit.core" />
+      <ReferenceFromRuntime Include="Xunit.NetCore.Extensions" />
+      <ReferenceFromRuntime Include="xunit.assert" />
+      <ReferenceFromRuntime Include="xunit.abstractions" />
+      <ReferenceFromRuntime Include="xunit.performance.core" />
+      <ReferenceFromRuntime Include="xunit.execution.dotnet" />
+      <ReferenceFromRuntime Include="Newtonsoft.Json" Condition="'$(SkipIncludeNewtonsoftJson)'!='true'" />
 
       <!-- Add Reference's to all files in the targeting pack folder, and to whitelisted items from the group above in the runtime folder. -->
       <TargetingPackItems Include="%(TargetingPackDirs.Identity)/*" Condition="'$(NoTargetingPackReferences)' != 'true'" />
       <Reference Include="%(TargetingPackItems.Filename)" Exclude="@(TargetingPackExclusions)"> <!-- TODO: System.Private.CoreLib shouldn't even be in the targeting pack. -->
         <Private>false</Private>
       </Reference>
-      <ReferencePath Include="@(RuntimeReferencedAssemblyNames->'$(RuntimePath)%(Identity).dll')" />
+      <ReferencePath Include="@(ReferenceFromRuntime->'$(RuntimePath)%(Identity).dll')" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
* When `NoTargetingPackReferences` is set to "true", no references are added to any assemblies in the targeting pack.
* Names in the `RuntimeReferencedAssemblyNames` item group are now used to add items into the `ReferencePath` group. Absolute paths of runtime assemblies are added directly to the list, and `AssemblySearchPaths` is no longer modified at all when runtime assemblies are referenced.
* Fix up System.Diagnostics.Debug.Tests and System.Linq.Expressions.Tests based on the above changes. Linq.Expressions.Tests no longer references its own src project, which should fix some race conditions in the build.
* Unrelated cleanup in the System.Diagnostics.Debug test project.

@joperezr @chcosta @weshaggard 