### PR TITLE
Fixing documentation for code coverage

### DIFF
--- a/Documentation/building/code-coverage.md
+++ b/Documentation/building/code-coverage.md
@@ -35,10 +35,12 @@ Code coverage runs are performed by Jenkins approximately twice a day.  The resu
 You can perform code coverage runs locally on your own machine.  Normally to build your entire CoreFX repo, from the root of your repo you'd run:
 
     build
+    build-tests
 
-To include code coverage in this run, augment it with the `coverage` argument:
+To include code coverage in this run, augment the `build-tests` call with the `coverage` argument:
 
-    build -coverage
+    build
+    build-tests -coverage
 
 This will do the build and testing as with the normal ```build```, but it will run the tests using the OpenCover tool.  A resulting index.htm file providing the results of the run will be available at:
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -55,7 +55,7 @@ def buildArchConfiguration = ['Debug': 'x86',
         def isLocal = (localType == 'local')
 
         def newJobName = 'code_coverage_windows'
-        def batchCommand = 'call build.cmd -coverage -outerloop -- /p:WithoutCategories=IgnoreForCI'
+        def batchCommand = 'call build.cmd && call build-tests.cmd -coverage -outerloop -- /p:WithoutCategories=IgnoreForCI'
         if (isLocal) {
             newJobName = "${newJobName}_local"
             batchCommand = "${batchCommand}"


### PR DESCRIPTION
Fixing docs for code coverage runs

Note: I'm not skipping CI since I'll use this PR to validate outerloop and coverage runs.

cc: @weshaggard 