### PR TITLE
For full framework test build, pass in win-x64 as testnugetruntimeid

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -529,7 +529,7 @@
             "TestContainerSuffix": "windows10desktop",
             "TargetTestCategory": "Full Framework",
             "FilterToTestTFM": "net46",
-            "TestNugetRuntimeId": "win10-x64",
+            "TestNugetRuntimeId": "win-x64",
             "EnableCloudTest": "true"
           },
           "ReportingParameters": {
@@ -903,7 +903,7 @@
             "TestContainerSuffix": "windows10desktop",
             "TargetTestCategory": "Full Framework",            
             "FilterToTestTFM": "net46",
-            "TestNugetRuntimeId": "win10-x64",
+            "TestNugetRuntimeId": "win-x64",
             "EnableCloudTest": "true"
           },
           "ReportingParameters": {

--- a/src/System.Composition.Convention/tests/System.Composition.Convention.Tests.csproj
+++ b/src/System.Composition.Convention/tests/System.Composition.Convention.Tests.csproj
@@ -5,6 +5,7 @@
     <ProjectGuid>{853BB14F-8A5B-42B4-A053-21DE1AEBB335}</ProjectGuid>
     <RootNamespace>ConventionsUnitTests</RootNamespace>
     <AssemblyName>System.Composition.Convention.Tests</AssemblyName>
+    <NugetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NugetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />


### PR DESCRIPTION
This is because of the simple exact string match required by the FilterRuntimeForSupports.