### PR TITLE
Ensure we set Configuration on P2P and traversal

### DIFF
--- a/buildvertical.targets
+++ b/buildvertical.targets
@@ -47,8 +47,12 @@
                            BuildConfiguration="$(BuildConfiguration)" 
                            Condition="'$(BuildConfigurations)' != ''"
                            ContinueOnError="true">
-      <Output TaskParameter="BestConfiguration" ItemName="_Configuration" />                          
+      <Output TaskParameter="BestConfiguration" ItemName="_Configuration" />
     </FindBestConfiguration>  
+
+    <ItemGroup>
+      <_Configuration Condition="'$(BuildConfigurations)' == ''" Include="$(BuildConfiguration)" />
+    </ItemGroup>
 
     <PropertyGroup>
       <_BestConfiguration>%(_Configuration.Identity)</_BestConfiguration>
@@ -69,8 +73,12 @@
                            BuildConfiguration="$(BuildConfiguration)" 
                            Condition="'$(BuildConfigurations)' != ''"
                            ContinueOnError="true">
-      <Output TaskParameter="BestConfiguration" ItemName="_Configuration" />                          
+      <Output TaskParameter="BestConfiguration" ItemName="_Configuration" />
     </FindBestConfiguration>  
+    
+    <ItemGroup>
+      <_Configuration Condition="'$(BuildConfigurations)' == ''" Include="$(BuildConfiguration)" />
+    </ItemGroup>
   </Target>
 
   <Target Name="AnnotateProjectReference"

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -152,7 +152,6 @@
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
       <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
       <Name>RemoteExecutorConsoleApp</Name>
-      <UndefineProperties>%(ProjectReference.UndefineProperties);TargetGroup</UndefineProperties>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -124,12 +124,10 @@
     <ProjectReference Include="VoidMainWithExitCodeApp\VoidMainWithExitCodeApp.csproj">
       <Project>{9F312D76-9AF1-4E90-B3B0-815A1EC6C346}</Project>
       <Name>VoidMainWithExitCodeApp</Name>
-      <UndefineProperties>TargetGroup;OSGroup</UndefineProperties>
     </ProjectReference>
     <ProjectReference Include="TestApp\TestApp.csproj">
       <Project>{9F312D76-9AF1-4E90-B3B0-815A1EC6C346}</Project>
       <Name>TestApp</Name>
-      <UndefineProperties>TargetGroup;OSGroup</UndefineProperties>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/System.ServiceProcess.ServiceController.Tests.csproj
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/System.ServiceProcess.ServiceController.Tests.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\System.ServiceProcess.ServiceController.TestNativeService\System.ServiceProcess.ServiceController.TestNativeService.vcxproj">
       <Project>{ceb0775c-4273-4ac4-b50e-4492718051ae}</Project>
       <Name>System.ServiceProcess.ServiceController.TestNativeService</Name>
-      <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>
+      <UndefineProperties>OSGroup;TargetGroup;Configuration</UndefineProperties>
       <SetConfiguration>Configuration=Release</SetConfiguration>
       <SetPlatform Condition="'$(Platform)'=='AnyCPU'">Platform=x64</SetPlatform>
     </ProjectReference>

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <TestProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\System.Security.AccessControl.Tests.csproj" />
-    <TestProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\WebServer.csproj" Condition="'$(OS)' != 'Windows_NT'" />
+    <TestProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\WebServer.csproj" />
     <TestProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\System.Configuration.Tests.csproj" />
     <TestProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\System.DirectoryServices.AccountManagement.Tests.csproj" />
     <TestProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\System.Xml.XmlSerializer.ReflectionOnly.Tests.csproj" />


### PR DESCRIPTION
Similar to https://github.com/dotnet/corefx/pull/15037/commits/c572ae1d2169eccdd1827b9bdcab991a3f916d50
which solved this problem for static evaulation, do the same
on traversal builds and P2P references.

Submitting for CI coverage.  @alexperovich will pick this up in his change.

/cc @weshaggard @chcosta 