### PR TITLE
EnsureValidDataType should reject whitespaces in DataTypeAttribute.Cu…

### DIFF
--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DataTypeAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DataTypeAttribute.cs
@@ -115,7 +115,7 @@ namespace System.ComponentModel.DataAnnotations
         /// <exception cref="InvalidOperationException"> is thrown if the current attribute is ill-formed.</exception>
         private void EnsureValidDataType()
         {
-            if (DataType == DataType.Custom && string.IsNullOrEmpty(CustomDataType))
+            if (DataType == DataType.Custom && string.IsNullOrWhiteSpace(CustomDataType))
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
                     SR.DataTypeAttribute_EmptyDataTypeString));

--- a/src/System.ComponentModel.Annotations/tests/DataTypeAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/DataTypeAttributeTests.cs
@@ -68,6 +68,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [Theory]
         [InlineData("CustomValue")]
         [InlineData("")]
+        [InlineData(" ")]
         [InlineData(null)]
         public static void Ctor_String(string customDataType)
         {
@@ -75,7 +76,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             Assert.Equal(DataType.Custom, attribute.DataType);
             Assert.Equal(customDataType, attribute.CustomDataType);
 
-            if (string.IsNullOrEmpty(customDataType))
+            if (string.IsNullOrWhiteSpace(customDataType))
             {
                 Assert.Throws<InvalidOperationException>(() => attribute.GetDataTypeName());
                 Assert.Throws<InvalidOperationException>(() => attribute.Validate(new object(), s_testValidationContext));


### PR DESCRIPTION
EnsureValidDataType should reject whitespaces in DataTypeAttribute.CustomDataType property because it is mandatory and it does not make sense that the property is whitespaces.
Modify Ctor_String(string customDataType) test to validate whitespaces adding new InlineData.

Fix #4465