### PR TITLE
Replace API Set with Win32 DLL in tests

### DIFF
--- a/src/Microsoft.Win32.Primitives/tests/Win32Exception.cs
+++ b/src/Microsoft.Win32.Primitives/tests/Win32Exception.cs
@@ -16,7 +16,7 @@ namespace System.ComponentModel.Tests
         private const int ERROR_INSUFFICIENT_BUFFER = 0x7A;
         private const int FirstPassBufferSize = 256;
 
-        [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode, EntryPoint = "FormatMessageW", SetLastError = true, BestFitMapping = true)]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, EntryPoint = "FormatMessageW", SetLastError = true, BestFitMapping = true)]
         private static extern int FormatMessage(
             int dwFlags,
             IntPtr lpSource_mustBeNull,

--- a/src/System.Diagnostics.Process/tests/Interop.cs
+++ b/src/System.Diagnostics.Process/tests/Interop.cs
@@ -52,10 +52,10 @@ namespace System.Diagnostics.Tests
             public int Attributes;
         }
 
-        [DllImport("api-ms-win-core-memory-l1-1-1.dll")]
+        [DllImport("kernel32.dll")]
         public static extern bool GetProcessWorkingSetSizeEx(SafeProcessHandle hProcess, out IntPtr lpMinimumWorkingSetSize, out IntPtr lpMaximumWorkingSetSize, out uint flags);
         
-        [DllImport("api-ms-win-core-processthreads-l1-1-0.dll")]
+        [DllImport("kernel32.dll")]
         internal static extern int GetCurrentProcessId();
 
         [DllImport("libc")]
@@ -64,22 +64,22 @@ namespace System.Diagnostics.Tests
         [DllImport("libc")]
         internal static extern int getsid(int pid);
 
-        [DllImport("api-ms-win-core-processthreads-l1-1-0.dll")]
+        [DllImport("kernel32.dll")]
         internal static extern bool ProcessIdToSessionId(uint dwProcessId, out uint pSessionId);
 
-        [DllImport("api-ms-win-core-processthreads-l1-1-0.dll")]
+        [DllImport("kernel32.dll")]
         public static extern int GetProcessId(SafeProcessHandle nativeHandle);
 
-        [DllImport("api-ms-win-core-console-l1-1-0.dll")]
+        [DllImport("kernel32.dll")]
         internal extern static int GetConsoleCP();
 
-        [DllImport("api-ms-win-core-console-l1-1-0.dll")]
+        [DllImport("kernel32.dll")]
         internal extern static int GetConsoleOutputCP();
 
-        [DllImport("api-ms-win-core-console-l1-1-0.dll")]
+        [DllImport("kernel32.dll")]
         internal extern static int SetConsoleCP(int codePage);
 
-        [DllImport("api-ms-win-core-console-l1-1-0.dll")]
+        [DllImport("kernel32.dll")]
         internal extern static int SetConsoleOutputCP(int codePage);
 
         [DllImport("netapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoAll.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoAll.cs
@@ -500,25 +500,25 @@ namespace System.Globalization.Tests
         internal const int CAL_PERSIAN = 22;
         internal const int CAL_UMALQURA = 23;
 
-        [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode)]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         internal extern static int GetLocaleInfoEx(string lpLocaleName, uint LCType, StringBuilder data, int cchData);
 
-        [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode)]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         internal extern static int GetLocaleInfoEx(string lpLocaleName, uint LCType, ref int data, int cchData);
 
-        [DllImport("api-ms-win-core-localization-l1-2-1.dll", CharSet = CharSet.Unicode)]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         internal extern static bool EnumSystemLocalesEx(EnumLocalesProcEx lpLocaleEnumProcEx, uint dwFlags, IntPtr lParam, IntPtr reserved);
 
-        [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode)]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         internal extern static int GetCalendarInfoEx(string lpLocaleName, int Calendar, IntPtr lpReserved, uint CalType, StringBuilder lpCalData, int cchData, IntPtr lpValue);
 
-        [DllImport("api-ms-win-core-localization-l1-2-1.dll", CharSet = CharSet.Unicode)]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         internal extern static int GetCalendarInfoEx(string lpLocaleName, int Calendar, IntPtr lpReserved, uint CalType, StringBuilder lpCalData, int cchData, ref uint lpValue);
 
-        [DllImport("api-ms-win-core-localization-l2-1-0.dll", CharSet = CharSet.Unicode)]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         internal extern static bool EnumCalendarInfoExEx(EnumCalendarInfoProcExEx pCalInfoEnumProcExEx, string lpLocaleName, uint Calendar, string lpReserved, uint CalType, IntPtr lParam);
 
-        [DllImport("api-ms-win-core-localization-l2-1-0.dll", CharSet = CharSet.Unicode)]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         internal extern static bool EnumTimeFormatsEx(EnumTimeFormatsProcEx lpTimeFmtEnumProcEx, string lpLocaleName, uint dwFlags, IntPtr lParam);
     }
 }

--- a/src/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Windows.Tests.cs
+++ b/src/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Windows.Tests.cs
@@ -206,16 +206,16 @@ namespace System.IO.FileSystem.DriveInfoTests
             }
         }
 
-        [DllImport("api-ms-win-core-file-l1-1-0.dll", SetLastError = true)]
+        [DllImport("kernel32.dll", SetLastError = true)]
         internal static extern int GetLogicalDrives();
 
-        [DllImport("api-ms-win-core-file-l1-1-0.dll", EntryPoint = "GetVolumeInformationW", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
+        [DllImport("kernel32.dll", EntryPoint = "GetVolumeInformationW", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
         internal static extern bool GetVolumeInformation(string drive, StringBuilder volumeName, int volumeNameBufLen, out int volSerialNumber, out int maxFileNameLen, out int fileSystemFlags, StringBuilder fileSystemName, int fileSystemNameBufLen);
 
-        [DllImport("api-ms-win-core-file-l1-1-0.dll", SetLastError = true)]
+        [DllImport("kernel32.dll", SetLastError = true)]
         internal static extern int GetDriveType(string drive);
 
-        [DllImport("api-ms-win-core-file-l1-1-0.dll", SetLastError = true)]
+        [DllImport("kernel32.dll", SetLastError = true)]
         internal static extern bool GetDiskFreeSpaceEx(string drive, out long freeBytesForUser, out long totalBytes, out long freeBytes);
 
         private IEnumerable<char> GetValidDriveLettersOnMachine()

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.NotifyFilter.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.NotifyFilter.cs
@@ -10,7 +10,7 @@ namespace System.IO.Tests
 {
     public class Directory_NotifyFilter_Tests : FileSystemWatcherTest
     {
-        [DllImport( "api-ms-win-security-provider-l1-1-0.dll", EntryPoint = "SetNamedSecurityInfoW", 
+        [DllImport("advapi32.dll", EntryPoint = "SetNamedSecurityInfoW",
             CallingConvention = CallingConvention.Winapi, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
         private static extern uint SetSecurityInfoByHandle( string name, uint objectType, uint securityInformation, 
             IntPtr owner, IntPtr group, IntPtr dacl, IntPtr sacl);

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.NotifyFilter.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.NotifyFilter.cs
@@ -12,7 +12,7 @@ namespace System.IO.Tests
 {
     public class File_NotifyFilter_Tests : FileSystemWatcherTest
     {
-        [DllImport("api-ms-win-security-provider-l1-1-0.dll", EntryPoint = "SetNamedSecurityInfoW",
+        [DllImport("advapi32.dll", EntryPoint = "SetNamedSecurityInfoW",
             CallingConvention = CallingConvention.Winapi, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
         private static extern uint SetSecurityInfoByHandle(string name, uint objectType, uint securityInformation,
             IntPtr owner, IntPtr group, IntPtr dacl, IntPtr sacl);

--- a/src/System.IO.FileSystem/tests/PortedCommon/DllImports.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/DllImports.cs
@@ -14,10 +14,10 @@ internal static class DllImports
     [DllImport("kernel32.dll", EntryPoint = "GetDiskFreeSpaceExW", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
     internal static extern bool GetDiskFreeSpaceEx(String drive, out long freeBytesForUser, out long totalBytes, out long freeBytes);
 
-    [DllImport("api-ms-win-core-file-l1-1-0.dll", EntryPoint = "GetVolumeInformationW", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
+    [DllImport("kernel32.dll", EntryPoint = "GetVolumeInformationW", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
     internal static extern bool GetVolumeInformation(String drive, [Out]StringBuilder volumeName, int volumeNameBufLen, out int volSerialNumber, out int maxFileNameLen, out int fileSystemFlags, [Out]StringBuilder fileSystemName, int fileSystemNameBufLen);
 
-    [DllImport("api-ms-win-core-file-l1-1-0.dll", EntryPoint = "GetDriveTypeW", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
+    [DllImport("kernel32.dll", EntryPoint = "GetDriveTypeW", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
     internal static extern int GetDriveType(string drive);
 }
 

--- a/src/System.IO.FileSystem/tests/PortedCommon/ReparsePointUtilities.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/ReparsePointUtilities.cs
@@ -21,12 +21,12 @@ using System.Threading;
 using System.Threading.Tasks;
 public static class MountHelper
 {
-    [DllImport("api-ms-win-core-file-l1-2-0.dll", EntryPoint = "GetVolumeNameForVolumeMountPointW", CharSet = CharSet.Unicode, BestFitMapping = false, SetLastError = true)]
+    [DllImport("kernel32.dll", EntryPoint = "GetVolumeNameForVolumeMountPointW", CharSet = CharSet.Unicode, BestFitMapping = false, SetLastError = true)]
     private static extern bool GetVolumeNameForVolumeMountPoint(String volumeName, StringBuilder uniqueVolumeName, int uniqueNameBufferCapacity);
     // unique volume name must be "\\?\Volume{GUID}\"
-    [DllImport("api-ms-win-core-kernel32-legacy-l1-1-1.dll", EntryPoint = "SetVolumeMountPointW", CharSet = CharSet.Unicode, BestFitMapping = false, SetLastError = true)]
+    [DllImport("kernel32.dll", EntryPoint = "SetVolumeMountPointW", CharSet = CharSet.Unicode, BestFitMapping = false, SetLastError = true)]
     private static extern bool SetVolumeMountPoint(String mountPoint, String uniqueVolumeName);
-    [DllImport("api-ms-win-core-file-l1-1-0.dll", EntryPoint = "DeleteVolumeMountPointW", CharSet = CharSet.Unicode, BestFitMapping = false, SetLastError = true)]
+    [DllImport("kernel32.dll", EntryPoint = "DeleteVolumeMountPointW", CharSet = CharSet.Unicode, BestFitMapping = false, SetLastError = true)]
     private static extern bool DeleteVolumeMountPoint(String mountPoint);
 
     /// <summary>Creates a symbolic link using command line tools</summary>

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFilesTestsBase.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFilesTestsBase.cs
@@ -328,7 +328,7 @@ namespace System.IO.MemoryMappedFiles.Tests
 
         private const uint HANDLE_FLAG_INHERIT = 0x00000001;
 
-        [DllImport("api-ms-win-core-sysinfo-l1-1-0.dll")]
+        [DllImport("kernel32.dll")]
         private static extern void GetSystemInfo(out SYSTEM_INFO input);
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
@@ -224,7 +224,7 @@ namespace System.Tests
             Assert.True(success);
         }
 
-        [DllImport("api-ms-win-core-processenvironment-l1-1-0.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern bool SetEnvironmentVariable(string lpName, string lpValue);
 
         [DllImport("libc")]

--- a/src/System.Runtime.Extensions/tests/System/Environment.ProcessorCount.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.ProcessorCount.cs
@@ -48,7 +48,7 @@ namespace System.Tests
         [DllImport("libc")]
         private static extern long sysconf(int name);
 
-        [DllImport("api-ms-win-core-sysinfo-l1-1-0.dll", SetLastError = true)]
+        [DllImport("kernel32.dll", SetLastError = true)]
         internal static extern void GetSystemInfo(ref SYSTEM_INFO lpSystemInfo);
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -345,7 +345,7 @@ namespace System.Tests
             }
         }
 
-        [DllImport("api-ms-win-core-file-l1-1-0.dll", SetLastError = true)]
+        [DllImport("kernel32.dll", SetLastError = true)]
         internal static extern int GetLogicalDrives();
 
         [DllImport("shell32.dll", SetLastError = false, BestFitMapping = false, ExactSpelling = true)]

--- a/src/System.Threading.Overlapped/tests/DllImport.cs
+++ b/src/System.Threading.Overlapped/tests/DllImport.cs
@@ -8,20 +8,20 @@ using System.Threading;
 
 internal static class DllImport
 {
-    [DllImport("api-ms-win-core-file-l1-1-0.dll", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
     internal static extern Win32Handle CreateFile(String lpFileName,
        FileAccess dwDesiredAccess, FileShare dwShareMode,
        IntPtr securityAttrs, CreationDisposition dwCreationDisposition,
        FileAttributes dwFlagsAndAttributes, IntPtr hTemplateFile);
 
-    [DllImport("api-ms-win-core-file-l1-1-0.dll", SetLastError = true)]
+    [DllImport("kernel32.dll", SetLastError = true)]
     internal static extern unsafe int WriteFile(SafeHandle handle, byte* bytes, int numBytesToWrite, IntPtr numBytesWritten_mustBeZero, NativeOverlapped* lpOverlapped);
 
 
-    [DllImport("api-ms-win-core-handle-l1-1-0.dll", SetLastError = true)]
+    [DllImport("kernel32.dll", SetLastError = true)]
     internal static extern bool CloseHandle(IntPtr handle);
 
-    [DllImport("api-ms-win-core-handle-l1-1-0.dll", ExactSpelling = true, SetLastError = true)]
+    [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true)]
     internal static extern bool GetHandleInformation(IntPtr handle, out int flags);
 
     internal const int ERROR_IO_PENDING = 0x000003E5;


### PR DESCRIPTION
API Sets are not available on Windows 7, thus tests need to
import from Win32 DLL to run successfully on Windows 7.
Resolves issue #14728.