### PR TITLE
Fix System.Net.Primitives.Functional.Tests to run on net46

### DIFF
--- a/src/System.Net.Primitives/tests/FunctionalTests/CookieCollectionTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CookieCollectionTest.cs
@@ -156,7 +156,17 @@ namespace System.Net.Primitives.Functional.Tests
             enumerator.MoveNext();
 
             cc.Add(new Cookie("name5", "value"));
-            Assert.NotNull(enumerator.Current);
+
+            object current = null;
+            var exception = Record.Exception(() => current = enumerator.Current);
+
+            // on desktop, enumerator.Current throw an exception because the collection has been modified after 
+            // creating the enumerator.
+            if (exception == null)
+            {
+                Assert.NotNull(current);
+            }
+
             Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext()); // Enumerator out of sync
         }
     }

--- a/src/System.Net.Primitives/tests/FunctionalTests/CookieCollectionTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CookieCollectionTest.cs
@@ -160,7 +160,7 @@ namespace System.Net.Primitives.Functional.Tests
             object current = null;
             var exception = Record.Exception(() => current = enumerator.Current);
 
-            // on desktop, enumerator.Current throw an exception because the collection has been modified after 
+            // On full framework, enumerator.Current throws an exception because the collection has been modified after 
             // creating the enumerator.
             if (exception == null)
             {

--- a/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
@@ -240,13 +240,13 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.Equal(string.Empty, c.Value);
         }
         
-        // NOTE: This test is expected to fail on the full desktop.
-        // The behavior this tests was only recently added in #8206.
         [Fact]
         public static void Value_PassNullToCtor_GetReturnsEmptyString()
         {
             var cookie = new Cookie("SomeName", null);
-            Assert.Equal(string.Empty, cookie.Value);
+            // cookie.Value will return empty string on netcore and null on full framework.
+            // The behavior this tests was only recently added in #8206.
+            Assert.True(string.IsNullOrEmpty(cookie.Value));
         }
 
         [Fact]

--- a/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CookieTest.cs
@@ -241,12 +241,21 @@ namespace System.Net.Primitives.Functional.Tests
         }
         
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp | TargetFrameworkMonikers.NetcoreUwp)]
+        public static void Value_PassNullToCtor_GetReturnsEmptyString_net46()
+        {
+            var cookie = new Cookie("SomeName", null);
+            // Cookie.Value returns null on full framework.
+            Assert.Null(cookie.Value);
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void Value_PassNullToCtor_GetReturnsEmptyString()
         {
             var cookie = new Cookie("SomeName", null);
-            // cookie.Value will return empty string on netcore and null on full framework.
-            // The behavior this tests was only recently added in #8206.
-            Assert.True(string.IsNullOrEmpty(cookie.Value));
+            // Cookie.Value returns empty string on netcore.
+            Assert.Equal(string.Empty, cookie.Value);
         }
 
         [Fact]

--- a/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
@@ -163,7 +163,7 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.Throws<ArgumentNullException>("authenticationType", () => cc.Add("host", 500, null, new NetworkCredential())); //Null authenticationType
 
             var exception = Record.Exception(() => cc.Add("", 500, "authenticationType", new NetworkCredential())); 
-            // on desktop we get exception.ParamName as null while it is "host" on netcore
+            // On full framework we get exception.ParamName as null while it is "host" on netcore
             Assert.NotNull(exception);
             Assert.True(exception is ArgumentException);
             ArgumentException ae = exception as ArgumentException;
@@ -251,7 +251,7 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.Throws<ArgumentNullException>("authenticationType", () => cc.GetCredential("host", 500, null)); //Null authenticationType
 
             var exception = Record.Exception(() => cc.GetCredential("", 500, "authenticationType")); //Empty host
-            // on desktop we get exception.ParamName as null while it is "host" on netcore
+            // On full framework we get exception.ParamName as null while it is "host" on netcore
             Assert.NotNull(exception);
             Assert.True(exception is ArgumentException);
             ArgumentException ae = exception as ArgumentException;
@@ -400,8 +400,8 @@ namespace System.Net.Primitives.Functional.Tests
             NetworkCredential nc = CredentialCache.DefaultNetworkCredentials as NetworkCredential;
             CredentialCache cc = new CredentialCache();
 
-            // full framework throw System.ArgumentException with the message
-            // Default credentials cannot be supplied for the authenticationType1 authentication scheme.
+            // The full framework throw System.ArgumentException with the message
+            // 'Default credentials cannot be supplied for the authenticationType1 authentication scheme.'
             Assert.Throws<ArgumentException>("authType", () => cc.Add(uriPrefix1, authenticationType1, nc));
         }
 

--- a/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/CredentialCacheTest.cs
@@ -162,7 +162,13 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.Throws<ArgumentNullException>("host", () => cc.Add(null, 500, "authenticationType", new NetworkCredential())); //Null host
             Assert.Throws<ArgumentNullException>("authenticationType", () => cc.Add("host", 500, null, new NetworkCredential())); //Null authenticationType
 
-            Assert.Throws<ArgumentException>("host", () => cc.Add("", 500, "authenticationType", new NetworkCredential())); //Empty host
+            var exception = Record.Exception(() => cc.Add("", 500, "authenticationType", new NetworkCredential())); 
+            // on desktop we get exception.ParamName as null while it is "host" on netcore
+            Assert.NotNull(exception);
+            Assert.True(exception is ArgumentException);
+            ArgumentException ae = exception as ArgumentException;
+            Assert.True(ae.ParamName == "host" || ae.ParamName == null);
+
             Assert.Throws<ArgumentOutOfRangeException>("port", () => cc.Add("host", -1, "authenticationType", new NetworkCredential())); //Port < 0
         }
 
@@ -244,7 +250,12 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.Throws<ArgumentNullException>("host", () => cc.GetCredential(null, 500, "authenticationType")); //Null host
             Assert.Throws<ArgumentNullException>("authenticationType", () => cc.GetCredential("host", 500, null)); //Null authenticationType
 
-            Assert.Throws<ArgumentException>("host", () => cc.GetCredential("", 500, "authenticationType")); //Empty host
+            var exception = Record.Exception(() => cc.GetCredential("", 500, "authenticationType")); //Empty host
+            // on desktop we get exception.ParamName as null while it is "host" on netcore
+            Assert.NotNull(exception);
+            Assert.True(exception is ArgumentException);
+            ArgumentException ae = exception as ArgumentException;
+            Assert.True(ae.ParamName == "host" || ae.ParamName == null);
 
             Assert.Throws<ArgumentOutOfRangeException>("port", () => cc.GetCredential("host", -1, "authenticationType")); //Port < 0
         }
@@ -383,6 +394,19 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp | TargetFrameworkMonikers.NetcoreUwp)]
+        public static void AddRemove_UriAuthenticationTypeDefaultCredentials_Success_net46()
+        {
+            NetworkCredential nc = CredentialCache.DefaultNetworkCredentials as NetworkCredential;
+            CredentialCache cc = new CredentialCache();
+
+            // full framework throw System.ArgumentException with the message
+            // Default credentials cannot be supplied for the authenticationType1 authentication scheme.
+            Assert.Throws<ArgumentException>("authType", () => cc.Add(uriPrefix1, authenticationType1, nc));
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void AddRemove_UriAuthenticationTypeDefaultCredentials_Success()
         {
             NetworkCredential nc = CredentialCache.DefaultNetworkCredentials as NetworkCredential;
@@ -397,6 +421,7 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void AddRemove_HostPortAuthenticationTypeDefaultCredentials_Success()
         {
             NetworkCredential nc = CredentialCache.DefaultNetworkCredentials as NetworkCredential;


### PR DESCRIPTION
Fixes #10817
Fixes #10816
Fixes #10815
Fixes #10814