### PR TITLE
Remove runtimeos parameter from CI command lines.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -311,8 +311,8 @@ def buildArchConfiguration = ['Debug': 'x86',
                         else {
                             // Use Server GC for Ubuntu/OSX Debug PR build & test
                             def useServerGC = (configurationGroup == 'Release' && isPR) ? 'useServerGC' : ''
-                            shell("HOME=\$WORKSPACE/tempHome ./build.sh -${configurationGroup.toLowerCase()} -framework:${targetGroup} -os:${osGroup} -runtimeos:${osName}")
-                            shell("HOME=\$WORKSPACE/tempHome ./build-tests.sh -${configurationGroup.toLowerCase()} -framework:${targetGroup} -os:${osGroup} -runtimeos:${osName} -- ${useServerGC} /p:WithoutCategories=IgnoreForCI")
+                            shell("HOME=\$WORKSPACE/tempHome ./build.sh -${configurationGroup.toLowerCase()} -framework:${targetGroup} -os:${osGroup}")
+                            shell("HOME=\$WORKSPACE/tempHome ./build-tests.sh -${configurationGroup.toLowerCase()} -framework:${targetGroup} -os:${osGroup} -- ${useServerGC} /p:WithoutCategories=IgnoreForCI")
                             // Tar up the appropriate bits.  On OSX the tarring is a different syntax for exclusion.
                             if (osName == 'OSX') {
                                 // TODO: Re-enable package archival when the build refactoring work allows it.


### PR DESCRIPTION
We don't need runtimeos passed when the machines we are running on
match the OS we want, so removing. If we ever need to do some cross
compiling then we might need to start passing them in again.

cc @chcosta 

skip ci please