### PR TITLE
Restore from v3 NuGet.org feed

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -92,7 +92,7 @@
     <!-- Including buildtools to pull in TestSuite packages and repackaged xunit dependencies-->
     <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <DnuSourceList Include="https:%2F%2Fwww.nuget.org/api/v2/" />
+    <DnuSourceList Include="https:%2F%2Fapi.nuget.org/v3/index.json" />
   </ItemGroup>
 
   <!-- This is the directory where we dynamically generate project.json's for our test build package dependencies -->

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -6,7 +6,7 @@
     <clear/>
     <add key="myget.org dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <config>
     <add key="repositoryPath" value="..\packages" />


### PR DESCRIPTION
I noticed that this feed was still v2 when looking at a timeout issue. I don't know if v3 will make timeouts more rare, but it's a common recommendation to improve NuGet behavior in general.

(The timeout issue I was looking at is in https://devdiv.visualstudio.com/DevDiv/_build?buildId=526691, specifically https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build?buildId=526699.)

@MattGal @ericstj