### PR TITLE
Filter tests.builds to **\*.Tests.csproj

### DIFF
--- a/src/tests.builds
+++ b/src/tests.builds
@@ -5,7 +5,7 @@
   <Import Project="$(ToolsDir)ConstructSharedFx.targets" Condition="Exists('$(ToolsDir)ConstructSharedFx.targets')" />
 
   <ItemGroup>
-    <Project Include="$(MSBuildThisFileDirectory)*\tests\**\*.csproj" Exclude="@(TestProjectExclusions)">
+    <Project Include="$(MSBuildThisFileDirectory)*\tests\**\*.Tests.csproj" Exclude="@(TestProjectExclusions)">
       <AdditionalMetadata>ConfigurationGroup=$(ConfigurationGroup)</AdditionalMetadata>
     </Project>
   </ItemGroup>


### PR DESCRIPTION
This should run all of the same "real" test assemblies as before, but skip all of the other project under "**\tests" that are not direct test assemblies. Those will still be built via ProjectReferences if they are used.

Fixes https://github.com/dotnet/corefx/issues/15125

@ericstj 