### PR TITLE
Allow AdditionalCodeCoverageAssemblies to be specified in project files

### DIFF
--- a/Tools-Override/CodeCoverage.targets
+++ b/Tools-Override/CodeCoverage.targets
@@ -41,6 +41,7 @@
          CodeCoverageAssemblies can be passed in to the build to gather coverage on additional assemblies. -->
     <ItemGroup>
       <_CodeCoverageAssemblies Include="$(AssemblyBeingTestedName)" /> 
+      <_CodeCoverageAssemblies Include="@(AdditionalCodeCoverageAssemblies)" />
       <_CodeCoverageAssemblies Include="$(CodeCoverageAssemblies)" Condition="'$(CodeCoverageAssemblies)' != ''" />
     </ItemGroup>
     <PropertyGroup>


### PR DESCRIPTION
Fixes #15429 

@weshaggard @JonHanna 