### PR TITLE
Add a "Helix Test" step to the official build definitions

### DIFF
--- a/Tools-Override/Build.Post.targets
+++ b/Tools-Override/Build.Post.targets
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+    enables cloud-distributed testing.  please see target VerifyInputs
+    in CloudTest.targets for the complete list of required properties.
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)CloudTest.targets" Condition="'$(EnableCloudTest)' == 'true'" />
+
+</Project>

--- a/Tools-Override/Build.Post.targets
+++ b/Tools-Override/Build.Post.targets
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <Target Name="CloudBuild" Condition="'$(EnableCloudTest)' != 'true'" />
+
   <!--
     enables cloud-distributed testing.  please see target VerifyInputs
     in CloudTest.targets for the complete list of required properties.
   -->
   <Import Project="$(MSBuildThisFileDirectory)CloudTest.targets" Condition="'$(EnableCloudTest)' == 'true'" />
-
-  <Target Name="CloudBuild" Condition="'$(EnableCloudTest)' != 'true'" />
 
 </Project>

--- a/Tools-Override/Build.Post.targets
+++ b/Tools-Override/Build.Post.targets
@@ -7,4 +7,6 @@
   -->
   <Import Project="$(MSBuildThisFileDirectory)CloudTest.targets" Condition="'$(EnableCloudTest)' == 'true'" />
 
+  <Target Name="CloudBuild" Condition="'$(EnableCloudTest)' != 'true'" />
+
 </Project>

--- a/Tools-Override/CloudTest.targets
+++ b/Tools-Override/CloudTest.targets
@@ -408,7 +408,7 @@
 
   <Target Name="CompressRuntimeDir" Condition="'$(SkipArchive)' != 'true'">
     <ZipFileCreateFromDirectory
-        SourceDirectory="$(RuntimePath)"
+        SourceDirectory="$(TestSharedFxDir)"
         DestinationArchive="$(TestRuntimeArchiveFile)"
         OverwriteDestination="true" />
     <ItemGroup>

--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -28,9 +28,15 @@
 
   <PropertyGroup>
     <XunitRuntimeConfig>$(ToolsDir)\xunit.console.netcore.runtimeconfig.json</XunitRuntimeConfig>
-    <TestHostExecutablePath Condition="'$(OS)'=='Windows_NT' AND '$(TestHostExecutablePath)' == ''">$(TestSharedFxDir)\dotnet.exe</TestHostExecutablePath>
-    <TestHostExecutablePath Condition="'$(OS)'!='Windows_NT' AND '$(TestHostExecutablePath)' == ''">$(TestSharedFxDir)\dotnet</TestHostExecutablePath>
-    <XunitExecutable Condition="'$(XunitExecutable)' == ''">$(TestPath)\xunit.console.netcore.exe</XunitExecutable>
+    <TestRuntimeEnvVar Condition="'$(OS)' == 'Windows_NT'">%RUNTIME_PATH%\</TestRuntimeEnvVar>
+    <TestRuntimeEnvVar Condition="'$(OS)' != 'Windows_NT'">$RUNTIME_PATH/</TestRuntimeEnvVar>
+    <TestHostExecutablePath Condition="'$(OS)'=='Windows_NT' AND '$(TestHostExecutablePath)' == ''">$(TestRuntimeEnvVar)dotnet.exe</TestHostExecutablePath>
+    <TestHostExecutablePath Condition="'$(OS)'!='Windows_NT' AND '$(TestHostExecutablePath)' == ''">$(TestRuntimeEnvVar)dotnet</TestHostExecutablePath>
+
+    <ExecutionDirEnvVar Condition="'$(OS)' == 'Windows_NT'">%EXECUTION_DIR%\</ExecutionDirEnvVar>
+    <ExecutionDirEnvVar Condition="'$(OS)' != 'Windows_NT'">$EXECUTION_DIR/</ExecutionDirEnvVar>
+    <XunitExecutable Condition="'$(XunitExecutable)' == ''">$(ExecutionDirEnvVar)xunit.console.netcore.exe</XunitExecutable>
+
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
 
@@ -188,7 +194,7 @@
 
     <MakeDir Condition="'$(CoverageEnabledForProject)'=='true'" Directories="$(CoverageReportDir)" />
 
-    <Exec Command="$(TestPath)/$(RunnerScriptName) $(RuntimePath)"
+    <Exec Command="$(TestPath)/$(RunnerScriptName) $(TestSharedFxDir)"
           CustomErrorRegularExpression="Failed: [^0]"
           ContinueOnError="true"
           IgnoreStandardErrorWarningFormat="true"

--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -227,7 +227,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/Tools/msbuild.sh src/tests.builds /t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=$(PB_TestProduct)\" /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:FilterToOSGroup=Linux /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
+        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/tests.builds /t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=$(PB_TestProduct)\" /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:FilterToOSGroup=Linux /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -227,7 +227,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/Tools/msbuild.sh src/tests.builds /t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=$(PB_TestProduct)\" /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
+        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/Tools/msbuild.sh src/tests.builds /t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=$(PB_TestProduct)\" /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:FilterToOSGroup=Linux /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -227,7 +227,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/Tools/msbuild.sh src/tests.builds /t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=corefx\" /p:\"Branch=master\" /p:\"CloudDropAccountName=dotnetbuilddrops\" /p:\"CloudResultsAccountName=dotnetjobresults\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(PB_CloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:\"HelixApiAccessKey=$(PB_HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
+        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/Tools/msbuild.sh src/tests.builds /t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=corefx\" /p:\"Branch=master\" /p:\"CloudDropAccountName=dotnetbuilddrops\" /p:\"CloudResultsAccountName=dotnetjobresults\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -209,7 +209,25 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/build-tests.sh -buildArch=$(PB_Platform) -$(PB_ConfigurationGroup) -SkipTests",
+        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/build-tests.sh -buildArch=$(PB_Platform) -$(PB_ConfigurationGroup) -SkipTests -- /p:ArchiveTests=true",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create Helix Test Jobs",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/Tools/msbuild.sh src/tests.builds /t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=corefx\" /p:\"Branch=master\" /p:\"CloudDropAccountName=dotnetbuilddrops\" /p:\"CloudResultsAccountName=dotnetjobresults\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(PB_CloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:\"HelixApiAccessKey=$(PB_HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -441,6 +459,10 @@
     },
     "PB_AdditionalArguments": {
       "value": ""
+    },
+    "PB_EnableCloudTest": {
+      "value": "true",
+      "allowOverride": true
     }
   },
   "demands": [

--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -227,7 +227,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/Tools/msbuild.sh src/tests.builds /t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=corefx\" /p:\"Branch=master\" /p:\"CloudDropAccountName=dotnetbuilddrops\" /p:\"CloudResultsAccountName=dotnetjobresults\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
+        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/Tools/msbuild.sh src/tests.builds /t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=$(PB_TestProduct)\" /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
@@ -155,7 +155,7 @@
       },
       "inputs": {
         "filename": "$(Agent.BuildDirectory)/s/corefx/Tools/msbuild.sh",
-        "arguments": "/t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=corefx\" /p:\"Branch=master\" /p:\"CloudDropAccountName=dotnetbuilddrops\" /p:\"CloudResultsAccountName=dotnetjobresults\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(PB_CloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=OSX\" /p:\"HelixApiAccessKey=$(PB_HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
+        "arguments": "/t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=corefx\" /p:\"Branch=master\" /p:\"CloudDropAccountName=dotnetbuilddrops\" /p:\"CloudResultsAccountName=dotnetjobresults\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=OSX\" /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
@@ -155,7 +155,7 @@
       },
       "inputs": {
         "filename": "$(Agent.BuildDirectory)/s/corefx/Tools/msbuild.sh",
-        "arguments": "/t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=$(PB_TestProduct)\" /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=OSX\" /p:FilterToOSGroup=OSX /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
+        "arguments": "$(Agent.BuildDirectory)/s/corefx/src/tests.builds /t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=$(PB_TestProduct)\" /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=OSX\" /p:FilterToOSGroup=OSX /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
@@ -155,7 +155,7 @@
       },
       "inputs": {
         "filename": "$(Agent.BuildDirectory)/s/corefx/Tools/msbuild.sh",
-        "arguments": "/t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=corefx\" /p:\"Branch=master\" /p:\"CloudDropAccountName=dotnetbuilddrops\" /p:\"CloudResultsAccountName=dotnetjobresults\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=OSX\" /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
+        "arguments": "/t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=$(PB_TestProduct)\" /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=OSX\" /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
@@ -155,7 +155,7 @@
       },
       "inputs": {
         "filename": "$(Agent.BuildDirectory)/s/corefx/Tools/msbuild.sh",
-        "arguments": "/t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=$(PB_TestProduct)\" /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=OSX\" /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
+        "arguments": "/t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=$(PB_TestProduct)\" /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=OSX\" /p:FilterToOSGroup=OSX /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
@@ -137,8 +137,26 @@
       },
       "inputs": {
         "filename": "$(Agent.BuildDirectory)/s/corefx/build-tests.sh",
-        "arguments": "-buildArch=$(PB_Platform) -$(PB_ConfigurationGroup) -SkipTests",
+        "arguments": "-buildArch=$(PB_Platform) -$(PB_ConfigurationGroup) -SkipTests -- /p:ArchiveTests=true",
         "workingFolder": "$(Agent.BuildDirectory)/s/corefx/",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create Helix Test Jobs",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(Agent.BuildDirectory)/s/corefx/Tools/msbuild.sh",
+        "arguments": "/t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=corefx\" /p:\"Branch=master\" /p:\"CloudDropAccountName=dotnetbuilddrops\" /p:\"CloudResultsAccountName=dotnetjobresults\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(PB_CloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=OSX\" /p:\"HelixApiAccessKey=$(PB_HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },
@@ -262,6 +280,10 @@
     },
     "Build.Clean": {
       "value": "all"
+    },
+    "PB_EnableCloudTest": {
+      "value": "true",
+      "allowOverride": true
     }
   },
   "demands": [
@@ -303,7 +325,6 @@
     "checkoutSubmodules": false
   },
   "quality": "definition",
-  "defaultBranch": "refs/heads/master",
   "queue": {
     "pool": {
       "id": 39,

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -159,9 +159,36 @@
       },
       "inputs": {
         "filename": "$(Build.SourcesDirectory)\\corefx\\build-tests.cmd",
-        "arguments": "-buildArch=$(PB_Platform) -$(PB_ConfigurationGroup) -SkipTests -- /p:RuntimeOS=$(PB_RuntimeOS)",
+        "arguments": "-buildArch=$(PB_Platform) -$(PB_ConfigurationGroup) -SkipTests -- /p:RuntimeOS=$(PB_RuntimeOS) /p:ArchiveTests=true",
         "workingFolder": "corefx",
         "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create Helix Test Jobs",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "solution": "src\\tests.builds",
+        "platform": "",
+        "configuration": "",
+        "msbuildArguments": "/t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=corefx\" /p:\"Branch=master\" /p:\"CloudDropAccountName=dotnetbuilddrops\" /p:\"CloudResultsAccountName=dotnetjobresults\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(PB_CloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:\"HelixApiAccessKey=$(PB_HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
+        "clean": "false",
+        "maximumCpuCount": "false",
+        "restoreNugetPackages": "false",
+        "logProjectEvents": "false",
+        "createLogFile": "false",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "14.0",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": ""
       }
     },
     {
@@ -427,6 +454,10 @@
     },
     "PB_SymbolsBuildId": {
       "value": "DotNet-CoreFx-$(System.DefinitionId)"
+    },
+    "PB_EnableCloudTest": {
+      "value": "true",
+      "allowOverride": true
     }
   },
   "demands": [

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -179,7 +179,7 @@
         "solution": "src\\tests.builds",
         "platform": "",
         "configuration": "",
-        "msbuildArguments": "/t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=corefx\" /p:\"Branch=master\" /p:\"CloudDropAccountName=dotnetbuilddrops\" /p:\"CloudResultsAccountName=dotnetjobresults\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(PB_CloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:\"HelixApiAccessKey=$(PB_HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
+        "msbuildArguments": "/t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=corefx\" /p:\"Branch=master\" /p:\"CloudDropAccountName=dotnetbuilddrops\" /p:\"CloudResultsAccountName=dotnetjobresults\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
         "clean": "false",
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -179,7 +179,7 @@
         "solution": "$(PB_GitDirectory)\\src\\tests.builds",
         "platform": "",
         "configuration": "",
-        "msbuildArguments": "/t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=$(PB_TestProduct)\" /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
+        "msbuildArguments": "/t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=$(PB_TestProduct)\" /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
         "clean": "false",
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -176,10 +176,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "solution": "src\\tests.builds",
+        "solution": "$(PB_GitDirectory)\\src\\tests.builds",
         "platform": "",
         "configuration": "",
-        "msbuildArguments": "/t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=corefx\" /p:\"Branch=master\" /p:\"CloudDropAccountName=dotnetbuilddrops\" /p:\"CloudResultsAccountName=dotnetjobresults\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
+        "msbuildArguments": "/t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=$(PB_TestProduct)\" /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
         "clean": "false",
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -176,7 +176,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "solution": "$(PB_GitDirectory)\\src\\tests.builds",
+        "solution": "$(Build.SourcesDirectory)\\corefx\\src\\tests.builds",
         "platform": "",
         "configuration": "",
         "msbuildArguments": "/t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=$(PB_TestProduct)\" /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -91,7 +91,8 @@
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
             "PB_DockerTag": "rhel7_prereqs_2",
-            "PB_AdditionalArguments": "-portableLinux"
+            "PB_TargetQueue": "Redhat.72.Amd64",
+            "PB_AdditionalArguments": "-portableLinux",
           },
           "ReportingParameters": {
             "OperatingSystem": "RedHat 7",

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -18,7 +18,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "debian82_prereqs_2"
+            "PB_DockerTag": "debian82_prereqs_2",
+            "PB_TargetQueue": "Debian.82.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "Debian 8.2",
@@ -29,10 +30,11 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "fedora23_prereqs"
+            "PB_DockerTag": "fedora23_prereqs",
+            "PB_TargetQueue": "Fedora.23.Amd64"
           },
           "ReportingParameters": {
-            "OperatingSystem": "Fedora 2.3",
+            "OperatingSystem": "Fedora 23",
             "Type": "build/product/",
             "ConfigurationGroup": "Release"
           }
@@ -40,7 +42,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "fedora24_prereqs_v4"
+            "PB_DockerTag": "fedora24_prereqs_v4",
+            "PB_TargetQueue": "Fedora.23.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "Fedora 24",
@@ -51,7 +54,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "opensuse132_prereqs_v4"
+            "PB_DockerTag": "opensuse132_prereqs_v4",
+            "PB_TargetQueue": "Suse.132.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "openSUSE 13.2",
@@ -62,7 +66,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "opensuse421_prereqs_v3"
+            "PB_DockerTag": "opensuse421_prereqs_v3",
+            "PB_EnableCloudTest": "false"
           },
           "ReportingParameters": {
             "OperatingSystem": "openSUSE 42.1",
@@ -73,7 +78,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "rhel7_prereqs_2"
+            "PB_DockerTag": "rhel7_prereqs_2",
+            "PB_TargetQueue": "Redhat.72.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "RedHat 7",
@@ -97,7 +103,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "ubuntu1404_prereqs_v3"
+            "PB_DockerTag": "ubuntu1404_prereqs_v3",
+            "PB_TargetQueue": "Ubuntu.1404.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "Ubuntu 14.04",
@@ -108,7 +115,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "ubuntu1604_prereqs"
+            "PB_DockerTag": "ubuntu1604_prereqs",
+            "PB_TargetQueue": "Ubuntu.1604.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "Ubuntu 16.04",
@@ -119,7 +127,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "ubuntu1610_prereqs_v2"
+            "PB_DockerTag": "ubuntu1610_prereqs_v2",
+            "PB_TargetQueue": "Ubuntu.1610.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "Ubuntu 16.10",
@@ -130,7 +139,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "alpine_prereqs"
+            "PB_DockerTag": "alpine_prereqs",
+            "PB_EnableCloudTest": "false"
           },
           "ReportingParameters": {
             "OperatingSystem": "Alpine 3.4.3",
@@ -140,6 +150,9 @@
         },        
         {
           "Name": "DotNet-CoreFx-Trusted-OSX",
+          "Parameters": {
+            "PB_TargetQueue": "OSX.1011.Amd64"
+          },
           "ReportingParameters": {
             "OperatingSystem": "OSX",
             "Type": "build/product/",
@@ -149,7 +162,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
-            "PB_Platform": "arm"
+            "PB_Platform": "arm",
+            "PB_EnableCloudTest": "false"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -161,7 +175,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
-            "PB_Platform": "arm64"
+            "PB_Platform": "arm64",
+            "PB_EnableCloudTest": "false"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -173,7 +188,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
-            "PB_Platform": "x64"
+            "PB_Platform": "x64",
+            "PB_TargetQueue": "Windows.10.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -185,7 +201,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
-            "PB_Platform": "x86"
+            "PB_Platform": "x86",
+            "PB_TargetQueue": "Windows.10.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -208,7 +225,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "debian82_prereqs_2"
+            "PB_DockerTag": "debian82_prereqs_2",
+            "PB_TargetQueue": "Debian.82.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "Debian 8.2",
@@ -219,10 +237,11 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "fedora23_prereqs"
+            "PB_DockerTag": "fedora23_prereqs",
+            "PB_TargetQueue": "Fedora.23.Amd64"
           },
           "ReportingParameters": {
-            "OperatingSystem": "Fedora 2.3",
+            "OperatingSystem": "Fedora 23",
             "Type": "build/product/",
             "ConfigurationGroup": "Debug"
           }
@@ -230,7 +249,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "fedora24_prereqs_v4"
+            "PB_DockerTag": "fedora24_prereqs_v4",
+            "PB_EnableCloudTest": "false"
           },
           "ReportingParameters": {
             "OperatingSystem": "Fedora 24",
@@ -241,7 +261,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "opensuse132_prereqs_v4"
+            "PB_DockerTag": "opensuse132_prereqs_v4",
+            "PB_TargetQueue": "Suse.132.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "openSUSE 13.2",
@@ -252,7 +273,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "opensuse421_prereqs_v3"
+            "PB_DockerTag": "opensuse421_prereqs_v3",
+            "PB_EnableCloudTest": "false"
           },
           "ReportingParameters": {
             "OperatingSystem": "openSUSE 42.1",
@@ -263,7 +285,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "rhel7_prereqs_2"
+            "PB_DockerTag": "rhel7_prereqs_2",
+            "PB_TargetQueue": "Redhat.72.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "RedHat 7",
@@ -274,7 +297,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "ubuntu1404_prereqs_v3"
+            "PB_DockerTag": "ubuntu1404_prereqs_v3",
+            "PB_TargetQueue": "Ubuntu.1404.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "Ubuntu 14.04",
@@ -285,7 +309,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "ubuntu1604_prereqs"
+            "PB_DockerTag": "ubuntu1604_prereqs",
+            "PB_TargetQueue": "Ubuntu.1604.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "Ubuntu 16.04",
@@ -296,7 +321,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "ubuntu1610_prereqs_v2"
+            "PB_DockerTag": "ubuntu1610_prereqs_v2",
+            "PB_TargetQueue": "Ubuntu.1610.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "Ubuntu 16.10",
@@ -307,7 +333,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
-            "PB_DockerTag": "alpine_prereqs"
+            "PB_DockerTag": "alpine_prereqs",
+            "PB_EnableCloudTest": "false"
           },
           "ReportingParameters": {
             "OperatingSystem": "Alpine 3.4.3",
@@ -317,6 +344,9 @@
         },        
         {
           "Name": "DotNet-CoreFx-Trusted-OSX",
+          "Parameters": {
+            "PB_TargetQueue": "OSX.1011.Amd64"
+          },
           "ReportingParameters": {
             "OperatingSystem": "OSX",
             "Type": "build/product/",
@@ -326,7 +356,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
-            "PB_Platform": "arm"
+            "PB_Platform": "arm",
+            "PB_EnableCloudTest": "false"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -338,7 +369,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
-            "PB_Platform": "arm64"
+            "PB_Platform": "arm64",
+            "PB_EnableCloudTest": "false"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -350,7 +382,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
-            "PB_Platform": "x64"
+            "PB_Platform": "x64",
+            "PB_TargetQueue": "Windows.10.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -362,7 +395,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
-            "PB_Platform": "x86"
+            "PB_Platform": "x86",
+            "PB_TargetQueue": "Windows.10.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",


### PR DESCRIPTION
@karajas @chcosta 

After this, the official definition needs to be updated to pass through the following variables:

`$(PB_CloudDropAccountName)`
`$(PB_CloudResultsAccountName)`
`$(PB_CloudResultsAccessToken)`
`$(PB_HelixApiAccessKey)`
`$(PB_HelixApiEndPoint)`

Once we get a clean official build, I'll try to modify it to include the above variables and then use it to test my local branch.

NOTE: You will see that some definitions are passing "EnableCloudTest=false". These are distros that we haven't previously done Helix testing on.