### PR TITLE
Fix MSB3568 warning on *NIX

### DIFF
--- a/src/System.Configuration.ConfigurationManager/src/Resources/Strings.resx
+++ b/src/System.Configuration.ConfigurationManager/src/Resources/Strings.resx
@@ -790,7 +790,4 @@
   <data name="Config_base_no_child_nodes" xml:space="preserve">
     <value>Child nodes not allowed.</value>
   </data>
-  <data name="Config_base_unrecognized_element" xml:space="preserve">
-    <value>Unrecognized element.</value>
-  </data>
 </root>


### PR DESCRIPTION
We have a duplicate resource name which is causing a warning on when
the build is run on *NIX.

Remove the duplicate resource.