### PR TITLE
Add argument that disables symbol stripping

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -13,7 +13,7 @@
       },
       "BuildParameters": {
         "PB_ConfigurationGroup": "Release",
-        "PB_BuildArguments": "-buildArch=x64 -Release",
+        "PB_BuildArguments": "-buildArch=x64 -Release -stripSymbols",
         "PB_BuildTestsArguments": "-buildArch=x64 -Release -SkipTests -- /p:ArchiveTests=true /p:EnableDumpling=true",
         "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=true\" /p:\"TestProduct=corefx /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:FilterToOSGroup=Linux /p:\"BuildMoniker=none\"",
         "PB_SyncArguments": "-p -- /p:ArchGroup=x64"
@@ -162,7 +162,7 @@
         "TreatWarningsAsErrors": "false"
       },
       "BuildParameters": {
-        "PB_BuildArguments": "-buildArch=x64 -Release",
+        "PB_BuildArguments": "-buildArch=x64 -Release -stripSymbols",
         "PB_BuildTestsArguments": "-buildArch=x64 -Release -SkipTests -- /p:ArchiveTests=true",
         "PB_SyncArguments": "-p -- /p:ArchGroup=x64",
         "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=true\" /p:\"TestProduct=corefx /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=OSX\" /p:FilterToOSGroup=OSX /p:\"BuildMoniker=none\""

--- a/config.json
+++ b/config.json
@@ -174,6 +174,12 @@
       "values": [],
       "defaultValue": ""
     },
+    "StripSymbolsAdditionalArg": {
+      "description": "Pass additional argument to native build to configure symbol stripping.",
+      "valueType": "passThrough",
+      "values": [],
+      "defaultValue": ""
+    },
     "Project": {
       "description": "Project where the commands are going to be applied.",
       "valueType": "passThrough",
@@ -244,6 +250,10 @@
           "settings": {
             "RuntimeOS":"linux"
           }
+        },
+        "stripSymbols": {
+          "description": "No-op. Added so that stripSymbols can be passed to build.sh without breaking build-managed.sh.",
+          "settings": { }
         },
         "tests": {
           "description": "Builds the tests that are in the repository, doesn't restore packages.",
@@ -361,6 +371,12 @@
           "description": "Make the build-native script generate binaries that are portable over glibc based Linux distros.",
           "settings": {
             "AdditionalArgs": "portableLinux"
+          }
+        },
+        "stripSymbols": {
+          "description": "Strip native symbols.",
+          "settings": {
+            "StripSymbolsAdditionalArg": "stripSymbols"
           }
         }
       },

--- a/src/Native/Unix/CMakeLists.txt
+++ b/src/Native/Unix/CMakeLists.txt
@@ -164,7 +164,7 @@ endif ()
 
 function(strip_symbols targetName outputFilename)
     if(CLR_CMAKE_PLATFORM_UNIX)
-        if(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)
+        if(STRIP_SYMBOLS)
 
             # On the older version of cmake (2.8.12) used on Ubuntu 14.04 the TARGET_FILE
             # generator expression doesn't work correctly returning the wrong path and on
@@ -201,7 +201,7 @@ function(strip_symbols targetName outputFilename)
             endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
             set(${outputFilename} ${strip_destination_file} PARENT_SCOPE)
-        endif(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)
+        endif(STRIP_SYMBOLS)
     endif(CLR_CMAKE_PLATFORM_UNIX)
 endfunction()
 

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -15,6 +15,7 @@ usage()
     echo "      - will use ROOTFS_DIR environment variable if set."
     echo "staticLibLink - Optional argument to statically link any native library."
     echo "portableLinux - Optional argument to build native libraries portable over GLIBC based Linux distros."
+    echo "stripSymbols - Optional argument to strip native symbols during the build."
     echo "generateversion - Pass this in to get a version on the build output."
     echo "cmakeargs - user-settable additional arguments passed to CMake."
     exit 1
@@ -196,7 +197,7 @@ while :; do
         release)
             __BuildType=Release
             __CMakeArgs=RELEASE 
-	    ;;
+            ;;
         freebsd)
             __BuildOS=FreeBSD
             ;;
@@ -208,6 +209,9 @@ while :; do
             ;;
         osx)
             __BuildOS=OSX
+            ;;
+        stripsymbols)
+            __CMakeExtraArgs="$__CMakeExtraArgs -DSTRIP_SYMBOLS=true"
             ;;
         --targetgroup)
             shift


### PR DESCRIPTION
Adds a flag that can be passed to the build to disable symbol stripping. Pass `noStripSymbols` to `src/Native/build-native.sh`, or pass `-noStripSymbols` to `build.sh` or `build-native.sh`. `build.sh` will try to pass it to `build-managed.sh`, so I have it no-op in the managed build.

If native symbols aren't stripped, no symbol package is created and the build exits normally. This is the same behavior as a Debug build, which never strips symbols due to the RELEASE check in the CMake file.

The flag is negative to preserve official build behavior. To clean that up, I could change it to `stripSymbols` and make the official builds pass it in. We could remove the RELEASE flag check, then.
@ellismg @chcosta Think that's a good way to go?

One thing I noticed about this is that CMake doesn't rebuild when I change whether or not I pass `noStripSymbols`. I don't know if this is a big issue. I think the cause is conditionally doing `add_custom_command`, because we aren't giving CMake a way to tell if the command's been done given the input arguments. I can look at fixing that before merging this PR if it's important.