### PR TITLE
Augment BinaryFormatter tests

### DIFF
--- a/src/System.Collections/tests/Generic/Comparers/EqualityComparer.Generic.Serialization.Tests.cs
+++ b/src/System.Collections/tests/Generic/Comparers/EqualityComparer.Generic.Serialization.Tests.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Collections.Generic.Tests
+{
+    public abstract partial class ComparersGenericTests<T>
+    {
+        [Fact]
+        public void EqualityComparer_SerializationRoundtrip()
+        {
+            var bf = new BinaryFormatter();
+            var s = new MemoryStream();
+
+            EqualityComparer<T> orig = EqualityComparer<T>.Default;
+            bf.Serialize(s, orig);
+            s.Position = 0;
+            object result = bf.Deserialize(s);
+
+            // On .NET Framework, some EnumEqualityComparers deserialize as ObjectEqualityComparer.
+            // On .NET Core, they deserialize as the right type.
+            Assert.IsAssignableFrom<EqualityComparer<T>>(result);
+        }
+    }
+}

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -147,6 +147,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
+    <Compile Include="Generic\Comparers\EqualityComparer.Generic.Serialization.Tests.cs" />
     <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs</Link>
     </Compile>

--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -291,26 +291,6 @@ namespace System.Runtime.Serialization.Formatters.Tests
             }
         }
 
-        public static IEnumerable<object[]> SerializeDeserialize_DeserializedTypeExpectedDifferentFromInput_MemberData()
-        {
-            yield return new object[] { EqualityComparer<Int16Enum>.Default };
-            yield return new object[] { EqualityComparer<Int64Enum>.Default };
-            yield return new object[] { EqualityComparer<UInt16Enum>.Default };
-            yield return new object[] { EqualityComparer<UInt32Enum>.Default };
-            yield return new object[] { EqualityComparer<UInt64Enum>.Default };
-            yield return new object[] { EqualityComparer<SByteEnum>.Default };
-            yield return new object[] { EqualityComparer<ByteEnum>.Default };
-        }
-
-        [Theory]
-        [MemberData(nameof(SerializeDeserialize_DeserializedTypeExpectedDifferentFromInput_MemberData))]
-        public void SerializeDeserialize_EqualityComparerThatDeserializesToADifferentType(object input)
-        {
-            Type expected = EqualityComparer<object>.Default.GetType().GetGenericTypeDefinition();
-            Assert.NotEqual(expected, input.GetType().GetGenericTypeDefinition());
-            Assert.Equal(expected, FormatterClone(input).GetType().GetGenericTypeDefinition());
-        }
-
         public static IEnumerable<object[]> SerializableExceptions()
         {
             yield return new object[] { new AbandonedMutexException() };

--- a/src/System.Runtime.Serialization.Formatters/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/SerializationTypes.cs
@@ -217,6 +217,15 @@ namespace System.Runtime.Serialization.Formatters.Tests
         Purple
     }
 
+    [Serializable] public enum ByteEnum : byte { }
+    [Serializable] public enum SByteEnum : sbyte { }
+    [Serializable] public enum Int16Enum : short { }
+    [Serializable] public enum UInt16Enum : ushort { }
+    [Serializable] public enum Int32Enum : int { }
+    [Serializable] public enum UInt32Enum : uint { }
+    [Serializable] public enum Int64Enum : long { }
+    [Serializable] public enum UInt64Enum : ulong { }
+
     public struct NonSerializableStruct
     {
         public int Value;


### PR DESCRIPTION
- Uncomment tests that had previously been commented out while waiting for more types to be properly serializable
- Add tests for various equality comparers, some of which are particularly interesting because they deserialize as a different object type
- Decrease the running time of the fuzzing tests
- Deleted dead code from a previous change that removed a test / remoting members

(This will fail CI until https://github.com/dotnet/coreclr/pull/8892 is brought into corefx.)
cc: @danmosemsft 