### PR TITLE
Fix some failing win7 net.security tests

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
@@ -100,18 +100,14 @@ namespace System.Net.Security.Tests
                     case SslPolicyErrors.RemoteCertificateNameMismatch:
                         return true;
                     case SslPolicyErrors.RemoteCertificateNotAvailable:
-                        if (PlatformDetection.IsWindows7 && !Capability.IsTrustedRootCertificateInstalled())
-                        {
-                            // https://technet.microsoft.com/en-us/library/hh831771.aspx#BKMK_Changes2012R2
-                            // Starting with Windows 8, the "Management of trusted issuers for client authentication" has changed:
-                            // The behavior to send the Trusted Issuers List by default is off.
-                            //
-                            // In Windows 7 the Trusted Issuers List is sent within the Server Hello TLS record. This list is built
-                            // by the server using certificates from the Trusted Root Authorities certificate store.
-                            // The client side will use the Trusted Issuers List, if not empty, to filter proposed certificates.
-                            return true;
-                        }
-                        return false;
+                        // https://technet.microsoft.com/en-us/library/hh831771.aspx#BKMK_Changes2012R2
+                        // Starting with Windows 8, the "Management of trusted issuers for client authentication" has changed:
+                        // The behavior to send the Trusted Issuers List by default is off.
+                        //
+                        // In Windows 7 the Trusted Issuers List is sent within the Server Hello TLS record. This list is built
+                        // by the server using certificates from the Trusted Root Authorities certificate store.
+                        // The client side will use the Trusted Issuers List, if not empty, to filter proposed certificates.
+                        return PlatformDetection.IsWindows7 && !Capability.IsTrustedRootCertificateInstalled();
                     default:
                         return false;
                 }


### PR DESCRIPTION
These tests are consistently failing all win7 runs. This is because of a behavioral difference between win7 and win8+ with regard to how the trusted issuers list is exchanged between the server and the client. The test was not written expecting the old behavior like other System.Net.Security tests are, so it was failing from unexpected RemoteCertificateNotAvailable PolicyErrors. This can be resolved either by manually installing the NDX Test Root CA cert to the test machine or by modding the code to handle the PolicyError when the cert is unavailable and the platform is win7 (which is what this code does).

resolves https://github.com/dotnet/corefx/issues/13637

PTAL: @steveharter @Priya91 
FYI: @CIPop @davidsh @karelz 