### PR TITLE
implement synchronous completion support in Sockets

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.SetFileCompletionNotificationModes.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.SetFileCompletionNotificationModes.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Kernel32
+    {
+        [Flags]
+        internal enum FileCompletionNotificationModes : byte
+        {
+            None = 0,
+            SkipCompletionPortOnSuccess = 1,
+            SkipSetEventOnHandle = 2
+        }
+
+        [DllImport(Libraries.Kernel32, SetLastError = true)]
+        internal static unsafe extern bool SetFileCompletionNotificationModes(SafeHandle handle, FileCompletionNotificationModes flags);
+    }
+}

--- a/src/Common/src/System/Net/CompletionPortHelper.Uap.cs
+++ b/src/Common/src/System/Net/CompletionPortHelper.Uap.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Net.Sockets
+{
+    internal static class CompletionPortHelper
+    {
+        internal static bool SkipCompletionPortOnSuccess(SafeHandle handle)
+        {
+            // SetFileCompletionNotificationModes is not supported on UAP.
+            return false;
+        }
+
+        internal static readonly bool PlatformHasUdpIssue = false;
+    }
+}

--- a/src/Common/src/System/Net/CompletionPortHelper.Windows.cs
+++ b/src/Common/src/System/Net/CompletionPortHelper.Windows.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Net.Sockets
+{
+    internal static class CompletionPortHelper
+    {
+        internal static bool SkipCompletionPortOnSuccess(SafeHandle handle)
+        {
+            return Interop.Kernel32.SetFileCompletionNotificationModes(handle,
+                Interop.Kernel32.FileCompletionNotificationModes.SkipCompletionPortOnSuccess |
+                Interop.Kernel32.FileCompletionNotificationModes.SkipSetEventOnHandle);
+        }
+
+        // There's a bug with using SetFileCompletionNotificationModes with UDP on Windows 7 and before.
+        // This check tells us if the problem exists on the platform we're running on.
+        internal static readonly bool PlatformHasUdpIssue = CheckIfPlatformHasUdpIssue();
+
+        private static bool CheckIfPlatformHasUdpIssue()
+        {
+            Version osVersion = Environment.OSVersion.Version;
+
+            // 6.1 == Windows 7
+            return (osVersion.Major < 6 ||
+                    (osVersion.Major == 6 && osVersion.Minor <= 1));
+        }
+    }
+}

--- a/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -138,6 +138,9 @@
     <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Windows.cs">
       <Link>Common\System\Net\ContextAwareResult.Windows.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\CompletionPortHelper.Windows.cs">
+      <Link>Common\System\Net\CompletionPortHelper.Windows.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\LazyAsyncResult.cs">
       <Link>Common\System\Net\LazyAsyncResult.cs</Link>
     </Compile>
@@ -196,6 +199,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.LocalFree.cs">
       <Link>Interop\Windows\kernel32\Interop.LocalFree.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetFileCompletionNotificationModes.cs">
+      <Link>Interop\Windows\kernel32\Interop.SetFileCompletionNotificationModes.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Winsock\Interop.accept.cs">
       <Link>Interop\Windows\Winsock\Interop.accept.cs</Link>

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -282,14 +282,23 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.LocalFree.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.LocalFree.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetFileCompletionNotificationModes.cs">
+      <Link>Interop\Windows\kernel32\Interop.SetFileCompletionNotificationModes.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Windows.cs">
       <Link>Common\System\Net\ContextAwareResult.Windows.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\CompletionPortHelper.Windows.cs">
+      <Link>Common\System\Net\CompletionPortHelper.Windows.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Windows : Win32 + WinRT -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(EnableWinRT)' == 'true'">
     <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Uap.cs">
       <Link>Common\System\Net\ContextAwareResult.Uap.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\CompletionPortHelper.Uap.cs">
+      <Link>Common\System\Net\CompletionPortHelper.Uap.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Unix.cs
@@ -23,16 +23,10 @@ namespace System.Net.Sockets
             if (NetEventSource.IsEnabled) NetEventSource.Info(this, socket);
         }
 
-        public void CompletionCallback(int numBytes, SocketError errorCode)
+        protected void CompletionCallback(int numBytes, SocketError errorCode)
         {
             ErrorCode = (int)errorCode;
             InvokeCallback(PostCompletion(numBytes));
-        }
-
-        private void ReleaseUnmanagedStructures()
-        {
-            // NOTE: this method needs to exist to conform to the contract expected by the
-            //       platform-independent code in BaseOverlappedAsyncResult.CheckAsyncCallOverlappedResult.
         }
     }
 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.cs
@@ -36,30 +36,5 @@ namespace System.Net.Sockets
             base.InternalWaitForCompletion();
             return _numBytes;
         }
-
-        // This method is called after an asynchronous call is made for the user.
-        // It checks and acts accordingly if the IO:
-        // 1) completed synchronously.
-        // 2) was pended.
-        // 3) failed.
-        internal unsafe SocketError CheckAsyncCallOverlappedResult(SocketError errorCode)
-        {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, errorCode);
-
-            if (errorCode == SocketError.Success || errorCode == SocketError.IOPending)
-            {
-                // Ignore cases in which a completion packet will be queued:
-                // we'll deal with this IO in the callback.
-                return SocketError.Success;
-            }
-
-            // In the remaining cases a completion packet will NOT be queued:
-            // we have to call the callback explicitly signaling an error.
-            ErrorCode = (int)errorCode;
-            Result = -1;
-
-            ReleaseUnmanagedStructures();  // Additional release for the completion that won't happen.
-            return errorCode;
-        }
     }
 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -11,27 +11,25 @@ using System.Threading;
 
 namespace System.Net.Sockets
 {
-    //
-    // NOTE: the publicly-exposed asynchronous methods should match the behavior of
-    //       Winsock overlapped sockets as closely as possible. Especially important are
-    //       completion semantics, as the consuming code relies on the Winsock behavior.
-    //
-    //       Winsock queues a completion callback for an overlapped operation in two cases:
-    //         1. the operation successfully completes synchronously, or
-    //         2. the operation completes asynchronously, successfully or otherwise.
-    //       In other words, a completion callback is queued iff an operation does not
-    //       fail synchronously. The asynchronous methods below (e.g. ReceiveAsync) may
-    //       fail synchronously for either of the following reasons:
-    //         1. an underlying system call fails synchronously, or
-    //         2. an underlying system call returns EAGAIN, but the socket is closed before
-    //            the method is able to enqueue its corresponding operation.
-    //       In the first case, the async method should return the SocketError that
-    //       corresponds to the native error code; in the second, the method should return
-    //       SocketError.OperationAborted (which matches what Winsock would return in this
-    //       case). The publicly-exposed synchronous methods may also encounter the second
-    //       case. In this situation these methods should return SocketError.Interrupted
-    //       (which again matches Winsock).
-    //
+    // Note on asynchronous behavior here:
+
+    // The asynchronous socket operations here generally do the following:
+    // (1) If the operation queue is empty, try to perform the operation immediately, non-blocking.
+    // If this completes (i.e. does not return EWOULDBLOCK), then we return the results immediately
+    // for both success (SocketError.Success) or failure.
+    // No callback will happen; callers are expected to handle these synchronous completions themselves.
+    // (2) If EWOULDBLOCK is returned, or the queue is not empty, then we enqueue an operation to the 
+    // appropriate queue and return SocketError.IOPending.
+    // Enqueuing itself may fail because the socket is closed before the operation can be enqueued;
+    // in this case, we return SocketError.OperationAborted (which matches what Winsock would return in this case).
+    // (3) When the queue completes the operation, it will post a work item to the threadpool
+    // to call the callback with results (either success or failure).
+
+    // Synchronous operations generally do the same, except that instead of returning IOPending,
+    // they block on an event handle until the operation is processed by the queue.
+    // Also, synchronous methods return SocketError.Interrupted when enqueuing fails
+    // (which again matches Winsock behavior).
+
     internal sealed class SocketAsyncContext
     {
         private abstract class AsyncOperation
@@ -662,7 +660,7 @@ namespace System.Net.Sockets
             }
         }
 
-        public SocketError AcceptAsync(byte[] socketAddress, int socketAddressLen, Action<IntPtr, byte[], int, SocketError> callback)
+        public SocketError AcceptAsync(byte[] socketAddress, ref int socketAddressLen, out IntPtr acceptedFd, Action<IntPtr, byte[], int, SocketError> callback)
         {
             Debug.Assert(socketAddress != null, "Expected non-null socketAddress");
             Debug.Assert(socketAddressLen > 0, $"Unexpected socketAddressLen: {socketAddressLen}");
@@ -670,20 +668,11 @@ namespace System.Net.Sockets
 
             SetNonBlocking();
 
-            IntPtr acceptedFd;
             SocketError errorCode;
             if (SocketPal.TryCompleteAccept(_socket, socketAddress, ref socketAddressLen, out acceptedFd, out errorCode))
             {
                 Debug.Assert(errorCode == SocketError.Success || acceptedFd == (IntPtr)(-1), $"Unexpected values: errorCode={errorCode}, acceptedFd={acceptedFd}");
 
-                if (errorCode == SocketError.Success)
-                {
-                    ThreadPool.QueueUserWorkItem(args =>
-                    {
-                        var tup = (Tuple<Action<IntPtr, byte[], int, SocketError>, IntPtr, byte[], int>)args;
-                        tup.Item1(tup.Item2, tup.Item3, tup.Item4, SocketError.Success);
-                    }, Tuple.Create(callback, acceptedFd, socketAddress, socketAddressLen));
-                }
                 return errorCode;
             }
 
@@ -782,11 +771,6 @@ namespace System.Net.Sockets
             {
                 RegisterConnectResult(errorCode);
 
-                if (errorCode == SocketError.Success)
-                {
-                    ThreadPool.QueueUserWorkItem(arg => ((Action<SocketError>)arg)(SocketError.Success), callback);
-                }
-
                 return errorCode;
             }
 
@@ -827,9 +811,10 @@ namespace System.Net.Sockets
             return ReceiveFrom(buffer, offset, count, ref flags, null, ref socketAddressLen, timeout, out bytesReceived);
         }
 
-        public SocketError ReceiveAsync(byte[] buffer, int offset, int count, SocketFlags flags, Action<int, byte[], int, SocketFlags, SocketError> callback)
+        public SocketError ReceiveAsync(byte[] buffer, int offset, int count, SocketFlags flags, out int bytesReceived, out SocketFlags receivedFlags, Action<int, byte[], int, SocketFlags, SocketError> callback)
         {
-            return ReceiveFromAsync(buffer, offset, count, flags, null, 0, callback);
+            int socketAddressLen = 0;
+            return ReceiveFromAsync(buffer, offset, count, flags, null, ref socketAddressLen, out bytesReceived, out receivedFlags, callback);
         }
 
         public SocketError ReceiveFrom(byte[] buffer, int offset, int count, ref SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, int timeout, out int bytesReceived)
@@ -897,29 +882,23 @@ namespace System.Net.Sockets
             }
         }
 
-        public SocketError ReceiveFromAsync(byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, SocketFlags, SocketError> callback)
+        public SocketError ReceiveFromAsync(byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, Action<int, byte[], int, SocketFlags, SocketError> callback)
         {
             SetNonBlocking();
 
             lock (_receiveLock)
             {
-                int bytesReceived;
-                SocketFlags receivedFlags;
                 SocketError errorCode;
 
                 if (_receiveQueue.IsEmpty &&
                     SocketPal.TryCompleteReceiveFrom(_socket, buffer, offset, count, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode))
                 {
-                    if (errorCode == SocketError.Success)
-                    {
-                        ThreadPool.QueueUserWorkItem(args =>
-                        {
-                            var tup = (Tuple<Action<int, byte[], int, SocketFlags, SocketError>, int, byte[], int, SocketFlags>)args;
-                            tup.Item1(tup.Item2, tup.Item3, tup.Item4, tup.Item5, SocketError.Success);
-                        }, Tuple.Create(callback, bytesReceived, socketAddress, socketAddressLen, receivedFlags));
-                    }
+                    // Synchronous success or failure
                     return errorCode;
                 }
+
+                bytesReceived = 0;
+                receivedFlags = SocketFlags.None;
 
                 var operation = new ReceiveOperation
                 {
@@ -955,9 +934,10 @@ namespace System.Net.Sockets
             return ReceiveFrom(buffers, ref flags, null, 0, timeout, out bytesReceived);
         }
 
-        public SocketError ReceiveAsync(IList<ArraySegment<byte>> buffers, SocketFlags flags, Action<int, byte[], int, SocketFlags, SocketError> callback)
+        public SocketError ReceiveAsync(IList<ArraySegment<byte>> buffers, SocketFlags flags, out int bytesReceived, out SocketFlags receivedFlags, Action<int, byte[], int, SocketFlags, SocketError> callback)
         {
-            return ReceiveFromAsync(buffers, flags, null, 0, callback);
+            int socketAddressLen = 0;
+            return ReceiveFromAsync(buffers, flags, null, ref socketAddressLen, out bytesReceived, out receivedFlags, callback);
         }
 
         public SocketError ReceiveFrom(IList<ArraySegment<byte>> buffers, ref SocketFlags flags, byte[] socketAddress, int socketAddressLen, int timeout, out int bytesReceived)
@@ -1024,7 +1004,7 @@ namespace System.Net.Sockets
             }
         }
 
-        public SocketError ReceiveFromAsync(IList<ArraySegment<byte>> buffers, SocketFlags flags, byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, SocketFlags, SocketError> callback)
+        public SocketError ReceiveFromAsync(IList<ArraySegment<byte>> buffers, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, Action<int, byte[], int, SocketFlags, SocketError> callback)
         {
             SetNonBlocking();
 
@@ -1032,22 +1012,16 @@ namespace System.Net.Sockets
 
             lock (_receiveLock)
             {
-                int bytesReceived;
-                SocketFlags receivedFlags;
                 SocketError errorCode;
                 if (_receiveQueue.IsEmpty &&
                     SocketPal.TryCompleteReceiveFrom(_socket, buffers, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode))
                 {
-                    if (errorCode == SocketError.Success)
-                    {
-                        ThreadPool.QueueUserWorkItem(args =>
-                        {
-                            var tup = (Tuple<Action<int, byte[], int, SocketFlags, SocketError>, int, byte[], int, SocketFlags>)args;
-                            tup.Item1(tup.Item2, tup.Item3, tup.Item4, tup.Item5, SocketError.Success);
-                        }, Tuple.Create(callback, bytesReceived, socketAddress, socketAddressLen, receivedFlags));
-                    }
+                    // Synchronous success or failure
                     return errorCode;
                 }
+
+                bytesReceived = 0;
+                receivedFlags = SocketFlags.None;
 
                 operation = new ReceiveOperation
                 {
@@ -1147,30 +1121,24 @@ namespace System.Net.Sockets
             }
         }
 
-        public SocketError ReceiveMessageFromAsync(byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, bool isIPv4, bool isIPv6, Action<int, byte[], int, SocketFlags, IPPacketInformation, SocketError> callback)
+        public SocketError ReceiveMessageFromAsync(byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out int bytesReceived, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, Action<int, byte[], int, SocketFlags, IPPacketInformation, SocketError> callback)
         {
             SetNonBlocking();
 
             lock (_receiveLock)
             {
-                int bytesReceived;
-                SocketFlags receivedFlags;
-                IPPacketInformation ipPacketInformation;
+                ipPacketInformation = default(IPPacketInformation);
                 SocketError errorCode;
 
                 if (_receiveQueue.IsEmpty &&
                     SocketPal.TryCompleteReceiveMessageFrom(_socket, buffer, offset, count, flags, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out bytesReceived, out receivedFlags, out ipPacketInformation, out errorCode))
                 {
-                    if (errorCode == SocketError.Success)
-                    {
-                        ThreadPool.QueueUserWorkItem(args =>
-                        {
-                            var tup = (Tuple<Action<int, byte[], int, SocketFlags, IPPacketInformation, SocketError>, int, byte[], int, SocketFlags, IPPacketInformation>)args;
-                            tup.Item1(tup.Item2, tup.Item3, tup.Item4, tup.Item5, tup.Item6, SocketError.Success);
-                        }, Tuple.Create(callback, bytesReceived, socketAddress, socketAddressLen, receivedFlags, ipPacketInformation));
-                    }
+                    // Synchronous success or failure
                     return errorCode;
                 }
+
+                bytesReceived = 0;
+                receivedFlags = SocketFlags.None;
 
                 var operation = new ReceiveMessageFromOperation
                 {
@@ -1208,9 +1176,10 @@ namespace System.Net.Sockets
             return SendTo(buffer, offset, count, flags, null, 0, timeout, out bytesSent);
         }
 
-        public SocketError SendAsync(byte[] buffer, int offset, int count, SocketFlags flags, Action<int, byte[], int, SocketFlags, SocketError> callback)
+        public SocketError SendAsync(byte[] buffer, int offset, int count, SocketFlags flags, out int bytesSent, Action<int, byte[], int, SocketFlags, SocketError> callback)
         {
-            return SendToAsync(buffer, offset, count, flags, null, 0, callback);
+            int socketAddressLen = 0;
+            return SendToAsync(buffer, offset, count, flags, null, ref socketAddressLen, out bytesSent, callback);
         }
 
         public SocketError SendTo(byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, int timeout, out int bytesSent)
@@ -1274,26 +1243,19 @@ namespace System.Net.Sockets
             }
         }
 
-        public SocketError SendToAsync(byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, SocketFlags, SocketError> callback)
+        public SocketError SendToAsync(byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesSent, Action<int, byte[], int, SocketFlags, SocketError> callback)
         {
             SetNonBlocking();
 
             lock (_sendAcceptConnectLock)
             {
-                int bytesSent = 0;
+                bytesSent = 0;
                 SocketError errorCode;
 
                 if (_sendQueue.IsEmpty &&
                     SocketPal.TryCompleteSendTo(_socket, buffer, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
                 {
-                    if (errorCode == SocketError.Success)
-                    {
-                        ThreadPool.QueueUserWorkItem(args =>
-                        {
-                            var tup = (Tuple<Action<int, byte[], int, SocketFlags, SocketError>, int, byte[], int>)args;
-                            tup.Item1(tup.Item2, tup.Item3, tup.Item4, 0, SocketError.Success);
-                        }, Tuple.Create(callback, bytesSent, socketAddress, socketAddressLen));
-                    }
+                    // Synchronous success or failure
                     return errorCode;
                 }
 
@@ -1332,9 +1294,10 @@ namespace System.Net.Sockets
             return SendTo(buffers, flags, null, 0, timeout, out bytesSent);
         }
 
-        public SocketError SendAsync(IList<ArraySegment<byte>> buffers, SocketFlags flags, Action<int, byte[], int, SocketFlags, SocketError> callback)
+        public SocketError SendAsync(IList<ArraySegment<byte>> buffers, SocketFlags flags, out int bytesSent, Action<int, byte[], int, SocketFlags, SocketError> callback)
         {
-            return SendToAsync(buffers, flags, null, 0, callback);
+            int socketAddressLen = 0;
+            return SendToAsync(buffers, flags, null, ref socketAddressLen, out bytesSent, callback);
         }
 
         public SocketError SendTo(IList<ArraySegment<byte>> buffers, SocketFlags flags, byte[] socketAddress, int socketAddressLen, int timeout, out int bytesSent)
@@ -1400,28 +1363,23 @@ namespace System.Net.Sockets
             }
         }
 
-        public SocketError SendToAsync(IList<ArraySegment<byte>> buffers, SocketFlags flags, byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, SocketFlags, SocketError> callback)
+
+
+        public SocketError SendToAsync(IList<ArraySegment<byte>> buffers, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesSent, Action<int, byte[], int, SocketFlags, SocketError> callback)
         {
             SetNonBlocking();
 
             lock (_sendAcceptConnectLock)
             {
+                bytesSent = 0;
                 int bufferIndex = 0;
                 int offset = 0;
-                int bytesSent = 0;
                 SocketError errorCode;
 
                 if (_sendQueue.IsEmpty &&
                     SocketPal.TryCompleteSendTo(_socket, buffers, ref bufferIndex, ref offset, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
                 {
-                    if (errorCode == SocketError.Success)
-                    {
-                        ThreadPool.QueueUserWorkItem(args =>
-                        {
-                            var tup = (Tuple<Action<int, byte[], int, SocketFlags, SocketError>, int, byte[], int>)args;
-                            tup.Item1(tup.Item2, tup.Item3, tup.Item4, SocketFlags.None, SocketError.Success);
-                        }, Tuple.Create(callback, bytesSent, socketAddress, socketAddressLen));
-                    }
+                    // Synchronous success or failure
                     return errorCode;
                 }
 
@@ -1512,26 +1470,19 @@ namespace System.Net.Sockets
             }
         }
 
-        public SocketError SendFileAsync(SafeFileHandle fileHandle, long offset, long count, Action<long, SocketError> callback)
+        public SocketError SendFileAsync(SafeFileHandle fileHandle, long offset, long count, out long bytesSent, Action<long, SocketError> callback)
         {
             SetNonBlocking();
 
             lock (_sendAcceptConnectLock)
             {
-                long bytesSent = 0;
+                bytesSent = 0;
                 SocketError errorCode;
 
                 if (_sendQueue.IsEmpty &&
                     SocketPal.TryCompleteSendFile(_socket, fileHandle, ref offset, ref count, ref bytesSent, out errorCode))
                 {
-                    if (errorCode == SocketError.Success)
-                    {
-                        ThreadPool.QueueUserWorkItem(args =>
-                        {
-                            var c = (Action<long, SocketError>)args;
-                            c(bytesSent, SocketError.Success);
-                        }, callback);
-                    }
+                    // Synchronous success or failure
                     return errorCode;
                 }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -127,7 +127,7 @@ namespace System.Net.Sockets
             Debug.Assert(_currentSocket.SafeHandle != null, "_currentSocket.SafeHandle is null");
             Debug.Assert(!_currentSocket.SafeHandle.IsInvalid, "_currentSocket.SafeHandle is invalid");
 
-            ThreadPoolBoundHandle boundHandle = _currentSocket.SafeHandle.GetOrAllocateThreadPoolBoundHandle();
+            ThreadPoolBoundHandle boundHandle = _currentSocket.GetOrAllocateThreadPoolBoundHandle();
 
             NativeOverlapped* overlapped = null;
             if (_preAllocatedOverlapped != null)
@@ -157,15 +157,40 @@ namespace System.Net.Sockets
             }
         }
 
+        private SocketError ProcessIOCPResult(bool success, int bytesTransferred)
+        {
+            if (success)
+            {
+                // Synchronous success.
+                if (_currentSocket.SafeHandle.SkipCompletionPortOnSuccess)
+                {
+                    // The socket handle is configured to skip completion on success, 
+                    // so we can set the results right now.
+                    FinishOperationSyncSuccess(bytesTransferred, SocketFlags.None);
+                    return SocketError.Success;
+                }
+
+                // Socket handle is going to post a completion to the completion port (may have done so already).
+                // Return pending and we will continue in the completion port callback.
+                return SocketError.IOPending;
+            }
+
+            // Get the socket error (which may be IOPending)
+            SocketError errorCode = SocketPal.GetLastSocketError();
+
+            if (errorCode == SocketError.IOPending)
+            {
+                return errorCode;
+            }
+
+            FinishOperationSyncFailure(errorCode, bytesTransferred, SocketFlags.None);
+
+            // Note, the overlapped will be release in CompleteIOCPOperation below, for either success or failure
+            return errorCode;
+        }
+
         private void CompleteIOCPOperation()
         {
-            // TODO #4900: Optimization to remove callbacks if the operations are completed synchronously:
-            //       Use SetFileCompletionNotificationModes(FILE_SKIP_COMPLETION_PORT_ON_SUCCESS).
-
-            // If SetFileCompletionNotificationModes(FILE_SKIP_COMPLETION_PORT_ON_SUCCESS) is not set on this handle
-            // it is guaranteed that the IOCP operation will be completed in the callback even if Socket.Success was 
-            // returned by the Win32 API.
-
             // Required to allow another IOCP operation for the same handle.  We release the native overlapped
             // in the safe handle, but keep the safe handle object around so as to be able to reuse it
             // for other operations.
@@ -180,13 +205,12 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe SocketError DoOperationAccept(Socket socket, SafeCloseSocket handle, SafeCloseSocket acceptHandle, out int bytesTransferred)
+        internal unsafe SocketError DoOperationAccept(Socket socket, SafeCloseSocket handle, SafeCloseSocket acceptHandle)
         {
             PrepareIOCPOperation();
 
-            SocketError socketError = SocketError.Success;
-
-            if (!socket.AcceptEx(
+            int bytesTransferred;
+            bool success = socket.AcceptEx(
                 handle,
                 acceptHandle,
                 (_ptrSingleBuffer != IntPtr.Zero) ? _ptrSingleBuffer : _ptrAcceptBuffer,
@@ -194,12 +218,9 @@ namespace System.Net.Sockets
                 _acceptAddressBufferCount / 2,
                 _acceptAddressBufferCount / 2,
                 out bytesTransferred,
-                _ptrNativeOverlapped))
-            {
-                socketError = SocketPal.GetLastSocketError();
-            }
+                _ptrNativeOverlapped);
 
-            return socketError;
+            return ProcessIOCPResult(success, bytesTransferred);
         }
 
         private void InnerStartOperationConnect()
@@ -213,25 +234,21 @@ namespace System.Net.Sockets
             CheckPinNoBuffer();
         }
 
-        internal unsafe SocketError DoOperationConnect(Socket socket, SafeCloseSocket handle, out int bytesTransferred)
+        internal unsafe SocketError DoOperationConnect(Socket socket, SafeCloseSocket handle)
         {
             PrepareIOCPOperation();
 
-            SocketError socketError = SocketError.Success;
-
-            if (!socket.ConnectEx(
+            int bytesTransferred;
+            bool success = socket.ConnectEx(
                 handle,
                 _ptrSocketAddressBuffer,
                 _socketAddress.Size,
                 _ptrSingleBuffer,
                 Count,
                 out bytesTransferred,
-                _ptrNativeOverlapped))
-            {
-                socketError = SocketPal.GetLastSocketError();
-            }
+                _ptrNativeOverlapped);
 
-            return socketError;
+            return ProcessIOCPResult(success, bytesTransferred);
         }
 
         private void InnerStartOperationDisconnect()
@@ -243,18 +260,13 @@ namespace System.Net.Sockets
         {
             PrepareIOCPOperation();
 
-            SocketError socketError = SocketError.Success;
-
-            if (!socket.DisconnectEx(
+            bool success = socket.DisconnectEx(
                     handle,
                     _ptrNativeOverlapped,
                     (int)(DisconnectReuseSocket ? TransmitFileOptions.ReuseSocket : 0),
-                    0))
-            {
-                socketError = SocketPal.GetLastSocketError();
-            }
+                    0);
 
-            return socketError;
+            return ProcessIOCPResult(success, 0);
         }
 
         private void InnerStartOperationReceive()
@@ -274,12 +286,13 @@ namespace System.Net.Sockets
             //   An array of WSABuffer descriptors is allocated.
         }
 
-        internal unsafe SocketError DoOperationReceive(SafeCloseSocket handle, out SocketFlags flags, out int bytesTransferred)
+        internal unsafe SocketError DoOperationReceive(SafeCloseSocket handle, out SocketFlags flags)
         {
             PrepareIOCPOperation();
 
             flags = _socketFlags;
 
+            int bytesTransferred;
             SocketError socketError;
             if (_buffer != null)
             {
@@ -306,12 +319,7 @@ namespace System.Net.Sockets
                     IntPtr.Zero);
             }
 
-            if (socketError == SocketError.SocketError)
-            {
-                socketError = SocketPal.GetLastSocketError();
-            }
-
-            return socketError;
+            return ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred);
         }
 
         private void InnerStartOperationReceiveFrom()
@@ -334,12 +342,13 @@ namespace System.Net.Sockets
             PinSocketAddressBuffer();
         }
 
-        internal unsafe SocketError DoOperationReceiveFrom(SafeCloseSocket handle, out SocketFlags flags, out int bytesTransferred)
+        internal unsafe SocketError DoOperationReceiveFrom(SafeCloseSocket handle, out SocketFlags flags)
         {
             PrepareIOCPOperation();
 
             flags = _socketFlags;
 
+            int bytesTransferred;
             SocketError socketError;
             if (_buffer != null)
             {
@@ -368,12 +377,7 @@ namespace System.Net.Sockets
                     IntPtr.Zero);
             }
 
-            if (socketError == SocketError.SocketError)
-            {
-                socketError = SocketPal.GetLastSocketError();
-            }
-
-            return socketError;
+            return ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred);
         }
 
         private void InnerStartOperationReceiveMessageFrom()
@@ -465,10 +469,11 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe SocketError DoOperationReceiveMessageFrom(Socket socket, SafeCloseSocket handle, out int bytesTransferred)
+        internal unsafe SocketError DoOperationReceiveMessageFrom(Socket socket, SafeCloseSocket handle)
         {
             PrepareIOCPOperation();
 
+            int bytesTransferred;
             SocketError socketError = socket.WSARecvMsg(
                 handle,
                 _ptrWSAMessageBuffer,
@@ -476,12 +481,7 @@ namespace System.Net.Sockets
                 _ptrNativeOverlapped,
                 IntPtr.Zero);
 
-            if (socketError == SocketError.SocketError)
-            {
-                socketError = SocketPal.GetLastSocketError();
-            }
-
-            return socketError;
+            return ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred);
         }
 
         private void InnerStartOperationSend()
@@ -501,11 +501,12 @@ namespace System.Net.Sockets
             //   An array of WSABuffer descriptors is allocated.
         }
 
-        internal unsafe SocketError DoOperationSend(SafeCloseSocket handle, out int bytesTransferred)
+        internal unsafe SocketError DoOperationSend(SafeCloseSocket handle)
         {
             PrepareIOCPOperation();
 
             SocketError socketError;
+            int bytesTransferred;
             if (_buffer != null)
             {
                 // Single buffer case.
@@ -531,12 +532,7 @@ namespace System.Net.Sockets
                     IntPtr.Zero);
             }
 
-            if (socketError == SocketError.SocketError)
-            {
-                socketError = SocketPal.GetLastSocketError();
-            }
-
-            return socketError;
+            return ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred);
         }
 
         private void InnerStartOperationSendPackets()
@@ -640,7 +636,7 @@ namespace System.Net.Sockets
                 _ptrNativeOverlapped,
                 _sendPacketsFlags);
 
-            return result ? SocketError.Success : SocketPal.GetLastSocketError();
+            return ProcessIOCPResult(result, 0);
         }
 
         private void InnerStartOperationSendTo()
@@ -663,10 +659,11 @@ namespace System.Net.Sockets
             PinSocketAddressBuffer();
         }
 
-        internal SocketError DoOperationSendTo(SafeCloseSocket handle, out int bytesTransferred)
+        internal SocketError DoOperationSendTo(SafeCloseSocket handle)
         {
             PrepareIOCPOperation();
 
+            int bytesTransferred;
             SocketError socketError;
             if (_buffer != null)
             {
@@ -696,12 +693,7 @@ namespace System.Net.Sockets
                     IntPtr.Zero);
             }
 
-            if (socketError == SocketError.SocketError)
-            {
-                socketError = SocketPal.GetLastSocketError();
-            }
-
-            return socketError;
+            return ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred);
         }
 
         // Ensures Overlapped object exists for operations that need no data buffer.
@@ -1218,7 +1210,7 @@ namespace System.Net.Sockets
 
                 if (socketError == SocketError.Success)
                 {
-                    FinishOperationSuccess(socketError, (int)numBytes, socketFlags);
+                    FinishOperationAsyncSuccess((int)numBytes, SocketFlags.None);
                 }
                 else
                 {
@@ -1249,6 +1241,7 @@ namespace System.Net.Sockets
                             }
                         }
                     }
+
                     FinishOperationAsyncFailure(socketError, (int)numBytes, socketFlags);
                 }
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFromAsync.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFromAsync.cs
@@ -44,7 +44,11 @@ namespace System.Net.Sockets.Tests
                     args.Completed += OnCompleted;
                     args.UserToken = completed;
 
-                    Assert.True(receiver.ReceiveMessageFromAsync(args));
+                    bool pending = receiver.ReceiveMessageFromAsync(args);
+                    if (!pending)
+                    {
+                        OnCompleted(null, args);
+                    }
 
                     Assert.True(completed.WaitOne(TestSettings.PassingTestTimeout), "Timeout while waiting for connection");
 
@@ -84,7 +88,11 @@ namespace System.Net.Sockets.Tests
                     args.Completed += OnCompleted;
                     args.UserToken = completed;
 
-                    Assert.True(receiver.ReceiveMessageFromAsync(args));
+                    bool pending = receiver.ReceiveMessageFromAsync(args);
+                    if (!pending)
+                    {
+                        OnCompleted(null, args);
+                    }
 
                     Assert.True(completed.WaitOne(TestSettings.PassingTestTimeout), "Timeout while waiting for connection");
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/Shutdown.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/Shutdown.cs
@@ -30,7 +30,11 @@ namespace System.Net.Sockets.Tests
                         args.SetBuffer(new byte[1], 0, 1);
                         args.UserToken = client;
 
-                        Assert.True(client.ReceiveAsync(args));
+                        bool pending = client.ReceiveAsync(args);
+                        if (!pending)
+                        {
+                            OnOperationCompleted(null, args);
+                        }
                         break;
                     }
 
@@ -43,7 +47,11 @@ namespace System.Net.Sockets.Tests
                             break;
                         }
 
-                        Assert.True(client.SendAsync(args));
+                        bool pending = client.SendAsync(args);
+                        if (!pending)
+                        {
+                            OnOperationCompleted(null, args);
+                        }
                         break;
                     }
 
@@ -52,7 +60,12 @@ namespace System.Net.Sockets.Tests
                         var client = (Socket)args.UserToken;
 
                         Assert.True(args.BytesTransferred == args.Buffer.Length);
-                        Assert.True(client.ReceiveAsync(args));
+
+                        bool pending = client.ReceiveAsync(args);
+                        if (!pending)
+                        {
+                            OnOperationCompleted(null, args);
+                        }
                         break;
                     }
             }

--- a/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
@@ -70,9 +70,11 @@ namespace System.Net.Sockets.Tests
 
                 using (Socket sock = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
                 {
-                    Assert.True(sock.ConnectAsync(args));
-
-                    await complete.Task;
+                    bool willRaiseEvent = sock.ConnectAsync(args);
+                    if (willRaiseEvent)
+                    {
+                        await complete.Task;
+                    }
 
                     Assert.Equal(SocketError.Success, args.SocketError);
                     Assert.Null(args.ConnectByNameError);


### PR DESCRIPTION
We complete all I/O asynchronously, even when the underlying OS operation actually completed synchronously.

Fix this so that both Windows and Unix can do synchronous socket completions.

@stephentoub @CIPop @davidsh @Priya91 