### PR TITLE
IndexOf/SequenceEqual methods for Span.

### DIFF
--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -83,6 +83,9 @@ namespace System
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] public static System.ReadOnlySpan<byte> AsBytes<T>(this ReadOnlySpan<T> source) where T : struct { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] public static System.Span<TTo> NonPortableCast<TFrom, TTo>(this System.Span<TFrom> source) where TFrom : struct where TTo : struct { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] public static System.ReadOnlySpan<TTo> NonPortableCast<TFrom, TTo>(this System.ReadOnlySpan<TFrom> source) where TFrom : struct where TTo : struct { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] public static int IndexOf<T>(this Span<T> span, T value) where T:struct, IEquatable<T> { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] public static bool SequenceEqual<T>(this Span<T> first, ReadOnlySpan<T> second) where T:struct, IEquatable<T> { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] public static int IndexOf<T>(this Span<T> span, ReadOnlySpan<T> value) where T : struct, IEquatable<T> { throw null; }
     }
 }
 

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -12,16 +12,16 @@ namespace System
     public partial struct ReadOnlySpan<T>
     {
         public static System.ReadOnlySpan<T> Empty { get { throw null; } }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public ReadOnlySpan(T[] array) { throw null;}
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public ReadOnlySpan(T[] array, int start) { throw null;}
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public ReadOnlySpan(T[] array, int start, int length) { throw null;}
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public unsafe ReadOnlySpan(void* pointer, int length) { throw null;}
+        public ReadOnlySpan(T[] array) { throw null;}
+        public ReadOnlySpan(T[] array, int start) { throw null;}
+        public ReadOnlySpan(T[] array, int start, int length) { throw null;}
+        public unsafe ReadOnlySpan(void* pointer, int length) { throw null;}
         public bool IsEmpty { get { throw null; } }
-        public T this[int index] { [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]get { throw null; }}
+        public T this[int index] { get { throw null; }}
         public int Length { get { throw null; } }
         public void CopyTo(System.Span<T> destination) { }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public static System.ReadOnlySpan<T> DangerousCreate(object obj, ref T objectData, int length) { throw null; }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public ref T DangerousGetPinnableReference() { throw null; }
+        public static System.ReadOnlySpan<T> DangerousCreate(object obj, ref T objectData, int length) { throw null; }
+        public ref T DangerousGetPinnableReference() { throw null; }
         [System.ObsoleteAttribute("Equals() on ReadOnlySpan will always throw an exception. Use == instead.")]
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
@@ -32,34 +32,34 @@ namespace System
         public static implicit operator System.ReadOnlySpan<T> (T[] array) { throw null; }
         public static implicit operator System.ReadOnlySpan<T> (System.ArraySegment<T> arraySegment) { throw null; }
         public static bool operator !=(System.ReadOnlySpan<T> left, System.ReadOnlySpan<T> right) { throw null; }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public System.ReadOnlySpan<T> Slice(int start) { throw null; }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public System.ReadOnlySpan<T> Slice(int start, int length) { throw null; }
+        public System.ReadOnlySpan<T> Slice(int start) { throw null; }
+        public System.ReadOnlySpan<T> Slice(int start, int length) { throw null; }
         public T[] ToArray() { throw null; }
         public bool TryCopyTo(System.Span<T> destination) { throw null; }
     }
 
     public static class ReadOnlySpanExtensions
     {
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public static ReadOnlySpan<char> Slice(this string text) { throw null; }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public static ReadOnlySpan<char> Slice(this string text, int start) { throw null; }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public static ReadOnlySpan<char> Slice(this string text, int start, int length) { throw null; }
+        public static ReadOnlySpan<char> Slice(this string text) { throw null; }
+        public static ReadOnlySpan<char> Slice(this string text, int start) { throw null; }
+        public static ReadOnlySpan<char> Slice(this string text, int start, int length) { throw null; }
     }
 
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct Span<T>
     {
         public static System.Span<T> Empty { get { throw null; } }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public Span(T[] array) { throw null;}
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public Span(T[] array, int start) { throw null;}
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public Span(T[] array, int start, int length) { throw null;}
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public unsafe Span(void* pointer, int length) { throw null;}
+        public Span(T[] array) { throw null;}
+        public Span(T[] array, int start) { throw null;}
+        public Span(T[] array, int start, int length) { throw null;}
+        public unsafe Span(void* pointer, int length) { throw null;}
         public bool IsEmpty { get { throw null; } }
-        public T this[int index] { [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]get { throw null; } [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]set { throw null; }}
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public ref T GetItem(int index) { throw null; }
+        public T this[int index] { get { throw null; } set { throw null; }}
+        public ref T GetItem(int index) { throw null; }
         public int Length { get { throw null; } }
         public void CopyTo(System.Span<T> destination) { }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public static System.Span<T> DangerousCreate(object obj, ref T objectData, int length) { throw null; }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public ref T DangerousGetPinnableReference() { throw null; }
+        public static System.Span<T> DangerousCreate(object obj, ref T objectData, int length) { throw null; }
+        public ref T DangerousGetPinnableReference() { throw null; }
         [System.ObsoleteAttribute("Equals() on Span will always throw an exception. Use == instead.")]
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
@@ -71,21 +71,21 @@ namespace System
         public static implicit operator System.Span<T> (System.ArraySegment<T> arraySegment) { throw null; }
         public static implicit operator System.ReadOnlySpan<T> (Span<T> span) { throw null; }
         public static bool operator !=(System.Span<T> left, System.Span<T> right) { throw null; }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public System.Span<T> Slice(int start) { throw null; }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public System.Span<T> Slice(int start, int length) { throw null; }
+        public System.Span<T> Slice(int start) { throw null; }
+        public System.Span<T> Slice(int start, int length) { throw null; }
         public T[] ToArray() { throw null; }
         public bool TryCopyTo(System.Span<T> destination) { throw null; }
     }
 
     public static class SpanExtensions
     {
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] public static System.Span<byte> AsBytes<T>(this Span<T> source) where T : struct { throw null; }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] public static System.ReadOnlySpan<byte> AsBytes<T>(this ReadOnlySpan<T> source) where T : struct { throw null; }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] public static System.Span<TTo> NonPortableCast<TFrom, TTo>(this System.Span<TFrom> source) where TFrom : struct where TTo : struct { throw null; }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] public static System.ReadOnlySpan<TTo> NonPortableCast<TFrom, TTo>(this System.ReadOnlySpan<TFrom> source) where TFrom : struct where TTo : struct { throw null; }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] public static int IndexOf<T>(this Span<T> span, T value) where T:struct, IEquatable<T> { throw null; }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] public static bool SequenceEqual<T>(this Span<T> first, ReadOnlySpan<T> second) where T:struct, IEquatable<T> { throw null; }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)] public static int IndexOf<T>(this Span<T> span, ReadOnlySpan<T> value) where T : struct, IEquatable<T> { throw null; }
+         public static System.Span<byte> AsBytes<T>(this Span<T> source) where T : struct { throw null; }
+         public static System.ReadOnlySpan<byte> AsBytes<T>(this ReadOnlySpan<T> source) where T : struct { throw null; }
+         public static System.Span<TTo> NonPortableCast<TFrom, TTo>(this System.Span<TFrom> source) where TFrom : struct where TTo : struct { throw null; }
+         public static System.ReadOnlySpan<TTo> NonPortableCast<TFrom, TTo>(this System.ReadOnlySpan<TFrom> source) where TFrom : struct where TTo : struct { throw null; }
+         public static int IndexOf<T>(this Span<T> span, T value) where T:struct, IEquatable<T> { throw null; }
+         public static bool SequenceEqual<T>(this Span<T> first, ReadOnlySpan<T> second) where T:struct, IEquatable<T> { throw null; }
+         public static int IndexOf<T>(this Span<T> span, ReadOnlySpan<T> value) where T : struct, IEquatable<T> { throw null; }
     }
 }
 

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -20,6 +20,7 @@
     <Compile Include="System\Span.cs" />
     <Compile Include="System\SpanExtensions.cs" />
     <Compile Include="System\SpanHelpers.cs" />
+    <Compile Include="System\SpanHelpers.T.cs" />
     <Compile Include="System\ThrowHelper.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">

--- a/src/System.Memory/src/System/SpanExtensions.cs
+++ b/src/System.Memory/src/System/SpanExtensions.cs
@@ -113,5 +113,40 @@ namespace System
             int newLength = checked((int)((long)source.Length * Unsafe.SizeOf<TFrom>() / Unsafe.SizeOf<TTo>()));
             return new ReadOnlySpan<TTo>(Unsafe.As<Pinnable<TTo>>(source.Pinnable), source.ByteOffset, newLength);
         }
+
+        /// <summary>
+        /// Searches for the specified value and returns the index of its first occurrence. If not found, returns -1. Values are compared using IEquatable&lt;T&gt;.Equals(T). 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value">The value to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf<T>(this Span<T> span, T value)
+            where T:struct, IEquatable<T>
+        {
+            return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), value, 0, span.Length);
+        }
+
+        /// <summary>
+        /// Searches for the specified sequence and returns the index of its first occurrence. If not found, returns -1. Values are compared using IEquatable&lt;T&gt;.Equals(T). 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value">The sequence to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf<T>(this Span<T> span, ReadOnlySpan<T> value)
+            where T : struct, IEquatable<T>
+        {
+            return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), span.Length, ref value.DangerousGetPinnableReference(), value.Length);
+        }
+
+        /// <summary>
+        /// Determines whether two sequences are equal by comparing the elements using IEquatable&lt;T&gt;.Equals(T). 
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool SequenceEqual<T>(this Span<T> first, ReadOnlySpan<T> second)
+            where T:struct, IEquatable<T>
+        {
+            int length = first.Length;
+            return length == second.Length && SpanHelpers.SequenceEqual(ref first.DangerousGetPinnableReference(), ref second.DangerousGetPinnableReference(), length);
+        }
     }
 }

--- a/src/System.Memory/src/System/SpanExtensions.cs
+++ b/src/System.Memory/src/System/SpanExtensions.cs
@@ -123,7 +123,7 @@ namespace System
         public static int IndexOf<T>(this Span<T> span, T value)
             where T:struct, IEquatable<T>
         {
-            return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), value, 0, span.Length);
+            return SpanHelpers.IndexOf<T>(ref span.DangerousGetPinnableReference(), value, span.Length);
         }
 
         /// <summary>

--- a/src/System.Memory/src/System/SpanHelpers.T.cs
+++ b/src/System.Memory/src/System/SpanHelpers.T.cs
@@ -1,0 +1,178 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    internal static partial class SpanHelpers
+    {
+        public static int IndexOf<T>(ref T searchSpace, int searchSpaceLength, ref T value, int valueLength)
+            where T : struct, IEquatable<T>
+        {
+            Debug.Assert(searchSpaceLength >= 0);
+            Debug.Assert(valueLength >= 0);
+
+            if (valueLength == 0)
+                return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
+
+            T valueHead = value;
+            ref T valueTail = ref Unsafe.Add(ref value, 1);
+            int valueTailLength = valueLength - 1;
+
+            int index = 0;
+            for (;;)
+            {
+                Debug.Assert(0 <= index && index <= searchSpaceLength); // Ensures no deceptive underflows in the computation of "remainingSearchSpaceLength".
+                int remainingSearchSpaceLength = searchSpaceLength - index - valueTailLength;
+                if (remainingSearchSpaceLength <= 0)
+                    return -1;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
+
+                // Do a quick search for the first element of "value".
+                index = IndexOf(ref searchSpace, valueHead, index, remainingSearchSpaceLength);
+                if (index == -1)
+                    return -1;
+
+                // Found the first element of "value". See if the tail matches.
+                if (SequenceEqual(ref Unsafe.Add(ref searchSpace, index + 1), ref valueTail, valueTailLength))
+                    return index;  // The tail matched. Return a successful find.
+
+                index++;
+            }
+        }
+
+        public static int IndexOf<T>(ref T searchSpace, T value, int start, int length)
+            where T : struct, IEquatable<T>
+        {
+            Debug.Assert(length >= 0);
+            Debug.Assert(start >= 0);
+
+            int index = start - 1;
+            int remainingLength = length;
+            while (remainingLength >= 8)
+            {
+                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
+                    return index;
+                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
+                    return index;
+                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
+                    return index;
+                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
+                    return index;
+                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
+                    return index;
+                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
+                    return index;
+                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
+                    return index;
+                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
+                    return index;
+
+                remainingLength -= 8;
+            }
+
+            while (remainingLength >= 4)
+            {
+                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
+                    return index;
+                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
+                    return index;
+                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
+                    return index;
+                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
+                    return index;
+
+                remainingLength -= 4;
+            }
+
+            while (remainingLength > 0)
+            {
+                if (value.Equals(Unsafe.Add(ref searchSpace, ++index)))
+                    return index;
+
+                remainingLength--;
+            }
+            return -1;
+        }
+
+        public static bool SequenceEqual<T>(ref T first, ref T second, int length)
+            where T : struct, IEquatable<T>
+        {
+            Debug.Assert(length >= 0);
+
+            if (Unsafe.AreSame(ref first, ref second))
+                return true;
+
+            int index = 0;
+            while (length >= 8)
+            {
+                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                    return false;
+                index++;
+
+                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                    return false;
+                index++;
+
+                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                    return false;
+                index++;
+
+                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                    return false;
+                index++;
+
+                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                    return false;
+                index++;
+
+                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                    return false;
+                index++;
+
+                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                    return false;
+                index++;
+
+                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                    return false;
+                index++;
+
+                length -= 8;
+            }
+
+            while (length >= 4)
+            {
+                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                    return false;
+                index++;
+
+                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                    return false;
+                index++;
+
+                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                    return false;
+                index++;
+
+                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                    return false;
+                index++;
+
+                length -= 4;
+            }
+
+            while (length > 0)
+            {
+                if (!Unsafe.Add(ref first, index).Equals(Unsafe.Add(ref second, index)))
+                    return false;
+                index++;
+                length--;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/System.Memory/src/System/SpanHelpers.T.cs
+++ b/src/System.Memory/src/System/SpanHelpers.T.cs
@@ -31,9 +31,10 @@ namespace System
                     return -1;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
 
                 // Do a quick search for the first element of "value".
-                index = IndexOf(ref searchSpace, valueHead, index, remainingSearchSpaceLength);
-                if (index == -1)
+                int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), valueHead, remainingSearchSpaceLength);
+                if (relativeIndex == -1)
                     return -1;
+                index += relativeIndex;
 
                 // Found the first element of "value". See if the tail matches.
                 if (SequenceEqual(ref Unsafe.Add(ref searchSpace, index + 1), ref valueTail, valueTailLength))
@@ -43,13 +44,12 @@ namespace System
             }
         }
 
-        public static int IndexOf<T>(ref T searchSpace, T value, int start, int length)
+        public static int IndexOf<T>(ref T searchSpace, T value, int length)
             where T : struct, IEquatable<T>
         {
             Debug.Assert(length >= 0);
-            Debug.Assert(start >= 0);
 
-            int index = start - 1;
+            int index = -1;
             int remainingLength = length;
             while (remainingLength >= 8)
             {

--- a/src/System.Memory/src/System/SpanHelpers.cs
+++ b/src/System.Memory/src/System/SpanHelpers.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 
 namespace System
 {
-    internal static class SpanHelpers
+    internal static partial class SpanHelpers
     {
         /// <summary>
         /// Computes "start + index * sizeof(T)", using the unsigned IntPtr-sized multiplication for 32 and 64 bits.

--- a/src/System.Memory/tests/Span/IndexOf.T.cs
+++ b/src/System.Memory/tests/Span/IndexOf.T.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.SpanTests
+{
+    public static partial class SpanTests
+    {
+        [Fact]
+        public static void ZeroLengthIndexOf()
+        {
+            Span<int> sp = new Span<int>(Array.Empty<int>());
+            int idx = sp.IndexOf(0);
+            Assert.Equal(-1, idx);
+        }
+
+        [Fact]
+        public static void TestMatch()
+        {
+            for (int length = 0; length < 32; length++)
+            {
+                int[] a = new int[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = 10 * (i + 1);
+                }
+                Span<int> span = new Span<int>(a);
+                
+                for (int targetIndex = 0; targetIndex < length; targetIndex++)
+                {
+                    int target = a[targetIndex];
+                    int idx = span.IndexOf(target);
+                    Assert.Equal(targetIndex, idx);
+                }
+            }
+        }
+
+        [Fact]
+        public static void TestMultipleMatch()
+        {
+            for (int length = 2; length < 32; length++)
+            {
+                int[] a = new int[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = 10 * (i + 1);
+                }
+
+                a[length - 1] = 5555;
+                a[length - 2] = 5555;
+
+                Span<int> span = new Span<int>(a);
+                int idx = span.IndexOf(5555);
+                Assert.Equal(length - 2, idx);
+            }
+        }
+
+        [Fact]
+        public static void OnNoMatchMakeSureEveryElementIsCompared()
+        {
+            for (int length = 0; length < 100; length++)
+            {
+                TIntLog log = new TIntLog();
+
+                TInt[] a = new TInt[length];
+                for (int i = 0; i < length; i++)
+                {
+                    a[i] = new TInt(10 * (i + 1), log);
+                }
+                Span<TInt> span = new Span<TInt>(a);
+                int idx = span.IndexOf(new TInt(9999, log));
+                Assert.Equal(-1, idx);
+
+                // Since we asked for a non-existent value, make sure each element of the array was compared once.
+                // (Strictly speaking, it would not be illegal for IndexOf to compare an element more than once but
+                // that would be a non-optimal implementation and a red flag. So we'll stick with the stricter test.)
+                Assert.Equal(a.Length, log.Count);
+                foreach (TInt elem in a)
+                {
+                    int numCompares = log.CountCompares(elem.Value, 9999);
+                    Assert.True(numCompares == 1);
+                }
+            }
+        }
+
+        [Fact]
+        public static void MakeSureNoChecksGoOutOfRange()
+        {
+            const int GuardValue = 77777;
+            const int GuardLength = 50;
+
+            Action<int, int> checkForOutOfRangeAccess =
+                delegate (int x, int y)
+                {
+                    if (x == GuardValue || y == GuardValue)
+                        throw new Exception("Detected out of range access in IndexOf()");
+                };
+
+            for (int length = 0; length < 100; length++)
+            {
+                TInt[] a = new TInt[GuardLength + length + GuardLength];
+                for (int i = 0; i < a.Length; i++)
+                {
+                    a[i] = new TInt(GuardValue, checkForOutOfRangeAccess);
+                }
+
+                for (int i = 0; i < length; i++)
+                {
+                    a[GuardLength + i] = new TInt(10 * (i + 1), checkForOutOfRangeAccess);
+                }
+
+                Span<TInt> span = new Span<TInt>(a, GuardLength, length);
+                int idx = span.IndexOf(new TInt(9999, checkForOutOfRangeAccess));
+                Assert.Equal(-1, idx);
+            }
+        }
+    }
+}

--- a/src/System.Memory/tests/Span/IndexOfSequence.T.cs
+++ b/src/System.Memory/tests/Span/IndexOfSequence.T.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.SpanTests
+{
+    public static partial class SpanTests
+    {
+        [Fact]
+        public static void IndexOfSequenceMatchAtStart()
+        {
+            Span<int> span = new Span<int>(new int[] { 5, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
+            Span<int> value = new Span<int>(new int[] { 5, 1, 77 });
+            int index = span.IndexOf(value);
+            Assert.Equal(0, index);
+        }
+
+        [Fact]
+        public static void IndexOfSequenceMultipleMatch()
+        {
+            Span<int> span = new Span<int>(new int[] { 1, 2, 3, 1, 2, 3, 1, 2, 3 });
+            Span<int> value = new Span<int>(new int[] { 2, 3 });
+            int index = span.IndexOf(value);
+            Assert.Equal(1, index);
+        }
+
+        [Fact]
+        public static void IndexOfSequenceRestart()
+        {
+            Span<int> span = new Span<int>(new int[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
+            Span<int> value = new Span<int>(new int[] { 77, 77, 88 });
+            int index = span.IndexOf(value);
+            Assert.Equal(10, index);
+        }
+
+        [Fact]
+        public static void IndexOfSequenceNoMatch()
+        {
+            Span<int> span = new Span<int>(new int[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
+            Span<int> value = new Span<int>(new int[] { 77, 77, 88, 99 });
+            int index = span.IndexOf(value);
+            Assert.Equal(-1, index);
+        }
+
+        [Fact]
+        public static void IndexOfSequenceNotEvenAHeadMatch()
+        {
+            Span<int> span = new Span<int>(new int[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
+            Span<int> value = new Span<int>(new int[] { 100, 77, 88, 99 });
+            int index = span.IndexOf(value);
+            Assert.Equal(-1, index);
+        }
+
+        [Fact]
+        public static void IndexOfSequenceMatchAtVeryEnd()
+        {
+            Span<int> span = new Span<int>(new int[] { 0, 1, 2, 3, 4, 5 });
+            Span<int> value = new Span<int>(new int[] { 3, 4, 5 });
+            int index = span.IndexOf(value);
+            Assert.Equal(3, index);
+        }
+
+        [Fact]
+        public static void IndexOfSequenceJustPastVeryEnd()
+        {
+            Span<int> span = new Span<int>(new int[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
+            Span<int> value = new Span<int>(new int[] { 3, 4, 5 });
+            int index = span.IndexOf(value);
+            Assert.Equal(-1, index);
+        }
+
+        [Fact]
+        public static void IndexOfSequenceZeroLengthValue()
+        {
+            // A zero-length value is always "found" at the start of the span.
+            Span<int> span = new Span<int>(new int[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
+            Span<int> value = new Span<int>(Array.Empty<int>());
+            int index = span.IndexOf(value);
+            Assert.Equal(0, index);
+        }
+
+        [Fact]
+        public static void IndexOfSequenceZeroLengthSpan()
+        {
+            Span<int> span = new Span<int>(Array.Empty<int>());
+            Span<int> value = new Span<int>(new int[] { 1, 2, 3 });
+            int index = span.IndexOf(value);
+            Assert.Equal(-1, index);
+        }
+
+        [Fact]
+        public static void IndexOfSequenceLengthOneValue()
+        {
+            // A zero-length value is always "found" at the start of the span.
+            Span<int> span = new Span<int>(new int[] { 0, 1, 2, 3, 4, 5 });
+            Span<int> value = new Span<int>(new int[] { 2 });
+            int index = span.IndexOf(value);
+            Assert.Equal(2, index);
+        }
+
+        [Fact]
+        public static void IndexOfSequenceLengthOneValueAtVeryEnd()
+        {
+            // A zero-length value is always "found" at the start of the span.
+            Span<int> span = new Span<int>(new int[] { 0, 1, 2, 3, 4, 5 });
+            Span<int> value = new Span<int>(new int[] { 5 });
+            int index = span.IndexOf(value);
+            Assert.Equal(5, index);
+        }
+
+        [Fact]
+        public static void IndexOfSequenceLengthOneValueJustPasttVeryEnd()
+        {
+            // A zero-length value is always "found" at the start of the span.
+            Span<int> span = new Span<int>(new int[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
+            Span<int> value = new Span<int>(new int[] { 5 });
+            int index = span.IndexOf(value);
+            Assert.Equal(-1, index);
+        }
+    }
+}

--- a/src/System.Memory/tests/Span/SequenceEqual.T.cs
+++ b/src/System.Memory/tests/Span/SequenceEqual.T.cs
@@ -1,0 +1,134 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.SpanTests
+{
+    public static partial class SpanTests
+    {
+        [Fact]
+        public static void ZeroLengthSequenceEqual()
+        {
+            int[] a = new int[3];
+
+            Span<int> first = new Span<int>(a, 1, 0);
+            Span<int> second = new Span<int>(a, 2, 0);
+            bool b = first.SequenceEqual(second);
+            Assert.True(b);
+        }
+
+        [Fact]
+        public static void SameSpanSequenceEqual()
+        {
+            int[] a = { 4, 5, 6 };
+            Span<int> span = new Span<int>(a);
+            bool b = span.SequenceEqual(span);
+            Assert.True(b);
+        }
+
+        [Fact]
+        public static void LengthMismatchSequenceEqual()
+        {
+            int[] a = { 4, 5, 6 };
+            Span<int> first = new Span<int>(a, 0, 3);
+            Span<int> second = new Span<int>(a, 0, 2);
+            bool b = first.SequenceEqual(second);
+            Assert.False(b);
+        }
+
+        [Fact]
+        public static void OnSequenceEqualOfEqualSpansMakeSureEveryElementIsCompared()
+        {
+            for (int length = 0; length < 100; length++)
+            {
+                TIntLog log = new TIntLog();
+
+                TInt[] first = new TInt[length];
+                TInt[] second = new TInt[length];
+                for (int i = 0; i < length; i++)
+                {
+                    first[i] = second[i] = new TInt(10 * (i + 1), log);
+                }
+
+                Span<TInt> firstSpan = new Span<TInt>(first);
+                ReadOnlySpan<TInt> secondSpan = new ReadOnlySpan<TInt>(second);
+                bool b = firstSpan.SequenceEqual(secondSpan);
+                Assert.True(b);
+
+                // Make sure each element of the array was compared once. (Strictly speaking, it would not be illegal for 
+                // SequenceEqual to compare an element more than once but that would be a non-optimal implementation and 
+                // a red flag. So we'll stick with the stricter test.)
+                Assert.Equal(first.Length, log.Count);
+                foreach (TInt elem in first)
+                {
+                    int numCompares = log.CountCompares(elem.Value, elem.Value);
+                    Assert.True(numCompares == 1);
+                }
+            }
+        }
+
+        [Fact]
+        public static void SequenceEqualNoMatch()
+        {
+            for (int length = 1; length < 32; length++)
+            {
+                for (int mismatchIndex = 0; mismatchIndex < length; mismatchIndex++)
+                {
+                    TIntLog log = new TIntLog();
+
+                    TInt[] first = new TInt[length];
+                    TInt[] second = new TInt[length];
+                    for (int i = 0; i < length; i++)
+                    {
+                        first[i] = second[i] = new TInt(10 * (i + 1), log);
+                    }
+
+                    second[mismatchIndex] = new TInt(second[mismatchIndex].Value + 1, log);
+
+                    Span<TInt> firstSpan = new Span<TInt>(first);
+                    ReadOnlySpan<TInt> secondSpan = new ReadOnlySpan<TInt>(second);
+                    bool b = firstSpan.SequenceEqual(secondSpan);
+                    Assert.False(b);
+
+                    Assert.Equal(1, log.CountCompares(first[mismatchIndex].Value, second[mismatchIndex].Value));
+                }
+            }
+        }
+
+        [Fact]
+        public static void MakeSureNoSequenceEqualChecksGoOutOfRange()
+        {
+            const int GuardValue = 77777;
+            const int GuardLength = 50;
+
+            Action<int, int> checkForOutOfRangeAccess =
+                delegate (int x, int y)
+                {
+                    if (x == GuardValue || y == GuardValue)
+                        throw new Exception("Detected out of range access in IndexOf()");
+                };
+
+            for (int length = 0; length < 100; length++)
+            {
+                TInt[] first = new TInt[GuardLength + length + GuardLength];
+                TInt[] second = new TInt[GuardLength + length + GuardLength];
+                for (int i = 0; i < first.Length; i++)
+                {
+                    first[i] = second[i] = new TInt(GuardValue, checkForOutOfRangeAccess);
+                }
+
+                for (int i = 0; i < length; i++)
+                {
+                    first[GuardLength + i] = second[GuardLength + i] = new TInt(10 * (i + 1), checkForOutOfRangeAccess);
+                }
+
+                Span<TInt> firstSpan = new Span<TInt>(first, GuardLength, length);
+                Span<TInt> secondSpan = new Span<TInt>(second, GuardLength, length);
+                bool b = firstSpan.SequenceEqual(secondSpan);
+                Assert.True(b);
+            }
+        }
+    }
+}

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -8,6 +8,9 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
+    <Compile Include="TInt.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="Span\AsBytes.cs" />
     <Compile Include="Span\CopyTo.cs" />
     <Compile Include="Span\CtorArray.cs" />
@@ -18,8 +21,11 @@
     <Compile Include="Span\DangerousGetPinnableReference.cs" />
     <Compile Include="Span\Empty.cs" />
     <Compile Include="Span\Equality.cs" />
+    <Compile Include="Span\IndexOf.T.cs" />
+    <Compile Include="Span\IndexOfSequence.T.cs" />
     <Compile Include="Span\NonPortableCast.cs" />
     <Compile Include="Span\Overflow.cs" />
+    <Compile Include="Span\SequenceEqual.T.cs" />
     <Compile Include="Span\Slice.cs" />
     <Compile Include="Span\TestHelpers.cs" />
     <Compile Include="Span\ToArray.cs" />

--- a/src/System.Memory/tests/TInt.cs
+++ b/src/System.Memory/tests/TInt.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+using Xunit;
+
+#pragma warning disable 0809  //warning CS0809: Obsolete member overrides non-obsolete member
+
+namespace System
+{
+    // A wrapped integer that invokes a custom delegate everytime IEquatable<TInt>.Equals() is invoked.
+    internal struct TInt : IEquatable<TInt>
+    {
+        public TInt(int value)
+            : this(value, (Action<int,int>)null)
+        {
+            // This constructor does not report comparisons but is still useful for catching uses of the boxing Equals().
+        }
+
+        public TInt(int value, Action<int, int> onCompare)
+        {
+            Value = value;
+            _onCompare = onCompare;
+        }
+
+        public TInt(int value, TIntLog log)
+        {
+            Value = value;
+            _onCompare = (x, y) => log.Add(x, y);
+        }
+
+        public bool Equals(TInt other)
+        {
+            if (_onCompare != null)
+            {
+                _onCompare(Value, other.Value);
+            }
+            return Value == other.Value;
+        }
+
+        [Obsolete("Don't call this. Call IEquatable<T>.Equals(T)")]
+        public override bool Equals(object obj)
+        {
+            throw new NotSupportedException("Unexpected use of boxing Equals().");
+        }
+
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
+
+        public int Value { get; }
+
+        private Action<int, int> _onCompare;
+    }
+
+    internal sealed class TIntLog
+    {
+        public void Add(int x, int y) => _log.Add(Tuple.Create(x, y));
+        public int Count => _log.Count;
+        public int CountCompares(int x, int y) => _log.Where(t => (t.Item1 == x && t.Item2 == y) || (t.Item1 == y && t.Item2 == x)).Count();
+
+        private List<Tuple<int, int>> _log = new List<Tuple<int, int>>();
+    }
+}


### PR DESCRIPTION
These are requested for the parsing libraries.

There will also be ReadOnlySpan<> versions as
well as char/byte-specific overloads (that 
bypass IEquatable.Equals() in favor of "==")
but most or all of that will be copy-paste of
these once we're happy with the generic versions.