### PR TITLE
Reduce HttpClient overheads on Unix

### DIFF
--- a/src/Common/src/System/Net/Http/TlsCertificateExtensions.cs
+++ b/src/Common/src/System/Net/Http/TlsCertificateExtensions.cs
@@ -78,6 +78,7 @@ namespace System.Net.Http
             var chain = new X509Chain();
             chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllFlags;
             chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
+            chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
             if (includeClientApplicationPolicy)
             {
                 chain.ChainPolicy.ApplicationPolicy.Add(s_clientCertOidInst);

--- a/src/Common/src/System/Net/HttpKnownHeaderNames.TryGetHeaderName.cs
+++ b/src/Common/src/System/Net/HttpKnownHeaderNames.TryGetHeaderName.cs
@@ -173,6 +173,7 @@ namespace System.Net
                         case 'c': potentialHeader = AcceptPatch; goto TryMatch; // Ac[c]ept-Patch
                         case 'n': potentialHeader = ContentType; goto TryMatch; // Co[n]tent-Type
                         case 'x': potentialHeader = MaxForwards; goto TryMatch; // Ma[x]-Forwards
+                        case 'M': potentialHeader = XMSEdgeRef; goto TryMatch;  // X-[M]SEdge-Ref
                         case 'P': potentialHeader = XPoweredBy; goto TryMatch;  // X-[P]owered-By
                         case 'R': potentialHeader = XRequestID; goto TryMatch;  // X-[R]equest-ID
                     }

--- a/src/Common/src/System/Net/HttpKnownHeaderNames.cs
+++ b/src/Common/src/System/Net/HttpKnownHeaderNames.cs
@@ -87,6 +87,7 @@ namespace System.Net
         public const string XContentDuration = "X-Content-Duration";
         public const string XContentTypeOptions = "X-Content-Type-Options";
         public const string XFrameOptions = "X-Frame-Options";
+        public const string XMSEdgeRef = "X-MSEdge-Ref";
         public const string XPoweredBy = "X-Powered-By";
         public const string XRequestID = "X-Request-ID";
         public const string XUACompatible = "X-UA-Compatible";

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -102,6 +102,9 @@
     <Compile Include="$(CommonPath)\System\IO\DelegatingStream.cs">
       <Link>Common\System\IO\DelegatingStream.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
+      <Link>Common\System\IO\StringBuilderCache.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -195,6 +195,9 @@
     <Compile Include="$(CommonPath)\System\Net\Security\CertificateValidation.Unix.cs">
       <Link>Common\System\Net\Security\CertificateValidation.Unix.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Threading\Tasks\TaskToApm.cs">
+      <Link>Common\System\Threading\Tasks\TaskToApm.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs">
       <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
     </Compile>

--- a/src/System.Net.Http/src/System/Net/Http/Headers/CacheControlHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/CacheControlHeaderValue.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Text;
 
 namespace System.Net.Http.Headers
@@ -207,7 +208,7 @@ namespace System.Net.Http.Headers
 
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = StringBuilderCache.Acquire();
 
             AppendValueIfRequired(sb, _noStore, noStoreString);
             AppendValueIfRequired(sb, _noTransform, noTransformString);
@@ -271,7 +272,7 @@ namespace System.Net.Http.Headers
 
             NameValueHeaderValue.ToString(_extensions, ',', false, sb);
 
-            return sb.ToString();
+            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         public override bool Equals(object obj)

--- a/src/System.Net.Http/src/System/Net/Http/Headers/ContentDispositionHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/ContentDispositionHeaderValue.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Text;
 
 namespace System.Net.Http.Headers
@@ -166,7 +167,10 @@ namespace System.Net.Http.Headers
 
         public override string ToString()
         {
-            return _dispositionType + NameValueHeaderValue.ToString(_parameters, ';', true);
+            StringBuilder sb = StringBuilderCache.Acquire();
+            sb.Append(_dispositionType);
+            NameValueHeaderValue.ToString(_parameters, ';', true, sb);
+            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         public override bool Equals(object obj)

--- a/src/System.Net.Http/src/System/Net/Http/Headers/ContentRangeHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/ContentRangeHeaderValue.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Text;
 
 namespace System.Net.Http.Headers
@@ -150,7 +151,8 @@ namespace System.Net.Http.Headers
 
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder(_unit);
+            StringBuilder sb = StringBuilderCache.Acquire();
+            sb.Append(_unit);
             sb.Append(' ');
 
             if (HasRange)
@@ -174,7 +176,7 @@ namespace System.Net.Http.Headers
                 sb.Append('*');
             }
 
-            return sb.ToString();
+            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         public static ContentRangeHeaderValue Parse(string input)

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -1194,10 +1194,11 @@ namespace System.Net.Http.Headers
             Contract.Ensures(Contract.Result<string[]>() != null);
 
             int length = GetValueCount(info);
-            string[] values = new string[length];
+            string[] values;
 
             if (length > 0)
             {
+                values = new string[length];
                 int currentIndex = 0;
 
                 ReadStoreValues<string>(values, info.RawValue, null, null, ref currentIndex);
@@ -1215,6 +1216,11 @@ namespace System.Net.Http.Headers
                     values = trimmedValues;
                 }
             }
+            else
+            {
+                values = Array.Empty<string>();
+            }
+
             return values;
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -286,7 +286,7 @@ namespace System.Net.Http.Headers
 
         private string GetHeaderString(HeaderStoreItemInfo info, object exclude)
         {
-            string stringValue = string.Empty; // returned if values.Length == 0
+            string stringValue;
 
             string[] values = GetValuesAsStrings(info, exclude);
 

--- a/src/System.Net.Http/src/System/Net/Http/Headers/MediaTypeHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/MediaTypeHeaderValue.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 
 namespace System.Net.Http.Headers
 {
@@ -102,7 +103,10 @@ namespace System.Net.Http.Headers
 
         public override string ToString()
         {
-            return _mediaType + NameValueHeaderValue.ToString(_parameters, ';', true);
+            var sb = StringBuilderCache.Acquire();
+            sb.Append(_mediaType);
+            NameValueHeaderValue.ToString(_parameters, ';', true, sb);
+            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         public override bool Equals(object obj)

--- a/src/System.Net.Http/src/System/Net/Http/Headers/NameValueHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/NameValueHeaderValue.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Text;
 
 namespace System.Net.Http.Headers
@@ -162,20 +163,6 @@ namespace System.Net.Http.Headers
                 }
                 destination.Append(value.ToString());
             }
-        }
-
-        internal static string ToString(ObjectCollection<NameValueHeaderValue> values, char separator, bool leadingSeparator)
-        {
-            if ((values == null) || (values.Count == 0))
-            {
-                return null;
-            }
-
-            StringBuilder sb = new StringBuilder();
-
-            ToString(values, separator, leadingSeparator, sb);
-
-            return sb.ToString();
         }
 
         internal static int GetHashCode(ObjectCollection<NameValueHeaderValue> values)

--- a/src/System.Net.Http/src/System/Net/Http/Headers/NameValueHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/NameValueHeaderValue.cs
@@ -144,6 +144,27 @@ namespace System.Net.Http.Headers
             return _name;
         }
 
+        private void AddToStringBuilder(StringBuilder sb)
+        {
+            if (GetType() != typeof(NameValueHeaderValue))
+            {
+                // If this is a derived instance, we need to give its
+                // ToString a chance.
+                sb.Append(ToString());
+            }
+            else
+            {
+                // Otherwise, we can use the base behavior and avoid
+                // the string concatenation.
+                sb.Append(_name);
+                if (!string.IsNullOrEmpty(_value))
+                {
+                    sb.Append('=');
+                    sb.Append(_value);
+                }
+            }
+        }
+
         internal static void ToString(ObjectCollection<NameValueHeaderValue> values, char separator, bool leadingSeparator,
             StringBuilder destination)
         {
@@ -161,7 +182,7 @@ namespace System.Net.Http.Headers
                     destination.Append(separator);
                     destination.Append(' ');
                 }
-                destination.Append(value.ToString());
+                value.AddToStringBuilder(destination);
             }
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Headers/NameValueWithParametersHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/NameValueWithParametersHeaderValue.cs
@@ -4,6 +4,8 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.Text;
 
 namespace System.Net.Http.Headers
 {
@@ -78,7 +80,11 @@ namespace System.Net.Http.Headers
 
         public override string ToString()
         {
-            return base.ToString() + NameValueHeaderValue.ToString(_parameters, ';', true);
+            string baseString = base.ToString();
+            StringBuilder sb = StringBuilderCache.Acquire();
+            sb.Append(baseString);
+            NameValueHeaderValue.ToString(_parameters, ';', true, sb);
+            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         public static new NameValueWithParametersHeaderValue Parse(string input)

--- a/src/System.Net.Http/src/System/Net/Http/Headers/RangeHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/RangeHeaderValue.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Text;
 
 namespace System.Net.Http.Headers
@@ -63,7 +64,8 @@ namespace System.Net.Http.Headers
 
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder(_unit);
+            StringBuilder sb = StringBuilderCache.Acquire();
+            sb.Append(_unit);
             sb.Append('=');
 
             if (_ranges != null)
@@ -86,7 +88,7 @@ namespace System.Net.Http.Headers
                 }
             }
 
-            return sb.ToString();
+            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         public override bool Equals(object obj)

--- a/src/System.Net.Http/src/System/Net/Http/Headers/TransferCodingHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/TransferCodingHeaderValue.cs
@@ -4,6 +4,8 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.Text;
 
 namespace System.Net.Http.Headers
 {
@@ -130,7 +132,10 @@ namespace System.Net.Http.Headers
 
         public override string ToString()
         {
-            return _value + NameValueHeaderValue.ToString(_parameters, ';', true);
+            StringBuilder sb = StringBuilderCache.Acquire();
+            sb.Append(_value);
+            NameValueHeaderValue.ToString(_parameters, ';', true, sb);
+            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         public override bool Equals(object obj)

--- a/src/System.Net.Http/src/System/Net/Http/Headers/ViaHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/ViaHeaderValue.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.IO;
 using System.Text;
 
 namespace System.Net.Http.Headers
@@ -81,7 +82,7 @@ namespace System.Net.Http.Headers
 
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = StringBuilderCache.Acquire();
 
             if (!string.IsNullOrEmpty(_protocolName))
             {
@@ -99,7 +100,7 @@ namespace System.Net.Http.Headers
                 sb.Append(_comment);
             }
 
-            return sb.ToString();
+            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         public override bool Equals(object obj)

--- a/src/System.Net.Http/src/System/Net/Http/Headers/WarningHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/WarningHeaderValue.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Text;
 
 namespace System.Net.Http.Headers
@@ -74,7 +75,7 @@ namespace System.Net.Http.Headers
 
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = StringBuilderCache.Acquire();
 
             // Warning codes are always 3 digits according to RFC2616
             sb.Append(_code.ToString("000", NumberFormatInfo.InvariantInfo));
@@ -91,7 +92,7 @@ namespace System.Net.Http.Headers
                 sb.Append('\"');
             }
 
-            return sb.ToString();
+            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         public override bool Equals(object obj)

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
@@ -237,10 +237,14 @@ namespace System.Net.Http
                 }
             }
 
-            public override int Read(byte[] buffer, int offset, int count)
-            {
-                return ReadAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
-            }
+            public override int Read(byte[] buffer, int offset, int count) =>
+                ReadAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
+
+            public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
+                TaskToApm.Begin(ReadAsync(buffer, offset, count, CancellationToken.None), callback, state);
+
+            public override int EndRead(IAsyncResult asyncResult) =>
+                TaskToApm.End<int>(asyncResult);
 
             public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -894,12 +894,15 @@ namespace System.Net.Http
                 if (urlResult == CURLcode.CURLE_OK && urlCharPtr != IntPtr.Zero)
                 {
                     string url = Marshal.PtrToStringAnsi(urlCharPtr);
-                    Uri finalUri;
-                    if (Uri.TryCreate(url, UriKind.Absolute, out finalUri))
+                    if (url != _requestMessage.RequestUri.OriginalString)
                     {
-                        _requestMessage.RequestUri = finalUri;
-                        return;
+                        Uri finalUri;
+                        if (Uri.TryCreate(url, UriKind.Absolute, out finalUri))
+                        {
+                            _requestMessage.RequestUri = finalUri;
+                        }
                     }
+                    return;
                 }
 
                 Debug.Fail("Expected to be able to get the last effective Uri from libcurl");

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -32,6 +32,9 @@ namespace System.Net.Http
         /// <summary>Provides all of the state associated with a single request/response, referred to as an "easy" request in libcurl parlance.</summary>
         private sealed class EasyRequest : TaskCompletionSource<HttpResponseMessage>
         {
+            /// <summary>Debugging flag used to enable CURLOPT_VERBOSE to dump to stderr when not redirecting it to the event source.</summary>
+            private static readonly bool s_curlDebugLogging = Environment.GetEnvironmentVariable("CURLHANDLER_DEBUG_VERBOSE") == "true";
+
             internal readonly CurlHandler _handler;
             internal readonly HttpRequestMessage _requestMessage;
             internal readonly CurlResponseMessage _responseMessage;
@@ -74,6 +77,14 @@ namespace System.Net.Http
                     throw new OutOfMemoryException();
                 }
                 _easyHandle = easyHandle;
+
+                // Before setting any other options, turn on curl's debug tracing
+                // if desired.  CURLOPT_VERBOSE may also be set subsequently if
+                // EventSource tracing is enabled.
+                if (s_curlDebugLogging)
+                {
+                    SetCurlOption(CURLoption.CURLOPT_VERBOSE, 1L);
+                }
 
                 // Configure the handle
                 SetUrl();

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlResponseHeaderReader.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlResponseHeaderReader.cs
@@ -96,7 +96,7 @@ namespace System.Net.Http
                 CheckResponseMsgFormat(index < _span.Length);
                 CheckResponseMsgFormat(_span[index] == ':');
                 HeaderBufferSpan headerNameSpan = _span.Substring(0, headerNameLength);
-                if (!HttpKnownHeaderNames.TryGetHeaderName(_span.Buffer, _span.Length, out headerName))
+                if (!HttpKnownHeaderNames.TryGetHeaderName(headerNameSpan.Buffer, headerNameSpan.Length, out headerName))
                 {
                     headerName = headerNameSpan.ToString();
                 }

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -26,6 +26,9 @@
     <Compile Include="$(CommonPath)\System\StringExtensions.cs">
       <Link>ProductionCode\Common\System\StringExtensions.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
+      <Link>Common\System\IO\StringBuilderCache.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\IO\StreamHelpers.CopyValidation.cs">
       <Link>ProductionCode\Common\System\IO\StreamHelpers.CopyValidation.cs</Link>
     </Compile>


### PR DESCRIPTION
This PR provides several commits for improving HttpClient performance on Unix (some apply to Windows as well):
- When POST'ing data via HttpClient, even if only a small amount of content, libcurl ends up sending out two packets for the request.  A commit adds an optimization whereby if a ByteArrayContent (or derived content type) is used such that we have all of the content in-memory and don't need to read from the content stream, we can instead provide the data to libcurl in advance.  This both lets it optimize the size of its writes (and thus the number of packets) and lets us avoid the overhead of the machinery involved in having libcurl pull from the request content stream.
- Both CurlHandler and WinHttpHandler know about a set of headers for which we have constant strings available, and they avoid allocating strings for such headers.  But CurlHandler has a bug where it passes in the wrong span, which means it always fails to match, and ends up allocating the string anyway.
- When CurlResponseStream is used from a consumer that uses Begin/EndRead, these calls end up going to the base implementation, which queues a work item that calls Read, which in turn calls ReadAsync and blocks waiting for it to complete.  The fix is to just override Begin/EndRead and wrap ReadAsync directly.
- Getting the request content stream is resulting in a fair number of unnecessary allocations and delegate invocations for a common case where the stream is returned synchronously.
- Lots of intermediate string values are getting allocated when rendering headers to strings.  This change uses StringBuffer and StringBufferCache to avoid most of them.
- When rendering headers, we're often making multiple calls to GetValuesAsStrings indirectly when we can get away with just one call (and resulting string[] allocation).
- Every request is allocating a Uri based on the actual url libcurl reports, but we only need to do that if it's actually changed.
- There's no need to do certificate revocation checking when the client is building a chain for its own certs.  But it's taking a significant chunk of time... one of our outerloop tests is frequently timing out even as a result.

cc: @mikeharder, @cesarbs, @davidsh, @cipop, @geoffkizer, @bartonjs @Priya91 