### PR TITLE
Resolved connection leak in SNI by adding dispose for underlying TCPstream in SNITcpHandle.Dispose()

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -22,7 +22,7 @@ namespace System.Data.SqlClient.SNI
         private readonly string _targetServer;
         private readonly object _callbackObject;
         private readonly Socket _socket;
-        private readonly NetworkStream _tcpStream;
+        private NetworkStream _tcpStream;
         private readonly TaskScheduler _writeScheduler;
         private readonly TaskFactory _writeTaskFactory;
 
@@ -56,6 +56,12 @@ namespace System.Data.SqlClient.SNI
                 {
                     _sslStream.Dispose();
                     _sslStream = null;
+                }
+
+                if (_tcpStream != null)
+                {
+                    _tcpStream.Dispose();
+                    _tcpStream = null;
                 }
             }
         }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -63,6 +63,10 @@ namespace System.Data.SqlClient.SNI
                     _tcpStream.Dispose();
                     _tcpStream = null;
                 }
+
+                //Release any references held by _stream.
+                _stream = null;
+
             }
         }
 


### PR DESCRIPTION
Fix for SqlConnection TCP connection leak.

Copied from master branch PR https://github.com/dotnet/corefx/pull/13653
Originally caused by https://github.com/dotnet/corefx/commit/30abd30421289509cd3bd18a9114501afdc0fb7c which removed a TcpClient.Dispose() in SNITcpHandle

This is a fix for https://github.com/dotnet/corefx/issues/13422 
