### PR TITLE
Fix some intermittently failing Desktop FSW tests

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
@@ -16,18 +16,22 @@ namespace System.IO.Tests
         public static void RenamedEventArgs_ctor(WatcherChangeTypes changeType, string directory, string name, string oldName)
         {
             RenamedEventArgs args = new RenamedEventArgs(changeType, directory, name, oldName);
-
-            if (!directory.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
-            {
-                directory += Path.DirectorySeparatorChar;
-            }
-
             Assert.Equal(changeType, args.ChangeType);
-            Assert.Equal(directory + name, args.FullPath);
+            Assert.Equal(directory + Path.DirectorySeparatorChar + name, args.FullPath);
             Assert.Equal(name, args.Name);
-
-            Assert.Equal(directory + oldName, args.OldFullPath);
             Assert.Equal(oldName, args.OldName);
+        }
+
+        [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "OldFullPath on Desktop demands FileIOPermissions which causes failures for invalid paths.")]
+        [InlineData(WatcherChangeTypes.Changed, "C:", "foo.txt", "bar.txt")]
+        [InlineData(WatcherChangeTypes.All, "C:", "foo.txt", "bar.txt")]
+        [InlineData(0, "", "", "")]
+        [InlineData(0, "", null, null)]
+        public static void RenamedEventArgs_ctor_OldFullPath(WatcherChangeTypes changeType, string directory, string name, string oldName)
+        {
+            RenamedEventArgs args = new RenamedEventArgs(changeType, directory, name, oldName);
+            Assert.Equal(directory + Path.DirectorySeparatorChar + oldName, args.OldFullPath);
         }
 
         [Fact]

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Changed.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Changed.cs
@@ -24,6 +24,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop FSW disallows modification of the watched folder.")]
         public void FileSystemWatcher_Directory_Changed_WatchedFolder()
         {
             using (var testDirectory = new TempDirectory(GetTestFilePath()))

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -311,23 +311,15 @@ namespace System.IO.Tests
             // This doesn't make sense, but it is permitted.
             watcher.NotifyFilter = 0;
             Assert.Equal((NotifyFilters)0, watcher.NotifyFilter);
-        }
 
-        [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "These throw InvalidEnumException on desktop, but ArgumentException on Core")]
-        public void FileSystemWatcher_NotifyFilter_InvalidEnum()
-        {
-            FileSystemWatcher watcher = new FileSystemWatcher();
-            var notifyFilters = Enum.GetValues(typeof(NotifyFilters)).Cast<NotifyFilters>();
-            var allFilters = notifyFilters.Aggregate((mask, flag) => mask | flag);
-
-            Assert.Throws<ArgumentException>(() => watcher.NotifyFilter = (NotifyFilters)(-1));
-            Assert.Throws<ArgumentException>(() => watcher.NotifyFilter = (NotifyFilters)int.MinValue);
-            Assert.Throws<ArgumentException>(() => watcher.NotifyFilter = (NotifyFilters)int.MaxValue);
-            Assert.Throws<ArgumentException>(() => watcher.NotifyFilter = allFilters + 1);
+            // These throw InvalidEnumException on desktop, but ArgumentException on K
+            Assert.ThrowsAny<ArgumentException>(() => watcher.NotifyFilter = (NotifyFilters)(-1));
+            Assert.ThrowsAny<ArgumentException>(() => watcher.NotifyFilter = (NotifyFilters)int.MinValue);
+            Assert.ThrowsAny<ArgumentException>(() => watcher.NotifyFilter = (NotifyFilters)int.MaxValue);
+            Assert.ThrowsAny<ArgumentException>(() => watcher.NotifyFilter = allFilters + 1);
 
             // Simulate a bit added to the flags
-            Assert.Throws<ArgumentException>(() => watcher.NotifyFilter = allFilters | (NotifyFilters)((int)notifyFilters.Max() << 1));
+            Assert.ThrowsAny<ArgumentException>(() => watcher.NotifyFilter = allFilters | (NotifyFilters)((int)notifyFilters.Max() << 1));
         }
 
         [Fact]

--- a/src/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
@@ -20,7 +20,7 @@ namespace System.IO.Tests
         // to keep the timeout short, as in a successful run we'll end up waiting for
         // the entire timeout specified.
         public const int WaitForExpectedEventTimeout = 500;         // ms to wait for an event to happen
-        public const int LongWaitTimeout = 10000;                   // ms to wait for an event that takes a longer time than the average operation
+        public const int LongWaitTimeout = 50000;                   // ms to wait for an event that takes a longer time than the average operation
         public const int SubsequentExpectedWait = 10;               // ms to wait for checks that occur after the first.
         public const int WaitForExpectedEventTimeout_NoRetry = 3000;// ms to wait for an event that isn't surrounded by a retry.
         public const int DefaultAttemptsForExpectedEvent = 3;       // Number of times an expected event should be retried if failing.

--- a/src/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
@@ -196,7 +196,7 @@ namespace System.IO.Tests
         /// <param name="assertExpected">True if results should be asserted. Used if there is no retry.</param>
         /// <param name="expectedPath"> Adds path verification to all expected events.</param>
         /// <returns>True if the events raised correctly; else, false.</returns>
-        private static bool ExecuteAndVerifyEvents(FileSystemWatcher watcher, WatcherChangeTypes expectedEvents, Action action, bool assertExpected, string[] expectedPaths, int timeout)
+        public static bool ExecuteAndVerifyEvents(FileSystemWatcher watcher, WatcherChangeTypes expectedEvents, Action action, bool assertExpected, string[] expectedPaths, int timeout)
         {
             bool result = true, verifyChanged = true, verifyCreated = true, verifyDeleted = true, verifyRenamed = true;
             AutoResetEvent changed = null, created = null, deleted = null, renamed = null;


### PR DESCRIPTION
They're failing for misc reasons but mostly are plagued by timeouts. I excluded some actual failures and increased timeouts for the other ones so desktop FSW runs should be clean going forward.

resolves https://github.com/dotnet/corefx/issues/14894
resolves https://github.com/dotnet/corefx/issues/14983
resolves https://github.com/dotnet/corefx/issues/13304
resolves https://github.com/dotnet/corefx/issues/13248
resolves https://github.com/dotnet/corefx/issues/13245
resolves https://github.com/dotnet/corefx/issues/13246