### PR TITLE
System.Xml.XmlSchemaSet.Tests fix

### DIFF
--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet.cs
@@ -8,11 +8,6 @@ namespace System.Xml.Tests
 {
     public class TestData
     {
-        static TestData()
-        {
-            AppContext.SetSwitch("TestSwitch.LocalAppContext.DisableCaching", true);
-        }
-        
         internal static string _Root = Path.Combine("TestFiles", "TestData");
         internal static string StandardPath = Path.Combine("TestFiles", "StandardTests");
         internal static string _FileXSD1 = Path.Combine(_Root, "schema1.xsd");
@@ -37,5 +32,13 @@ namespace System.Xml.Tests
         internal static string _XsdNoNs = Path.Combine(_Root, "nons.xsd");
 
         internal static string _SchemaXdr = Path.Combine(_Root, "schema1.xdr");
+    }
+
+    public class TC_SchemaSetBase
+    {
+        static TC_SchemaSetBase()
+        {
+            AppContext.SetSwitch("TestSwitch.LocalAppContext.DisableCaching", true);
+        }
     }
 }

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_Reader.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_Reader.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Xml.Tests
 {
-    public class TC_SchemaSet_Add_Reader
+    public class TC_SchemaSet_Add_Reader : TC_SchemaSetBase
     {
         [Fact]
         public void NullNamespaceAndNullReader()

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_Schema.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_Schema.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 
 namespace System.Xml.Tests
 {
-    public class TC_SchemaSet_Add_Schema
+    public class TC_SchemaSet_Add_Schema : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
         public TC_SchemaSet_Add_Schema(ITestOutputHelper output)

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_SchemaSet.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_SchemaSet.cs
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 
 namespace System.Xml.Tests
 {
-    public class TC_SchemaSet_Add_SchemaSet
+    public class TC_SchemaSet_Add_SchemaSet : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_URL.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_URL.cs
@@ -10,7 +10,7 @@ using System.Xml.XPath;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_Add_URL", Desc = "")]
-    public class TC_SchemaSet_Add_URL
+    public class TC_SchemaSet_Add_URL : TC_SchemaSetBase
     {
         //-----------------------------------------------------------------------------------
         [Fact]

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_AllowXmlAttributes.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_AllowXmlAttributes.cs
@@ -10,7 +10,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_AllowXmlAttributes", Desc = "")]
-    public class TC_SchemaSet_AllowXmlAttributes
+    public class TC_SchemaSet_AllowXmlAttributes : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -10,7 +10,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_Compile", Desc = "", Priority = 0)]
-    public class TC_SchemaSet_Compile
+    public class TC_SchemaSet_Compile : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Constructors.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Constructors.cs
@@ -9,7 +9,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_Constructors", Desc = "", Priority = 0)]
-    public class TC_SchemaSet_Constructors
+    public class TC_SchemaSet_Constructors : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Contains_ns.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Contains_ns.cs
@@ -9,7 +9,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_Contains_ns", Desc = "")]
-    public class TC_SchemaSet_Contains_ns
+    public class TC_SchemaSet_Contains_ns : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Contains_schema.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Contains_schema.cs
@@ -9,7 +9,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_Contains_Schema", Desc = "")]
-    public class TC_SchemaSet_Contains_Schema
+    public class TC_SchemaSet_Contains_Schema : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_CopyTo.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_CopyTo.cs
@@ -10,7 +10,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_CopyTo", Desc = "")]
-    public class TC_SchemaSet_CopyTo
+    public class TC_SchemaSet_CopyTo : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Count.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Count.cs
@@ -10,7 +10,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_Count", Desc = "", Priority = 0)]
-    public class TC_SchemaSet_Count
+    public class TC_SchemaSet_Count : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_EnableUpaCheck.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_EnableUpaCheck.cs
@@ -10,7 +10,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_EnableUpaCheck", Desc = "")]
-    public class TC_SchemaSet_EnableUpaCheck
+    public class TC_SchemaSet_EnableUpaCheck : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_GlobalAttributes.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_GlobalAttributes.cs
@@ -10,7 +10,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_GlobalAttributes", Desc = "")]
-    public class TC_SchemaSet_GlobalAttributes
+    public class TC_SchemaSet_GlobalAttributes : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_GlobalElements.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_GlobalElements.cs
@@ -10,7 +10,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_GlobalElements", Desc = "")]
-    public class TC_SchemaSet_GlobalElements
+    public class TC_SchemaSet_GlobalElements : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_GlobalTypes.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_GlobalTypes.cs
@@ -10,7 +10,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_GlobalTypes", Desc = "")]
-    public class TC_SchemaSet_GlobalTypes
+    public class TC_SchemaSet_GlobalTypes : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Imports.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Imports.cs
@@ -10,7 +10,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_Imports", Desc = "")]
-    public class TC_SchemaSet_Imports
+    public class TC_SchemaSet_Imports : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Includes.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Includes.cs
@@ -10,7 +10,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_Includes", Desc = "")]
-    public class TC_SchemaSet_Includes
+    public class TC_SchemaSet_Includes : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_IsCompiled.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_IsCompiled.cs
@@ -9,7 +9,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_IsCompiled", Desc = "")]
-    public class TC_SchemaSet_IsCompiled
+    public class TC_SchemaSet_IsCompiled : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Misc.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Misc.cs
@@ -11,7 +11,7 @@ using System.Xml.XPath;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_Misc", Desc = "")]
-    public class TC_SchemaSet_Misc
+    public class TC_SchemaSet_Misc : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_ProhibitDTD.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_ProhibitDTD.cs
@@ -10,7 +10,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_ProhibitDTD", Desc = "")]
-    public class TC_SchemaSet_ProhibitDTD
+    public class TC_SchemaSet_ProhibitDTD : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Remove.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Remove.cs
@@ -11,7 +11,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_Remove", Desc = "")]
-    public class TC_SchemaSet_Remove
+    public class TC_SchemaSet_Remove : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_RemoveRecursive.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_RemoveRecursive.cs
@@ -11,7 +11,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_RemoveRecursive", Desc = "")]
-    public class TC_SchemaSet_RemoveRecursive
+    public class TC_SchemaSet_RemoveRecursive : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Reprocess.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Reprocess.cs
@@ -10,7 +10,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_Reprocess", Desc = "", Priority = 1)]
-    public class TC_SchemaSet_Reprocess
+    public class TC_SchemaSet_Reprocess : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Schemas.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Schemas.cs
@@ -10,7 +10,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_Schemas", Desc = "")]
-    public class TC_SchemaSet_Schemas
+    public class TC_SchemaSet_Schemas : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Schemas_NS.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Schemas_NS.cs
@@ -10,7 +10,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_Schemas_ns", Desc = "")]
-    public class TC_SchemaSet_Schemas_ns
+    public class TC_SchemaSet_Schemas_ns : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_ValidationEventHandler.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_ValidationEventHandler.cs
@@ -10,7 +10,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_ValidationEventHandler", Desc = "")]
-    public class TC_SchemaSet_ValidationEventHandler
+    public class TC_SchemaSet_ValidationEventHandler : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlNameTable.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlNameTable.cs
@@ -9,7 +9,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_XmlNameTable", Desc = "")]
-    public class TC_SchemaSet_XmlNameTable
+    public class TC_SchemaSet_XmlNameTable : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlResolver.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlResolver.cs
@@ -10,7 +10,7 @@ using System.Xml.Schema;
 namespace System.Xml.Tests
 {
     //[TestCase(Name = "TC_SchemaSet_XmlResolver", Desc = "")]
-    public class TC_SchemaSet_XmlResolver
+    public class TC_SchemaSet_XmlResolver : TC_SchemaSetBase
     {
         private ITestOutputHelper _output;
 
@@ -94,7 +94,6 @@ namespace System.Xml.Tests
         }
 
         //[Variation(Desc = "v4 - schema(Local)->schema(Local)", Priority = 1)]
-        [ActiveIssue(14918)]
         [Fact]
         public void v4()
         {
@@ -110,7 +109,6 @@ namespace System.Xml.Tests
         }
 
         //[Variation(Desc = "v5 - schema(Local)->schema(Local)->schema(Local)", Priority = 1)]
-        [ActiveIssue(14918)]
         [Fact]
         public void v5()
         {

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/XmlSystemPathResolverTests.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/XmlSystemPathResolverTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Xml.Tests
 {
-    public class XmlSystemPathResolverTests
+    public class XmlSystemPathResolverTests : TC_SchemaSetBase
     {
         private const int k_getUniqueFileNameAttempts = 10;
 


### PR DESCRIPTION
Fixes #14918

Didn't get a repro even with a 100 times run with Helix repro tool. My guess of the failure was a timing thing because I was setting `DisableCaching` to `true` on `TestData`, so probably a test that didn't referenced `TestData` but did needed a switch value got it before caching was disable and that caused the failure. So I changed the approach to have a base class where all the tests in `System.Xml.XmlSchemaSet.Tests` inherit and on a static constructor disable caching so that we ensure that no matter what is the tests' timing or execution order `DisableCaching` is set to true from the beginning.

Will run CI tests multiple times before merging to make sure it passes multiple times and we should leave this tests enabled at least one day if they fail again to see if the failure is consistent.

/cc @sepidehMS @AlexGhiondea @danmosemsft 