### PR TITLE
Allow to force static linking on Windows in Release

### DIFF
--- a/src/Native/Windows/CMakeLists.txt
+++ b/src/Native/Windows/CMakeLists.txt
@@ -121,8 +121,11 @@ if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL "RELEASE")
     # Release build specific flags
     set(__LinkArgs "${__LinkArgs} /LTCG /OPT:REF /OPT:ICF /INCREMENTAL:NO")
     
-    # Force uCRT to be dynamically linked for Release build
-    set(__LinkArgs "${__LinkArgs} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
+    # Force uCRT to be dynamically linked for Release build (unless env variable CLR_CMAKE_WIN32_FORCE_STATIC_LINK is set to true)
+    set(CLR_CMAKE_WIN32_FORCE_STATIC_LINK $ENV{CLR_CMAKE_WIN32_FORCE_STATIC_LINK})
+    if(NOT CLR_CMAKE_WIN32_FORCE_STATIC_LINK)	
+      set(__LinkArgs "${__LinkArgs} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
+    endif()
     
     if ($ENV{__BuildArch} STREQUAL x86)
         set(__LinkArgs "${__LinkArgs} /SAFESEH")


### PR DESCRIPTION
This is related to the issue described on #14865 

This PR allows to build a release binaries on Windows without linking to the uCRT by setting the env variable `CLR_CMAKE_WIN32_FORCE_STATIC_LINK` to `true`

It is using the same variable as in the equivalent coreclr [PR#8807](https://github.com/dotnet/coreclr/pull/8807)