### PR TITLE
Fix #14961 and tweak perf in ImmutableArray

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableArray.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableArray.cs
@@ -22,7 +22,5 @@ namespace System.Collections.Immutable
         /// Gets an untyped reference to the array.
         /// </summary>
         Array Array { get; }
-
-        void ThrowInvalidOperationIfNotInitialized();
     }
 }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
@@ -106,14 +106,18 @@ namespace System.Collections.Immutable
             var immutableArray = items as IImmutableArray;
             if (immutableArray != null)
             {
-                immutableArray.ThrowInvalidOperationIfNotInitialized();
+                Array array = immutableArray.Array;
+                if (array == null)
+                {
+                    throw new InvalidOperationException(SR.InvalidOperationOnDefaultArray);
+                }
 
                 // immutableArray.Array must not be null at this point, and we know it's an
                 // ImmutableArray<T> or ImmutableArray<SomethingDerivedFromT> as they are
                 // the only types that could be both IEnumerable<T> and IImmutableArray.
                 // As such, we know that items is either an ImmutableArray<T> or
                 // ImmutableArray<TypeDerivedFromT>, and we can cast the array to T[].
-                return new ImmutableArray<T>((T[])immutableArray.Array);
+                return new ImmutableArray<T>((T[])array);
             }
 
             // We don't recognize the source as an array that is safe to use.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
@@ -112,7 +112,7 @@ namespace System.Collections.Immutable
                     throw new InvalidOperationException(SR.InvalidOperationOnDefaultArray);
                 }
 
-                // immutableArray.Array must not be null at this point, and we know it's an
+                // `array` must not be null at this point, and we know it's an
                 // ImmutableArray<T> or ImmutableArray<SomethingDerivedFromT> as they are
                 // the only types that could be both IEnumerable<T> and IImmutableArray.
                 // As such, we know that items is either an ImmutableArray<T> or

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -246,7 +246,7 @@ namespace System.Collections.Immutable
                 {
                     this.EnsureCapacity(this.Count + count);
 
-                    if (items.TryCopyTo(_elements, 0))
+                    if (items.TryCopyTo(_elements, _count))
                     {
                         _count += count;
                         return;

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -245,6 +245,12 @@ namespace System.Collections.Immutable
                 if (items.TryGetCount(out count))
                 {
                     this.EnsureCapacity(this.Count + count);
+
+                    if (items.TryCopyTo(_elements, 0))
+                    {
+                        _count += count;
+                        return;
+                    }
                 }
 
                 foreach (var item in items)

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
@@ -613,7 +613,7 @@ namespace System.Collections.Immutable
         {
             var self = this;
             self.ThrowNullRefIfNotInitialized();
-            ThrowNullRefIfNotInitialized(items);
+            items.ThrowNullRefIfNotInitialized();
             Requires.Range(index >= 0 && index <= self.Length, nameof(index));
 
             if (self.IsEmpty)
@@ -692,6 +692,7 @@ namespace System.Collections.Immutable
         public ImmutableArray<T> SetItem(int index, T item)
         {
             var self = this;
+            self.ThrowNullRefIfNotInitialized();
             Requires.Range(index >= 0 && index < self.Length, nameof(index));
 
             T[] tmp = new T[self.Length];
@@ -728,7 +729,7 @@ namespace System.Collections.Immutable
         public ImmutableArray<T> Replace(T oldValue, T newValue, IEqualityComparer<T> equalityComparer)
         {
             var self = this;
-            int index = self.IndexOf(oldValue, equalityComparer);
+            int index = self.IndexOf(oldValue, 0, self.Length, equalityComparer);
             if (index < 0)
             {
                 throw new ArgumentException(SR.CannotFindOldValue, nameof(oldValue));
@@ -764,7 +765,7 @@ namespace System.Collections.Immutable
         {
             var self = this;
             self.ThrowNullRefIfNotInitialized();
-            int index = self.IndexOf(item, equalityComparer);
+            int index = self.IndexOf(item, 0, self.Length, equalityComparer);
             return index < 0
                 ? self
                 : self.RemoveAt(index);
@@ -791,6 +792,7 @@ namespace System.Collections.Immutable
         public ImmutableArray<T> RemoveRange(int index, int length)
         {
             var self = this;
+            self.ThrowNullRefIfNotInitialized();
             Requires.Range(index >= 0 && index <= self.Length, nameof(index));
             Requires.Range(length >= 0 && index + length <= self.Length, nameof(length));
 
@@ -836,18 +838,18 @@ namespace System.Collections.Immutable
             self.ThrowNullRefIfNotInitialized();
             Requires.NotNull(items, nameof(items));
 
-            var indexesToRemove = new SortedSet<int>();
+            var indicesToRemove = new SortedSet<int>();
             foreach (var item in items)
             {
-                int index = self.IndexOf(item, equalityComparer);
-                while (index >= 0 && !indexesToRemove.Add(index) && index + 1 < self.Length)
+                int index = self.IndexOf(item, 0, self.Length, equalityComparer);
+                while (index >= 0 && !indicesToRemove.Add(index) && index + 1 < self.Length)
                 {
                     // This is a duplicate of one we've found. Try hard to find another instance in the list to remove.
                     index = self.IndexOf(item, index + 1, equalityComparer);
                 }
             }
 
-            return self.RemoveAtRange(indexesToRemove);
+            return self.RemoveAtRange(indicesToRemove);
         }
 
         /// <summary>
@@ -917,22 +919,22 @@ namespace System.Collections.Immutable
                 return self;
             }
 
-            List<int> removeIndexes = null;
+            List<int> removeIndices = null;
             for (int i = 0; i < self.array.Length; i++)
             {
                 if (match(self.array[i]))
                 {
-                    if (removeIndexes == null)
+                    if (removeIndices == null)
                     {
-                        removeIndexes = new List<int>();
+                        removeIndices = new List<int>();
                     }
 
-                    removeIndexes.Add(i);
+                    removeIndices.Add(i);
                 }
             }
 
-            return removeIndexes != null ?
-                self.RemoveAtRange(removeIndexes) :
+            return removeIndices != null ?
+                self.RemoveAtRange(removeIndices) :
                 self;
         }
 
@@ -1566,7 +1568,9 @@ namespace System.Collections.Immutable
                 var theirs = other as IImmutableArray;
                 if (theirs != null)
                 {
-                    if (self.array == null && theirs.Array == null)
+                    otherArray = theirs.Array;
+
+                    if (self.array == null && otherArray == null)
                     {
                         return true;
                     }
@@ -1574,8 +1578,6 @@ namespace System.Collections.Immutable
                     {
                         return false;
                     }
-
-                    otherArray = theirs.Array;
                 }
             }
 
@@ -1617,16 +1619,16 @@ namespace System.Collections.Immutable
                 var theirs = other as IImmutableArray;
                 if (theirs != null)
                 {
-                    if (self.array == null && theirs.Array == null)
+                    otherArray = theirs.Array;
+
+                    if (self.array == null && otherArray == null)
                     {
                         return 0;
                     }
-                    else if (self.array == null ^ theirs.Array == null)
+                    else if (self.array == null ^ otherArray == null)
                     {
                         throw new ArgumentException(SR.ArrayInitializedStateNotEqual, nameof(other));
                     }
-
-                    otherArray = theirs.Array;
                 }
             }
 
@@ -1673,33 +1675,28 @@ namespace System.Collections.Immutable
             }
         }
 
-        void IImmutableArray.ThrowInvalidOperationIfNotInitialized()
-        {
-            this.ThrowInvalidOperationIfNotInitialized();
-        }
-
         /// <summary>
-        /// Returns an array with items at the specified indexes removed.
+        /// Returns an array with items at the specified indices removed.
         /// </summary>
-        /// <param name="indexesToRemove">A **sorted set** of indexes to elements that should be omitted from the returned array.</param>
+        /// <param name="indicesToRemove">A **sorted set** of indices to elements that should be omitted from the returned array.</param>
         /// <returns>The new array.</returns>
-        private ImmutableArray<T> RemoveAtRange(ICollection<int> indexesToRemove)
+        private ImmutableArray<T> RemoveAtRange(ICollection<int> indicesToRemove)
         {
             var self = this;
             self.ThrowNullRefIfNotInitialized();
-            Requires.NotNull(indexesToRemove, nameof(indexesToRemove));
+            Requires.NotNull(indicesToRemove, nameof(indicesToRemove));
 
-            if (indexesToRemove.Count == 0)
+            if (indicesToRemove.Count == 0)
             {
                 // Be sure to return a !IsDefault instance.
                 return self;
             }
 
-            var newArray = new T[self.Length - indexesToRemove.Count];
+            var newArray = new T[self.Length - indicesToRemove.Count];
             int copied = 0;
             int removed = 0;
             int lastIndexRemoved = -1;
-            foreach (var indexToRemove in indexesToRemove)
+            foreach (var indexToRemove in indicesToRemove)
             {
                 int copyLength = lastIndexRemoved == -1 ? indexToRemove : (indexToRemove - lastIndexRemoved - 1);
                 Debug.Assert(indexToRemove > lastIndexRemoved); // We require that the input be a sorted set.
@@ -1712,14 +1709,6 @@ namespace System.Collections.Immutable
             Array.Copy(self.array, copied + removed, newArray, copied, self.Length - (copied + removed));
 
             return new ImmutableArray<T>(newArray);
-        }
-
-        /// <summary>
-        /// Throws a <see cref="NullReferenceException"/> if the specified array is uninitialized.
-        /// </summary>
-        private static void ThrowNullRefIfNotInitialized(ImmutableArray<T> array)
-        {
-            array.ThrowNullRefIfNotInitialized();
         }
     }
 }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
@@ -108,9 +108,9 @@ namespace System.Collections.Immutable
         {
             Debug.Assert(sequence != null);
             Debug.Assert(array != null);
-            Debug.Assert(arrayIndex >= 0 && arrayIndex < array.Length);
+            Debug.Assert(arrayIndex >= 0 && arrayIndex <= array.Length);
 
-            // IList is the GCD of what the following 2 types implement.
+            // IList is the GCD of what the following types implement.
             var listInterface = sequence as IList<T>;
             if (listInterface != null)
             {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
@@ -106,6 +106,10 @@ namespace System.Collections.Immutable
         /// </remarks>
         internal static bool TryCopyTo<T>(this IEnumerable<T> sequence, T[] array, int arrayIndex)
         {
+            Debug.Assert(sequence != null);
+            Debug.Assert(array != null);
+            Debug.Assert(arrayIndex >= 0 && arrayIndex < array.Length);
+
             // IList is the GCD of what the following 2 types implement.
             var listInterface = sequence as IList<T>;
             if (listInterface != null)
@@ -114,6 +118,16 @@ namespace System.Collections.Immutable
                 if (list != null)
                 {
                     list.CopyTo(array, arrayIndex);
+                    return true;
+                }
+
+                // Array.Copy can throw an ArrayTypeMismatchException if the underlying type of
+                // the destination array is not typeof(T[]), but is assignment-compatible with T[].
+                // See https://github.com/dotnet/corefx/issues/2241 for more info.
+                if (sequence.GetType() == typeof(T[]))
+                {
+                    var sourceArray = (T[])sequence;
+                    Array.Copy(sourceArray, 0, array, arrayIndex, sourceArray.Length);
                     return true;
                 }
 

--- a/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
@@ -75,6 +75,9 @@ namespace System.Collections.Immutable.Tests
             builder.AddRange((IEnumerable<int>)new[] { 2 });
             Assert.Equal(2, builder.Count);
 
+            builder.AddRange((IEnumerable<int>)new int[0]);
+            Assert.Equal(2, builder.Count);
+
             // Exceed capacity
             builder.AddRange(Enumerable.Range(3, 2)); // use an enumerable without a breakable Count
             Assert.Equal(4, builder.Count);

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -1127,7 +1127,7 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Theory]
-        [InlineData(-1, Skip = "#14961")]
+        [InlineData(-1)]
         [InlineData(0)]
         [InlineData(1)]
         public void RemoveAtDefaultInvalid(int index)
@@ -1217,7 +1217,7 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Theory]
-        [InlineData(-1, 0, Skip = "#14961")]
+        [InlineData(-1, 0)]
         [InlineData(0, -1)]
         [InlineData(0, 0)]
         [InlineData(1, -1)]
@@ -1446,9 +1446,8 @@ namespace System.Collections.Immutable.Tests
         {
             Assert.All(SharedEqualityComparers<int>(), comparer =>
             {
-                // Uncomment when #14961 is fixed.
-                // Assert.Throws<NullReferenceException>(() => s_emptyDefault.Replace(123, 123));
-                // Assert.Throws<NullReferenceException>(() => s_emptyDefault.Replace(123, 123, comparer));
+                Assert.Throws<NullReferenceException>(() => s_emptyDefault.Replace(123, 123));
+                Assert.Throws<NullReferenceException>(() => s_emptyDefault.Replace(123, 123, comparer));
 
                 Assert.Throws<InvalidOperationException>(() => ((IImmutableList<int>)s_emptyDefault).Replace(123, 123));
                 Assert.Throws<InvalidOperationException>(() => ((IImmutableList<int>)s_emptyDefault).Replace(123, 123, comparer));

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -1484,7 +1484,7 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Theory]
-        [InlineData(-1, Skip = "#14961")]
+        [InlineData(-1)]
         [InlineData(0)]
         [InlineData(1)]
         public void SetItemDefaultInvalid(int index)


### PR DESCRIPTION
Follow-up for https://github.com/dotnet/corefx/pull/14798 and https://github.com/dotnet/corefx/pull/13158. Specializes `InsertRange` for arrays, uses `TryCopyTo` in `ImmutableArray.Builder`, removes some unnecessary boxing in `Remove` / `Replace`, makes exceptions consistent in `SetItem` / `Replace` / `Remove`, and reenables corresponding tests.

Fixes #14961, https://github.com/dotnet/corefx/issues/13695