### PR TITLE
Remove Debug Failures from FSW Win32

### DIFF
--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
@@ -316,28 +316,19 @@ namespace System.IO
                 // If the action is RENAMED_FROM, save the name of the file
                 if (action == Interop.Kernel32.FileOperations.FILE_ACTION_RENAMED_OLD_NAME)
                 {
-                    Debug.Assert(oldName == null, "Two FILE_ACTION_RENAMED_OLD_NAME in a row!  [" + oldName + "], [ " + name + "]");
                     oldName = name;
                 }
                 else if (action == Interop.Kernel32.FileOperations.FILE_ACTION_RENAMED_NEW_NAME)
                 {
-                    if (oldName != null)
-                    {
-                        NotifyRenameEventArgs(WatcherChangeTypes.Renamed, name, oldName);
-                        oldName = null;
-                    }
-                    else
-                    {
-                        Debug.Fail("FILE_ACTION_RENAMED_NEW_NAME with no old name! [ " + name + "]");
-                        NotifyRenameEventArgs(WatcherChangeTypes.Renamed, name, oldName);
-                        oldName = null;
-                    }
+                    // oldName may be null here if we received a FILE_ACTION_RENAMED_NEW_NAME with no old name
+                    NotifyRenameEventArgs(WatcherChangeTypes.Renamed, name, oldName);
+                    oldName = null;
                 }
                 else
                 {
                     if (oldName != null)
                     {
-                        Debug.Fail("Previous FILE_ACTION_RENAMED_OLD_NAME with no new name!  [" + oldName + "]");
+                        // Previous FILE_ACTION_RENAMED_OLD_NAME with no new name
                         NotifyRenameEventArgs(WatcherChangeTypes.Renamed, null, oldName);
                         oldName = null;
                     }
@@ -364,7 +355,7 @@ namespace System.IO
 
             if (oldName != null)
             {
-                Debug.Fail("FILE_ACTION_RENAMED_OLD_NAME with no new name!  [" + oldName + "]");
+                // Previous FILE_ACTION_RENAMED_OLD_NAME with no new name
                 NotifyRenameEventArgs(WatcherChangeTypes.Renamed, null, oldName);
                 oldName = null;
             }


### PR DESCRIPTION
There are some Debug.Fail calls in the win32 FileSystemWatcher that can be hit in normal operation sometimes. We've already established a behavior for these scenarios (use null as the old/new names when they're not available), so we shouldn't be debug asserting that they're not possible.

resolves https://github.com/dotnet/corefx/issues/14701