### PR TITLE
Enable Dumpling for all Helix test runs

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows-Build-Test.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows-Build-Test.json
@@ -176,7 +176,7 @@
       },
       "inputs": {
         "filename": "$(build.SourcesDirectory)/corefx/build-tests.cmd",
-        "arguments": "-BuildTestsAgainstPackages -$(ConfigurationGroup) -SkipTests -target-os=$(TargetOS) -OuterLoop  -- /p:\"PackagesDrops=$(PackagesTransferDirectory)\\$(ConfigurationGroup)\" /p:\"ArchiveTests=true\" /p:\"Performance=$(Performance)\" /p:\"FuncTestsDisabled=$(FuncTestsDisabled)\" /p:\"TestNugetRuntimeId=$(TestNugetRuntimeId)\" /p:XunitTraitOptions=\\\"-notrait category=requireselevation\\\" /flp:v=detailed",
+        "arguments": "-BuildTestsAgainstPackages -$(ConfigurationGroup) -SkipTests -target-os=$(TargetOS) -OuterLoop  -- /p:\"PackagesDrops=$(PackagesTransferDirectory)\\$(ConfigurationGroup)\" /p:\"ArchiveTests=true\" /p:\"Performance=$(Performance)\" /p:\"FuncTestsDisabled=$(FuncTestsDisabled)\" /p:\"TestNugetRuntimeId=$(TestNugetRuntimeId)\" /p:\"EnableDumpling=true\" /p:XunitTraitOptions=\\\"-notrait category=requireselevation\\\" /flp:v=detailed",
         "modifyEnvironment": "false",
         "workingFolder": "$(build.SourcesDirectory)/corefx",
         "failOnStandardError": "false"


### PR DESCRIPTION
This is a follow-up change for https://github.com/dotnet/buildtools/pull/1254 since `/p:EnableCloudTest=true` is not being passed to Helix runs anymore and so Dumpling.targets was not being imported as expected.

cc: @danmosemsft @MattGal @weshaggard 