### PR TITLE
Use TryEnsureSufficientExecutionStack in Expressions.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/StackGuard.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/StackGuard.cs
@@ -16,16 +16,17 @@ namespace System.Linq.Expressions
 
         public bool TryEnterOnCurrentStack()
         {
-            try
+            if (RuntimeHelpers.TryEnsureSufficientExecutionStack())
             {
-                RuntimeHelpers.EnsureSufficientExecutionStack();
+                return true;
             }
-            catch (InsufficientExecutionStackException) when (_executionStackCount < MaxExecutionStackCount)
+
+            if (_executionStackCount < MaxExecutionStackCount)
             {
                 return false;
             }
 
-            return true;
+            throw new InsufficientExecutionStackException();
         }
 
         public void RunOnEmptyStack<T1, T2>(Action<T1, T2> action, T1 arg1, T2 arg2)


### PR DESCRIPTION
Instead of catching exception from TryEnsureSufficientExecutionStack.

Fixes #11556

<s>If `MaxExecutionStackCount` is hit this just lets the caller try to use the current stack. This changes the behaviour with code that pushes past the limit of the stack guard from throwing `InsufficientExecutionStackException` to throwing `StackOverflowException` (unless the caller was *really* lucky!). This seems reasonable in that it should be rare, is what more developers would expect from the sort of deeply recursive code that could do that, and is what would have happened prior to #11091, except it'll have gone through 1024 stacks' worth of calls before it does so. The exception could be easily changed to ``InsufficientExecutionStackException` if preferred.