### PR TITLE
Remove SSRP for TCP connections without port and Instance name

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -264,8 +264,7 @@ namespace System.Data.SqlClient.SNI
 
             if (serverNamePartsByComma.Length < 2 && serverNamePartsByBackSlash.Length < 2)
             {
-                int defaultInstancePort = TryToGetDefaultInstancePort(fullServerName);
-                return new SNITCPHandle(fullServerName, (defaultInstancePort > 0 ? defaultInstancePort : DefaultSqlServerPort), timerExpire, callbackObject, parallel);
+                return new SNITCPHandle(fullServerName, DefaultSqlServerPort, timerExpire, callbackObject, parallel);
             }
             else if (serverNamePartsByComma.Length == 2 && serverNamePartsByBackSlash.Length < 2)
             {


### PR DESCRIPTION
Fixes #15089

The fix is to bring the behavior in sync with Windows Version of SqlClient. Comment https://github.com/dotnet/corefx/issues/15089#issuecomment-272268114 describes the behavior.

I ran a test to connect to Azure using Managed version of SNI on Windows. 
With this change, 30 connnections to Azure SQL take about 13500 ms vs ~24000 ms before the change. 

cc @corivera  @geleems 