### PR TITLE
Fix XLinqTests.TreeManipulation outerloop failures

### DIFF
--- a/src/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
@@ -869,7 +869,7 @@ namespace System.Xml.Linq
             }
             if (r.ReadState != ReadState.Interactive) throw new InvalidOperationException(SR.InvalidOperation_ExpectedInteractive);
 
-            ContentReader cr = new ContentReader(this);
+            ContentReader cr = new ContentReader(this, r, o);
             while (cr.ReadContentFrom(this, r, o) && r.Read()) ;
         }
 
@@ -894,7 +894,7 @@ namespace System.Xml.Linq
             }
             if (r.ReadState != ReadState.Interactive) throw new InvalidOperationException(SR.InvalidOperation_ExpectedInteractive);
  
-            ContentReader cr = new ContentReader(this);
+            ContentReader cr = new ContentReader(this, r, o);
             do
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/System.Private.Xml.Linq/tests/TreeManipulation/LoadFromStream.cs
+++ b/src/System.Private.Xml.Linq/tests/TreeManipulation/LoadFromStream.cs
@@ -41,15 +41,13 @@ namespace XLinqTests
             AddChild(new TestVariation(LoadOptionsPWS) { Attribute = new VariationAttribute("XDocument.Load(), Load options, preserveWhitespace, Stream") { Param = "Stream", Priority = 0 } });
             AddChild(new TestVariation(LoadOptionsPWS) { Attribute = new VariationAttribute("XDocument.Load(), Load options, preserveWhitespace, Uri") { Param = "Uri", Priority = 0 } });
             AddChild(new TestVariation(LoadOptionsBU) { Attribute = new VariationAttribute("XDocument.Load(), Load options, BaseUri, Uri") { Param = "Uri", Priority = 0 } });
-            // TODO [ActiveIssue(14856)]: Re-enable when fixed
-            //AddChild(new TestVariation(LoadOptionsLI) { Attribute = new VariationAttribute("XDocument.Load(), Load options, LineInfo, Uri") { Param = "Uri", Priority = 0 } });
-            //AddChild(new TestVariation(LoadOptionsLI) { Attribute = new VariationAttribute("XDocument.Load(), Load options, LineInfo, Stream") { Param = "Stream", Priority = 0 } });
+            AddChild(new TestVariation(LoadOptionsLI) { Attribute = new VariationAttribute("XDocument.Load(), Load options, LineInfo, Uri") { Param = "Uri", Priority = 0 } });
+            AddChild(new TestVariation(LoadOptionsLI) { Attribute = new VariationAttribute("XDocument.Load(), Load options, LineInfo, Stream") { Param = "Stream", Priority = 0 } });
             AddChild(new TestVariation(XE_LoadOptionsPWS) { Attribute = new VariationAttribute("XElement.Load(), Load options, preserveWhitespace, Uri") { Param = "Uri", Priority = 0 } });
             AddChild(new TestVariation(XE_LoadOptionsPWS) { Attribute = new VariationAttribute("XElement.Load(), Load options, preserveWhitespace, Stream") { Param = "Stream", Priority = 0 } });
             AddChild(new TestVariation(XE_LoadOptionsBU) { Attribute = new VariationAttribute("XElement.Load(), Load options, BaseUri, Uri") { Param = "Uri", Priority = 0 } });
-            // TODO [ActiveIssue(14856)]: Re-enable when fixed
-            //AddChild(new TestVariation(XE_LoadOptionsLI) { Attribute = new VariationAttribute("XElement.Load(), Load options, LineInfo, Stream") { Param = "Stream", Priority = 0 } });
-            //AddChild(new TestVariation(XE_LoadOptionsLI) { Attribute = new VariationAttribute("XElement.Load(), Load options, LineInfo, Uri") { Param = "Uri", Priority = 0 } });
+            AddChild(new TestVariation(XE_LoadOptionsLI) { Attribute = new VariationAttribute("XElement.Load(), Load options, LineInfo, Stream") { Param = "Stream", Priority = 0 } });
+            AddChild(new TestVariation(XE_LoadOptionsLI) { Attribute = new VariationAttribute("XElement.Load(), Load options, LineInfo, Uri") { Param = "Uri", Priority = 0 } });
             AddChild(new TestVariation(SaveOptionsTests) { Attribute = new VariationAttribute("XDocument.Save(), SaveOptions.DisableFormatting | SaveOptions.OmitDuplicateNamespaces") { Param = 3, Priority = 1 } });
             AddChild(new TestVariation(SaveOptionsTests) { Attribute = new VariationAttribute("XDocument.Save(), SaveOptions.OmitDuplicateNamespaces") { Param = 2, Priority = 1 } });
             AddChild(new TestVariation(SaveOptionsTests) { Attribute = new VariationAttribute("XDocument.Save(), SaveOptions.None") { Param = 0, Priority = 1 } });
@@ -437,7 +435,7 @@ namespace XLinqTests
                         return XElement.Load(s, lo);
                     }
                 default:
-                    throw new TestFailedException("TEST FAILED: don't know how to create XDocument");
+                    throw new TestFailedException("TEST FAILED: don't know how to create XElement");
             }
         }
         #endregion


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/14856. The bug was introduced after https://github.com/dotnet/corefx/commit/b119ec518b1ccc13e420862ff68dfbbd3bfee28e. The problem was in case of `loadOption != LoadOptions.None`, wrong constructor of `ContentReader` was called, which did not set LineInfo as expected.

cc: @stephentoub @danmosemsft 