### PR TITLE
Prebuild CoreFx.Tools

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -164,6 +164,24 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "Pre-build CoreFx.Tools",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/Tools/CoreFx.Tools/CoreFx.Tools.csproj",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Run build.sh",
       "timeoutInMinutes": 0,
       "task": {
@@ -479,6 +497,6 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097435
+    "revision": 418097459
   }
 }


### PR DESCRIPTION
MSBuild is not reloading CoreFx.Tools on some Linux variants, it is re-using the same msbuild instance.  When tools.builds completes building CoreFx.Tools and then tries to build generateprops, generateprops fails, unable to find the CoreFx.Tools tasks.  pre-building CoreFx.Tools seems to resolve the problem.

/cc @weshaggard 