### PR TITLE
SQL Tests: Refactoring tests and adding auto execution for Diagnostics test

### DIFF
--- a/src/System.Data.SqlClient/System.Data.SqlClient.sln
+++ b/src/System.Data.SqlClient/System.Data.SqlClient.sln
@@ -12,6 +12,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Data.SqlClient.Manua
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Data.SqlClient.Stress.Tests", "tests\StressTests\System.Data.SqlClient.Stress.Tests\System.Data.SqlClient.Stress.Tests.csproj", "{B94B8E6D-3E41-4046-B758-4A2E281F74EE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TDS.EndPoint", "tests\Tools\TDS\TDS.EndPoint\TDS.EndPoint.csproj", "{1FF891B4-D3DE-4CCE-887C-CB48F5351A45}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TDS.Servers", "tests\Tools\TDS\TDS.Servers\TDS.Servers.csproj", "{978063D3-FBB5-4E10-8C45-67C90BE1B931}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TDS", "tests\Tools\TDS\TDS\TDS.csproj", "{8DC9D1A0-351B-47BC-A90F-B9DA542550E9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -54,8 +60,7 @@ Global
 		{45DB5F86-7AE3-45C6-870D-F9357B66BDB5}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
 		{45DB5F86-7AE3-45C6-870D-F9357B66BDB5}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{45DB5F86-7AE3-45C6-870D-F9357B66BDB5}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
-        {B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
-		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
 		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
 		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Unix_Debug|Any CPU.ActiveCfg = Windows_Release|Any CPU
@@ -66,6 +71,42 @@ Global
 		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
 		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{1FF891B4-D3DE-4CCE-887C-CB48F5351A45}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{1FF891B4-D3DE-4CCE-887C-CB48F5351A45}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{1FF891B4-D3DE-4CCE-887C-CB48F5351A45}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{1FF891B4-D3DE-4CCE-887C-CB48F5351A45}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{1FF891B4-D3DE-4CCE-887C-CB48F5351A45}.Unix_Debug|Any CPU.ActiveCfg = Unix_Debug|Any CPU
+		{1FF891B4-D3DE-4CCE-887C-CB48F5351A45}.Unix_Debug|Any CPU.Build.0 = Unix_Debug|Any CPU
+		{1FF891B4-D3DE-4CCE-887C-CB48F5351A45}.Unix_Release|Any CPU.ActiveCfg = Unix_Release|Any CPU
+		{1FF891B4-D3DE-4CCE-887C-CB48F5351A45}.Unix_Release|Any CPU.Build.0 = Unix_Release|Any CPU
+		{1FF891B4-D3DE-4CCE-887C-CB48F5351A45}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{1FF891B4-D3DE-4CCE-887C-CB48F5351A45}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{1FF891B4-D3DE-4CCE-887C-CB48F5351A45}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{1FF891B4-D3DE-4CCE-887C-CB48F5351A45}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{978063D3-FBB5-4E10-8C45-67C90BE1B931}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{978063D3-FBB5-4E10-8C45-67C90BE1B931}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{978063D3-FBB5-4E10-8C45-67C90BE1B931}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{978063D3-FBB5-4E10-8C45-67C90BE1B931}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{978063D3-FBB5-4E10-8C45-67C90BE1B931}.Unix_Debug|Any CPU.ActiveCfg = Unix_Debug|Any CPU
+		{978063D3-FBB5-4E10-8C45-67C90BE1B931}.Unix_Debug|Any CPU.Build.0 = Unix_Debug|Any CPU
+		{978063D3-FBB5-4E10-8C45-67C90BE1B931}.Unix_Release|Any CPU.ActiveCfg = Unix_Release|Any CPU
+		{978063D3-FBB5-4E10-8C45-67C90BE1B931}.Unix_Release|Any CPU.Build.0 = Unix_Release|Any CPU
+		{978063D3-FBB5-4E10-8C45-67C90BE1B931}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{978063D3-FBB5-4E10-8C45-67C90BE1B931}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{978063D3-FBB5-4E10-8C45-67C90BE1B931}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{978063D3-FBB5-4E10-8C45-67C90BE1B931}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{8DC9D1A0-351B-47BC-A90F-B9DA542550E9}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{8DC9D1A0-351B-47BC-A90F-B9DA542550E9}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{8DC9D1A0-351B-47BC-A90F-B9DA542550E9}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{8DC9D1A0-351B-47BC-A90F-B9DA542550E9}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{8DC9D1A0-351B-47BC-A90F-B9DA542550E9}.Unix_Debug|Any CPU.ActiveCfg = Unix_Debug|Any CPU
+		{8DC9D1A0-351B-47BC-A90F-B9DA542550E9}.Unix_Debug|Any CPU.Build.0 = Unix_Debug|Any CPU
+		{8DC9D1A0-351B-47BC-A90F-B9DA542550E9}.Unix_Release|Any CPU.ActiveCfg = Unix_Release|Any CPU
+		{8DC9D1A0-351B-47BC-A90F-B9DA542550E9}.Unix_Release|Any CPU.Build.0 = Unix_Release|Any CPU
+		{8DC9D1A0-351B-47BC-A90F-B9DA542550E9}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{8DC9D1A0-351B-47BC-A90F-B9DA542550E9}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{8DC9D1A0-351B-47BC-A90F-B9DA542550E9}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{8DC9D1A0-351B-47BC-A90F-B9DA542550E9}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -74,5 +115,8 @@ Global
 		{F3E72F35-0351-4D67-9388-725BCAD807BA} = {ECE6CCAC-682B-4054-B737-E6DB4A4FA79A}
 		{45DB5F86-7AE3-45C6-870D-F9357B66BDB5} = {ECE6CCAC-682B-4054-B737-E6DB4A4FA79A}
 		{B94B8E6D-3E41-4046-B758-4A2E281F74EE} = {ECE6CCAC-682B-4054-B737-E6DB4A4FA79A}
+		{1FF891B4-D3DE-4CCE-887C-CB48F5351A45} = {ECE6CCAC-682B-4054-B737-E6DB4A4FA79A}
+		{978063D3-FBB5-4E10-8C45-67C90BE1B931} = {ECE6CCAC-682B-4054-B737-E6DB4A4FA79A}
+		{8DC9D1A0-351B-47BC-A90F-B9DA542550E9} = {ECE6CCAC-682B-4054-B737-E6DB4A4FA79A}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
@@ -4,10 +4,6 @@
 
 
 using Xunit;
-using Microsoft.SqlServer.TDS;
-using Microsoft.SqlServer.TDS.Servers;
-using Microsoft.SqlServer.TDS.EndPoint;
-using System.Net;
 
 namespace System.Data.SqlClient.Tests
 {
@@ -36,38 +32,4 @@ namespace System.Data.SqlClient.Tests
 
     }
 
-    internal class TestTdsServer : GenericTDSServer, IDisposable
-    {
-        private TDSServerEndPoint _endpoint = null;
-
-        private SqlConnectionStringBuilder connectionStringBuilder;
-
-        public TestTdsServer(TDSServerArguments args) : base(args) { }
-
-        public static TestTdsServer StartTestServer(bool enableFedAuth = false)
-        {
-            TDSServerArguments args = new TDSServerArguments()
-            {
-                Log = Console.Out,
-            };
-
-            if (enableFedAuth)
-            {
-                args.FedAuthRequiredPreLoginOption = Microsoft.SqlServer.TDS.PreLogin.TdsPreLoginFedAuthRequiredOption.FedAuthRequired;
-            }
-
-            TestTdsServer server = new TestTdsServer(args);
-            server._endpoint = new TDSServerEndPoint(server) { ServerEndPoint = new IPEndPoint(IPAddress.Any, 0) };
-            server._endpoint.Start();
-            int port = server._endpoint.ServerEndPoint.Port;
-            server.connectionStringBuilder = new SqlConnectionStringBuilder() { DataSource = "localhost,"+port, ConnectTimeout = 30, Encrypt = false };
-            server.ConnectionString = server.connectionStringBuilder.ConnectionString;
-            return server;
-        }
-
-        public void Dispose() => _endpoint?.Stop();
-
-        public string ConnectionString { get; private set; }
-
-    }
 }

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -12,10 +12,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
-  <ItemGroup Condition=" '$(EnableManualTests)' == 'true' ">
-    <Compile Include="DiagnosticTest.cs" />
-  </ItemGroup>
   <ItemGroup>
+    <Compile Include="DiagnosticTest.cs" />
     <Compile Include="ExceptionTest.cs" />
     <Compile Include="FakeDiagnosticListenerObserver.cs" />
     <Compile Include="SqlBulkCopyColumnMappingCollectionTest.cs" />
@@ -23,6 +21,7 @@
     <Compile Include="SqlErrorCollectionTest.cs" />
     <Compile Include="TcpDefaultForAzureTest.cs" />
     <Compile Include="SqlConnectionTest.cs" />
+    <Compile Include="TestTdsServer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\pkg\System.Data.SqlClient.pkgproj" />

--- a/src/System.Data.SqlClient/tests/FunctionalTests/TestTdsServer.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/TestTdsServer.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using Microsoft.SqlServer.TDS.EndPoint;
+using Microsoft.SqlServer.TDS.Servers;
+using System.Net;
+
+namespace System.Data.SqlClient.Tests
+{
+    internal class TestTdsServer : GenericTDSServer, IDisposable
+    {
+        private TDSServerEndPoint _endpoint = null;
+
+        private SqlConnectionStringBuilder connectionStringBuilder;
+
+        public TestTdsServer(TDSServerArguments args) : base(args) { }
+
+        public TestTdsServer(QueryEngine engine, TDSServerArguments args) : base(args)
+        {
+            this.Engine = engine;
+        }
+
+        public static TestTdsServer StartServerWithQueryEngine(QueryEngine engine, bool enableFedAuth = false, bool enableLog = false)
+        {
+            TDSServerArguments args = new TDSServerArguments()
+            {
+                Log = enableLog ? Console.Out : null,
+            };
+
+            if (enableFedAuth)
+            {
+                args.FedAuthRequiredPreLoginOption = Microsoft.SqlServer.TDS.PreLogin.TdsPreLoginFedAuthRequiredOption.FedAuthRequired;
+            }
+
+            TestTdsServer server = engine == null ? new TestTdsServer(args) : new TestTdsServer(engine, args);
+            server._endpoint = new TDSServerEndPoint(server) { ServerEndPoint = new IPEndPoint(IPAddress.Any, 0) };
+            server._endpoint.Start();
+            int port = server._endpoint.ServerEndPoint.Port;
+            server.connectionStringBuilder = new SqlConnectionStringBuilder() { DataSource = "localhost," + port, ConnectTimeout = 30, Encrypt = false };
+            server.ConnectionString = server.connectionStringBuilder.ConnectionString;
+            return server;
+        }
+
+        public static TestTdsServer StartTestServer(bool enableFedAuth = false, bool enableLog = false)
+        {
+            return StartServerWithQueryEngine(null, false, false);
+        }
+
+        public void Dispose() => _endpoint?.Stop();
+
+        public string ConnectionString { get; private set; }
+
+    }
+}

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS.Servers/QueryEngine.cs
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS.Servers/QueryEngine.cs
@@ -55,6 +55,17 @@ namespace Microsoft.SqlServer.TDS.Servers
             }
 
             // Prepare response message
+            return CreateQueryResponse(session, batchRequest);
+        }
+
+        /// <summary>
+        /// Create a response for the query
+        /// </summary>
+        /// <param name="session"></param>
+        /// <param name="batchRequest"></param>
+        /// <returns></returns>
+        protected virtual TDSMessageCollection CreateQueryResponse(ITDSServerSession session, TDSSQLBatchToken batchRequest)
+        {
             TDSMessage responseMessage = new TDSMessage(TDSMessageType.Response);
 
             // Prepare query text
@@ -348,6 +359,7 @@ namespace Microsoft.SqlServer.TDS.Servers
             // Response collection will contain only one message
             return new TDSMessageCollection(responseMessage);
         }
+
 
         /// <summary>
         /// Handle attention from the client


### PR DESCRIPTION
The Diagnostics tests in System.Data.SqlClient were meant for manual execution. 
With the TDS server, its possible to automate many of the diagnostics tests run. 

The change includes:
1. Refactoring of the test server
2. Refactor Query engine to allow plugging in custom queries.
3. Moving some of the Diagnostics tests queries to existing queries in the QueryEngine.
4. Adding support for error queries in the custom query engine.
5. Added the TDS project to SqlClient solution.
This change can be used to drive #13511 to completion.

Improves test line coverage to 21.7% for #14346 