### PR TITLE
Refresh System.Transactions ref based on the src

### DIFF
--- a/src/System.Transactions/ref/System.Transactions.cs
+++ b/src/System.Transactions/ref/System.Transactions.cs
@@ -7,7 +7,7 @@
 
 namespace System.Transactions
 {
-    public sealed partial class CommittableTransaction : System.Transactions.Transaction, System.IAsyncResult, System.IDisposable, System.Runtime.Serialization.ISerializable
+    public sealed partial class CommittableTransaction : System.Transactions.Transaction, System.IAsyncResult
     {
         public CommittableTransaction() { }
         public CommittableTransaction(System.TimeSpan timeout) { }
@@ -18,19 +18,17 @@ namespace System.Transactions
         bool System.IAsyncResult.IsCompleted { get { throw null; } }
         public System.IAsyncResult BeginCommit(System.AsyncCallback asyncCallback, object asyncState) { throw null; }
         public void Commit() { }
-        public void EndCommit(System.IAsyncResult ar) { }
-        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public void EndCommit(System.IAsyncResult asyncResult) { }
     }
     public enum DependentCloneOption
     {
         BlockCommitUntilComplete = 0,
         RollbackIfNotComplete = 1,
     }
-    public sealed partial class DependentTransaction : System.Transactions.Transaction, System.Runtime.Serialization.ISerializable
+    public sealed partial class DependentTransaction : System.Transactions.Transaction
     {
         internal DependentTransaction() { }
         public void Complete() { }
-        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public partial class Enlistment
     {
@@ -50,7 +48,6 @@ namespace System.Transactions
         None = 0,
     }
     public delegate System.Transactions.Transaction HostCurrentTransactionCallback();
-    //[System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(1))] // TODO: Put back when available
     public partial interface IDtcTransaction
     {
         void Abort(System.IntPtr reason, int retaining, int async);
@@ -118,7 +115,7 @@ namespace System.Transactions
         internal Transaction() { }
         public static System.Transactions.Transaction Current { get { throw null; } set { } }
         public System.Transactions.IsolationLevel IsolationLevel { get { throw null; } }
-        public System.Guid PromoterType { get; }
+        public System.Guid PromoterType { get { throw null; } }
         public System.Transactions.TransactionInformation TransactionInformation { get { throw null; } }
         public event System.Transactions.TransactionCompletedEventHandler TransactionCompleted { add { } remove { } }
         public System.Transactions.Transaction Clone() { throw null; }
@@ -139,7 +136,7 @@ namespace System.Transactions
         public void Rollback() { }
         public void Rollback(System.Exception e) { }
         public void SetDistributedTransactionIdentifier(System.Transactions.IPromotableSinglePhaseNotification promotableNotification, System.Guid distributedTransactionIdentifier) { }
-        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext context) { }
     }
     public partial class TransactionAbortedException : System.Transactions.TransactionException
     {
@@ -154,16 +151,16 @@ namespace System.Transactions
         public TransactionEventArgs() { }
         public System.Transactions.Transaction Transaction { get { throw null; } }
     }
-    public partial class TransactionException : System.Exception //System.SystemException  // TODO: Put back when available
+    public partial class TransactionException : System.SystemException
     {
-        protected TransactionException() { }
+        public TransactionException() { }
         protected TransactionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public TransactionException(string message) { }
         public TransactionException(string message, System.Exception innerException) { }
     }
     public partial class TransactionInDoubtException : System.Transactions.TransactionException
     {
-        protected TransactionInDoubtException() { }
+        public TransactionInDoubtException() { }
         protected TransactionInDoubtException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public TransactionInDoubtException(string message) { }
         public TransactionInDoubtException(string message, System.Exception innerException) { }
@@ -198,7 +195,7 @@ namespace System.Transactions
     }
     public partial class TransactionManagerCommunicationException : System.Transactions.TransactionException
     {
-        protected TransactionManagerCommunicationException() { }
+        public TransactionManagerCommunicationException() { }
         protected TransactionManagerCommunicationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public TransactionManagerCommunicationException(string message) { }
         public TransactionManagerCommunicationException(string message, System.Exception innerException) { }
@@ -210,12 +207,12 @@ namespace System.Transactions
         public System.TimeSpan Timeout { get { throw null; } set { } }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(System.Transactions.TransactionOptions o1, System.Transactions.TransactionOptions o2) { throw null; }
-        public static bool operator !=(System.Transactions.TransactionOptions o1, System.Transactions.TransactionOptions o2) { throw null; }
+        public static bool operator ==(System.Transactions.TransactionOptions x, System.Transactions.TransactionOptions y) { throw null; }
+        public static bool operator !=(System.Transactions.TransactionOptions x, System.Transactions.TransactionOptions y) { throw null; }
     }
     public partial class TransactionPromotionException : System.Transactions.TransactionException
     {
-        protected TransactionPromotionException() { }
+        public TransactionPromotionException() { }
         protected TransactionPromotionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public TransactionPromotionException(string message) { }
         public TransactionPromotionException(string message, System.Exception innerException) { }
@@ -227,8 +224,8 @@ namespace System.Transactions
         public TransactionScope(System.Transactions.Transaction transactionToUse, System.TimeSpan scopeTimeout) { }
         public TransactionScope(System.Transactions.Transaction transactionToUse, System.TimeSpan scopeTimeout, System.Transactions.EnterpriseServicesInteropOption interopOption) { }
         public TransactionScope(System.Transactions.Transaction transactionToUse, System.TimeSpan scopeTimeout, System.Transactions.TransactionScopeAsyncFlowOption asyncFlowOption) { }
-        public TransactionScope(Transaction transactionToUse, TransactionScopeAsyncFlowOption asyncFlowOption) { }
-        public TransactionScope(TransactionScopeAsyncFlowOption asyncFlowOption) { }
+        public TransactionScope(System.Transactions.Transaction transactionToUse, System.Transactions.TransactionScopeAsyncFlowOption asyncFlowOption) { }
+        public TransactionScope(System.Transactions.TransactionScopeAsyncFlowOption asyncFlowOption) { }
         public TransactionScope(System.Transactions.TransactionScopeOption scopeOption) { }
         public TransactionScope(System.Transactions.TransactionScopeOption scopeOption, System.TimeSpan scopeTimeout) { }
         public TransactionScope(System.Transactions.TransactionScopeOption scopeOption, System.TimeSpan scopeTimeout, System.Transactions.TransactionScopeAsyncFlowOption asyncFlowOption) { }
@@ -239,7 +236,8 @@ namespace System.Transactions
         public void Complete() { }
         public void Dispose() { }
     }
-    public enum TransactionScopeAsyncFlowOption {
+    public enum TransactionScopeAsyncFlowOption
+    {
         Enabled = 1,
         Suppress = 0,
     }

--- a/src/System.Transactions/src/System/Transactions/TransactionException.cs
+++ b/src/System.Transactions/src/System/Transactions/TransactionException.cs
@@ -11,7 +11,7 @@ namespace System.Transactions
     /// Summary description for TransactionException.
     /// </summary>
     [Serializable]
-    public class TransactionException : Exception // SystemException
+    public class TransactionException : SystemException
     {
         internal static bool IncludeDistributedTxId(Guid distributedTxId)
         {
@@ -70,14 +70,14 @@ namespace System.Transactions
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public TransactionException()
         {
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="message"></param>
         public TransactionException(string message) : base(message)
@@ -85,7 +85,7 @@ namespace System.Transactions
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="message"></param>
         /// <param name="innerException"></param>
@@ -94,11 +94,11 @@ namespace System.Transactions
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>
-        protected TransactionException(SerializationInfo info, StreamingContext context) // : base(info, context) // TODO #9582: Restore this when Exception exposes the appropriate ctor 
+        protected TransactionException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
 
@@ -195,14 +195,14 @@ namespace System.Transactions
             return new TransactionAbortedException(message, innerException);
         }
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public TransactionAbortedException() : base(SR.TransactionAborted)
         {
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="message"></param>
         public TransactionAbortedException(string message) : base(message)
@@ -210,7 +210,7 @@ namespace System.Transactions
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="message"></param>
         /// <param name="innerException"></param>
@@ -219,7 +219,7 @@ namespace System.Transactions
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="message"></param>
         /// <param name="innerException"></param>
@@ -235,7 +235,7 @@ namespace System.Transactions
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>
@@ -271,14 +271,14 @@ namespace System.Transactions
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public TransactionInDoubtException() : base(SR.TransactionIndoubt)
         {
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="message"></param>
         public TransactionInDoubtException(string message) : base(message)
@@ -286,7 +286,7 @@ namespace System.Transactions
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="message"></param>
         /// <param name="innerException"></param>
@@ -295,7 +295,7 @@ namespace System.Transactions
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>
@@ -317,7 +317,7 @@ namespace System.Transactions
             {
                 etwLog.TransactionExceptionTrace(TransactionExceptionType.TransactionManagerCommunicationException, message, innerException==null?String.Empty:innerException.ToString());
             }
- 
+
             return new TransactionManagerCommunicationException(message, innerException);
         }
 
@@ -327,14 +327,14 @@ namespace System.Transactions
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public TransactionManagerCommunicationException() : base(SR.TransactionManagerCommunicationException)
         {
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="message"></param>
         public TransactionManagerCommunicationException(string message) : base(message)
@@ -342,7 +342,7 @@ namespace System.Transactions
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="message"></param>
         /// <param name="innerException"></param>
@@ -354,7 +354,7 @@ namespace System.Transactions
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>
@@ -368,14 +368,14 @@ namespace System.Transactions
     public class TransactionPromotionException : TransactionException
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public TransactionPromotionException() : this(SR.PromotionFailed)
         {
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="message"></param>
         public TransactionPromotionException(string message) : base(message)
@@ -383,7 +383,7 @@ namespace System.Transactions
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="message"></param>
         /// <param name="innerException"></param>
@@ -392,7 +392,7 @@ namespace System.Transactions
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>


### PR DESCRIPTION
Fixed TransactionException to derive from SystemException.
Regenerated ref using genapi tool against the src.

With this the only differences between the API surface in
.NET Core and .NET Framework are the following types aren't
in .NET Core.

DistributedTransactionPermission
DistributedTransactionPermissionAttribute
DefaultSettingsSection
MachineSettingsSection
TransactionsSectionGroup

Which are all expected as we don't support configuration or permissions
in .NET Core

cc @stephentoub @terrajobst 