### PR TITLE
Throw ArgumentException for invalid uses of global members in Expressions.

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
@@ -10,7 +10,7 @@ namespace System.Dynamic.Utils
     {
         public static bool AreEquivalent(Type t1, Type t2)
         {
-            return t1.IsEquivalentTo(t2);
+            return t1 != null && t1.IsEquivalentTo(t2);
         }
 
         public static bool AreReferenceAssignable(Type dest, Type src)

--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -366,6 +366,9 @@
   <data name="NotAMemberOfType" xml:space="preserve">
     <value>'{0}' is not a member of type '{1}'</value>
   </data>
+  <data name="NotAMemberOfAnyType" xml:space="preserve">
+    <value>'{0}' is not a member of any </value>
+  </data>
   <data name="ExpressionNotSupportedForType" xml:space="preserve">
     <value>The expression '{0}' is not supported for type '{1}'</value>
   </data>

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -180,6 +180,10 @@ namespace System.Dynamic.Utils
             {
                 return true;
             }
+            if (targetType == null)
+            {
+                return false;
+            }
             if (instanceType.GetTypeInfo().IsValueType)
             {
                 if (AreReferenceAssignable(targetType, typeof(object)))

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -824,8 +824,13 @@ namespace System.Linq.Expressions
             {
                 left = left.GetNonNullableType();
             }
-            MethodInfo opTrue = TypeUtils.GetBooleanOperator(method.DeclaringType, "op_True");
-            MethodInfo opFalse = TypeUtils.GetBooleanOperator(method.DeclaringType, "op_False");
+            Type declaringType = method.DeclaringType;
+            if (declaringType == null)
+            {
+                throw Error.LogicalOperatorMustHaveBooleanOperators(nodeType, method.Name);
+            }
+            MethodInfo opTrue = TypeUtils.GetBooleanOperator(declaringType, "op_True");
+            MethodInfo opFalse = TypeUtils.GetBooleanOperator(declaringType, "op_False");
             if (opTrue == null || opTrue.ReturnType != typeof(bool) ||
                 opFalse == null || opFalse.ReturnType != typeof(bool))
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -834,6 +834,15 @@ namespace System.Linq.Expressions
         {
             return NotAMemberOfType(p0, p1, GetParamName(paramName, index));
         }
+
+        /// <summary>
+        /// ArgumentException with message like "'{0}' is not a member of any type"
+        /// </summary>
+        internal static Exception NotAMemberOfAnyType(object p0, string paramName)
+        {
+            return new ArgumentException(Strings.NotAMemberOfAnyType(p0), paramName);
+        }
+
         /// <summary>
         /// PlatformNotSupportedException with message like "The instruction '{0}' is not supported for type '{1}'"
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -300,20 +300,24 @@ namespace System.Linq.Expressions
         private static PropertyInfo GetProperty(MethodInfo mi, string paramName, int index = -1)
         {
             Type type = mi.DeclaringType;
-            BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic;
-            flags |= (mi.IsStatic) ? BindingFlags.Static : BindingFlags.Instance;
-            PropertyInfo[] props = type.GetProperties(flags);
-            foreach (PropertyInfo pi in props)
+            if (type != null)
             {
-                if (pi.CanRead && CheckMethod(mi, pi.GetGetMethod(nonPublic: true)))
+                BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic;
+                flags |= (mi.IsStatic) ? BindingFlags.Static : BindingFlags.Instance;
+                PropertyInfo[] props = type.GetProperties(flags);
+                foreach (PropertyInfo pi in props)
                 {
-                    return pi;
-                }
-                if (pi.CanWrite && CheckMethod(mi, pi.GetSetMethod(nonPublic: true)))
-                {
-                    return pi;
+                    if (pi.CanRead && CheckMethod(mi, pi.GetGetMethod(nonPublic: true)))
+                    {
+                        return pi;
+                    }
+                    if (pi.CanWrite && CheckMethod(mi, pi.GetSetMethod(nonPublic: true)))
+                    {
+                        return pi;
+                    }
                 }
             }
+
             throw Error.MethodNotPropertyAccessor(mi.DeclaringType, mi.Name, paramName, index);
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
@@ -131,6 +131,11 @@ namespace System.Linq.Expressions
             }
             else
             {
+                if (fi.DeclaringType == null)
+                {
+                    throw Error.NotAMemberOfAnyType(fi, nameof(member));
+                }
+
                 memberType = fi.FieldType;
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -510,6 +510,11 @@ namespace System.Linq.Expressions
         internal static string NotAMemberOfType(object p0, object p1) => SR.Format(SR.NotAMemberOfType, p0, p1);
 
         /// <summary>
+        /// A string like "'{0}' is not a member of any type"
+        /// </summary>
+        internal static string NotAMemberOfAnyType(object p0) => SR.Format(SR.NotAMemberOfAnyType, p0);
+
+        /// <summary>
         /// A string like "The expression '{0}' is not supported for type '{1}'"
         /// </summary>
         internal static string ExpressionNotSupportedForType(object p0, object p1) => SR.Format(SR.ExpressionNotSupportedForType, p0, p1);

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
@@ -775,11 +775,35 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal("(a OrElse b)", e2.ToString());
         }
 
+
+        [Fact]
+        public static void AndAlsoGlobalMethod()
+        {
+            MethodInfo method = GlobalMethod(typeof(int), new[] { typeof(int), typeof(int) });
+            Assert.Throws<ArgumentException>(() => Expression.AndAlso(Expression.Constant(1), Expression.Constant(2), method));
+        }
+
+        [Fact]
+        public static void OrElseGlobalMethod()
+        {
+            MethodInfo method = GlobalMethod(typeof(int), new [] { typeof(int), typeof(int) });
+            Assert.Throws<ArgumentException>(() => Expression.OrElse(Expression.Constant(1), Expression.Constant(2), method));
+        }
+
         private static TypeBuilder GetTypeBuilder()
         {
             AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.Run);
             ModuleBuilder module = assembly.DefineDynamicModule("Name");
             return module.DefineType("Type");
+        }
+
+        private static MethodInfo GlobalMethod(Type returnType, Type[] parameterTypes)
+        {
+            ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.Run).DefineDynamicModule("Module");
+            MethodBuilder globalMethod = module.DefineGlobalMethod("GlobalMethod", MethodAttributes.Public | MethodAttributes.Static, returnType, parameterTypes);
+            globalMethod.GetILGenerator().Emit(OpCodes.Ret);
+            module.CreateGlobalFunctions();
+            return module.GetMethod(globalMethod.Name);
         }
 
         public class NonGenericClass

--- a/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
+using System.Reflection.Emit;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -254,6 +255,17 @@ namespace System.Linq.Expressions.Tests
         {
             MemberAssignment bind = Expression.Bind(typeof(PropertyAndFields).GetProperty("StringProperty"), Expression.Constant("Hello Property"));
             Assert.Equal(MemberBindingType.Assignment, bind.BindingType);
+        }
+
+        [Fact]
+        public void GlobalMethod()
+        {
+            ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.Run).DefineDynamicModule("Module");
+            MethodBuilder globalMethod = module.DefineGlobalMethod("GlobalMethod", MethodAttributes.Public | MethodAttributes.Static, typeof(int), new [] {typeof(int)});
+            globalMethod.GetILGenerator().Emit(OpCodes.Ret);
+            module.CreateGlobalFunctions();
+            MethodInfo globalMethodInfo = module.GetMethod(globalMethod.Name);
+            Assert.Throws<ArgumentException>("propertyAccessor", () => Expression.Bind(globalMethodInfo, Expression.Constant(2)));
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/BindTests.cs
@@ -267,5 +267,15 @@ namespace System.Linq.Expressions.Tests
             MethodInfo globalMethodInfo = module.GetMethod(globalMethod.Name);
             Assert.Throws<ArgumentException>("propertyAccessor", () => Expression.Bind(globalMethodInfo, Expression.Constant(2)));
         }
+
+        [Fact]
+        public void GlobalField()
+        {
+            ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.Run).DefineDynamicModule("Module");
+            FieldBuilder fieldBuilder = module.DefineInitializedData("GlobalField", new byte[4], FieldAttributes.Public);
+            module.CreateGlobalFunctions();
+            FieldInfo globalField = module.GetField(fieldBuilder.Name);
+            Assert.Throws<ArgumentException>("member", () => Expression.Bind(globalField, Expression.Default(globalField.FieldType)));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Reflection;
+using System.Reflection.Emit;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -251,6 +252,18 @@ namespace System.Linq.Expressions.Tests
                     )
                 );
             Assert.Throws<InvalidProgramException>(() => exp.Compile(useInterpreter));
+        }
+
+
+        [Fact]
+        public void GlobalMethod()
+        {
+            ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.Run).DefineDynamicModule("Module");
+            MethodBuilder globalMethod = module.DefineGlobalMethod("GlobalMethod", MethodAttributes.Public | MethodAttributes.Static, typeof(int), Type.EmptyTypes);
+            globalMethod.GetILGenerator().Emit(OpCodes.Ret);
+            module.CreateGlobalFunctions();
+            MethodInfo globalMethodInfo = module.GetMethod(globalMethod.Name);
+            Assert.Throws<ArgumentException>("propertyAccessor", () => Expression.MemberBind(globalMethodInfo));
         }
 
         public void WriteOnlyInnerProperty()

--- a/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
@@ -254,7 +254,6 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidProgramException>(() => exp.Compile(useInterpreter));
         }
 
-
         [Fact]
         public void GlobalMethod()
         {

--- a/src/System.Linq.Expressions/tests/New/NewTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Reflection;
+using System.Reflection.Emit;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -511,6 +512,33 @@ namespace System.Linq.Expressions.Tests
             {
                 Assert.Throws<ArgumentException>("constructor", () => Expression.New(ctor));
             }
+        }
+
+        [Fact]
+        public static void GlobalMethodInMembers()
+        {
+            ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.Run).DefineDynamicModule("Module");
+            MethodBuilder globalMethod = module.DefineGlobalMethod("GlobalMethod", MethodAttributes.Public | MethodAttributes.Static, typeof(int), Type.EmptyTypes);
+            globalMethod.GetILGenerator().Emit(OpCodes.Ret);
+            module.CreateGlobalFunctions();
+            MethodInfo globalMethodInfo = module.GetMethod(globalMethod.Name);
+            ConstructorInfo constructor = typeof(ClassWithCtors).GetConstructor(new Type[] { typeof(string) });
+            Expression[] arguments = { Expression.Constant(5) };
+            MemberInfo[] members = { globalMethodInfo };
+            Assert.Throws<ArgumentException>(() => Expression.New(constructor, arguments, members));
+        }
+
+        [Fact]
+        public static void GlobalFieldInMembers()
+        {
+            ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.Run).DefineDynamicModule("Module");
+            FieldBuilder fieldBuilder = module.DefineInitializedData("GlobalField", new byte[1], FieldAttributes.Public);
+            module.CreateGlobalFunctions();
+            FieldInfo globalField = module.GetField(fieldBuilder.Name);
+            ConstructorInfo constructor = typeof(ClassWithCtors).GetConstructor(new Type[] { typeof(string) });
+            Expression[] arguments = { Expression.Constant(5) };
+            MemberInfo[] members = { globalField };
+            Assert.Throws<ArgumentException>(() => Expression.New(constructor, arguments, members));
         }
 
         static class StaticCtor


### PR DESCRIPTION
Several methods of `Expression` will throw `NullReferenceException` if called with a `MethodInfo` or `FieldInfo` for a global method or field. These exceptions are all thrown from validation of the (null) `DeclaringType`, so fix these validation methods to throw the same exception they would throw for a non-null but inappropriate `DeclaringType`.

Using a global field with a `MemberBinding` does not throw, but any attempt to use that binding will similarly throw `NullReferenceException`. Change to throw an `ArgumentException` immediately.

Fixes #12943