### PR TITLE
Fix tests run on desktop

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -32,19 +32,15 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentException>(() => Create(string.Empty));
         }
 
-        [Fact]
-        public void PathWithInvalidCharactersAsPath_ThrowsArgumentException()
+        [Theory MemberData("PathsWithInvalidCharacters")]
+        public void PathWithInvalidCharactersAsPath_ThrowsArgumentException(string invalidPath)
         {
-            var paths = IOInputs.GetPathsWithInvalidCharacters();
-            Assert.All(paths, (path) =>
-            {
-                if (path.Equals(@"\\?\"))
-                    Assert.Throws<IOException>(() => Create(path));
-                else if (path.Contains(@"\\?\"))
-                    Assert.Throws<DirectoryNotFoundException>(() => Create(path));
-                else
-                    Assert.Throws<ArgumentException>(() => Create(path));
-            });
+            if (invalidPath.Equals(@"\\?\") && !PathFeatures.IsUsingLegacyPathNormalization())
+                Assert.Throws<IOException>(() => Create(invalidPath));
+            else if (invalidPath.Contains(@"\\?\") && !PathFeatures.IsUsingLegacyPathNormalization())
+                Assert.Throws<DirectoryNotFoundException>(() => Create(invalidPath));
+            else
+                Assert.Throws<ArgumentException>(() => Create(invalidPath));
         }
 
         [Fact]
@@ -130,7 +126,8 @@ namespace System.IO.Tests
             });
         }
 
-        [Fact]
+        [ConditionalFact("UsingNewNormalization")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void ValidExtendedPathWithTrailingSlash()
         {
@@ -223,18 +220,17 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [Fact]
+        // This is updated to be correct, need to update CoreCLR path code so this will pass on all platforms
+        [ActiveIssue(15098)]
+        [Theory MemberData("PathsWithInvalidColons")]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public void PathWithInvalidColons_ThrowsNotSupportedException()
+        public void PathWithInvalidColons_ThrowsArgumentException(string invalidPath)
         {
-            var paths = IOInputs.GetPathsWithInvalidColons();
-            Assert.All(paths, (path) =>
-            {
-                Assert.Throws<NotSupportedException>(() => Create(path));
-            });
+            Assert.Throws<ArgumentException>(() => Create(invalidPath));
         }
 
-        [Fact]
+        [ConditionalFact("AreAllLongPathsAvailable")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void DirectoryLongerThanMaxPath_Succeeds()
         {
@@ -258,7 +254,8 @@ namespace System.IO.Tests
             });
         }
 
-        [Fact]
+        [ConditionalFact("LongPathsAreNotBlocked", "UsingNewNormalization")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void DirectoryLongerThanMaxLongPathWithExtendedSyntax_ThrowsPathTooLongException()
         {
@@ -269,8 +266,8 @@ namespace System.IO.Tests
             });
         }
 
-
-        [Fact]
+        [ConditionalFact("LongPathsAreNotBlocked", "UsingNewNormalization")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void ExtendedDirectoryLongerThanLegacyMaxPath_Succeeds()
         {
@@ -281,7 +278,8 @@ namespace System.IO.Tests
             });
         }
 
-        [Fact]
+        [ConditionalFact("AreAllLongPathsAvailable")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void DirectoryLongerThanMaxDirectoryAsPath_Succeeds()
         {
@@ -357,7 +355,8 @@ namespace System.IO.Tests
             });
         }
 
-        [Fact]
+        [ConditionalFact("UsingNewNormalization")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void WindowsExtendedSyntaxWhiteSpace()
         {
@@ -413,7 +412,8 @@ namespace System.IO.Tests
             });
         }
 
-        [Fact]
+        [ConditionalFact("UsingNewNormalization")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)] // device name prefixes
         public void PathWithReservedDeviceNameAsExtendedPath()
         {

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -32,7 +32,7 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentException>(() => Create(string.Empty));
         }
 
-        [Theory MemberData("PathsWithInvalidCharacters")]
+        [Theory, MemberData(nameof(PathsWithInvalidCharacters))]
         public void PathWithInvalidCharactersAsPath_ThrowsArgumentException(string invalidPath)
         {
             if (invalidPath.Equals(@"\\?\") && !PathFeatures.IsUsingLegacyPathNormalization())
@@ -126,7 +126,7 @@ namespace System.IO.Tests
             });
         }
 
-        [ConditionalFact("UsingNewNormalization")]
+        [ConditionalFact(nameof(UsingNewNormalization))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void ValidExtendedPathWithTrailingSlash()
@@ -222,14 +222,14 @@ namespace System.IO.Tests
 
         // This is updated to be correct, need to update CoreCLR path code so this will pass on all platforms
         [ActiveIssue(15098)]
-        [Theory MemberData("PathsWithInvalidColons")]
+        [Theory, MemberData(nameof(PathsWithInvalidColons))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void PathWithInvalidColons_ThrowsArgumentException(string invalidPath)
         {
             Assert.Throws<ArgumentException>(() => Create(invalidPath));
         }
 
-        [ConditionalFact("AreAllLongPathsAvailable")]
+        [ConditionalFact(nameof(AreAllLongPathsAvailable))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void DirectoryLongerThanMaxPath_Succeeds()
@@ -254,7 +254,7 @@ namespace System.IO.Tests
             });
         }
 
-        [ConditionalFact("LongPathsAreNotBlocked", "UsingNewNormalization")]
+        [ConditionalFact(nameof(LongPathsAreNotBlocked), nameof(UsingNewNormalization))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void DirectoryLongerThanMaxLongPathWithExtendedSyntax_ThrowsPathTooLongException()
@@ -266,7 +266,7 @@ namespace System.IO.Tests
             });
         }
 
-        [ConditionalFact("LongPathsAreNotBlocked", "UsingNewNormalization")]
+        [ConditionalFact(nameof(LongPathsAreNotBlocked), nameof(UsingNewNormalization))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void ExtendedDirectoryLongerThanLegacyMaxPath_Succeeds()
@@ -278,7 +278,7 @@ namespace System.IO.Tests
             });
         }
 
-        [ConditionalFact("AreAllLongPathsAvailable")]
+        [ConditionalFact(nameof(AreAllLongPathsAvailable))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void DirectoryLongerThanMaxDirectoryAsPath_Succeeds()
@@ -355,7 +355,7 @@ namespace System.IO.Tests
             });
         }
 
-        [ConditionalFact("UsingNewNormalization")]
+        [ConditionalFact(nameof(UsingNewNormalization))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void WindowsExtendedSyntaxWhiteSpace()
@@ -412,7 +412,7 @@ namespace System.IO.Tests
             });
         }
 
-        [ConditionalFact("UsingNewNormalization")]
+        [ConditionalFact(nameof(UsingNewNormalization))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)] // device name prefixes
         public void PathWithReservedDeviceNameAsExtendedPath()

--- a/src/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -112,7 +112,8 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [Fact]
+        [ConditionalFact("UsingNewNormalization")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void WindowsExtendedDirectoryWithSubdirectories()
         {
@@ -122,7 +123,8 @@ namespace System.IO.Tests
             Assert.True(testDir.Exists);
         }
 
-        [Fact]
+        [ConditionalFact("LongPathsAreNotBlocked", "UsingNewNormalization")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void WindowsLongPathExtendedDirectory()
         {
@@ -142,7 +144,8 @@ namespace System.IO.Tests
             testDir.Attributes = FileAttributes.Normal;
         }
 
-        [Fact]
+        [ConditionalFact("UsingNewNormalization")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void WindowsDeleteExtendedReadOnlyDirectory()
         {
@@ -173,7 +176,8 @@ namespace System.IO.Tests
             Assert.False(testDir.Exists);
         }
 
-        [Fact]
+        [ConditionalFact("UsingNewNormalization")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void WindowsShouldBeAbleToDeleteExtendedHiddenDirectory()
         {

--- a/src/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -112,7 +112,7 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [ConditionalFact("UsingNewNormalization")]
+        [ConditionalFact(nameof(UsingNewNormalization))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void WindowsExtendedDirectoryWithSubdirectories()
@@ -123,7 +123,7 @@ namespace System.IO.Tests
             Assert.True(testDir.Exists);
         }
 
-        [ConditionalFact("LongPathsAreNotBlocked", "UsingNewNormalization")]
+        [ConditionalFact(nameof(LongPathsAreNotBlocked), nameof(UsingNewNormalization))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void WindowsLongPathExtendedDirectory()
@@ -144,7 +144,7 @@ namespace System.IO.Tests
             testDir.Attributes = FileAttributes.Normal;
         }
 
-        [ConditionalFact("UsingNewNormalization")]
+        [ConditionalFact(nameof(UsingNewNormalization))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void WindowsDeleteExtendedReadOnlyDirectory()
@@ -176,7 +176,7 @@ namespace System.IO.Tests
             Assert.False(testDir.Exists);
         }
 
-        [ConditionalFact("UsingNewNormalization")]
+        [ConditionalFact(nameof(UsingNewNormalization))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void WindowsShouldBeAbleToDeleteExtendedHiddenDirectory()

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -53,7 +53,7 @@ namespace System.IO.Tests
             });
         }
 
-        [Theory MemberData("PathsWithInvalidCharacters")]
+        [Theory, MemberData(nameof(PathsWithInvalidCharacters))]
         public void PathWithInvalidCharactersAsPath_ReturnsFalse(string invalidPath)
         {
             // Checks that errors aren't thrown when calling Exists() on paths with impossible to create characters
@@ -176,7 +176,7 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [ConditionalFact("UsingNewNormalization")]
+        [ConditionalFact(nameof(UsingNewNormalization))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void ValidExtendedPathExists_ReturnsTrue()
@@ -189,7 +189,7 @@ namespace System.IO.Tests
             });
         }
 
-        [ConditionalFact("UsingNewNormalization")]
+        [ConditionalFact(nameof(UsingNewNormalization))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void ExtendedPathAlreadyExistsAsFile()
@@ -202,7 +202,7 @@ namespace System.IO.Tests
             Assert.False(Exists(IOServices.RemoveTrailingSlash(IOServices.AddTrailingSlashIfNeeded(path))));
         }
 
-        [ConditionalFact("UsingNewNormalization")]
+        [ConditionalFact(nameof(UsingNewNormalization))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void ExtendedPathAlreadyExistsAsDirectory()
@@ -215,7 +215,7 @@ namespace System.IO.Tests
             Assert.True(Exists(IOServices.RemoveTrailingSlash(IOServices.AddTrailingSlashIfNeeded(path))));
         }
 
-        [ConditionalFact("AreAllLongPathsAvailable")]
+        [ConditionalFact(nameof(AreAllLongPathsAvailable))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void DirectoryLongerThanMaxDirectoryAsPath_DoesntThrow()
@@ -257,7 +257,7 @@ namespace System.IO.Tests
             Assert.False(Exists(testDir.FullName.ToLowerInvariant()));
         }
 
-        [ConditionalFact("UsingNewNormalization")]
+        [ConditionalFact(nameof(UsingNewNormalization))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)] // In Windows, trailing whitespace in a path is trimmed appropriately
         public void TrailingWhitespaceExistence()

--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -53,17 +53,14 @@ namespace System.IO.Tests
             });
         }
 
-        [Fact]
-        public void PathWithInvalidCharactersAsPath_ReturnsFalse()
+        [Theory MemberData("PathsWithInvalidCharacters")]
+        public void PathWithInvalidCharactersAsPath_ReturnsFalse(string invalidPath)
         {
             // Checks that errors aren't thrown when calling Exists() on paths with impossible to create characters
             char[] trimmed = { (char)0x9, (char)0xA, (char)0xB, (char)0xC, (char)0xD, (char)0x20, (char)0x85, (char)0xA0 };
-            Assert.All((IOInputs.GetPathsWithInvalidCharacters()), (component) =>
-            {
-                Assert.False(Exists(component));
-                if (!trimmed.Contains(component.ToCharArray()[0]))
-                    Assert.False(Exists(TestDirectory + Path.DirectorySeparatorChar + component));
-            });
+            Assert.False(Exists(invalidPath));
+            if (!trimmed.Contains(invalidPath.ToCharArray()[0]))
+                Assert.False(Exists(TestDirectory + Path.DirectorySeparatorChar + invalidPath));
         }
 
         [Fact]
@@ -179,7 +176,8 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [Fact]
+        [ConditionalFact("UsingNewNormalization")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void ValidExtendedPathExists_ReturnsTrue()
         {
@@ -191,7 +189,8 @@ namespace System.IO.Tests
             });
         }
 
-        [Fact]
+        [ConditionalFact("UsingNewNormalization")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void ExtendedPathAlreadyExistsAsFile()
         {
@@ -203,7 +202,8 @@ namespace System.IO.Tests
             Assert.False(Exists(IOServices.RemoveTrailingSlash(IOServices.AddTrailingSlashIfNeeded(path))));
         }
 
-        [Fact]
+        [ConditionalFact("UsingNewNormalization")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void ExtendedPathAlreadyExistsAsDirectory()
         {
@@ -215,7 +215,8 @@ namespace System.IO.Tests
             Assert.True(Exists(IOServices.RemoveTrailingSlash(IOServices.AddTrailingSlashIfNeeded(path))));
         }
 
-        [Fact]
+        [ConditionalFact("AreAllLongPathsAvailable")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void DirectoryLongerThanMaxDirectoryAsPath_DoesntThrow()
         {
@@ -256,10 +257,13 @@ namespace System.IO.Tests
             Assert.False(Exists(testDir.FullName.ToLowerInvariant()));
         }
 
-        [Fact]
+        [ConditionalFact("UsingNewNormalization")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)] // In Windows, trailing whitespace in a path is trimmed appropriately
         public void TrailingWhitespaceExistence()
         {
+            // This test relies on \\?\ support
+
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
             Assert.All(IOInputs.GetWhiteSpace(), (component) =>
             {

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -219,9 +219,13 @@ namespace System.IO.Tests
             Assert.Throws<PathTooLongException>(() => GetEntries(testDir.FullName, longName));
         }
 
-        [Fact]
+        [ConditionalFact("AreAllLongPathsAvailable")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         public void SearchPatternLongPath()
         {
+            if (!PathFeatures.AreAllLongPathsAvailable())
+                return;
+
             // Create a destination path longer than the traditional Windows limit of 256 characters
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
 

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -219,13 +219,10 @@ namespace System.IO.Tests
             Assert.Throws<PathTooLongException>(() => GetEntries(testDir.FullName, longName));
         }
 
-        [ConditionalFact("AreAllLongPathsAvailable")]
+        [ConditionalFact(nameof(AreAllLongPathsAvailable))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         public void SearchPatternLongPath()
         {
-            if (!PathFeatures.AreAllLongPathsAvailable())
-                return;
-
             // Create a destination path longer than the traditional Windows limit of 256 characters
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
 

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -143,7 +143,8 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [Fact]
+        [ConditionalFact("AreAllLongPathsAvailable")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void Path_With_Longer_Than_MaxDirectory_Succeeds()
         {

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -143,7 +143,7 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [ConditionalFact("AreAllLongPathsAvailable")]
+        [ConditionalFact(nameof(AreAllLongPathsAvailable))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void Path_With_Longer_Than_MaxDirectory_Succeeds()

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
@@ -204,7 +204,8 @@ namespace System.IO.Tests
             });
         }
 
-        [Fact]
+        [ConditionalFact("UsingNewNormalization")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void ExtendedPathSubdirectory()
         {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
@@ -204,7 +204,7 @@ namespace System.IO.Tests
             });
         }
 
-        [ConditionalFact("UsingNewNormalization")]
+        [ConditionalFact(nameof(UsingNewNormalization))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void ExtendedPathSubdirectory()

--- a/src/System.IO.FileSystem/tests/File/Create.cs
+++ b/src/System.IO.FileSystem/tests/File/Create.cs
@@ -56,7 +56,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact("UsingNewNormalization")]
+        [ConditionalFact(nameof(UsingNewNormalization))]
         [PlatformSpecific(TestPlatforms.Windows)]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "dos device path support added in 4.6.2")]
         public void ValidCreation_ExtendedSyntax()
@@ -72,7 +72,7 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact("AreAllLongPathsAvailable")]
+        [ConditionalFact(nameof(AreAllLongPathsAvailable))]
         [PlatformSpecific(TestPlatforms.Windows)]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         public void ValidCreation_LongPathExtendedSyntax()

--- a/src/System.IO.FileSystem/tests/File/Create.cs
+++ b/src/System.IO.FileSystem/tests/File/Create.cs
@@ -56,8 +56,9 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact("UsingNewNormalization")]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "dos device path support added in 4.6.2")]
         public void ValidCreation_ExtendedSyntax()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(IOInputs.ExtendedPrefix + GetTestFilePath());
@@ -71,8 +72,9 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact("AreAllLongPathsAvailable")]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         public void ValidCreation_LongPathExtendedSyntax()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(IOServices.GetPath(IOInputs.ExtendedPrefix + TestDirectory, characterCount: 500).FullPath);

--- a/src/System.IO.FileSystem/tests/File/Exists.cs
+++ b/src/System.IO.FileSystem/tests/File/Exists.cs
@@ -52,7 +52,7 @@ namespace System.IO.Tests
             });
         }
 
-        [Theory MemberData("PathsWithInvalidCharacters")]
+        [Theory, MemberData(nameof(PathsWithInvalidCharacters))]
         public void PathWithInvalidCharactersAsPath_ReturnsFalse(string invalidPath)
         {
             // Checks that errors aren't thrown when calling Exists() on paths with impossible to create characters

--- a/src/System.IO.FileSystem/tests/File/Exists.cs
+++ b/src/System.IO.FileSystem/tests/File/Exists.cs
@@ -52,14 +52,11 @@ namespace System.IO.Tests
             });
         }
 
-        [Fact]
-        public void PathWithInvalidCharactersAsPath_ReturnsFalse()
+        [Theory MemberData("PathsWithInvalidCharacters")]
+        public void PathWithInvalidCharactersAsPath_ReturnsFalse(string invalidPath)
         {
             // Checks that errors aren't thrown when calling Exists() on paths with impossible to create characters
-            Assert.All((IOInputs.GetPathsWithInvalidCharacters()), (component) =>
-            {
-                Assert.False(Exists(component));
-            });
+            Assert.False(Exists(invalidPath));
 
             Assert.False(Exists(".."));
             Assert.False(Exists("."));

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -43,7 +43,7 @@ namespace System.IO.Tests
             Assert.Throws<FileNotFoundException>(() => Move(Path.Combine(TestDirectory, GetTestFileName(), GetTestFileName()), testFile.FullName));
         }
 
-        [Theory MemberData("PathsWithInvalidCharacters")]
+        [Theory MemberData(nameof(PathsWithInvalidCharacters))]
         public void PathWithIllegalCharacters(string invalidPath)
         {
             FileInfo testFile = new FileInfo(GetTestFilePath());
@@ -147,7 +147,7 @@ namespace System.IO.Tests
             Assert.False(File.Exists(testFileSource));
         }
 
-        [ConditionalFact("AreAllLongPathsAvailable")]
+        [ConditionalFact(nameof(AreAllLongPathsAvailable))]
         [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void OverMaxPathWorks_Windows()
@@ -199,7 +199,7 @@ namespace System.IO.Tests
 
         // This is updated to be correct, need to update CoreCLR path code so this will pass on all platforms
         [ActiveIssue(15098)]
-        [Theory MemberData("PathsWithInvalidColons")]
+        [Theory MemberData(nameof(PathsWithInvalidColons))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void WindowsPathWithIllegalColons(string invalidPath)
         {

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -43,18 +43,18 @@ namespace System.IO.Tests
             Assert.Throws<FileNotFoundException>(() => Move(Path.Combine(TestDirectory, GetTestFileName(), GetTestFileName()), testFile.FullName));
         }
 
-        [Fact]
-        public void PathWithIllegalCharacters()
+        [Theory MemberData("PathsWithInvalidCharacters")]
+        public void PathWithIllegalCharacters(string invalidPath)
         {
             FileInfo testFile = new FileInfo(GetTestFilePath());
             testFile.Create().Dispose();
-            Assert.All(IOInputs.GetPathsWithInvalidCharacters(), (invalid) =>
-            {
-                if (invalid.Contains(@"\\?\"))
-                    Assert.Throws<IOException>(() => Move(testFile.FullName, invalid));
-                else
-                    Assert.Throws<ArgumentException>(() => Move(testFile.FullName, invalid));
-            });
+
+            // Under legacy normalization we kick \\?\ paths back as invalid with ArgumentException
+            // New style we don't prevalidate \\?\ at all
+            if (invalidPath.Contains(@"\\?\") && !PathFeatures.IsUsingLegacyPathNormalization())
+                Assert.Throws<IOException>(() => Move(testFile.FullName, invalidPath));
+            else
+                Assert.Throws<ArgumentException>(() => Move(testFile.FullName, invalidPath));
         }
 
         [Fact]
@@ -147,9 +147,10 @@ namespace System.IO.Tests
             Assert.False(File.Exists(testFileSource));
         }
 
-        [Fact]
+        [ConditionalFact("AreAllLongPathsAvailable")]
+        [SkipOnTargetFramework(Tfm.BelowNet462 | Tfm.Core50, "long path support added in 4.6.2")]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public void MaxPath_Windows()
+        public void OverMaxPathWorks_Windows()
         {
             // Create a destination path longer than the traditional Windows limit of 256 characters,
             // but under the long path limitation (32K).
@@ -196,16 +197,15 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [Fact]
+        // This is updated to be correct, need to update CoreCLR path code so this will pass on all platforms
+        [ActiveIssue(15098)]
+        [Theory MemberData("PathsWithInvalidColons")]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public void WindowsPathWithIllegalColons()
+        public void WindowsPathWithIllegalColons(string invalidPath)
         {
             FileInfo testFile = new FileInfo(GetTestFilePath());
             testFile.Create().Dispose();
-            Assert.All(IOInputs.GetPathsWithInvalidColons(), (invalid) =>
-            {
-                Assert.Throws<NotSupportedException>(() => Move(testFile.FullName, invalid));
-            });
+            Assert.Throws<ArgumentException>(() => Move(testFile.FullName, invalidPath));
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -14,6 +14,16 @@ namespace System.IO.Tests
         protected const TestPlatforms CaseInsensitivePlatforms = TestPlatforms.Windows | TestPlatforms.OSX;
         protected const TestPlatforms CaseSensitivePlatforms = TestPlatforms.AnyUnix & ~TestPlatforms.OSX;
 
+        public static bool AreAllLongPathsAvailable => PathFeatures.AreAllLongPathsAvailable();
+
+        public static bool LongPathsAreNotBlocked => !PathFeatures.AreLongPathsBlocked();
+
+        public static bool UsingNewNormalization => !PathFeatures.IsUsingLegacyPathNormalization();
+
+        public static TheoryData<string> PathsWithInvalidColons => TestData.PathsWithInvalidColons;
+
+        public static TheoryData<string> PathsWithInvalidCharacters => TestData.PathsWithInvalidCharacters;
+
         /// <summary>
         /// In some cases (such as when running without elevated privileges),
         /// the symbolic link may fail to create. Only run this test if it creates

--- a/src/System.IO.FileSystem/tests/PathFeatures.cs
+++ b/src/System.IO.FileSystem/tests/PathFeatures.cs
@@ -1,0 +1,92 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace System.IO
+{
+    public static class PathFeatures
+    {
+        // Note that this class is using APIs that allow it to run on all platforms (including Core 5.0)
+        // That is why we have .GetTypeInfo(), don't use the Registry, etc...
+
+        private static bool? s_osEnabled;
+        private static bool? s_onCore;
+
+        /// <summary>
+        /// Returns true if you can use long paths, including long DOS style paths (e.g. over 260 without \\?\).
+        /// </summary>
+        public static bool AreAllLongPathsAvailable()
+        {
+            // We have support built-in for all platforms in Core
+            if (RunningOnCore)
+                return true;
+
+            // Otherwise we're running on Windows, see if we've got the capability in .NET, and that the feature is enabled in the OS
+            return !AreLongPathsBlocked() && AreOsLongPathsEnabled();
+        }
+
+        public static bool IsUsingLegacyPathNormalization()
+        {
+            return HasLegacyIoBehavior("UseLegacyPathHandling");
+        }
+
+        /// <summary>
+        /// Returns true if > MAX_PATH (260) character paths are blocked.
+        /// Note that this doesn't reflect that you can actually use long paths without device syntax when on Windows.
+        /// Use AreAllLongPathsAvailable() to see that you can use long DOS style paths if on Windows.
+        /// </summary>
+        public static bool AreLongPathsBlocked()
+        {
+            return HasLegacyIoBehavior("BlockLongPaths");
+        }
+
+        private static bool HasLegacyIoBehavior(string propertyName)
+        {
+            // Core doesn't have legacy behaviors
+            if (RunningOnCore)
+                return false;
+
+            Type t = typeof(object).GetTypeInfo().Assembly.GetType("System.AppContextSwitches");
+            var p = t.GetProperty(propertyName, BindingFlags.Static | BindingFlags.Public);
+
+            // If the switch actually exists use it, otherwise we predate the switch and are effectively on
+            return (bool)(p?.GetValue(null) ?? true);
+        }
+
+        private static bool RunningOnCore
+        {
+            get
+            {
+                // Not particularly elegant
+                if (!s_onCore.HasValue)
+                    s_onCore = typeof(object).GetTypeInfo().Assembly.GetName().Name == "System.Private.CoreLib";
+
+                return s_onCore.Value;
+            }
+        }
+
+        private static bool AreOsLongPathsEnabled()
+        {
+            if (!s_osEnabled.HasValue)
+            {
+                // No official way to check yet this is good enough for tests
+                try
+                {
+                    s_osEnabled = RtlAreLongPathsEnabled();
+                }
+                catch
+                {
+                    s_osEnabled = false;
+                }
+            }
+
+            return s_osEnabled.Value;
+        }
+
+        [DllImport("ntdll", ExactSpelling = true)]
+        static extern bool RtlAreLongPathsEnabled();
+    }
+}

--- a/src/System.IO.FileSystem/tests/Performance/System.IO.FileSystem.Performance.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/Performance/System.IO.FileSystem.Performance.Tests.csproj
@@ -33,7 +33,9 @@
       <Name>RemoteExecutorConsoleApp</Name>
     </ProjectReference>
     <Compile Include="..\PortedCommon\ReparsePointUtilities.cs" />
+    <Compile Include="..\TestData.cs" />
     <Compile Include="..\FileSystemTest.cs" />
+    <Compile Include="..\PathFeatures.cs" />
     <Compile Include="Perf.Directory.cs" />
     <Compile Include="Perf.File.cs" />
     <Compile Include="Perf.FileInfo.cs" />

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
@@ -10,11 +10,6 @@ using System.Runtime.InteropServices;
 
 internal static class IOInputs
 {
-    // see: http://msdn.microsoft.com/en-us/library/aa365247.aspx
-    private static readonly char[] s_invalidFileNameChars = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-        new char[] { '\"', '<', '>', '|', '\0', (Char)1, (Char)2, (Char)3, (Char)4, (Char)5, (Char)6, (Char)7, (Char)8, (Char)9, (Char)10, (Char)11, (Char)12, (Char)13, (Char)14, (Char)15, (Char)16, (Char)17, (Char)18, (Char)19, (Char)20, (Char)21, (Char)22, (Char)23, (Char)24, (Char)25, (Char)26, (Char)27, (Char)28, (Char)29, (Char)30, (Char)31, '*', '?' } :
-        new char[] { '\0' };
-
     public static bool SupportsSettingCreationTime { get { return RuntimeInformation.IsOSPlatform(OSPlatform.Windows); } }
     public static bool SupportsGettingCreationTime { get { return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) | RuntimeInformation.IsOSPlatform(OSPlatform.OSX); } }
 
@@ -141,60 +136,6 @@ internal static class IOInputs
         yield return @"C:\fileName:FileName.txt:AA";
         yield return @"C:\fileName:FileName.txt:AAA";
         yield return @"ftp://fileName:FileName.txt:AAA";
-    }
-
-    public static IEnumerable<string> GetPathsWithInvalidColons()
-    {
-        // Windows specific. We document that these return NotSupportedException.
-        yield return @":";
-        yield return @" :";
-        yield return @"  :";
-        yield return @"C::";
-        yield return @"C::FileName";
-        yield return @"C::FileName.txt";
-        yield return @"C::FileName.txt:";
-        yield return @"C::FileName.txt::";
-        yield return @":f";
-        yield return @":filename";
-        yield return @"file:";
-        yield return @"file:file";
-        yield return @"http:";
-        yield return @"http:/";
-        yield return @"http://";
-        yield return @"http://www";
-        yield return @"http://www.microsoft.com";
-        yield return @"http://www.microsoft.com/index.html";
-        yield return @"http://server";
-        yield return @"http://server/";
-        yield return @"http://server/home";
-        yield return @"file://";
-        yield return @"file:///C|/My Documents/ALetter.html";
-    }
-
-    public static IEnumerable<string> GetPathsWithInvalidCharacters()
-    {
-        // NOTE: That I/O treats "file"/http" specially and throws ArgumentException.
-        // Otherwise, it treats all other urls as alternative data streams
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // alternate data streams, drive labels, etc.
-        {
-            yield return "\0";
-            yield return "middle\0path";
-            yield return "trailing\0";
-            yield return @"\\?\";
-            yield return @"\\?\UNC\";
-            yield return @"\\?\UNC\LOCALHOST";
-        }
-        else
-        {
-            yield return "\0";
-            yield return "middle\0path";
-            yield return "trailing\0";
-        }
-
-        foreach (char c in s_invalidFileNameChars)
-        {
-            yield return c.ToString();
-        }
     }
 
     public static IEnumerable<string> GetPathsWithComponentLongerThanMaxComponent()

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
@@ -106,6 +106,9 @@
     <Compile Include="File\Move.cs" />
     <Compile Include="File\ReadWriteAllText.cs" />
     <Compile Include="File\ReadWriteAllLines.cs" />
+    <Compile Include="PathFeatures.cs" />
+    <Compile Include="TestData.cs" />
+    <Compile Include="Tfm.cs" />
     <Compile Include="UnseekableFileStream.cs" />
     <Compile Include="FSAssert.cs" />
     <Compile Include="FileSystemTest.cs" />

--- a/src/System.IO.FileSystem/tests/TestData.cs
+++ b/src/System.IO.FileSystem/tests/TestData.cs
@@ -1,0 +1,87 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+internal static class TestData
+{
+    // see: http://msdn.microsoft.com/en-us/library/aa365247.aspx
+    private static readonly char[] s_invalidFileNameChars = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+        new char[]
+        {
+            '\"', '<', '>', '|', '\0', (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7,
+            (char)8, (char)9, (char)10, (char)11, (char)12, (char)13, (char)14, (char)15, (char)16,
+            (char)17, (char)18, (char)19, (char)20, (char)21, (char)22, (char)23, (char)24, (char)25,
+            (char)26, (char)27, (char)28, (char)29, (char)30, (char)31, '*', '?'
+        } :
+        new char[] { '\0' };
+
+    public static TheoryData<string> PathsWithInvalidColons
+    {
+        get
+        {
+            return new TheoryData<string>
+            {
+                // Windows specific. We document that these return NotSupportedException.
+                @":",
+                @" :",
+                @"  :",
+                @"C::",
+                @"C::FileName",
+                @"C::FileName.txt",
+                @"C::FileName.txt:",
+                @"C::FileName.txt::",
+                @":f",
+                @":filename",
+                @"file:",
+                @"file:file",
+                @"http:",
+                @"http:/",
+                @"http://",
+                @"http://www",
+                @"http://www.microsoft.com",
+                @"http://www.microsoft.com/index.html",
+                @"http://server",
+                @"http://server/",
+                @"http://server/home",
+                @"file://",
+                @"file:///C|/My Documents/ALetter.html"
+            };
+        }
+    }
+
+    public static TheoryData<string> PathsWithInvalidCharacters
+    {
+        get
+        {
+            TheoryData<string> data = new TheoryData<string>();
+
+            // NOTE: That I/O treats "file"/http" specially and throws ArgumentException.
+            // Otherwise, it treats all other urls as alternative data streams
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // alternate data streams, drive labels, etc.
+            {
+                data.Add("\0");
+                data.Add("middle\0path");
+                data.Add("trailing\0");
+                data.Add(@"\\?\");
+                data.Add(@"\\?\UNC\");
+                data.Add(@"\\?\UNC\LOCALHOST");
+            }
+            else
+            {
+                data.Add("\0");
+                data.Add("middle\0path");
+                data.Add("trailing\0");
+            }
+
+            foreach (char c in s_invalidFileNameChars)
+            {
+                data.Add(c.ToString());
+            }
+
+            return data;
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/Tfm.cs
+++ b/src/System.IO.FileSystem/tests/Tfm.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+
+public static class Tfm
+{
+    public const TargetFrameworkMonikers BelowNet462 = TargetFrameworkMonikers.Net45 | TargetFrameworkMonikers.Net451 | TargetFrameworkMonikers.Net452 | TargetFrameworkMonikers.Net46 | TargetFrameworkMonikers.Net461;
+    public const TargetFrameworkMonikers BelowNet47 = BelowNet462 | TargetFrameworkMonikers.Net462 | TargetFrameworkMonikers.Net463;
+    public const TargetFrameworkMonikers Core50 = TargetFrameworkMonikers.Netcore50 | TargetFrameworkMonikers.Netcore50aot;
+}


### PR DESCRIPTION
Conditionalize tests appropriately so long path and new syntax
support are taken into account.

Move some test data into Theories for easier debugging.

Fix and add issue to colon check tests until we fix CoreCLR.

Note that there are still some failing tests, but this addresses all of the long path & invalid syntax issues (the majority).  #14986

@tarekgh @ianhays @danmosemsft 