### PR TITLE
[dev/eng] Revert secrets and tokens in checked-in definitions to be VSTS secrets

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -444,7 +444,8 @@
       "value": "dotnetbuildoutput"
     },
     "CloudDropAccessToken": {
-      "value": "PassedViaPipeBuild"
+      "value": null,
+      "isSecret": true
     },
     "OfficialBuildId": {
       "value": "$(Build.BuildNumber)",
@@ -465,7 +466,8 @@
       "value": "dn-bot"
     },
     "VsoPassword": {
-      "value": "PassedViaPipeBuild"
+      "value": null,
+      "isSecret": true
     },
     "PB_VsoRepoName": {
       "value": "DotNet-CoreFX-Trusted",

--- a/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
@@ -250,7 +250,8 @@
       "value": "dotnetbuildoutput"
     },
     "CloudDropAccessToken": {
-      "value": "PassedViaPipeBuild"
+      "value": null,
+      "isSecret": true
     },
     "OfficialBuildId": {
       "value": "$(Build.BuildNumber)",
@@ -268,7 +269,8 @@
       "value": "dn-bot"
     },
     "VsoPassword": {
-      "value": "PassedViaPipeBuild"
+      "value": null,
+      "isSecret": true
     },
     "PB_VsoRepositoryName": {
       "value": "DotNet-CoreFX-Trusted",

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -403,7 +403,8 @@
       "value": "dotnetbuildoutput"
     },
     "CloudDropAccessToken": {
-      "value": "PassedViaPipeBuild"
+      "value": null,
+      "isSecret": true
     },
     "OfficialBuildId": {
       "value": "$(Build.BuildNumber)",
@@ -424,7 +425,8 @@
       "value": "dn-bot"
     },
     "VsoPassword": {
-      "value": "PassedViaPipeBuild"
+      "value": null,
+      "isSecret": true
     },
     "PB_VsoRepositoryName": {
       "value": "DotNet-CoreFX-Trusted",


### PR DESCRIPTION
Reverts some of https://github.com/dotnet/corefx/pull/14694 to turn leg build secrets back into secrets. This slightly improves security.