### PR TITLE
Add portable linux flavor for NETCoreApp package

### DIFF
--- a/config.json
+++ b/config.json
@@ -242,7 +242,7 @@
         "portableLinux":{
           "description": "Make the build-native script generate binaries that are portable over glibc based Linux distros.",
           "settings": {
-            "FilterToOSGroup":"linux"
+            "RuntimeOS":"linux"
           }
         },
         "tests": {

--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.props
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.props
@@ -37,6 +37,7 @@
     <OfficialBuildRID Include="debian.8-x64" />
     <OfficialBuildRID Include="fedora.23-x64" />
     <OfficialBuildRID Include="fedora.24-x64" />
+    <OfficialBuildRID Include="linux-x64" />
     <OfficialBuildRID Include="opensuse.13.2-x64" />
     <OfficialBuildRID Include="opensuse.42.1-x64" />
     <OfficialBuildRID Include="osx.10.10-x64" />


### PR DESCRIPTION
Add linux-x64 to the lineup for NETCoreApp.  We need a build definition for this @chcosta.

I would imagine that the build definition does something to tell the native build to produce portable binaries and passes in /p:PackageRID=linux-x64 to tell packaging to produce a package with a different RID than the native system (alternatively pass in RuntimeOS=linux-x64, if that'd work).