### PR TITLE
Correctly process useServerGC in build-tests.sh

### DIFF
--- a/build-managed.sh
+++ b/build-managed.sh
@@ -5,7 +5,6 @@ usage()
     echo "Usage: $0 [platform] [useservergc]"
     echo
     echo "platform can be: FreeBSD, Linux, NetBSD, OSX, Windows."
-    echo "useservergc - Switch used by configure the hosted coreclr instance when executing tests."
     echo
 }
 
@@ -16,7 +15,6 @@ __UnprocessedBuildArgs=
 __TestNugetRuntimeId=-distroRid
 __BuildOS=-os
 __TargetOS=-target-os
-__ServerGC=0
 
 while :; do
     if [ $# -le 0 ]; then
@@ -45,17 +43,12 @@ while :; do
             __BuildOS="$__BuildOS=windows_nt"
             __TargetOS="$__TargetOS=Windows_NT"
             ;;
-        useservergc)
-            __ServerGC=1
-            ;;
         *)
             __UnprocessedBuildArgs="$__UnprocessedBuildArgs $1"
     esac
 
     shift
 done
-
-export CORECLR_SERVER_GC="$__ServerGC"
 
 $__scriptpath/run.sh build-managed $__BuildOS $__TargetOS $__TestNugetRuntimeId $__UnprocessedBuildArgs
 exit $?

--- a/build-tests.sh
+++ b/build-tests.sh
@@ -1,4 +1,35 @@
 #!/usr/bin/env bash
+
+usage()
+{
+    echo "Usage: $0 [useservergc]"
+    echo
+    echo "useservergc - Switch used by configure the hosted coreclr instance when executing tests."
+    echo
+}
+
+__UnprocessedBuildArgs=
+__ServerGC=0
+
+while :; do
+    if [ $# -le 0 ]; then
+        break
+    fi
+
+    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    case $lowerI in
+        useservergc)
+            __ServerGC=1
+            ;;
+        *)
+            __UnprocessedBuildArgs="$__UnprocessedBuildArgs $1"
+    esac
+
+    shift
+done
+
+export CORECLR_SERVER_GC="$__ServerGC"
+
 working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$working_tree_root/run.sh build-managed -tests $*
+$working_tree_root/run.sh build-managed -tests $__UnprocessedBuildArgs
 exit $?


### PR DESCRIPTION
This moves the processing logic for `useServerGC` into build-tests.sh.

~~This is part of why the CI is broken, but not everything. The main problem is still that `-notrait category=non<xyz>tests` is not being used for some reason.~~ Never mind, that stopped happening. This should fix everything.

@weshaggard @alexperovich 