### PR TITLE
Optimized complex sqrt, added strict test for sqrt(-1)=i

### DIFF
--- a/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
@@ -123,7 +123,6 @@ namespace System.Numerics
             // |value| == sqrt(a^2 + b^2)
             // sqrt(a^2 + b^2) == a/a * sqrt(a^2 + b^2) = a * sqrt(a^2/a^2 + b^2/a^2)
             // Using the above we can factor out the square of the larger component to dodge overflow.
-            // Really this should be public on Math; it is a very standard numerical method.
 
             double c = Math.Abs(a);
             double d = Math.Abs(b);

--- a/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
@@ -20,6 +20,9 @@ namespace System.Numerics
 
         private const double InverseOfLog10 = 0.43429448190325; // 1 / Log(10)
 
+        // This is the largest x for which (Hypot(x,x) + x) will not overflow. It is used for branching inside Sqrt.
+        private static readonly double s_sqrtRescaleThreshold = Double.MaxValue / (Math.Sqrt(2.0) + 1.0);
+
         private double _real;
         private double _imaginary;
         
@@ -375,9 +378,6 @@ namespace System.Numerics
             }
             
         }
-
-        // This is the largest x for which (Hypot(x,x) + x) will not overflow. It is used for branching inside Sqrt.
-        private static readonly double s_sqrtRescaleThreshold = Double.MaxValue / (Math.Sqrt(2.0) + 1.0);
 
         public static Complex Pow(Complex value, Complex power)
         {

--- a/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
@@ -344,7 +344,7 @@ namespace System.Numerics
                 // make the result representable. To avoid this, we re-scale (by exact powers of 2 for accuracy)
                 // when we encounter very large components to avoid intermediate infinities.
                 bool rescale = false;
-                if ((Math.Abs(value._real) >= sqrtLimit) || (Math.Abs(value._imaginary) >= sqrtLimit))
+                if ((Math.Abs(value._real) >= s_sqrtRescaleThreshold) || (Math.Abs(value._imaginary) >= s_sqrtRescaleThreshold))
                 {
                     value._real *= 0.25;
                     value._imaginary *= 0.25;
@@ -377,7 +377,7 @@ namespace System.Numerics
         }
 
         // This is the largest x for which (Hypot(x,x) + x) will not overflow. It is used for branching inside Sqrt.
-        private static readonly double sqrtLimit = Double.MaxValue / (Math.Sqrt(2.0) + 1.0);
+        private static readonly double s_sqrtRescaleThreshold = Double.MaxValue / (Math.Sqrt(2.0) + 1.0);
 
         public static Complex Pow(Complex value, Complex power)
         {

--- a/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
@@ -21,7 +21,7 @@ namespace System.Numerics
         private const double InverseOfLog10 = 0.43429448190325; // 1 / Log(10)
 
         // This is the largest x for which (Hypot(x,x) + x) will not overflow. It is used for branching inside Sqrt.
-        private static readonly double s_sqrtRescaleThreshold = Double.MaxValue / (Math.Sqrt(2.0) + 1.0);
+        private static readonly double s_sqrtRescaleThreshold = double.MaxValue / (Math.Sqrt(2.0) + 1.0);
 
         private double _real;
         private double _imaginary;
@@ -119,7 +119,7 @@ namespace System.Numerics
         private static double Hypot(double a, double b)
         {
             // Using
-            //   sqrt(a^2 + b^2) = |a| * sqrt(a^2/a^2 + b^2/a^2)
+            //   sqrt(a^2 + b^2) = |a| * sqrt(1 + (b/a)^2)
             // we can factor out the larger component to dodge overflow even when a * a would overflow.
 
             a = Math.Abs(a);
@@ -141,11 +141,11 @@ namespace System.Numerics
             {
                 return (large);
             }
-            else if (Double.IsPositiveInfinity(large) && !Double.IsNaN(small))
+            else if (double.IsPositiveInfinity(large) && !double.IsNaN(small))
             {
                 // The NaN test is necessary so we don't return +inf when small=NaN and large=+inf.
                 // NaN in any other place returns NaN without any special handling.
-                return (Double.PositiveInfinity);
+                return (double.PositiveInfinity);
             }
             else
             {
@@ -358,12 +358,12 @@ namespace System.Numerics
                 bool rescale = false;
                 if ((Math.Abs(value._real) >= s_sqrtRescaleThreshold) || (Math.Abs(value._imaginary) >= s_sqrtRescaleThreshold))
                 {
-                    if (Double.IsInfinity(value._imaginary) && !Double.IsNaN(value._real))
+                    if (double.IsInfinity(value._imaginary) && !double.IsNaN(value._real))
                     {
                         // We need to handle infinite imaginary parts specially because otherwise
                         // our formulas below produce inf/inf = NaN. The NaN test is necessary
                         // so that we return NaN rather than (+inf,inf) for (NaN,inf).
-                        return (new Complex(Double.PositiveInfinity, value._imaginary));
+                        return (new Complex(double.PositiveInfinity, value._imaginary));
                     }
                     else
                     {

--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -65,9 +65,9 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void SqrtMinusOne()
         {
-            // Sqrt(-1) should be I exactly, not just tollerably close.
             Assert.Equal(Complex.Sqrt(-1.0), Complex.ImaginaryOne);
         }
 
@@ -359,12 +359,6 @@ namespace System.Numerics.Tests
         {
             yield return new object[] { -1234000000, 0, -1.5707963267948966, 21.62667394298955 }; // Real part is negative, imaginary part is 0
             yield return new object[] { 0, 1234000000, 0, 21.62667394298955 }; // Imaginary part is positive
-
-            // Boundary values
-            // We used to test that MinValue and MaxValue produced NaNs, but that's an implementation artifact and
-            // mathematically incorrect. For example, asin(Double.MaxValue) ~ 1.5708 \pm 710.47 i. In fact,
-            // for all arguments in the repesentable range, asin and acos lie in the representable range.
-            // We should fix the implementation so it returns the right values.
 
             // Invalid values
             foreach (double invalidReal in s_invalidDoubleValues)

--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -64,6 +64,13 @@ namespace System.Numerics.Tests
             VerifyMagnitudePhaseProperties(Complex.ImaginaryOne, 1, Math.PI / 2);
         }
 
+        [Fact]
+        public static void SqrtMinusOne()
+        {
+            // Sqrt(-1) should be I exactly, not just tollerably close.
+            Assert.Equal(Complex.Sqrt(-1.0), Complex.ImaginaryOne);
+        }
+
         public static IEnumerable<object[]> Valid_2_TestData()
         {
             foreach (double real in s_validDoubleValues)
@@ -354,12 +361,10 @@ namespace System.Numerics.Tests
             yield return new object[] { 0, 1234000000, 0, 21.62667394298955 }; // Imaginary part is positive
 
             // Boundary values
-            yield return new object[] { double.MaxValue, 0, double.NaN, double.NaN };
-            yield return new object[] { double.MinValue, 0, double.NaN, double.NaN };
-            yield return new object[] { 0, double.MaxValue, double.NaN, double.NaN };
-            yield return new object[] { 0, double.MinValue, double.NaN, double.NaN };
-            yield return new object[] { double.MaxValue, double.MaxValue, double.NaN, double.NaN };
-            yield return new object[] { double.MinValue, double.MinValue, double.NaN, double.NaN };
+            // We used to test that MinValue and MaxValue produced NaNs, but that's an implementation artifact and
+            // mathematically incorrect. For example, asin(Double.MaxValue) ~ 1.5708 \pm 710.47 i. In fact,
+            // for all arguments in the repesentable range, asin and acos lie in the representable range.
+            // We should fix the implementation so it returns the right values.
 
             // Invalid values
             foreach (double invalidReal in s_invalidDoubleValues)
@@ -1245,6 +1250,7 @@ namespace System.Numerics.Tests
         {
             yield return new object[] { 0, 0, 0, 0 };
             yield return new object[] { 1, 0, 1, 0 };
+            yield return new object[] { -1, 0, 0, 1 };
             yield return new object[] { 0, 1, 0.707106781186547, 0.707106781186547 };
             yield return new object[] { 0, -1, 0.707106781186547, -0.707106781186547 };
 

--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -357,8 +357,20 @@ namespace System.Numerics.Tests
 
         public static IEnumerable<object[]> ASin_Advanced_TestData()
         {
+            // Simple values
+            yield return new object[] { 0.0, 0.0, 0.0, 0.0 };
+            yield return new object[] { 1.0, 0.0, Math.PI / 2.0, 0.0 };
+            yield return new object[] { -1.0, 0.0, -Math.PI / 2.0, 0.0 };
+            yield return new object[] { 0.0, 1.0, 0.0, Math.Log(1.0 + Math.Sqrt(2.0)) };
+            yield return new object[] { 0.0, -1.0, 0.0, -Math.Log(1.0 + Math.Sqrt(2.0)) };
+
             yield return new object[] { -1234000000, 0, -1.5707963267948966, 21.62667394298955 }; // Real part is negative, imaginary part is 0
             yield return new object[] { 0, 1234000000, 0, 21.62667394298955 }; // Imaginary part is positive
+
+            // Extreme values
+            yield return new object[] { Double.MaxValue, 0.0, Math.PI / 2.0, Math.Log(2.0) + Math.Log(Double.MaxValue) };
+            yield return new object[] { 0.0, Double.MaxValue, 0.0, Math.Log(2.0) + Math.Log(Double.MaxValue) };
+            yield return new object[] { Double.MaxValue, Double.MaxValue, Math.PI / 4.0, Math.Log(2.0 * Math.Sqrt(2.0)) + Math.Log(Double.MaxValue) };
 
             // Invalid values
             foreach (double invalidReal in s_invalidDoubleValues)
@@ -372,6 +384,7 @@ namespace System.Numerics.Tests
             }
         }
 
+        [ActiveIssue(15455)]
         [Theory, MemberData("ASin_Advanced_TestData")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void ASin_Advanced(double real, double imaginary, double expectedReal, double expectedImaginary)
@@ -1248,9 +1261,11 @@ namespace System.Numerics.Tests
             yield return new object[] { 0, 1, 0.707106781186547, 0.707106781186547 };
             yield return new object[] { 0, -1, 0.707106781186547, -0.707106781186547 };
 
-            yield return new object[] { double.MaxValue, 0, 1.34078079299426E+154, 0 };
+            yield return new object[] { double.MaxValue, 0.0, Math.Sqrt(double.MaxValue), 0.0 };
+            yield return new object[] { -double.MaxValue, 0.0, 0.0, Math.Sqrt(double.MaxValue) };
             yield return new object[] { 0, double.MaxValue, 9.48075190810917E+153, 9.48075190810917E+153 };
             yield return new object[] { 0, double.MinValue, 9.48075190810917E+153, -9.48075190810917E+153 };
+            yield return new object[] { double.MaxValue, double.MaxValue, Math.Sqrt(Math.Sqrt(2.0)) * Math.Sqrt(double.MaxValue) * Math.Cos(Math.PI / 8.0), Math.Sqrt(Math.Sqrt(2.0)) * Math.Sqrt(double.MaxValue) * Math.Sin(Math.PI / 8.0) };
         }
 
         [Theory, MemberData("Sqrt_TestData")]

--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -256,6 +256,7 @@ namespace System.Numerics.Tests
 
         [Theory]
         [MemberData(nameof(Abs_Advanced_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void Abs_Advanced(double real, double imaginary, double expected)
         {
             var complex = new Complex(real, imaginary);
@@ -389,9 +390,9 @@ namespace System.Numerics.Tests
             yield return new object[] { 0, 1234000000, 0, 21.62667394298955 }; // Imaginary part is positive
 
             // Extreme values
-            yield return new object[] { Double.MaxValue, 0.0, Math.PI / 2.0, Math.Log(2.0) + Math.Log(Double.MaxValue) };
-            yield return new object[] { 0.0, Double.MaxValue, 0.0, Math.Log(2.0) + Math.Log(Double.MaxValue) };
-            yield return new object[] { Double.MaxValue, Double.MaxValue, Math.PI / 4.0, Math.Log(2.0 * Math.Sqrt(2.0)) + Math.Log(Double.MaxValue) };
+            yield return new object[] { double.MaxValue, 0.0, Math.PI / 2.0, Math.Log(2.0) + Math.Log(double.MaxValue) };
+            yield return new object[] { 0.0, double.MaxValue, 0.0, Math.Log(2.0) + Math.Log(double.MaxValue) };
+            yield return new object[] { double.MaxValue, double.MaxValue, Math.PI / 4.0, Math.Log(2.0 * Math.Sqrt(2.0)) + Math.Log(double.MaxValue) };
 
             // Invalid values
             foreach (double invalidReal in s_invalidDoubleValues)
@@ -1288,6 +1289,11 @@ namespace System.Numerics.Tests
             yield return new object[] { -double.MaxValue, 0.0, 0.0, Math.Sqrt(double.MaxValue) };
             yield return new object[] { 0, double.MaxValue, 9.48075190810917E+153, 9.48075190810917E+153 };
             yield return new object[] { 0, double.MinValue, 9.48075190810917E+153, -9.48075190810917E+153 };
+        }
+
+        public static IEnumerable<object> Sqrt_AdvancedTestData ()
+        {
+            // Extreme values don't overflow, even when intermediate quantities would if handled naively.
             yield return new object[] { double.MaxValue, double.MaxValue, Math.Sqrt(Math.Sqrt(2.0)) * Math.Sqrt(double.MaxValue) * Math.Cos(Math.PI / 8.0), Math.Sqrt(Math.Sqrt(2.0)) * Math.Sqrt(double.MaxValue) * Math.Sin(Math.PI / 8.0) };
 
             // Infinities produce the expected infinities.
@@ -1309,11 +1315,23 @@ namespace System.Numerics.Tests
             yield return new object[] { double.NegativeInfinity, double.NaN, double.NaN, double.NaN };
             yield return new object[] { double.NaN, -double.MaxValue, double.NaN, double.NaN };
             yield return new object[] { double.NaN, double.PositiveInfinity, double.NaN, double.NaN };
-            yield return new object[] { double.NaN, double.NaN, double.NaN, double.NaN }; 
+            yield return new object[] { double.NaN, double.NaN, double.NaN, double.NaN };
+
         }
 
-        [Theory, MemberData("Sqrt_TestData")]
+        [Theory]
+        [MemberData("Sqrt_TestData")]
         public static void Sqrt(double real, double imaginary, double expectedReal, double expectedImaginary)
+        {
+            var complex = new Complex(real, imaginary);
+            Complex result = Complex.Sqrt(complex);
+            VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
+        }
+
+        [Theory]
+        [MemberData("Sqrt_AdvancedTestData")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void Sqrt_Advanced(double real, double imaginary, double expectedReal, double expectedImaginary)
         {
             var complex = new Complex(real, imaginary);
             Complex result = Complex.Sqrt(complex);


### PR DESCRIPTION
The current implementation of Complex.Sqrt(z) is just Complex.Pow(z, 0.5). This results in several problems, most glaringly Complex.Sqrt(-1)!=Complex.ImaginaryOne. It is also not optimized. I have changed the implementation to be the standard optimized complex square root algorithm well known in the numerical computing community. I also added a test for Complex.Sqrt(-1)==Complex.ImaginaryOne, which the current implementation fails and the new implementation passes.

In the course of making this modification, I noticed several tests which demand NaNs be returned for extreme inputs to Complex.Asin, and for which NaNs are no longer returned after my changes to Complex.Sqrt. Actually, asin is perfectly well-defined and re-presentable for these inputs, and the tests were presumably added simply to reflect the current behavior of Complex.Asin.  For the moment, I have simply deleted the erroneous tests. In future, Complex.Asin and Complex.Acos can be updated to use an optimized algorithm which will give correct results for all re-presentable inputs.