### PR TITLE
Disable two XmlSchemaSet tests

### DIFF
--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlResolver.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlResolver.cs
@@ -94,6 +94,7 @@ namespace System.Xml.Tests
         }
 
         //[Variation(Desc = "v4 - schema(Local)->schema(Local)", Priority = 1)]
+        [ActiveIssue(14918)]
         [Fact]
         public void v4()
         {
@@ -109,6 +110,7 @@ namespace System.Xml.Tests
         }
 
         //[Variation(Desc = "v5 - schema(Local)->schema(Local)->schema(Local)", Priority = 1)]
+        [ActiveIssue(14918)]
         [Fact]
         public void v5()
         {


### PR DESCRIPTION
Disabling these two tests for now as they have been failing randomly on CentOS and RedHat in latest builds. (Seems like a problem with AppContext caching again)

Tracking issue: https://github.com/dotnet/corefx/issues/14918#event-914392725

cc: @danmosemsft @AlexGhiondea 