### PR TITLE
Minor cleanup in Helix targets, cherry-pick a change from master

### DIFF
--- a/Tools-Override/CloudTest.targets
+++ b/Tools-Override/CloudTest.targets
@@ -234,7 +234,7 @@
     </CreateAzureContainer>
     <!-- now that we have a drop URI create the list of correlation payloads -->
     <ItemGroup>
-      <CorrelationPayloadUri Include="$(DropUri)$(Platform)$(ConfigurationGroup)/Packages.zip$(DropUriReadOnlyToken)" />
+      <CorrelationPayloadUri Include="$(DropUri)$(Platform)$(ConfigurationGroup)/$(TestRuntimeArchiveFilename)$(DropUriReadOnlyToken)" />
       <CorrelationPayloadUri Include="@(SupplementalPayload->'$(DropUri)%(RelativeBlobPath)$(DropUriReadOnlyToken)')" />
     </ItemGroup>
     <!-- flatten it into a property as msbuild chokes on @(CorrelationPayloadUri) in FunctionalTest.CorrelationPayloadUris :( -->
@@ -413,7 +413,7 @@
         OverwriteDestination="true" />
     <ItemGroup>
       <ForUpload Include="$(TestRuntimeArchiveFile)">
-        <RelativeBlobPath>$(Platform)$(ConfigurationGroup)/$(PackagesArchiveFilename)</RelativeBlobPath>
+        <RelativeBlobPath>$(Platform)$(ConfigurationGroup)/$(TestRuntimeArchiveFilename)</RelativeBlobPath>
       </ForUpload>
     </ItemGroup>
   </Target>

--- a/build.proj
+++ b/build.proj
@@ -72,8 +72,8 @@
   </Target>
 
   <!-- TODO: Can we move this archive test build to BuildTools -->
-  <UsingTask TaskName="ZipFileCreateFromDependencyLists" Condition="'$(ArchiveTests)' == 'true'" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <Target Name="ArchiveTestBuild" Condition="'$(ArchiveTests)' == 'true'" AfterTargets="Build" >
+  <UsingTask TaskName="ZipFileCreateFromDependencyLists" Condition="'$(Platform)' == 'ARM64' and '$(ArchiveTests)' == 'true'" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <Target Name="ArchiveTestBuild" Condition="'$(Platform)' == 'ARM64' and '$(ArchiveTests)' == 'true'" AfterTargets="Build" >
     <ItemGroup>
       <ExcludeFromArchive Include="nupkg$" />
       <ExcludeFromArchive Include="Microsoft.DotNet.BuildTools" />
@@ -83,7 +83,7 @@
 
     <ZipFileCreateFromDependencyLists
       DependencyListFiles="@(TestDependencyListFile)"
-      DestinationArchive="$(TestWorkingDir)$(OSPlatformConfig)/archive/Packages.zip"
+      DestinationArchive="$(TestWorkingDir)$(OSPlatformConfig)/archive/tests/Packages.zip"
       RelativePathBaseDirectory="$(PackagesDir)"
       OverwriteDestination="true" />
   </Target>

--- a/build.proj
+++ b/build.proj
@@ -83,7 +83,7 @@
 
     <ZipFileCreateFromDependencyLists
       DependencyListFiles="@(TestDependencyListFile)"
-      DestinationArchive="$(TestWorkingDir)$(OSPlatformConfig)/archive/tests/Packages.zip"
+      DestinationArchive="$(TestWorkingDir)$(OSPlatformConfig)/archive/Packages.zip"
       RelativePathBaseDirectory="$(PackagesDir)"
       OverwriteDestination="true" />
   </Target>

--- a/tests.builds
+++ b/tests.builds
@@ -33,8 +33,8 @@
   </PropertyGroup>
 
   <!-- TODO: Can we move this archive test build to BuildTools -->
-  <UsingTask TaskName="ZipFileCreateFromDependencyLists" Condition="'$(ArchiveTests)' == 'true'" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <Target Name="ArchiveTestBuild" Condition="'$(ArchiveTests)' == 'true'" AfterTargets="Build" >
+  <UsingTask TaskName="ZipFileCreateFromDependencyLists" Condition="'$(Platform)' == 'ARM64' and '$(ArchiveTests)' == 'true'" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <Target Name="ArchiveTestBuild" Condition="'$(Platform)' == 'ARM64' and '$(ArchiveTests)' == 'true'" AfterTargets="Build" >
     <ItemGroup>
       <ExcludeFromArchive Include="nupkg$" />
       <ExcludeFromArchive Include="Microsoft.DotNet.BuildTools" />
@@ -42,14 +42,9 @@
       <TestDependencyListFile Include="$(BinDir)/TestDependencies/*.dependencylist.txt" />
     </ItemGroup>
 
-    <PropertyGroup>
-      <TestArchiveDir>$(TestWorkingDir)$(OSPlatformConfig)/archive/tests/</TestArchiveDir>
-      <TestArchiveDir Condition="'$(TestTFM)' != ''">$(TestArchiveDir)$(TestTFM)/</TestArchiveDir>
-    </PropertyGroup>
-
     <ZipFileCreateFromDependencyLists
       DependencyListFiles="@(TestDependencyListFile)"
-      DestinationArchive="$(TestArchiveDir)\Packages.zip"
+      DestinationArchive="$(TestWorkingDir)$(OSPlatformConfig)/archive/Packages.zip"
       RelativePathBaseDirectory="$(PackagesDir)"
       OverwriteDestination="true" />
   </Target>


### PR DESCRIPTION
I've renamed the "test runtime" in the payload to match the real file name. Previously I had just re-used the old name ("Packages.zip") to avoid breaking things.

I also cherry-picked two commits from master (https://github.com/dotnet/corefx/pull/14860) to fix some spurious Helix failures. That PR changed some things in build.proj that I have since migrated to tests.builds, so I migrated those changes over, as well.

I've already got a clean Windows Helix build with these changes, and now I'm doing an Ubuntu build as well. The only previous failures where from a problem fixed by the commits I cherry-picked.

@karajas @MattGal 