### PR TITLE
Refactor build definitions, enable portableLinux, merge helix changes

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -173,7 +173,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/sync.sh -p -- /p:ArchGroup=$(PB_Platform)",
+        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/sync.sh $(PB_SyncArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -191,7 +191,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/build.sh -buildArch=$(PB_Platform) -$(PB_ConfigurationGroup) $(PB_AdditionalArguments)",
+        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/build.sh $(PB_BuildArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -209,7 +209,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/build-tests.sh -buildArch=$(PB_Platform) -$(PB_ConfigurationGroup) -SkipTests -- /p:ArchiveTests=true",
+        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/build-tests.sh $(PB_BuildTestsArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -227,7 +227,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/tests.builds /t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=$(PB_TestProduct)\" /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:FilterToOSGroup=Linux /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
+        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/tests.builds $(PB_CreateHelixArguments) /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint) /p:\"Branch=$(SourceBranch)\" /p:\"TargetQueue=$(PB_TargetQueue)\"",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -397,14 +397,6 @@
       "value": "false",
       "allowOverride": true
     },
-    "PB_Platform": {
-      "value": "x64",
-      "allowOverride": true
-    },
-    "PB_ConfigurationGroup": {
-      "value": "Release",
-      "allowOverride": true
-    },
     "PB_GitDirectory": {
       "value": "/root/corefx"
     },
@@ -457,13 +449,23 @@
     "PB_VsoCorefxGitUrl": {
       "value": "https://github.com/dotnet/corefx"
     },
-    "PB_AdditionalArguments": {
-      "value": ""
+    "PB_BuildArguments": {
+      "value": "-buildArch=x64 -Release",
+      "allowOverride": true
     },
-    "PB_EnableCloudTest": {
-      "value": "true",
+    "PB_SyncArguments": {
+      "value": "-p -- /p:ArchGroup=x64",
+      "allowOverride": true
+    },
+    "PB_BuildTestsArguments": {
+      "value": "-BuildArch=x64 -Debug -SkipTests",
+      "allowOverride": true
+    },
+    "PB_CreateHelixArguments": {
+      "value": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=true /p:\"TestProduct=corefx  /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:FilterToOSGroup=Linux",
       "allowOverride": true
     }
+    
   },
   "demands": [
     "Agent.OS -equals linux"
@@ -504,7 +506,6 @@
     "checkoutSubmodules": false
   },
   "quality": "definition",
-  "defaultBranch": "refs/heads/master",
   "queue": {
     "pool": {
       "id": 39,

--- a/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-OSX.json
@@ -83,7 +83,7 @@
       },
       "inputs": {
         "filename": "$(Agent.BuildDirectory)/s/corefx/sync.sh",
-        "arguments": "-p -- /p:ArchGroup=$(PB_Platform)",
+        "arguments": "$(PB_SyncArguments)",
         "workingFolder": "$(Agent.BuildDirectory)/s/corefx/",
         "failOnStandardError": "false"
       }
@@ -119,7 +119,7 @@
       },
       "inputs": {
         "filename": "$(Agent.BuildDirectory)/s/corefx/build.sh",
-        "arguments": "-buildArch=$(PB_Platform) -$(PB_ConfigurationGroup)",
+        "arguments": "$(PB_BuildArguments)",
         "workingFolder": "$(Agent.BuildDirectory)/s/corefx/",
         "failOnStandardError": "false"
       }
@@ -137,7 +137,7 @@
       },
       "inputs": {
         "filename": "$(Agent.BuildDirectory)/s/corefx/build-tests.sh",
-        "arguments": "-buildArch=$(PB_Platform) -$(PB_ConfigurationGroup) -SkipTests -- /p:ArchiveTests=true",
+        "arguments": "$(PB_BuildTestsArguments)",
         "workingFolder": "$(Agent.BuildDirectory)/s/corefx/",
         "failOnStandardError": "false"
       }
@@ -155,7 +155,7 @@
       },
       "inputs": {
         "filename": "$(Agent.BuildDirectory)/s/corefx/Tools/msbuild.sh",
-        "arguments": "$(Agent.BuildDirectory)/s/corefx/src/tests.builds /t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=$(PB_TestProduct)\" /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=OSX\" /p:FilterToOSGroup=OSX /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
+        "arguments": "$(Agent.BuildDirectory)/s/corefx/src/tests.builds $(PB_CreateHelixArguments) /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint) /p:\"Branch=$(SourceBranch)\" /p:\"TargetQueue=$(PB_TargetQueue)\"",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -237,14 +237,6 @@
       "value": "false",
       "allowOverride": true
     },
-    "PB_Platform": {
-      "value": "x64",
-      "allowOverride": true
-    },
-    "PB_ConfigurationGroup": {
-      "value": "Release",
-      "allowOverride": true
-    },
     "PB_CloudDropAccountName": {
       "value": "dotnetbuildoutput"
     },
@@ -281,8 +273,20 @@
     "Build.Clean": {
       "value": "all"
     },
-    "PB_EnableCloudTest": {
-      "value": "true",
+    "PB_BuildArguments": {
+      "value": "-buildArch=x64 -Release",
+      "allowOverride": true
+    },
+    "PB_BuildTestsArguments": {
+      "value": "-buildArch=x64 -Release -SkipTests",
+      "allowOverride": true
+    },
+    "PB_SyncArguments": {
+      "value": "-p -- /p:ArchGroup=x64",
+      "allowOverride": true
+    },
+    "PB_CreateHelixArguments": {
+      "value": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=true /p:\"TestProduct=corefx /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=OSX\" /p:FilterToOSGroup=OSX",
       "allowOverride": true
     }
   },

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows.json
@@ -105,7 +105,7 @@
       },
       "inputs": {
         "filename": "$(Build.SourcesDirectory)\\corefx\\sync.cmd",
-        "arguments": "-p -- /p:ArchGroup=$(PB_Platform)  /p:RuntimeOS=$(PB_RuntimeOS)",
+        "arguments": "$(PB_SyncArguments)",
         "workingFolder": "corefx",
         "failOnStandardError": "false"
       }
@@ -141,7 +141,7 @@
       },
       "inputs": {
         "filename": "$(Build.SourcesDirectory)\\corefx\\build.cmd",
-        "arguments": "-buildArch=$(PB_Platform) -$(PB_ConfigurationGroup) -- /p:SignType=$(PB_SignType) /p:RuntimeOS=$(PB_RuntimeOS)",
+        "arguments": "$(PB_BuildArguments)",
         "workingFolder": "corefx",
         "failOnStandardError": "false"
       }
@@ -159,7 +159,7 @@
       },
       "inputs": {
         "filename": "$(Build.SourcesDirectory)\\corefx\\build-tests.cmd",
-        "arguments": "-buildArch=$(PB_Platform) -$(PB_ConfigurationGroup) -SkipTests -- /p:RuntimeOS=$(PB_RuntimeOS) /p:ArchiveTests=true",
+        "arguments": "$(PB_BuildTestsArguments)",
         "workingFolder": "corefx",
         "failOnStandardError": "false"
       }
@@ -179,7 +179,7 @@
         "solution": "$(Build.SourcesDirectory)\\corefx\\src\\tests.builds",
         "platform": "",
         "configuration": "",
-        "msbuildArguments": "/t:CloudBuild /p:ArchGroup=$(PB_Platform) /p:ConfigurationGroup=$(PB_ConfigurationGroup) /p:\"EnableCloudTest=$(PB_EnableCloudTest)\" /p:\"BuildMoniker=$(PB_BuildMoniker)\" /p:\"TargetQueue=$(PB_TargetQueue)\" /p:\"TestProduct=$(PB_TestProduct)\" /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
+        "msbuildArguments": "$(PB_CreateHelixArguments) /p:\"Branch=$(SourceBranch)\" /p:\"CloudDropAccountName=$(PB_CloudDropAccountName)\" /p:\"CloudResultsAccountName=$(PB_CloudResultsAccountName)\" /p:\"CloudDropAccessToken=$(CloudDropAccessToken)\" /p:\"CloudResultsAccessToken=$(OutputCloudResultsAccessToken)\" /p:\"HelixApiAccessKey=$(HelixApiAccessKey)\" /p:HelixApiEndpoint=$(PB_HelixApiEndPoint)",
         "clean": "false",
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
@@ -232,7 +232,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Publish symbols path: \\\\cpvsbuild\\drops\\DotNetCore\\$(PB_SymbolsBuildId)\\$(Build.BuildNumber)\\symbols",
+      "displayName": "Publish symbols path: \\\\cpvsbuild\\drops\\DotNetCore\\$(PB_SymbolsBuildIdRoot)$(System.DefinitionId)\\$(Build.BuildNumber)\\symbols",
       "timeoutInMinutes": 0,
       "task": {
         "id": "0675668a-7bba-4ccb-901d-5ad6554ca653",
@@ -240,7 +240,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "SymbolsPath": "\\\\cpvsbuild\\drops\\DotNetCore\\$(PB_SymbolsBuildId)\\$(Build.BuildNumber)\\symbols",
+        "SymbolsPath": "\\\\cpvsbuild\\drops\\DotNetCore\\$(PB_SymbolsBuildIdRoot)$(System.DefinitionId)\\$(Build.BuildNumber)\\symbols",
         "SearchPattern": "corefx\\bin\\*$(PB_Platform).$(PB_ConfigurationGroup)\\**\\*.pdb",
         "SymbolsFolder": "",
         "SkipIndexing": "false",
@@ -263,7 +263,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "symbolStore": "\\\\cpvsbuild\\drops\\DotNetCore\\$(PB_SymbolsBuildId)\\$(Build.BuildNumber)\\symbols",
+        "symbolStore": "\\\\cpvsbuild\\drops\\DotNetCore\\$(PB_SymbolsBuildIdRoot)$(System.DefinitionId)\\$(Build.BuildNumber)\\symbols",
         "contacts": "jhendrix;mawilkie",
         "project": "DDE"
       }
@@ -388,18 +388,6 @@
       "value": "false",
       "allowOverride": true
     },
-    "PB_ConfigurationGroup": {
-      "value": "Release",
-      "allowOverride": true
-    },
-    "PB_Platform": {
-      "value": "AnyCPU",
-      "allowOverride": true
-    },
-    "PB_SignType": {
-      "value": "test",
-      "allowOverride": true
-    },
     "PB_CloudDropAccountName": {
       "value": "dotnetbuildoutput"
     },
@@ -452,11 +440,23 @@
     "PB_CleanAgent": {
       "value": "true"
     },
-    "PB_SymbolsBuildId": {
-      "value": "DotNet-CoreFx-$(System.DefinitionId)"
+    "PB_SymbolsBuildIdRoot": {
+      "value": "DotNet-CoreFx-"
     },
-    "PB_EnableCloudTest": {
-      "value": "true",
+    "PB_SyncArguments": {
+      "value": "-p -- /p:ArchGroup=x64  /p:RuntimeOS=win10",
+      "allowOverride": true
+    },
+    "PB_BuildArguments": {
+      "value": "-buildArch=x64 -Release -- /p:SignType=test /p:RuntimeOS=win10",
+      "allowOverride": true
+    },
+    "PB_BuildTestsArguments": {
+      "value": "-buildArch=x64 -Release -SkipTests -- /p:RuntimeOS=win10",
+      "allowOverride": true
+    },
+    "PB_CreateHelixArguments": {
+      "value": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=true\" /p:\"BuildMoniker=none\" /p:\"TargetQueue=Windows.10.Amd64\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT",
       "allowOverride": true
     }
   },

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -7,12 +7,16 @@
   },
   "Pipelines": [
     {
-      "Name": "Trusted-All-Release",
+      "Name": "Trusted-All-Release-Linux",
       "Parameters": {
         "TreatWarningsAsErrors": "false"
       },
       "BuildParameters": {
-        "PB_ConfigurationGroup": "Release"
+        "PB_ConfigurationGroup": "Release",
+        "PB_BuildArguments": "-buildArch=x64 -Release",
+        "PB_BuildTestsArguments": "-buildArch=x64 -Release -SkipTests -- /p:ArchiveTests=true",
+        "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=true /p:\"TestProduct=corefx /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:FilterToOSGroup=Linux /p:\"BuildMoniker=none\"",
+        "PB_SyncArguments": "-p -- /p:ArchGroup=x64"
       },
       "Definitions": [
         {
@@ -67,7 +71,7 @@
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
             "PB_DockerTag": "opensuse421_prereqs_v3",
-            "PB_EnableCloudTest": "false"
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=false /p:\"TestProduct=corefx /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:FilterToOSGroup=Linux /p:\"BuildMoniker=none\""
           },
           "ReportingParameters": {
             "OperatingSystem": "openSUSE 42.1",
@@ -91,8 +95,8 @@
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
             "PB_DockerTag": "rhel7_prereqs_2",
-            "PB_TargetQueue": "Redhat.72.Amd64",
-            "PB_AdditionalArguments": "-portableLinux",
+            "PB_BuildArguments": "-buildArch=x64 -Release -portableLinux",
+            "PB_SyncArguments": "-p -portableLinux -- /p:ArchGroup=x64"
           },
           "ReportingParameters": {
             "OperatingSystem": "RedHat 7",
@@ -110,7 +114,7 @@
           "ReportingParameters": {
             "OperatingSystem": "Ubuntu 14.04",
             "Type": "build/product/",
-            "ConfigurationGroup": "Release",
+            "ConfigurationGroup": "Release"
           }
         },
         {
@@ -141,14 +145,28 @@
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
             "PB_DockerTag": "alpine_prereqs",
-            "PB_EnableCloudTest": "false"
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=false /p:\"TestProduct=corefx /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:FilterToOSGroup=Linux /p:\"BuildMoniker=none\""
           },
           "ReportingParameters": {
             "OperatingSystem": "Alpine 3.4.3",
             "Type": "build/product/",
             "ConfigurationGroup": "Release"
           }
-        },        
+        }
+      ]
+    },
+    {
+      "Name": "Trusted-All-Release-OSX",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "BuildParameters": {
+        "PB_BuildArguments": "-buildArch=x64 -Release",
+        "PB_BuildTestsArguments": "-buildArch=x64 -Release -SkipTests -- /p:ArchiveTests=true",
+        "PB_SyncArguments": "-p -- /p:ArchGroup=x64",
+        "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=true /p:\"TestProduct=corefx /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=OSX\" /p:FilterToOSGroup=OSX /p:\"BuildMoniker=none\""
+      },
+      "Definitions": [
         {
           "Name": "DotNet-CoreFx-Trusted-OSX",
           "Parameters": {
@@ -159,12 +177,23 @@
             "Type": "build/product/",
             "ConfigurationGroup": "Release"
           }
-        },
+        }
+      ]
+    },
+    {
+      "Name": "Trusted-All-Release-Windows",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "BuildParameters": {},
+      "Definitions": [
         {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
-            "PB_Platform": "arm",
-            "PB_EnableCloudTest": "false"
+            "PB_BuildArguments": "-buildArch=arm -Release -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_BuildTestsArguments": "-buildArch=arm -Release -SkipTests -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=arm /p:ConfigurationGroup=Release /p:\"EnableCloudTest=false\" /p:\"BuildMoniker=none\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -176,8 +205,10 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
-            "PB_Platform": "arm64",
-            "PB_EnableCloudTest": "false"
+            "PB_BuildArguments": "-buildArch=arm64 -Release -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_BuildTestsArguments": "-buildArch=arm64 -Release -SkipTests -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=arm64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=false\" /p:\"BuildMoniker=none\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -189,8 +220,10 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
-            "PB_Platform": "x64",
-            "PB_TargetQueue": "Windows.10.Amd64"
+            "PB_BuildArguments": "-buildArch=x64 -Release -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_BuildTestsArguments": "-buildArch=x64 -Release -SkipTests -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=true\" /p:\"BuildMoniker=none\" /p:\"TargetQueue=Windows.10.Amd64\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -202,8 +235,11 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
-            "PB_Platform": "x86",
-            "PB_TargetQueue": "Windows.10.Amd64"
+            "PB_TargetQueue": "Windows.10.Amd64",
+            "PB_BuildArguments": "-buildArch=x86 -Release -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_BuildTestsArguments": "-buildArch=x86 -Release -SkipTests -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x86 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=true\" /p:\"BuildMoniker=none\" /p:\"TargetQueue=Windows.10.Amd64\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -215,12 +251,16 @@
       ]
     },
     {
-      "Name": "Trusted-All-Debug",
+      "Name": "Trusted-All-Debug-Linux",
       "Parameters": {
         "TreatWarningsAsErrors": "false"
       },
       "BuildParameters": {
-        "PB_ConfigurationGroup": "Debug"
+        "PB_ConfigurationGroup": "Debug",
+        "PB_BuildArguments": "-buildArch=x64 -Debug",
+        "PB_BuildTestsArguments": "-buildArch=x64 -Debug -SkipTests -- /p:ArchiveTests=true",
+        "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=true /p:\"TestProduct=corefx /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:FilterToOSGroup=Linux /p:\"BuildMoniker=none\"",
+        "PB_SyncArguments": "-p -- /p:ArchGroup=x64"
       },
       "Definitions": [
         {
@@ -251,7 +291,7 @@
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
             "PB_DockerTag": "fedora24_prereqs_v4",
-            "PB_EnableCloudTest": "false"
+            "PB_TargetQueue": "Fedora.23.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "Fedora 24",
@@ -275,7 +315,7 @@
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
             "PB_DockerTag": "opensuse421_prereqs_v3",
-            "PB_EnableCloudTest": "false"
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=false /p:\"TestProduct=corefx /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:FilterToOSGroup=Linux /p:\"BuildMoniker=none\""
           },
           "ReportingParameters": {
             "OperatingSystem": "openSUSE 42.1",
@@ -298,13 +338,27 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
+            "PB_DockerTag": "rhel7_prereqs_2",
+            "PB_BuildArguments": "-buildArch=x64 -Debug -portableLinux",
+            "PB_SyncArguments": "-p -portableLinux -- /p:ArchGroup=x64"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "RedHat 7",
+            "Type": "build/product/",
+            "ConfigurationGroup": "Debug",
+            "SubType": "PortableLinux"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Linux",
+          "Parameters": {
             "PB_DockerTag": "ubuntu1404_prereqs_v3",
             "PB_TargetQueue": "Ubuntu.1404.Amd64"
           },
           "ReportingParameters": {
             "OperatingSystem": "Ubuntu 14.04",
             "Type": "build/product/",
-            "ConfigurationGroup": "Debug",
+            "ConfigurationGroup": "Debug"
           }
         },
         {
@@ -335,14 +389,28 @@
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
             "PB_DockerTag": "alpine_prereqs",
-            "PB_EnableCloudTest": "false"
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=false /p:\"TestProduct=corefx /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:FilterToOSGroup=Linux /p:\"BuildMoniker=none\""
           },
           "ReportingParameters": {
             "OperatingSystem": "Alpine 3.4.3",
             "Type": "build/product/",
             "ConfigurationGroup": "Debug"
           }
-        },        
+        }
+      ]
+    },
+    {
+      "Name": "Trusted-All-Debug-OSX",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "BuildParameters": {
+        "PB_BuildArguments": "-buildArch=x64 -Debug",
+        "PB_BuildTestsArguments": "-buildArch=x64 -Debug -SkipTests -- /p:ArchiveTests=true",
+        "PB_SyncArguments": "-p -- /p:ArchGroup=x64",
+        "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=true /p:\"TestProduct=corefx /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=OSX\" /p:FilterToOSGroup=OSX /p:\"BuildMoniker=none\""
+      },
+      "Definitions": [
         {
           "Name": "DotNet-CoreFx-Trusted-OSX",
           "Parameters": {
@@ -353,12 +421,23 @@
             "Type": "build/product/",
             "ConfigurationGroup": "Debug"
           }
-        },
+        }
+      ]
+    },
+    {
+      "Name": "Trusted-All-Debug-Windows",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "BuildParameters": {},
+      "Definitions": [
         {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
-            "PB_Platform": "arm",
-            "PB_EnableCloudTest": "false"
+            "PB_BuildArguments": "-buildArch=arm -Debug -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_BuildTestsArguments": "-buildArch=arm -Debug -SkipTests -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=arm /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=false\" /p:\"BuildMoniker=none\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -370,8 +449,10 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
-            "PB_Platform": "arm64",
-            "PB_EnableCloudTest": "false"
+            "PB_BuildArguments": "-buildArch=arm64 -Debug -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_BuildTestsArguments": "-buildArch=arm64 -Debug -SkipTests -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=arm64 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=false\" /p:\"BuildMoniker=none\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -383,8 +464,10 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
-            "PB_Platform": "x64",
-            "PB_TargetQueue": "Windows.10.Amd64"
+            "PB_BuildArguments": "-buildArch=x64 -Debug -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_BuildTestsArguments": "-buildArch=x64 -Debug -SkipTests -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=true\" /p:\"BuildMoniker=none\" /p:\"TargetQueue=Windows.10.Amd64\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -396,8 +479,11 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Windows",
           "Parameters": {
-            "PB_Platform": "x86",
-            "PB_TargetQueue": "Windows.10.Amd64"
+            "PB_TargetQueue": "Windows.10.Amd64",
+            "PB_BuildArguments": "-buildArch=x86 -Debug -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_BuildTestsArguments": "-buildArch=x86 -Debug -SkipTests -- /p:RuntimeOS=win10 /p:ArchiveTests=true",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x86 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=true\" /p:\"BuildMoniker=none\" /p:\"TargetQueue=Windows.10.Amd64\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -431,7 +517,9 @@
         }
       ],
       "DependsOn": [
-        "Trusted-All-Release"
+        "Trusted-All-Release-Windows",
+        "Trusted-All-Release-OSX",
+        "Trusted-All-Release-Linux"
       ]
     },
     {
@@ -457,7 +545,9 @@
         }
       ],
       "DependsOn": [
-        "Trusted-All-Debug"
+        "Trusted-All-Debug-Windows",
+        "Trusted-All-Debug-OSX",
+        "Trusted-All-Debug-Linux"
       ]
     }    
   ]

--- a/config.json
+++ b/config.json
@@ -502,6 +502,12 @@
             "BuildNumberMinor": "default"
           }
         },
+        "portableLinux":{
+          "description": "Download packages that are portable over glibc based Linux distros.",
+          "settings": {
+            "RuntimeOS":"linux"
+          }
+        },
         "verbose": {
           "description": "Passes /flp:v=diag to the msbuild command or the value passed by the user.",
           "settings": {


### PR DESCRIPTION
- Re-enable portableLinux
- Refactor build definitions so that arguments are passed from pipeline.json to each of the primary build steps (sync, build, build-tests, createhelix).