### PR TITLE
Fix exception when parsing HTTP/2 status line

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlResponseHeaderReader.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlResponseHeaderReader.cs
@@ -31,13 +31,20 @@ namespace System.Net.Http
             int index = HttpPrefix.Length;
             int majorVersion = _span.ReadInt(ref index);
             CheckResponseMsgFormat(majorVersion != 0);
+            CheckResponseMsgFormat(index < _span.Length);
 
-            CheckResponseMsgFormat(index < _span.Length && _span[index] == '.');
-            index++;
+            int minorVersion;
+            if (_span[index] == '.')
+            {
+                index++;
 
-            // Need minor version.
-            CheckResponseMsgFormat(index < _span.Length && _span[index] >= '0' && _span[index] <= '9');
-            int minorVersion = _span.ReadInt(ref index);
+                CheckResponseMsgFormat(index < _span.Length && _span[index] >= '0' && _span[index] <= '9');
+                minorVersion = _span.ReadInt(ref index);
+            }
+            else
+            {
+                minorVersion = 0;
+            }
 
             CheckResponseMsgFormat(_span.SkipSpace(ref index));
 

--- a/src/System.Net.Http/tests/UnitTests/Headers/CurlResponseHeaderReaderTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/CurlResponseHeaderReaderTest.cs
@@ -15,6 +15,7 @@ namespace System.Net.Http.Tests
         private const string MissingSpaceFormat = "HTTP/1.1 {0}InvalidPhrase";
 
         private const string StatusCodeVersionFormat = "HTTP/{0}.{1} 200 OK";
+        private const string StatusCodeMajorVersionOnlyFormat = "HTTP/{0} 200 OK";
 
         private const string ValidHeader = "Content-Type: text/xml; charset=utf-8";
         private const string HeaderNameWithInvalidChar = "Content{0}Type: text/xml; charset=utf-8";
@@ -23,7 +24,7 @@ namespace System.Net.Http.Tests
 
         public static readonly IEnumerable<object[]> ValidStatusCodeLines = GetStatusCodeLines(StatusCodeTemplate);
         public static readonly IEnumerable<object[]> InvalidStatusCodeLines = GetStatusCodeLines(MissingSpaceFormat);
-        public static readonly IEnumerable<object[]> StatusCodeVersionLines = GetStatusCodeLinesForVersions(1, 10);
+        public static readonly IEnumerable<object[]> StatusCodeVersionLines = GetStatusCodeLinesForMajorVersions(1, 10).Concat(GetStatusCodeLinesForMajorMinorVersions(1, 10));
         public static readonly IEnumerable<object[]> InvalidHeaderLines = GetInvalidHeaderLines();
 
         private static IEnumerable<object[]> GetStatusCodeLines(string template)
@@ -35,7 +36,15 @@ namespace System.Net.Http.Tests
             }
         }
 
-        private static IEnumerable<object[]> GetStatusCodeLinesForVersions(int min, int max)
+        private static IEnumerable<object[]> GetStatusCodeLinesForMajorVersions(int min, int max)
+        {
+            for(int major = min; major < max; major++)
+            {
+                yield return new object[] { string.Format(StatusCodeMajorVersionOnlyFormat, major), major, 0 };
+            }
+        }
+
+        private static IEnumerable<object[]> GetStatusCodeLinesForMajorMinorVersions(int min, int max)
         {
             for(int major = min; major < max; major++)
             {
@@ -104,6 +113,11 @@ namespace System.Net.Http.Tests
                     {
                         expectedMajor = 1;
                         expectedMinor = minor;
+                    }
+                    else if (major == 2 && minor == 0)
+                    {
+                        expectedMajor = 2;
+                        expectedMinor = 0;
                     }
 
                     Assert.Equal(expectedMajor, response.Version.Major);


### PR DESCRIPTION
Related issue: #14715

It appears that `CurlResponseHeaderReader` and it's tests always assume that the HTTP status line starts with a string `HTTP/x.y` where `x` and `y` are the HTTP major and minor version numbers, respectively.

For HTTP 2, the status line is `HTTP/2` followed by a space and then the rest of the line. There is no `.` character to delimit between major and minor versions.

I believe this PR should be OK to merge unless you strictly require a unit test. In this area, I'm unsure as to how to modify `CurlResponseParseUtilsTest` and the `MemberData` provided to the test in order to create new test cases for `HTTP/2` for all tests. Can I get a hand with including HTTP/2 unit tests?

Thanks.