### PR TITLE
Add RIDs for RHEL 7.3 and 7.4

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -230,6 +230,20 @@
             "#import": [ "rhel.7.2", "rhel.7.1-x64" ]
         },
 
+        "rhel.7.3": {
+            "#import": [ "rhel.7.2" ]
+        },
+        "rhel.7.3-x64": {
+            "#import": [ "rhel.7.3", "rhel.7.2-x64" ]
+        },
+
+        "rhel.7.4": {
+            "#import": [ "rhel.7.3" ]
+        },
+        "rhel.7.4-x64": {
+            "#import": [ "rhel.7.4", "rhel.7.3-x64" ]
+        },
+
         "ol": {
             "#import": [ "rhel" ]
         },


### PR DESCRIPTION
Teach .NET Core that RHEL 7.3 (released) and 7.4 (currently in development) are just newer versions of RHEL 7.2 and are compatible with RHEL 7.2.

This (along with some other fixes) allows us to build various .NET Core projects on RHEL 7.3.

cc @ellismg 