### PR TITLE
Expose String.Trim overloads that take a single char

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -2099,8 +2099,11 @@ namespace System
         public System.String ToUpper(System.Globalization.CultureInfo culture) { throw null; }
         public string ToUpperInvariant() { throw null; }
         public string Trim() { throw null; }
+        public string Trim(char trimChar) { throw null; }
         public string Trim(params char[] trimChars) { throw null; }
+        public string TrimEnd(char trimChar) { throw null; }
         public string TrimEnd(params char[] trimChars) { throw null; }
+        public string TrimStart(char trimChar) { throw null; }
         public string TrimStart(params char[] trimChars) { throw null; }
     }
     public enum StringComparison

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -2313,6 +2313,12 @@ namespace System.Tests
             {
                 Assert.Equal(expected, s.Trim());
             }
+
+            if (trimChars?.Length == 1)
+            {
+                Assert.Equal(expected, s.Trim(trimChars[0]));
+            }
+
             Assert.Equal(expected, s.Trim(trimChars));
         }
 
@@ -2331,6 +2337,12 @@ namespace System.Tests
             {
                 Assert.Equal(expected, s.TrimEnd());
             }
+
+            if (trimChars?.Length == 1)
+            {
+                Assert.Equal(expected, s.TrimEnd(trimChars[0]));
+            }
+
             Assert.Equal(expected, s.TrimEnd(trimChars));
         }
 
@@ -2349,6 +2361,12 @@ namespace System.Tests
             {
                 Assert.Equal(expected, s.TrimStart());
             }
+
+            if (trimChars?.Length == 1)
+            {
+                Assert.Equal(expected, s.TrimStart(trimChars[0]));
+            }
+
             Assert.Equal(expected, s.TrimStart(trimChars));
         }
 


### PR DESCRIPTION
Expose and add tests for https://github.com/dotnet/coreclr/pull/9009.

The new tests should compile/run on older platforms that don't have the new overloads yet since the existing overloads are `params`. Though, I assume it won't pass CI until the changes to coreclr are available to corefx due to the ref update.

Fixes #14337