### PR TITLE
Redefining IsTestProject and cleaning all projects that were defining it

### DIFF
--- a/Tools-Override/Build.Common.props
+++ b/Tools-Override/Build.Common.props
@@ -44,7 +44,7 @@
   
   <!-- Setting IsTestProject prior to Build.Common.targets -->
   <PropertyGroup>
-    <IsTestProject Condition="'$(IsTestProject)'=='' And $(MSBuildProjectName.EndsWith('.tests', StringComparison.OrdinalIgnoreCase))">true</IsTestProject>
+    <IsTestProject Condition="'$(IsTestProject)'=='' And ($(MSBuildProjectFullPath.Contains('\tests\')) OR $(MSBuildProjectFullPath.Contains('/tests/')))">true</IsTestProject>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Roslyn.Common.props" />

--- a/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/RemoteExecutorConsoleApp.csproj
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/RemoteExecutorConsoleApp.csproj
@@ -8,7 +8,6 @@
     <AssemblyName>RemoteExecutorConsoleApp</AssemblyName>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <CopyNuGetImplementations>false</CopyNuGetImplementations>
-    <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
@@ -20,7 +19,7 @@
     <Compile Include="RemoteExecutorConsoleApp.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
-    <Compile Include="AssemblyAttributes.cs"/>
+    <Compile Include="AssemblyAttributes.cs" />
     <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
       <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
     </Compile>

--- a/src/Common/tests/System/Xml/BaseLibManaged/BaseLibManaged.csproj
+++ b/src/Common/tests/System/Xml/BaseLibManaged/BaseLibManaged.csproj
@@ -1,10 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{42F10363-C2A2-42B5-B7B9-1B5DBB0BC71E}</ProjectGuid>
     <RootNamespace>WebData.BaseLib</RootNamespace>
-    <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Common/tests/System/Xml/ModuleCore/ModuleCore.csproj
+++ b/src/Common/tests/System/Xml/ModuleCore/ModuleCore.csproj
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{3CF0CC76-4CE0-460A-BA37-657CFED39AB0}</ProjectGuid>
-    <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Common/tests/System/Xml/XmlCoreTest/XmlCoreTest.csproj
+++ b/src/Common/tests/System/Xml/XmlCoreTest/XmlCoreTest.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{89701565-F68B-46D9-BD78-95B0F052C50B}</ProjectGuid>
     <AssemblyName>XmlCoreTest</AssemblyName>
     <RootNamespace>XmlCoreTest.Common</RootNamespace>
-    <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Common/tests/System/Xml/XmlDiff/XmlDiff.csproj
+++ b/src/Common/tests/System/Xml/XmlDiff/XmlDiff.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{466D87DF-BDEC-4E6C-BACD-317D79B8EDBE}</ProjectGuid>
     <AssemblyName>XmlDiff</AssemblyName>
     <RootNamespace>System.Xml.XmlDiff</RootNamespace>
-    <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/System.Data.SqlClient/tests/StressTests/IMonitorLoader/IMonitorLoader.csproj
+++ b/src/System.Data.SqlClient/tests/StressTests/IMonitorLoader/IMonitorLoader.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{AF78BA88-6428-47EA-8682-442DAF8E9656}</ProjectGuid>
     <RootNamespace>Monitoring</RootNamespace>
     <AssemblyName>Monitoring</AssemblyName>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressFramework/System.Data.StressFramework.csproj
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressFramework/System.Data.StressFramework.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <ProjectGuid>{518A4E22-0144-4699-80AE-757B744E8E38}</ProjectGuid>
     <RootNamespace>Stress.Data</RootNamespace>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />

--- a/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/System.Data.StressRunner.csproj
+++ b/src/System.Data.SqlClient/tests/StressTests/System.Data.StressRunner/System.Data.StressRunner.csproj
@@ -9,7 +9,6 @@
          Though this is an EXE it is built as netstandard and will be 
          published for a specific framework/runtime by a referencing project. -->
     <CopyNuGetImplementations>false</CopyNuGetImplementations>
-    <IsTestProject>true</IsTestProject>
     <NoWarn>3021</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/TDS.EndPoint.csproj
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/TDS.EndPoint.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>Microsoft.SqlServer.TDS.EndPoint</RootNamespace>
     <AssemblyName>Microsoft.SqlServer.TDS.EndPoint</AssemblyName>
     <ClsCompliant>false</ClsCompliant>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS.Servers/TDS.Servers.csproj
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS.Servers/TDS.Servers.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>Microsoft.SqlServer.TDS.Servers</RootNamespace>
     <AssemblyName>Microsoft.SqlServer.TDS.Servers</AssemblyName>
     <ClsCompliant>false</ClsCompliant>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />

--- a/src/System.Data.SqlClient/tests/Tools/TDS/TDS/TDS.csproj
+++ b/src/System.Data.SqlClient/tests/Tools/TDS/TDS/TDS.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>Microsoft.SqlServer.TDS</RootNamespace>
     <AssemblyName>Microsoft.SqlServer.TDS</AssemblyName>
     <ClsCompliant>false</ClsCompliant>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Unix_Release|AnyCPU'" />

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.TestAssembly/System.Diagnostics.FileVersionInfo.TestAssembly.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.TestAssembly/System.Diagnostics.FileVersionInfo.TestAssembly.csproj
@@ -8,7 +8,6 @@
     <AssemblyName>System.Diagnostics.FileVersionInfo.TestAssembly</AssemblyName>
     <ProjectGuid>{28EB14BE-3BC9-4543-ABA6-A932424DFBD0}</ProjectGuid>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />

--- a/src/System.Private.Xml.Linq/tests/XDocument.Common/XDocument.Common.csproj
+++ b/src/System.Private.Xml.Linq/tests/XDocument.Common/XDocument.Common.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{52666206-B6C9-49FA-A1D7-D0A0C68807B0}</ProjectGuid>
     <AssemblyName>XDocument.Common</AssemblyName>
     <RootNamespace>CoreXml.Test.XLinq</RootNamespace>
-    <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Private.Xml.Linq/tests/XDocument.Test.ModuleCore/XDocument.Test.ModuleCore.csproj
+++ b/src/System.Private.Xml.Linq/tests/XDocument.Test.ModuleCore/XDocument.Test.ModuleCore.csproj
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{979510CE-9042-4F8D-9C74-EE03B89194CC}</ProjectGuid>
-    <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Private.Xml/tests/XmlReaderLib/System.Xml.RW.XmlReaderLib.csproj
+++ b/src/System.Private.Xml/tests/XmlReaderLib/System.Xml.RW.XmlReaderLib.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <ProjectGuid>{6D9B0285-5E8A-4C20-9C53-9E2084EF64C4}</ProjectGuid>
     <RootNamespace>XmlReaderTest.Common</RootNamespace>
-    <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Reflection/tests/TestExe/System.Reflection.TestExe.csproj
+++ b/src/System.Reflection/tests/TestExe/System.Reflection.TestExe.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <ProjectGuid>{8C19B991-41E9-4B38-9602-E19375397F1D}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Runtime.Extensions/tests/AssemblyResolveTests/AssemblyResolveTests.csproj
+++ b/src/System.Runtime.Extensions/tests/AssemblyResolveTests/AssemblyResolveTests.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <ProjectGuid>ad83807c-8be5-4f27-85df-9793613233e1</ProjectGuid>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Runtime.Extensions/tests/TestApp/TestApp.csproj
+++ b/src/System.Runtime.Extensions/tests/TestApp/TestApp.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{24BCEC6B-B9D2-47BC-9D66-725BD6B526FA}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Runtime.Extensions/tests/TestAppOutsideOfTPA/TestAppOutsideOfTPA.csproj
+++ b/src/System.Runtime.Extensions/tests/TestAppOutsideOfTPA/TestAppOutsideOfTPA.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{C44B33E3-F89F-40B9-B353-D380C1524988}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.csproj
+++ b/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/VoidMainWithExitCodeApp.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{9F312D76-9AF1-4E90-B3B0-815A1EC6C346}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Runtime.Loader/tests/System.Runtime.Loader.Noop.Assembly/System.Runtime.Loader.Noop.Assembly.csproj
+++ b/src/System.Runtime.Loader/tests/System.Runtime.Loader.Noop.Assembly/System.Runtime.Loader.Noop.Assembly.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{396D6EBF-60BD-4DAF-8783-FB403E070A57}</ProjectGuid>
     <!-- Test expects an un-signed assembly -->
     <SkipSigning>true</SkipSigning>
-    <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/System.Runtime.Loader.Test.Assembly.csproj
+++ b/src/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/System.Runtime.Loader.Test.Assembly.csproj
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{396D6EBF-60BD-4DAF-8783-FB403E070A56}</ProjectGuid>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TestClass.cs" />

--- a/src/System.Runtime/tests/TestAssembly/TestAssembly.csproj
+++ b/src/System.Runtime/tests/TestAssembly/TestAssembly.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <ProjectGuid>{9F312D76-9AF1-4E90-B3B0-815A1EC6C346}</ProjectGuid>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Runtime/tests/TestLoadAssembly/TestLoadAssembly.csproj
+++ b/src/System.Runtime/tests/TestLoadAssembly/TestLoadAssembly.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{9F312D76-9AF1-4E90-B3B0-815A1EC6C346}</ProjectGuid>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <IsTestProject>true</IsTestProject>
     <NoWarn>0436</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestNativeService/System.ServiceProcess.ServiceController.TestNativeService.vcxproj
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestNativeService/System.ServiceProcess.ServiceController.TestNativeService.vcxproj
@@ -1,9 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  <PropertyGroup>
-    <IsTestProject>true</IsTestProject>
-  </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/14543

For some time we have intended to change the way we calculate if a project is a test project. The current way we do it is if they end with a `.Tests.csproj`, but because of that logic we had to hadcode the property in a bunch of projects. With this change,  we are moving to instead check if their path contains a `tests` folder, to match the way we calculate `IsReferenceAssembly`.

I did an audit to make sure that we don't lose or gain any projects, and I validated that we didn't lose any, plus we are now also considering as a test project `corefx\src\System.Runtime\tests\TestModule\System.Reflection.TestModule.ilproj`

I did however left the hardcoded property in two projects that had it and don't have tests folder in their path, which are:
```
corefx\src\System.Composition\demos\Microsoft.Composition.Demos.ExtendedCollectionImports\Microsoft.Composition.Demos.ExtendedCollectionImports.csproj
corefx\src\System.Composition\scenarios\TestLibrary\TestLibrary.csproj
```

cc: @weshaggard @mellinoe 