### PR TITLE
Refactor build traversal

### DIFF
--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -48,7 +48,7 @@
 
     <XunitOptions Condition="'$(TestTFM)'!=''">$(XunitOptions) -notrait category=non$(TestTFM)tests</XunitOptions>
     <XunitOptions Condition="'$(XunitMaxThreads)'!=''">$(XunitOptions) -maxthreads $(XunitMaxThreads)</XunitOptions>
-    <XunitTestAssembly Condition="'$(XunitTestAssembly)' == ''">$(AssemblyName).dll</XunitTestAssembly>
+    <XunitTestAssembly Condition="'$(XunitTestAssembly)' == ''">$(TargetFileName)</XunitTestAssembly>
     <XunitArguments>$(XunitTestAssembly) $(XunitOptions)</XunitArguments>
 
     <TestProgram Condition="'$(TestHostExecutablePath)'!=''">$(TestHostExecutablePath)</TestProgram>

--- a/buildvertical.targets
+++ b/buildvertical.targets
@@ -5,106 +5,82 @@
     <ImportedBuildVerticalTargets>true</ImportedBuildVerticalTargets>
   </PropertyGroup>
 
- <!-- Required for FindBestConfiguration task -->
- <Import Project="$(MSBuildThisFileDirectory)src/Tools/GenerateProps/properties.props" />
+  <!-- Import configuration data model -->
+  <Import Project="$(MSBuildThisFileDirectory)src/Tools/GenerateProps/properties.props" />
 
- <Target Name="AnnotateProjects"
-         BeforeTargets="BuildAllProjects"
-         Condition="!$(MSBuildProjectFullPath.EndsWith('.proj'))">
-   <!-- Clear ProjectWithConfiguration to prevent circular dependency -->
-   <ItemGroup><ProjectWithConfiguration Remove="@(ProjectWithConfiguration)" /></ItemGroup>
-   <MSBuild Targets="AnnotateProjectsWithConfiguration" 
-            Projects="@(Project)"> 
-     <Output TaskParameter="TargetOutputs" 
-             ItemName="ProjectWithConfiguration" /> 
-   </MSBuild> 
-   <ItemGroup>
-     <Project Remove="@(Project)" />
-     <Project Include="@(ProjectWithConfiguration)" />
-   </ItemGroup>
- </Target>
+  <!-- Runs during traversal to select which projects and configurations of those projects to build -->
+  <Target Name="AnnotateAndFilterProjects"
+          BeforeTargets="BuildAllProjects;TestAllProjects"
+          Condition="!$(MSBuildProjectFullPath.EndsWith('.proj'))">
 
- <Target Name="AnnotateProjectsWithConfiguration" 
-         Returns="@(ProjectWithConfiguration)"> 
-    <ItemGroup> 
-       <ProjectWithConfiguration Include="$(MSBuildProjectFullPath)"> 
-         <AdditionalProperties Condition="'$(_BestConfiguration)' != ''">Configuration=$(_BestConfiguration);%(ProjectWithConfiguration.AdditionalProperties)</AdditionalProperties>
-         <UndefineProperties Condition="'$(_BestConfiguration)' == ''">Configuration;%(ProjectWithConfiguration.UndefineProperties)</UndefineProperties>
-       </ProjectWithConfiguration>
-       <ProjectWithConfiguration Remove="@(OmitProject)" />
-     </ItemGroup>
-  </Target>
-
-  <!-- The initial shaking target for trimming down applicable projects for specified vertical -->
-  <Target Name="DetermineProjectsConfiguration"
-          Returns="@(OmitProject)"
-          BeforeTargets="AnnotateProjectsWithConfiguration">
-    <!-- Clear the _Configuration item -->
-    <ItemGroup><_Configuration Remove="@(_Configuration)" /></ItemGroup>
-    <FindBestConfiguration Properties="@(Property)"
-                           PropertyValues="@(PropertyValue)"
-                           BuildConfigurations="$(BuildConfigurations)"
-                           BuildConfiguration="$(BuildConfiguration)" 
-                           Condition="'$(BuildConfigurations)' != ''"
-                           ContinueOnError="true">
-      <Output TaskParameter="BestConfiguration" ItemName="_Configuration" />
-    </FindBestConfiguration>  
-
-    <ItemGroup>
-      <_Configuration Condition="'$(BuildConfigurations)' == ''" Include="$(BuildConfiguration)" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <_BestConfiguration>%(_Configuration.Identity)</_BestConfiguration>
-    </PropertyGroup>
- 
-    <ItemGroup>
-      <OmitProject Include="$(MSBuildProjectFullPath)" Condition="'$(BuildConfigurations)' != '' and '$(_BestConfiguration)' == ''" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="FindBestConfiguration"
-          Returns="@(_Configuration)">
-     <!-- Clear the _Configuration item -->
-    <ItemGroup><_Configuration Remove="@(_Configuration)" /></ItemGroup>
-    <FindBestConfiguration Properties="@(Property)"
-                           PropertyValues="@(PropertyValue)"
-                           BuildConfigurations="$(BuildConfigurations)"
-                           BuildConfiguration="$(BuildConfiguration)" 
-                           Condition="'$(BuildConfigurations)' != ''"
-                           ContinueOnError="true">
-      <Output TaskParameter="BestConfiguration" ItemName="_Configuration" />
-    </FindBestConfiguration>  
-    
-    <ItemGroup>
-      <_Configuration Condition="'$(BuildConfigurations)' == ''" Include="$(BuildConfiguration)" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="AnnotateProjectReference"
-          Inputs="%(ProjectReference.Identity)"
-          Outputs="fake"
-          BeforeTargets="BeforeResolveReferences">
-    <PropertyGroup>
-      <_ProjectReferenceToAnnotate>%(ProjectReference.Identity)</_ProjectReferenceToAnnotate>
-    </PropertyGroup>
-
-    <ItemGroup><_Configuration Remove="@(_Configuration)" /></ItemGroup>
+    <!-- find the best configuration for each project, projects that shouldn't build for this configuration
+         return an empty item.  -->
     <MSBuild Targets="FindBestConfiguration"
-             Projects="$(_ProjectReferenceToAnnotate)">
-      <Output TaskParameter="TargetOutputs" ItemName="_Configuration" />
+             Projects="@(Project)">
+      <Output TaskParameter="TargetOutputs"
+              ItemName="_ProjectBestConfigurations" />
     </MSBuild>
 
-    <PropertyGroup>
-      <_BestConfiguration>%(_Configuration.Identity)</_BestConfiguration>
-      <_AdditionalProperties />
-      <_AdditionalProperties Condition="'$(_BestConfiguration)' != ''">Configuration=$(_BestConfiguration)</_AdditionalProperties>
-    </PropertyGroup>
     <ItemGroup>
-      <ProjectReference>
-        <AdditionalProperties Condition="'$(_AdditionalProperties)' != ''">$(_AdditionalProperties);%(ProjectReference.AdditionalProperties)</AdditionalProperties>
-        <UndefineProperties Condition="'$(_AdditionalProperties)' == ''">Configuration;%(ProjectReference.Configuration)</UndefineProperties>
-      </ProjectReference>
+      <!-- transform back to project -->
+      <ProjectWithConfiguration Include="@(_ProjectBestConfigurations->'%(OriginalItemSpec)')">
+        <AdditionalProperties>Configuration=%(Identity);%(_ProjectBestConfigurations.AdditionalProperties)</AdditionalProperties>
+      </ProjectWithConfiguration>
+    </ItemGroup>
+
+    <ItemGroup>
+      <Project Remove="@(Project)" />
+      <Project Include="@(ProjectWithConfiguration)" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Runs in a leaf project (eg: csproj) to determine best configuration if one exists for purposes of filtering -->
+  <Target Name="FindBestConfiguration"
+          Returns="$(_BestConfiguration)">
+
+    <!-- if BuildConfigurations is defined, find the best one -->
+    <FindBestConfiguration Condition="'$(BuildConfigurations)' != ''"
+                           Properties="@(Property)"
+                           PropertyValues="@(PropertyValue)"
+                           BuildConfigurations="$(BuildConfigurations)"
+                           BuildConfiguration="$(BuildConfiguration)">
+      <Output TaskParameter="BestConfiguration" PropertyName="_BestConfiguration" />
+    </FindBestConfiguration>
+
+    <!-- if BuildConfigurations is not defined, use BuildConfiguration -->
+    <PropertyGroup>
+      <_BestConfiguration Condition="'$(BuildConfigurations)' == ''">$(BuildConfiguration)</_BestConfiguration>
+    </PropertyGroup>
+  </Target>
+
+  <!-- Runs in a leaf project (eg: csproj) to determine best configuration if one exists for purposes of project references -->
+  <Target Name="FindBestConfigurationForProjectReference"
+          DependsOnTargets="FindBestConfiguration"
+          Returns="$(_BestConfiguration)">
+    <Error Condition="'$(_BestConfiguration)' == ''" Text="Could not find a configuration for $(BuildConfiguration) from $(BuildConfigurations)" />
+  </Target>
+
+  <!-- Runs in a leaf project (csproj) to determine best configuration for ProjectReferences -->
+  <Target Name="AnnotateProjectReference"
+          BeforeTargets="BeforeResolveReferences">
+
+    <!-- find the best configuration for each project, projects that do not have an 
+        applicable configuration will fail the build.  -->
+    <MSBuild Targets="FindBestConfigurationForProjectReference"
+             Projects="@(ProjectReference)">
+      <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceBestConfigurations" />
+    </MSBuild>
+
+    <ItemGroup>
+      <!-- transform back to ProjectReference -->
+      <ProjectReferenceWithConfiguration Include="@(_ProjectReferenceBestConfigurations->'%(OriginalItemSpec)')">
+        <AdditionalProperties>Configuration=%(Identity);%(_ProjectReferenceBestConfigurations.AdditionalProperties)</AdditionalProperties>
+      </ProjectReferenceWithConfiguration>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Remove="@(ProjectReference)" />
+      <ProjectReference Include="@(ProjectReferenceWithConfiguration)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -54,42 +54,6 @@
     <Error Condition="'$(MSBuildLastTaskResult)'=='false'" />
   </Target>
 
-  <!-- FilterProjectsToTest will filter the project list according to the FilterToTestTFM value -->
-  <Target Name="FilterProjectsToTest"
-          BeforeTargets="TestAllProjects"
-          Condition="$(MSBuildProjectName.EndsWith('tests'))">
-
-    <ItemGroup>
-      <Project>
-        <!-- default to DefaultTestTFM defined in root dir.props if TestTFMs aren't set on the project -->
-        <TestTFMs Condition="'%(Project.TestTFMs)'==''">$(DefaultTestTFM)</TestTFMs>
-      </Project>
-      <Project>
-        <!-- make sure every defined TestTFM value are surrounded by semicolons for easier search, e.g. ";net46;"" -->
-        <TestTFMs>;%(Project.TestTFMs);</TestTFMs>
-      </Project>
-
-      <!-- Include all projects which have TestTFM from the supported set -->
-      <ProjectsToTest Include="@(Project)" Condition="'%(Project.Extension)'=='.csproj' And $([System.String]::new('%(Project.Identity)').Contains('.Tests'))">
-        <TestTFM>$(FilterToTestTFM)</TestTFM>
-      </ProjectsToTest>
-
-      <ProjectsToTest>
-       <AdditionalProperties Condition="'%(ProjectsToTest.TestTFM)'!=''">TestTFM=%(ProjectsToTest.TestTFM);%(ProjectsToTest.AdditionalProperties)</AdditionalProperties>
-      </ProjectsToTest>
-      <ProjectsToTest>
-        <AdditionalProperties Condition="'%(ProjectsToTest.FilterToTestTFM)'!=''">FilterToTestTFM=%(ProjectsToTest.FilterToTestTFM);%(ProjectsToTest.AdditionalProperties)</AdditionalProperties>
-      </ProjectsToTest>
-      <ProjectsToTest>
-        <FilterToTestTFM>$(FilterToTestTFM)</FilterToTestTFM>
-      </ProjectsToTest>
-      <ProjectsToTest>
-        <AdditionalProperties Condition="'%(ProjectsToTest.FilterToTestTFM)'!=''">FilterToTestTFM=%(ProjectsToTest.FilterToTestTFM);%(ProjectsToTest.AdditionalProperties)</AdditionalProperties>
-      </ProjectsToTest>
-    </ItemGroup>
-  </Target>
-
-  <!-- TestAllProjects will run all tests according to TestTFM value we are filtering with -->
   <Target Name="TestAllProjects"
           AfterTargets="BuildAllProjects"
           Condition="$(MSBuildProjectName.EndsWith('tests'))">
@@ -97,13 +61,13 @@
          however since the project names are unique it will essentially force each to run in its own batch -->
 
     <MSBuild Targets="Test"
-             Projects="@(ProjectsToTest)"
+             Projects="@(Project)"
              Condition="'$(SerializeProjects)'=='true' AND '%(Identity)' != ''"
              Properties="DefaultBuildAllTarget=$(DefaultBuildAllTarget);BuildAllProjects=true"
              ContinueOnError="ErrorAndContinue" />
 
     <MSBuild Targets="Test"
-             Projects="@(ProjectsToTest)"
+             Projects="@(Project)"
              Condition="'$(SerializeProjects)'!='true'"
              Properties="DefaultBuildAllTarget=$(DefaultBuildAllTarget);BuildAllProjects=true"
              BuildInParallel="true"

--- a/src/Tools/CoreFx.Tools/FindBestConfiguration.cs
+++ b/src/Tools/CoreFx.Tools/FindBestConfiguration.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
             if (bestConfiguration == null)
             {
-                Log.LogError($"Could not find any applicable configuration for '{buildConfiguration}' among projectConfigurations {string.Join(", ", supportedProjectConfigurations.Select(c => c.ToString()))}");
+                Log.LogMessage($"Could not find any applicable configuration for '{buildConfiguration}' among projectConfigurations {string.Join(", ", supportedProjectConfigurations.Select(c => c.ToString()))}");
                 Log.LogMessage(MessageImportance.Low, $"Compatible configurations: {string.Join(", ", compatibleConfigurations.Select(c => c.ToString()))}");
             }
             else


### PR DESCRIPTION
Change contract of cross-project target to return configuration rather
than trying to construct a project item.  This preserves the metadata of
the original Project/ProjectReference.  When the MSBuild task creates
the TargetOutputs it will copy all the original metadata from the
Project items and create the OriginalItemSpec metadata.  From this
we can simply transform back to a Project/ProjectReference and prepend
Configuration to the AdditionalProperties.  This fixes a case where
projects were setting AdditionalProperties and we were squashing it.

To make it clearer how this worked I made the targets only return a
property so that we don't accidentally squash any metadata set on the
project.

I found that we were never using the DetermineProjectsConfiguration
target so I deleted it.

I've also cleaned up the targets to make things a bit more consistent
and added comments.
