### PR TITLE
S.M.Span: Handle OutOfMemoryException in longer-than-uint-MaxValue Clear tests

### DIFF
--- a/src/System.Memory/tests/Span/Clear.cs
+++ b/src/System.Memory/tests/Span/Clear.cs
@@ -198,39 +198,42 @@ namespace System.SpanTests
         {
             if (sizeof(IntPtr) == sizeof(long))
             {
+                // Arrange
+                int[] a = null;
                 try
                 {
                     // The maximum index in any single dimension is 2,147,483,591 (0x7FFFFFC7) 
                     // for byte arrays and arrays of single-byte structures, 
                     // and 2,146,435,071 (0X7FEFFFFF) for other types.
                     const int maxArraySizeForLargerThanByteTypes = 0X7FEFFFFF;
-                    var a = new int[maxArraySizeForLargerThanByteTypes];
-
-                    int initial = 5;
-                    for (int i = 0; i < a.Length; i++)
-                    {
-                        a[i] = initial;
-                    }
-
-                    var span = new Span<int>(a);
-
-                    // Act
-                    span.Clear();
-
-                    // Assert using custom code for perf and to avoid allocating extra memory
-                    for (int i = 0; i < a.Length; i++)
-                    {
-                        var actual = a[i];
-                        if (actual != 0)
-                        {
-                            Assert.Equal(0, actual);
-                        }
-                    }
+                    a = new int[maxArraySizeForLargerThanByteTypes];
                 }
                 // Skipping test if Out-of-Memory, since this test can only be run, if there is enough memory
                 catch (OutOfMemoryException)
                 {
                     Console.WriteLine($"Span.Clear test {nameof(ClearLongerThanUintMaxValueBytes)} skipped due to {nameof(OutOfMemoryException)}.");
+                    return;
+                }
+
+                int initial = 5;
+                for (int i = 0; i < a.Length; i++)
+                {
+                    a[i] = initial;
+                }
+
+                var span = new Span<int>(a);
+
+                // Act
+                span.Clear();
+
+                // Assert using custom code for perf and to avoid allocating extra memory
+                for (int i = 0; i < a.Length; i++)
+                {
+                    var actual = a[i];
+                    if (actual != 0)
+                    {
+                        Assert.Equal(0, actual);
+                    }
                 }
             }
         }
@@ -241,45 +244,48 @@ namespace System.SpanTests
         {
             if (sizeof(IntPtr) == sizeof(long))
             {
+                // Arrange
+                IntPtr bytes = (IntPtr)(((long)int.MaxValue) * sizeof(int));
+                int length = (int)(((long)bytes) / sizeof(int));
+
+                int* ptr = null;
                 try
                 {
-                    // Arrange
-                    IntPtr bytes = (IntPtr)(((long)int.MaxValue) * sizeof(int));
-                    int length = (int)(((long)bytes) / sizeof(int));
-
-                    var ptr = (int*)Runtime.InteropServices.Marshal.AllocHGlobal(bytes);
-                    try
-                    {
-                        int initial = 5;
-                        for (int i = 0; i < length; i++)
-                        {
-                            *(ptr + i) = initial;
-                        }
-
-                        var span = new Span<int>(ptr, length);
-
-                        // Act
-                        span.Clear();
-
-                        // Assert using custom code for perf and to avoid allocating extra memory
-                        for (int i = 0; i < length; i++)
-                        {
-                            var actual = *(ptr + i);
-                            if (actual != 0)
-                            {
-                                Assert.Equal(0, actual);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        Runtime.InteropServices.Marshal.FreeHGlobal(new IntPtr(ptr));
-                    }
+                    ptr = (int*)Runtime.InteropServices.Marshal.AllocHGlobal(bytes);
                 }
                 // Skipping test if Out-of-Memory, since this test can only be run, if there is enough memory
                 catch (OutOfMemoryException)
                 {
                     Console.WriteLine($"Span.Clear test {nameof(ClearNativeLongerThanUintMaxValueBytes)} skipped due to {nameof(OutOfMemoryException)}.");
+                    return;
+                }
+
+                try
+                {
+                    int initial = 5;
+                    for (int i = 0; i < length; i++)
+                    {
+                        *(ptr + i) = initial;
+                    }
+
+                    var span = new Span<int>(ptr, length);
+
+                    // Act
+                    span.Clear();
+
+                    // Assert using custom code for perf and to avoid allocating extra memory
+                    for (int i = 0; i < length; i++)
+                    {
+                        var actual = *(ptr + i);
+                        if (actual != 0)
+                        {
+                            Assert.Equal(0, actual);
+                        }
+                    }
+                }
+                finally
+                {
+                    Runtime.InteropServices.Marshal.FreeHGlobal(new IntPtr(ptr));
                 }
             }
         }


### PR DESCRIPTION
Handle OutOfMemoryException in longer-than-uint-MaxValue Clear test by catching the exception and skipping.

Close #15348

cc @AtsushiKan @jkotas @danmosemsft 