### PR TITLE
Remove CodeDom dependency from S.P.DataContractSerialization.

### DIFF
--- a/src/Common/src/System/CodeDom/CodeObject.cs
+++ b/src/Common/src/System/CodeDom/CodeObject.cs
@@ -5,14 +5,18 @@
 using System.Collections;
 using System.Collections.Specialized;
 
-#if !Feature_Serialization
+#if !FEATURE_SERIALIZATION
 namespace System.CodeDom
 #else
 namespace System.Runtime.Serialization
 #endif
 {
     [Serializable]
+#if !FEATURE_SERIALIZATION
     public class CodeObject
+#else
+    internal class CodeObject
+#endif
     {
         private IDictionary _userData = null;
 

--- a/src/Common/src/System/CodeDom/CodeObject.cs
+++ b/src/Common/src/System/CodeDom/CodeObject.cs
@@ -5,7 +5,11 @@
 using System.Collections;
 using System.Collections.Specialized;
 
+#if !Feature_Serialization
 namespace System.CodeDom
+#else
+namespace System.Runtime.Serialization
+#endif
 {
     [Serializable]
     public class CodeObject

--- a/src/Common/src/System/CodeDom/CodeTypeReference.cs
+++ b/src/Common/src/System/CodeDom/CodeTypeReference.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 
-#if !Feature_Serialization
+#if !FEATURE_SERIALIZATION
 namespace System.CodeDom
 #else
 namespace System.Runtime.Serialization
@@ -14,14 +14,22 @@ namespace System.Runtime.Serialization
 {
     [Serializable]
     [Flags]
+#if !FEATURE_SERIALIZATION
     public enum CodeTypeReferenceOptions
+#else
+    internal enum CodeTypeReferenceOptions
+#endif
     {
         GlobalReference = 0x00000001,
         GenericTypeParameter = 0x00000002
     }
 
     [Serializable]
+#if !FEATURE_SERIALIZATION
     public class CodeTypeReference : CodeObject
+#else
+    internal class CodeTypeReference : CodeObject
+#endif
     {
         private string _baseType;
         private readonly bool _isInterface;
@@ -276,7 +284,7 @@ namespace System.Runtime.Serialization
             }
         }
 
-#if !Feature_Serialization
+#if !FEATURE_SERIALIZATION
         public CodeTypeReference(CodeTypeParameter typeParameter) :
             this(typeParameter?.Name)
         {

--- a/src/Common/src/System/CodeDom/CodeTypeReference.cs
+++ b/src/Common/src/System/CodeDom/CodeTypeReference.cs
@@ -6,7 +6,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 
+#if !Feature_Serialization
 namespace System.CodeDom
+#else
+namespace System.Runtime.Serialization
+#endif
 {
     [Serializable]
     [Flags]
@@ -272,11 +276,13 @@ namespace System.CodeDom
             }
         }
 
+#if !Feature_Serialization
         public CodeTypeReference(CodeTypeParameter typeParameter) :
             this(typeParameter?.Name)
         {
             Options = CodeTypeReferenceOptions.GenericTypeParameter;
         }
+#endif
 
         public CodeTypeReference(string baseType, int rank)
         {

--- a/src/Common/src/System/CodeDom/CodeTypeReferenceCollection.cs
+++ b/src/Common/src/System/CodeDom/CodeTypeReferenceCollection.cs
@@ -4,14 +4,18 @@
 
 using System.Collections;
 
-#if !Feature_Serialization
+#if !FEATURE_SERIALIZATION
 namespace System.CodeDom
 #else
 namespace System.Runtime.Serialization
 #endif
 {
     [Serializable]
+#if !FEATURE_SERIALIZATION
     public class CodeTypeReferenceCollection : CollectionBase
+#else
+    internal class CodeTypeReferenceCollection : CollectionBase
+#endif
     {
         public CodeTypeReferenceCollection() { }
 

--- a/src/Common/src/System/CodeDom/CodeTypeReferenceCollection.cs
+++ b/src/Common/src/System/CodeDom/CodeTypeReferenceCollection.cs
@@ -4,7 +4,11 @@
 
 using System.Collections;
 
+#if !Feature_Serialization
 namespace System.CodeDom
+#else
+namespace System.Runtime.Serialization
+#endif
 {
     [Serializable]
     public class CodeTypeReferenceCollection : CollectionBase

--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -243,6 +243,7 @@
       "dependencies": {
         "Microsoft.Win32.Registry": "4.4.0-beta-24911-02",
         "Microsoft.Win32.Registry.AccessControl": "4.4.0-beta-24911-02",
+        "System.CodeDom": "4.4.0-beta-24911-02",
         "System.Configuration": "4.4.0-beta-24911-02",
         "System.Diagnostics.Process": "4.4.0-beta-24911-02",
         "System.IO.FileSystem.AccessControl": "4.4.0-beta-24911-02",

--- a/src/System.CodeDom/src/System.CodeDom.csproj
+++ b/src/System.CodeDom/src/System.CodeDom.csproj
@@ -73,7 +73,7 @@
     <Compile Include="System\CodeDom\CodeNamespaceCollection.cs" />
     <Compile Include="System\CodeDom\CodeNamespaceImport.cs" />
     <Compile Include="System\CodeDom\CodeNamespaceImportCollection.cs" />
-    <Compile Include="System\CodeDom\CodeObject.cs" />
+    <Compile Include="$(CommonPath)\System\CodeDom\CodeObject.cs" />
     <Compile Include="System\CodeDom\CodeObjectCreateExpression.cs" />
     <Compile Include="System\CodeDom\CodeParameterDeclarationExpression.cs" />
     <Compile Include="System\CodeDom\CodeParameterDeclarationExpressionCollection.cs" />
@@ -101,8 +101,8 @@
     <Compile Include="System\CodeDom\CodeTypeOfExpression.cs" />
     <Compile Include="System\CodeDom\CodeTypeParameter.cs" />
     <Compile Include="System\CodeDom\CodeTypeParameterCollection.cs" />
-    <Compile Include="System\CodeDom\CodeTypeReference.cs" />
-    <Compile Include="System\CodeDom\CodeTypeReferenceCollection.cs" />
+    <Compile Include="$(CommonPath)\System\CodeDom\CodeTypeReference.cs" />
+    <Compile Include="$(CommonPath)\System\CodeDom\CodeTypeReferenceCollection.cs" />
     <Compile Include="System\CodeDom\CodeTypeReferenceExpression.cs" />
     <Compile Include="System\CodeDom\CodeVariableDeclarationStatement.cs" />
     <Compile Include="System\CodeDom\CodeVariableReferenceExpression.cs" />

--- a/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -10,7 +10,7 @@
     <FileAlignment>512</FileAlignment>
     <DebugSymbols>true</DebugSymbols>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DefineConstants>$(DefineConstants);Feature_Serialization</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZATION</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='uap101aot'">$(DefineConstants);NET_NATIVE</DefineConstants>
     <!-- We do not want to block reflection for this assembly -->
     <BlockReflectionAttribute Condition="'$(TargetGroup)'=='uap101aot'">false</BlockReflectionAttribute>

--- a/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -10,6 +10,7 @@
     <FileAlignment>512</FileAlignment>
     <DebugSymbols>true</DebugSymbols>
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <DefineConstants>$(DefineConstants);Feature_Serialization</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='uap101aot'">$(DefineConstants);NET_NATIVE</DefineConstants>
     <!-- We do not want to block reflection for this assembly -->
     <BlockReflectionAttribute Condition="'$(TargetGroup)'=='uap101aot'">false</BlockReflectionAttribute>
@@ -143,6 +144,9 @@
     <Compile Include="$(JsonSources)\JsonEncodingStreamWrapper.cs" />
     <Compile Include="$(JsonSources)\JsonFormatGeneratorStatics.cs" Condition="!$(NetNative)" />
     <Compile Include="System\Runtime\Serialization\AccessorBuilder.cs" />
+    <Compile Include="$(CommonPath)\System\CodeDom\CodeTypeReference.cs" />
+    <Compile Include="$(CommonPath)\System\CodeDom\CodeTypeReferenceCollection.cs" />
+    <Compile Include="$(CommonPath)\System\CodeDom\CodeObject.cs" />
     <Compile Include="System\Runtime\Serialization\DataContractSet.cs" />
     <Compile Include="System\Runtime\Serialization\ExportOptions.cs" />
     <Compile Include="System\Runtime\Serialization\IExtensibleDataObject.cs" />

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -5,7 +5,6 @@
 namespace System.Runtime.Serialization
 {
     using System;
-    using System.CodeDom;
     using System.Collections.Generic;
     using System.Globalization;
     using System.Reflection;

--- a/src/System.Private.DataContractSerialization/src/project.json
+++ b/src/System.Private.DataContractSerialization/src/project.json
@@ -3,7 +3,6 @@
     "netstandard1.7": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.2.0-beta-24911-02",
-        "System.CodeDom": "4.4.0-beta-24911-02",
         "System.Collections": "4.4.0-beta-24911-02",
         "System.Collections.Concurrent": "4.4.0-beta-24911-02",
         "System.Diagnostics.Debug": "4.4.0-beta-24911-02",


### PR DESCRIPTION
Removing CodeDom dependency from S.P.DataContractSerialization. as System.CodeDom is a higher level OOB component.

Fix #15047 

/cc: @zhenlan @weshaggard 