### PR TITLE
Fix XmlSerializerFactoryTest in ReflectionOnly Mode.

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializerFactory.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializerFactory.cs
@@ -66,8 +66,7 @@ namespace System.Xml.Serialization
         /// </devdoc>
         public XmlSerializer CreateSerializer(XmlTypeMapping xmlTypeMapping)
         {
-            TempAssembly tempAssembly = XmlSerializer.GenerateTempAssembly(xmlTypeMapping);
-            return (XmlSerializer)tempAssembly.Contract.TypedSerializers[xmlTypeMapping.Key];
+            return new XmlSerializer(xmlTypeMapping);
         }
 
         /// <include file='doc\XmlSerializerFactory.uex' path='docs/doc[@for="XmlSerializerFactory.CreateSerializer6"]/*' />
@@ -85,59 +84,12 @@ namespace System.Xml.Serialization
         /// </devdoc>
         public XmlSerializer CreateSerializer(Type type, string defaultNamespace)
         {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
-            TempAssembly tempAssembly = s_cache[defaultNamespace, type];
-            XmlTypeMapping mapping = null;
-            if (tempAssembly == null)
-            {
-                lock (s_cache)
-                {
-                    tempAssembly = s_cache[defaultNamespace, type];
-                    if (tempAssembly == null)
-                    {
-                        XmlSerializerImplementation contract;
-                        Assembly assembly = TempAssembly.LoadGeneratedAssembly(type, defaultNamespace, out contract);
-                        if (assembly == null)
-                        {
-                            // need to reflect and generate new serialization assembly
-                            XmlReflectionImporter importer = new XmlReflectionImporter(defaultNamespace);
-                            mapping = importer.ImportTypeMapping(type, null, defaultNamespace);
-                            tempAssembly = XmlSerializer.GenerateTempAssembly(mapping, type, defaultNamespace);
-                        }
-                        else
-                        {
-                            tempAssembly = new TempAssembly(contract);
-                        }
-                        s_cache.Add(defaultNamespace, type, tempAssembly);
-                    }
-                }
-            }
-            if (mapping == null)
-            {
-                mapping = XmlReflectionImporter.GetTopLevelMapping(type, defaultNamespace);
-            }
-            return (XmlSerializer)tempAssembly.Contract.GetSerializer(type);
+            return new XmlSerializer(type, defaultNamespace);
         }
 
         public XmlSerializer CreateSerializer(Type type, XmlAttributeOverrides overrides, Type[] extraTypes, XmlRootAttribute root, string defaultNamespace, string location)
         {
-            if (type == null)
-            {
-                throw new ArgumentNullException(nameof(type));
-            }
-
-            if (location != null)
-            {
-                DemandForUserLocationOrEvidence();
-            }
-
-            XmlReflectionImporter importer = new XmlReflectionImporter(overrides, defaultNamespace);
-            for (int i = 0; i < extraTypes.Length; i++)
-                importer.IncludeType(extraTypes[i]);
-            XmlTypeMapping mapping = importer.ImportTypeMapping(type, root, defaultNamespace);
-            TempAssembly tempAssembly = XmlSerializer.GenerateTempAssembly(mapping, type, defaultNamespace, location);
-            return (XmlSerializer)tempAssembly.Contract.TypedSerializers[mapping.Key];
+            return new XmlSerializer(type, overrides, extraTypes, root, defaultNamespace, location);
         }
 
         private void DemandForUserLocationOrEvidence()

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -2365,9 +2365,6 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
         Assert.Equal(originalmapping.XsdTypeNamespace, newmapping.XsdTypeNamespace);
     }
 
-#if ReflectionOnly
-    [ActiveIssue(11919)]
-#endif
     [Fact]
     public static void XmlSerializerFactoryTest()
     {


### PR DESCRIPTION
The test failed in ReflectionOnly mode because XmlSerializerFactory does not know how to deal with ReflectionOnly mode. The fix is to make XmlSerializerFactory use XmlSerializer consturctor who knows how to handle logic for ReflectinOnly/non-ReflectionOnly scenarios.

Fix #11919

/cc: @zhenlan @mconnew @huanwu 