### PR TITLE
Add missing RID packages - Private.CoreFx.NETCoreApp

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.props
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.props
@@ -34,6 +34,9 @@
 
   <ItemGroup>
     <OfficialBuildRID Include="alpine.3.4.3-x64" />
+    <OfficialBuildRID Include="debian.8-armel">
+      <Platform>armel</Platform>
+    </OfficialBuildRID>
     <OfficialBuildRID Include="debian.8-x64" />
     <OfficialBuildRID Include="fedora.23-x64" />
     <OfficialBuildRID Include="fedora.24-x64" />
@@ -42,8 +45,20 @@
     <OfficialBuildRID Include="opensuse.42.1-x64" />
     <OfficialBuildRID Include="osx.10.10-x64" />
     <OfficialBuildRID Include="rhel.7-x64" />
+    <OfficialBuildRID Include="tizen.4.0.0-armel">
+      <Platform>armel</Platform>
+    </OfficialBuildRID>
+    <OfficialBuildRID Include="ubuntu.14.04-arm">
+      <Platform>arm</Platform>
+    </OfficialBuildRID>
     <OfficialBuildRID Include="ubuntu.14.04-x64" />
+    <OfficialBuildRID Include="ubuntu.16.04-arm">
+      <Platform>arm</Platform>
+    </OfficialBuildRID>
     <OfficialBuildRID Include="ubuntu.16.04-x64" />
+    <OfficialBuildRID Include="ubuntu.16.10-arm">
+      <Platform>arm</Platform>
+    </OfficialBuildRID>
     <OfficialBuildRID Include="ubuntu.16.10-x64" />
     <OfficialBuildRID Include="win7-x86">
       <Platform>x86</Platform>

--- a/src/Tools/GenerateProps/archgroups.props
+++ b/src/Tools/GenerateProps/archgroups.props
@@ -5,5 +5,6 @@
     <ArchGroups Include="x64" />
     <ArchGroups Include="arm" />
     <ArchGroups Include="arm64" />
+    <ArchGroups Include="armel" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
These RIDs were added to the native shims between when we branched
dev/eng and merged back to master.  We don't have an official build leg
building these, but I'm adding them to the identity package so that our
officially built identity package will have entries for them in its
runtime.json.

Note that this is not a requirement if all you are doing is building the
stack yourself without publishing the output of your builds to a common 
feed.  In that case your build for ubuntu.14.04-arm would have an entry
for that in the MS.Private.CoreFx.NETCoreApp package.

I've also added `armel` to our property data model as @hseok-oh pointed
out this is missing. 

/cc @chunseoklee @hseok-oh @weshaggard @ellismg 