### PR TITLE
Remove bad ProjectReference's to src/ref projects from test projects

### DIFF
--- a/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/Microsoft.Composition.Demos.ExtendedCollectionImports.csproj
+++ b/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/Microsoft.Composition.Demos.ExtendedCollectionImports.csproj
@@ -19,19 +19,5 @@
       <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\System.Composition.AttributedModel\src\System.Composition.AttributedModel.csproj">
-      <Project>{c6257381-c624-494a-a9d9-5586e60856ea}</Project>
-      <Name>System.Composition.AttributedModel</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\System.Composition.Hosting\src\System.Composition.Hosting.csproj">
-      <Project>{2b8fecc6-34a1-48fe-ba75-99572d2d6db2}</Project>
-      <Name>System.Composition.Hosting</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\System.Composition.Runtime\src\System.Composition.Runtime.csproj">
-      <Project>{2711dfd2-8541-4628-bc53-eb784a14cdcf}</Project>
-      <Name>System.Composition.Runtime</Name>
-    </ProjectReference>
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Composition/perftests/Microsoft.Composition.ThroughputHarness.csproj
+++ b/src/System.Composition/perftests/Microsoft.Composition.ThroughputHarness.csproj
@@ -27,27 +27,5 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\System.Composition.AttributedModel\src\System.Composition.AttributedModel.csproj">
-      <Project>{c6257381-c624-494a-a9d9-5586e60856ea}</Project>
-      <Name>System.Composition.AttributedModel</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\System.Composition.Convention\src\System.Composition.Convention.csproj">
-      <Project>{e6592fad-10b5-4b56-9287-d72dd136992f}</Project>
-      <Name>System.Composition.Convention</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\System.Composition.Hosting\src\System.Composition.Hosting.csproj">
-      <Project>{2b8fecc6-34a1-48fe-ba75-99572d2d6db2}</Project>
-      <Name>System.Composition.Hosting</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\System.Composition.Runtime\src\System.Composition.Runtime.csproj">
-      <Project>{2711dfd2-8541-4628-bc53-eb784a14cdcf}</Project>
-      <Name>System.Composition.Runtime</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\System.Composition.TypedParts\src\System.Composition.TypedParts.csproj">
-      <Project>{b4b5e15c-e6b9-48ea-94c2-f067484d4d3e}</Project>
-      <Name>System.Composition.TypedParts</Name>
-    </ProjectReference>
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Composition/scenarios/TestLibrary/TestLibrary.csproj
+++ b/src/System.Composition/scenarios/TestLibrary/TestLibrary.csproj
@@ -14,11 +14,5 @@
       <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\System.Composition.AttributedModel\src\System.Composition.AttributedModel.csproj">
-      <Project>{c6257381-c624-494a-a9d9-5586e60856ea}</Project>
-      <Name>System.Composition.AttributedModel</Name>
-    </ProjectReference>
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
A helper library for the System.Composition tests was referencing the source library for System.Composition. Because that is a "ref-less" project, it's output is placed into the "ref" folder directly. This caused race conditions in the build when one project was re-building the System.Composition src projects, and another was trying to read the refs out of the targeting pack.

These project references aren't necessary in the first place; test projects automatically reference everything from the targeting pack.

@weshaggard @ericstj 