### PR TITLE
Update NETStandard.Library to 2.0.0-beta-24919-01

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -29,6 +29,7 @@
     <CoreClrExpectedPrerelease>beta-24917-03</CoreClrExpectedPrerelease>
     <ExternalExpectedPrerelease>beta-24727-00</ExternalExpectedPrerelease>
     <ProjectNTfsExpectedPrerelease>beta-24917-00</ProjectNTfsExpectedPrerelease>
+    <StandardExpectedPrerelease>beta-24919-01</StandardExpectedPrerelease>
   </PropertyGroup>
 
   <!-- Full package version strings that are used in other parts of the build. -->

--- a/external/netstandard/netstandard.depproj
+++ b/external/netstandard/netstandard.depproj
@@ -6,5 +6,22 @@
     <NugetRuntimeIdentifier>None</NugetRuntimeIdentifier>
     <OutputPath>$(NetStandardRefPath)</OutputPath>
   </PropertyGroup>
+  
+  <Target Name="AddNETStandardRefs" AfterTargets="ResolveReferences"
+          Condition="'$(NuGetTargetMoniker)' == '.NETStandard,Version=v2.0'">
+    <PropertyGroup>
+      <_NETStandardPackageId>NETStandard.Library</_NETStandardPackageId>
+      <_NETStandardPackageVersion>2.0.0-$(StandardExpectedPrerelease)</_NETStandardPackageVersion>
+      <_NETStandardRefFolder>$(PackagesDir)$(_NETStandardPackageId)\$(_NETStandardPackageVersion)\build\netstandard2.0\ref</_NETStandardRefFolder>
+    </PropertyGroup>
+    <ItemGroup>
+      <Reference Include="$(_NETStandardRefFolder)\*.dll">
+        <Private>False</Private>
+        <NuGetPackageId>NETStandard.Library</NuGetPackageId>
+        <NuGetPackageVersion>$(_NETStandardPackageVersion)</NuGetPackageVersion>
+      </Reference>
+    </ItemGroup>
+  </Target>
+  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/external/netstandard/project.json
+++ b/external/netstandard/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netstandard2.0": {
       "dependencies": {
-        "NETStandard.Library2": "2.0.0-beta-24815-05"
+        "NETStandard.Library": "2.0.0-beta-24919-01"
       }
     }
   }

--- a/src/shims/ApiCompatBaseline.netstandard20.txt
+++ b/src/shims/ApiCompatBaseline.netstandard20.txt
@@ -1,1 +1,27 @@
-Total Issues: 0
+Compat issues with assembly mscorlib:
+TypesMustExist : Type 'System.ArgIterator' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Console.Write(System.String, System.Object, System.Object, System.Object, System.Object, __arglist)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Console.WriteLine(System.String, System.Object, System.Object, System.Object, System.Object, __arglist)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.RuntimeArgumentHandle' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.Concat(System.Object, System.Object, System.Object, System.Object, __arglist)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.TypedReference' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.FieldInfo.GetValueDirect(System.TypedReference)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.FieldInfo.SetValueDirect(System.TypedReference, System.Object)' does not exist in the implementation but it does exist in the contract.
+Compat issues with assembly netstandard:
+TypesMustExist : Type 'System.ArgIterator' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Console.Write(System.String, System.Object, System.Object, System.Object, System.Object, __arglist)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Console.WriteLine(System.String, System.Object, System.Object, System.Object, System.Object, __arglist)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.RuntimeArgumentHandle' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.String.Concat(System.Object, System.Object, System.Object, System.Object, __arglist)' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'System.TypedReference' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.FieldInfo.GetValueDirect(System.TypedReference)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.FieldInfo.SetValueDirect(System.TypedReference, System.Object)' does not exist in the implementation but it does exist in the contract.
+Compat issues with assembly System.Console:
+MembersMustExist : Member 'System.Console.Write(System.String, System.Object, System.Object, System.Object, System.Object, __arglist)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Console.WriteLine(System.String, System.Object, System.Object, System.Object, System.Object, __arglist)' does not exist in the implementation but it does exist in the contract.
+Compat issues with assembly System.Reflection:
+MembersMustExist : Member 'System.Reflection.FieldInfo.GetValueDirect(System.TypedReference)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Reflection.FieldInfo.SetValueDirect(System.TypedReference, System.Object)' does not exist in the implementation but it does exist in the contract.
+Compat issues with assembly System.Runtime:
+MembersMustExist : Member 'System.String.Concat(System.Object, System.Object, System.Object, System.Object, __arglist)' does not exist in the implementation but it does exist in the contract.
+Total Issues: 21


### PR DESCRIPTION
Update corefx to use latest NETStandard.Library package.

I had to use some custom logic to get the refs out because these are now added via targets.  This can go away once we use MSBuild-based CLI.  I do this in a target so that I can ensure that restore has been run.

@weshaggard /@danmosemsft, take a look at that baseline that was automatically added.  This means we're missing API that's currently part of netstandard.

@dagood / @bryanar: I faked up some of the maestro data until that is set up.  Filed issue https://github.com/dotnet/standard/issues/170 to track that.