### PR TITLE
Revert SslStream.WriteAsync, change SslStream to use innerStream.Read/WriteAsync

### DIFF
--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -176,7 +176,6 @@ namespace System.Net.Security
 #endif
         public void Write(byte[] buffer) { }
         public override void Write(byte[] buffer, int offset, int count) { }
-        public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
 }
 namespace System.Security.Authentication

--- a/src/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
@@ -575,7 +575,7 @@ namespace System.Net.Security
 
                 if (!_negoState.CanGetSecureStream)
                 {
-                    return InnerStream.BeginRead(buffer, offset, count, asyncCallback, asyncState);
+                    return TaskToApm.Begin(InnerStream.ReadAsync(buffer, offset, count), asyncCallback, asyncState);
                 }
 
                 BufferAsyncResult bufferResult = new BufferAsyncResult(this, buffer, offset, count, asyncState, asyncCallback);
@@ -597,7 +597,7 @@ namespace System.Net.Security
 
                 if (!_negoState.CanGetSecureStream)
                 {
-                    return InnerStream.EndRead(asyncResult);
+                    return TaskToApm.End<int>(asyncResult);
                 }
 
 
@@ -647,7 +647,7 @@ namespace System.Net.Security
 
                 if (!_negoState.CanGetSecureStream)
                 {
-                    return InnerStream.BeginWrite(buffer, offset, count, asyncCallback, asyncState);
+                    return TaskToApm.Begin(InnerStream.WriteAsync(buffer, offset, count), asyncCallback, asyncState);
                 }
 
                 BufferAsyncResult bufferResult = new BufferAsyncResult(this, buffer, offset, count, asyncState, asyncCallback);
@@ -670,7 +670,7 @@ namespace System.Net.Security
 
                 if (!_negoState.CanGetSecureStream)
                 {
-                    InnerStream.EndWrite(asyncResult);
+                    TaskToApm.End(asyncResult);
                     return;
                 }
 
@@ -705,68 +705,6 @@ namespace System.Net.Security
 #if DEBUG
             }
 #endif
-        }
-
-        // ReadAsync - provide async read functionality.
-        // 
-        // This method provides async read functionality. All we do is
-        // call through to the Begin/EndRead methods.
-        // 
-        // Input:
-        // 
-        //     buffer            - Buffer to read into.
-        //     offset            - Offset into the buffer where we're to read.
-        //     size              - Number of bytes to read.
-        //     cancellationToken - Token used to request cancellation of the operation
-        // 
-        // Returns:
-        // 
-        //     A Task<int> representing the read.
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int size, CancellationToken cancellationToken)
-        {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return Task.FromCanceled<int>(cancellationToken);
-            }
-
-            return Task.Factory.FromAsync(
-                (bufferArg, offsetArg, sizeArg, callback, state) => ((NegotiateStream)state).BeginRead(bufferArg, offsetArg, sizeArg, callback, state),
-                iar => ((NegotiateStream)iar.AsyncState).EndRead(iar),
-                buffer,
-                offset,
-                size,
-                this);
-        }
-
-        // WriteAsync - provide async write functionality.
-        // 
-        // This method provides async write functionality. All we do is
-        // call through to the Begin/EndWrite methods.
-        // 
-        // Input:
-        // 
-        //     buffer  - Buffer to write into.
-        //     offset  - Offset into the buffer where we're to write.
-        //     size    - Number of bytes to write.
-        //     cancellationToken - Token used to request cancellation of the operation
-        // 
-        // Returns:
-        // 
-        //     A Task representing the write.
-        public override Task WriteAsync(byte[] buffer, int offset, int size, CancellationToken cancellationToken)
-        {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return Task.FromCanceled<int>(cancellationToken);
-            }
-
-            return Task.Factory.FromAsync(
-                (bufferArg, offsetArg, sizeArg, callback, state) => ((NegotiateStream)state).BeginWrite(bufferArg, offsetArg, sizeArg, callback, state),
-                iar => ((NegotiateStream)iar.AsyncState).EndWrite(iar),
-                buffer,
-                offset,
-                size,
-                this);
         }
     }
 }

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -527,11 +527,6 @@ namespace System.Net.Security
             _sslState.SecureStream.Write(buffer, offset, count);
         }
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            return _sslState.SecureStream.WriteAsync(buffer, offset, count, cancellationToken);
-        }
-
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
         {
             return _sslState.SecureStream.BeginRead(buffer, offset, count, asyncCallback, asyncState);

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamInternal.cs
@@ -5,7 +5,6 @@
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace System.Net.Security
 {
@@ -31,8 +30,6 @@ namespace System.Net.Security
         private AsyncProtocolRequest _readProtocolRequest; // cached, reusable AsyncProtocolRequest used for read operations
         private AsyncProtocolRequest _writeProtocolRequest; // cached, reusable AsyncProtocolRequest used for write operations
 
-        private SemaphoreSlim _asyncWriteActiveSemaphore;
-
         // Never updated directly, special properties are used.  This is the read buffer.
         private byte[] _internalBuffer;
         private bool _internalBufferFromPinnableCache;
@@ -54,13 +51,6 @@ namespace System.Net.Security
 
             _sslState = sslState;
             _reader = new FixedSizeReader(_sslState.InnerStream);
-        }
-
-        internal SemaphoreSlim EnsureAsyncActiveWriteSemaphoreInitialized()
-        {
-            // Lazily-initialize _asyncWriteActiveSemaphore.  As we're never accessing the SemaphoreSlim's
-            // WaitHandle, we don't need to worry about Disposing it.
-            return LazyInitializer.EnsureInitialized(ref _asyncWriteActiveSemaphore, () => new SemaphoreSlim(1, 1));
         }
 
         // If we have a read buffer from the pinnable cache, return it.
@@ -139,55 +129,6 @@ namespace System.Net.Security
         internal void Write(byte[] buffer, int offset, int count)
         {
             ProcessWrite(buffer, offset, count, null);
-        }
-
-        internal Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            if (!_sslState.InnerStream.CanWrite) return Task.FromException(new NotSupportedException(SR.NotSupported_UnwritableStream));
-            // If cancellation was requested, bail early with an already completed task.
-            // Otherwise, return a task that represents the Begin/End methods.
-            return cancellationToken.IsCancellationRequested
-                        ? Task.FromCanceled(cancellationToken)
-                        : WriteAsyncImpl(buffer, offset, count, cancellationToken);
-        }
-
-        private async Task WriteAsyncImpl(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            var semaphore = EnsureAsyncActiveWriteSemaphoreInitialized();
-            await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-            InitiateWrite(buffer, offset, count, null);
-
-            bool failed = false;
-            try
-            {
-                await StartWritingAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
-
-                if (Interlocked.Exchange(ref _nestedWrite, 0) == 0)
-                {
-                    throw new InvalidOperationException(SR.Format(SR.net_io_invalidendcall, "WriteAsyncImpl"));
-                }
-            }
-            catch (Exception e)
-            {
-                _sslState.FinishWrite();
-
-                failed = true;
-                if (e is IOException)
-                {
-                    throw;
-                }
-
-                throw new IOException(SR.net_io_write, e);
-            }
-            finally
-            {
-                semaphore.Release();
-                if (failed)
-                {
-                    _nestedWrite = 0;
-                }
-            }
         }
 
         internal IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
@@ -404,7 +345,17 @@ namespace System.Net.Security
         //
         private void ProcessWrite(byte[] buffer, int offset, int count, LazyAsyncResult asyncResult)
         {
-            var asyncRequest = InitiateWrite(buffer, offset, count, asyncResult);
+            _sslState.CheckThrow(authSuccessCheck:true, shutdownCheck:true);
+            ValidateParameters(buffer, offset, count);
+
+            if (Interlocked.Exchange(ref _nestedWrite, 1) == 1)
+            {
+                throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, "Write", "write"));
+            }
+
+            // If this is an async operation, get the AsyncProtocolRequest to use.
+            // We do this only after we verify we're the sole write operation in flight.
+            AsyncProtocolRequest asyncRequest = GetOrCreateProtocolRequest(ref _writeProtocolRequest, asyncResult);
 
             bool failed = false;
 
@@ -431,22 +382,6 @@ namespace System.Net.Security
                     _nestedWrite = 0;
                 }
             }
-        }
-
-        private AsyncProtocolRequest InitiateWrite(byte[] buffer, int offset, int count, LazyAsyncResult asyncResult)
-        {
-            _sslState.CheckThrow(authSuccessCheck: true, shutdownCheck: true);
-            ValidateParameters(buffer, offset, count);
-
-            if (Interlocked.Exchange(ref _nestedWrite, 1) == 1)
-            {
-                throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, "Write", "write"));
-            }
-
-            // If this is an async operation, get the AsyncProtocolRequest to use.
-            // We do this only after we verify we're the sole write operation in flight.
-            AsyncProtocolRequest asyncRequest = GetOrCreateProtocolRequest(ref _writeProtocolRequest, asyncResult);
-            return asyncRequest;
         }
 
         private void StartWriting(byte[] buffer, int offset, int count, AsyncProtocolRequest asyncRequest)
@@ -553,81 +488,6 @@ namespace System.Net.Security
                 if (PinnableBufferCacheEventSource.Log.IsEnabled())
                 {
                     PinnableBufferCacheEventSource.Log.DebugMessage1("In System.Net._SslStream.StartWriting Freeing buffer.", this.GetHashCode());
-                }
-            }
-        }
-
-        private async Task StartWritingAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            // We loop to this method from the callback.
-            // If the last chunk was just completed from async callback (count < 0), we complete user request.
-            if (count >= 0 )
-            {
-                byte[] outBuffer = null;
-                if (_pinnableOutputBufferInUse == null)
-                {
-                    if (_pinnableOutputBuffer == null)
-                    {
-                        _pinnableOutputBuffer = s_PinnableWriteBufferCache.AllocateBuffer();
-                    }
-
-                    _pinnableOutputBufferInUse = buffer;
-                    outBuffer = _pinnableOutputBuffer;
-                    if (PinnableBufferCacheEventSource.Log.IsEnabled())
-                    {
-                        PinnableBufferCacheEventSource.Log.DebugMessage3("In System.Net._SslStream.StartWritingAsync Trying Pinnable", this.GetHashCode(), count, PinnableBufferCacheEventSource.AddressOfByteArray(outBuffer));
-                    }
-                }
-                else
-                {
-                    if (PinnableBufferCacheEventSource.Log.IsEnabled())
-                    {
-                        PinnableBufferCacheEventSource.Log.DebugMessage2("In System.Net._SslStream.StartWritingAsync BufferInUse", this.GetHashCode(), count);
-                    }
-                }
-
-                do
-                {
-                    if (count == 0 && !SslStreamPal.CanEncryptEmptyMessage)
-                    {
-                        // If it's an empty message and the PAL doesn't support that,
-                        // we're done.
-                        break;
-                    }
-
-                    int chunkBytes = Math.Min(count, _sslState.MaxDataSize);
-                    int encryptedBytes;
-                    SecurityStatusPal status = _sslState.EncryptData(buffer, offset, chunkBytes, ref outBuffer, out encryptedBytes);
-                    if (status.ErrorCode != SecurityStatusPalErrorCode.OK)
-                    {
-                        // Re-handshake status is not supported.
-                        ProtocolToken message = new ProtocolToken(null, status);
-                        throw new IOException(SR.net_io_encrypt, message.GetException());
-                    }
-
-                    if (PinnableBufferCacheEventSource.Log.IsEnabled())
-                    {
-                        PinnableBufferCacheEventSource.Log.DebugMessage3("In System.Net._SslStream.StartWritingAsync Got Encrypted Buffer",
-                            this.GetHashCode(), encryptedBytes, PinnableBufferCacheEventSource.AddressOfByteArray(outBuffer));
-                    }
-
-                    await _sslState.InnerStream.WriteAsync(outBuffer, 0, encryptedBytes, cancellationToken);
-
-                    offset += chunkBytes;
-                    count -= chunkBytes;
-
-                    // Release write IO slot.
-                    _sslState.FinishWrite();
-
-                } while (count != 0);
-            }
-
-            if (buffer == _pinnableOutputBufferInUse)
-            {
-                _pinnableOutputBufferInUse = null;
-                if (PinnableBufferCacheEventSource.Log.IsEnabled())
-                {
-                    PinnableBufferCacheEventSource.Log.DebugMessage1("In System.Net._SslStream.StartWritingAsync Freeing buffer.", this.GetHashCode());
                 }
             }
         }

--- a/src/System.Net.Security/src/System/Net/StreamFramer.cs
+++ b/src/System.Net.Security/src/System/Net/StreamFramer.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Globalization;
+using System.Threading.Tasks;
 
 namespace System.Net
 {
@@ -136,7 +137,7 @@ namespace System.Net
                                                                    _readHeaderBuffer, 0,
                                                                    _readHeaderBuffer.Length);
 
-            IAsyncResult result = _transport.BeginRead(_readHeaderBuffer, 0, _readHeaderBuffer.Length,
+            IAsyncResult result = TaskToApm.Begin(_transport.ReadAsync(_readHeaderBuffer, 0, _readHeaderBuffer.Length),
                 _readFrameCallback, workerResult);
 
             if (result.CompletedSynchronously)
@@ -199,7 +200,7 @@ namespace System.Net
 
                 WorkerAsyncResult workerResult = (WorkerAsyncResult)transportResult.AsyncState;
 
-                int bytesRead = _transport.EndRead(transportResult);
+                int bytesRead = TaskToApm.End<int>(transportResult);
                 workerResult.Offset += bytesRead;
 
                 if (!(workerResult.Offset <= workerResult.End))
@@ -260,7 +261,7 @@ namespace System.Net
                         workerResult.End = frame.Length;
                         workerResult.Offset = 0;
 
-                        // Transport.BeginRead below will pickup those changes.
+                        // Transport.ReadAsync below will pickup those changes.
                     }
                     else
                     {
@@ -271,7 +272,7 @@ namespace System.Net
                 }
 
                 // This means we need more data to complete the data block.
-                transportResult = _transport.BeginRead(workerResult.Buffer, workerResult.Offset, workerResult.End - workerResult.Offset,
+                transportResult = TaskToApm.Begin(_transport.ReadAsync(workerResult.Buffer, workerResult.Offset, workerResult.End - workerResult.Offset),
                                             _readFrameCallback, workerResult);
             } while (transportResult.CompletedSynchronously);
         }
@@ -352,7 +353,7 @@ namespace System.Net
 
             if (message.Length == 0)
             {
-                return _transport.BeginWrite(_writeHeaderBuffer, 0, _writeHeaderBuffer.Length,
+                return TaskToApm.Begin(_transport.WriteAsync(_writeHeaderBuffer, 0, _writeHeaderBuffer.Length),
                                                    asyncCallback, stateObject);
             }
 
@@ -361,7 +362,7 @@ namespace System.Net
                                                                    message, 0, message.Length);
             
             // Charge the first:
-            IAsyncResult result = _transport.BeginWrite(_writeHeaderBuffer, 0, _writeHeaderBuffer.Length,
+            IAsyncResult result = TaskToApm.Begin(_transport.WriteAsync(_writeHeaderBuffer, 0, _writeHeaderBuffer.Length),
                                  _beginWriteCallback, workerResult);
 
             if (result.CompletedSynchronously)
@@ -412,7 +413,7 @@ namespace System.Net
                 WorkerAsyncResult workerResult = (WorkerAsyncResult)transportResult.AsyncState;
 
                 // First, complete the previous portion write.
-                _transport.EndWrite(transportResult);
+                TaskToApm.End(transportResult);
 
                 // Check on exit criterion.
                 if (workerResult.Offset == workerResult.End)
@@ -425,7 +426,7 @@ namespace System.Net
                 workerResult.Offset = workerResult.End;
 
                 // Write next portion (frame body) using Async IO.
-                transportResult = _transport.BeginWrite(workerResult.Buffer, 0, workerResult.End,
+                transportResult = TaskToApm.Begin(_transport.WriteAsync(workerResult.Buffer, 0, workerResult.End),
                                             _beginWriteCallback, workerResult);
             }
             while (transportResult.CompletedSynchronously);
@@ -454,7 +455,7 @@ namespace System.Net
             }
             else
             {
-                _transport.EndWrite(asyncResult);
+                TaskToApm.End(asyncResult);
             }
         }
     }


### PR DESCRIPTION
First commit reverts the addition of SslStream.WriteAsync from #14771.  We still want to override it, but the implementation needs more thought.

Second commit fixes #14698. In .NET Core 1.x, SslStream's usage of Begin/EndRead/Write was actually using extension methods that just used TaskToApm.Begin/End with Read/WriteAsync.  When the base Stream's Begin/EndRead/Write methods were added back, SslStream's usage of these methods started binding to the base methods, such that it was no longer using the inner stream's Read/WriteAsync.

This change explicitly switches all of those calls (for both SslStream and NegotiateStream) to use Read/WriteAsync.  A better solution is to actually add SslStream.Read/WriteAsync overrides that use async/await and tasks all the way down, rather than going back and forth between Tasks and APM, but that is a more complicated work item.  This addressesses the immediate need (problems related to deadlocks on SslStream when read and writes are issued to run concurrently on the same stream) and can be undone or augmented subsequently when a better solution is available.

This is at least as good performance-wise as what we had in .NET Core 1.x, and in some cases is a bit better, as we can avoid creating the IAsyncResult wrapper in some cases if the returned task is already completed.

cc: @cipop, @benaadams, @cesarbs 