### PR TITLE
Add StateChangeHasSubscribers to DbConnection

### DIFF
--- a/src/System.Data.Common/src/System/Data/Common/DbConnection.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbConnection.cs
@@ -103,6 +103,15 @@ namespace System.Data.Common
             StateChange?.Invoke(this, stateChange);
         }
 
+        protected bool StateChangeHasSubscribers
+        {
+            get
+            {
+                var stateChange = StateChange;
+                return stateChange != null && stateChange.GetInvocationList().Length > 0;
+            }
+        }
+
         internal bool ForceNewConnection { get; set; }
 
         public abstract void Open();


### PR DESCRIPTION
ADO.NET providers are supposed to call DbConnection.OnStateChange on connection state changes. The problem is that this design forces the allocation of the StateChangeEventArgs parameter regardless of whether there are subscribers to StateChange or not.

Added a simple getter to check whether subscribers exist or not. If not calling OnStateChange can be skipped altogether.