### PR TITLE
Add more config tests

### DIFF
--- a/src/System.Configuration/src/System/Configuration/ConfigurationCollectionAttribute.cs
+++ b/src/System.Configuration/src/System/Configuration/ConfigurationCollectionAttribute.cs
@@ -4,8 +4,10 @@
 
 namespace System.Configuration
 {
-    // This attribute is expected on section properties of type derivied from ConfigurationElementCollection
-    // or on the itself
+    /// <summary>
+    /// Used on classes derived from ConfigurationElementCollection. Specifies the collection item type and
+    /// verbs used for add/remove/clear.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class)]
     public sealed class ConfigurationCollectionAttribute : Attribute
     {

--- a/src/System.Configuration/src/System/Configuration/ConfigurationElementCollection.cs
+++ b/src/System.Configuration/src/System/Configuration/ConfigurationElementCollection.cs
@@ -254,7 +254,7 @@ namespace System.Configuration
             Hashtable inheritance = new Hashtable();
             _lockedAllExceptAttributesList = sourceElement._lockedAllExceptAttributesList;
             _lockedAllExceptElementsList = sourceElement._lockedAllExceptElementsList;
-            _fItemLocked = sourceElement._fItemLocked;
+            _itemLockedFlag = sourceElement._itemLockedFlag;
             _lockedAttributesList = sourceElement._lockedAttributesList;
             _lockedElementsList = sourceElement._lockedElementsList;
 
@@ -661,11 +661,12 @@ namespace System.Configuration
                 Items.Insert(index, new Entry(entryType, key, element));
             }
             else
+            {
                 Items.Add(new Entry(entryType, key, element));
+            }
 
             _modified = true;
         }
-
 
         protected virtual void BaseAdd(int index, ConfigurationElement element)
         {

--- a/src/System.Configuration/src/System/Configuration/ConfigurationLockCollection.cs
+++ b/src/System.Configuration/src/System/Configuration/ConfigurationLockCollection.cs
@@ -83,6 +83,7 @@ namespace System.Configuration
             {
                 // return true if there is at least one element that was defined in the parent
                 bool result = false;
+
                 // Check to see if the exception list is empty as a result of a merge from config
                 // If so the there were some parent elements because empty string is invalid in config.
                 // and the only way to get an empty list is for the merged config to have no elements
@@ -211,6 +212,7 @@ namespace System.Configuration
         {
             if (name == null)
                 return false;
+
             if (!ExceptionList)
             {
                 return _internalDictionary.Contains(name) &&

--- a/src/System.Configuration/src/System/Configuration/ConnectionStringSettings.cs
+++ b/src/System.Configuration/src/System/Configuration/ConnectionStringSettings.cs
@@ -47,7 +47,7 @@ namespace System.Configuration
         protected internal override ConfigurationPropertyCollection Properties => s_properties;
 
         [ConfigurationProperty("name",
-         Options = ConfigurationPropertyOptions.IsRequired | ConfigurationPropertyOptions.IsKey, DefaultValue = "")]
+            Options = ConfigurationPropertyOptions.IsRequired | ConfigurationPropertyOptions.IsKey, DefaultValue = "")]
         public string Name
         {
             get { return (string)base[s_propName]; }

--- a/src/System.Configuration/src/System/Configuration/Internal/InternalConfigConfigurationFactory.cs
+++ b/src/System.Configuration/src/System/Configuration/Internal/InternalConfigConfigurationFactory.cs
@@ -8,7 +8,8 @@ namespace System.Configuration.Internal
     {
         private InternalConfigConfigurationFactory() { }
 
-        Configuration IInternalConfigConfigurationFactory.Create(Type typeConfigHost,
+        Configuration IInternalConfigConfigurationFactory.Create(
+            Type typeConfigHost,
             params object[] hostInitConfigurationParams)
         {
             return new Configuration(null, typeConfigHost, hostInitConfigurationParams);

--- a/src/System.Configuration/src/System/Configuration/Internal/WriteFileContext.cs
+++ b/src/System.Configuration/src/System/Configuration/Internal/WriteFileContext.cs
@@ -144,9 +144,9 @@ namespace System.Configuration.Internal
             }
         }
 
-        // Replace one file with another using MoveFileEx.  This will
-        // retry the operation if the file is locked because someone
-        // is reading it
+        /// <summary>
+        /// Replace one file with another, retrying if locked.
+        /// </summary>
         private void ReplaceFile(string source, string target)
         {
             bool writeSucceeded;

--- a/src/System.Configuration/src/System/Configuration/KeyValueConfigurationCollection.cs
+++ b/src/System.Configuration/src/System/Configuration/KeyValueConfigurationCollection.cs
@@ -38,7 +38,9 @@ namespace System.Configuration
             // when add is called and teh key already exists.
             KeyValueConfigurationElement oldValue = (KeyValueConfigurationElement)BaseGet(keyValue.Key);
             if (oldValue == null)
+            {
                 BaseAdd(keyValue);
+            }
             else
             {
                 oldValue.Value += "," + keyValue.Value;

--- a/src/System.Configuration/src/System/Configuration/ProtectedProviderSettings.cs
+++ b/src/System.Configuration/src/System/Configuration/ProtectedProviderSettings.cs
@@ -7,8 +7,11 @@ namespace System.Configuration
     public class ProtectedProviderSettings : ConfigurationElement
     {
         private readonly ConfigurationProperty _propProviders =
-            new ConfigurationProperty(null, typeof(ProviderSettingsCollection), null,
-                ConfigurationPropertyOptions.IsDefaultCollection);
+            new ConfigurationProperty(
+                name: null,
+                type: typeof(ProviderSettingsCollection),
+                defaultValue: null,
+                options: ConfigurationPropertyOptions.IsDefaultCollection);
 
         private readonly ConfigurationPropertyCollection _properties;
 
@@ -20,9 +23,7 @@ namespace System.Configuration
 
         protected internal override ConfigurationPropertyCollection Properties => _properties;
 
-
-        [ConfigurationProperty("", IsDefaultCollection = true,
-         Options = ConfigurationPropertyOptions.IsDefaultCollection)]
+        [ConfigurationProperty("", IsDefaultCollection = true, Options = ConfigurationPropertyOptions.IsDefaultCollection)]
         public ProviderSettingsCollection Providers => (ProviderSettingsCollection)base[_propProviders];
     }
 }

--- a/src/System.Configuration/tests/System.Configuration.Tests.csproj
+++ b/src/System.Configuration/tests/System.Configuration.Tests.csproj
@@ -52,6 +52,12 @@
     </Compile>
     <Compile Include="System\Configuration\AppSettingsTests.cs" />
     <Compile Include="System\Configuration\ConfigPathUtilityTests.cs" />
+    <Compile Include="System\Configuration\ConfigurationElementCollectionTests.cs" />
+    <Compile Include="System\Configuration\ConfigurationElementTests.cs" />
+    <Compile Include="System\Configuration\ConfigurationPropertyAttributeTests.cs" />
+    <Compile Include="System\Configuration\ConfigurationPropertyTests.cs" />
+    <Compile Include="System\Configuration\ConfigurationTests.cs" />
+    <Compile Include="System\Configuration\BasicCustomSectionTests.cs" />
     <Compile Include="System\Configuration\ExceptionUtilTests.cs" />
     <Compile Include="System\Configuration\ImplicitMachineConfigTests.cs" />
     <Compile Include="System\Configuration\SmokeTest.cs" />

--- a/src/System.Configuration/tests/System/Configuration/AppSettingsTests.cs
+++ b/src/System.Configuration/tests/System/Configuration/AppSettingsTests.cs
@@ -83,5 +83,26 @@ namespace System.ConfigurationTests
                 Assert.Equal("NewValue", config.AppSettings.Settings["NewKey"].Value);
             }
         }
+
+        [Fact]
+        public void AppSettingsCannotLoadFromUser()
+        {
+            // By default you can't load a section from a user config file- validating that appSettings falls in this bucket
+            using (var machine = new TempConfig(TestData.ImplicitMachineConfig))
+            using (var exe = new TempConfig(TestData.EmptyConfig))
+            using (var user = new TempConfig(TestData.SimpleConfig))
+            {
+                ExeConfigurationFileMap map = new ExeConfigurationFileMap
+                {
+                    MachineConfigFilename = machine.ConfigPath,
+                    ExeConfigFilename = exe.ConfigPath,
+                    RoamingUserConfigFilename = user.ConfigPath
+                };
+
+                var config = ConfigurationManager.OpenMappedExeConfiguration(map, ConfigurationUserLevel.PerUserRoaming);
+
+                Assert.Throws<ConfigurationErrorsException>(() => config.AppSettings);
+            }
+        }
     }
 }

--- a/src/System.Configuration/tests/System/Configuration/BasicCustomSectionTests.cs
+++ b/src/System.Configuration/tests/System/Configuration/BasicCustomSectionTests.cs
@@ -1,0 +1,194 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Configuration;
+using System.IO;
+using Xunit;
+
+namespace System.ConfigurationTests
+{
+    public class BasicCustomSectionTests
+    {
+        public class SimpleCustomSection : ConfigurationSection
+        {
+            [ConfigurationProperty("test")]
+            public string Test
+            {
+                get { return (string)this["test"]; }
+                set { this["test"] = value; }
+            }
+        }
+
+        public static string SimpleCustomData =
+@"<?xml version='1.0' encoding='utf-8' ?>
+<configuration>
+    <configSections>
+        <section name='simpleCustomSection' type='System.ConfigurationTests.BasicCustomSectionTests+SimpleCustomSection, System.Configuration.Tests' />
+    </configSections>
+    <simpleCustomSection />
+</configuration>";
+
+        [Fact]
+        public void SimpleCustomSectionExists()
+        {
+            using (var temp = new TempConfig(SimpleCustomData))
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                SimpleCustomSection section = config.GetSection("simpleCustomSection") as SimpleCustomSection;
+                Assert.NotNull(section);
+                Assert.Equal(string.Empty, section.Test);
+            }
+        }
+
+        public static string SimpleCustomDataWithValue =
+@"<?xml version='1.0' encoding='utf-8' ?>
+<configuration>
+    <configSections>
+        <section name='simpleCustomSection' type='System.ConfigurationTests.BasicCustomSectionTests+SimpleCustomSection, System.Configuration.Tests' />
+    </configSections>
+    <simpleCustomSection test='Foo' />
+</configuration>";
+
+        [Fact]
+        public void SimpleCustomSectionWithData()
+        {
+            using (var temp = new TempConfig(SimpleCustomDataWithValue))
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                SimpleCustomSection section = config.GetSection("simpleCustomSection") as SimpleCustomSection;
+                Assert.NotNull(section);
+                Assert.Equal("Foo", section.Test);
+            }
+        }
+
+        public class SimpleCustomSectionRequiredValue : ConfigurationSection
+        {
+            [ConfigurationProperty("test", IsRequired = true)]
+            public string Test
+            {
+                get { return (string)this["test"]; }
+                set { this["test"] = value; }
+            }
+        }
+
+        public static string MissingRequiredData =
+@"<?xml version='1.0' encoding='utf-8' ?>
+<configuration>
+    <configSections>
+        <section name='simpleCustomSectionRequiredValue' type='System.ConfigurationTests.BasicCustomSectionTests+SimpleCustomSectionRequiredValue, System.Configuration.Tests' />
+    </configSections>
+    <simpleCustomSectionRequiredValue />
+</configuration>";
+
+        [Fact]
+        public void SimpleCustomSectionMissingRequired()
+        {
+            using (var temp = new TempConfig(MissingRequiredData))
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+
+                Assert.Throws<ConfigurationErrorsException>(() => config.GetSection("simpleCustomSectionRequiredValue") as SimpleCustomSectionRequiredValue);
+            }
+        }
+
+        public class SimpleCustomSectionDefaultValue: ConfigurationSection
+        {
+            [ConfigurationProperty("test", DefaultValue = "Bar" )]
+            public string Test
+            {
+                get { return (string)this["test"]; }
+                set { this["test"] = value; }
+            }
+        }
+
+        public static string DefaultAppliedData =
+@"<?xml version='1.0' encoding='utf-8' ?>
+<configuration>
+    <configSections>
+        <section name='simpleCustomSectionDefaultValue' type='System.ConfigurationTests.BasicCustomSectionTests+SimpleCustomSectionDefaultValue, System.Configuration.Tests' />
+    </configSections>
+    <simpleCustomSectionDefaultValue />
+</configuration>";
+
+        [Fact]
+        public void SimpleCustomSectionWithDefault()
+        {
+            using (var temp = new TempConfig(DefaultAppliedData))
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                SimpleCustomSectionDefaultValue section = config.GetSection("simpleCustomSectionDefaultValue") as SimpleCustomSectionDefaultValue;
+                Assert.NotNull(section);
+                Assert.Equal("Bar", section.Test);
+            }
+        }
+
+        public class SimpleDefaultCollectionSection : ConfigurationSection
+        {
+            [ConfigurationProperty("", IsDefaultCollection = true)]
+            public KeyValueConfigurationCollection Settings => (KeyValueConfigurationCollection)base[""];
+        }
+
+        public static string SimpleDefaultCollection =
+@"<?xml version='1.0' encoding='utf-8' ?>
+<configuration>
+    <configSections>
+        <section name='simpleDefaultCollectionSection' type='System.ConfigurationTests.BasicCustomSectionTests+SimpleDefaultCollectionSection, System.Configuration.Tests' />
+    </configSections>
+    <simpleDefaultCollectionSection>
+        <add key='Fruit' value='Pear' />
+        <add key='Nut' value='Cashew' />
+    </simpleDefaultCollectionSection>
+</configuration>";
+
+        [Fact]
+        public void CustomSectionDefaultCollection()
+        {
+            using (var temp = new TempConfig(SimpleDefaultCollection))
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                SimpleDefaultCollectionSection section = config.GetSection("simpleDefaultCollectionSection") as SimpleDefaultCollectionSection;
+                Assert.NotNull(section);
+
+                Assert.Equal(2, section.Settings.Count);
+                Assert.Equal("Pear", section.Settings["Fruit"].Value);
+                Assert.Equal("Cashew", section.Settings["Nut"].Value);
+            }
+        }
+
+        public class SimpleCollectionSection : ConfigurationSection
+        {
+            [ConfigurationProperty("foods", IsDefaultCollection = true)]
+            public KeyValueConfigurationCollection Foods => (KeyValueConfigurationCollection)base["foods"];
+        }
+
+        public static string SimpleCollection =
+@"<?xml version='1.0' encoding='utf-8' ?>
+<configuration>
+    <configSections>
+        <section name='simpleCollectionSection' type='System.ConfigurationTests.BasicCustomSectionTests+SimpleCollectionSection, System.Configuration.Tests' />
+    </configSections>
+    <simpleCollectionSection>
+        <foods>
+            <add key='Fruit' value='Pear' />
+            <add key='Nut' value='Cashew' />
+        </foods>
+    </simpleCollectionSection>
+</configuration>";
+
+        [Fact]
+        public void CustomSectionCollection()
+        {
+            using (var temp = new TempConfig(SimpleCollection))
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                SimpleCollectionSection section = config.GetSection("simpleCollectionSection") as SimpleCollectionSection;
+                Assert.NotNull(section);
+
+                Assert.Equal(2, section.Foods.Count);
+                Assert.Equal("Pear", section.Foods["Fruit"].Value);
+                Assert.Equal("Cashew", section.Foods["Nut"].Value);
+            }
+        }
+    }
+}

--- a/src/System.Configuration/tests/System/Configuration/ConfigurationElementCollectionTests.cs
+++ b/src/System.Configuration/tests/System/Configuration/ConfigurationElementCollectionTests.cs
@@ -1,0 +1,187 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Configuration;
+using System.IO;
+using Xunit;
+
+namespace System.ConfigurationTests
+{
+    public class ConfigurationElementCollectionTests
+    {
+        public class SimpleElement : ConfigurationElement
+        {
+        }
+
+        private class SimpleCollection : ConfigurationElementCollection
+        {
+            public SimpleCollection()
+                : base()
+            { }
+
+            public SimpleCollection(IComparer comparer)
+                : base(comparer)
+            { }
+
+            protected override ConfigurationElement CreateNewElement()
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override object GetElementKey(ConfigurationElement element)
+            {
+                return "FooKey";
+            }
+
+            public bool TestThrowOnDuplicate => ThrowOnDuplicate;
+            public string TestElementName => ElementName;
+
+            public void TestBaseAdd(ConfigurationElement element)
+            {
+                BaseAdd(element);
+            }
+
+            public void TestBaseAdd(int index, ConfigurationElement element)
+            {
+                BaseAdd(index, element);
+            }
+        }
+
+        private class ReadOnlySimpleCollection : SimpleCollection
+        {
+            public override bool IsReadOnly() => true;
+        }
+
+        [Fact]
+        public void NullComparerThrows()
+        {
+            Assert.Equal("comparer", Assert.Throws<ArgumentNullException>(() => new SimpleCollection(null)).ParamName);
+        }
+
+        [Fact]
+        public void ReadOnlyFalseByDefault()
+        {
+            Assert.False(new SimpleCollection().IsReadOnly());
+        }
+
+        [Fact]
+        public void InitialCountIsZero()
+        {
+            Assert.Equal(0, new SimpleCollection().Count);
+        }
+
+        [Fact]
+        public void ElementNameIsEmpty()
+        {
+            Assert.Equal("", new SimpleCollection().TestElementName);
+        }
+
+        [Fact]
+        public void CollectionTypeIsAddRemoveMap()
+        {
+            Assert.Equal(ConfigurationElementCollectionType.AddRemoveClearMap, new SimpleCollection().CollectionType);
+        }
+
+        [Fact]
+        public void SyncRootIsNull()
+        {
+            Assert.Null(new SimpleCollection().SyncRoot);
+        }
+
+        [Fact]
+        public void SynchronizedIsFalse()
+        {
+            Assert.False(new SimpleCollection().IsSynchronized);
+        }
+
+        [Fact]
+        public void EmitClearIsFalse()
+        {
+            Assert.False(new SimpleCollection().EmitClear);
+        }
+
+        [Fact]
+        public void SetEmitClear()
+        {
+            var collection = new SimpleCollection();
+            collection.EmitClear = true;
+            Assert.True(collection.EmitClear);
+        }
+
+        [Fact]
+        public void AddBaseElementSucceeds()
+        {
+            var collection = new SimpleCollection();
+            collection.TestBaseAdd(new SimpleElement());
+            Assert.Equal(1, collection.Count);
+        }
+
+        [Fact]
+        public void AddBaseElementAtIndexSucceeds()
+        {
+            var collection = new SimpleCollection();
+            collection.TestBaseAdd(-1, new SimpleElement());
+            Assert.Equal(1, collection.Count);
+        }
+
+        [Fact]
+        public void BaseAddIndexOutOfRangeThrows()
+        {
+            Assert.Throws<ConfigurationErrorsException>(() => new SimpleCollection().TestBaseAdd(-2, null));
+        }
+
+        [Fact]
+        public void BaseAddReadOnlyThrows()
+        {
+            Assert.Throws<ConfigurationErrorsException>(() => new ReadOnlySimpleCollection().TestBaseAdd(null));
+        }
+
+        [Fact]
+        public void BaseAddIndexReadOnlyThrows()
+        {
+            Assert.Throws<ConfigurationErrorsException>(() => new ReadOnlySimpleCollection().TestBaseAdd(-1, null));
+        }
+
+        [Fact]
+        public void BaseAddNullThrows()
+        {
+            Assert.Throws<NullReferenceException>(() => new SimpleCollection().TestBaseAdd(null));
+        }
+
+        [Fact]
+        public void BaseAddIndexNullThrows()
+        {
+            Assert.Throws<NullReferenceException>(() => new SimpleCollection().TestBaseAdd(-1, null));
+        }
+
+        [Fact]
+        public void ThrowOnDuplicateIsTrue()
+        {
+            Assert.True(new SimpleCollection().TestThrowOnDuplicate);
+        }
+
+        public class BasicCollection : ConfigurationElementCollection
+        {
+            protected override ConfigurationElement CreateNewElement()
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override object GetElementKey(ConfigurationElement element)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override ConfigurationElementCollectionType CollectionType => ConfigurationElementCollectionType.BasicMap;
+            public bool TestThrowOnDuplicate => ThrowOnDuplicate;
+        }
+
+        [Fact]
+        public void BasicThrowOnDuplicateIsFalse()
+        {
+            Assert.False(new BasicCollection().TestThrowOnDuplicate);
+        }
+    }
+}

--- a/src/System.Configuration/tests/System/Configuration/ConfigurationElementTests.cs
+++ b/src/System.Configuration/tests/System/Configuration/ConfigurationElementTests.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Configuration;
+using Xunit;
+
+namespace System.ConfigurationTests
+{
+    public class ConfigurationElementTests
+    {
+        [Fact]
+        public void HasNoConfiguration()
+        {
+            Assert.Null(new SimpleElement().CurrentConfiguration);
+        }
+
+        [Fact]
+        public void HasNoContext()
+        {
+            // There should be no configuration record and thus, no context
+            Assert.False(new SimpleElement().TestHasContext);
+        }
+
+        [Fact]
+        public void EvaluationContextThrows()
+        {
+            // If we haven't associated a configuration record we should fail
+            SimpleElement element = new SimpleElement();
+            Assert.Throws<ConfigurationErrorsException>(() => element.TestEvaluationContext);
+        }
+
+        [Fact]
+        public void TransformedNullTypeStringIsNull()
+        {
+            Assert.Null(new SimpleElement().TestGetTransformedTypeString(null));
+        }
+
+        [Fact]
+        public void TransformedTypeStringIsOriginal()
+        {
+            string foo = "foo";
+
+            // With no config record the transformed typename should be original
+            Assert.Same(foo, new SimpleElement().TestGetTransformedTypeString(foo));
+        }
+
+        [Fact]
+        public void TransformedNullAssemblyStringIsNull()
+        {
+            Assert.Null(new SimpleElement().TestGetTransformedAssemblyString(null));
+        }
+
+        [Fact]
+        public void TransformedAssemblyStringIsOriginal()
+        {
+            string foo = "foo";
+
+            // With no config record the transformed assembly name should be original
+            Assert.Same(foo, new SimpleElement().TestGetTransformedAssemblyString(foo));
+        }
+
+        public class SimpleElement : ConfigurationElement
+        {
+            public ContextInformation TestEvaluationContext => EvaluationContext;
+
+            public bool TestHasContext => HasContext;
+
+            public string TestGetTransformedTypeString(string typeName)
+            {
+                return GetTransformedTypeString(typeName);
+            }
+
+            public string TestGetTransformedAssemblyString(string assemblyName)
+            {
+                return GetTransformedAssemblyString(assemblyName);
+            }
+        }
+
+    }
+}

--- a/src/System.Configuration/tests/System/Configuration/ConfigurationPropertyAttributeTests.cs
+++ b/src/System.Configuration/tests/System/Configuration/ConfigurationPropertyAttributeTests.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Configuration;
+using Xunit;
+
+namespace System.ConfigurationTests
+{
+    public class ConfigurationPropertyAttributeTests
+    {
+        [Fact]
+        public void DefaultValueIsNullObject()
+        {
+            // It isn't publicly exposed anywhere else, first check that it is the same object instance here
+            ConfigurationPropertyAttribute one = new ConfigurationPropertyAttribute("one");
+            ConfigurationPropertyAttribute two = new ConfigurationPropertyAttribute("two");
+
+            Assert.IsType<object>(one.DefaultValue);
+            Assert.Same(one.DefaultValue, two.DefaultValue);
+        }
+
+        [Fact]
+        public void DefaultOptionsIsNone()
+        {
+            Assert.Equal(ConfigurationPropertyOptions.None, new ConfigurationPropertyAttribute("foo").Options);
+        }
+
+        [Fact]
+        public void IsDefaultCollection()
+        {
+            ConfigurationPropertyAttribute attribute = new ConfigurationPropertyAttribute("foo");
+            Assert.False(attribute.IsDefaultCollection);
+
+            attribute.Options = ConfigurationPropertyOptions.IsDefaultCollection;
+            Assert.True(attribute.IsDefaultCollection);
+            attribute.IsDefaultCollection = false;
+            Assert.False(attribute.IsDefaultCollection);
+
+            Assert.Equal(ConfigurationPropertyOptions.None, attribute.Options);
+        }
+
+        [Fact]
+        public void IsRequired()
+        {
+            ConfigurationPropertyAttribute attribute = new ConfigurationPropertyAttribute("foo");
+            Assert.False(attribute.IsDefaultCollection);
+
+            attribute.Options = ConfigurationPropertyOptions.IsRequired;
+            Assert.True(attribute.IsRequired);
+            attribute.IsRequired = false;
+            Assert.False(attribute.IsRequired);
+
+            Assert.Equal(ConfigurationPropertyOptions.None, attribute.Options);
+        }
+
+        [Fact]
+        public void IsKey()
+        {
+            ConfigurationPropertyAttribute attribute = new ConfigurationPropertyAttribute("foo");
+            Assert.False(attribute.IsDefaultCollection);
+
+            attribute.Options = ConfigurationPropertyOptions.IsKey;
+            Assert.True(attribute.IsKey);
+            attribute.IsKey = false;
+            Assert.False(attribute.IsKey);
+
+            Assert.Equal(ConfigurationPropertyOptions.None, attribute.Options);
+        }
+    }
+}

--- a/src/System.Configuration/tests/System/Configuration/ConfigurationPropertyTests.cs
+++ b/src/System.Configuration/tests/System/Configuration/ConfigurationPropertyTests.cs
@@ -1,0 +1,231 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Configuration;
+using Xunit;
+
+namespace System.ConfigurationTests
+{
+    public class ConfigurationPropertyTests
+    {
+        [Fact]
+        public void ConfigurationSectionThrows()
+        {
+            Assert.Throws<ConfigurationErrorsException>(() => new ConfigurationProperty("foo", typeof(ConfigurationSection)));
+        }
+
+        [Fact]
+        public void AppSettingsSectionThrows()
+        {
+            Assert.Throws<ConfigurationErrorsException>(() => new ConfigurationProperty("foo", typeof(AppSettingsSection)));
+        }
+
+        [Fact]
+        public void NullNameThrows()
+        {
+            Assert.Throws<ArgumentException>(() => new ConfigurationProperty(null, typeof(string)));
+        }
+
+        [Fact]
+        public void EmptyNameThrows()
+        {
+            Assert.Throws<ArgumentException>(() => new ConfigurationProperty("", typeof(string)));
+        }
+
+        [Theory
+            InlineData("lock")
+            InlineData("locks")
+            InlineData("config")
+            InlineData("configuration")
+            ]
+        public void ReservedNameThrows(string name)
+        {
+            Assert.Throws<ArgumentException>(() => new ConfigurationProperty(name, typeof(string)));
+        }
+
+        [Theory
+            InlineData("Lock")
+            InlineData("ilock")
+            InlineData("LOCKS")
+            InlineData("CoNfig")
+            InlineData("conFIGuration")
+            ]
+        public void ReservedNameOrdinallyCompared(string name)
+        {
+            // Want to make sure the comparison is ordinal and starts with if people have depended on this
+            new ConfigurationProperty(name, typeof(string));
+        }
+
+        // Base class returns false for CanValidate by default
+        public class CantValidateValidator : ConfigurationValidatorBase
+        {
+            public override void Validate(object value)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Fact]
+        public void NonMatchingValidatorThrows()
+        {
+            CantValidateValidator validator = new CantValidateValidator();
+            Assert.Throws<ConfigurationErrorsException>(() => new ConfigurationProperty("foo", typeof(string), null, null, validator, ConfigurationPropertyOptions.None));
+        }
+
+        public class FooFailsValidator : ConfigurationValidatorBase
+        {
+            public override bool CanValidate(Type type)
+            {
+                return true;
+            }
+
+            public override void Validate(object value)
+            {
+                if (string.Equals(value, "foo"))
+                    throw new InvalidOperationException();
+            }
+        }
+
+        [Fact]
+        public void BadDefaultValueThrows()
+        {
+            FooFailsValidator validator = new FooFailsValidator();
+            Action action = () => new ConfigurationProperty("bar", typeof(string), "foo", null, validator, ConfigurationPropertyOptions.None);
+            Assert.IsType<InvalidOperationException>(Assert.Throws<ConfigurationErrorsException>(action).InnerException);
+        }
+
+        [TypeConverter(typeof(DummyCantConverter))]
+        public class SimpleConfigurationElement : ConfigurationElement
+        {
+        }
+
+        // By default can't convert from or to
+        public class DummyCantConverter : TypeConverter
+        {
+        }
+
+        public class DummyCanConverter : TypeConverter
+        {
+            public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+            {
+                return sourceType == typeof(string);
+            }
+
+            public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+            {
+                return destinationType == typeof(string);
+            }
+        }
+
+        [Fact]
+        public void ConfigurationElementConverterIgnored()
+        {
+            ConfigurationProperty property = new ConfigurationProperty("foo", typeof(SimpleConfigurationElement));
+            Assert.Null(property.Converter);
+        }
+
+        [TypeConverter(typeof(DummyCanConverter))]
+        public class MyConvertableClass
+        {
+        }
+
+        [Fact]
+        public void TypeConverterRecognized()
+        {
+            ConfigurationProperty property = new ConfigurationProperty("foo", typeof(MyConvertableClass));
+            Assert.IsType<DummyCanConverter>(property.Converter);
+        }
+
+        [TypeConverter(typeof(DummyCantConverter))]
+        public class MyUnconvertableClass
+        {
+        }
+
+        [Fact]
+        public void UnconvertableFailsOnConverterAccess()
+        {
+            ConfigurationProperty property = new ConfigurationProperty("foo", typeof(MyUnconvertableClass));
+            Assert.Throws<ConfigurationErrorsException>(() => property.Converter);
+        }
+
+        [TypeConverter(typeof(DummyCantConverter))]
+        public enum AllSay
+        {
+            Yea,
+            Nay
+        }
+
+        [Fact]
+        public void EnumsGetGenericEnumConverter()
+        {
+            ConfigurationProperty property = new ConfigurationProperty("foo", typeof(AllSay));
+            Assert.IsType<GenericEnumConverter>(property.Converter);
+        }
+
+        [Theory
+            InlineData(typeof(string), typeof(StringConverter))
+            InlineData(typeof(int), typeof(Int32Converter))
+            ]
+        public void FindConverterForBuiltInTypes(Type type, Type converterType)
+        {
+            ConfigurationProperty property = new ConfigurationProperty("foo", type);
+            Assert.IsType(converterType, property.Converter);
+        }
+
+        [Fact]
+        public void IsRequiredExposed()
+        {
+            Assert.False(new ConfigurationProperty("foo", typeof(string)).IsRequired);
+            Assert.True(new ConfigurationProperty("foo", typeof(string), null, ConfigurationPropertyOptions.IsRequired).IsRequired);
+        }
+
+        [Fact]
+        public void IsKeyExposed()
+        {
+            Assert.False(new ConfigurationProperty("foo", typeof(string)).IsRequired);
+            Assert.True(new ConfigurationProperty("foo", typeof(string), null, ConfigurationPropertyOptions.IsKey).IsKey);
+        }
+
+        [Fact]
+        public void IsDefaultCollectionExposed()
+        {
+            Assert.False(new ConfigurationProperty("foo", typeof(string)).IsDefaultCollection);
+            Assert.True(new ConfigurationProperty("foo", typeof(string), null, ConfigurationPropertyOptions.IsDefaultCollection).IsDefaultCollection);
+        }
+
+        [Fact]
+        public void IsTypeStringTransformationRequiredExposed()
+        {
+            Assert.False(new ConfigurationProperty("foo", typeof(string)).IsTypeStringTransformationRequired);
+            Assert.True(new ConfigurationProperty("foo", typeof(string), null, ConfigurationPropertyOptions.IsTypeStringTransformationRequired).IsTypeStringTransformationRequired);
+        }
+
+        [Fact]
+        public void IsAssemblyStringTransformationRequiredExposed()
+        {
+            Assert.False(new ConfigurationProperty("foo", typeof(string)).IsAssemblyStringTransformationRequired);
+            Assert.True(new ConfigurationProperty("foo", typeof(string), null, ConfigurationPropertyOptions.IsAssemblyStringTransformationRequired).IsAssemblyStringTransformationRequired);
+        }
+
+        [Fact]
+        public void IsVersionCheckRequiredExposed()
+        {
+            Assert.False(new ConfigurationProperty("foo", typeof(string)).IsVersionCheckRequired);
+            Assert.True(new ConfigurationProperty("foo", typeof(string), null, ConfigurationPropertyOptions.IsVersionCheckRequired).IsVersionCheckRequired);
+        }
+
+        [Fact]
+        public void TypeIsExposed()
+        {
+            Assert.Equal(typeof(string), new ConfigurationProperty("foo", typeof(string)).Type);
+        }
+
+        [Fact]
+        public void DefaultValueIsExposed()
+        {
+            Assert.Equal("bar", new ConfigurationProperty("foo", typeof(string), "bar").DefaultValue);
+        }
+    }
+}

--- a/src/System.Configuration/tests/System/Configuration/ConfigurationTests.cs
+++ b/src/System.Configuration/tests/System/Configuration/ConfigurationTests.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Configuration;
+using System.IO;
+using Xunit;
+
+namespace System.ConfigurationTests
+{
+    public class ConfigurationTests
+    {
+        [Fact]
+        public void UnspecifiedTypeStringTransformer()
+        {
+            using (var temp = new TempConfig(TestData.EmptyConfig))
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                Assert.Null(config.TypeStringTransformer);
+            }
+        }
+
+        [Fact]
+        public void SpecifiedTypeStringTransformerReturned()
+        {
+            using (var temp = new TempConfig(TestData.EmptyConfig))
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                Func<string, string> transformer = s => s;
+                config.TypeStringTransformer = transformer;
+                Assert.Same(transformer, config.TypeStringTransformer);
+            }
+        }
+
+        [Fact]
+        public void UnspecifiedAssemblyStringTransformer()
+        {
+            using (var temp = new TempConfig(TestData.EmptyConfig))
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                Assert.Null(config.AssemblyStringTransformer);
+            }
+        }
+
+        [Fact]
+        public void SpecifiedAssemblyStringTransformerReturned()
+        {
+            using (var temp = new TempConfig(TestData.EmptyConfig))
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                Func<string, string> transformer = s => s;
+                config.AssemblyStringTransformer = transformer;
+                Assert.Same(transformer, config.AssemblyStringTransformer);
+            }
+        }
+    }
+}

--- a/src/System.Configuration/tests/System/Configuration/TestData.cs
+++ b/src/System.Configuration/tests/System/Configuration/TestData.cs
@@ -6,6 +6,13 @@ namespace System.ConfigurationTests
 {
     public static class TestData
     {
+        public static string ImplicitMachineConfig =
+@"<configuration>
+    <configSections>
+        <section name='appSettings' type='System.Configuration.AppSettingsSection, System.Configuration' restartOnExternalChanges='false' requirePermission='false'/>
+    </configSections>
+</configuration>";
+
         public static string EmptyConfig =
 @"<?xml version='1.0' encoding='utf-8' ?>
 <configuration>
@@ -15,8 +22,8 @@ namespace System.ConfigurationTests
 @"<?xml version='1.0' encoding='utf-8' ?>
 <configuration>
   <appSettings>
-    <add key='FooKey' value='FooValue'/>
-    <add key='BarKey' value='BarValue'/>
+    <add key='FooKey' value='FooValue' />
+    <add key='BarKey' value='BarValue' />
   </appSettings>
 </configuration>";
     }


### PR DESCRIPTION
- Adds a number of new tests
- Cleans up / clarifies some code
- Removes a chunk of duplicate code

As I'm plowing through writing tests I'm cleaning up code that is particularly hard to follow. I obviously have a lot more tests to write- they should come in bursts as I figure out reasonable ways to test the various components.

Note that I'm concurrently writing both "unit" and "end user" tests (e.g. loading real config files). They're informing each other as I progress.

@AlexGhiondea 

