### PR TITLE
Prefer using Array.Length as upper for loop limit

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
@@ -177,7 +177,7 @@ namespace System.Collections.Immutable
             }
 
             var array = new T[length];
-            for (int i = 0; i < length; i++)
+            for (int i = 0; i < array.Length; i++)
             {
                 array[i] = items[start + i];
             }
@@ -240,7 +240,7 @@ namespace System.Collections.Immutable
             }
 
             var array = new TResult[length];
-            for (int i = 0; i < length; i++)
+            for (int i = 0; i < array.Length; i++)
             {
                 array[i] = selector(items[i]);
             }
@@ -275,7 +275,7 @@ namespace System.Collections.Immutable
             }
 
             var array = new TResult[length];
-            for (int i = 0; i < length; i++)
+            for (int i = 0; i < array.Length; i++)
             {
                 array[i] = selector(items[i + start]);
             }
@@ -307,7 +307,7 @@ namespace System.Collections.Immutable
             }
 
             var array = new TResult[length];
-            for (int i = 0; i < length; i++)
+            for (int i = 0; i < array.Length; i++)
             {
                 array[i] = selector(items[i], arg);
             }
@@ -343,7 +343,7 @@ namespace System.Collections.Immutable
             }
 
             var array = new TResult[length];
-            for (int i = 0; i < length; i++)
+            for (int i = 0; i < array.Length; i++)
             {
                 array[i] = selector(items[i + start], arg);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -613,7 +613,7 @@ namespace System.Linq.Expressions.Interpreter
                 var boxes = new List<IStrongBox>();
                 var vars = new List<ParameterExpression>();
                 var indexes = new int[count];
-                for (int i = 0; i < count; i++)
+                for (int i = 0; i < indexes.Length; i++)
                 {
                     IStrongBox box = GetBox(node.Variables[i]);
                     if (box == null)

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuntimeOps.ExpressionQuoter.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuntimeOps.ExpressionQuoter.cs
@@ -132,7 +132,7 @@ namespace System.Runtime.CompilerServices
                 var boxes = new List<IStrongBox>();
                 var vars = new List<ParameterExpression>();
                 var indexes = new int[count];
-                for (int i = 0; i < count; i++)
+                for (int i = 0; i < indexes.Length; i++)
                 {
                     IStrongBox box = GetBox(node.Variables[i]);
                     if (box == null)

--- a/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -530,7 +530,7 @@ namespace System.Linq
         {
             ComputeKeys(elements, count);
             int[] map = new int[count];
-            for (int i = 0; i < count; i++)
+            for (int i = 0; i < map.Length; i++)
             {
                 map[i] = i;
             }

--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -563,26 +563,27 @@ namespace System.Net
             if (ipParts != null && ipParts.Length == 4 && ipParts[0] == "127")
             {
                 int i;
-                for (i = 1; i < 4; i++)
+                for (i = 1; i < ipParts.Length; i++)
                 {
-                    switch (ipParts[i].Length)
+                    string part = ipParts[i];
+                    switch (part.Length)
                     {
                         case 3:
-                            if (ipParts[i][2] < '0' || ipParts[i][2] > '9')
+                            if (part[2] < '0' || part[2] > '9')
                             {
                                 break;
                             }
                             goto case 2;
 
                         case 2:
-                            if (ipParts[i][1] < '0' || ipParts[i][1] > '9')
+                            if (part[1] < '0' || part[1] > '9')
                             {
                                 break;
                             }
                             goto case 1;
 
                         case 1:
-                            if (ipParts[i][0] < '0' || ipParts[i][0] > '9')
+                            if (part[0] < '0' || part[0] > '9')
                             {
                                 break;
                             }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -392,7 +392,7 @@ namespace System.Text.RegularExpressions
                 int max = capsize;
                 result = new int[max];
 
-                for (int i = 0; i < max; i++)
+                for (int i = 0; i < result.Length; i++)
                 {
                     result[i] = i;
                 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -201,7 +201,7 @@ namespace System.Text.RegularExpressions
                     {
                         int[] newarray = new int[256];
 
-                        for (int k = 0; k < 256; k++)
+                        for (int k = 0; k < newarray.Length; k++)
                             newarray[k] = last - beforefirst;
 
                         if (i == 0)


### PR DESCRIPTION
The JIT can't eliminate range checks if it can't "see" `Length` and uses loop cloning which generates a lot of code. Even in cases where not all range checks can be eliminated and loop cloning is used anyway it's still preferable to have fewer range checks.

For example, a loop like the one from `CookieContainer.IsLocalDomain` is ~1.8x smaller (421 bytes vs. 230 bytes) despite the fact that loop cloning is still being used.