### PR TITLE
Fix error handling in Process.Kill on Unix

### DIFF
--- a/src/Native/Unix/System.Native/pal_process.cpp
+++ b/src/Native/Unix/System.Native/pal_process.cpp
@@ -459,7 +459,7 @@ extern "C" int64_t SystemNative_GetMaximumPath()
 
 extern "C" int32_t SystemNative_GetPriority(PriorityWhich which, int32_t who)
 {
-    // GetPriority uses errno 0 to show succes to make sure we don't have a stale value
+    // GetPriority uses errno 0 to show success to make sure we don't have a stale value
     errno = 0;
 #if PRIORITY_REQUIRES_INT_WHO
     return getpriority(which, who);


### PR DESCRIPTION
Process.Kill is mishandling error values. set_PriorityClass also had some dead code due to arguments having been validated earlier in the call chain.
Fixes https://github.com/dotnet/corefx/issues/15234
cc: @Priya91, @tmds 