### PR TITLE
Fix EventSource test to be aware of ArrayPoolEventSource

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
@@ -23,7 +23,8 @@ namespace BasicEventSourceTests
             foreach (var eventSource in EventSource.GetSources())
             {
                 if (eventSource.Name != "System.Threading.Tasks.TplEventSource"
-                   && eventSource.Name != "System.Diagnostics.Eventing.FrameworkEventSource")
+                   && eventSource.Name != "System.Diagnostics.Eventing.FrameworkEventSource"
+                   && eventSource.Name != "System.Buffers.ArrayPoolEventSource")
                 {
                     eventSourceNames += eventSource.Name + " ";
                 }


### PR DESCRIPTION
See https://github.com/dotnet/corefx/pull/14919#issuecomment-270832193
cc: @jkotas, @davmason 