### PR TITLE
Add tests and other fixes

### DIFF
--- a/src/System.Configuration/src/System.Configuration.csproj
+++ b/src/System.Configuration/src/System.Configuration.csproj
@@ -14,6 +14,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System\Configuration\DictionarySectionHandler.cs" />
+    <Compile Include="System\Configuration\DpapiProtectedConfigurationProvider.cs" />
     <Compile Include="System\Configuration\IConfigurationSystem.cs" />
     <Compile Include="System\Configuration\IPersistComponentSettings.cs" />
     <Compile Include="System\Configuration\ApplicationSettingsBase.cs" />
@@ -174,6 +175,7 @@
     <Compile Include="System\Configuration\ReadOnlyNameValueCollection.cs" />
     <Compile Include="System\Configuration\RegexStringValidator.cs" />
     <Compile Include="System\Configuration\RegexStringValidatorAttribute.cs" />
+    <Compile Include="System\Configuration\RsaProtectedConfigurationProvider.cs" />
     <Compile Include="System\Configuration\RuntimeConfigurationRecord.cs" />
     <Compile Include="System\Configuration\SafeBitVector32.cs" />
     <Compile Include="System\Configuration\SchemeSettingElement.cs" />

--- a/src/System.Configuration/src/System/Configuration/ConfigurationFileMap.cs
+++ b/src/System.Configuration/src/System/Configuration/ConfigurationFileMap.cs
@@ -27,11 +27,10 @@ namespace System.Configuration
         {
             if (string.IsNullOrEmpty(machineConfigFilename))
                 throw new ArgumentNullException(nameof(machineConfigFilename));
+
             if (!File.Exists(machineConfigFilename))
-            {
                 throw new ArgumentException(string.Format(SR.Machine_config_file_not_found, machineConfigFilename),
                     nameof(machineConfigFilename));
-            }
 
             MachineConfigFilename = machineConfigFilename;
         }
@@ -57,5 +56,7 @@ namespace System.Configuration
         {
             return ClientConfigurationHost.MachineConfigFilePath;
         }
+
+        internal bool IsMachinePathDefault => _getFilenameThunk == GetFilenameFromMachineConfigFilePath;
     }
 }

--- a/src/System.Configuration/src/System/Configuration/DpapiProtectedConfigurationProvider.cs
+++ b/src/System.Configuration/src/System/Configuration/DpapiProtectedConfigurationProvider.cs
@@ -1,0 +1,137 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Specialized;
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml;
+
+namespace System.Configuration
+{
+    public sealed class DpapiProtectedConfigurationProvider : ProtectedConfigurationProvider
+    {
+        private const int CRYPTPROTECT_UI_FORBIDDEN = 0x1;
+        private const int CRYPTPROTECT_LOCAL_MACHINE = 0x4;
+        private bool _useMachineProtection = true;
+        private string _keyEntropy;
+
+        public override XmlNode Decrypt(XmlNode encryptedNode)
+        {
+            if (encryptedNode.NodeType != XmlNodeType.Element ||
+                encryptedNode.Name != "EncryptedData")
+            {
+                throw new ConfigurationErrorsException(SR.DPAPI_bad_data);
+            }
+
+            XmlNode cipherNode = TraverseToChild(encryptedNode, "CipherData", false);
+            if (cipherNode == null)
+                throw new ConfigurationErrorsException(SR.DPAPI_bad_data);
+
+            XmlNode cipherValue = TraverseToChild(cipherNode, "CipherValue", true);
+            if (cipherValue == null)
+                throw new ConfigurationErrorsException(SR.DPAPI_bad_data);
+
+            string encText = cipherValue.InnerText;
+            if (encText == null)
+                throw new ConfigurationErrorsException(SR.DPAPI_bad_data);
+
+            string decText = DecryptText(encText);
+            XmlDocument xmlDocument = new XmlDocument();
+            xmlDocument.PreserveWhitespace = true;
+            xmlDocument.LoadXml(decText);
+            return xmlDocument.DocumentElement;
+        }
+
+        public override XmlNode Encrypt(XmlNode node)
+        {
+            string text = node.OuterXml;
+            string encText = EncryptText(text);
+            string pre = @"<EncryptedData><CipherData><CipherValue>";
+            string post = @"</CipherValue></CipherData></EncryptedData>";
+            string xmlText = pre + encText + post;
+
+            XmlDocument xmlDocument = new XmlDocument();
+            xmlDocument.PreserveWhitespace = true;
+            xmlDocument.LoadXml(xmlText);
+            return xmlDocument.DocumentElement;
+        }
+
+        private string EncryptText(string clearText)
+        {
+            if (clearText == null || clearText.Length < 1)
+                return clearText;
+
+            byte[] inputData = PrepareDataBlob(clearText);
+            byte[] entropyData = PrepareDataBlob(_keyEntropy);
+
+            byte[] encryptedData = ProtectedData.Protect(
+                userData: inputData,
+                optionalEntropy: entropyData,
+                scope: UseMachineProtection ? DataProtectionScope.LocalMachine : DataProtectionScope.CurrentUser);
+
+            return Convert.ToBase64String(encryptedData);
+        }
+
+        private string DecryptText(string encText)
+        {
+            if (encText == null || encText.Length < 1)
+                return encText;
+
+            byte[] inputData = Convert.FromBase64String(encText);
+            byte[] entropyData = PrepareDataBlob(_keyEntropy);
+
+            byte[] decryptedData = ProtectedData.Unprotect(
+                encryptedData: inputData,
+                optionalEntropy: entropyData,
+                scope: UseMachineProtection ? DataProtectionScope.LocalMachine : DataProtectionScope.CurrentUser);
+
+            return Encoding.Unicode.GetString(decryptedData);
+        }
+
+        public bool UseMachineProtection { get { return _useMachineProtection; } }
+
+        public override void Initialize(string name, NameValueCollection configurationValues)
+        {
+            base.Initialize(name, configurationValues);
+            _useMachineProtection = GetBooleanValue(configurationValues, "useMachineProtection", true);
+            _keyEntropy = configurationValues["keyEntropy"];
+            configurationValues.Remove("keyEntropy");
+            if (configurationValues.Count > 0)
+                throw new ConfigurationErrorsException(string.Format(SR.Unrecognized_initialization_value, configurationValues.GetKey(0)));
+        }
+
+        private static XmlNode TraverseToChild(XmlNode node, string name, bool onlyChild)
+        {
+            foreach (XmlNode child in node.ChildNodes)
+            {
+                if (child.NodeType != XmlNodeType.Element)
+                    continue;
+                if (child.Name == name)
+                    return child; // found it!
+                if (onlyChild)
+                    return null;
+            }
+
+            return null;
+        }
+
+        private static byte[] PrepareDataBlob(string s)
+        {
+            return (s != null) ? Encoding.Unicode.GetBytes(s) : new byte[0];
+        }
+
+        private static bool GetBooleanValue(NameValueCollection configurationValues, string valueName, bool defaultValue)
+        {
+            string s = configurationValues[valueName];
+            if (s == null)
+                return defaultValue;
+            configurationValues.Remove(valueName);
+            if (s == "true")
+                return true;
+            if (s == "false")
+                return false;
+            throw new ConfigurationErrorsException(string.Format(SR.Config_invalid_boolean_attribute, valueName));
+        }
+    }
+}

--- a/src/System.Configuration/src/System/Configuration/DpapiProtectedConfigurationProvider.cs
+++ b/src/System.Configuration/src/System/Configuration/DpapiProtectedConfigurationProvider.cs
@@ -118,7 +118,7 @@ namespace System.Configuration
 
         private static byte[] PrepareDataBlob(string s)
         {
-            return (s != null) ? Encoding.Unicode.GetBytes(s) : new byte[0];
+            return (s != null) ? Encoding.Unicode.GetBytes(s) : Array.Empty<byte>();
         }
 
         private static bool GetBooleanValue(NameValueCollection configurationValues, string valueName, bool defaultValue)

--- a/src/System.Configuration/src/System/Configuration/ImplicitMachineConfigHost.cs
+++ b/src/System.Configuration/src/System/Configuration/ImplicitMachineConfigHost.cs
@@ -39,7 +39,7 @@ namespace System.Configuration
             string name = base.GetStreamName(configPath);
 
             if (ConfigPathUtility.GetName(configPath) == ClientConfigurationHost.MachineConfigName
-                && !string.Equals(_fileMap?.MachineConfigFilename, name))
+                && (_fileMap?.IsMachinePathDefault ?? true))
             {
                 // The machine config was asked for and wasn't explicitly
                 // specified, stash the "default" machine.config path
@@ -66,7 +66,22 @@ namespace System.Configuration
 @"<configuration>
     <configSections>
         <section name='appSettings' type='System.Configuration.AppSettingsSection, System.Configuration' restartOnExternalChanges='false' requirePermission='false'/>
+        <section name='connectionStrings' type='System.Configuration.ConnectionStringsSection, System.Configuration' requirePermission='false'/>
+        <section name='mscorlib' type='System.Configuration.IgnoreSection, System.Configuration' allowLocation='false'/>
+        <section name='runtime' type='System.Configuration.IgnoreSection, System.Configuration' allowLocation='false'/>
+        <section name='assemblyBinding' type='System.Configuration.IgnoreSection, System.Configuration' allowLocation='false'/>
+        <section name='satelliteassemblies' type='System.Configuration.IgnoreSection, System.Configuration' allowLocation='false'/>
+        <section name='startup' type='System.Configuration.IgnoreSection, System.Configuration' allowLocation='false'/>
     </configSections>
+    <configProtectedData defaultProvider='RsaProtectedConfigurationProvider'>
+        <providers>
+            <add name = 'RsaProtectedConfigurationProvider' type='System.Configuration.RsaProtectedConfigurationProvider,System.Configuration' description='Uses RsaCryptoServiceProvider to encrypt and decrypt' keyContainerName='NetFrameworkConfigurationKey' cspProviderName='' useMachineContainer='true' useOAEP='false'/>
+            <add name = 'DataProtectionConfigurationProvider' type='System.Configuration.DpapiProtectedConfigurationProvider,System.Configuration' description='Uses CryptProtectData and CryptUnProtectData Windows APIs to encrypt and decrypt' useMachineProtection='true' keyEntropy=''/>
+        </providers>
+    </configProtectedData>
+    <connectionStrings>
+        <add name = 'LocalSqlServer' connectionString='data source=.\SQLEXPRESS;Integrated Security=SSPI;AttachDBFilename=|DataDirectory|aspnetdb.mdf;User Instance=true' providerName='System.Data.SqlClient'/>
+    </connectionStrings>
 </configuration>";
     }
 }

--- a/src/System.Configuration/src/System/Configuration/Internal/WriteFileContext.cs
+++ b/src/System.Configuration/src/System/Configuration/Internal/WriteFileContext.cs
@@ -173,12 +173,19 @@ namespace System.Configuration.Internal
             }
         }
 
-        // Attempt to move a file from one location to another
+        // Attempt to move a file from one location to another, overwriting if needed
         private bool AttemptMove(string source, string target)
         {
             try
             {
-                File.Replace(source, target, null);
+                if (File.Exists(target))
+                {
+                    File.Replace(source, target, null);
+                }
+                else
+                {
+                    File.Move(source, target);
+                }
                 return true;
             }
             catch

--- a/src/System.Configuration/src/System/Configuration/RsaProtectedConfigurationProvider.cs
+++ b/src/System.Configuration/src/System/Configuration/RsaProtectedConfigurationProvider.cs
@@ -1,0 +1,280 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Specialized;
+using System.IO;
+using System.Security.Cryptography;
+using System.Xml;
+
+namespace System.Configuration
+{
+    // Need the System.Security.Cryptography.Xml package published before this can be enabled,
+    // for now, make it throw PlatformNotSupported.
+    //
+    // https://github.com/dotnet/corefx/issues/14950
+
+    public sealed class RsaProtectedConfigurationProvider : ProtectedConfigurationProvider
+    {
+        public override XmlNode Decrypt(XmlNode encryptedNode)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public override XmlNode Encrypt(XmlNode node)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public void AddKey(int keySize, bool exportable)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public void DeleteKey()
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public void ImportKey(string xmlFileName, bool exportable)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public void ExportKey(string xmlFileName, bool includePrivateParameters)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public string KeyContainerName { get { throw new PlatformNotSupportedException(); } }
+        public string CspProviderName { get { throw new PlatformNotSupportedException(); } }
+        public bool UseMachineContainer { get { throw new PlatformNotSupportedException(); } }
+        public bool UseOAEP { get { throw new PlatformNotSupportedException(); } }
+        public bool UseFIPS { get { throw new PlatformNotSupportedException(); } }
+        public RSAParameters RsaPublicKey { get { throw new PlatformNotSupportedException(); } }
+    }
+
+
+#if FALSE
+    public sealed class RsaProtectedConfigurationProvider : ProtectedConfigurationProvider
+    {
+        // Note: this name has to match the name used in RegiisUtility 
+        const string DefaultRsaKeyContainerName = "NetFrameworkConfigurationKey";
+        const uint PROV_Rsa_FULL = 1;
+        const uint CRYPT_MACHINE_KEYSET = 0x00000020;
+
+        private string _keyName;
+        private string _keyContainerName;
+        private string _cspProviderName;
+        private bool _useMachineContainer;
+        private bool _useOAEP;
+        private bool _useFIPS;
+
+        public override XmlNode Decrypt(XmlNode encryptedNode)
+        {
+            XmlDocument xmlDocument = new XmlDocument();
+            EncryptedXml exml = null;
+            RSACryptoServiceProvider rsa = GetCryptoServiceProvider(false, true);
+
+            xmlDocument.PreserveWhitespace = true;
+            xmlDocument.LoadXml(encryptedNode.OuterXml);
+            exml = new FipsAwareEncryptedXml(xmlDocument);
+            exml.AddKeyNameMapping(_keyName, rsa);
+            exml.DecryptDocument();
+            rsa.Clear();
+            return xmlDocument.DocumentElement;
+        }
+
+        public override XmlNode Encrypt(XmlNode node)
+        {
+            XmlDocument xmlDocument;
+            EncryptedXml exml;
+            byte[] rgbOutput;
+            EncryptedData ed;
+            KeyInfoName kin;
+            EncryptedKey ek;
+            KeyInfoEncryptedKey kek;
+            XmlElement inputElement;
+            RSACryptoServiceProvider rsa = GetCryptoServiceProvider(false, false);
+
+            // Encrypt the node with the new key
+            xmlDocument = new XmlDocument();
+            xmlDocument.PreserveWhitespace = true;
+            xmlDocument.LoadXml("<foo>" + node.OuterXml + "</foo>");
+            exml = new EncryptedXml(xmlDocument);
+            inputElement = xmlDocument.DocumentElement;
+
+            using (SymmetricAlgorithm symAlg = GetSymAlgorithmProvider())
+            {
+                rgbOutput = exml.EncryptData(inputElement, symAlg, true);
+                ed = new EncryptedData();
+                ed.Type = EncryptedXml.XmlEncElementUrl;
+                ed.EncryptionMethod = GetSymEncryptionMethod();
+                ed.KeyInfo = new KeyInfo();
+
+                ek = new EncryptedKey();
+                ek.EncryptionMethod = new EncryptionMethod(EncryptedXml.XmlEncRSA15Url);
+                ek.KeyInfo = new KeyInfo();
+                ek.CipherData = new CipherData();
+                ek.CipherData.CipherValue = EncryptedXml.EncryptKey(symAlg.Key, rsa, UseOAEP);
+            }
+
+            kin = new KeyInfoName();
+            kin.Value = _keyName;
+            ek.KeyInfo.AddClause(kin);
+            kek = new KeyInfoEncryptedKey(ek);
+            ed.KeyInfo.AddClause(kek);
+            ed.CipherData = new CipherData();
+            ed.CipherData.CipherValue = rgbOutput;
+            EncryptedXml.ReplaceElement(inputElement, ed, true);
+
+            rsa.Clear();
+
+            // Get node from the document
+            foreach (XmlNode node2 in xmlDocument.ChildNodes)
+                if (node2.NodeType == XmlNodeType.Element)
+                    foreach (XmlNode node3 in node2.ChildNodes) // node2 is the "foo" node
+                        if (node3.NodeType == XmlNodeType.Element)
+                            return node3; // node3 is the "EncryptedData" node
+            return null;
+        }
+
+        public void AddKey(int keySize, bool exportable)
+        {
+            RSACryptoServiceProvider rsa = GetCryptoServiceProvider(exportable, false);
+            rsa.KeySize = keySize;
+            rsa.PersistKeyInCsp = true;
+            rsa.Clear();
+        }
+
+        public void DeleteKey()
+        {
+            RSACryptoServiceProvider rsa = GetCryptoServiceProvider(false, true);
+            rsa.PersistKeyInCsp = false;
+            rsa.Clear();
+        }
+
+        public void ImportKey(string xmlFileName, bool exportable)
+        {
+            RSACryptoServiceProvider rsa = GetCryptoServiceProvider(exportable, false);
+            rsa.FromXmlString(File.ReadAllText(xmlFileName));
+            rsa.PersistKeyInCsp = true;
+            rsa.Clear();
+        }
+
+        public void ExportKey(string xmlFileName, bool includePrivateParameters)
+        {
+            RSACryptoServiceProvider rsa = GetCryptoServiceProvider(false, false);
+            string xmlString = rsa.ToXmlString(includePrivateParameters);
+            File.WriteAllText(xmlFileName, xmlString);
+            rsa.Clear();
+        }
+
+        public string KeyContainerName { get { return _keyContainerName; } }
+        public string CspProviderName { get { return _cspProviderName; } }
+        public bool UseMachineContainer { get { return _useMachineContainer; } }
+        public bool UseOAEP { get { return _useOAEP; } }
+        public bool UseFIPS { get { return _useFIPS; } }
+
+        public override void Initialize(string name, NameValueCollection configurationValues)
+        {
+            base.Initialize(name, configurationValues);
+
+            _keyName = "Rsa Key";
+            _keyContainerName = configurationValues["keyContainerName"];
+            configurationValues.Remove("keyContainerName");
+            if (_keyContainerName == null || _keyContainerName.Length < 1)
+                _keyContainerName = DefaultRsaKeyContainerName;
+
+            _cspProviderName = configurationValues["cspProviderName"];
+            configurationValues.Remove("cspProviderName");
+            _useMachineContainer = GetBooleanValue(configurationValues, "useMachineContainer", true);
+            _useOAEP = GetBooleanValue(configurationValues, "useOAEP", false);
+            _useFIPS = GetBooleanValue(configurationValues, "useFIPS", false);
+            if (configurationValues.Count > 0)
+                throw new ConfigurationErrorsException(string.Format(SR.Unrecognized_initialization_value, configurationValues.GetKey(0)));
+        }
+
+        public RSAParameters RsaPublicKey { get { return GetCryptoServiceProvider(false, false).ExportParameters(false); } }
+
+        private RSACryptoServiceProvider GetCryptoServiceProvider(bool exportable, bool keyMustExist)
+        {
+            try
+            {
+                CspParameters csp = new CspParameters();
+                csp.KeyContainerName = KeyContainerName;
+                csp.KeyNumber = 1;
+                csp.ProviderType = 1; // Dev10 Bug #548719: Explicitly require "RSA Full (Signature and Key Exchange)"
+
+                if (CspProviderName != null && CspProviderName.Length > 0)
+                    csp.ProviderName = CspProviderName;
+
+                if (UseMachineContainer)
+                    csp.Flags |= CspProviderFlags.UseMachineKeyStore;
+                if (!exportable && !keyMustExist)
+                    csp.Flags |= CspProviderFlags.UseNonExportableKey;
+                if (keyMustExist)
+                    csp.Flags |= CspProviderFlags.UseExistingKey;
+
+                return new RSACryptoServiceProvider(csp);
+
+            }
+            catch
+            {
+                // On NetFX (Desktop) we try to P/Invoke directly to Windows to get a "better" exception
+                // ThrowBetterException(keyMustExist);
+                throw;
+            }
+        }
+
+        private byte[] GetRandomKey()
+        {
+            byte[] buf = new byte[24];
+            (new RNGCryptoServiceProvider()).GetBytes(buf);
+            return buf;
+        }
+
+        private static bool GetBooleanValue(NameValueCollection configurationValues, string valueName, bool defaultValue)
+        {
+            string s = configurationValues[valueName];
+            if (s == null)
+                return defaultValue;
+            configurationValues.Remove(valueName);
+            if (s == "true")
+                return true;
+            if (s == "false")
+                return false;
+            throw new ConfigurationErrorsException(string.Format(SR.Config_invalid_boolean_attribute, valueName));
+        }
+
+        private SymmetricAlgorithm GetSymAlgorithmProvider()
+        {
+            SymmetricAlgorithm symAlg;
+
+            if (UseFIPS)
+            {
+                // AesCryptoServiceProvider implementation is FIPS certified
+                symAlg = new AesCryptoServiceProvider();
+            }
+            else
+            {
+                // Use the 3DES. FIPS obsolated 3DES
+                symAlg = new TripleDESCryptoServiceProvider();
+
+                byte[] rgbKey1 = GetRandomKey();
+                symAlg.Key = rgbKey1;
+                symAlg.Mode = CipherMode.ECB;
+                symAlg.Padding = PaddingMode.PKCS7;
+            }
+
+            return symAlg;
+        }
+
+        private EncryptionMethod GetSymEncryptionMethod()
+        {
+            return UseFIPS ? new EncryptionMethod(EncryptedXml.XmlEncAES256Url) :
+                             new EncryptionMethod(EncryptedXml.XmlEncTripleDESUrl);
+        }
+    }
+#endif
+}

--- a/src/System.Configuration/src/project.json
+++ b/src/System.Configuration/src/project.json
@@ -18,6 +18,8 @@
         "System.Runtime.Extensions": "4.4.0-beta-24909-02",
         "System.Runtime.Serialization.Formatters": "4.4.0-beta-24909-02",
         "System.Security.Cryptography.Algorithms": "4.4.0-beta-24909-02",
+        "System.Security.Cryptography.Csp": "4.4.0-beta-24909-02",
+        "System.Security.Cryptography.ProtectedData": "4.4.0-beta-24909-02",
         "System.Text.Encoding": "4.4.0-beta-24909-02",
         "System.Text.Encoding.Extensions": "4.4.0-beta-24909-02",
         "System.Text.RegularExpressions": "4.4.0-beta-24909-02",

--- a/src/System.Configuration/tests/Mono/CallbackValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/CallbackValidatorTest.cs
@@ -1,0 +1,108 @@
+//
+// System.Configuration.CallbackValidatorTest.cs - Unit tests
+// for System.Configuration.CallbackValidator.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class CallbackValidatorTest
+    {
+        [Fact]
+        public void CanValidate()
+        {
+            CallbackValidator v = new CallbackValidator(typeof(int), success);
+
+            Assert.False(v.CanValidate(typeof(string)));
+            Assert.True(v.CanValidate(typeof(int)));
+            Assert.False(v.CanValidate(typeof(object)));
+        }
+
+        public void NullCallback()
+        {
+            CallbackValidator v = new CallbackValidator(typeof(int), null);
+        }
+
+        public void NullType()
+        {
+            CallbackValidator v = new CallbackValidator(null, success);
+        }
+
+        bool hit_success;
+        bool hit_failure;
+
+        void success(object o)
+        {
+            hit_success = true;
+        }
+
+        void failure(object o)
+        {
+            hit_failure = true;
+            throw new Exception();
+        }
+
+        [Fact]
+        public void TestSuccess()
+        {
+            hit_success = false;
+            CallbackValidator v = new CallbackValidator(typeof(int), success);
+            v.Validate(5);
+
+            Assert.True(hit_success, "A1");
+        }
+
+        [Fact]
+        public void TestFailure1()
+        {
+            CallbackValidator v = new CallbackValidator(typeof(int), failure);
+            Assert.Throws<Exception>(() => v.Validate(5));
+        }
+
+        [Fact]
+        public void TestFailure2()
+        {
+            hit_failure = false;
+            CallbackValidator v = new CallbackValidator(typeof(int), failure);
+            try
+            {
+                v.Validate(5);
+            }
+            catch { }
+            finally
+            {
+                Assert.True(hit_failure, "A1");
+            }
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/CallbackValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/CallbackValidatorTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.CallbackValidatorTest.cs - Unit tests
 // for System.Configuration.CallbackValidator.
@@ -25,9 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/CommaDelimitedStringCollectionConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/CommaDelimitedStringCollectionConverterTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.CommaDelimitedStringCollectionConverterTest.cs - Unit tests
 // for System.Configuration.CommaDelimitedStringCollectionConverter.
@@ -25,9 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/CommaDelimitedStringCollectionConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/CommaDelimitedStringCollectionConverterTest.cs
@@ -1,0 +1,121 @@
+//
+// System.Configuration.CommaDelimitedStringCollectionConverterTest.cs - Unit tests
+// for System.Configuration.CommaDelimitedStringCollectionConverter.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class CommaDelimitedStringCollectionConverterTest
+    {
+        [Fact]
+        public void CanConvertFrom()
+        {
+            CommaDelimitedStringCollectionConverter cv = new CommaDelimitedStringCollectionConverter();
+
+            Assert.True(cv.CanConvertFrom(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertFrom(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertFrom(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertFrom(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void CanConvertTo()
+        {
+            CommaDelimitedStringCollectionConverter cv = new CommaDelimitedStringCollectionConverter();
+
+            Assert.True(cv.CanConvertTo(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertTo(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertTo(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertTo(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void ConvertFrom()
+        {
+            CommaDelimitedStringCollectionConverter cv = new CommaDelimitedStringCollectionConverter();
+            object o;
+            CommaDelimitedStringCollection col;
+
+            o = cv.ConvertFrom(null, null, "hi,bye");
+            Assert.Equal(typeof(CommaDelimitedStringCollection), o.GetType());
+
+            col = (CommaDelimitedStringCollection)o;
+            Assert.Equal(2, col.Count);
+            Assert.Equal("hi", col[0]);
+            Assert.Equal("bye", col[1]);
+
+            col = (CommaDelimitedStringCollection)cv.ConvertFrom(null, null, "hi, bye");
+            Assert.Equal(2, col.Count);
+            Assert.Equal("hi", col[0]);
+            Assert.Equal("bye", col[1]);
+        }
+
+        [Fact]
+        public void ConvertFrom_TypeError()
+        {
+            CommaDelimitedStringCollectionConverter cv = new CommaDelimitedStringCollectionConverter();
+            object o = null;
+
+            Assert.Throws<InvalidCastException>(() => o = cv.ConvertFrom(null, null, 59));
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void ConvertTo()
+        {
+            CommaDelimitedStringCollectionConverter cv = new CommaDelimitedStringCollectionConverter();
+            CommaDelimitedStringCollection col = new CommaDelimitedStringCollection();
+            col.Add("hi");
+            col.Add("bye");
+
+            Assert.Equal("hi,bye", cv.ConvertTo(null, null, col, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_NullError()
+        {
+            CommaDelimitedStringCollectionConverter cv = new CommaDelimitedStringCollectionConverter();
+
+            Assert.Equal(null, cv.ConvertTo(null, null, null, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_TypeError()
+        {
+            CommaDelimitedStringCollectionConverter cv = new CommaDelimitedStringCollectionConverter();
+
+            Assert.Throws<ArgumentException>(() => cv.ConvertTo(null, null, 59, typeof(string)));
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/CommaDelimitedStringCollectionTest.cs
+++ b/src/System.Configuration/tests/Mono/CommaDelimitedStringCollectionTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.CommaDelimitedStringCollectionTest.cs - Unit tests
 // for System.Configuration.CommaDelimitedStringCollection.
@@ -25,9 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/CommaDelimitedStringCollectionTest.cs
+++ b/src/System.Configuration/tests/Mono/CommaDelimitedStringCollectionTest.cs
@@ -1,0 +1,128 @@
+//
+// System.Configuration.CommaDelimitedStringCollectionTest.cs - Unit tests
+// for System.Configuration.CommaDelimitedStringCollection.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class CommaDelimitedStringCollectionTest
+    {
+        [Fact]
+        public void Defaults()
+        {
+            CommaDelimitedStringCollection c = new CommaDelimitedStringCollection();
+            Assert.False(c.IsModified, "A1");
+            Assert.False(c.IsReadOnly, "A1");
+        }
+
+        [Fact]
+        public void Manipulations()
+        {
+            CommaDelimitedStringCollection c = new CommaDelimitedStringCollection();
+
+            c.Add("1");
+            Assert.Equal("1", c.ToString());
+
+            c.Add("2");
+            c.Add("3");
+            Assert.Equal("1,2,3", c.ToString());
+
+            c.Remove("2");
+            Assert.Equal("1,3", c.ToString());
+
+            c.Insert(1, "2");
+            Assert.Equal("1,2,3", c.ToString());
+
+            c.Clear();
+            Assert.Equal(null, c.ToString());
+
+            string[] foo = new string[3];
+            foo[0] = "1";
+            foo[1] = "2";
+            foo[2] = "3";
+            c.AddRange(foo);
+            Assert.Equal("1,2,3", c.ToString());
+        }
+
+        [Fact]
+        public void RO_Add()
+        {
+            CommaDelimitedStringCollection c = new CommaDelimitedStringCollection();
+
+            c.SetReadOnly();
+            Assert.Throws<ConfigurationErrorsException>(() => c.Add("hi"));
+        }
+
+        [Fact]
+        public void RO_AddRange()
+        {
+            CommaDelimitedStringCollection c = new CommaDelimitedStringCollection();
+            string[] foo = new string[2];
+
+            foo[0] = "hi";
+            foo[1] = "bye";
+
+            c.SetReadOnly();
+            Assert.Throws<ConfigurationErrorsException>(() => c.AddRange(foo));
+        }
+
+        [Fact]
+        public void RO_Clear()
+        {
+            CommaDelimitedStringCollection c = new CommaDelimitedStringCollection();
+
+            c.SetReadOnly();
+            Assert.Throws<ConfigurationErrorsException>(() => c.Clear());
+        }
+
+        [Fact]
+        public void RO_Remove()
+        {
+            CommaDelimitedStringCollection c = new CommaDelimitedStringCollection();
+
+            c.SetReadOnly();
+            Assert.Throws<ConfigurationErrorsException>(() => c.Clear());
+        }
+
+        [Fact]
+        public void RO_Insert()
+        {
+            CommaDelimitedStringCollection c = new CommaDelimitedStringCollection();
+
+            c.Add("hi");
+            c.SetReadOnly();
+            Assert.Throws<ConfigurationErrorsException>(() => c.Insert(0, "bye"));
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/ConfigurationElementTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationElementTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.ConfigurationElementTest.cs - Unit tests
 // for System.Configuration.ConfigurationElement.
@@ -25,9 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/ConfigurationElementTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationElementTest.cs
@@ -1,0 +1,52 @@
+//
+// System.Configuration.ConfigurationElementTest.cs - Unit tests
+// for System.Configuration.ConfigurationElement.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2006 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class ConfigurationElementTest
+    {
+        [Fact]
+        public void ElementInformation_validator()
+        {
+            /* pick a Configuration class that doesn't
+             * specify an ElementInformation override */
+            DefaultSection sect = new DefaultSection();
+            ElementInformation info = sect.ElementInformation;
+
+            Assert.Equal(typeof(DefaultValidator), info.Validator.GetType());
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/ConfigurationErrorsExceptionTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationErrorsExceptionTest.cs
@@ -1,0 +1,641 @@
+//
+// ConfigurationErrorsExceptionTest.cs
+//
+// Author:
+//	Gert Driesen  <drieseng@users.sourceforge.net>
+//
+// Copyright (C) 2008 Gert Driesen
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Configuration;
+using System.Configuration.Internal;
+using System.IO;
+using System.Xml;
+
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class ConfigurationErrorsExceptionTest
+    {
+        [Fact] // ctor ()
+        public void Constructor1()
+        {
+            ConfigurationErrorsException cee = new ConfigurationErrorsException();
+            Assert.NotNull(cee.BareMessage);
+            Assert.True(cee.BareMessage.IndexOf("'" + typeof(ConfigurationErrorsException).FullName + "'") != -1, "#2:" + cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Null(cee.Filename);
+            Assert.Null(cee.InnerException);
+            Assert.Equal(0, cee.Line);
+            Assert.Equal(cee.BareMessage, cee.Message);
+        }
+
+        [Fact] // ctor (String)
+        public void Constructor2()
+        {
+            string msg;
+            ConfigurationErrorsException cee;
+
+            msg = "MSG";
+            cee = new ConfigurationErrorsException(msg);
+            Assert.Same(msg, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Null(cee.Filename);
+            Assert.Null(cee.InnerException);
+            Assert.Equal(0, cee.Line);
+            Assert.Same(msg, cee.Message);
+
+            msg = null;
+            cee = new ConfigurationErrorsException(msg);
+            Assert.Equal(new ConfigurationErrorsException().Message, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Null(cee.Filename);
+            Assert.Null(cee.InnerException);
+            Assert.Equal(0, cee.Line);
+            Assert.Equal(cee.BareMessage, cee.Message);
+        }
+
+        [Fact] // ctor (String, Exception)
+        public void Constructor3()
+        {
+            string msg;
+            Exception inner;
+            ConfigurationErrorsException cee;
+
+            msg = "MSG";
+            inner = new Exception();
+            cee = new ConfigurationErrorsException(msg, inner);
+            Assert.Same(msg, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Null(cee.Filename);
+            Assert.Same(inner, cee.InnerException);
+            Assert.Equal(0, cee.Line);
+            Assert.Same(msg, cee.Message);
+
+            msg = null;
+            inner = null;
+            cee = new ConfigurationErrorsException(msg, inner);
+            Assert.Equal(new ConfigurationErrorsException().Message, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Null(cee.Filename);
+            Assert.Same(inner, cee.InnerException);
+            Assert.Equal(0, cee.Line);
+            Assert.Equal(cee.BareMessage, cee.Message);
+        }
+
+        [Fact] // ctor (String, XmlNode)
+        // Doesn't pass on Mono
+        // [Category("NotWorking")]
+        public void Constructor4()
+        {
+            using (var temp = new TempDirectory())
+            {
+                string msg;
+                XmlNode node;
+                ConfigurationErrorsException cee;
+
+                string xmlfile = Path.Combine(temp.Path, "test.xml");
+                XmlDocument doc = new XmlDocument();
+                doc.AppendChild(doc.CreateElement("test"));
+                doc.Save(xmlfile);
+
+                msg = "MSG";
+                node = new XmlDocument();
+                cee = new ConfigurationErrorsException(msg, node);
+                Assert.Same(msg, cee.BareMessage);
+                Assert.NotNull(cee.Data);
+                Assert.Equal(0, cee.Data.Count);
+                Assert.Null(cee.Filename);
+                Assert.Null(cee.InnerException);
+                Assert.Equal(0, cee.Line);
+                Assert.Same(msg, cee.Message);
+
+                doc = new XmlDocument();
+                doc.Load(xmlfile);
+
+                msg = "MSG";
+                node = doc.DocumentElement;
+                cee = new ConfigurationErrorsException(msg, node);
+                Assert.Same(msg, cee.BareMessage);
+                Assert.NotNull(cee.Data);
+                Assert.Equal(0, cee.Data.Count);
+                Assert.Null(cee.Filename);
+                Assert.Null(cee.InnerException);
+                Assert.Equal(0, cee.Line);
+                Assert.Same(msg, cee.Message);
+
+                doc = new ConfigXmlDocument();
+                doc.Load(xmlfile);
+
+                msg = "MSG";
+                node = doc.DocumentElement;
+                cee = new ConfigurationErrorsException(msg, node);
+                Assert.Same(msg, cee.BareMessage);
+                Assert.NotNull(cee.Data);
+                Assert.Equal(0, cee.Data.Count);
+                Assert.Equal(xmlfile, cee.Filename);
+                Assert.Null(cee.InnerException);
+                Assert.Equal(1, cee.Line);
+                Assert.Equal(msg + " (" + xmlfile + " line 1)", cee.Message);
+
+                msg = null;
+                node = null;
+                cee = new ConfigurationErrorsException(msg, node);
+                Assert.Equal(new ConfigurationErrorsException().Message, cee.BareMessage);
+                Assert.NotNull(cee.Data);
+                Assert.Equal(0, cee.Data.Count);
+                Assert.Null(cee.Filename);
+                Assert.Null(cee.InnerException);
+                Assert.Equal(0, cee.Line);
+                Assert.Equal(cee.BareMessage, cee.Message);
+            }
+        }
+
+        [Fact] // ctor (String, Exception, XmlNode)
+        // Doesn't pass on Mono
+        // [Category("NotWorking")]
+        public void Constructor6()
+        {
+            using (var temp = new TempDirectory())
+            {
+                string msg;
+                Exception inner;
+                XmlNode node;
+                ConfigurationErrorsException cee;
+
+                string xmlfile = Path.Combine(temp.Path, "test.xml");
+                XmlDocument doc = new XmlDocument();
+                doc.AppendChild(doc.CreateElement("test"));
+                doc.Save(xmlfile);
+
+                msg = "MSG";
+                inner = new Exception();
+                node = new XmlDocument();
+                cee = new ConfigurationErrorsException(msg, inner, node);
+                Assert.Same(msg, cee.BareMessage);
+                Assert.NotNull(cee.Data);
+                Assert.Equal(0, cee.Data.Count);
+                Assert.Null(cee.Filename);
+                Assert.Same(inner, cee.InnerException);
+                Assert.Equal(0, cee.Line);
+                Assert.Same(msg, cee.Message);
+
+                doc = new XmlDocument();
+                doc.Load(xmlfile);
+
+                msg = null;
+                inner = null;
+                node = doc.DocumentElement;
+                cee = new ConfigurationErrorsException(msg, inner, node);
+                Assert.Equal(new ConfigurationErrorsException().Message, cee.BareMessage);
+                Assert.NotNull(cee.Data);
+                Assert.Equal(0, cee.Data.Count);
+                Assert.Null(cee.Filename);
+                Assert.Same(inner, cee.InnerException);
+                Assert.Equal(0, cee.Line);
+                Assert.Equal(cee.BareMessage, cee.Message);
+
+                doc = new ConfigXmlDocument();
+                doc.Load(xmlfile);
+
+                msg = null;
+                inner = null;
+                node = doc.DocumentElement;
+                cee = new ConfigurationErrorsException(msg, inner, node);
+                Assert.Equal(new ConfigurationErrorsException().Message, cee.BareMessage);
+                Assert.NotNull(cee.Data);
+                Assert.Equal(0, cee.Data.Count);
+                Assert.Equal(xmlfile, cee.Filename);
+                Assert.Same(inner, cee.InnerException);
+                Assert.Equal(1, cee.Line);
+                Assert.Equal(cee.BareMessage + " (" + xmlfile + " line 1)", cee.Message);
+
+                msg = null;
+                inner = null;
+                node = null;
+                cee = new ConfigurationErrorsException(msg, inner, node);
+                Assert.Equal(new ConfigurationErrorsException().Message, cee.BareMessage);
+                Assert.NotNull(cee.Data);
+                Assert.Equal(0, cee.Data.Count);
+                Assert.Null(cee.Filename);
+                Assert.Same(inner, cee.InnerException);
+                Assert.Equal(0, cee.Line);
+                Assert.Equal(cee.BareMessage, cee.Message);
+            }
+        }
+
+        [Fact] // ctor (String, String, Int32)
+        public void Constructor8()
+        {
+            string msg;
+            string filename;
+            int line;
+            ConfigurationErrorsException cee;
+
+            msg = "MSG";
+            filename = "abc.txt";
+            line = 7;
+            cee = new ConfigurationErrorsException(msg, filename, line);
+            Assert.Same(msg, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Null(cee.InnerException);
+            Assert.Equal(line, cee.Line);
+            Assert.Equal("MSG (abc.txt line 7)", cee.Message);
+
+            msg = null;
+            filename = null;
+            line = 0;
+            cee = new ConfigurationErrorsException(msg, filename, line);
+            Assert.Equal(new ConfigurationErrorsException().Message, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Null(cee.InnerException);
+            Assert.Equal(0, cee.Line);
+            Assert.Equal(cee.BareMessage, cee.Message);
+
+            msg = null;
+            filename = "abc.txt";
+            line = 5;
+            cee = new ConfigurationErrorsException(msg, filename, line);
+            Assert.Equal(new ConfigurationErrorsException().Message, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Null(cee.InnerException);
+            Assert.Equal(5, cee.Line);
+            Assert.Equal(cee.BareMessage + " (abc.txt line 5)", cee.Message);
+
+            msg = "MSG";
+            filename = null;
+            line = 5;
+            cee = new ConfigurationErrorsException(msg, filename, line);
+            Assert.Same(msg, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Null(cee.InnerException);
+            Assert.Equal(5, cee.Line);
+            Assert.Equal(msg + " (line 5)", cee.Message);
+
+            msg = "MSG";
+            filename = "abc.txt";
+            line = 0;
+            cee = new ConfigurationErrorsException(msg, filename, line);
+            Assert.Same(msg, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Null(cee.InnerException);
+            Assert.Equal(0, cee.Line);
+            Assert.Equal(msg + " (abc.txt)", cee.Message);
+
+            msg = null;
+            filename = null;
+            line = 4;
+            cee = new ConfigurationErrorsException(msg, filename, line);
+            Assert.Equal(new ConfigurationErrorsException().Message, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Null(cee.InnerException);
+            Assert.Equal(4, cee.Line);
+            Assert.Equal(cee.BareMessage + " (line 4)", cee.Message);
+
+            msg = string.Empty;
+            filename = string.Empty;
+            line = 0;
+            cee = new ConfigurationErrorsException(msg, filename, line);
+            Assert.Same(msg, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Null(cee.InnerException);
+            Assert.Equal(0, cee.Line);
+            Assert.Same(msg, cee.Message);
+
+            msg = string.Empty;
+            filename = "abc.txt";
+            line = 6;
+            cee = new ConfigurationErrorsException(msg, filename, line);
+            Assert.Same(msg, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Null(cee.InnerException);
+            Assert.Equal(6, cee.Line);
+            Assert.Equal(msg + " (abc.txt line 6)", cee.Message);
+
+            msg = "MSG";
+            filename = string.Empty;
+            line = 6;
+            cee = new ConfigurationErrorsException(msg, filename, line);
+            Assert.Same(msg, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Null(cee.InnerException);
+            Assert.Equal(6, cee.Line);
+            Assert.Equal(msg + " (line 6)", cee.Message);
+
+            msg = string.Empty;
+            filename = string.Empty;
+            line = 4;
+            cee = new ConfigurationErrorsException(msg, filename, line);
+            Assert.Same(msg, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Null(cee.InnerException);
+            Assert.Equal(4, cee.Line);
+            Assert.Equal(msg + " (line 4)", cee.Message);
+
+            msg = "MSG";
+            filename = string.Empty;
+            line = 0;
+            cee = new ConfigurationErrorsException(msg, filename, line);
+            Assert.Same(msg, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Null(cee.InnerException);
+            Assert.Equal(0, cee.Line);
+            Assert.Equal(msg, cee.Message);
+        }
+
+        [Fact] // ctor (String, Exception, String, Int32)
+        public void Constructor9()
+        {
+            string msg;
+            Exception inner;
+            string filename;
+            int line;
+            ConfigurationErrorsException cee;
+
+            msg = "MSG";
+            inner = new Exception();
+            filename = "abc.txt";
+            line = 7;
+            cee = new ConfigurationErrorsException(msg, inner, filename, line);
+            Assert.Same(msg, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Same(inner, cee.InnerException);
+            Assert.Equal(line, cee.Line);
+            Assert.Equal(msg + " (abc.txt line 7)", cee.Message);
+
+            msg = null;
+            inner = null;
+            filename = null;
+            line = 0;
+            cee = new ConfigurationErrorsException(msg, inner, filename, line);
+            Assert.Equal(new ConfigurationErrorsException().Message, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Same(inner, cee.InnerException);
+            Assert.Equal(0, cee.Line);
+            Assert.Equal(cee.BareMessage, cee.Message);
+
+            msg = null;
+            inner = new Exception();
+            filename = null;
+            line = 7;
+            cee = new ConfigurationErrorsException(msg, inner, filename, line);
+            Assert.Equal(new ConfigurationErrorsException().Message, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Same(inner, cee.InnerException);
+            Assert.Equal(line, cee.Line);
+            Assert.Equal(cee.BareMessage + " (line 7)", cee.Message);
+
+            msg = string.Empty;
+            inner = new Exception();
+            filename = string.Empty;
+            line = 7;
+            cee = new ConfigurationErrorsException(msg, inner, filename, line);
+            Assert.Same(msg, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Same(inner, cee.InnerException);
+            Assert.Equal(line, cee.Line);
+            Assert.Equal(" (line 7)", cee.Message);
+
+            msg = string.Empty;
+            inner = new Exception();
+            filename = "abc.txt";
+            line = 7;
+            cee = new ConfigurationErrorsException(msg, inner, filename, line);
+            Assert.Same(msg, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Same(inner, cee.InnerException);
+            Assert.Equal(line, cee.Line);
+            Assert.Equal(" (abc.txt line 7)", cee.Message);
+
+            msg = "MSG";
+            inner = new Exception();
+            filename = null;
+            line = 7;
+            cee = new ConfigurationErrorsException(msg, inner, filename, line);
+            Assert.Same(msg, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Same(inner, cee.InnerException);
+            Assert.Equal(line, cee.Line);
+            Assert.Equal(cee.BareMessage + " (line 7)", cee.Message);
+
+            msg = null;
+            inner = new Exception();
+            filename = "abc.txt";
+            line = 7;
+            cee = new ConfigurationErrorsException(msg, inner, filename, line);
+            Assert.Equal(new ConfigurationErrorsException().Message, cee.BareMessage);
+            Assert.NotNull(cee.Data);
+            Assert.Equal(0, cee.Data.Count);
+            Assert.Same(filename, cee.Filename);
+            Assert.Same(inner, cee.InnerException);
+            Assert.Equal(line, cee.Line);
+            Assert.Equal(cee.BareMessage + " (abc.txt line 7)", cee.Message);
+        }
+
+        [Fact] // GetFilename (XmlReader)
+        public void GetFilename1_Reader_Null()
+        {
+            XmlReader reader = null;
+            string filename = ConfigurationErrorsException.GetFilename(reader);
+            Assert.Null(filename);
+        }
+
+        [Fact] // GetFilename (XmlNode)
+        // Doesn't pass on Mono
+        // [Category("NotWorking")]
+        public void GetFilename2()
+        {
+            using (var temp = new TempDirectory())
+            {
+                XmlNode node;
+                string filename;
+
+                string xmlfile = Path.Combine(temp.Path, "test.xml");
+                XmlDocument doc = new XmlDocument();
+                doc.AppendChild(doc.CreateElement("test"));
+                doc.Save(xmlfile);
+
+                node = new XmlDocument();
+                filename = ConfigurationErrorsException.GetFilename(node);
+                Assert.Null(filename);
+
+                doc = new XmlDocument();
+                doc.Load(xmlfile);
+
+                node = doc.DocumentElement;
+                filename = ConfigurationErrorsException.GetFilename(node);
+                Assert.Null(filename);
+
+                doc = new ConfigXmlDocument();
+                doc.Load(xmlfile);
+
+                node = doc.DocumentElement;
+                filename = ConfigurationErrorsException.GetFilename(node);
+                Assert.Equal(xmlfile, filename);
+            }
+        }
+
+        [Fact] // GetFilename (XmlNode)
+        public void GetFilename2_Node_Null()
+        {
+            XmlNode node = null;
+            string filename = ConfigurationErrorsException.GetFilename(node);
+            Assert.Null(filename);
+        }
+
+        [Fact] // GetLineNumber (XmlReader)
+        public void GetLineNumber1()
+        {
+            using (var temp = new TempDirectory())
+            {
+                string xmlfile = Path.Combine(temp.Path, "test.xml");
+                XmlDocument doc = new XmlDocument();
+                doc.AppendChild(doc.CreateElement("test"));
+                doc.Save(xmlfile);
+
+                using (XmlReader reader = new XmlTextReader(xmlfile))
+                {
+                    int line = ConfigurationErrorsException.GetLineNumber(reader);
+                    Assert.Equal(0, line);
+                }
+
+                using (XmlErrorReader reader = new XmlErrorReader(xmlfile))
+                {
+                    int line = ConfigurationErrorsException.GetLineNumber(reader);
+                    Assert.Equal(666, line);
+                }
+            }
+        }
+
+        [Fact] // GetLineNumber (XmlReader)
+        public void GetLineNumber1_Reader_Null()
+        {
+            XmlReader reader = null;
+            int line = ConfigurationErrorsException.GetLineNumber(reader);
+            Assert.Equal(0, line);
+        }
+
+        [Fact] // GetLineNumber (XmlNode)
+        // Doesn't pass on Mono
+        // [Category("NotWorking")]
+        public void GetLineNumber2()
+        {
+            using (var temp = new TempDirectory())
+            {
+                XmlNode node;
+                int line;
+
+                string xmlfile = Path.Combine(temp.Path, "test.xml");
+                XmlDocument doc = new XmlDocument();
+                doc.AppendChild(doc.CreateElement("test"));
+                doc.Save(xmlfile);
+
+                node = new XmlDocument();
+                line = ConfigurationErrorsException.GetLineNumber(node);
+                Assert.Equal(0, line);
+
+                doc = new XmlDocument();
+                doc.Load(xmlfile);
+
+                node = doc.DocumentElement;
+                line = ConfigurationErrorsException.GetLineNumber(node);
+                Assert.Equal(0, line);
+
+                doc = new ConfigXmlDocument();
+                doc.Load(xmlfile);
+
+                node = doc.DocumentElement;
+                line = ConfigurationErrorsException.GetLineNumber(node);
+                Assert.Equal(1, line);
+            }
+        }
+
+        [Fact] // GetLineNumber (XmlNode)
+        public void GetLineNumber2_Node_Null()
+        {
+            XmlNode node = null;
+            int line = ConfigurationErrorsException.GetLineNumber(node);
+            Assert.Equal(0, line);
+        }
+
+        class XmlErrorReader : XmlTextReader, IConfigErrorInfo
+        {
+            public XmlErrorReader(string filename) : base(filename)
+            {
+            }
+
+            string IConfigErrorInfo.Filename
+            {
+                get { return "FILE"; }
+            }
+
+            int IConfigErrorInfo.LineNumber
+            {
+                get { return 666; }
+            }
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/ConfigurationErrorsExceptionTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationErrorsExceptionTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // ConfigurationErrorsExceptionTest.cs
 //
@@ -24,9 +26,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/ConfigurationLockCollectionTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationLockCollectionTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.ConfigurationLockCollectionTest.cs - Unit
 // tests for System.Configuration.ConfigurationLockCollection.
@@ -25,9 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System.Configuration;
 using System.Collections;

--- a/src/System.Configuration/tests/Mono/ConfigurationLockCollectionTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationLockCollectionTest.cs
@@ -1,0 +1,174 @@
+//
+// System.Configuration.ConfigurationLockCollectionTest.cs - Unit
+// tests for System.Configuration.ConfigurationLockCollection.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System.Configuration;
+using System.Collections;
+using Xunit;
+using SysConfig = System.Configuration.Configuration;
+
+namespace MonoTests.System.Configuration
+{
+    public class ConfigurationLockCollectionTest
+    {
+        [Fact]
+        public void InitialState()
+        {
+            SysConfig cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            ConfigurationLockCollection col;
+
+            col = cfg.AppSettings.LockAttributes;
+            Assert.Equal(0, col.Count);
+            Assert.False(col.Contains("file"), "A2");
+            Assert.False(col.HasParentElements, "A4");
+            Assert.False(col.IsModified, "A5");
+            Assert.False(col.IsSynchronized);
+            Assert.Equal(col, col.SyncRoot);
+
+            col = cfg.AppSettings.LockElements;
+            Assert.Equal(0, col.Count);
+            Assert.False(col.HasParentElements, "A11");
+            Assert.False(col.IsModified, "A12");
+            Assert.False(col.IsSynchronized, "A13");
+            Assert.Equal(col, col.SyncRoot);
+
+            col = cfg.ConnectionStrings.LockAttributes;
+            Assert.Equal(0, col.Count);
+            Assert.False(col.HasParentElements, "A11");
+            Assert.False(col.IsModified, "A12");
+            Assert.False(col.IsSynchronized, "A13");
+            Assert.Equal(col, col.SyncRoot);
+
+            col = cfg.ConnectionStrings.LockElements;
+            Assert.Equal(0, col.Count);
+            Assert.False(col.HasParentElements, "A11");
+            Assert.False(col.IsModified, "A12");
+            Assert.False(col.IsSynchronized, "A13");
+            Assert.Equal(col, col.SyncRoot);
+        }
+
+        [Fact]
+        public void NonExistantItem()
+        {
+            SysConfig cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            ConfigurationLockCollection col;
+
+            col = cfg.AppSettings.LockAttributes;
+
+            Assert.Throws<ConfigurationErrorsException>(() => col.IsReadOnly("file"));
+        }
+
+        [Fact]
+        public void Populate()
+        {
+            SysConfig cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            ConfigurationLockCollection col = cfg.AppSettings.LockAttributes;
+
+            col.Add("file");
+
+            Assert.Equal(1, col.Count);
+            Assert.False(col.HasParentElements, "A2");
+            Assert.True(col.IsModified, "A3");
+            Assert.True(col.Contains("file"), "A4");
+        }
+
+        [Fact]
+        public void Populate_Error()
+        {
+            SysConfig cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            ConfigurationLockCollection col = cfg.AppSettings.LockAttributes;
+
+            Assert.Throws<ConfigurationErrorsException>(() => col.Add("boo"));
+        }
+
+        [Fact]
+        public void Enumerator()
+        {
+            SysConfig cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            ConfigurationLockCollection col = cfg.AppSettings.LockAttributes;
+
+            col.Add("file");
+
+            IEnumerator e = col.GetEnumerator();
+            Assert.True(e.MoveNext(), "A1");
+            Assert.Equal("file", (string)e.Current);
+            Assert.False(e.MoveNext(), "A3");
+        }
+
+        [Fact]
+        public void SetFromList()
+        {
+            SysConfig cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            ConfigurationLockCollection col = cfg.AppSettings.LockAttributes;
+
+            col.SetFromList("file");
+            Assert.Equal(1, col.Count);
+            Assert.True(col.Contains("file"), "A2");
+
+            col.Clear();
+            Assert.Equal(0, col.Count);
+
+            col.SetFromList(" file ");
+            Assert.Equal(1, col.Count);
+            Assert.True(col.Contains("file"), "A2");
+        }
+
+        [Fact]
+        public void DuplicateAdd()
+        {
+            SysConfig cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            AppSettingsSection app = cfg.AppSettings;
+
+            app.LockAttributes.Clear();
+
+            app.LockAttributes.Add("file");
+            app.LockAttributes.Add("file");
+
+            Assert.Equal(1, app.LockAttributes.Count);
+        }
+
+        [Fact]
+        public void IsReadOnly()
+        {
+            SysConfig cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            AppSettingsSection app = cfg.AppSettings;
+
+            app.LockAttributes.Clear();
+            app.LockAllAttributesExcept.Clear();
+
+            app.LockAttributes.Add("file");
+            Assert.False(app.LockAttributes.IsReadOnly("file"), "A1");
+
+            app.LockAllAttributesExcept.Add("file");
+            Assert.False(app.LockAllAttributesExcept.IsReadOnly("file"), "A2");
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/ConfigurationManagerTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationManagerTest.cs
@@ -54,6 +54,7 @@ namespace MonoTests.System.Configuration
         public void OpenExeConfiguration1_UserLevel_PerUserRoaming()
         {
             SysConfig config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoaming);
+            Assert.False(string.IsNullOrEmpty(config.FilePath), "should have some file path");
             FileInfo fi = new FileInfo(config.FilePath);
             Assert.Equal("user.config", fi.Name);
         }
@@ -133,9 +134,13 @@ namespace MonoTests.System.Configuration
         [Fact]
         public void exePath_UserLevelPerRoaming()
         {
+            string applicationData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            Assert.False(string.IsNullOrEmpty(applicationData), "application data shouldn't be empty");
+            Assert.True(Directory.Exists(applicationData), "application data should exist");
+
             SysConfig config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoaming);
             string filePath = config.FilePath;
-            string applicationData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            Assert.False(string.IsNullOrEmpty(filePath), "should have some file path");
             Assert.True(filePath.StartsWith(applicationData), "#1:" + filePath);
             Assert.Equal("user.config", Path.GetFileName(filePath));
         }

--- a/src/System.Configuration/tests/Mono/ConfigurationManagerTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationManagerTest.cs
@@ -1,0 +1,416 @@
+//
+// System.Configuration.ConfigurationManagerTest.cs - Unit tests
+// for System.Configuration.ConfigurationManager.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//	Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2005-2006 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Specialized;
+using System.Configuration;
+using System.IO;
+using Xunit;
+using SysConfig = System.Configuration.Configuration;
+using System.Runtime.InteropServices;
+using System.Reflection;
+
+namespace MonoTests.System.Configuration
+{
+    using Util;
+
+    public class ConfigurationManagerTest
+    {
+        [Fact] // OpenExeConfiguration (ConfigurationUserLevel)
+        public void OpenExeConfiguration1_UserLevel_None()
+        {
+            SysConfig config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            FileInfo fi = new FileInfo(config.FilePath);
+            Assert.Equal(TestUtil.ThisConfigFileName, fi.Name);
+        }
+
+        [Fact]
+        public void OpenExeConfiguration1_UserLevel_PerUserRoaming()
+        {
+            SysConfig config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoaming);
+            FileInfo fi = new FileInfo(config.FilePath);
+            Assert.Equal("user.config", fi.Name);
+        }
+
+        [Fact]
+        public void OpenExeConfiguration1_UserLevel_PerUserRoamingAndLocal()
+        {
+            SysConfig config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoamingAndLocal);
+            FileInfo fi = new FileInfo(config.FilePath);
+            Assert.Equal("user.config", fi.Name);
+        }
+
+        [Fact] // OpenExeConfiguration (String)
+        public void OpenExeConfiguration2()
+        {
+            using (var temp = new TempDirectory())
+            {
+                string exePath;
+                SysConfig config;
+
+                exePath = Path.Combine(temp.Path, "DoesNotExist.whatever");
+                File.Create(exePath).Close();
+
+                config = ConfigurationManager.OpenExeConfiguration(exePath);
+                Assert.Equal(exePath + ".config", config.FilePath);
+
+                exePath = Path.Combine(temp.Path, "SomeExecutable.exe");
+                File.Create(exePath).Close();
+
+                config = ConfigurationManager.OpenExeConfiguration(exePath);
+                Assert.Equal(exePath + ".config", config.FilePath);
+
+                exePath = Path.Combine(temp.Path, "Foo.exe.config");
+                File.Create(exePath).Close();
+
+                config = ConfigurationManager.OpenExeConfiguration(exePath);
+                Assert.Equal(exePath + ".config", config.FilePath);
+            }
+        }
+
+        [Fact] // OpenExeConfiguration (String)
+        public void OpenExeConfiguration2_ExePath_DoesNotExist()
+        {
+            using (var temp = new TempDirectory())
+            {
+                string exePath = Path.Combine(temp.Path, "DoesNotExist.exe");
+
+                ConfigurationErrorsException ex = Assert.Throws<ConfigurationErrorsException>(
+                    () => ConfigurationManager.OpenExeConfiguration(exePath));
+
+                // An error occurred loading a configuration file:
+                // The parameter 'exePath' is invalid
+                Assert.Equal(typeof(ConfigurationErrorsException), ex.GetType());
+                Assert.Null(ex.Filename);
+                Assert.NotNull(ex.InnerException);
+                Assert.Equal(0, ex.Line);
+                Assert.NotNull(ex.Message);
+
+                // The parameter 'exePath' is invalid
+                ArgumentException inner = ex.InnerException as ArgumentException;
+                Assert.NotNull(inner);
+                Assert.Equal(typeof(ArgumentException), inner.GetType());
+                Assert.Null(inner.InnerException);
+                Assert.NotNull(inner.Message);
+                Assert.Equal("exePath", inner.ParamName);
+            }
+        }
+
+        [Fact]
+        public void exePath_UserLevelNone()
+        {
+            string name = TestUtil.ThisApplicationPath;
+            SysConfig config = ConfigurationManager.OpenExeConfiguration(name);
+            Assert.Equal(TestUtil.ThisApplicationPath + ".config", config.FilePath);
+        }
+
+        [Fact]
+        public void exePath_UserLevelPerRoaming()
+        {
+            SysConfig config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoaming);
+            string filePath = config.FilePath;
+            string applicationData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            Assert.True(filePath.StartsWith(applicationData), "#1:" + filePath);
+            Assert.Equal("user.config", Path.GetFileName(filePath));
+        }
+
+        [Fact]
+        public void exePath_UserLevelPerRoamingAndLocal()
+        {
+            SysConfig config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoamingAndLocal);
+            string filePath = config.FilePath;
+            string applicationData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            Assert.True(filePath.StartsWith(applicationData), "#1:" + filePath);
+            Assert.Equal("user.config", Path.GetFileName(filePath));
+        }
+
+        [Fact]
+        public void mapped_UserLevelNone()
+        {
+            ExeConfigurationFileMap map = new ExeConfigurationFileMap();
+            map.ExeConfigFilename = "execonfig";
+
+            SysConfig config = ConfigurationManager.OpenMappedExeConfiguration(map, ConfigurationUserLevel.None);
+            FileInfo fi = new FileInfo(config.FilePath);
+            Assert.Equal("execonfig", fi.Name);
+
+        }
+
+        [Fact]
+        public void mapped_UserLevelPerRoaming()
+        {
+            ExeConfigurationFileMap map = new ExeConfigurationFileMap();
+            map.ExeConfigFilename = "execonfig";
+            map.RoamingUserConfigFilename = "roaminguser";
+
+            SysConfig config = ConfigurationManager.OpenMappedExeConfiguration(map, ConfigurationUserLevel.PerUserRoaming);
+            FileInfo fi = new FileInfo(config.FilePath);
+            Assert.Equal("roaminguser", fi.Name);
+        }
+
+        [Fact]
+        // Doesn't pass on Mono
+        // [Category("NotWorking")]
+        public void mapped_UserLevelPerRoaming_no_execonfig()
+        {
+            ExeConfigurationFileMap map = new ExeConfigurationFileMap();
+            map.RoamingUserConfigFilename = "roaminguser";
+
+            Assert.Throws<ArgumentException>(() => ConfigurationManager.OpenMappedExeConfiguration(map, ConfigurationUserLevel.PerUserRoaming));
+        }
+
+        [Fact]
+        public void mapped_UserLevelPerRoamingAndLocal()
+        {
+            ExeConfigurationFileMap map = new ExeConfigurationFileMap();
+            map.ExeConfigFilename = "execonfig";
+            map.RoamingUserConfigFilename = "roaminguser";
+            map.LocalUserConfigFilename = "localuser";
+
+            SysConfig config = ConfigurationManager.OpenMappedExeConfiguration(map, ConfigurationUserLevel.PerUserRoamingAndLocal);
+            FileInfo fi = new FileInfo(config.FilePath);
+            Assert.Equal("localuser", fi.Name);
+        }
+
+        [Fact]
+        // Doesn't pass on Mono
+        // [Category("NotWorking")]
+        public void mapped_UserLevelPerRoamingAndLocal_no_execonfig()
+        {
+            ExeConfigurationFileMap map = new ExeConfigurationFileMap();
+            map.RoamingUserConfigFilename = "roaminguser";
+            map.LocalUserConfigFilename = "localuser";
+
+            Assert.Throws<ArgumentException>(() => ConfigurationManager.OpenMappedExeConfiguration(map, ConfigurationUserLevel.PerUserRoamingAndLocal));
+        }
+
+        [Fact]
+        // Doesn't pass on Mono
+        // [Category("NotWorking")]
+        public void mapped_UserLevelPerRoamingAndLocal_no_roaminguser()
+        {
+            ExeConfigurationFileMap map = new ExeConfigurationFileMap();
+            map.ExeConfigFilename = "execonfig";
+            map.LocalUserConfigFilename = "localuser";
+
+            Assert.Throws<ArgumentException>(() => ConfigurationManager.OpenMappedExeConfiguration(map, ConfigurationUserLevel.PerUserRoamingAndLocal));
+        }
+
+        [Fact]
+        public void MachineConfig()
+        {
+            SysConfig config = ConfigurationManager.OpenMachineConfiguration();
+            FileInfo fi = new FileInfo(config.FilePath);
+            Assert.Equal("machine.config", fi.Name);
+        }
+
+        [Fact]
+        public void mapped_MachineConfig()
+        {
+            ConfigurationFileMap map = new ConfigurationFileMap();
+            map.MachineConfigFilename = "machineconfig";
+
+            SysConfig config = ConfigurationManager.OpenMappedMachineConfiguration(map);
+
+            FileInfo fi = new FileInfo(config.FilePath);
+            Assert.Equal("machineconfig", fi.Name);
+        }
+
+        [Fact]
+        // Doesn't pass on Mono
+        // [Category("NotWorking")]
+        public void mapped_ExeConfiguration_null()
+        {
+            SysConfig config = ConfigurationManager.OpenMappedExeConfiguration(null, ConfigurationUserLevel.None);
+
+            FileInfo fi = new FileInfo(config.FilePath);
+            Assert.Equal(TestUtil.ThisConfigFileName, fi.Name);
+        }
+
+        [Fact]
+        // Doesn't pass on Mono
+        // [Category("NotWorking")]
+        public void mapped_MachineConfig_null()
+        {
+            SysConfig config = ConfigurationManager.OpenMappedMachineConfiguration(null);
+
+            FileInfo fi = new FileInfo(config.FilePath);
+            Assert.Equal("machine.config", fi.Name);
+        }
+
+        [Fact]
+        public void GetSectionReturnsNativeObject()
+        {
+            Assert.True(ConfigurationManager.GetSection("appSettings") is NameValueCollection);
+        }
+
+        [Fact]  // Test for bug #3412
+        // Doesn't pass on Mono
+        // [Category("NotWorking")]
+        public void TestAddRemoveSection()
+        {
+            const string name = "testsection";
+            var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+
+            // ensure not present
+            if (config.Sections.Get(name) != null)
+            {
+                config.Sections.Remove(name);
+            }
+
+            // add
+            config.Sections.Add(name, new TestSection());
+
+            // remove
+            var section = config.Sections.Get(name);
+            Assert.NotNull(section);
+            Assert.NotNull(section as TestSection);
+            config.Sections.Remove(name);
+
+            // add
+            config.Sections.Add(name, new TestSection());
+
+            // remove
+            section = config.Sections.Get(name);
+            Assert.NotNull(section);
+            Assert.NotNull(section as TestSection);
+            config.Sections.Remove(name);
+        }
+
+        [Fact]
+        public void TestFileMap()
+        {
+            var name = Path.GetRandomFileName() + ".config";
+            Assert.False(File.Exists(name));
+
+            try
+            {
+                var map = new ExeConfigurationFileMap();
+                map.ExeConfigFilename = name;
+
+                var config = ConfigurationManager.OpenMappedExeConfiguration(
+                    map, ConfigurationUserLevel.None);
+
+                config.Sections.Add("testsection", new TestSection());
+
+                config.Save();
+
+                Assert.True(File.Exists(name), "#1");
+                Assert.True(File.Exists(Path.GetFullPath(name)), "#2");
+            }
+            finally
+            {
+                File.Delete(name);
+            }
+        }
+
+        [Fact]
+        public void TestContext()
+        {
+            var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            const string name = "testsection";
+
+            // ensure not present
+            if (config.GetSection(name) != null)
+                config.Sections.Remove(name);
+
+            var section = new TestContextSection();
+
+            // Can't access EvaluationContext ....
+            Assert.Throws<ConfigurationErrorsException>(() => section.TestContext(null));
+
+            // ... until it's been added to a section.
+            config.Sections.Add(name, section);
+            section.TestContext("#2");
+
+            // Remove ...
+            config.Sections.Remove(name);
+
+            // ... and it doesn't lose its context
+            section.TestContext(null);
+        }
+
+        [Fact]
+        public void TestContext2()
+        {
+            var name = Path.GetRandomFileName() + ".config";
+            Assert.False(File.Exists(name));
+
+            try
+            {
+                var map = new ExeConfigurationFileMap();
+                map.ExeConfigFilename = name;
+
+                var config = ConfigurationManager.OpenMappedExeConfiguration(
+                    map, ConfigurationUserLevel.None);
+
+                config.Sections.Add("testsection", new TestSection());
+                config.Sections.Add("testcontext", new TestContextSection());
+
+                config.Save();
+
+                Assert.True(File.Exists(name), "#1");
+            }
+            finally
+            {
+                File.Delete(name);
+            }
+        }
+
+        class TestSection : ConfigurationSection { }
+
+        class TestContextSection : ConfigurationSection
+        {
+            public void TestContext(string label)
+            {
+                Assert.NotNull(EvaluationContext);
+            }
+        }
+
+        [Fact]
+        public void BadConfig()
+        {
+            using (var temp = new TempDirectory())
+            {
+                string xml = @" badXml";
+
+                var file = Path.Combine(temp.Path, "badConfig.config");
+                File.WriteAllText(file, xml);
+
+                var fileMap = new ConfigurationFileMap(file);
+                Assert.Equal(file,
+                    Assert.Throws<ConfigurationErrorsException>(() => ConfigurationManager.OpenMappedMachineConfiguration(fileMap)).Filename);
+            }
+        }
+    }
+}

--- a/src/System.Configuration/tests/Mono/ConfigurationManagerTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationManagerTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.ConfigurationManagerTest.cs - Unit tests
 // for System.Configuration.ConfigurationManager.
@@ -26,19 +28,13 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections;
 using System.Collections.Specialized;
 using System.Configuration;
 using System.IO;
 using Xunit;
 using SysConfig = System.Configuration.Configuration;
-using System.Runtime.InteropServices;
-using System.Reflection;
 
 namespace MonoTests.System.Configuration
 {

--- a/src/System.Configuration/tests/Mono/ConfigurationManagerTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationManagerTest.cs
@@ -53,6 +53,12 @@ namespace MonoTests.System.Configuration
         [Fact]
         public void OpenExeConfiguration1_UserLevel_PerUserRoaming()
         {
+            string applicationData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+
+            // If there is not ApplicationData folder PerUserRoaming won't work
+            if (string.IsNullOrEmpty(applicationData)) return;
+
+
             SysConfig config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoaming);
             Assert.False(string.IsNullOrEmpty(config.FilePath), "should have some file path");
             FileInfo fi = new FileInfo(config.FilePath);
@@ -135,7 +141,10 @@ namespace MonoTests.System.Configuration
         public void exePath_UserLevelPerRoaming()
         {
             string applicationData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            Assert.False(string.IsNullOrEmpty(applicationData), "application data shouldn't be empty");
+
+            // If there is not ApplicationData folder PerUserRoaming won't work
+            if (string.IsNullOrEmpty(applicationData)) return;
+
             Assert.True(Directory.Exists(applicationData), "application data should exist");
 
             SysConfig config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoaming);

--- a/src/System.Configuration/tests/Mono/ConfigurationPropertyTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationPropertyTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.ConfigurationElementTest.cs - Unit tests
 // for System.Configuration.ConfigurationElement.
@@ -25,10 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
-
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/ConfigurationPropertyTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationPropertyTest.cs
@@ -1,0 +1,69 @@
+//
+// System.Configuration.ConfigurationElementTest.cs - Unit tests
+// for System.Configuration.ConfigurationElement.
+//
+// Author:
+//	Konstantin Triger <kostat@mainsoft.com>
+//
+// Copyright (C) 2006 Mainsoft, Inc (http://www.mainsoft.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class ConfigurationPropertyTest
+    {
+        [Fact]
+        public void CostructorTest()
+        {
+            Assert.Throws<ConfigurationErrorsException>(() => new ConfigurationProperty("Name", typeof(char), 5));
+        }
+
+        [Fact]
+        public void CostructorTest1()
+        {
+            ConfigurationProperty poker = new ConfigurationProperty("Name", typeof(string));
+            Assert.NotNull(poker.Validator);
+            Assert.NotNull(poker.Converter);
+        }
+
+        [Fact]
+        public void DefaultValueTest()
+        {
+            ConfigurationProperty poker = new ConfigurationProperty("Name", typeof(char));
+            Assert.Equal(typeof(char), poker.DefaultValue.GetType());
+
+            ConfigurationProperty poker1 = new ConfigurationProperty("Name", typeof(ConfigurationProperty));
+            Assert.Equal(null, poker1.DefaultValue);
+
+            ConfigurationProperty poker2 = new ConfigurationProperty("Name", typeof(string));
+            Assert.Equal(string.Empty, poker2.DefaultValue);
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/ConfigurationSaveTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationSaveTest.cs
@@ -1,0 +1,931 @@
+//
+// ConfigurationSaveTest.cs
+//
+// Author:
+//       Martin Baulig <martin.baulig@xamarin.com>
+//
+// Copyright (c) 2012 Xamarin Inc. (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.XPath;
+using System.Text;
+using System.Reflection;
+using System.Globalization;
+using System.Configuration;
+using System.Collections.Generic;
+using SysConfig = System.Configuration.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    using Util;
+
+    public class ConfigurationSaveTest
+    {
+        #region Test Framework
+        public abstract class ConfigProvider
+        {
+            public void Create(string filename)
+            {
+                if (File.Exists(filename))
+                    File.Delete(filename);
+
+                var settings = new XmlWriterSettings();
+                settings.Indent = true;
+
+                using (var writer = XmlTextWriter.Create(filename, settings))
+                {
+                    writer.WriteStartElement("configuration");
+                    WriteXml(writer);
+                    writer.WriteEndElement();
+                }
+            }
+
+            public abstract UserLevel Level
+            {
+                get;
+            }
+
+            public enum UserLevel
+            {
+                MachineAndExe,
+                RoamingAndExe
+            }
+
+            public virtual SysConfig OpenConfig(string parentFile, string configFile)
+            {
+                ConfigurationUserLevel level;
+                var map = new ExeConfigurationFileMap();
+                switch (Level)
+                {
+                    case UserLevel.MachineAndExe:
+                        map.ExeConfigFilename = configFile;
+                        map.MachineConfigFilename = parentFile;
+                        level = ConfigurationUserLevel.None;
+                        break;
+                    case UserLevel.RoamingAndExe:
+                        map.RoamingUserConfigFilename = configFile;
+                        map.ExeConfigFilename = parentFile;
+                        level = ConfigurationUserLevel.PerUserRoaming;
+                        break;
+                    default:
+                        throw new InvalidOperationException();
+                }
+
+                return ConfigurationManager.OpenMappedExeConfiguration(map, level);
+            }
+
+            protected abstract void WriteXml(XmlWriter writer);
+        }
+
+        public abstract class MachineConfigProvider : ConfigProvider
+        {
+            protected override void WriteXml(XmlWriter writer)
+            {
+                writer.WriteStartElement("configSections");
+                WriteSections(writer);
+                writer.WriteEndElement();
+                WriteValues(writer);
+            }
+
+            public override UserLevel Level
+            {
+                get { return UserLevel.MachineAndExe; }
+            }
+
+            protected abstract void WriteSections(XmlWriter writer);
+
+            protected abstract void WriteValues(XmlWriter writer);
+        }
+
+        class DefaultMachineConfig : MachineConfigProvider
+        {
+            protected override void WriteSections(XmlWriter writer)
+            {
+                writer.WriteStartElement("section");
+                writer.WriteAttributeString("name", "my");
+                writer.WriteAttributeString("type", typeof(MySection).AssemblyQualifiedName);
+                writer.WriteAttributeString("allowLocation", "true");
+                writer.WriteAttributeString("allowDefinition", "Everywhere");
+                writer.WriteAttributeString("allowExeDefinition", "MachineToRoamingUser");
+                writer.WriteAttributeString("restartOnExternalChanges", "true");
+                writer.WriteAttributeString("requirePermission", "true");
+                writer.WriteEndElement();
+            }
+
+            internal static void WriteConfigSections(XmlWriter writer)
+            {
+                var provider = new DefaultMachineConfig();
+                writer.WriteStartElement("configSections");
+                provider.WriteSections(writer);
+                writer.WriteEndElement();
+            }
+
+            protected override void WriteValues(XmlWriter writer)
+            {
+                writer.WriteStartElement("my");
+                writer.WriteEndElement();
+            }
+        }
+
+        class DefaultMachineConfig2 : MachineConfigProvider
+        {
+            protected override void WriteSections(XmlWriter writer)
+            {
+                writer.WriteStartElement("section");
+                writer.WriteAttributeString("name", "my2");
+                writer.WriteAttributeString("type", typeof(MySection2).AssemblyQualifiedName);
+                writer.WriteAttributeString("allowLocation", "true");
+                writer.WriteAttributeString("allowDefinition", "Everywhere");
+                writer.WriteAttributeString("allowExeDefinition", "MachineToRoamingUser");
+                writer.WriteAttributeString("restartOnExternalChanges", "true");
+                writer.WriteAttributeString("requirePermission", "true");
+                writer.WriteEndElement();
+            }
+
+            internal static void WriteConfigSections(XmlWriter writer)
+            {
+                var provider = new DefaultMachineConfig2();
+                writer.WriteStartElement("configSections");
+                provider.WriteSections(writer);
+                writer.WriteEndElement();
+            }
+
+            protected override void WriteValues(XmlWriter writer)
+            {
+            }
+        }
+
+        abstract class ParentProvider : ConfigProvider
+        {
+            protected override void WriteXml(XmlWriter writer)
+            {
+                DefaultMachineConfig.WriteConfigSections(writer);
+                writer.WriteStartElement("my");
+                writer.WriteStartElement("test");
+                writer.WriteAttributeString("Hello", "29");
+                writer.WriteEndElement();
+                writer.WriteEndElement();
+            }
+        }
+
+        class RoamingAndExe : ParentProvider
+        {
+            public override UserLevel Level
+            {
+                get { return UserLevel.RoamingAndExe; }
+            }
+        }
+
+        public delegate void TestFunction(SysConfig config, TestLabel label);
+        public delegate void XmlCheckFunction(XPathNavigator nav, TestLabel label);
+
+        public static void Run(string name, TestFunction func)
+        {
+            var label = new TestLabel(name);
+
+            TestUtil.RunWithTempFile(filename =>
+            {
+                var fileMap = new ExeConfigurationFileMap();
+                fileMap.ExeConfigFilename = filename;
+                var config = ConfigurationManager.OpenMappedExeConfiguration(
+                    fileMap, ConfigurationUserLevel.None);
+
+                func(config, label);
+            });
+        }
+
+        public static void Run<TConfig>(string name, TestFunction func)
+            where TConfig : ConfigProvider, new()
+        {
+            Run<TConfig>(new TestLabel(name), func, null);
+        }
+
+        public static void Run<TConfig>(TestLabel label, TestFunction func)
+            where TConfig : ConfigProvider, new()
+        {
+            Run<TConfig>(label, func, null);
+        }
+
+        public static void Run<TConfig>(
+            string name, TestFunction func, XmlCheckFunction check)
+            where TConfig : ConfigProvider, new()
+        {
+            Run<TConfig>(new TestLabel(name), func, check);
+        }
+
+        public static void Run<TConfig>(
+            TestLabel label, TestFunction func, XmlCheckFunction check)
+            where TConfig : ConfigProvider, new()
+        {
+            TestUtil.RunWithTempFiles((parent, filename) =>
+            {
+                var provider = new TConfig();
+                provider.Create(parent);
+
+                Assert.False(File.Exists(filename));
+
+                var config = provider.OpenConfig(parent, filename);
+
+                Assert.False(File.Exists(filename));
+
+                try
+                {
+                    label.EnterScope("config");
+                    func(config, label);
+                }
+                finally
+                {
+                    label.LeaveScope();
+                }
+
+                if (check == null)
+                    return;
+
+                var xml = new XmlDocument();
+                xml.Load(filename);
+
+                var nav = xml.CreateNavigator().SelectSingleNode("/configuration");
+                try
+                {
+                    label.EnterScope("xml");
+                    check(nav, label);
+                }
+                finally
+                {
+                    label.LeaveScope();
+                }
+            });
+        }
+
+        #endregion
+
+        #region Assertion Helpers
+
+        static void AssertNotModified(MySection my, TestLabel label)
+        {
+            label.EnterScope("modified");
+            Assert.NotNull(my);
+            Assert.False(my.IsModified, label.Get());
+            Assert.NotNull(my.List);
+            Assert.Equal(0, my.List.Collection.Count);
+            Assert.False(my.List.IsModified, label.Get());
+            label.LeaveScope();
+        }
+
+        static void AssertListElement(XPathNavigator nav, TestLabel label)
+        {
+            Assert.True(nav.HasChildren, label.Get());
+            var iter = nav.SelectChildren(XPathNodeType.Element);
+
+            Assert.Equal(1, iter.Count);
+            Assert.True(iter.MoveNext(), label.Get());
+
+            var my = iter.Current;
+            label.EnterScope("my");
+            Assert.Equal("my", my.Name);
+            Assert.False(my.HasAttributes, label.Get());
+
+            label.EnterScope("children");
+            Assert.True(my.HasChildren, label.Get());
+            var iter2 = my.SelectChildren(XPathNodeType.Element);
+            Assert.Equal(1, iter2.Count);
+            Assert.True(iter2.MoveNext(), label.Get());
+
+            var test = iter2.Current;
+            label.EnterScope("test");
+            Assert.Equal("test", test.Name);
+            Assert.False(test.HasChildren, label.Get());
+            Assert.True(test.HasAttributes, label.Get());
+
+            var attr = test.GetAttribute("Hello", string.Empty);
+            Assert.Equal("29", attr);
+            label.LeaveScope();
+            label.LeaveScope();
+            label.LeaveScope();
+        }
+
+        #endregion
+
+        #region Tests
+
+        [Fact]
+        public void DefaultValues()
+        {
+            Run<DefaultMachineConfig>("DefaultValues", (config, label) =>
+            {
+                var my = config.Sections["my"] as MySection;
+
+                AssertNotModified(my, label);
+
+                label.EnterScope("file");
+                Assert.False(File.Exists(config.FilePath), label.Get());
+
+                config.Save(ConfigurationSaveMode.Minimal);
+                Assert.False(File.Exists(config.FilePath), label.Get());
+                label.LeaveScope();
+            });
+        }
+
+        [Fact]
+        public void AddDefaultListElement()
+        {
+            Run<DefaultMachineConfig>("AddDefaultListElement", (config, label) =>
+            {
+                var my = config.Sections["my"] as MySection;
+
+                AssertNotModified(my, label);
+
+                label.EnterScope("add");
+                var element = my.List.Collection.AddElement();
+                Assert.True(my.IsModified, label.Get());
+                Assert.True(my.List.IsModified, label.Get());
+                Assert.True(my.List.Collection.IsModified, label.Get());
+                Assert.False(element.IsModified, label.Get());
+                label.LeaveScope();
+
+                config.Save(ConfigurationSaveMode.Minimal);
+                Assert.False(File.Exists(config.FilePath), label.Get());
+            });
+        }
+
+        [Fact]
+        public void AddDefaultListElement2()
+        {
+            Run<DefaultMachineConfig>("AddDefaultListElement2", (config, label) =>
+            {
+                var my = config.Sections["my"] as MySection;
+
+                AssertNotModified(my, label);
+
+                label.EnterScope("add");
+                var element = my.List.Collection.AddElement();
+                Assert.True(my.IsModified, label.Get());
+                Assert.True(my.List.IsModified, label.Get());
+                Assert.True(my.List.Collection.IsModified, label.Get());
+                Assert.False(element.IsModified, label.Get());
+                label.LeaveScope();
+
+                config.Save(ConfigurationSaveMode.Modified);
+                Assert.True(File.Exists(config.FilePath), label.Get());
+            }, (nav, label) =>
+            {
+                Assert.True(nav.HasChildren, label.Get());
+                var iter = nav.SelectChildren(XPathNodeType.Element);
+
+                Assert.Equal(1, iter.Count);
+                Assert.True(iter.MoveNext(), label.Get());
+
+                var my = iter.Current;
+                label.EnterScope("my");
+                Assert.Equal("my", my.Name);
+                Assert.False(my.HasAttributes, label.Get());
+                Assert.False(my.HasChildren, label.Get());
+                label.LeaveScope();
+            });
+        }
+
+        [Fact]
+        public void AddDefaultListElement3()
+        {
+            Run<DefaultMachineConfig>("AddDefaultListElement3", (config, label) =>
+            {
+                var my = config.Sections["my"] as MySection;
+
+                AssertNotModified(my, label);
+
+                label.EnterScope("add");
+                var element = my.List.Collection.AddElement();
+                Assert.True(my.IsModified, label.Get());
+                Assert.True(my.List.IsModified, label.Get());
+                Assert.True(my.List.Collection.IsModified, label.Get());
+                Assert.False(element.IsModified, label.Get());
+                label.LeaveScope();
+
+                config.Save(ConfigurationSaveMode.Full);
+                Assert.True(File.Exists(config.FilePath), label.Get());
+            }, (nav, label) =>
+            {
+                Assert.True(nav.HasChildren, label.Get());
+                var iter = nav.SelectChildren(XPathNodeType.Element);
+
+                Assert.Equal(1, iter.Count);
+                Assert.True(iter.MoveNext(), label.Get());
+
+                var my = iter.Current;
+                label.EnterScope("my");
+                Assert.Equal("my", my.Name);
+                Assert.False(my.HasAttributes, label.Get());
+
+                label.EnterScope("children");
+                Assert.True(my.HasChildren, label.Get());
+                var iter2 = my.SelectChildren(XPathNodeType.Element);
+                Assert.Equal(2, iter2.Count);
+
+                label.EnterScope("list");
+                var iter3 = my.Select("list/*");
+                Assert.Equal(1, iter3.Count);
+                Assert.True(iter3.MoveNext(), label.Get());
+                var collection = iter3.Current;
+                Assert.Equal("collection", collection.Name);
+                Assert.False(collection.HasChildren, label.Get());
+                Assert.True(collection.HasAttributes, label.Get());
+                var hello = collection.GetAttribute("Hello", string.Empty);
+                Assert.Equal("8", hello);
+                var world = collection.GetAttribute("World", string.Empty);
+                Assert.Equal("0", world);
+                label.LeaveScope();
+
+                label.EnterScope("test");
+                var iter4 = my.Select("test");
+                Assert.Equal(1, iter4.Count);
+                Assert.True(iter4.MoveNext(), label.Get());
+                var test = iter4.Current;
+                Assert.Equal("test", test.Name);
+                Assert.False(test.HasChildren, label.Get());
+                Assert.True(test.HasAttributes, label.Get());
+
+                var hello2 = test.GetAttribute("Hello", string.Empty);
+                Assert.Equal("8", hello2);
+                var world2 = test.GetAttribute("World", string.Empty);
+                Assert.Equal("0", world2);
+                label.LeaveScope();
+                label.LeaveScope();
+                label.LeaveScope();
+            });
+        }
+
+        [Fact]
+        public void AddListElement()
+        {
+            Run<DefaultMachineConfig>("AddListElement", (config, label) =>
+            {
+                var my = config.Sections["my"] as MySection;
+
+                AssertNotModified(my, label);
+
+                my.Test.Hello = 29;
+
+                label.EnterScope("file");
+                Assert.False(File.Exists(config.FilePath), label.Get());
+
+                config.Save(ConfigurationSaveMode.Minimal);
+                Assert.True(File.Exists(config.FilePath), label.Get());
+                label.LeaveScope();
+            }, (nav, label) =>
+            {
+                AssertListElement(nav, label);
+            });
+        }
+
+        [Fact]
+        public void NotModifiedAfterSave()
+        {
+            Run<DefaultMachineConfig>("NotModifiedAfterSave", (config, label) =>
+            {
+                var my = config.Sections["my"] as MySection;
+
+                AssertNotModified(my, label);
+
+                label.EnterScope("add");
+                var element = my.List.Collection.AddElement();
+                Assert.True(my.IsModified, label.Get());
+                Assert.True(my.List.IsModified, label.Get());
+                Assert.True(my.List.Collection.IsModified, label.Get());
+                Assert.False(element.IsModified, label.Get());
+                label.LeaveScope();
+
+                label.EnterScope("1st-save");
+                config.Save(ConfigurationSaveMode.Minimal);
+                Assert.False(File.Exists(config.FilePath), label.Get());
+                config.Save(ConfigurationSaveMode.Modified);
+                Assert.False(File.Exists(config.FilePath), label.Get());
+                label.LeaveScope();
+
+                label.EnterScope("modify");
+                element.Hello = 12;
+                Assert.True(my.IsModified, label.Get());
+                Assert.True(my.List.IsModified, label.Get());
+                Assert.True(my.List.Collection.IsModified, label.Get());
+                Assert.True(element.IsModified, label.Get());
+                label.LeaveScope();
+
+                label.EnterScope("2nd-save");
+                config.Save(ConfigurationSaveMode.Modified);
+                Assert.True(File.Exists(config.FilePath), label.Get());
+
+                Assert.False(my.IsModified, label.Get());
+                Assert.False(my.List.IsModified, label.Get());
+                Assert.False(my.List.Collection.IsModified, label.Get());
+                Assert.False(element.IsModified, label.Get());
+                label.LeaveScope(); // 2nd-save
+            });
+        }
+
+        [Fact]
+        public void AddSection()
+        {
+            Run("AddSection", (config, label) =>
+            {
+                Assert.Null(config.Sections["my"]);
+
+                var my = new MySection();
+                config.Sections.Add("my2", my);
+                config.Save(ConfigurationSaveMode.Full);
+
+                Assert.True(File.Exists(config.FilePath), label.Get());
+            });
+        }
+
+        [Fact]
+        public void AddElement()
+        {
+            Run<DefaultMachineConfig>("AddElement", (config, label) =>
+            {
+                var my = config.Sections["my"] as MySection;
+
+                AssertNotModified(my, label);
+
+                var element = my.List.DefaultCollection.AddElement();
+                element.Hello = 12;
+
+                config.Save(ConfigurationSaveMode.Modified);
+
+                label.EnterScope("file");
+                Assert.True(File.Exists(config.FilePath), "#c2");
+                label.LeaveScope();
+            }, (nav, label) =>
+            {
+                Assert.True(nav.HasChildren, label.Get());
+                var iter = nav.SelectChildren(XPathNodeType.Element);
+
+                Assert.Equal(1, iter.Count);
+                Assert.True(iter.MoveNext(), label.Get());
+
+                var my = iter.Current;
+                label.EnterScope("my");
+                Assert.Equal("my", my.Name);
+                Assert.False(my.HasAttributes, label.Get());
+                Assert.True(my.HasChildren, label.Get());
+
+                label.EnterScope("children");
+                var iter2 = my.SelectChildren(XPathNodeType.Element);
+                Assert.Equal(1, iter2.Count);
+                Assert.True(iter2.MoveNext(), label.Get());
+
+                var list = iter2.Current;
+                label.EnterScope("list");
+                Assert.Equal("list", list.Name);
+                Assert.False(list.HasChildren, label.Get());
+                Assert.True(list.HasAttributes, label.Get());
+
+                var attr = list.GetAttribute("Hello", string.Empty);
+                Assert.Equal("12", attr);
+                label.LeaveScope();
+                label.LeaveScope();
+                label.LeaveScope();
+            });
+        }
+
+        [Fact]
+        public void ModifyListElement()
+        {
+            Run<RoamingAndExe>("ModifyListElement", (config, label) =>
+            {
+                var my = config.Sections["my"] as MySection;
+
+                AssertNotModified(my, label);
+
+                my.Test.Hello = 29;
+
+                label.EnterScope("file");
+                Assert.False(File.Exists(config.FilePath), label.Get());
+
+                config.Save(ConfigurationSaveMode.Minimal);
+                Assert.False(File.Exists(config.FilePath), label.Get());
+                label.LeaveScope();
+            });
+        }
+
+        [Fact]
+        public void ModifyListElement2()
+        {
+            Run<RoamingAndExe>("ModifyListElement2", (config, label) =>
+            {
+                var my = config.Sections["my"] as MySection;
+
+                AssertNotModified(my, label);
+
+                my.Test.Hello = 29;
+
+                label.EnterScope("file");
+                Assert.False(File.Exists(config.FilePath), label.Get());
+
+                config.Save(ConfigurationSaveMode.Modified);
+                Assert.True(File.Exists(config.FilePath), label.Get());
+                label.LeaveScope();
+            }, (nav, label) =>
+            {
+                AssertListElement(nav, label);
+            });
+        }
+
+        [Fact]
+        public void TestElementWithCollection()
+        {
+            Run<DefaultMachineConfig2>("TestElementWithCollection", (config, label) =>
+            {
+                label.EnterScope("section");
+                var my2 = config.Sections["my2"] as MySection2;
+                Assert.NotNull(my2);
+
+                Assert.NotNull(my2.Test);
+                Assert.NotNull(my2.Test.DefaultCollection);
+                Assert.Equal(0, my2.Test.DefaultCollection.Count);
+                label.LeaveScope();
+
+                my2.Test.DefaultCollection.AddElement();
+
+                my2.Element.Hello = 29;
+
+                label.EnterScope("file");
+                Assert.False(File.Exists(config.FilePath), label.Get());
+
+                config.Save(ConfigurationSaveMode.Minimal);
+                Assert.True(File.Exists(config.FilePath), label.Get());
+                label.LeaveScope();
+            }, (nav, label) =>
+            {
+                Assert.True(nav.HasChildren, label.Get());
+                var iter = nav.SelectChildren(XPathNodeType.Element);
+
+                Assert.Equal(1, iter.Count);
+                Assert.True(iter.MoveNext(), label.Get());
+
+                var my = iter.Current;
+                label.EnterScope("my2");
+                Assert.Equal("my2", my.Name);
+                Assert.False(my.HasAttributes, label.Get());
+                Assert.True(my.HasChildren, label.Get());
+
+                label.EnterScope("children");
+                var iter2 = my.SelectChildren(XPathNodeType.Element);
+                Assert.Equal(1, iter2.Count);
+                Assert.True(iter2.MoveNext(), label.Get());
+
+                var element = iter2.Current;
+                label.EnterScope("element");
+                Assert.Equal("element", element.Name);
+                Assert.False(element.HasChildren, label.Get());
+                Assert.True(element.HasAttributes, label.Get());
+
+                var attr = element.GetAttribute("Hello", string.Empty);
+                Assert.Equal("29", attr);
+                label.LeaveScope();
+                label.LeaveScope();
+                label.LeaveScope();
+            });
+        }
+
+        [Fact]
+        public void TestElementWithCollection2()
+        {
+            Run<DefaultMachineConfig2>("TestElementWithCollection2", (config, label) =>
+            {
+                label.EnterScope("section");
+                var my2 = config.Sections["my2"] as MySection2;
+                Assert.NotNull(my2);
+
+                Assert.NotNull(my2.Test);
+                Assert.NotNull(my2.Test.DefaultCollection);
+                Assert.Equal(0, my2.Test.DefaultCollection.Count);
+                label.LeaveScope();
+
+                var element = my2.Test.DefaultCollection.AddElement();
+                var element2 = element.Test.DefaultCollection.AddElement();
+                element2.Hello = 1;
+
+                label.EnterScope("file");
+                Assert.False(File.Exists(config.FilePath), label.Get());
+
+                config.Save(ConfigurationSaveMode.Minimal);
+                Assert.True(File.Exists(config.FilePath), label.Get());
+                label.LeaveScope();
+            }, (nav, label) =>
+            {
+                Assert.True(nav.HasChildren, label.Get());
+                var iter = nav.SelectChildren(XPathNodeType.Element);
+
+                Assert.Equal(1, iter.Count);
+                Assert.True(iter.MoveNext(), label.Get());
+
+                var my = iter.Current;
+                label.EnterScope("my2");
+                Assert.Equal("my2", my.Name);
+                Assert.False(my.HasAttributes, label.Get());
+                Assert.True(my.HasChildren, label.Get());
+
+                label.EnterScope("children");
+                var iter2 = my.SelectChildren(XPathNodeType.Element);
+                Assert.Equal(1, iter2.Count);
+                Assert.True(iter2.MoveNext(), label.Get());
+
+                var collection = iter2.Current;
+                label.EnterScope("collection");
+                Assert.Equal("collection", collection.Name);
+                Assert.True(collection.HasChildren, label.Get());
+                Assert.False(collection.HasAttributes, label.Get());
+
+                label.EnterScope("children");
+                var iter3 = collection.SelectChildren(XPathNodeType.Element);
+                Assert.Equal(1, iter3.Count);
+                Assert.True(iter3.MoveNext(), label.Get());
+
+                var element = iter3.Current;
+                label.EnterScope("element");
+                Assert.Equal("test", element.Name);
+                Assert.False(element.HasChildren, label.Get());
+                Assert.True(element.HasAttributes, label.Get());
+
+                var attr = element.GetAttribute("Hello", string.Empty);
+                Assert.Equal("1", attr);
+                label.LeaveScope();
+                label.LeaveScope();
+                label.LeaveScope();
+                label.LeaveScope();
+                label.LeaveScope();
+            });
+        }
+
+        #endregion
+
+        #region Configuration Classes
+
+        public class MyElement : ConfigurationElement
+        {
+            [ConfigurationProperty("Hello", DefaultValue = 8)]
+            public int Hello
+            {
+                get { return (int)base["Hello"]; }
+                set { base["Hello"] = value; }
+            }
+
+            [ConfigurationProperty("World", IsRequired = false)]
+            public int World
+            {
+                get { return (int)base["World"]; }
+                set { base["World"] = value; }
+            }
+
+            new public bool IsModified
+            {
+                get { return base.IsModified(); }
+            }
+        }
+
+        public class MyCollection<T> : ConfigurationElementCollection
+            where T : ConfigurationElement, new()
+        {
+            #region implemented abstract members of ConfigurationElementCollection
+            protected override ConfigurationElement CreateNewElement()
+            {
+                return new T();
+            }
+            protected override object GetElementKey(ConfigurationElement element)
+            {
+                return ((T)element).GetHashCode();
+            }
+            #endregion
+
+            public override ConfigurationElementCollectionType CollectionType
+            {
+                get
+                {
+                    return ConfigurationElementCollectionType.BasicMap;
+                }
+            }
+
+            public T AddElement()
+            {
+                var element = new T();
+                BaseAdd(element);
+                return element;
+            }
+
+            public void RemoveElement(T element)
+            {
+                BaseRemove(GetElementKey(element));
+            }
+
+            public new bool IsModified
+            {
+                get { return base.IsModified(); }
+            }
+        }
+
+        public class MyCollectionElement<T> : ConfigurationElement
+            where T : ConfigurationElement, new()
+        {
+            [ConfigurationProperty("",
+                                    Options = ConfigurationPropertyOptions.IsDefaultCollection,
+                                    IsDefaultCollection = true)]
+            public MyCollection<T> DefaultCollection
+            {
+                get { return (MyCollection<T>)this[string.Empty]; }
+                set { this[string.Empty] = value; }
+            }
+
+            [ConfigurationProperty("collection", Options = ConfigurationPropertyOptions.None)]
+            public MyCollection<T> Collection
+            {
+                get { return (MyCollection<T>)this["collection"]; }
+                set { this["collection"] = value; }
+            }
+
+            public new bool IsModified
+            {
+                get { return base.IsModified(); }
+            }
+        }
+
+        public class MySection : ConfigurationSection
+        {
+            [ConfigurationProperty("list", Options = ConfigurationPropertyOptions.None)]
+            public MyCollectionElement<MyElement> List
+            {
+                get { return (MyCollectionElement<MyElement>)this["list"]; }
+            }
+
+            [ConfigurationProperty("test", Options = ConfigurationPropertyOptions.None)]
+            public MyElement Test
+            {
+                get { return (MyElement)this["test"]; }
+            }
+
+            new public bool IsModified
+            {
+                get { return base.IsModified(); }
+            }
+        }
+
+
+        public class MyElementWithCollection : ConfigurationElement
+        {
+            [ConfigurationProperty("test")]
+            public MyCollectionElement<MyElement> Test
+            {
+                get { return (MyCollectionElement<MyElement>)this["test"]; }
+            }
+        }
+
+        public class MySection2 : ConfigurationSection
+        {
+            [ConfigurationProperty("collection", Options = ConfigurationPropertyOptions.None)]
+            public MyCollectionElement<MyElementWithCollection> Test
+            {
+                get { return (MyCollectionElement<MyElementWithCollection>)this["collection"]; }
+            }
+
+            [ConfigurationProperty("element", Options = ConfigurationPropertyOptions.None)]
+            public MyElement Element
+            {
+                get { return (MyElement)this["element"]; }
+            }
+        }
+
+        public class MySectionGroup : ConfigurationSectionGroup
+        {
+            public MySection2 My2
+            {
+                get { return (MySection2)Sections["my2"]; }
+            }
+        }
+
+        #endregion
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/ConfigurationSaveTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationSaveTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // ConfigurationSaveTest.cs
 //
@@ -23,9 +25,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/System.Configuration/tests/Mono/ConfigurationSectionGroupTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationSectionGroupTest.cs
@@ -1,0 +1,60 @@
+//
+// ConfigurationSectionGroupTest.cs
+//
+// Author:
+//	Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Configuration;
+using Xunit;
+
+using Config = System.Configuration.Configuration;
+
+namespace MonoTests.System.Configuration
+{
+    public class ConfigurationSectionGroupTest
+    {
+        [Fact]
+        public void EditBeforeAdd()
+        {
+            UserSettingsGroup u = new UserSettingsGroup();
+            ClientSettingsSection c = new ClientSettingsSection();
+            Assert.Throws<InvalidOperationException>(() => u.Sections.Add("mine", c));
+        }
+
+        [Fact]
+        public void EditAfterAdd()
+        {
+            Config cfg = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            UserSettingsGroup u = new UserSettingsGroup();
+            cfg.SectionGroups.Add("userSettings", u);
+            ClientSettingsSection c = new ClientSettingsSection();
+            u.Sections.Add("mine", c);
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/ConfigurationSectionGroupTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationSectionGroupTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // ConfigurationSectionGroupTest.cs
 //
@@ -24,9 +26,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/ConfigurationSectionTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationSectionTest.cs
@@ -1,0 +1,127 @@
+//
+// System.Configuration.ConfigurationSectionTest.cs - Unit tests
+//
+// Author:
+//	Greg Smolyn
+//	Gonzalo Paniagua Javier <gonzalo@novell.com
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Configuration;
+using System.IO;
+using System.Xml;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class ConfigurationSectionTest
+    {
+        [Fact]
+        public void TwoConfigElementsInARow() // Bug #521231
+        {
+            string config = @"<fooconfig><foos><foo id=""1"" /></foos><bars><bar id=""1"" /></bars></fooconfig>";
+            var fooSection = new FooConfigSection();
+            fooSection.Load(config);
+        }
+
+        class FooConfigSection : ConfigurationSection
+        {
+            public void Load(string xml)
+            {
+                Init();
+                using (StringReader sr = new StringReader(xml))
+                using (XmlReader reader = new XmlTextReader(sr))
+                {
+                    DeserializeSection(reader);
+                }
+            }
+
+            [ConfigurationProperty("foos")]
+            [ConfigurationCollection(typeof(FooConfigElementCollection), AddItemName = "foo")]
+            public FooConfigElementCollection Foos
+            {
+                get { return (FooConfigElementCollection)base["foos"]; }
+                set { base["foos"] = value; }
+            }
+
+            [ConfigurationProperty("bars")]
+            [ConfigurationCollection(typeof(BarConfigElementCollection), AddItemName = "bar")]
+            public BarConfigElementCollection Bars
+            {
+                get { return (BarConfigElementCollection)base["bars"]; }
+                set { base["bars"] = value; }
+            }
+        }
+
+        class FooConfigElementCollection : ConfigurationElementCollection
+        {
+            protected override ConfigurationElement CreateNewElement()
+            {
+                return new FooConfigElement();
+            }
+
+            protected override object GetElementKey(ConfigurationElement element)
+            {
+                return ((FooConfigElement)element).Id;
+            }
+        }
+
+        class FooConfigElement : ConfigurationElement
+        {
+            [ConfigurationProperty("id")]
+            public int Id
+            {
+                get { return (int)base["id"]; }
+                set { base["id"] = value; }
+            }
+
+        }
+
+        class BarConfigElementCollection : ConfigurationElementCollection
+        {
+            protected override ConfigurationElement CreateNewElement()
+            {
+                return new BarConfigElement();
+            }
+
+            protected override object GetElementKey(ConfigurationElement element)
+            {
+                return ((BarConfigElement)element).Id;
+            }
+        }
+
+        class BarConfigElement : ConfigurationElement
+        {
+            [ConfigurationProperty("id")]
+            public int Id
+            {
+                get { return (int)base["id"]; }
+                set { base["id"] = value; }
+            }
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/ConfigurationSectionTest.cs
+++ b/src/System.Configuration/tests/Mono/ConfigurationSectionTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.ConfigurationSectionTest.cs - Unit tests
 //
@@ -25,9 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/ConnectionStringSettingsTest.cs
+++ b/src/System.Configuration/tests/Mono/ConnectionStringSettingsTest.cs
@@ -1,0 +1,127 @@
+//
+// System.Configuration.ConnectionStringSettingsTest.cs - Unit tests
+// for System.Configuration.ConnectionStringSettings
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class ConnectionStringSettingsTest
+    {
+        [Fact]
+        public void Defaults()
+        {
+            ConnectionStringSettings s;
+
+            s = new ConnectionStringSettings();
+
+            Assert.Equal(null, s.Name);
+            Assert.Equal("", s.ProviderName);
+            Assert.Equal("", s.ConnectionString);
+
+            s = new ConnectionStringSettings("name", "connectionString");
+            Assert.Equal("name", s.Name);
+            Assert.Equal("", s.ProviderName);
+            Assert.Equal("connectionString", s.ConnectionString);
+
+            s = new ConnectionStringSettings("name", "connectionString", "provider");
+            Assert.Equal("name", s.Name);
+            Assert.Equal("provider", s.ProviderName);
+            Assert.Equal("connectionString", s.ConnectionString);
+        }
+
+        [Fact]
+        public void NameNull()
+        {
+            ConnectionStringSettings s;
+
+            s = new ConnectionStringSettings("name", "connectionString", "provider");
+            Assert.Equal("name", s.Name);
+            s.Name = null;
+            Assert.Null(s.Name);
+        }
+
+        [Fact]
+        // This test fails on Mono
+        // [Category("NotWorking")]
+        public void Validators_Name1()
+        {
+            ConnectionStringSettings s = new ConnectionStringSettings();
+            Assert.Throws<ConfigurationErrorsException>(() => s.Name = "");
+        }
+
+        [Fact]
+        public void Validators_Name2()
+        {
+            ConnectionStringSettings s = new ConnectionStringSettings();
+            s.Name = null;
+        }
+
+        [Fact]
+        public void Validators_ProviderName1()
+        {
+            ConnectionStringSettings s = new ConnectionStringSettings();
+            s.ProviderName = "";
+        }
+
+        [Fact]
+        public void Validators_ProviderName2()
+        {
+            ConnectionStringSettings s = new ConnectionStringSettings();
+            s.ProviderName = null;
+        }
+
+        [Fact]
+        public void Validators_ConnectionString1()
+        {
+            ConnectionStringSettings s = new ConnectionStringSettings();
+            s.ConnectionString = "";
+        }
+
+        [Fact]
+        public void Validators_ConnectionString2()
+        {
+            ConnectionStringSettings s = new ConnectionStringSettings();
+            s.ConnectionString = null;
+        }
+
+        [Fact]
+        public void ToStringTest()
+        {
+            ConnectionStringSettings s = new ConnectionStringSettings(
+                "name", "connectionString", "provider");
+            Assert.Equal("connectionString", s.ToString());
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/ConnectionStringSettingsTest.cs
+++ b/src/System.Configuration/tests/Mono/ConnectionStringSettingsTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.ConnectionStringSettingsTest.cs - Unit tests
 // for System.Configuration.ConnectionStringSettings
@@ -25,10 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
-
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/DefaultValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/DefaultValidatorTest.cs
@@ -1,0 +1,62 @@
+//
+// System.Configuration.DefaultValidatorTest.cs - Unit tests
+// for System.Configuration.DefaultValidator.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class DefaultValidatorTest
+    {
+        [Fact]
+        public void CanValidate()
+        {
+            DefaultValidator v = new DefaultValidator();
+
+            Assert.True(v.CanValidate(typeof(string)));
+            Assert.True(v.CanValidate(typeof(int)));
+            Assert.True(v.CanValidate(typeof(object)));
+        }
+
+        [Fact]
+        public void Validate()
+        {
+            DefaultValidator v = new DefaultValidator();
+
+            v.Validate(5);
+            v.Validate(5.4);
+            v.Validate("hi there");
+            v.Validate(v);
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/DefaultValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/DefaultValidatorTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.DefaultValidatorTest.cs - Unit tests
 // for System.Configuration.DefaultValidator.
@@ -25,9 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/ExeConfigurationFileMapTest.cs
+++ b/src/System.Configuration/tests/Mono/ExeConfigurationFileMapTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.ExeConfigurationFileMapTest.cs - Unit tests
 // for System.Configuration.ExeConfigurationFileMap.
@@ -25,10 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
-
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/ExeConfigurationFileMapTest.cs
+++ b/src/System.Configuration/tests/Mono/ExeConfigurationFileMapTest.cs
@@ -1,0 +1,143 @@
+//
+// System.Configuration.ExeConfigurationFileMapTest.cs - Unit tests
+// for System.Configuration.ExeConfigurationFileMap.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    using Util;
+
+    public class ExeConfigurationFileMapTest
+    {
+        [Fact]
+        public void Properties()
+        {
+            ExeConfigurationFileMap map = new ExeConfigurationFileMap();
+
+            /* defaults */
+            Assert.Equal("", map.ExeConfigFilename);
+            Assert.Equal("", map.LocalUserConfigFilename);
+            Assert.Equal("", map.RoamingUserConfigFilename);
+
+            /* setter */
+            map.ExeConfigFilename = "foo";
+            Assert.Equal("foo", map.ExeConfigFilename);
+            map.LocalUserConfigFilename = "bar";
+            Assert.Equal("bar", map.LocalUserConfigFilename);
+            map.RoamingUserConfigFilename = "baz";
+            Assert.Equal("baz", map.RoamingUserConfigFilename);
+
+            /* null setter */
+            map.ExeConfigFilename = null;
+            Assert.Null(map.ExeConfigFilename);
+            map.LocalUserConfigFilename = null;
+            Assert.Null(map.LocalUserConfigFilename);
+            map.RoamingUserConfigFilename = null;
+            Assert.Null(map.RoamingUserConfigFilename);
+        }
+
+        [Fact]
+        public void MissingRoamingFilename()
+        {
+            TestUtil.RunWithTempFile(filename =>
+            {
+                var map = new ExeConfigurationFileMap();
+                map.ExeConfigFilename = filename;
+
+                Assert.Throws<ArgumentException>(() =>
+                    ConfigurationManager.OpenMappedExeConfiguration(
+                        map, ConfigurationUserLevel.PerUserRoaming));
+            });
+        }
+
+        [Fact]
+        public void MissingRoamingFilename2()
+        {
+            TestUtil.RunWithTempFile(filename =>
+            {
+                var map = new ExeConfigurationFileMap();
+                map.LocalUserConfigFilename = filename;
+
+                Assert.Throws<ArgumentException>(() =>
+                    ConfigurationManager.OpenMappedExeConfiguration(
+                        map, ConfigurationUserLevel.PerUserRoamingAndLocal));
+            });
+        }
+
+        [Fact]
+        public void MissingLocalFilename()
+        {
+            TestUtil.RunWithTempFile(filename =>
+            {
+                var map = new ExeConfigurationFileMap();
+                map.ExeConfigFilename = filename;
+                map.RoamingUserConfigFilename = filename;
+
+                Assert.Throws<ArgumentException>(() =>
+                    ConfigurationManager.OpenMappedExeConfiguration(
+                        map, ConfigurationUserLevel.PerUserRoamingAndLocal));
+            });
+        }
+
+        [Fact]
+        public void MissingExeFilename()
+        {
+            TestUtil.RunWithTempFiles((roaming, local) =>
+            {
+                var map = new ExeConfigurationFileMap();
+                map.RoamingUserConfigFilename = roaming;
+                map.LocalUserConfigFilename = local;
+
+                Assert.Throws<ArgumentException>(() =>
+                    ConfigurationManager.OpenMappedExeConfiguration(
+                        map, ConfigurationUserLevel.PerUserRoamingAndLocal));
+            });
+        }
+
+        [Fact]
+        public void MissingExeFilename2()
+        {
+            TestUtil.RunWithTempFile((machine) =>
+            {
+                var map = new ExeConfigurationFileMap();
+                map.MachineConfigFilename = machine;
+
+                Assert.Throws<ArgumentException>(() =>
+                    ConfigurationManager.OpenMappedExeConfiguration(
+                        map, ConfigurationUserLevel.None));
+            });
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/GenericEnumConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/GenericEnumConverterTest.cs
@@ -1,0 +1,149 @@
+//
+// System.Configuration.GenericEnumConverterTest.cs - Unit tests
+// for System.Configuration.GenericEnumConverter.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class GenericEnumConverterTest
+    {
+        enum FooEnum
+        {
+            Foo = 1,
+            Bar = 2
+        }
+
+        [Fact]
+        public void Ctor_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GenericEnumConverter(null));
+        }
+
+        [Fact]
+        public void Ctor_TypeError()
+        {
+            GenericEnumConverter cv = new GenericEnumConverter(typeof(object));
+        }
+
+        [Fact]
+        public void CanConvertFrom()
+        {
+            GenericEnumConverter cv = new GenericEnumConverter(typeof(FooEnum));
+
+            Assert.True(cv.CanConvertFrom(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertFrom(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertFrom(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertFrom(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void CanConvertTo()
+        {
+            GenericEnumConverter cv = new GenericEnumConverter(typeof(FooEnum));
+
+            Assert.True(cv.CanConvertTo(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertTo(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertTo(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertTo(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void ConvertFrom()
+        {
+            GenericEnumConverter cv = new GenericEnumConverter(typeof(FooEnum));
+            Assert.Equal(FooEnum.Foo, cv.ConvertFrom(null, null, "Foo"));
+            Assert.Equal(FooEnum.Bar, cv.ConvertFrom(null, null, "Bar"));
+        }
+
+        [Fact]
+        public void ConvertFrom_Case()
+        {
+            GenericEnumConverter cv = new GenericEnumConverter(typeof(FooEnum));
+            Assert.Throws<ArgumentException>(() => cv.ConvertFrom(null, null, "foo"));
+        }
+
+        [Fact]
+        public void ConvertFrom_InvalidString()
+        {
+            GenericEnumConverter cv = new GenericEnumConverter(typeof(FooEnum));
+            object o = null;
+
+            Assert.Throws<ArgumentException>(() => o = cv.ConvertFrom(null, null, "baz"));
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void ConvertFrom_Null()
+        {
+            GenericEnumConverter cv = new GenericEnumConverter(typeof(FooEnum));
+            object o = null;
+
+            Assert.Throws<ArgumentException>(() => o = cv.ConvertFrom(null, null, null));
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void ConvertTo()
+        {
+            GenericEnumConverter cv = new GenericEnumConverter(typeof(FooEnum));
+
+            Assert.Equal("Foo", cv.ConvertTo(null, null, FooEnum.Foo, typeof(string)));
+            Assert.Equal("Bar", cv.ConvertTo(null, null, FooEnum.Bar, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_NullError()
+        {
+            GenericEnumConverter cv = new GenericEnumConverter(typeof(FooEnum));
+
+            Assert.Throws<NullReferenceException>(() => cv.ConvertTo(null, null, null, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_TypeError1()
+        {
+            GenericEnumConverter cv = new GenericEnumConverter(typeof(FooEnum));
+
+            Assert.Equal("0", cv.ConvertTo(null, null, 0, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_TypeError2()
+        {
+            GenericEnumConverter cv = new GenericEnumConverter(typeof(FooEnum));
+
+            Assert.Equal("", cv.ConvertTo(null, null, "", typeof(string)));
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/GenericEnumConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/GenericEnumConverterTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.GenericEnumConverterTest.cs - Unit tests
 // for System.Configuration.GenericEnumConverter.
@@ -25,9 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/InfiniteIntConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/InfiniteIntConverterTest.cs
@@ -1,0 +1,138 @@
+//
+// System.Configuration.InfiniteIntConverterTest.cs - Unit tests
+// for System.Configuration.InfiniteIntConverter.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class InfiniteIntConverterTest
+    {
+        [Fact]
+        public void CanConvertFrom()
+        {
+            InfiniteIntConverter cv = new InfiniteIntConverter();
+
+            Assert.True(cv.CanConvertFrom(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertFrom(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertFrom(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertFrom(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void CanConvertTo()
+        {
+            InfiniteIntConverter cv = new InfiniteIntConverter();
+
+            Assert.True(cv.CanConvertTo(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertTo(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertTo(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertTo(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void ConvertFrom()
+        {
+            InfiniteIntConverter cv = new InfiniteIntConverter();
+            object o;
+
+            o = cv.ConvertFrom(null, null, "59");
+            Assert.Equal(typeof(int), o.GetType());
+            Assert.Equal(59, o);
+
+            /* and now test infinity */
+            o = cv.ConvertFrom(null, null, "Infinite");
+            Assert.Equal(Int32.MaxValue, o);
+        }
+
+        [Fact]
+        public void ConvertFrom_FormatError()
+        {
+            InfiniteIntConverter cv = new InfiniteIntConverter();
+            object o = null;
+
+            Assert.Throws<FormatException>(() => o = cv.ConvertFrom(null, null, "100.5"));
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void ConvertFrom_TypeError()
+        {
+            InfiniteIntConverter cv = new InfiniteIntConverter();
+            object o = null;
+
+            Assert.Throws<FormatException>(() => o = cv.ConvertFrom(null, null, "hi"));
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void ConvertTo()
+        {
+            InfiniteIntConverter cv = new InfiniteIntConverter();
+
+            Assert.Equal("59", cv.ConvertTo(null, null, 59, typeof(string)));
+
+            Assert.Equal("144", cv.ConvertTo(null, null, 144, typeof(string)));
+
+            /* infinity tests */
+            Assert.Equal("Infinite", cv.ConvertTo(null, null, Int32.MaxValue, typeof(string)));
+            Assert.Equal("2147483646", cv.ConvertTo(null, null, Int32.MaxValue - 1, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_NullError()
+        {
+            InfiniteIntConverter cv = new InfiniteIntConverter();
+
+            Assert.Throws<NullReferenceException>(() => cv.ConvertTo(null, null, null, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_TypeError1()
+        {
+            InfiniteIntConverter cv = new InfiniteIntConverter();
+
+            Assert.Throws<ArgumentException>(() => cv.ConvertTo(null, null, "hi", typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_TypeError2()
+        {
+            InfiniteIntConverter cv = new InfiniteIntConverter();
+
+            Assert.Equal("59", cv.ConvertTo(null, null, 59, typeof(int)));
+            Assert.Equal("59", cv.ConvertTo(null, null, 59, null));
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/InfiniteIntConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/InfiniteIntConverterTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.InfiniteIntConverterTest.cs - Unit tests
 // for System.Configuration.InfiniteIntConverter.
@@ -25,10 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
-
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/InfiniteTimeSpanConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/InfiniteTimeSpanConverterTest.cs
@@ -1,0 +1,127 @@
+//
+// System.Configuration.InfiniteTimeSpanConverterTest.cs - Unit tests
+// for System.Configuration.InfiniteTimeSpanConverter.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class InfiniteTimeSpanConverterTest
+    {
+        [Fact]
+        public void CanConvertFrom()
+        {
+            InfiniteTimeSpanConverter cv = new InfiniteTimeSpanConverter();
+
+            Assert.True(cv.CanConvertFrom(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertFrom(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertFrom(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertFrom(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void CanConvertTo()
+        {
+            InfiniteTimeSpanConverter cv = new InfiniteTimeSpanConverter();
+
+            Assert.True(cv.CanConvertTo(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertTo(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertTo(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertTo(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void ConvertFrom()
+        {
+            InfiniteTimeSpanConverter cv = new InfiniteTimeSpanConverter();
+            object o;
+
+            o = cv.ConvertFrom(null, null, "00:00:59");
+            Assert.Equal(typeof(TimeSpan), o.GetType());
+            Assert.Equal(TimeSpan.FromSeconds(59), o);
+
+            /* and now test infinity */
+            o = cv.ConvertFrom(null, null, "Infinite");
+            Assert.Equal(TimeSpan.MaxValue, o);
+        }
+
+        [Fact]
+        public void ConvertFrom_TypeError()
+        {
+            InfiniteTimeSpanConverter cv = new InfiniteTimeSpanConverter();
+            object o = null;
+
+            Assert.Throws<InvalidCastException>(() => o = cv.ConvertFrom(null, null, 59));
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void ConvertTo()
+        {
+            InfiniteTimeSpanConverter cv = new InfiniteTimeSpanConverter();
+
+            Assert.Equal("00:00:59", cv.ConvertTo(null, null, TimeSpan.FromSeconds(59), typeof(string)));
+
+            Assert.Equal("00:02:24", cv.ConvertTo(null, null, TimeSpan.FromSeconds(144), typeof(string)));
+
+            /* infinity tests */
+            Assert.Equal("Infinite", cv.ConvertTo(null, null, TimeSpan.MaxValue, typeof(string)));
+            Assert.Equal("10675199.02:48:04.4775807", cv.ConvertTo(null, null, TimeSpan.MaxValue - TimeSpan.FromSeconds(1), typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_NullError()
+        {
+            InfiniteTimeSpanConverter cv = new InfiniteTimeSpanConverter();
+
+            Assert.Throws<NullReferenceException>(() => cv.ConvertTo(null, null, null, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_TypeError1()
+        {
+            InfiniteTimeSpanConverter cv = new InfiniteTimeSpanConverter();
+
+            Assert.Throws<ArgumentException>(() => cv.ConvertTo(null, null, "hi", typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_TypeError2()
+        {
+            InfiniteTimeSpanConverter cv = new InfiniteTimeSpanConverter();
+
+            Assert.Throws<ArgumentException>(() => cv.ConvertTo(null, null, 59, typeof(int)));
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/InfiniteTimeSpanConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/InfiniteTimeSpanConverterTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.InfiniteTimeSpanConverterTest.cs - Unit tests
 // for System.Configuration.InfiniteTimeSpanConverter.
@@ -25,10 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
-
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/IntegerValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/IntegerValidatorTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.IntegerValidatorTest.cs - Unit tests
 // for System.Configuration.IntegerValidator.
@@ -27,10 +29,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
-
 
 using System;
 using System.Xml;

--- a/src/System.Configuration/tests/Mono/IntegerValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/IntegerValidatorTest.cs
@@ -1,0 +1,176 @@
+//
+// System.Configuration.IntegerValidatorTest.cs - Unit tests
+// for System.Configuration.IntegerValidator.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//	Andres G. Aragoneses  <andres@7digital.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+// Copyright (C) 2012 7digital Media, Ltd (http://www.7digital.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Xml;
+using System.IO;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class IntegerValidatorTest
+    {
+        [Fact]
+        public void CanValidate()
+        {
+            IntegerValidator v = new IntegerValidator(1, 1);
+
+            Assert.False(v.CanValidate(typeof(TimeSpan)), "A1");
+            Assert.True(v.CanValidate(typeof(int)), "A2");
+            Assert.False(v.CanValidate(typeof(long)), "A3");
+        }
+
+        [Fact]
+        public void Validate_inRange()
+        {
+            IntegerValidator v = new IntegerValidator(5000, 10000);
+            v.Validate(7000);
+        }
+
+        [Fact]
+        public void Validate_Inclusive()
+        {
+            IntegerValidator v = new IntegerValidator(5000, 10000, false);
+            v.Validate(5000);
+            v.Validate(10000);
+        }
+
+        [Fact]
+        public void Validate_Exclusive()
+        {
+            IntegerValidator v = new IntegerValidator(5000, 10000, true);
+            v.Validate(1000);
+            v.Validate(15000);
+        }
+
+        [Fact]
+        public void Validate_Exclusive_fail1()
+        {
+            IntegerValidator v = new IntegerValidator(5000, 10000, true);
+            Assert.Throws<ArgumentException>(() => v.Validate(5000));
+        }
+
+        [Fact]
+        public void Validate_Exclusive_fail2()
+        {
+            IntegerValidator v = new IntegerValidator(5000, 10000, true);
+            Assert.Throws<ArgumentException>(() => v.Validate(10000));
+        }
+
+        [Fact]
+        public void Validate_Exclusive_fail3()
+        {
+            IntegerValidator v = new IntegerValidator(5000, 10000, true);
+            Assert.Throws<ArgumentException>(() => v.Validate(7000));
+        }
+
+        [Fact]
+        public void Validate_Resolution()
+        {
+            IntegerValidator v = new IntegerValidator(20000,
+                                   50000,
+                                   false,
+                                   3000);
+
+            Assert.Throws<ArgumentException>(() => v.Validate(40000));
+        }
+
+        #region BNC654721 https://bugzilla.novell.com/show_bug.cgi?id=654721
+        public sealed class TestSection : ConfigurationSection
+        {
+            public void Load(string xml)
+            {
+                Init();
+                using (var sr = new StringReader(xml))
+                using (var reader = new XmlTextReader(sr))
+                {
+                    DeserializeSection(reader);
+                }
+            }
+
+            [ConfigurationProperty("integerValidatorMinValue")]
+            public IntegerValidatorMinValueChildElement IntegerValidatorMinValue
+            {
+                get { return (IntegerValidatorMinValueChildElement)base["integerValidatorMinValue"]; }
+                set { base["integerValidatorMinValue"] = value; }
+            }
+
+            [ConfigurationProperty("integerValidatorMaxValue")]
+            public IntegerValidatorMaxValueChildElement IntegerValidatorMaxValue
+            {
+                get { return (IntegerValidatorMaxValueChildElement)base["integerValidatorMaxValue"]; }
+                set { base["integerValidatorMaxValue"] = value; }
+            }
+        }
+
+        public sealed class IntegerValidatorMaxValueChildElement : ConfigurationElement
+        {
+            [ConfigurationProperty("theProperty"), IntegerValidator(MaxValue = 100)]
+            public int TheProperty
+            {
+                get { return (int)base["theProperty"]; }
+                set { base["theProperty"] = value; }
+            }
+        }
+
+        public sealed class IntegerValidatorMinValueChildElement : ConfigurationElement
+        {
+            [ConfigurationProperty("theProperty"), IntegerValidator(MinValue = 0)]
+            public int TheProperty
+            {
+                get { return (int)base["theProperty"]; }
+                set { base["theProperty"] = value; }
+            }
+        }
+
+        [Fact]
+        public void IntegerValidatorMinValueTest()
+        {
+            var section = new TestSection();
+            section.Load(@"<someSection><integerValidatorMinValue theProperty=""15"" /></someSection>");
+            Assert.Equal(15, section.IntegerValidatorMinValue.TheProperty);
+        }
+
+        [Fact]
+        public void IntegerValidatorMaxValueTest()
+        {
+            var section = new TestSection();
+            section.Load(@"<someSection><integerValidatorMaxValue theProperty=""25"" /></someSection>");
+            Assert.Equal(25, section.IntegerValidatorMaxValue.TheProperty);
+        }
+        #endregion
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/KeyValueConfigurationCollectionTest.cs
+++ b/src/System.Configuration/tests/Mono/KeyValueConfigurationCollectionTest.cs
@@ -1,0 +1,191 @@
+//
+// System.Configuration.KeyValueConfigurationCollectionTest.cs - Unit tests
+// for System.Configuration.KeyValueConfigurationCollection.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class KeyValueConfigurationCollectionTest
+    {
+        class Poker : KeyValueConfigurationCollection
+        {
+            bool useElementPoker;
+
+            public Poker() : this(false)
+            { }
+
+            public Poker(bool useElementPoker)
+            {
+                this.useElementPoker = useElementPoker;
+            }
+
+            public ConfigurationPropertyCollection GetProperties()
+            {
+                return base.Properties;
+            }
+
+            public ConfigurationElement DoCreateNewElement()
+            {
+                if (useElementPoker)
+                    return new ElementPoker("", "");
+                else
+                    return base.CreateNewElement();
+            }
+
+            public object DoGetElementKey(ConfigurationElement element)
+            {
+                return base.GetElementKey(element);
+            }
+
+            public object[] GetAllKeys()
+            {
+                return base.BaseGetAllKeys();
+            }
+
+            public bool GetThrowOnDuplicate()
+            {
+                return base.ThrowOnDuplicate;
+            }
+        }
+
+        class ElementPoker : KeyValueConfigurationElement
+        {
+            public ElementPoker(string name, string value)
+                : base(name, value)
+            {
+            }
+
+            protected override void InitializeDefault()
+            {
+                Console.WriteLine(Environment.StackTrace);
+                base.InitializeDefault();
+            }
+
+            protected override void Init()
+            {
+                base.Init();
+            }
+
+            public ConfigurationPropertyCollection GetProperties()
+            {
+                return base.Properties;
+            }
+        }
+
+        [Fact]
+        public void ThrowOnDuplicate()
+        {
+            Poker p = new Poker();
+            Assert.False(p.GetThrowOnDuplicate(), "A1");
+        }
+
+        [Fact]
+        public void Properties()
+        {
+            Poker p = new Poker();
+            ConfigurationPropertyCollection props = p.GetProperties();
+
+            Assert.NotNull(props);
+            Assert.Equal(0, props.Count);
+        }
+
+        [Fact]
+        public void CreateNewElement()
+        {
+            Poker p = new Poker();
+            ConfigurationElement e = p.DoCreateNewElement();
+
+            Assert.Equal(typeof(KeyValueConfigurationElement), e.GetType());
+
+            KeyValueConfigurationElement kv = (KeyValueConfigurationElement)e;
+
+            Assert.Equal("", kv.Key);
+            Assert.Equal("", kv.Value);
+        }
+
+        [Fact]
+        public void Add()
+        {
+            Poker p = new Poker(true);
+            ElementPoker ep = new ElementPoker("", "");
+
+            p.Add(ep);
+        }
+
+
+        [Fact]
+        public void AddDuplicate()
+        {
+            Poker p = new Poker(true);
+            ElementPoker ep;
+
+            ep = new ElementPoker("hi", "bye");
+            p.Add(ep);
+
+            ep = new ElementPoker("hi", "bye2");
+            p.Add(ep);
+
+            Assert.Equal(1, p.AllKeys.Length);
+            Assert.Equal(1, p.GetAllKeys().Length);
+        }
+
+        [Fact]
+        public void GetElementKey()
+        {
+            Poker p = new Poker();
+            ElementPoker ep = new ElementPoker("foo", "there");
+            p.Add(ep);
+            Assert.Equal("foo", p.DoGetElementKey(ep));
+        }
+
+        [Fact]
+        // This test fails on Mono
+        // [Category("NotWorking")]
+        public void GetElementKey_withoutAdd()
+        {
+            Poker p = new Poker();
+            ElementPoker ep = new ElementPoker("hi", "there");
+            Assert.Equal("", p.DoGetElementKey(ep));
+        }
+
+        [Fact]
+        public void GetElementKey_null()
+        {
+            Poker p = new Poker();
+            Assert.Throws<NullReferenceException>(() => p.DoGetElementKey(null));
+        }
+    }
+
+}
+

--- a/src/System.Configuration/tests/Mono/KeyValueConfigurationCollectionTest.cs
+++ b/src/System.Configuration/tests/Mono/KeyValueConfigurationCollectionTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.KeyValueConfigurationCollectionTest.cs - Unit tests
 // for System.Configuration.KeyValueConfigurationCollection.
@@ -25,10 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
-
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/KeyValueConfigurationElementTest.cs
+++ b/src/System.Configuration/tests/Mono/KeyValueConfigurationElementTest.cs
@@ -1,0 +1,99 @@
+//
+// System.Configuration.KeyValueConfigurationElementTest.cs - Unit tests
+// for System.Configuration.KeyValueConfigurationElement.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Configuration;
+using System.ComponentModel;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class KeyValueConfigurationElementTest
+    {
+        class Poker : KeyValueConfigurationElement
+        {
+            public Poker(string name, string value)
+                : base(name, value)
+            {
+            }
+
+            protected override void Init()
+            {
+                Console.WriteLine(Environment.StackTrace);
+                base.Init();
+            }
+
+            public ConfigurationPropertyCollection GetProperties()
+            {
+                return base.Properties;
+            }
+        }
+
+        [Fact]
+        // [NUnit.Framework.Category("NotWorking")]
+        public void Properties()
+        {
+            Poker p = new Poker("name", "value");
+            ConfigurationPropertyCollection props = p.GetProperties();
+
+            Assert.NotNull(props);
+            Assert.Equal(2, props.Count);
+
+            ConfigurationProperty prop;
+
+            prop = props["key"];
+            Assert.Equal("key", prop.Name);
+            Assert.Null(prop.Description);
+            Assert.Equal(typeof(string), prop.Type);
+            Assert.Equal(typeof(StringConverter), prop.Converter.GetType());
+            Assert.NotNull(prop.Validator);
+            Assert.Equal(typeof(DefaultValidator), prop.Validator.GetType());
+            Assert.Equal("", prop.DefaultValue);
+            Assert.True(prop.IsKey, "A9");
+            Assert.True(prop.IsRequired, "A10");
+
+            Assert.False(prop.IsDefaultCollection, "A11");
+
+            prop = props["value"];
+            Assert.Equal("value", prop.Name);
+            Assert.Null(prop.Description);
+            Assert.Equal(typeof(string), prop.Type);
+            Assert.Equal(typeof(StringConverter), prop.Converter.GetType());
+            Assert.Equal(typeof(DefaultValidator), prop.Validator.GetType());
+            Assert.Equal("", prop.DefaultValue);
+            Assert.False(prop.IsKey, "A18");
+            Assert.False(prop.IsRequired, "A19");
+
+            Assert.False(prop.IsDefaultCollection, "A20");
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/KeyValueConfigurationElementTest.cs
+++ b/src/System.Configuration/tests/Mono/KeyValueConfigurationElementTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.KeyValueConfigurationElementTest.cs - Unit tests
 // for System.Configuration.KeyValueConfigurationElement.
@@ -25,9 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/LongValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/LongValidatorTest.cs
@@ -1,0 +1,106 @@
+//
+// System.Configuration.LongValidatorTest.cs - Unit tests
+// for System.Configuration.LongValidator.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class LongValidatorTest
+    {
+        [Fact]
+        public void CanValidate()
+        {
+            LongValidator v = new LongValidator(1L, 1L);
+
+            Assert.False(v.CanValidate(typeof(TimeSpan)), "A1");
+            Assert.False(v.CanValidate(typeof(int)), "A2");
+            Assert.True(v.CanValidate(typeof(long)), "A3");
+        }
+
+        [Fact]
+        public void Validate_inRange()
+        {
+            LongValidator v = new LongValidator(5000L, 10000L);
+            v.Validate(7000L);
+        }
+
+        [Fact]
+        public void Validate_Inclusive()
+        {
+            LongValidator v = new LongValidator(5000L, 10000L, false);
+            v.Validate(5000L);
+            v.Validate(10000L);
+        }
+
+        [Fact]
+        public void Validate_Exclusive()
+        {
+            LongValidator v = new LongValidator(5000L, 10000L, true);
+            v.Validate(1000L);
+            v.Validate(15000L);
+        }
+
+        [Fact]
+        public void Validate_Exclusive_fail1()
+        {
+            LongValidator v = new LongValidator(5000L, 10000L, true);
+            Assert.Throws<ArgumentException>(() => v.Validate(5000L));
+        }
+
+        [Fact]
+        public void Validate_Exclusive_fail2()
+        {
+            LongValidator v = new LongValidator(5000L, 10000L, true);
+            Assert.Throws<ArgumentException>(() => v.Validate(10000L));
+        }
+
+        [Fact]
+        public void Validate_Exclusive_fail3()
+        {
+            LongValidator v = new LongValidator(5000L, 10000L, true);
+            Assert.Throws<ArgumentException>(() => v.Validate(7000L));
+        }
+
+        [Fact]
+        public void Validate_Resolution()
+        {
+            LongValidator v = new LongValidator(20000L,
+                                 50000L,
+                                 false,
+                                 3000L);
+
+            Assert.Throws<ArgumentException>(() => v.Validate(40000L));
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/LongValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/LongValidatorTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.LongValidatorTest.cs - Unit tests
 // for System.Configuration.LongValidator.
@@ -24,10 +26,6 @@
 // NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
-
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/PositiveTimeSpanValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/PositiveTimeSpanValidatorTest.cs
@@ -1,0 +1,73 @@
+//
+// System.Configuration.PositiveTimeSpanValidatorTest.cs - Unit tests
+// for System.Configuration.PositiveTimeSpanValidator.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class PositiveTimeSpanValidatorTest
+    {
+        [Fact]
+        public void CanValidate()
+        {
+            PositiveTimeSpanValidator v = new PositiveTimeSpanValidator();
+
+            Assert.True(v.CanValidate(typeof(TimeSpan)), "A1");
+            Assert.False(v.CanValidate(typeof(int)), "A2");
+            Assert.False(v.CanValidate(typeof(long)), "A3");
+        }
+
+        [Fact]
+        public void Validate_inRange()
+        {
+            PositiveTimeSpanValidator v = new PositiveTimeSpanValidator();
+            v.Validate(new TimeSpan(7000));
+        }
+
+        [Fact]
+        public void Validate_fail1()
+        {
+            PositiveTimeSpanValidator v = new PositiveTimeSpanValidator();
+            Assert.Throws<ArgumentException>(() => v.Validate(new TimeSpan(0)));
+        }
+
+        [Fact]
+        public void Validate_fail2()
+        {
+            PositiveTimeSpanValidator v = new PositiveTimeSpanValidator();
+            Assert.Throws<ArgumentException>(() => v.Validate(new TimeSpan(-10000)));
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/PositiveTimeSpanValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/PositiveTimeSpanValidatorTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.PositiveTimeSpanValidatorTest.cs - Unit tests
 // for System.Configuration.PositiveTimeSpanValidator.
@@ -25,10 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
-
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/RegexStringValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/RegexStringValidatorTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.RegexStringValidatorTest.cs - Unit tests
 // for System.Configuration.RegexStringValidator.
@@ -25,9 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/RegexStringValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/RegexStringValidatorTest.cs
@@ -1,0 +1,75 @@
+//
+// System.Configuration.RegexStringValidatorTest.cs - Unit tests
+// for System.Configuration.RegexStringValidator.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class RegexStringValidatorTest
+    {
+        [Fact]
+        public void CanValidate()
+        {
+            RegexStringValidator v = new RegexStringValidator("[0-9]+");
+
+            Assert.True(v.CanValidate(typeof(string)));
+            Assert.False(v.CanValidate(typeof(int)));
+            Assert.False(v.CanValidate(typeof(object)));
+        }
+
+        [Fact]
+        public void Match_succeed()
+        {
+            RegexStringValidator v = new RegexStringValidator("[0-9]+");
+
+            v.Validate("123456789");
+            v.Validate("1234567");
+            v.Validate("12345");
+        }
+
+        [Fact]
+        public void Match_fail()
+        {
+            RegexStringValidator v = new RegexStringValidator("[a-z]+");
+
+            Assert.Throws<ArgumentException>(() => v.Validate("1234"));
+        }
+
+        [Fact]
+        public void IllegalRegex()
+        {
+            Assert.Throws<ArgumentException>(() => new RegexStringValidator("[0-9+"));
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/StringValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/StringValidatorTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.StringValidatorTest.cs - Unit tests
 // for System.Configuration.StringValidator.
@@ -25,10 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
-
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/StringValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/StringValidatorTest.cs
@@ -1,0 +1,136 @@
+//
+// System.Configuration.StringValidatorTest.cs - Unit tests
+// for System.Configuration.StringValidator.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class StringValidatorTest
+    {
+        [Fact]
+        public void CanValidate()
+        {
+            StringValidator v = new StringValidator(5);
+
+            Assert.True(v.CanValidate(typeof(string)));
+            Assert.False(v.CanValidate(typeof(int)));
+            Assert.False(v.CanValidate(typeof(object)));
+        }
+
+        [Fact]
+        public void NullZero()
+        {
+            StringValidator v = new StringValidator(0);
+
+            v.Validate(null);
+        }
+
+        [Fact]
+        public void Null()
+        {
+            StringValidator v = new StringValidator(1);
+
+            Assert.Throws<ArgumentException>(() => v.Validate(null));
+        }
+
+        [Fact]
+        public void MinLenth()
+        {
+            StringValidator v = new StringValidator(5);
+
+            v.Validate("123456789");
+            v.Validate("1234567");
+            v.Validate("12345");
+        }
+
+        [Fact]
+        public void MinLength_fail()
+        {
+            StringValidator v = new StringValidator(5);
+
+            Assert.Throws<ArgumentException>(() => v.Validate("1234"));
+        }
+
+        [Fact]
+        public void Bounded()
+        {
+            StringValidator v = new StringValidator(5, 7);
+
+            v.Validate("12345");
+            v.Validate("123456");
+            v.Validate("123457");
+        }
+
+        [Fact]
+        public void Bounded_fail1()
+        {
+            StringValidator v = new StringValidator(5, 7);
+
+            Assert.Throws<ArgumentException>(() => v.Validate("1234"));
+        }
+
+        [Fact]
+        public void Bounded_fail2()
+        {
+            StringValidator v = new StringValidator(5, 7);
+
+            Assert.Throws<ArgumentException>(() => v.Validate("12345678"));
+        }
+
+        [Fact]
+        public void Invalid()
+        {
+            StringValidator v = new StringValidator(5, 7, "890");
+
+            v.Validate("123456");
+        }
+
+        [Fact]
+        public void Invalid_fail()
+        {
+            StringValidator v = new StringValidator(5, 7, "345");
+
+            Assert.Throws<ArgumentException>(() => v.Validate("123456"));
+        }
+
+        [Fact]
+        public void Invalid_fail_length()
+        {
+            StringValidator v = new StringValidator(5, 7, "890");
+
+            Assert.Throws<ArgumentException>(() => v.Validate("12345678"));
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/SubclassTypeValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/SubclassTypeValidatorTest.cs
@@ -1,0 +1,72 @@
+//
+// System.Configuration.SubclassTypeValidatorTest.cs - Unit tests
+// for System.Configuration.SubclassTypeValidator.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    class A { }
+    class B : A { }
+
+    public class SubclassTypeValidatorTest
+    {
+        [Fact]
+        public void CanValidate()
+        {
+            SubclassTypeValidator v = new SubclassTypeValidator(typeof(A));
+
+            Assert.False(v.CanValidate(typeof(string)));
+            Assert.False(v.CanValidate(typeof(int)));
+            Assert.False(v.CanValidate(typeof(object)));
+            Assert.True(v.CanValidate(typeof(Type)));
+        }
+
+        [Fact]
+        public void Success()
+        {
+            SubclassTypeValidator v = new SubclassTypeValidator(typeof(A));
+
+            v.Validate(typeof(B));
+            v.Validate(typeof(A));
+        }
+
+        [Fact]
+        public void Failure()
+        {
+            SubclassTypeValidator v = new SubclassTypeValidator(typeof(B));
+
+            Assert.Throws<ArgumentException>(() => v.Validate(typeof(A)));
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/SubclassTypeValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/SubclassTypeValidatorTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.SubclassTypeValidatorTest.cs - Unit tests
 // for System.Configuration.SubclassTypeValidator.
@@ -25,9 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/TestLabel.cs
+++ b/src/System.Configuration/tests/Mono/TestLabel.cs
@@ -1,0 +1,148 @@
+﻿//
+// TestLabel.cs
+//
+// Author:
+//       Martin Baulig <martin.baulig@xamarin.com>
+//
+// Copyright (c) 2012 Xamarin Inc. (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using System.Collections.Generic;
+
+namespace MonoTests.System.Configuration.Util
+{
+
+    public class TestLabel
+    {
+
+        List<Scope> scopes;
+        string delimiter;
+        Style defaultStyle;
+
+        public enum Style
+        {
+            Letter,
+            Number,
+            HexNumer
+        }
+
+        public TestLabel(string prefix)
+            : this(prefix, ".", Style.Letter)
+        {
+        }
+
+        public TestLabel(string prefix, string delimiter, Style style)
+        {
+            if ((prefix == null) || (prefix.Equals(string.Empty)))
+                throw new ArgumentException("Cannot be null or empty.", "prefix");
+            if (delimiter == null)
+                throw new ArgumentNullException("delimiter");
+
+            scopes = new List<Scope>();
+            scopes.Add(new Scope(prefix, style));
+
+            this.delimiter = delimiter;
+            this.defaultStyle = style;
+        }
+
+        class Scope
+        {
+            public readonly string Text;
+            public readonly Style Style;
+            int id;
+
+            public Scope(string text, Style style)
+            {
+                this.Text = text;
+                this.Style = style;
+                this.id = 0;
+            }
+
+            public int GetID()
+            {
+                return ++id;
+            }
+        }
+
+        public void EnterScope(string scope)
+        {
+            scopes.Add(new Scope(scope, defaultStyle));
+        }
+
+        public void LeaveScope()
+        {
+            if (scopes.Count <= 1)
+                throw new InvalidOperationException();
+            scopes.RemoveAt(scopes.Count - 1);
+        }
+
+        public string Get()
+        {
+            var sb = new StringBuilder();
+            for (int i = 0; i < scopes.Count; i++)
+            {
+                sb.Append(scopes[i].Text);
+                sb.Append(delimiter);
+            }
+
+            var scope = scopes[scopes.Count - 1];
+            var id = scope.GetID();
+
+            switch (scope.Style)
+            {
+                case Style.Letter:
+                    if (id <= 26)
+                        sb.Append((char)('a' + id - 1));
+                    else
+                        goto case Style.Number;
+                    break;
+
+                case Style.Number:
+                    sb.Append(id);
+                    break;
+
+                case Style.HexNumer:
+                    sb.AppendFormat("{0:x2}", id);
+                    break;
+            }
+
+            return sb.ToString();
+        }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("[");
+            for (int i = 0; i < scopes.Count; i++)
+            {
+                if (i > 0)
+                    sb.Append(delimiter);
+                sb.Append(scopes[i].Text);
+            }
+            sb.Append("]");
+            return sb.ToString();
+        }
+    }
+}

--- a/src/System.Configuration/tests/Mono/TestLabel.cs
+++ b/src/System.Configuration/tests/Mono/TestLabel.cs
@@ -1,4 +1,6 @@
-﻿//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
 // TestLabel.cs
 //
 // Author:
@@ -23,9 +25,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/System.Configuration/tests/Mono/TestUtil.cs
+++ b/src/System.Configuration/tests/Mono/TestUtil.cs
@@ -1,4 +1,6 @@
-﻿//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+//
 // TestUtil.cs
 //
 // Author:
@@ -23,9 +25,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/System.Configuration/tests/Mono/TestUtil.cs
+++ b/src/System.Configuration/tests/Mono/TestUtil.cs
@@ -1,0 +1,98 @@
+﻿//
+// TestUtil.cs
+//
+// Author:
+//       Martin Baulig <martin.baulig@xamarin.com>
+//
+// Copyright (c) 2012 Xamarin Inc. (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace MonoTests.System.Configuration.Util
+{
+
+    public static class TestUtil
+    {
+
+        public static void RunWithTempFile(Action<string> action)
+        {
+            var filename = Path.GetTempFileName();
+
+            try
+            {
+                File.Delete(filename);
+                action(filename);
+            }
+            finally
+            {
+                if (File.Exists(filename))
+                    File.Delete(filename);
+            }
+        }
+
+        // Action<T1,T2> doesn't exist in .NET 2.0
+        public delegate void MyAction<T1, T2>(T1 t1, T2 t2);
+
+        public static void RunWithTempFiles(MyAction<string, string> action)
+        {
+            var file1 = Path.GetTempFileName();
+            var file2 = Path.GetTempFileName();
+
+            try
+            {
+                File.Delete(file1);
+                File.Delete(file2);
+                action(file1, file2);
+            }
+            finally
+            {
+                if (File.Exists(file1))
+                    File.Delete(file1);
+                if (File.Exists(file2))
+                    File.Delete(file2);
+            }
+        }
+
+        public static string ThisApplicationPath
+        {
+            get
+            {
+                var asm = Assembly.GetEntryAssembly();
+                return asm.Location;
+            }
+        }
+
+        public static string ThisConfigFileName
+        {
+            get
+            {
+                var exe = Path.GetFileName(ThisApplicationPath);
+                return exe + ".config";
+            }
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/TimeSpanMinutesConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/TimeSpanMinutesConverterTest.cs
@@ -1,0 +1,141 @@
+//
+// System.Configuration.TimeSpanMinutesConverterTest.cs - Unit tests
+// for System.Configuration.TimeSpanMinutesConverter.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class TimeSpanMinutesConverterTest
+    {
+        [Fact]
+        public void CanConvertFrom()
+        {
+            TimeSpanMinutesConverter cv = new TimeSpanMinutesConverter();
+
+            Assert.True(cv.CanConvertFrom(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertFrom(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertFrom(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertFrom(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void CanConvertTo()
+        {
+            TimeSpanMinutesConverter cv = new TimeSpanMinutesConverter();
+
+            Assert.True(cv.CanConvertTo(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertTo(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertTo(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertTo(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void ConvertFrom()
+        {
+            TimeSpanMinutesConverter cv = new TimeSpanMinutesConverter();
+            object o;
+
+            o = cv.ConvertFrom(null, null, "59");
+            Assert.Equal(typeof(TimeSpan), o.GetType());
+            Assert.Equal("00:59:00", o.ToString());
+            o = cv.ConvertFrom(null, null, "104");
+            Assert.Equal("01:44:00", o.ToString());
+        }
+
+        [Fact]
+        public void ConvertFrom_FormatError()
+        {
+            TimeSpanMinutesConverter cv = new TimeSpanMinutesConverter();
+            object o = null;
+
+            Assert.Throws<FormatException>(() => o = cv.ConvertFrom(null, null, "100.5"));
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void ConvertFrom_TypeError()
+        {
+            TimeSpanMinutesConverter cv = new TimeSpanMinutesConverter();
+            object o = null;
+
+            Assert.Throws<InvalidCastException>(() => o = cv.ConvertFrom(null, null, 59));
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void ConvertTo()
+        {
+            TimeSpanMinutesConverter cv = new TimeSpanMinutesConverter();
+            TimeSpan ts;
+
+            ts = TimeSpan.FromMinutes(59);
+            Assert.Equal("59", cv.ConvertTo(null, null, ts, typeof(string)));
+
+            ts = TimeSpan.FromMinutes(144);
+            Assert.Equal("144", cv.ConvertTo(null, null, ts, typeof(string)));
+
+            ts = TimeSpan.FromSeconds(390);
+            Assert.Equal("6", cv.ConvertTo(null, null, ts, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_NullError()
+        {
+            TimeSpanMinutesConverter cv = new TimeSpanMinutesConverter();
+
+            Assert.Throws<NullReferenceException>(() => cv.ConvertTo(null, null, null, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_TypeError1()
+        {
+            TimeSpanMinutesConverter cv = new TimeSpanMinutesConverter();
+
+            Assert.Throws<ArgumentException>(() => cv.ConvertTo(null, null, 59, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_TypeError2()
+        {
+            TimeSpanMinutesConverter cv = new TimeSpanMinutesConverter();
+            TimeSpan ts;
+
+            ts = TimeSpan.FromMinutes(59);
+
+            Assert.Equal("59", cv.ConvertTo(null, null, ts, typeof(int)));
+            Assert.Equal("59", cv.ConvertTo(null, null, ts, null));
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/TimeSpanMinutesConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/TimeSpanMinutesConverterTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.TimeSpanMinutesConverterTest.cs - Unit tests
 // for System.Configuration.TimeSpanMinutesConverter.
@@ -25,10 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
-
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/TimeSpanMinutesOrInfiniteConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/TimeSpanMinutesOrInfiniteConverterTest.cs
@@ -1,0 +1,151 @@
+//
+// System.Configuration.TimeSpanMinutesOrInfiniteConverterTest.cs - Unit tests
+// for System.Configuration.TimeSpanMinutesOrInfiniteConverter.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class TimeSpanMinutesOrInfiniteConverterTest
+    {
+        [Fact]
+        public void CanConvertFrom()
+        {
+            TimeSpanMinutesOrInfiniteConverter cv = new TimeSpanMinutesOrInfiniteConverter();
+
+            Assert.True(cv.CanConvertFrom(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertFrom(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertFrom(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertFrom(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void CanConvertTo()
+        {
+            TimeSpanMinutesOrInfiniteConverter cv = new TimeSpanMinutesOrInfiniteConverter();
+
+            Assert.True(cv.CanConvertTo(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertTo(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertTo(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertTo(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void ConvertFrom()
+        {
+            TimeSpanMinutesOrInfiniteConverter cv = new TimeSpanMinutesOrInfiniteConverter();
+            object o;
+
+            /* make sure the TimeSpanMinutesConverter tests work here too */
+            o = cv.ConvertFrom(null, null, "59");
+            Assert.Equal(typeof(TimeSpan), o.GetType());
+            Assert.Equal("00:59:00", o.ToString());
+            o = cv.ConvertFrom(null, null, "104");
+            Assert.Equal("01:44:00", o.ToString());
+
+            /* and now test infinity */
+            o = cv.ConvertFrom(null, null, "Infinite");
+            Assert.Equal(TimeSpan.MaxValue.ToString(), o.ToString());
+        }
+
+        [Fact]
+        public void ConvertFrom_FormatError()
+        {
+            TimeSpanMinutesOrInfiniteConverter cv = new TimeSpanMinutesOrInfiniteConverter();
+            object o = null;
+
+            Assert.Throws<FormatException>(() => o = cv.ConvertFrom(null, null, "100.5"));
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void ConvertFrom_TypeError()
+        {
+            TimeSpanMinutesOrInfiniteConverter cv = new TimeSpanMinutesOrInfiniteConverter();
+            object o = null;
+
+            Assert.Throws<InvalidCastException>(() => o = cv.ConvertFrom(null, null, 59));
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void ConvertTo()
+        {
+            TimeSpanMinutesOrInfiniteConverter cv = new TimeSpanMinutesOrInfiniteConverter();
+            TimeSpan ts;
+
+            ts = TimeSpan.FromMinutes(59);
+            Assert.Equal("59", cv.ConvertTo(null, null, ts, typeof(string)));
+
+            ts = TimeSpan.FromMinutes(144);
+            Assert.Equal("144", cv.ConvertTo(null, null, ts, typeof(string)));
+
+            ts = TimeSpan.FromSeconds(390);
+            Assert.Equal("6", cv.ConvertTo(null, null, ts, typeof(string)));
+
+            /* infinity tests */
+            Assert.Equal("Infinite", cv.ConvertTo(null, null, TimeSpan.MaxValue, typeof(string)));
+            Assert.Equal("Infinite", cv.ConvertTo(null, null, new TimeSpan(Int64.MaxValue), typeof(string)));
+            Assert.Equal("15372286728", cv.ConvertTo(null, null, new TimeSpan(Int64.MaxValue - 1), typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_NullError()
+        {
+            TimeSpanMinutesOrInfiniteConverter cv = new TimeSpanMinutesOrInfiniteConverter();
+
+            Assert.Throws<NullReferenceException>(() => cv.ConvertTo(null, null, null, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_TypeError1()
+        {
+            TimeSpanMinutesOrInfiniteConverter cv = new TimeSpanMinutesOrInfiniteConverter();
+
+            Assert.Throws<ArgumentException>(() => cv.ConvertTo(null, null, 59, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_TypeError2()
+        {
+            TimeSpanMinutesOrInfiniteConverter cv = new TimeSpanMinutesOrInfiniteConverter();
+            TimeSpan ts;
+
+            ts = TimeSpan.FromMinutes(59);
+
+            Assert.Equal("59", cv.ConvertTo(null, null, ts, typeof(int)));
+            Assert.Equal("59", cv.ConvertTo(null, null, ts, null));
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/TimeSpanMinutesOrInfiniteConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/TimeSpanMinutesOrInfiniteConverterTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.TimeSpanMinutesOrInfiniteConverterTest.cs - Unit tests
 // for System.Configuration.TimeSpanMinutesOrInfiniteConverter.
@@ -25,10 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
-
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/TimeSpanSecondsConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/TimeSpanSecondsConverterTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.TimeSpanSecondsConverterTest.cs - Unit tests
 // for System.Configuration.TimeSpanSecondsConverter.
@@ -25,10 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
-
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/TimeSpanSecondsConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/TimeSpanSecondsConverterTest.cs
@@ -1,0 +1,141 @@
+//
+// System.Configuration.TimeSpanSecondsConverterTest.cs - Unit tests
+// for System.Configuration.TimeSpanSecondsConverter.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class TimeSpanSecondsConverterTest
+    {
+        [Fact]
+        public void CanConvertFrom()
+        {
+            TimeSpanSecondsConverter cv = new TimeSpanSecondsConverter();
+
+            Assert.True(cv.CanConvertFrom(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertFrom(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertFrom(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertFrom(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void CanConvertTo()
+        {
+            TimeSpanSecondsConverter cv = new TimeSpanSecondsConverter();
+
+            Assert.True(cv.CanConvertTo(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertTo(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertTo(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertTo(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void ConvertFrom()
+        {
+            TimeSpanSecondsConverter cv = new TimeSpanSecondsConverter();
+            object o;
+
+            o = cv.ConvertFrom(null, null, "59");
+            Assert.Equal(typeof(TimeSpan), o.GetType());
+            Assert.Equal("00:00:59", o.ToString());
+            o = cv.ConvertFrom(null, null, "104");
+            Assert.Equal("00:01:44", o.ToString());
+        }
+
+        [Fact]
+        public void ConvertFrom_FormatError()
+        {
+            TimeSpanSecondsConverter cv = new TimeSpanSecondsConverter();
+            object o = null;
+
+            Assert.Throws<ArgumentException>(() => o = cv.ConvertFrom(null, null, "100.5"));
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void ConvertFrom_TypeError()
+        {
+            TimeSpanSecondsConverter cv = new TimeSpanSecondsConverter();
+            object o = null;
+
+            Assert.Throws<ArgumentException>(() => o = cv.ConvertFrom(null, null, 59));
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void ConvertTo()
+        {
+            TimeSpanSecondsConverter cv = new TimeSpanSecondsConverter();
+            TimeSpan ts;
+
+            ts = TimeSpan.FromSeconds(59);
+            Assert.Equal("59", cv.ConvertTo(null, null, ts, typeof(string)));
+
+            ts = TimeSpan.FromSeconds(144);
+            Assert.Equal("144", cv.ConvertTo(null, null, ts, typeof(string)));
+
+            ts = TimeSpan.FromMilliseconds(3900);
+            Assert.Equal("3", cv.ConvertTo(null, null, ts, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_NullError()
+        {
+            TimeSpanSecondsConverter cv = new TimeSpanSecondsConverter();
+
+            Assert.Throws<NullReferenceException>(() => cv.ConvertTo(null, null, null, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_TypeError1()
+        {
+            TimeSpanSecondsConverter cv = new TimeSpanSecondsConverter();
+
+            Assert.Throws<ArgumentException>(() => cv.ConvertTo(null, null, 59, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_TypeError2()
+        {
+            TimeSpanSecondsConverter cv = new TimeSpanSecondsConverter();
+            TimeSpan ts;
+
+            ts = TimeSpan.FromSeconds(59);
+
+            Assert.Equal("59", cv.ConvertTo(null, null, ts, typeof(int)));
+            Assert.Equal("59", cv.ConvertTo(null, null, ts, null));
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/TimeSpanSecondsOrInfiniteConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/TimeSpanSecondsOrInfiniteConverterTest.cs
@@ -1,0 +1,148 @@
+//
+// System.Configuration.TimeSpanSecondsOrInfiniteConverterTest.cs - Unit tests
+// for System.Configuration.TimeSpanSecondsOrInfiniteConverter.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class TimeSpanSecondsOrInfiniteConverterTest
+    {
+        [Fact]
+        public void CanConvertFrom()
+        {
+            TimeSpanSecondsOrInfiniteConverter cv = new TimeSpanSecondsOrInfiniteConverter();
+
+            Assert.True(cv.CanConvertFrom(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertFrom(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertFrom(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertFrom(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void CanConvertTo()
+        {
+            TimeSpanSecondsOrInfiniteConverter cv = new TimeSpanSecondsOrInfiniteConverter();
+
+            Assert.True(cv.CanConvertTo(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertTo(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertTo(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertTo(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void ConvertFrom()
+        {
+            TimeSpanSecondsOrInfiniteConverter cv = new TimeSpanSecondsOrInfiniteConverter();
+            object o;
+
+            /* make sure the TimeSpanSecondsConverter tests work here too */
+            o = cv.ConvertFrom(null, null, "59");
+            Assert.Equal(typeof(TimeSpan), o.GetType());
+            Assert.Equal("00:00:59", o.ToString());
+            o = cv.ConvertFrom(null, null, "104");
+            Assert.Equal("00:01:44", o.ToString());
+
+            /* and now test infinity */
+            o = cv.ConvertFrom(null, null, "Infinite");
+            Assert.Equal(TimeSpan.MaxValue.ToString(), o.ToString());
+        }
+
+        [Fact]
+        public void ConvertFrom_FormatError()
+        {
+            TimeSpanSecondsOrInfiniteConverter cv = new TimeSpanSecondsOrInfiniteConverter();
+            object o = null;
+
+            Assert.Throws<ArgumentException>(() => o = cv.ConvertFrom(null, null, "100.5"));
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void ConvertFrom_TypeError()
+        {
+            TimeSpanSecondsOrInfiniteConverter cv = new TimeSpanSecondsOrInfiniteConverter();
+            object o = null;
+
+            Assert.Throws<InvalidCastException>(() => o = cv.ConvertFrom(null, null, 59));
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void ConvertTo()
+        {
+            TimeSpanSecondsOrInfiniteConverter cv = new TimeSpanSecondsOrInfiniteConverter();
+            TimeSpan ts;
+
+            ts = TimeSpan.FromSeconds(59);
+            Assert.Equal("59", cv.ConvertTo(null, null, ts, typeof(string)));
+
+            ts = TimeSpan.FromSeconds(144);
+            Assert.Equal("144", cv.ConvertTo(null, null, ts, typeof(string)));
+
+            /* infinity tests */
+            Assert.Equal("Infinite", cv.ConvertTo(null, null, TimeSpan.MaxValue, typeof(string)));
+            Assert.Equal("Infinite", cv.ConvertTo(null, null, new TimeSpan(Int64.MaxValue), typeof(string)));
+            Assert.Equal("922337203685", cv.ConvertTo(null, null, new TimeSpan(Int64.MaxValue - 1), typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_NullError()
+        {
+            TimeSpanSecondsOrInfiniteConverter cv = new TimeSpanSecondsOrInfiniteConverter();
+
+            Assert.Throws<NullReferenceException>(() => cv.ConvertTo(null, null, null, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_TypeError1()
+        {
+            TimeSpanSecondsOrInfiniteConverter cv = new TimeSpanSecondsOrInfiniteConverter();
+
+            Assert.Throws<ArgumentException>(() => cv.ConvertTo(null, null, 59, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_TypeError2()
+        {
+            TimeSpanSecondsOrInfiniteConverter cv = new TimeSpanSecondsOrInfiniteConverter();
+            TimeSpan ts;
+
+            ts = TimeSpan.FromSeconds(59);
+
+            Assert.Equal("59", cv.ConvertTo(null, null, ts, typeof(int)));
+            Assert.Equal("59", cv.ConvertTo(null, null, ts, null));
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/TimeSpanSecondsOrInfiniteConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/TimeSpanSecondsOrInfiniteConverterTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.TimeSpanSecondsOrInfiniteConverterTest.cs - Unit tests
 // for System.Configuration.TimeSpanSecondsOrInfiniteConverter.
@@ -25,10 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
-
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/TimeSpanValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/TimeSpanValidatorTest.cs
@@ -1,0 +1,108 @@
+//
+// System.Configuration.TimeSpanValidatorTest.cs - Unit tests
+// for System.Configuration.TimeSpanValidator.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class TimeSpanValidatorTest
+    {
+        [Fact]
+        public void CanValidate()
+        {
+            TimeSpan t = new TimeSpan(1000);
+            TimeSpanValidator v = new TimeSpanValidator(t, t);
+
+            Assert.True(v.CanValidate(typeof(TimeSpan)), "A1");
+            Assert.False(v.CanValidate(typeof(int)), "A2");
+            Assert.False(v.CanValidate(typeof(long)), "A3");
+        }
+
+        [Fact]
+        public void Validate_inRange()
+        {
+            TimeSpanValidator v = new TimeSpanValidator(new TimeSpan(5000), new TimeSpan(10000));
+            v.Validate(new TimeSpan(7000));
+        }
+
+        [Fact]
+        public void Validate_Inclusive()
+        {
+            TimeSpanValidator v = new TimeSpanValidator(new TimeSpan(5000), new TimeSpan(10000), false);
+            v.Validate(new TimeSpan(5000));
+            v.Validate(new TimeSpan(10000));
+        }
+
+        [Fact]
+        public void Validate_Exclusive()
+        {
+            TimeSpanValidator v = new TimeSpanValidator(new TimeSpan(5000), new TimeSpan(10000), true);
+            v.Validate(new TimeSpan(1000));
+            v.Validate(new TimeSpan(15000));
+        }
+
+        [Fact]
+        public void Validate_Exclusive_fail1()
+        {
+            TimeSpanValidator v = new TimeSpanValidator(new TimeSpan(5000), new TimeSpan(10000), true);
+            Assert.Throws<ArgumentException>(() => v.Validate(new TimeSpan(5000)));
+        }
+
+        [Fact]
+        public void Validate_Exclusive_fail2()
+        {
+            TimeSpanValidator v = new TimeSpanValidator(new TimeSpan(5000), new TimeSpan(10000), true);
+            Assert.Throws<ArgumentException>(() => v.Validate(new TimeSpan(10000)));
+        }
+
+        [Fact]
+        public void Validate_Exclusive_fail3()
+        {
+            TimeSpanValidator v = new TimeSpanValidator(new TimeSpan(5000), new TimeSpan(10000), true);
+            Assert.Throws<ArgumentException>(() => v.Validate(new TimeSpan(7000)));
+        }
+
+        [Fact]
+        public void Validate_Resolution()
+        {
+            TimeSpanValidator v = new TimeSpanValidator(new TimeSpan(20000),
+                                     new TimeSpan(50000),
+                                     false,
+                                     2);
+
+            Assert.Throws<ArgumentException>(() => v.Validate(TimeSpan.FromTicks(40000)));
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/TimeSpanValidatorTest.cs
+++ b/src/System.Configuration/tests/Mono/TimeSpanValidatorTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.TimeSpanValidatorTest.cs - Unit tests
 // for System.Configuration.TimeSpanValidator.
@@ -25,10 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
-
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/TypeNameConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/TypeNameConverterTest.cs
@@ -1,0 +1,110 @@
+//
+// System.Configuration.TypeNameConverterTest.cs - Unit tests
+// for System.Configuration.TypeNameConverter.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class TypeNameConverterTest
+    {
+        [Fact]
+        public void CanConvertFrom()
+        {
+            TypeNameConverter cv = new TypeNameConverter();
+
+            Assert.True(cv.CanConvertFrom(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertFrom(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertFrom(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertFrom(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void CanConvertTo()
+        {
+            TypeNameConverter cv = new TypeNameConverter();
+
+            Assert.True(cv.CanConvertTo(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertTo(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertTo(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertTo(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void ConvertFrom()
+        {
+            TypeNameConverter cv = new TypeNameConverter();
+            object t;
+
+            t = cv.ConvertFrom(null, null, typeof(object).AssemblyQualifiedName);
+            Assert.True(t is Type, "A1");
+            object o = Activator.CreateInstance((Type)t);
+            Assert.Equal(typeof(object), o.GetType());
+        }
+
+        [Fact]
+        public void ConvertFrom_TypeError()
+        {
+            TypeNameConverter cv = new TypeNameConverter();
+            object o = null;
+
+            Assert.Throws<InvalidCastException>(() => o = cv.ConvertFrom(null, null, 59));
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void ConvertTo()
+        {
+            TypeNameConverter cv = new TypeNameConverter();
+
+            Assert.Equal(typeof(string).AssemblyQualifiedName, cv.ConvertTo(null, null, typeof(string), typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_NullError()
+        {
+            TypeNameConverter cv = new TypeNameConverter();
+
+            Assert.Equal(null, cv.ConvertTo(null, null, null, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_TypeError1()
+        {
+            TypeNameConverter cv = new TypeNameConverter();
+
+            Assert.Throws<ArgumentException>(() => cv.ConvertTo(null, null, 59, typeof(string)));
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/Mono/TypeNameConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/TypeNameConverterTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.TypeNameConverterTest.cs - Unit tests
 // for System.Configuration.TypeNameConverter.
@@ -25,10 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
-
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/WhiteSpaceTrimStringConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/WhiteSpaceTrimStringConverterTest.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
 //
 // System.Configuration.WhiteSpaceTrimStringConverterTest.cs - Unit tests
 // for System.Configuration.WhiteSpaceTrimStringConverter.
@@ -25,9 +27,6 @@
 // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// Licensed to the .NET Foundation under one or more agreements.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Configuration;

--- a/src/System.Configuration/tests/Mono/WhiteSpaceTrimStringConverterTest.cs
+++ b/src/System.Configuration/tests/Mono/WhiteSpaceTrimStringConverterTest.cs
@@ -1,0 +1,113 @@
+//
+// System.Configuration.WhiteSpaceTrimStringConverterTest.cs - Unit tests
+// for System.Configuration.WhiteSpaceTrimStringConverter.
+//
+// Author:
+//	Chris Toshok  <toshok@ximian.com>
+//
+// Copyright (C) 2005 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Configuration;
+using Xunit;
+
+namespace MonoTests.System.Configuration
+{
+    public class WhiteSpaceTrimStringConverterTest
+    {
+        [Fact]
+        public void CanConvertFrom()
+        {
+            WhiteSpaceTrimStringConverter cv = new WhiteSpaceTrimStringConverter();
+
+            Assert.True(cv.CanConvertFrom(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertFrom(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertFrom(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertFrom(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void CanConvertTo()
+        {
+            WhiteSpaceTrimStringConverter cv = new WhiteSpaceTrimStringConverter();
+
+            Assert.True(cv.CanConvertTo(null, typeof(string)), "A1");
+            Assert.False(cv.CanConvertTo(null, typeof(TimeSpan)), "A2");
+            Assert.False(cv.CanConvertTo(null, typeof(int)), "A3");
+            Assert.False(cv.CanConvertTo(null, typeof(object)), "A4");
+        }
+
+        [Fact]
+        public void ConvertFrom()
+        {
+            WhiteSpaceTrimStringConverter cv = new WhiteSpaceTrimStringConverter();
+            object o;
+
+            o = cv.ConvertFrom(null, null, "hi there");
+            Assert.Equal(typeof(string), o.GetType());
+            Assert.Equal("hi there", (string)o);
+            o = cv.ConvertFrom(null, null, " hi there ");
+            Assert.Equal("hi there", (string)o);
+        }
+
+        [Fact]
+        public void ConvertFrom_TypeError()
+        {
+            WhiteSpaceTrimStringConverter cv = new WhiteSpaceTrimStringConverter();
+            object o = null;
+
+            Assert.Throws<InvalidCastException>(() => o = cv.ConvertFrom(null, null, 59));
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void ConvertTo()
+        {
+            WhiteSpaceTrimStringConverter cv = new WhiteSpaceTrimStringConverter();
+
+            Assert.Equal("59", cv.ConvertTo(null, null, "59", typeof(string)));
+            Assert.Equal("59", cv.ConvertTo(null, null, " 59", typeof(string)));
+            Assert.Equal("59", cv.ConvertTo(null, null, "59 ", typeof(string)));
+            Assert.Equal("59", cv.ConvertTo(null, null, " 59 ", typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_NullError()
+        {
+            WhiteSpaceTrimStringConverter cv = new WhiteSpaceTrimStringConverter();
+
+            Assert.Equal("", cv.ConvertTo(null, null, null, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertTo_TypeError1()
+        {
+            WhiteSpaceTrimStringConverter cv = new WhiteSpaceTrimStringConverter();
+
+            Assert.Throws<ArgumentException>(() => cv.ConvertTo(null, null, 59, typeof(string)));
+        }
+    }
+}
+

--- a/src/System.Configuration/tests/System.Configuration.Tests.csproj
+++ b/src/System.Configuration/tests/System.Configuration.Tests.csproj
@@ -45,6 +45,40 @@
     <Compile Include="..\src\System\Configuration\ValidatorUtils.cs">
       <Link>Source\ValidatorUtils.cs</Link>
     </Compile>
+    <Compile Include="Mono\CallbackValidatorTest.cs" />
+    <Compile Include="Mono\CommaDelimitedStringCollectionConverterTest.cs" />
+    <Compile Include="Mono\CommaDelimitedStringCollectionTest.cs" />
+    <Compile Include="Mono\ConfigurationElementTest.cs" />
+    <Compile Include="Mono\ConfigurationErrorsExceptionTest.cs" />
+    <Compile Include="Mono\ConfigurationLockCollectionTest.cs" />
+    <Compile Include="Mono\ConfigurationManagerTest.cs" />
+    <Compile Include="Mono\ConfigurationPropertyTest.cs" />
+    <Compile Include="Mono\ConfigurationSaveTest.cs" />
+    <Compile Include="Mono\ConfigurationSectionGroupTest.cs" />
+    <Compile Include="Mono\ConfigurationSectionTest.cs" />
+    <Compile Include="Mono\ConnectionStringSettingsTest.cs" />
+    <Compile Include="Mono\DefaultValidatorTest.cs" />
+    <Compile Include="Mono\ExeConfigurationFileMapTest.cs" />
+    <Compile Include="Mono\GenericEnumConverterTest.cs" />
+    <Compile Include="Mono\InfiniteIntConverterTest.cs" />
+    <Compile Include="Mono\InfiniteTimeSpanConverterTest.cs" />
+    <Compile Include="Mono\IntegerValidatorTest.cs" />
+    <Compile Include="Mono\KeyValueConfigurationCollectionTest.cs" />
+    <Compile Include="Mono\KeyValueConfigurationElementTest.cs" />
+    <Compile Include="Mono\LongValidatorTest.cs" />
+    <Compile Include="Mono\PositiveTimeSpanValidatorTest.cs" />
+    <Compile Include="Mono\RegexStringValidatorTest.cs" />
+    <Compile Include="Mono\StringValidatorTest.cs" />
+    <Compile Include="Mono\SubclassTypeValidatorTest.cs" />
+    <Compile Include="Mono\TestLabel.cs" />
+    <Compile Include="Mono\TestUtil.cs" />
+    <Compile Include="Mono\TimeSpanMinutesConverterTest.cs" />
+    <Compile Include="Mono\TimeSpanMinutesOrInfiniteConverterTest.cs" />
+    <Compile Include="Mono\TimeSpanSecondsConverterTest.cs" />
+    <Compile Include="Mono\TimeSpanSecondsOrInfiniteConverterTest.cs" />
+    <Compile Include="Mono\TimeSpanValidatorTest.cs" />
+    <Compile Include="Mono\TypeNameConverterTest.cs" />
+    <Compile Include="Mono\WhiteSpaceTrimStringConverterTest.cs" />
     <Compile Include="Resources\Strings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -60,6 +94,7 @@
     <Compile Include="System\Configuration\BasicCustomSectionTests.cs" />
     <Compile Include="System\Configuration\ExceptionUtilTests.cs" />
     <Compile Include="System\Configuration\ImplicitMachineConfigTests.cs" />
+    <Compile Include="System\Configuration\KeyValueConfigurationCollectionTests.cs" />
     <Compile Include="System\Configuration\SmokeTest.cs" />
     <Compile Include="System\Configuration\StringUtilTests.cs" />
     <Compile Include="System\Configuration\TempConfig.cs" />

--- a/src/System.Configuration/tests/System/Configuration/ConfigurationElementTests.cs
+++ b/src/System.Configuration/tests/System/Configuration/ConfigurationElementTests.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Configuration;
+using System.Reflection;
+using System.Xml;
 using Xunit;
 
 namespace System.ConfigurationTests
@@ -60,22 +62,98 @@ namespace System.ConfigurationTests
             Assert.Same(foo, new SimpleElement().TestGetTransformedAssemblyString(foo));
         }
 
+        private static PropertyInfo LockType = typeof(ConfigurationLockCollection).GetProperty("LockType", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        [Fact]
+        public void LockAttributesCollectionIsCorrectType()
+        {
+            var lockCollection = new SimpleElement().LockAttributes;
+            Assert.Equal(0, lockCollection.Count);
+            Assert.Equal("LockedAttributes", LockType.GetValue(lockCollection).ToString());
+        }
+
+        [Fact]
+        public void LockAllAttributesExceptCollectionIsCorrectType()
+        {
+            var lockCollection = new SimpleElement().LockAllAttributesExcept;
+            Assert.Equal(0, lockCollection.Count);
+            Assert.Equal("LockedExceptionList", LockType.GetValue(lockCollection).ToString());
+        }
+
+        [Fact]
+        public void LockElementsCollectionIsCorrectType()
+        {
+            var lockCollection = new SimpleElement().LockElements;
+            Assert.Equal(0, lockCollection.Count);
+            Assert.Equal("LockedElements", LockType.GetValue(lockCollection).ToString());
+        }
+
+        [Fact]
+        public void LockAllElementsExceptCollectionIsCorrectType()
+        {
+            var lockCollection = new SimpleElement().LockAllElementsExcept;
+            Assert.Equal(0, lockCollection.Count);
+            Assert.Equal("LockedElementsExceptionList", LockType.GetValue(lockCollection).ToString());
+        }
+
+        [Fact]
+        public void LockItemIsFalse()
+        {
+            Assert.False(new SimpleElement().LockItem);
+        }
+
+        [Fact]
+        public void SetLockItem()
+        {
+            var element = new SimpleElement();
+            element.LockItem = true;
+            Assert.True(element.LockItem);
+        }
+
+        [Fact]
+        public void ElementInformationIsNotCollection()
+        {
+            Assert.False(new SimpleElement().ElementInformation.IsCollection);
+        }
+
+        [Fact]
+        public void ElementInformationIsNotPresent()
+        {
+            Assert.False(new SimpleElement().ElementInformation.IsPresent);
+        }
+
+        [Fact]
+        public void ElementInformationPropertiesEmpty()
+        {
+            Assert.Empty(new SimpleElement().ElementInformation.Properties);
+        }
+
+        [Fact]
+        public void CurrentConfigurationIsNull()
+        {
+            Assert.Null(new SimpleElement().CurrentConfiguration);
+        }
+
+        [Fact]
+        public void OnDeserializeUnrecognizedAttributeReturnsFalse()
+        {
+            Assert.False(new SimpleElement().TestOnDeserializeUnrecognizedAttribute(null, null));
+        }
+
+        [Fact]
+        public void OnDeserializeUnrecognizedElementReturnsFalse()
+        {
+            Assert.False(new SimpleElement().TestOnDeserializeUnrecognizedElement(null, null));
+        }
+
         public class SimpleElement : ConfigurationElement
         {
             public ContextInformation TestEvaluationContext => EvaluationContext;
-
             public bool TestHasContext => HasContext;
-
-            public string TestGetTransformedTypeString(string typeName)
-            {
-                return GetTransformedTypeString(typeName);
-            }
-
-            public string TestGetTransformedAssemblyString(string assemblyName)
-            {
-                return GetTransformedAssemblyString(assemblyName);
-            }
+            public string TestGetTransformedTypeString(string typeName) => GetTransformedTypeString(typeName);
+            public string TestGetTransformedAssemblyString(string assemblyName) => GetTransformedAssemblyString(assemblyName);
+            public bool TestOnDeserializeUnrecognizedAttribute(string name, string value) => OnDeserializeUnrecognizedAttribute(name, value);
+            public bool TestOnDeserializeUnrecognizedElement(string elementName, XmlReader reader) => OnDeserializeUnrecognizedElement(elementName, reader);
         }
-
     }
 }

--- a/src/System.Configuration/tests/System/Configuration/KeyValueConfigurationCollectionTests.cs
+++ b/src/System.Configuration/tests/System/Configuration/KeyValueConfigurationCollectionTests.cs
@@ -1,0 +1,137 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Configuration;
+using Xunit;
+
+namespace System.ConfigurationTests
+{
+    public class KeyValueConfigurationCollectionTests
+    {
+        [Fact]
+        public void MsdnRootSample()
+        {
+            // https://msdn.microsoft.com/en-us/library/system.configuration.keyvalueconfigurationcollection(v=vs.110).aspx
+            using (var temp = new TempConfig(TestData.EmptyConfig))
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                AppSettingsSection configSection = (AppSettingsSection)config.GetSection("appSettings");
+                Assert.Equal("appSettings", configSection.SectionInformation.Name);
+                KeyValueConfigurationElement myAdminKeyVal = new KeyValueConfigurationElement("myAdminTool", "admin.aspx");
+                KeyValueConfigurationCollection configSettings = config.AppSettings.Settings;
+                Assert.Equal(0, configSettings.AllKeys.Length);
+                config.AppSettings.Settings.Add(myAdminKeyVal);
+                Assert.False(configSection.SectionInformation.IsLocked);
+                config.Save();
+
+                KeyValueConfigurationCollection settings =
+                  config.AppSettings.Settings;
+                foreach (KeyValueConfigurationElement keyValueElement in settings)
+                {
+                    Assert.Equal("myAdminTool", keyValueElement.Key);
+                    Assert.Equal("admin.aspx", keyValueElement.Value);
+                }
+            }
+        }
+
+        [Fact]
+        public void CollectionTypeIsAddRemoveMap()
+        {
+            Assert.Equal(ConfigurationElementCollectionType.AddRemoveClearMap, new KeyValueConfigurationCollection().CollectionType);
+        }
+
+        [Fact]
+        public void ThrowOnDuplicateIsFalse()
+        {
+            Assert.False(new TestKeyValueCollection().TestThrowOnDuplicate);
+        }
+
+        [Fact]
+        public void CreateNewElement()
+        {
+            var element = new TestKeyValueCollection().TestCreateNewElement();
+            Assert.IsType<KeyValueConfigurationElement>(element);
+            Assert.Equal("", ((KeyValueConfigurationElement)element).Key);
+            Assert.Equal("", ((KeyValueConfigurationElement)element).Value);
+        }
+
+        [Fact]
+        public void EmptyAllKeys()
+        {
+            Assert.Equal(0, new KeyValueConfigurationCollection().AllKeys.Length);
+        }
+
+        [Fact]
+        public void AddNullKeyValueThrows()
+        {
+            Assert.Throws<ConfigurationErrorsException>(() => new KeyValueConfigurationCollection().Add(null, null));
+        }
+
+        [Fact]
+        public void AddNullKeyValueElementThrows()
+        {
+            var element = new KeyValueConfigurationElement(null, null);
+            Assert.Throws<ConfigurationErrorsException>(() => new KeyValueConfigurationCollection().Add(element));
+        }
+
+        [Fact]
+        public void AddNullKeyThrows()
+        {
+            Assert.Throws<ConfigurationErrorsException>(() => new KeyValueConfigurationCollection().Add(null, "foo"));
+        }
+
+        [Fact]
+        public void AddNullValue()
+        {
+            var collection = new KeyValueConfigurationCollection();
+            collection.Add("foo", null);
+            Assert.Null(collection["foo"].Value);
+        }
+
+        [Fact]
+        public void AddOverValue()
+        {
+            var collection = new KeyValueConfigurationCollection();
+            collection.Add("foo", "foo");
+            Assert.Equal("foo", collection["foo"].Value);
+            collection.Add("foo", "bar");
+            Assert.Equal("foo,bar", collection["foo"].Value);
+        }
+
+        [Fact]
+        public void ModifyElementValue()
+        {
+            var collection = new KeyValueConfigurationCollection();
+            collection.Add("foo", "foo");
+            collection["foo"].Value = "bar";
+            Assert.Equal("bar", collection["foo"].Value);
+        }
+
+        [Fact]
+        public void RemoveKey()
+        {
+            var collection = new KeyValueConfigurationCollection();
+            collection.Add("foo", "foo");
+            Assert.Equal("foo", collection["foo"].Value);
+            collection.Remove("foo");
+            Assert.Null(collection["foo"]);
+        }
+
+        [Fact]
+        public void Clear()
+        {
+            var collection = new KeyValueConfigurationCollection();
+            collection.Add("foo", "foo");
+            Assert.Equal("foo", collection["foo"].Value);
+            collection.Clear();
+            Assert.Null(collection["foo"]);
+        }
+
+        private class TestKeyValueCollection : KeyValueConfigurationCollection
+        {
+            public bool TestThrowOnDuplicate => ThrowOnDuplicate;
+            public ConfigurationElement TestCreateNewElement() => CreateNewElement();
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/System.Runtime.Extensions.sln
+++ b/src/System.Runtime.Extensions/System.Runtime.Extensions.sln
@@ -40,14 +40,14 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
-		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Debug|Any CPU.ActiveCfg = net462_Release|Any CPU
-		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Debug|Any CPU.Build.0 = net462_Release|Any CPU
-		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Release|Any CPU.ActiveCfg = net462_Release|Any CPU
-		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Release|Any CPU.Build.0 = net462_Release|Any CPU
-		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.netstandard1.7_Debug|Any CPU.ActiveCfg = net463_Release|Any CPU
-		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.netstandard1.7_Debug|Any CPU.Build.0 = net463_Release|Any CPU
-		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.netstandard1.7_Release|Any CPU.ActiveCfg = net463_Debug|Any CPU
-		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.netstandard1.7_Release|Any CPU.Build.0 = net463_Debug|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Debug|Any CPU.ActiveCfg = net461_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Debug|Any CPU.Build.0 = net461_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Release|Any CPU.ActiveCfg = net461_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Release|Any CPU.Build.0 = net461_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.netstandard1.7_Debug|Any CPU.ActiveCfg = net461_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.netstandard1.7_Debug|Any CPU.Build.0 = net461_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.netstandard1.7_Release|Any CPU.ActiveCfg = net461_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.netstandard1.7_Release|Any CPU.Build.0 = net461_Release|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Unix_Debug|Any CPU.ActiveCfg = Unix_Debug|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Unix_Debug|Any CPU.Build.0 = Unix_Debug|Any CPU


### PR DESCRIPTION
- Ports the majority of Mono Configuration tests (the relevant ones, all pass)
- Add a number of new tests
- Expand the implicit machine config
- Make check for default machine config explicit
- Fix file move helper to move over existing
- Add Dpapi protected section provider
- Port the RSA protected section provider

@AlexGhiondea, @danmosemsft 

@bartonjs, can you look at the Dpapi provider? It was using direct P/Invokes, now is using our library.