### PR TITLE
Avoid trimming groupings in GroupBy with result selectors

### DIFF
--- a/src/System.Linq/src/System/Linq/Grouping.cs
+++ b/src/System.Linq/src/System/Linq/Grouping.cs
@@ -85,14 +85,6 @@ namespace System.Linq
             _count++;
         }
 
-        internal void Trim()
-        {
-            if (_elements.Length != _count)
-            {
-                Array.Resize(ref _elements, _count);
-            }
-        }
-
         public IEnumerator<TElement> GetEnumerator()
         {
             for (int i = 0; i < _count; i++)

--- a/src/System.Linq/src/System/Linq/Lookup.cs
+++ b/src/System.Linq/src/System/Linq/Lookup.cs
@@ -189,8 +189,7 @@ namespace System.Linq
                 do
                 {
                     g = g._next;
-                    g.Trim();
-                    array[index] = resultSelector(g._key, g._elements);
+                    array[index] = resultSelector(g._key, g);
                     ++index;
                 }
                 while (g != _lastGrouping);
@@ -225,8 +224,7 @@ namespace System.Linq
                 do
                 {
                     g = g._next;
-                    g.Trim();
-                    list.Add(resultSelector(g._key, g._elements));
+                    list.Add(resultSelector(g._key, g));
                 }
                 while (g != _lastGrouping);
             }
@@ -247,8 +245,7 @@ namespace System.Linq
                 do
                 {
                     g = g._next;
-                    g.Trim();
-                    yield return resultSelector(g._key, g._elements);
+                    yield return resultSelector(g._key, g);
                 }
                 while (g != _lastGrouping);
             }


### PR DESCRIPTION
AFAICS we can pass the grouping as the enumerable rather than the array, which eliminates the need for an expensive resize. It also prevents users from getting at the underlying array of the grouping by casting the enumerable to a `TElement[]`.

**Related:** https://github.com/dotnet/corefx/issues/8848