### PR TITLE
Add a crossgen.sh script, which can be used to run crossgen on Tools assemblies

### DIFF
--- a/Tools-Override/crossgen.sh
+++ b/Tools-Override/crossgen.sh
@@ -61,6 +61,9 @@ __dotnet=$__toolsDir/dotnetcli/dotnet
 __packagesDir=$__scriptpath/../packages
 __sharedFxDir=$__toolsDir/dotnetcli/shared/Microsoft.NETCore.App/$__CoreClrVersion/
 __rid=$($__dotnet --info | sed -n -e 's/^.*RID:[[:space:]]*//p')
+if [[ $__rid == *"osx"* ]]; then
+    __rid="osx.10.10-x64"
+fi
 
 restore_crossgen
 crossgen_everything

--- a/Tools-Override/crossgen.sh
+++ b/Tools-Override/crossgen.sh
@@ -55,6 +55,11 @@ crossgen_single()
     fi
 }
 
+if [ ! -z $BUILDTOOLS_SKIP_CROSSGEN ]; then
+    echo "BUILDTOOLS_SKIP_CROSSGEN is set. Skipping crossgen step."
+    exit 0
+fi
+
 if [[ -z "$1" || "$1" == "-?" || "$1" == "--help" || "$1" == "-h" ]]; then
     usage
 fi

--- a/Tools-Override/crossgen.sh
+++ b/Tools-Override/crossgen.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Restores crossgen and runs it on all tools components.
+
+__CoreClrVersion=1.1.0
+
+usage()
+{
+    echo "crossgen.sh <directory>"
+    echo "    Restores crossgen and runs it on all assemblies in <directory>."
+    exit 0
+}
+
+restore_crossgen()
+{
+    __pjDir=$__toolsDir/crossgen
+    mkdir -p $__pjDir
+    echo "{\"frameworks\":{\"netcoreapp1.1\":{\"dependencies\":{\"Microsoft.NETCore.Runtime.CoreCLR\":\"$__CoreClrVersion\"}}},\"runtimes\":{\"$__rid\":{}}}" > "$__pjDir/project.json"
+    $__dotnet restore $__pjDir/project.json --packages $__packagesDir
+    cp $__packagesDir/runtime.$__rid.Microsoft.NETCore.Runtime.CoreCLR/$__CoreClrVersion/tools/crossgen $__sharedFxDir
+    __crossgen=$__sharedFxDir/crossgen
+}
+
+crossgen_everything()
+{
+    echo "Running crossgen on all assemblies in $__targetDir."
+    for file in $__targetDir/*.{dll,exe}
+    do
+        if [ $(basename $file) != "Microsoft.Build.Framework.dll" ]; then
+            crossgen_single $file & pid=$!
+            __pids+=" $pid"
+        fi
+    done
+
+    trap "kill $__pids 2&> /dev/null" SIGINT
+    wait $__pids
+    echo "Crossgen finished."
+}
+
+crossgen_single()
+{
+    __file=$1
+    $__crossgen /Platform_Assemblies_Paths $__toolsDir:$__sharedFxDir /nologo /MissingDependenciesOK $__file > /dev/null
+    if [ $? -eq 0 ]; then
+      __outname="${__file/.dll/.ni.dll}"
+      __outname="${__outname/.exe/.ni.exe}"
+      echo "$__file -> $__outname"
+    else
+      echo "Unable to successfully compile $__file"
+    fi
+}
+
+if [ -z "$1" ]; then
+    usage
+fi
+
+__targetDir=$1
+__scriptpath=$(cd "$(dirname "$0")"; pwd -P)
+__toolsDir=$__scriptpath/../Tools
+__dotnet=$__toolsDir/dotnetcli/dotnet
+__packagesDir=$__scriptpath/../packages
+__sharedFxDir=$__toolsDir/dotnetcli/shared/Microsoft.NETCore.App/$__CoreClrVersion/
+__rid=$($__dotnet --info | sed -n -e 's/^.*RID:[[:space:]]*//p')
+
+restore_crossgen
+crossgen_everything
+exit 0

--- a/Tools-Override/crossgen.sh
+++ b/Tools-Override/crossgen.sh
@@ -15,7 +15,7 @@ restore_crossgen()
 {
     __pjDir=$__toolsDir/crossgen
     mkdir -p $__pjDir
-    echo "{\"frameworks\":{\"netcoreapp1.1\":{\"dependencies\":{\"Microsoft.NETCore.Runtime.CoreCLR\":\"$__CoreClrVersion\"}}},\"runtimes\":{\"$__rid\":{}}}" > "$__pjDir/project.json"
+    echo "{\"frameworks\":{\"netcoreapp1.1\":{\"dependencies\":{\"Microsoft.NETCore.Runtime.CoreCLR\":\"$__CoreClrVersion\", \"Microsoft.NETCore.Platforms\": \"$__CoreClrVersion\"}}},\"runtimes\":{\"$__rid\":{}}}" > "$__pjDir/project.json"
     $__dotnet restore $__pjDir/project.json --packages $__packagesDir
     __crossgenInPackage=$__packagesDir/runtime.$__packageRid.Microsoft.NETCore.Runtime.CoreCLR/$__CoreClrVersion/tools/crossgen
     if [ ! -e $__crossgenInPackage ]; then

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -164,6 +164,8 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
     echo Copying supplemental overrides from Tools-Override.
     cp $__scriptpath/Tools-Override/* $__scriptpath/Tools
 
+    Tools-Override/crossgen.sh $__scriptpath/Tools
+
     touch $__INIT_TOOLS_DONE_MARKER
 
     echo "Done initializing tools."


### PR DESCRIPTION
`crossgen.sh` does the following:
* Restores crossgen for the current RID (as determined via "dotnet --info")
* Copies crossgen into the shared framework folder
* Runs crossgen on all of the assemblies in the folder passed as the first parameter to the script. This is done in parallel.

This speeds up build time considerably. My build completes in about half the time, and the entire crossgen script only takes about 10 seconds to run. I am interested in seeing times in CI.

Feedback wanted on how the crossgen package is located and restored. It's the ugliest part here.

@ellismg @weshaggard @ericstj 