### PR TITLE
Add Dumpling to targets in Tools-Override

### DIFF
--- a/Tools-Override/Dumpling.targets
+++ b/Tools-Override/Dumpling.targets
@@ -1,0 +1,16 @@
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Setup Dumpling service to collect crash dumps -->
+  <Target Name="SetupDumpling"
+          BeforeTargets="RunTestsForProject"
+          Condition="'$(TargetOS)'!='Windows_NT'">
+    <ReadLinesFromFile File="$(MSBuildThisFileDirectory)Dumpling.txt">
+      <Output TaskParameter="Lines" ItemName="DumplingCommands" />
+    </ReadLinesFromFile>
+    <ItemGroup>
+      <TestCommandLines Include="@(DumplingCommands)" />
+    </ItemGroup>
+    <ItemGroup>
+      <PostExecutionTestCommandLines Include="CollectDumps $%3f $(MSBuildProjectName)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/Tools-Override/Dumpling.targets
+++ b/Tools-Override/Dumpling.targets
@@ -1,7 +1,7 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Setup Dumpling service to collect crash dumps -->
   <Target Name="SetupDumpling"
-          BeforeTargets="RunTestsForProject"
+          BeforeTargets="GenerateTestExecutionScripts"
           Condition="'$(TargetOS)'!='Windows_NT'">
     <ReadLinesFromFile File="$(MSBuildThisFileDirectory)Dumpling.txt">
       <Output TaskParameter="Lines" ItemName="DumplingCommands" />

--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -262,4 +262,6 @@
   <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />
   <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" />
 
+  <!-- This helps collect crash dumps and requires python installed -->
+  <Import Project="$(MSBuildThisFileDirectory)Dumpling.targets" Condition="'$(EnableDumpling)' == 'true' OR '$(EnableCloudTest)' == 'true'" />
 </Project>


### PR DESCRIPTION
Merges https://github.com/dotnet/buildtools/pull/1254/ into Tools-Override directory as currently we are overriding `tests.targets` in Tools grabbed from buildtools. (This change was left behind from `tests.targets` when Tools-Override was added)

@danmosemsft @joperezr @weshaggard @MattGal @karajas 