### PR TITLE
Fixing hack of pre-building CoreFx.Tools to avoid assembly loading issue

### DIFF
--- a/Tools-Override/MSBuild.runtimeconfig.json
+++ b/Tools-Override/MSBuild.runtimeconfig.json
@@ -1,0 +1,11 @@
+{
+  "runtimeOptions": {
+    "framework": {
+      "name": "Microsoft.NETCore.App",
+      "version": "1.1.0"
+    },
+    "configProperties": {
+    	"Microsoft.NETCore.DotNetHostPolicy.SetAppPaths": true
+    }
+  }
+}

--- a/build.sh
+++ b/build.sh
@@ -28,10 +28,5 @@ if [ $? -ne 0 ];then
    exit 1
 fi
 
-# Building CoreFx.Tools before calling build-managed.sh to workaround an Assembly loading bug caused by the new cli host.
-"$__scriptpath/Tools/msbuild.sh" "$__scriptpath/src/Tools/CoreFx.Tools/CoreFx.Tools.csproj" /v:m /m
-if [ $? -ne 0 ];then
-   exit 1
-fi
 "$__scriptpath/build-managed.sh" $*
 exit $?

--- a/sync.sh
+++ b/sync.sh
@@ -6,16 +6,5 @@ fi
 
 working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-$working_tree_root/init-tools.sh
-if [ $? -ne 0 ]; then
-    exit 1
-fi
-
-# Building CoreFx.Tools before calling build-managed.sh to workaround an Assembly loading bug caused by the new cli host.
-"$working_tree_root/Tools/msbuild.sh" "$working_tree_root/src/Tools/CoreFx.Tools/CoreFx.Tools.csproj /v:m /m"
-if [ $? -ne 0 ];then
-   exit 1
-fi
-
 $working_tree_root/run.sh sync $__args $*
 exit $?


### PR DESCRIPTION
cc: @ericstj @weshaggard

Adding extra config option to fix Assembly loading issue we started seeing when updating the CLI version.