### PR TITLE
Fix Windows 7 issue with RC2 EffectiveKeyLength

### DIFF
--- a/src/Common/src/Internal/Cryptography/BasicSymmetricCipherBCrypt.cs
+++ b/src/Common/src/Internal/Cryptography/BasicSymmetricCipherBCrypt.cs
@@ -16,7 +16,7 @@ namespace Internal.Cryptography
         private byte[] _currentIv;  // CNG mutates this with the updated IV for the next stage on each Encrypt/Decrypt call.
                                     // The base IV holds a copy of the original IV for Reset(), until it is cleared by Dispose().
 
-        public BasicSymmetricCipherBCrypt(SafeAlgorithmHandle algorithm, CipherMode cipherMode, int blockSizeInBytes, byte[] key, int effectiveKeyLength, byte[] iv, bool encrypting)
+        public BasicSymmetricCipherBCrypt(SafeAlgorithmHandle algorithm, CipherMode cipherMode, int blockSizeInBytes, byte[] key, bool ownsParentHandle, byte[] iv, bool encrypting)
             : base(cipherMode.GetCipherIv(iv), blockSizeInBytes)
         {
             Debug.Assert(algorithm != null);
@@ -30,9 +30,9 @@ namespace Internal.Cryptography
 
             _hKey = algorithm.BCryptImportKey(key);
 
-            if (effectiveKeyLength != 0)
+            if (ownsParentHandle)
             {
-                Cng.SetEffectiveKeyLength(_hKey, effectiveKeyLength);
+                _hKey.SetParentHandle(algorithm);
             }
 
             Reset();

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherTests.cs
@@ -140,7 +140,6 @@ namespace System.Security.Cryptography.Encryption.RC2.Tests
             }
         }
 
-        [ActiveIssue(12926)]
         [Theory, MemberData(nameof(RC2TestData))]
         public static void RC2RoundTrip(CipherMode cipherMode, PaddingMode paddingMode, string key, string iv, string textHex, string expectedDecrypted, string expectedEncrypted)
         {
@@ -164,7 +163,6 @@ namespace System.Security.Cryptography.Encryption.RC2.Tests
             }
         }
 
-        [ActiveIssue(12926)]
         [Fact]
         public static void RC2ReuseEncryptorDecryptor()
         {
@@ -206,7 +204,6 @@ namespace System.Security.Cryptography.Encryption.RC2.Tests
             }
         }
 
-        [ActiveIssue(12926)]
         [Fact]
         public static void RC2ExplicitEncryptorDecryptor_WithIV()
         {
@@ -226,7 +223,6 @@ namespace System.Security.Cryptography.Encryption.RC2.Tests
             }
         }
 
-        [ActiveIssue(12926)]
         [Fact]
         public static void RC2ExplicitEncryptorDecryptor_NoIV()
         {

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.Windows.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.Windows.cs
@@ -19,7 +19,7 @@ namespace Internal.Cryptography
         {
             SafeAlgorithmHandle algorithm = AesBCryptModes.GetSharedHandle(cipherMode);
 
-            BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, key, 0, iv, encrypting);
+            BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, key, false, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
         }
 

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.Windows.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.Windows.cs
@@ -19,7 +19,7 @@ namespace Internal.Cryptography
         {
             SafeAlgorithmHandle algorithm = DesBCryptModes.GetSharedHandle(cipherMode);
 
-            BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, key, 0, iv, encrypting);
+            BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, key, false, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
         }
     }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.Windows.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.Windows.cs
@@ -19,7 +19,7 @@ namespace Internal.Cryptography
         {
             SafeAlgorithmHandle algorithm = TripleDesBCryptModes.GetSharedHandle(cipherMode);
 
-            BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, key, 0, iv, encrypting);
+            BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, key, false, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
         }
 

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngSymmetricAlgorithmCore.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngSymmetricAlgorithmCore.cs
@@ -164,7 +164,7 @@ namespace Internal.Cryptography
                 _outer.Mode,
                 blockSizeInBytes,
                 key,
-                0,
+                false,
                 iv,
                 encrypting);
 


### PR DESCRIPTION
The SymmetricAlgorithm RC2 is broken with Windows 7; this fixes that by setting EffectiveKeyLength on the algorithm handle instead of the key handle.

Addresses https://github.com/dotnet/corefx/issues/12926 : RC2CipherTests failing on Win7 with "unknown error"