### PR TITLE
Pass architecturegroup to build-managed

### DIFF
--- a/config.json
+++ b/config.json
@@ -42,8 +42,8 @@
       "values": ["True", "False"],
       "defaultValue": true
     },
-    "TestArchitecture": {
-      "description": "Sets the architecture value that will be used for testing.",
+    "ArchitectureGroup": {
+      "description": "Sets the architecture value that will be used for managed builds.",
       "valueType": "property",
       "values": ["AnyCPU", "x86", "arm", "x64", "arm64"],
       "defaultValue": "x64"
@@ -302,7 +302,7 @@
         "buildArch": {
           "description": "Passes the value of the test architecture to the respective build-managed script.",
           "settings": {
-            "TestArchitecture": "default"
+            "ArchitectureGroup": "default"
           }
         },
         "verbose": {

--- a/src/Tools/GenerateProps/archgroups.props
+++ b/src/Tools/GenerateProps/archgroups.props
@@ -3,7 +3,7 @@
   <ItemGroup>
     <ArchGroups Include="x86" />
     <ArchGroups Include="x64" />
-    <ArchGroups Include="ARM" />
-    <ArchGroups Include="ARM64" />
+    <ArchGroups Include="arm" />
+    <ArchGroups Include="arm64" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Remove 'TestArchitecture' (I don't see it being used anywhere), and pass architecturegroup to build-managed.  We have to pass the arch to both build-native and build-managed to ensure that we build and package the correct bits.

/cc @weshaggard @ericstj 