### PR TITLE
Send the SNIPacket to the Error handler in MARS to prevent null dereference

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -128,12 +128,12 @@ namespace System.Data.SqlClient.SNI
         /// <summary>
         /// Process a receive error
         /// </summary>
-        public void HandleReceiveError()
+        public void HandleReceiveError(SNIPacket packet)
         {
             Debug.Assert(Monitor.IsEntered(this), "HandleReceiveError was called without being locked.");
             foreach (SNIMarsHandle handle in _sessions.Values)
             {
-                handle.HandleReceiveError();
+                handle.HandleReceiveError(packet);
             }
         }
 
@@ -162,7 +162,7 @@ namespace System.Data.SqlClient.SNI
             {
                 lock (this)
                 {
-                    HandleReceiveError();
+                    HandleReceiveError(packet);
                     return;
                 }
             }
@@ -191,7 +191,7 @@ namespace System.Data.SqlClient.SNI
                                     return;
                                 }
 
-                                HandleReceiveError();
+                                HandleReceiveError(packet);
                                 return;
                             }
                         }
@@ -230,7 +230,7 @@ namespace System.Data.SqlClient.SNI
                                     return;
                                 }
 
-                                HandleReceiveError();
+                                HandleReceiveError(packet);
                                 return;
                             }
                         }
@@ -241,7 +241,7 @@ namespace System.Data.SqlClient.SNI
                     if (!_sessions.ContainsKey(_currentHeader.sessionId))
                     {
                         SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.SMUX_PROV, 0, SNICommon.InvalidParameterError, string.Empty);
-                        HandleReceiveError();
+                        HandleReceiveError(packet);
                         _lowerHandle.Dispose();
                         _lowerHandle = null;
                         return;
@@ -285,7 +285,7 @@ namespace System.Data.SqlClient.SNI
                             return;
                         }
 
-                        HandleReceiveError();
+                        HandleReceiveError(packet);
                         return;
                     }
                 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -310,7 +310,7 @@ namespace System.Data.SqlClient.SNI
         /// <summary>
         /// Handle receive error
         /// </summary>
-        public void HandleReceiveError()
+        public void HandleReceiveError(SNIPacket packet)
         {
             lock (_receivedPacketQueue)
             {
@@ -318,7 +318,7 @@ namespace System.Data.SqlClient.SNI
                 _packetEvent.Set();
             }
 
-            ((TdsParserStateObject)_callbackObject).ReadAsyncCallback(null, 1);
+            ((TdsParserStateObject)_callbackObject).ReadAsyncCallback(packet, 1);
         }
 
         /// <summary>


### PR DESCRIPTION
Adding the SNIPacket parameter to be sent down the error path for MARS failures so that the null object is not dereferenced in `TdsParserStateObject.ReadAsyncCallback`

Fixes #11437