### PR TITLE
Remove System.Security.Permissions dependency from System.ComponentModel.TypeConverter

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
@@ -13,8 +13,6 @@ namespace System.ComponentModel
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Diagnostics;
-    using System.Security.Permissions;
-    using CodeAccessPermission = System.Security.CodeAccessPermission;
 
     /// <summary>
     /// </summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/misc.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/misc.cs
@@ -89,7 +89,6 @@ namespace System
 
 namespace System.ComponentModel
 {
-    [HostProtection(SharedState = true)]
     internal static class CompModSwitches
     {
         private static volatile BooleanSwitch commonDesignerServices;

--- a/src/System.ComponentModel.TypeConverter/src/project.json
+++ b/src/System.ComponentModel.TypeConverter/src/project.json
@@ -29,7 +29,6 @@
         "System.Runtime.InteropServices": "4.4.0-beta-24910-02",
         "System.Runtime.Serialization.Formatters": "4.4.0-beta-24910-02",
         "System.Runtime.Serialization.Primitives": "4.4.0-beta-24910-02",
-        "System.Security.Permissions": "4.4.0-beta-24910-02",
         "System.Text.RegularExpressions": "4.4.0-beta-24910-02",
         "System.Threading.Tasks": "4.4.0-beta-24910-02",
         "System.Threading.Timer": "4.4.0-beta-24910-02"


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/15049
No API changes needed other than removing an attribute (that wasn't in ref).
cc: @weshaggard, @danmosemsft 