### PR TITLE
Remove memory leak in Microsoft.CSharp.RuntimeBinder.Semantics.SYMTBL

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolTable.cs
@@ -47,6 +47,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private void InsertChildNoGrow(Symbol child)
         {
+            switch (child.getKind())
+            {
+                case SYMKIND.SK_Scope:
+                case SYMKIND.SK_LocalVariableSymbol:
+                    return;
+            }
+
             Key k = new Key(child.name, child.parent);
             Symbol sym;
 
@@ -60,7 +67,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 Debug.Assert(sym != null && sym.nextSameName == null);
                 sym.nextSameName = child;
-                return;
             }
             else
             {

--- a/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
+++ b/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -8,6 +8,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="CSharpArgumentInfoTests.cs" />
+    <Compile Include="RuntimeBinderTests.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
+++ b/src/Microsoft.CSharp/tests/RuntimeBinderTests.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.CSharp.RuntimeBinder.Tests
+{
+    public class RuntimeBinderTests
+    {
+        [Fact]
+        public void MultipleUseOfSameLocalInSameScope()
+        {
+            dynamic d0 = 23;
+            dynamic d1 = 14;
+            if (d0 == 23)
+            {
+                dynamic d2 = 19;
+                d0 = d0 - d1 + d2;
+                Assert.Equal(28, new string(' ', d0).Length);
+            }
+            dynamic dr = d0 * d1 + d0 + d0 + d0 / d1 - Math.Pow(d1, 2);
+            Assert.Equal(254, dr);
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -23,6 +23,9 @@
     <Compile Include="$(CommonTestPath)\System\TypeBuilderExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
+    <AdditionalCodeCoverageAssemblies Include="Microsoft.CSharp" /> 
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="CompilerTests.cs" />
     <Compile Include="DebugViewTests.cs" />
     <Compile Include="Array\ArrayAccessTests.cs" />


### PR DESCRIPTION
If a scope with a dynamic operation is entered in a loop, the runtime binder will keep storing new symbols for that scope and hence also its locals, consuming memory.

Since `SYMTBL` isn't queried for scopes or locals, skip adding them, removing the memory leak.

Fixes #11934.