### PR TITLE
Adding temporal hack to sync.sh to avoid Assembly loading issue

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -5,5 +5,17 @@ if [ $# == 0 ]; then
 fi
 
 working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+$working_tree_root/init-tools.sh
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+
+# Building CoreFx.Tools before calling build-managed.sh to workaround an Assembly loading bug caused by the new cli host.
+"$working_tree_root/Tools/msbuild.sh" "$working_tree_root/src/Tools/CoreFx.Tools/CoreFx.Tools.csproj /v:m /m"
+if [ $? -ne 0 ];then
+   exit 1
+fi
+
 $working_tree_root/run.sh sync $__args $*
 exit $?


### PR DESCRIPTION
Fixing sync.sh assembly loading issue.

cc: @chcosta @weshaggard 