### PR TITLE
Remove System.Security.Permissions dependency from System.CodeDom

### DIFF
--- a/src/System.CodeDom/ref/System.CodeDom.cs
+++ b/src/System.CodeDom/ref/System.CodeDom.cs
@@ -1105,8 +1105,6 @@ namespace System.CodeDom.Compiler
         public string CompilerOptions { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string CoreAssemblyFileName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Collections.Specialized.StringCollection EmbeddedResources { get { throw null; } }
-        [System.ObsoleteAttribute("CAS policy is obsolete and will be removed in a future release of the .NET Framework. Please see http://go2.microsoft.com/fwlink/?LinkId=131738 for more information.")]
-        public System.Security.Policy.Evidence Evidence { get { throw null; } set { } }
         public bool GenerateExecutable { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool GenerateInMemory { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool IncludeDebugInformation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
@@ -1125,8 +1123,6 @@ namespace System.CodeDom.Compiler
         public CompilerResults(System.CodeDom.Compiler.TempFileCollection tempFiles) { }
         public System.Reflection.Assembly CompiledAssembly { get { throw null; } set { } }
         public System.CodeDom.Compiler.CompilerErrorCollection Errors { get { throw null; } }
-        [System.ObsoleteAttribute("CAS policy is obsolete and will be removed in a future release of the .NET Framework. Please see http://go2.microsoft.com/fwlink/?LinkId=131738 for more information.")]
-        public System.Security.Policy.Evidence Evidence { get { throw null; } set { } }
         public int NativeCompilerReturnValue { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Collections.Specialized.StringCollection Output { get { throw null; } }
         public string PathToAssembly { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/System.CodeDom/ref/project.json
+++ b/src/System.CodeDom/ref/project.json
@@ -7,7 +7,6 @@
     "System.Reflection": "4.4.0-beta-24910-02",
     "System.Runtime": "4.4.0-beta-24910-02",
     "System.Runtime.Extensions": "4.4.0-beta-24910-02",
-    "System.Security.Permissions": "4.4.0-beta-24910-02",
     "System.Text.Encoding": "4.4.0-beta-24910-02"
   },
   "frameworks": {

--- a/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerParameters.cs
+++ b/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerParameters.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Specialized;
-using System.Security.Policy;
 
 namespace System.CodeDom.Compiler
 {
@@ -16,8 +15,6 @@ namespace System.CodeDom.Compiler
 
         [NonSerialized]
         private TempFileCollection _tempFiles;
-        [NonSerialized]
-        private Evidence _evidence;
 
         public CompilerParameters() : this(null, null)
         {
@@ -90,21 +87,5 @@ namespace System.CodeDom.Compiler
         public StringCollection LinkedResources => _linkedResources;
 
         public IntPtr UserToken { get; set; }
-
-        [Obsolete("CAS policy is obsolete and will be removed in a future release of the .NET Framework."
-                + " Please see http://go2.microsoft.com/fwlink/?LinkId=131738 for more information.")]
-        public Evidence Evidence
-        {
-            get
-            {
-                Evidence e = null;
-                if (_evidence != null)
-                {
-                    e = _evidence.Clone();
-                }
-                return e;
-            }
-            set { _evidence = value?.Clone(); }
-        }
     }
 }

--- a/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerResults.cs
+++ b/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerResults.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Specialized;
 using System.Reflection;
-using System.Security.Policy;
 
 namespace System.CodeDom.Compiler
 {
@@ -14,7 +13,6 @@ namespace System.CodeDom.Compiler
         private readonly CompilerErrorCollection _errors = new CompilerErrorCollection();
         private readonly StringCollection _output = new StringCollection();
         private Assembly _compiledAssembly;
-        private Evidence _evidence;
 
         public CompilerResults(TempFileCollection tempFiles)
         {
@@ -22,21 +20,6 @@ namespace System.CodeDom.Compiler
         }
 
         public TempFileCollection TempFiles { get; set; }
-
-        [Obsolete("CAS policy is obsolete and will be removed in a future release of the .NET Framework. Please see http://go2.microsoft.com/fwlink/?LinkId=131738 for more information.")]
-        public Evidence Evidence
-        {
-            get
-            {
-                Evidence e = null;
-                if (_evidence != null)
-                {
-                    e = _evidence.Clone();
-                }
-                return e;
-            }
-            set { _evidence = value?.Clone(); }
-        }
 
         public Assembly CompiledAssembly
         {

--- a/src/System.CodeDom/src/project.json
+++ b/src/System.CodeDom/src/project.json
@@ -20,7 +20,6 @@
         "System.Resources.ResourceManager": "4.4.0-beta-24910-02",
         "System.Runtime": "4.4.0-beta-24910-02",
         "System.Runtime.Extensions": "4.4.0-beta-24910-02",
-        "System.Security.Permissions": "4.4.0-beta-24910-02",
         "System.Text.Encoding": "4.4.0-beta-24910-02",
         "System.Text.RegularExpressions": "4.4.0-beta-24910-02",
         "System.Threading": "4.4.0-beta-24910-02",


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/15049
Required removing two public but obsolete members.

cc: @weshaggard, @danmosemsft 