### PR TITLE
Update symbol indexing

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -426,7 +426,7 @@
       "value": "true"
     },
     "PB_SymbolsBuildId": {
-      "value": "DotNet-CoreFx-Windows"
+      "value": "DotNet-CoreFx-$(System.DefinitionId)"
     }
   },
   "demands": [

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -205,7 +205,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Publish symbols path: \\\\cpvsbuild\\drops\\DotNetCore\\$(Build.DefinitionName)\\$(Build.BuildNumber)\\symbols",
+      "displayName": "Publish symbols path: \\\\cpvsbuild\\drops\\DotNetCore\\$(PB_SymbolsBuildId)\\$(Build.BuildNumber)\\symbols",
       "timeoutInMinutes": 0,
       "task": {
         "id": "0675668a-7bba-4ccb-901d-5ad6554ca653",
@@ -213,7 +213,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "SymbolsPath": "\\\\cpvsbuild\\drops\\DotNetCore\\$(Build.DefinitionName)\\$(Build.BuildNumber)\\symbols",
+        "SymbolsPath": "\\\\cpvsbuild\\drops\\DotNetCore\\$(PB_SymbolsBuildId)\\$(Build.BuildNumber)\\symbols",
         "SearchPattern": "corefx\\bin\\*$(PB_Platform).$(PB_ConfigurationGroup)\\**\\*.pdb",
         "SymbolsFolder": "",
         "SkipIndexing": "false",
@@ -221,7 +221,7 @@
         "SymbolsMaximumWaitTime": "",
         "SymbolsProduct": "",
         "SymbolsVersion": "",
-        "SymbolsArtifactName": "Symbols_$(ConfigurationGroup)"
+        "SymbolsArtifactName": "Symbols_$(PB_ConfigurationGroup)"
       }
     },
     {

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -236,7 +236,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "symbolStore": "\\\\cpvsbuild\\drops\\DotNetCore\\$(Build.DefinitionName)\\$(Build.BuildNumber)\\symbols",
+        "symbolStore": "\\\\cpvsbuild\\drops\\DotNetCore\\$(PB_SymbolsBuildId)\\$(Build.BuildNumber)\\symbols",
         "contacts": "jhendrix;mawilkie",
         "project": "DDE"
       }
@@ -424,6 +424,9 @@
     },
     "PB_CleanAgent": {
       "value": "true"
+    },
+    "PB_SymbolsBuildId": {
+      "value": "DotNet-CoreFx-Windows"
     }
   },
   "demands": [
@@ -465,7 +468,6 @@
     "checkoutSubmodules": false
   },
   "quality": "definition",
-  "defaultBranch": "refs/heads/master",
   "queue": {
     "pool": {
       "id": 39,


### PR DESCRIPTION
Use a consistent length BuildId part of the path name (DotNet-CoreFx-Windows).  Align publish and index steps to use the same path.

/cc @dagood @weshaggard 