### PR TITLE
Fix flaky test in XslCompiledTransform

### DIFF
--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/Errata4.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/Errata4.cs
@@ -120,9 +120,9 @@ namespace System.Xml.Tests
 
         #endregion private const string createElementsXsltInline = ...
 
-        //[Variation(Priority = 1, Desc = "Crate elment/attribute :: Invalid start name char", Params = new object[] { false, CharType.NameStartChar })]
+        //[Variation(Priority = 1, Desc = "Crate elment/attribute :: Invalid start name char", Params = new object[] { false, CharType.NCNameStartChar })]
         [InlineData(false, CharType.NameStartChar)]
-        //[Variation(Priority = 1, Desc = "Crate elment/attribute :: Invalid name char", Params = new object[] { false, CharType.NameChar })]
+        //[Variation(Priority = 1, Desc = "Crate elment/attribute :: Invalid name char", Params = new object[] { false, CharType.NCNameChar })]
         [InlineData(false, CharType.NameChar)]
         //[Variation(Priority = 1, Desc = "Crate elment/attribute :: Invalid name CharType.NameStartSurrogateHighChar", Params = new object[] { false, CharType.NameStartSurrogateHighChar })]
         [InlineData(false, CharType.NameStartSurrogateHighChar)]
@@ -133,9 +133,9 @@ namespace System.Xml.Tests
         //[Variation(Priority = 1, Desc = "Crate elment/attribute :: Invalid name CharType.NameSurrogateLowChar", Params = new object[] { false, CharType.NameSurrogateLowChar })]
         [InlineData(false, CharType.NameSurrogateLowChar)]
         // ---
-        //[Variation(Priority = 0, Desc = "Crate elment/attribute :: Valid start name char", Params = new object[] { true, CharType.NameStartChar })]
+        //[Variation(Priority = 0, Desc = "Crate elment/attribute :: Valid start name char", Params = new object[] { true, CharType.NCNameStartChar })]
         [InlineData(true, CharType.NameStartChar)]
-        //[Variation(Priority = 0, Desc = "Crate elment/attribute :: Valid name char", Params = new object[] { true, CharType.NameChar })]
+        //[Variation(Priority = 0, Desc = "Crate elment/attribute :: Valid name char", Params = new object[] { true, CharType.NCNameChar })]
         [InlineData(true, CharType.NameChar)]
         // Only Valid for Fifth Edition Xml
         //[Variation(Priority = 0, Desc = "Crate elment/attribute :: Valid name CharType.NameStartSurrogateHighChar", Params = new object[] { true, CharType.NameStartSurrogateHighChar })]
@@ -175,19 +175,18 @@ namespace System.Xml.Tests
                     }
                     catch (Exception)
                     {
-                        Assert.True(!isValidChar);
-                        // TODO: verification of the exception params/message
+                        if (isValidChar) throw;
+                        else continue; //exception expected -> continue
                     }
                 }
             }
             return;
         }
 
-        [ActiveIssue(14772)]
-        //[Variation(Priority = 1, Desc = "Crate elment/attribute (Inline) :: Invalid start name char", Params = new object[] { false, CharType.NameStartChar })]
-        [InlineData(false, CharType.NameStartChar)]
-        //[Variation(Priority = 1, Desc = "Crate elment/attribute (Inline) :: Invalid name char", Params = new object[] { false, CharType.NameChar })]
-        [InlineData(false, CharType.NameChar)]
+        //[Variation(Priority = 1, Desc = "Crate elment/attribute (Inline) :: Invalid start name char", Params = new object[] { false, CharType.NCNameStartChar })]
+        [InlineData(false, CharType.NCNameStartChar)]
+        //[Variation(Priority = 1, Desc = "Crate elment/attribute (Inline) :: Invalid name char", Params = new object[] { false, CharType.NCNameChar })]
+        [InlineData(false, CharType.NCNameChar)]
         //[Variation(Priority = 1, Desc = "Crate elment/attribute (Inline) :: Invalid name CharType.NameStartSurrogateHighChar", Params = new object[] { false, CharType.NameStartSurrogateHighChar })]
         [InlineData(false, CharType.NameStartSurrogateHighChar)]
         //[Variation(Priority = 1, Desc = "Crate elment/attribute (Inline) :: Invalid name CharType.NameStartSurrogateLowChar", Params = new object[] { false, CharType.NameStartSurrogateLowChar })]
@@ -197,10 +196,10 @@ namespace System.Xml.Tests
         //[Variation(Priority = 1, Desc = "Crate elment/attribute (Inline) :: Invalid name CharType.NameSurrogateLowChar", Params = new object[] { false, CharType.NameSurrogateLowChar })]
         [InlineData(false, CharType.NameSurrogateLowChar)]
         // ---
-        //[Variation(Priority = 0, Desc = "Crate elment/attribute (Inline) :: Valid start name char", Params = new object[] { true, CharType.NameStartChar })]
-        [InlineData(true, CharType.NameStartChar)]
-        //[Variation(Priority = 0, Desc = "Crate elment/attribute (Inline) :: Valid name char", Params = new object[] { true, CharType.NameChar })]
-        [InlineData(true, CharType.NameChar)]
+        //[Variation(Priority = 0, Desc = "Crate elment/attribute (Inline) :: Valid start name char", Params = new object[] { true, CharType.NCNameStartChar })]
+        [InlineData(true, CharType.NCNameStartChar)]
+        //[Variation(Priority = 0, Desc = "Crate elment/attribute (Inline) :: Valid name char", Params = new object[] { true, CharType.NCNameChar })]
+        [InlineData(true, CharType.NCNameChar)]
         // Only Valid for Fifth Edition Xml
         //[Variation(Priority = 0, Desc = "Crate elment/attribute (Inline) :: Valid name CharType.NameStartSurrogateHighChar", Params = new object[] { true, CharType.NameStartSurrogateHighChar })]
         //[Variation(Priority = 0, Desc = "Crate elment/attribute (Inline) :: Valid name CharType.NameStartSurrogateLowChar", Params = new object[] { true, CharType.NameStartSurrogateLowChar })]
@@ -231,9 +230,8 @@ namespace System.Xml.Tests
                     }
                     catch (Exception)
                     {
-                        Assert.True(!isValidChar);
-                        // TODO: verification of the exception params/message
-                        return;
+                        if (isValidChar) throw;
+                        else continue; //exception expected -> continue
                     }
 
                     // if loading of the stylesheet passed, then we should be able to provide
@@ -267,11 +265,10 @@ namespace System.Xml.Tests
             }
         }
 
-        [ActiveIssue(14775)]
-        //[Variation(Priority = 1, Desc = "Invalid start name char", Params = new object[] { false, CharType.NameStartChar })]
-        [InlineData(false, CharType.NameStartChar)]
-        //[Variation(Priority = 1, Desc = "Invalid name char", Params = new object[] { false, CharType.NameChar })]
-        [InlineData(false, CharType.NameChar)]
+        //[Variation(Priority = 1, Desc = "Invalid start name char", Params = new object[] { false, CharType.NCNameStartChar })]
+        [InlineData(false, CharType.NCNameStartChar)]
+        //[Variation(Priority = 1, Desc = "Invalid name char", Params = new object[] { false, CharType.NCNameChar })]
+        [InlineData(false, CharType.NCNameChar)]
         //[Variation(Priority = 1, Desc = "Invalid name CharType.NameStartSurrogateHighChar", Params = new object[] { false, CharType.NameStartSurrogateHighChar })]
         [InlineData(false, CharType.NameStartSurrogateHighChar)]
         //[Variation(Priority = 1, Desc = "Invalid name CharType.NameStartSurrogateLowChar", Params = new object[] { false, CharType.NameStartSurrogateLowChar })]
@@ -281,10 +278,10 @@ namespace System.Xml.Tests
         //[Variation(Priority = 1, Desc = "Invalid name CharType.NameSurrogateLowChar", Params = new object[] { false, CharType.NameSurrogateLowChar })]
         [InlineData(false, CharType.NameSurrogateLowChar)]
         // ---
-        //[Variation(Priority = 0, Desc = "Valid start name char", Params = new object[] { true, CharType.NameStartChar })]
-        [InlineData(true, CharType.NameStartChar)]
-        //[Variation(Priority = 0, Desc = "Valid name char", Params = new object[] { true, CharType.NameChar })]
-        [InlineData(true, CharType.NameChar)]
+        //[Variation(Priority = 0, Desc = "Valid start name char", Params = new object[] { true, CharType.NCNameStartChar })]
+        [InlineData(true, CharType.NCNameStartChar)]
+        //[Variation(Priority = 0, Desc = "Valid name char", Params = new object[] { true, CharType.NCNameChar })]
+        [InlineData(true, CharType.NCNameChar)]
         // Only Valid for Fifth Edition Xml
         //[Variation(Priority = 0, Desc = "Valid name CharType.NameStartSurrogateHighChar", Params = new object[] { true, CharType.NameStartSurrogateHighChar })]
         //[Variation(Priority = 0, Desc = "Valid name CharType.NameStartSurrogateLowChar", Params = new object[] { true, CharType.NameStartSurrogateLowChar })]
@@ -313,8 +310,8 @@ namespace System.Xml.Tests
                 }
                 catch (XsltException)
                 {
-                    Assert.True(!isValidChar);
-                    continue; //if exception expected -> continue
+                    if (isValidChar) throw;
+                    else continue; //exception expected -> continue
                 }
 
                 XmlDocument xmlDoc = new XmlDocument();
@@ -356,10 +353,10 @@ namespace System.Xml.Tests
         {
             switch (charType)
             {
-                case CharType.NameStartChar:
+                case CharType.NCNameStartChar:
                     return new string(new char[] { c, 'a', 'b' });
 
-                case CharType.NameChar:
+                case CharType.NCNameChar:
                     return new string(new char[] { 'a', c, 'b' });
 
                 case CharType.NameStartSurrogateHighChar:


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/14775 and https://github.com/dotnet/corefx/issues/14772. These tests used to throw the following exception occasionally:

`System.Xml.XmlException: The ':' character, hexadecimal value 0x3A, cannot be included in a name.`

Which happens because in the random selection of valid characters to be included in the name of an element, the character `':'` was sometimes present, which is not allowed. This behavior is also the expected behavior in Full Framework.

As a fix, `CharType.NameStartChar` and `CharType.NameChar` have been replaced with `CharType.NCNameStartChar` and `CharType.NCNameChar` which are exactly the same collection with only leaving `':'` out. Some more logging has also been added to these tests.

cc: @danmosemsft @stephentoub @AlexGhiondea 