### PR TITLE
Issue #14833 - Disable build for fast span

### DIFF
--- a/src/System.Memory/src/System.Memory.builds
+++ b/src/System.Memory/src/System.Memory.builds
@@ -3,9 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Memory.csproj" />
-    <Project Include="System.Memory.csproj">
-      <TargetGroup>netcoreapp1.1</TargetGroup>
-    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Memory/tests/System.Memory.Tests.builds
+++ b/src/System.Memory/tests/System.Memory.Tests.builds
@@ -4,7 +4,7 @@
   <ItemGroup>
     <Project Include="System.Memory.Tests.csproj">
       <OSGroup>Windows_NT</OSGroup>
-      <TestTFMs>netcore50;netcoreapp1.0;net46</TestTFMs>
+      <TestTFMs>netcore50;netcoreapp1.0;net46;netcoreapp1.1</TestTFMs>
     </Project>
     <!-- Add these tests back for fast span once the GC correctness work is done.
     <Project Include="System.Memory.Tests.csproj">


### PR DESCRIPTION
Temporarily disable fast span within the package until JIT work is done.
The package should contain only slow span for now.
Related to issue #14833 