### PR TITLE
Symbol indexing has some minor dependency on ConfigurationGroup env variable

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -410,6 +410,9 @@
     },
     "PB_ToolPackageSource": {
       "value": "https://www.myget.org/F/dagood-test-buildtools/api/v3/index.json"
+    },
+    "ConfigurationGroup": {
+      "value": "$(PB_ConfigurationGroup)"
     }
   },
   "retentionRules": [
@@ -449,7 +452,6 @@
     "checkoutSubmodules": false
   },
   "quality": "definition",
-  "defaultBranch": "refs/heads/master",
   "queue": {
     "pool": {
       "id": 39,


### PR DESCRIPTION
If you got to the artifacts tab or a recent dev/eng build, you'll see that the Symbols folder is named `Symbols_$(ConfigurationGroup)`.  I *think* that this is the only dependency, and things still appear to work even without setting the ConfigurationGroup property.  But, it's possible that there is some other dependency in the task on the variable...

https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build?_a=summary&buildId=519500&tab=artifacts

It's possible that VSTS won't properly resolve ConfigurationGroup=$(PB_ConfigurationGroup), I won't know until we have a job run with this change.  It is unlikely that, even if that is the case, it would cause any behavior other than what is currently happening.

I'm not certain why "defaultBranch" was removed when saving the updated build definition, presumably some change on the VSTS side specifying that it's not required if it's master.  

/cc @weshaggard 