### PR TITLE
Remove byte[] allocation from IPAddress.{Try}Parse

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.IPAddress.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.IPAddress.cs
@@ -76,10 +76,10 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_IPv6StringToAddress", SetLastError = true)]
-        internal static extern int IPv6StringToAddress(string address, string port, byte[] buffer, int bufferLength, out uint scope);
+        internal static extern unsafe int IPv6StringToAddress(string address, string port, byte* buffer, int bufferLength, out uint scope);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_IPv4StringToAddress", SetLastError = true)]
-        internal static extern int IPv4StringToAddress(string address, byte[] buffer, int bufferLength, out ushort port);
+        internal static extern unsafe int IPv4StringToAddress(string address, byte* buffer, int bufferLength, out ushort port);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_IPAddressToString")]
         internal static extern unsafe int IPAddressToString(byte* address, int addressLength, bool isIPv6, byte* str, int stringLength, uint scope = 0);

--- a/src/Common/src/Interop/Windows/NtDll/Interop.RtlIpv4StringToAddressEx.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.RtlIpv4StringToAddressEx.cs
@@ -9,10 +9,10 @@ internal static partial class Interop
     internal static partial class NtDll
     {
         [DllImport(Interop.Libraries.NtDll, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        internal extern static uint RtlIpv4StringToAddressExW(
+        internal extern static unsafe uint RtlIpv4StringToAddressExW(
             [In] string s,
             [In] bool strict,
-            [Out] byte[] address,
+            [Out] byte* address,
             [Out] out ushort port);
     }
 }

--- a/src/Common/src/Interop/Windows/NtDll/Interop.RtlIpv6StringToAddressEx.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.RtlIpv6StringToAddressEx.cs
@@ -9,9 +9,9 @@ internal static partial class Interop
     internal static partial class NtDll
     {
         [DllImport(Interop.Libraries.NtDll, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        internal extern static uint RtlIpv6StringToAddressExW(
+        internal extern static unsafe uint RtlIpv6StringToAddressExW(
             [In] string s,
-            [Out] byte[] address,
+            [Out] byte* address,
             [Out] out uint scopeId,
             [Out] out ushort port);
     }

--- a/src/System.Net.Primitives/src/System/Net/IPAddressPal.Unix.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddressPal.Unix.cs
@@ -32,13 +32,13 @@ namespace System.Net
             return Interop.Sys.IPAddressToString(address, true, buffer, scopeId);
         }
 
-        public static unsafe uint Ipv4StringToAddress(string ipString, byte[] bytes, out ushort port)
+        public static unsafe uint Ipv4StringToAddress(string ipString, byte* bytes, int bytesLength, out ushort port)
         {
             Debug.Assert(ipString != null);
             Debug.Assert(bytes != null);
-            Debug.Assert(bytes.Length >= IPAddressParserStatics.IPv4AddressBytes);
+            Debug.Assert(bytesLength >= IPAddressParserStatics.IPv4AddressBytes);
 
-            return unchecked((uint)Interop.Sys.IPv4StringToAddress(ipString, bytes, bytes.Length, out port));
+            return unchecked((uint)Interop.Sys.IPv4StringToAddress(ipString, bytes, bytesLength, out port));
         }
 
         private static bool IsHexString(string input, int startIndex)
@@ -121,11 +121,11 @@ namespace System.Net
             return true;
         }
 
-        public static unsafe uint Ipv6StringToAddress(string ipString, byte[] bytes, out uint scope)
+        public static unsafe uint Ipv6StringToAddress(string ipString, byte* bytes, int bytesLength, out uint scope)
         {
             Debug.Assert(ipString != null);
             Debug.Assert(bytes != null);
-            Debug.Assert(bytes.Length >= IPAddressParserStatics.IPv6AddressBytes);
+            Debug.Assert(bytesLength >= IPAddressParserStatics.IPv6AddressBytes);
 
             string host, port;
             if (!TryPreprocessIPv6Address(ipString, out host, out port))
@@ -134,7 +134,7 @@ namespace System.Net
                 return unchecked((uint)Interop.Sys.GetAddrInfoErrorFlags.EAI_NONAME);
             }
 
-            return unchecked((uint)Interop.Sys.IPv6StringToAddress(host, port, bytes, bytes.Length, out scope));
+            return unchecked((uint)Interop.Sys.IPv6StringToAddress(host, port, bytes, bytesLength, out scope));
         }
 
         public static SocketError GetSocketErrorForErrorCode(uint status)

--- a/src/System.Net.Primitives/src/System/Net/IPAddressPal.Windows.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddressPal.Windows.cs
@@ -34,20 +34,20 @@ namespace System.Net
             return Interop.NtDll.RtlIpv6AddressToStringExW(address, scopeId, 0, buffer, ref length);
         }
 
-        public static uint Ipv4StringToAddress(string ipString, byte[] bytes, out ushort port)
+        public static unsafe uint Ipv4StringToAddress(string ipString, byte* bytes, int bytesLength, out ushort port)
         {
             Debug.Assert(ipString != null);
             Debug.Assert(bytes != null);
-            Debug.Assert(bytes.Length == IPAddressParserStatics.IPv4AddressBytes);
+            Debug.Assert(bytesLength == IPAddressParserStatics.IPv4AddressBytes);
 
             return Interop.NtDll.RtlIpv4StringToAddressExW(ipString, false, bytes, out port);
         }
 
-        public static uint Ipv6StringToAddress(string ipString, byte[] bytes, out uint scope)
+        public static unsafe uint Ipv6StringToAddress(string ipString, byte* bytes, int bytesLength, out uint scope)
         {
             Debug.Assert(ipString != null);
             Debug.Assert(bytes != null);
-            Debug.Assert(bytes.Length == IPAddressParserStatics.IPv6AddressBytes);
+            Debug.Assert(bytesLength == IPAddressParserStatics.IPv6AddressBytes);
 
             ushort port;
             return Interop.NtDll.RtlIpv6StringToAddressExW(ipString, bytes, out scope, out port);

--- a/src/System.Net.Primitives/src/System/Net/IPAddressParser.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddressParser.cs
@@ -12,7 +12,7 @@ namespace System.Net
         internal const int INET_ADDRSTRLEN = 22;
         internal const int INET6_ADDRSTRLEN = 65;
 
-        internal static IPAddress Parse(string ipString, bool tryParse)
+        internal static unsafe IPAddress Parse(string ipString, bool tryParse)
         {
             if (ipString == null)
             {
@@ -34,21 +34,21 @@ namespace System.Net
                 // port specification at the end of address and so can
                 // make this decision.
                 uint scope;
-                byte[] bytes = new byte[IPAddressParserStatics.IPv6AddressBytes];
-                error = IPAddressPal.Ipv6StringToAddress(ipString, bytes, out scope);
+                byte* bytes = stackalloc byte[IPAddressParserStatics.IPv6AddressBytes];
+                error = IPAddressPal.Ipv6StringToAddress(ipString, bytes, IPAddressParserStatics.IPv6AddressBytes, out scope);
 
                 if (error == IPAddressPal.SuccessErrorCode)
                 {
                     // AppCompat: .Net 4.5 ignores a correct port if the address was specified in brackets.
                     // Will still throw for an incorrect port.
-                    return new IPAddress(bytes, (long)scope);
+                    return new IPAddress(bytes, IPAddressParserStatics.IPv6AddressBytes, (long)scope);
                 }
             }
             else
             {
                 ushort port;
-                byte[] bytes = new byte[IPAddressParserStatics.IPv4AddressBytes];
-                error = IPAddressPal.Ipv4StringToAddress(ipString, bytes, out port);
+                byte* bytes = stackalloc byte[IPAddressParserStatics.IPv4AddressBytes];
+                error = IPAddressPal.Ipv4StringToAddress(ipString, bytes, IPAddressParserStatics.IPv4AddressBytes, out port);
 
                 if (error == IPAddressPal.SuccessErrorCode)
                 {
@@ -57,7 +57,7 @@ namespace System.Net
                         throw new FormatException(SR.dns_bad_ip_address);
                     }
 
-                    return new IPAddress(bytes);
+                    return new IPAddress(bytes, IPAddressParserStatics.IPv4AddressBytes);
                 }
             }
 

--- a/src/System.Net.Primitives/tests/UnitTests/Fakes/IPAddressPal.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/Fakes/IPAddressPal.cs
@@ -22,13 +22,13 @@ namespace System.Net
             return 0;
         }
 
-        public static uint Ipv4StringToAddress(string ipString, byte[] bytes, out ushort port)
+        public static unsafe uint Ipv4StringToAddress(string ipString, byte* bytes, int bytesLength, out ushort port)
         {
             port = 0;
             return 0;
         }
 
-        public static uint Ipv6StringToAddress(string ipString, byte[] bytes, out uint scope)
+        public static unsafe uint Ipv6StringToAddress(string ipString, byte* bytes, int bytesLength, out uint scope)
         {
             scope = 0;
             return 0;


### PR DESCRIPTION
IPAddress.Parse and TryParse both allocate a byte[] to store the parsed address bytes, only to then have those bytes turned into either a uint or an array of ushorts.  This commit eliminates the allocation, for both IPv4 and IPv6.  This is relevant to TryParse even when the string isn't an address, as the array is allocated regardless.

cc: @davidsh, @cipop, @geoffkizer @Priya91 