### PR TITLE
 Remove the SqlConnection Test

### DIFF
--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
@@ -11,6 +11,7 @@ namespace System.Data.SqlClient.Tests
     {
 
         [Fact]
+        [ActiveIssue(14017)]
         public void ConnectionTest()
         {
             Exception e = null;


### PR DESCRIPTION
This is to fix the failures in CI from SqlConnection Test.

I will continue to investigate the failure. I dont see any coverage impact with this test being removed because this usecase is taken care of, in Diagnostics test.



cc @stephentoub @danmosemsft 