### PR TITLE
[dev/eng] Better OSEnvironment detection

### DIFF
--- a/Tools-Override/Build.Common.props
+++ b/Tools-Override/Build.Common.props
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- 
+     This file will contain all of the common properties from most repos. The intention is to only have 
+     repo specific properties inside the repos, and move to this file everything that is common.
+  -->
+
+  <!--
+    Import the reference assembly props
+    
+      Sets Properties:
+        IsReferenceAssembly - Set if the project is in the ref assm path
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)ReferenceAssemblies.props" Condition="'$(ExcludeReferenceAssembliesImport)'!='true'" />
+
+  <PropertyGroup>
+    <CompilerResponseFile Condition="'$(CheckSumSHA256)'!='false'">$(MSBuildThisFileDirectory)checksum.rsp</CompilerResponseFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GetNuGetPackageVersionsDependsOn>CreateVersionFileDuringBuild</GetNuGetPackageVersionsDependsOn>
+  </PropertyGroup>
+
+  <!-- Common BuildTools properties -->
+  <PropertyGroup>
+    <ToolRuntimePath Condition="'$(ToolRuntimePath)'=='' and '$(ProjectDir)'==''">$(MSBuildThisFileDirectory)</ToolRuntimePath>
+    <ToolRuntimePath Condition="'$(ToolRuntimePath)'=='' and '$(ProjectDir)'!=''">$(ProjectDir)Tools/</ToolRuntimePath>
+    <ToolsDir Condition="'$(ToolsDir)'==''">$(MSBuildThisFileDirectory)</ToolsDir>
+    <DotnetCliPath Condition="'$(DotnetCliPath)'==''">$(ToolRuntimePath)dotnetcli/</DotnetCliPath>
+    <OverrideToolHost>$(DotnetCliPath)dotnet</OverrideToolHost>
+    <BuildToolsTaskDir Condition="'$(BuildToolsTargets45)' == 'true'">$(ToolsDir)net45/</BuildToolsTaskDir>
+    <BuildToolsTaskDir Condition="'$(BuildToolsTaskDir)'==''">$(ToolsDir)</BuildToolsTaskDir>
+    <UseRoslynCompilers Condition="'$(UseRoslynCompilers)'=='' and '$(OSEnvironment)'!='Windows_NT'">false</UseRoslynCompilers>
+    <UseSharedCompilation Condition="'$(UseSharedCompilation)' == '' and '$(OSEnvironment)' == 'Windows_NT' and '$(UseRoslynCompilers)' != 'false'">true</UseSharedCompilation>
+  </PropertyGroup>
+  
+  <!-- Setting IsTestProject prior to Build.Common.targets -->
+  <PropertyGroup>
+    <IsTestProject Condition="'$(IsTestProject)'=='' And $(MSBuildProjectName.EndsWith('.tests', StringComparison.OrdinalIgnoreCase))">true</IsTestProject>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)Roslyn.Common.props" />
+
+  <!--
+    import the MicroBuild boot-strapper props (only relevant for shipping binaries)
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)MicroBuild.Core.props" Condition="'$(IsTestProject)'!='true' AND Exists('$(MSBuildThisFileDirectory)MicroBuild.Core.props')" />
+</Project>

--- a/Tools-Override/Build.Common.props
+++ b/Tools-Override/Build.Common.props
@@ -21,6 +21,14 @@
     <GetNuGetPackageVersionsDependsOn>CreateVersionFileDuringBuild</GetNuGetPackageVersionsDependsOn>
   </PropertyGroup>
 
+  <!-- Platform detection -->
+  <PropertyGroup>
+    <OsEnvironment Condition="'$(OsEnvironment)'=='' AND '$(OS)'=='Unix' AND Exists('/Applications')">OSX</OsEnvironment>
+    <OsEnvironment Condition="'$(OsEnvironment)'=='' AND '$(OS)'=='Unix'">Linux</OsEnvironment>
+    <OsEnvironment Condition="'$(OsEnvironment)'==''">$(OS)</OsEnvironment>
+    <RunningOnUnix Condition="'$(OS)' != 'Windows_NT'">true</RunningOnUnix>
+  </PropertyGroup>
+
   <!-- Common BuildTools properties -->
   <PropertyGroup>
     <ToolRuntimePath Condition="'$(ToolRuntimePath)'=='' and '$(ProjectDir)'==''">$(MSBuildThisFileDirectory)</ToolRuntimePath>
@@ -28,10 +36,10 @@
     <ToolsDir Condition="'$(ToolsDir)'==''">$(MSBuildThisFileDirectory)</ToolsDir>
     <DotnetCliPath Condition="'$(DotnetCliPath)'==''">$(ToolRuntimePath)dotnetcli/</DotnetCliPath>
     <OverrideToolHost>$(DotnetCliPath)dotnet</OverrideToolHost>
-    <BuildToolsTaskDir Condition="'$(BuildToolsTargets45)' == 'true'">$(ToolsDir)net45/</BuildToolsTaskDir>
-    <BuildToolsTaskDir Condition="'$(BuildToolsTaskDir)'==''">$(ToolsDir)</BuildToolsTaskDir>
-    <UseRoslynCompilers Condition="'$(UseRoslynCompilers)'=='' and '$(OSEnvironment)'!='Windows_NT'">false</UseRoslynCompilers>
-    <UseSharedCompilation Condition="'$(UseSharedCompilation)' == '' and '$(OSEnvironment)' == 'Windows_NT' and '$(UseRoslynCompilers)' != 'false'">true</UseSharedCompilation>
+    <BuildToolsTaskDir Condition="'$(MSBuildRuntimeType)'!='core'">$(ToolsDir)net45/</BuildToolsTaskDir>
+    <BuildToolsTaskDir Condition="'$(MSBuildRuntimeType)'=='core'">$(ToolsDir)</BuildToolsTaskDir>
+    <UseRoslynCompilers Condition="'$(UseRoslynCompilers)'=='' and '$(RunningOnUnix)'=='true'">false</UseRoslynCompilers>
+    <UseSharedCompilation Condition="'$(UseSharedCompilation)' == '' and '$(RunningOnUnix)' != 'true' and '$(UseRoslynCompilers)' != 'false'">true</UseSharedCompilation>
   </PropertyGroup>
   
   <!-- Setting IsTestProject prior to Build.Common.targets -->

--- a/Tools-Override/Roslyn.Common.props
+++ b/Tools-Override/Roslyn.Common.props
@@ -6,13 +6,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RoslynPropsFile Condition="'$(RoslynPropsFile)' == '' and '$(OS)' != 'Unix'">$(ToolRuntimePath)/net45/roslyn/build/Microsoft.Net.Compilers.props</RoslynPropsFile>
+    <RoslynPropsFile Condition="'$(RoslynPropsFile)' == '' and '$(RunningOnUnix)' != 'true'">$(ToolRuntimePath)/net45/roslyn/build/Microsoft.Net.Compilers.props</RoslynPropsFile>
   </PropertyGroup>
 
   <!--
     On Unix we always use a version of Roslyn we restore from NuGet and we have to work around some known issues.
   -->
-  <PropertyGroup Condition="'$(RoslynPropsFile)' == '' and '$(OS)'=='Unix'">
+  <PropertyGroup Condition="'$(RoslynPropsFile)' == '' and '$(RunningOnUnix)' == 'true'">
     <RoslynPackageDir>$(PackagesDir)/$(RoslynPackageName).$(RoslynVersion)/</RoslynPackageDir>
     <RoslynPropsFile>$(RoslynPackageDir)build/$(RoslynPackageName).props</RoslynPropsFile>
 

--- a/Tools-Override/Roslyn.Common.props
+++ b/Tools-Override/Roslyn.Common.props
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <RoslynVersion>2.0.0-beta3</RoslynVersion>
+    <RoslynPackageName>Microsoft.Net.Compilers</RoslynPackageName>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <RoslynPropsFile Condition="'$(RoslynPropsFile)' == '' and '$(OS)' != 'Unix'">$(ToolRuntimePath)/net45/roslyn/build/Microsoft.Net.Compilers.props</RoslynPropsFile>
+  </PropertyGroup>
+
+  <!--
+    On Unix we always use a version of Roslyn we restore from NuGet and we have to work around some known issues.
+  -->
+  <PropertyGroup Condition="'$(RoslynPropsFile)' == '' and '$(OS)'=='Unix'">
+    <RoslynPackageDir>$(PackagesDir)/$(RoslynPackageName).$(RoslynVersion)/</RoslynPackageDir>
+    <RoslynPropsFile>$(RoslynPackageDir)build/$(RoslynPackageName).props</RoslynPropsFile>
+
+    <!--
+      Portable PDBs are now supported in Linux and OSX with .Net Core MSBuild.
+    -->
+    <DebugType>Portable</DebugType>
+
+    <!--
+      Delay signing with the ECMA key currently doesn't work.
+      https://github.com/dotnet/roslyn/issues/2444
+    -->
+    <UseECMAKey>false</UseECMAKey>
+
+    <!--
+      Full signing with Open key doesn't work with Portable Csc.
+      https://github.com/dotnet/roslyn/issues/8210
+    -->
+    <UseOpenKey>false</UseOpenKey>
+
+    <!--
+      Mono currently doesn't include VB targets for portable, notably /lib/mono/xbuild/Microsoft/Portable/v4.5/Microsoft.Portable.VisualBasic.targets.
+      Fixed in https://github.com/mono/mono/pull/1726.
+    -->
+    <IncludeVbProjects>false</IncludeVbProjects>
+  </PropertyGroup>
+  
+</Project>

--- a/dir.props
+++ b/dir.props
@@ -9,12 +9,9 @@
     <MinorVersion>6</MinorVersion>
   </PropertyGroup>
 
-  <!--
-    $(OS) is set to Unix/Windows_NT. This comes from an environment variable on Windows and MSBuild on Unix.
-  -->
   <PropertyGroup>
-    <!-- Temp change to make OS X build behave as a Linux build -->
-    <OsEnvironment Condition="'$(OsEnvironment)'=='' AND '$(OS)'=='OSX'">Unix</OsEnvironment>
+    <OsEnvironment Condition="'$(OsEnvironment)'=='' AND '$(OS)'=='Unix' AND Exists('/Applications')">OSX</OsEnvironment>
+    <OsEnvironment Condition="'$(OsEnvironment)'=='' AND '$(OS)'=='Unix'">Linux</OsEnvironment>
     <OsEnvironment Condition="'$(OsEnvironment)'==''">$(OS)</OsEnvironment>
   </PropertyGroup>
 
@@ -125,10 +122,10 @@
 
   <PropertyGroup>
     <DnxPackageDir Condition="'$(DnxPackageDir)'==''">$(PackagesDir)/$(DnxPackageName)/</DnxPackageDir>
-    <DnuToolPath Condition="'$(DnuToolPath)'=='' and '$(OsEnvironment)'!='Unix'">$(DnxPackageDir)/bin/dnu.cmd</DnuToolPath>
-    <DnuToolPath Condition="'$(DnuToolPath)'=='' and '$(OsEnvironment)'=='Unix'">$(DnxPackageDir)/bin/dnu</DnuToolPath>
-    <DotnetToolCommand Condition="'$(DotnetToolCommand)' == '' and '$(OsEnvironment)'!='Unix'">$(DotnetCliPath)dotnet.exe</DotnetToolCommand>
-    <DotnetToolCommand Condition="'$(DotnetToolCommand)' == '' and '$(OsEnvironment)'=='Unix'">$(DotnetCliPath)dotnet</DotnetToolCommand>
+    <DnuToolPath Condition="'$(DnuToolPath)'=='' and '$(OS)'!='Unix'">$(DnxPackageDir)/bin/dnu.cmd</DnuToolPath>
+    <DnuToolPath Condition="'$(DnuToolPath)'=='' and '$(OS)'=='Unix'">$(DnxPackageDir)/bin/dnu</DnuToolPath>
+    <DotnetToolCommand Condition="'$(DotnetToolCommand)' == '' and '$(OS)'!='Unix'">$(DotnetCliPath)dotnet.exe</DotnetToolCommand>
+    <DotnetToolCommand Condition="'$(DotnetToolCommand)' == '' and '$(OS)'=='Unix'">$(DotnetCliPath)dotnet</DotnetToolCommand>
     <DnuToolPath>$(DotnetToolCommand)</DnuToolPath>
 
     <DnuRestoreSource>@(DnuSourceList -> '--source %(Identity)', ' ')</DnuRestoreSource>
@@ -151,7 +148,7 @@
 
   <PropertyGroup>
     <ArchGroup Condition="'$(ArchGroup)'==''">x64</ArchGroup>
-    <BuildConfiguration_OSGroup>$(OS)</BuildConfiguration_OSGroup>
+    <BuildConfiguration_OSGroup>$(OSEnvironment)</BuildConfiguration_OSGroup>
     <BuildConfiguration_OSGroup Condition="'$(OSGroup)' != ''">$(OSGroup)</BuildConfiguration_OSGroup>
     <BuildConfiguration_ConfigurationGroup>Debug</BuildConfiguration_ConfigurationGroup>
     <BuildConfiguration_ConfigurationGroup Condition="'$(ConfigurationGroup)' != ''">$(ConfigurationGroup)</BuildConfiguration_ConfigurationGroup>
@@ -269,6 +266,6 @@
   </PropertyGroup>
 
   <!-- Use Roslyn Compilers to build -->
-  <Import Project="$(RoslynPropsFile)" Condition="'$(OSEnvironment)'!='Unix' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false'" />
-  <Import Project="$(RoslynPropsFile)" Condition="'$(OSEnvironment)'=='Unix' and Exists('$(RoslynPropsFile)')" />
+  <Import Project="$(RoslynPropsFile)" Condition="'$(OS)'!='Unix' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false'" />
+  <Import Project="$(RoslynPropsFile)" Condition="'$(OS)'=='Unix' and Exists('$(RoslynPropsFile)')" />
 </Project>

--- a/dir.props
+++ b/dir.props
@@ -9,25 +9,11 @@
     <MinorVersion>6</MinorVersion>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <OsEnvironment Condition="'$(OsEnvironment)'=='' AND '$(OS)'=='Unix' AND Exists('/Applications')">OSX</OsEnvironment>
-    <OsEnvironment Condition="'$(OsEnvironment)'=='' AND '$(OS)'=='Unix'">Linux</OsEnvironment>
-    <OsEnvironment Condition="'$(OsEnvironment)'==''">$(OS)</OsEnvironment>
-  </PropertyGroup>
-
   <Import Condition="Exists('$(MSBuildProjectDirectory)/Configurations.props')" Project="$(MSBuildProjectDirectory)/Configurations.props" />
-
-  <PropertyGroup>
-    <InputOSGroup Condition="'$(InputOSGroup)'==''">$(OSEnvironment)</InputOSGroup>
-  </PropertyGroup>
 
   <!-- Informs build tools to apply .NET Framework metadata if not a test project -->
   <PropertyGroup>
     <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <BuildToolsTargets45 Condition="'$(OsEnvironment)'=='Windows_NT'">true</BuildToolsTargets45>
   </PropertyGroup>
 
   <!-- Common repo directories -->
@@ -67,6 +53,11 @@
 
   <!-- Import Build tools common props file where repo-independent properties are found -->
   <Import Project="$(ToolsDir)Build.Common.props" Condition="Exists('$(ToolsDir)Build.Common.props')" />
+
+  <PropertyGroup>
+    <InputOSGroup Condition="'$(InputOSGroup)'==''">$(OSEnvironment)</InputOSGroup>
+    <BuildToolsTargets45 Condition="'$(OsEnvironment)'=='Windows_NT'">true</BuildToolsTargets45>
+  </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)targetingpacks.props" />
 
@@ -122,10 +113,10 @@
 
   <PropertyGroup>
     <DnxPackageDir Condition="'$(DnxPackageDir)'==''">$(PackagesDir)/$(DnxPackageName)/</DnxPackageDir>
-    <DnuToolPath Condition="'$(DnuToolPath)'=='' and '$(OS)'!='Unix'">$(DnxPackageDir)/bin/dnu.cmd</DnuToolPath>
-    <DnuToolPath Condition="'$(DnuToolPath)'=='' and '$(OS)'=='Unix'">$(DnxPackageDir)/bin/dnu</DnuToolPath>
-    <DotnetToolCommand Condition="'$(DotnetToolCommand)' == '' and '$(OS)'!='Unix'">$(DotnetCliPath)dotnet.exe</DotnetToolCommand>
-    <DotnetToolCommand Condition="'$(DotnetToolCommand)' == '' and '$(OS)'=='Unix'">$(DotnetCliPath)dotnet</DotnetToolCommand>
+    <DnuToolPath Condition="'$(DnuToolPath)'=='' and '$(RunningOnUnix)'!='true'">$(DnxPackageDir)/bin/dnu.cmd</DnuToolPath>
+    <DnuToolPath Condition="'$(DnuToolPath)'=='' and '$(RunningOnUnix)'=='true'">$(DnxPackageDir)/bin/dnu</DnuToolPath>
+    <DotnetToolCommand Condition="'$(DotnetToolCommand)' == '' and '$(RunningOnUnix)'!='true'">$(DotnetCliPath)dotnet.exe</DotnetToolCommand>
+    <DotnetToolCommand Condition="'$(DotnetToolCommand)' == '' and '$(RunningOnUnix)'=='true'">$(DotnetCliPath)dotnet</DotnetToolCommand>
     <DnuToolPath>$(DotnetToolCommand)</DnuToolPath>
 
     <DnuRestoreSource>@(DnuSourceList -> '--source %(Identity)', ' ')</DnuRestoreSource>
@@ -266,6 +257,6 @@
   </PropertyGroup>
 
   <!-- Use Roslyn Compilers to build -->
-  <Import Project="$(RoslynPropsFile)" Condition="'$(OS)'!='Unix' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false'" />
-  <Import Project="$(RoslynPropsFile)" Condition="'$(OS)'=='Unix' and Exists('$(RoslynPropsFile)')" />
+  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'!='true' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false'" />
+  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'=='true' and Exists('$(RoslynPropsFile)')" />
 </Project>

--- a/src/Tools/corefxTools.props
+++ b/src/Tools/corefxTools.props
@@ -5,7 +5,7 @@
     <!-- Temporarily enable local build of tools -->
     <CoreFxToolsDir Condition="'$(CoreFxToolsDir)' == ''">$(ToolsDir)</CoreFxToolsDir>
     <CoreFxDesktopToolsDir Condition="'$(CoreFxDesktopToolsDir)' == ''">$(ToolsDir)net45/</CoreFxDesktopToolsDir>
-    <CoreFxToolsTaskDir Condition="'$(CoreFxToolsTaskDir)' == '' AND '$(BuildToolsTargets45)' != 'true'">$(CoreFxToolsDir)</CoreFxToolsTaskDir>
-    <CoreFxToolsTaskDir Condition="'$(CoreFxToolsTaskDir)' == '' AND '$(BuildToolsTargets45)' == 'true'">$(CoreFxDesktopToolsDir)</CoreFxToolsTaskDir>
+    <CoreFxToolsTaskDir Condition="'$(CoreFxToolsTaskDir)' == '' AND '$(MSBuildRuntimeType)' == 'core'">$(CoreFxToolsDir)</CoreFxToolsTaskDir>
+    <CoreFxToolsTaskDir Condition="'$(CoreFxToolsTaskDir)' == '' AND '$(MSBuildRuntimeType)' != 'core'">$(CoreFxDesktopToolsDir)</CoreFxToolsTaskDir>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Right now, `$(OSEnvironment)` always defaults to "Unix" outside of Windows. Before this change, it essentially always has the exact same value as `$(OS)`. We have some logic in dir.props that is supposed to normalize the values to Windows/Unix, but .NET Core MSBuild already does that by default, so we aren't actually doing anything useful there anymore.

This change makes dir.props default `$(OSEnvironment)` to a value representing one of our actual OSGroups: Windows_NT, Linux, or OSX. Places expecting "Unix" have been changed to just use `$(OS)`. We differentiate between Linux and OSX by checking for the existence of an OSX-specific folder.

This allows you to simply run `msbuild /t:rebuildandtest <testproject>` and have it work, without needing to pass `/p:OSGroup=Linux/OSX` manually.

@joperezr @weshaggard 

Roslyn.Common.props is unchanged except `$(OSEnvironment)` has been changed to `$(OS)`.