### PR TITLE
Update CodeDom TempFileCollection to match .net API

### DIFF
--- a/src/System.CodeDom/ref/System.CodeDom.cs
+++ b/src/System.CodeDom/ref/System.CodeDom.cs
@@ -1215,6 +1215,7 @@ namespace System.CodeDom.Compiler
         public string AddExtension(string fileExtension, bool keepFile) { throw null; }
         public void AddFile(string fileName, bool keepFile) { }
         public void CopyTo(string[] fileNames, int start) { }
+        public void Delete() { }
         protected virtual void Dispose(bool disposing) { }
         ~TempFileCollection() { }
         public System.Collections.IEnumerator GetEnumerator() { throw null; }

--- a/src/System.CodeDom/src/System/CodeDom/Compiler/TempFiles.cs
+++ b/src/System.CodeDom/src/System/CodeDom/Compiler/TempFiles.cs
@@ -143,6 +143,11 @@ namespace System.CodeDom.Compiler
             return keep != null ? (bool)keep : false;
         }
 
+        public void Delete()
+        {
+            SafeDelete();
+        }
+
         internal void Delete(string fileName)
         {
             try

--- a/src/System.CodeDom/tests/CodeCollections/TempFileCollectionTests.cs
+++ b/src/System.CodeDom/tests/CodeCollections/TempFileCollectionTests.cs
@@ -248,6 +248,31 @@ namespace System.CodeDom.Tests
             }
         }
 
+        [Fact]
+        public void Delete()
+        {
+            string directory = TempDirectory();
+            string filePath1 = Path.Combine(directory, "file1.extension");
+
+            File.Create(filePath1).Dispose();
+
+            try
+            {
+                using (var collection = new TempFileCollection(directory))
+                {
+                    collection.AddFile(filePath1, false);
+                    Assert.True(File.Exists(filePath1));
+                    collection.Delete();
+                    Assert.False(File.Exists(filePath1));
+                    Assert.Equal(0, collection.Count);
+                }
+            }
+            finally
+            {
+                File.Delete(filePath1);
+            }
+        }
+
         private static string s_tempDirectory = null;
         private static string TempDirectory()
         {

--- a/src/shims/ApiCompatBaseline.netfx461.txt
+++ b/src/shims/ApiCompatBaseline.netfx461.txt
@@ -1011,7 +1011,6 @@ MembersMustExist : Member 'System.CodeDom.Compiler.CompilerParameters.Evidence.s
 MembersMustExist : Member 'System.CodeDom.Compiler.CompilerResults.Evidence.get()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.CodeDom.Compiler.CompilerResults.Evidence.set(System.Security.Policy.Evidence)' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.CodeDom.Compiler.GeneratedCodeAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
-MembersMustExist : Member 'System.CodeDom.Compiler.TempFileCollection.Delete()' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.ComponentModel.AmbientValueAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.
 MembersMustExist : Member 'System.ComponentModel.AsyncCompletedEventArgs..ctor()' does not exist in the implementation but it does exist in the contract.
 CannotRemoveBaseTypeOrInterface : Type 'System.ComponentModel.AttributeProviderAttribute' does not implement interface 'System.Runtime.InteropServices._Attribute' in the implementation but it does in the contract.


### PR DESCRIPTION
Missing method is documented here https://msdn.microsoft.com/en-us/library/system.codedom.compiler.tempfilecollection.delete(v=vs.110).aspx