### PR TITLE
Adds CodeDomProvider base type to match .net

### DIFF
--- a/src/System.CodeDom/ref/System.CodeDom.cs
+++ b/src/System.CodeDom/ref/System.CodeDom.cs
@@ -876,7 +876,7 @@ namespace System.CodeDom.Compiler
         System.CodeDom.Compiler.CompilerResults System.CodeDom.Compiler.ICodeCompiler.CompileAssemblyFromSource(System.CodeDom.Compiler.CompilerParameters options, string source) { throw null; }
         System.CodeDom.Compiler.CompilerResults System.CodeDom.Compiler.ICodeCompiler.CompileAssemblyFromSourceBatch(System.CodeDom.Compiler.CompilerParameters options, string[] sources) { throw null; }
     }
-    public abstract partial class CodeDomProvider
+    public abstract partial class CodeDomProvider : System.ComponentModel.Component
     {
         protected CodeDomProvider() { }
         public virtual string FileExtension { get { throw null; } }

--- a/src/System.CodeDom/ref/System.CodeDom.csproj
+++ b/src/System.CodeDom/ref/System.CodeDom.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\System.Runtime.Extensions\ref\System.Runtime.Extensions.csproj" />
     <ProjectReference Include="..\..\System.Security.Permissions\ref\System.Security.Permissions.csproj" />
     <ProjectReference Include="..\..\System.Text.Encoding\ref\System.Text.Encoding.csproj" />
+    <ProjectReference Include="..\..\System.ComponentModel.Primitives\ref\System.ComponentModel.Primitives.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.CodeDom/src/System/CodeDom/Compiler/CodeDomProvider.cs
+++ b/src/System.CodeDom/src/System/CodeDom/Compiler/CodeDomProvider.cs
@@ -11,7 +11,7 @@ using System.Runtime.Serialization;
 
 namespace System.CodeDom.Compiler
 {
-    public abstract class CodeDomProvider // TODO: Inherit Component
+    public abstract class CodeDomProvider : Component
     {
         private static readonly Dictionary<string, CompilerInfo> s_compilerLanguages = new Dictionary<string, CompilerInfo>(StringComparer.OrdinalIgnoreCase);
         private static readonly Dictionary<string, CompilerInfo> s_compilerExtensions = new Dictionary<string, CompilerInfo>(StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
by implementing commented out TODO

https://msdn.microsoft.com/en-us/library/system.codedom.compiler.codedomprovider(v=vs.110).aspx