### PR TITLE
Minor fix in Console test

### DIFF
--- a/src/System.Console/tests/ConsoleEncoding.cs
+++ b/src/System.Console/tests/ConsoleEncoding.cs
@@ -59,7 +59,7 @@ public class ConsoleEncoding
             string inString = new String(Console.InputEncoding.GetChars(inputBytesNoBom));
 
             string outString;
-            using (MemoryStream ms = new MemoryStream(inputBytes, false))
+            using (MemoryStream ms = new MemoryStream(inputBytesNoBom, false))
             {
                 using (StreamReader sr = new StreamReader(ms, Console.InputEncoding))
                 {
@@ -68,7 +68,7 @@ public class ConsoleEncoding
                 }
             }
 
-            Assert.Equal(inString, outString);
+            Assert.True(inString.Equals(outString), $"Encdoing: {Console.InputEncoding}, codepage: {Console.InputEncoding.CodePage}, expected: {inString}, Actual: {outString} ");
         }
         finally
         {

--- a/src/System.Console/tests/ConsoleEncoding.cs
+++ b/src/System.Console/tests/ConsoleEncoding.cs
@@ -68,7 +68,7 @@ public class ConsoleEncoding
                 }
             }
 
-            Assert.True(inString.Equals(outString), $"Encdoing: {Console.InputEncoding}, codepage: {Console.InputEncoding.CodePage}, expected: {inString}, Actual: {outString} ");
+            Assert.True(inString.Equals(outString), $"Encoding: {Console.InputEncoding}, Codepage: {Console.InputEncoding.CodePage}, Expected: {inString}, Actual: {outString} ");
         }
         finally
         {


### PR DESCRIPTION
This is a minor fix in the the console encoding test and added a small logging to the check to help telling about the used encoding in the test