### PR TITLE
Fix P2P reference Configuration selection

### DIFF
--- a/buildvertical.targets
+++ b/buildvertical.targets
@@ -15,7 +15,14 @@
     <!-- find the best configuration for each project, projects that shouldn't build for this configuration
          return an empty item.  -->
     <MSBuild Targets="FindBestConfiguration"
-             Projects="@(Project)">
+             Projects="@(Project)"
+             Condition="'$(BuildAllConfigurations)' != 'true'">
+      <Output TaskParameter="TargetOutputs"
+              ItemName="_ProjectBestConfigurations" />
+    </MSBuild>
+    <MSBuild Targets="GetBuildConfigurations"
+             Projects="@(Project)"
+             Condition="'$(BuildAllConfigurations)' == 'true'">
       <Output TaskParameter="TargetOutputs"
               ItemName="_ProjectBestConfigurations" />
     </MSBuild>
@@ -51,35 +58,56 @@
       <_BestConfiguration Condition="'$(BuildConfigurations)' == ''">$(BuildConfiguration)</_BestConfiguration>
     </PropertyGroup>
   </Target>
-
-  <!-- Runs in a leaf project (eg: csproj) to determine best configuration if one exists for purposes of project references -->
-  <Target Name="FindBestConfigurationForProjectReference"
-          DependsOnTargets="FindBestConfiguration"
-          Returns="$(_BestConfiguration)">
-    <Error Condition="'$(_BestConfiguration)' == ''" Text="Could not find a configuration for $(BuildConfiguration) from $(BuildConfigurations)" />
+  
+  <!-- Runs in a leaf project (eg: csproj) to determine all configurations -->
+  <Target Name="GetBuildConfigurations"
+          Returns="$(_AllBuildConfigurations)">
+     <PropertyGroup>
+       <_AllBuildConfigurations>$(BuildConfigurations)</_AllBuildConfigurations>
+       <_AllBuildConfigurations Condition="'$(BuildConfigurations)' == ''">$(BuildConfiguration)</_AllBuildConfigurations>
+     </PropertyGroup>
   </Target>
 
   <!-- Runs in a leaf project (csproj) to determine best configuration for ProjectReferences -->
   <Target Name="AnnotateProjectReference"
-          BeforeTargets="BeforeResolveReferences">
+          BeforeTargets="BeforeResolveReferences"
+          Condition="'@(ProjectReference)' != ''"
+          Inputs="%(ProjectReference.Identity)"
+          Outputs="unused">
 
-    <!-- find the best configuration for each project, projects that do not have an 
-        applicable configuration will fail the build.  -->
-    <MSBuild Targets="FindBestConfigurationForProjectReference"
+    <!-- Get all configurations for each ProjectReference.  We use this 
+         rather than the FindBestConfiguration target since we need to 
+         choose the best configuration for the referencing project's 
+         configuration, not the BuildConfiguration.  -->
+    <MSBuild Targets="GetBuildConfigurations"
              Projects="@(ProjectReference)">
-      <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceBestConfigurations" />
+      <Output TaskParameter="TargetOutputs" PropertyName="_projectReferenceBuildConfigurations" />
     </MSBuild>
 
-    <ItemGroup>
-      <!-- transform back to ProjectReference -->
-      <ProjectReferenceWithConfiguration Include="@(_ProjectReferenceBestConfigurations->'%(OriginalItemSpec)')">
-        <AdditionalProperties>Configuration=%(Identity);%(_ProjectReferenceBestConfigurations.AdditionalProperties)</AdditionalProperties>
-      </ProjectReferenceWithConfiguration>
-    </ItemGroup>
+    <!-- Find the best configuration for the current Project's Configuration -->
+    <FindBestConfiguration Properties="@(Property)"
+                           PropertyValues="@(PropertyValue)"
+                           BuildConfigurations="$(_ProjectReferenceBuildConfigurations)"
+                           BuildConfiguration="$(Configuration)">
+      <Output TaskParameter="BestConfiguration" PropertyName="_projectReferenceConfiguration" />
+    </FindBestConfiguration>
+
+    <Error Condition="'$(_projectReferenceConfiguration)' == ''" Text="Could not find a configuration for ProjectReference '@(ProjectReference)' from configurations '$(_projectReferenceBuildConfigurations)' when building '$(MSBuildProjectName)' for configuration '$(Configuration)' ." />
 
     <ItemGroup>
-      <ProjectReference Remove="@(ProjectReference)" />
-      <ProjectReference Include="@(ProjectReferenceWithConfiguration)" />
+      <ProjectReference>
+        <AdditionalProperties>Configuration=$(_projectReferenceConfiguration);%(ProjectReference.AdditionalProperties)</AdditionalProperties>
+      </ProjectReference>
     </ItemGroup>
+  </Target>
+
+  <Target Name="BuildAll">
+    <ItemGroup>
+      <_buildConfigurations Include="$(BuildConfigurations)" />
+      <_buildConfigurations Condition="'@(_buildConfigurations)' == ''" Include="$(BuildConfiguration)" />
+    </ItemGroup>
+
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Properties="Configuration=%(_buildConfigurations.Identity)" />
   </Target>
 </Project>

--- a/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/Configurations.props
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard1.3;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/Common/tests/System/Xml/ModuleCore/Configurations.props
+++ b/src/Common/tests/System/Xml/ModuleCore/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard1.3;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/Common/tests/System/Xml/XmlCoreTest/Configurations.props
+++ b/src/Common/tests/System/Xml/XmlCoreTest/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard1.3;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/Common/tests/System/Xml/XmlDiff/Configurations.props
+++ b/src/Common/tests/System/Xml/XmlDiff/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard1.3;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.TargetingPack.Private.WinRT/ref/Configurations.props
+++ b/src/Microsoft.TargetingPack.Private.WinRT/ref/Configurations.props
@@ -2,11 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      net463-Windows_NT;
-      uap101aot-Windows_NT;
-      netcoreapp1.2corert;
-      netcoreapp-Windows_NT;
-      netcoreapp-Unix;
+      netstandard;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/Configurations.props
+++ b/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard1.3;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Composition/scenarios/TestLibrary/Configurations.props
+++ b/src/System.Composition/scenarios/TestLibrary/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard1.3;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Diagnostics.StackTrace/src/Configurations.props
+++ b/src/System.Diagnostics.StackTrace/src/Configurations.props
@@ -4,7 +4,8 @@
     <BuildConfigurations>
       net463-Windows_NT;
       uap101aot-Windows_NT;
-      netcoreapp;
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Diagnostics.Tracing/src/Configurations.props
+++ b/src/System.Diagnostics.Tracing/src/Configurations.props
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <BuildConfigurations>
       net461-Windows_NT;
-      netcoreapp;
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Private.Xml.Linq/src/Configurations.props
+++ b/src/System.Private.Xml.Linq/src/Configurations.props
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <BuildConfigurations>
       net463-Windows_NT;
-      netstandard;
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Private.Xml.Linq/src/System.Private.Xml.Linq.csproj
+++ b/src/System.Private.Xml.Linq/src/System.Private.Xml.Linq.csproj
@@ -12,9 +12,9 @@
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='net463-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='net463-Windows_NT-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netcoreapp-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netcoreapp-Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <ProjectReference Include="..\..\System.Private.Xml\src\System.Private.Xml.csproj" />
     <Compile Include="$(CommonPath)\System\Collections\Generic\ArrayBuilder.cs">
       <Link>System\Collections\Generic\ArrayBuilder.cs</Link>
@@ -62,7 +62,7 @@
     <Compile Include="System\Xml\XPath\XNodeNavigator.cs" />
     <Compile Include="System\Xml\XPath\XObjectExtensions.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net463'">

--- a/src/System.Private.Xml.Linq/tests/XDocument.Test.ModuleCore/Configurations.props
+++ b/src/System.Private.Xml.Linq/tests/XDocument.Test.ModuleCore/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard1.3;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/Configurations.props
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Reflection/tests/TestExe/Configurations.props
+++ b/src/System.Reflection/tests/TestExe/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard1.5;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Runtime.Extensions/tests/AssemblyResolveTests/Configurations.props
+++ b/src/System.Runtime.Extensions/tests/AssemblyResolveTests/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard1.5;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Runtime.Extensions/tests/TestApp/Configurations.props
+++ b/src/System.Runtime.Extensions/tests/TestApp/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard1.5;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Runtime.Extensions/tests/TestAppOutsideOfTPA/Configurations.props
+++ b/src/System.Runtime.Extensions/tests/TestAppOutsideOfTPA/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard1.5;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/Configurations.props
+++ b/src/System.Runtime.Extensions/tests/VoidMainWithExitCodeApp/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard1.5;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Runtime/src/Configurations.props
+++ b/src/System.Runtime/src/Configurations.props
@@ -5,7 +5,8 @@
       net461-Windows_NT;
       uap101aot-Windows_NT;
       netcoreapp1.2corert-Windows_NT;
-      netcoreapp;
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime/tests/TestAssembly/Configurations.props
+++ b/src/System.Runtime/tests/TestAssembly/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Runtime/tests/TestLoadAssembly/Configurations.props
+++ b/src/System.Runtime/tests/TestLoadAssembly/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestNativeService/Configurations.props
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestNativeService/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Threading.Tasks/src/Configurations.props
+++ b/src/System.Threading.Tasks/src/Configurations.props
@@ -4,7 +4,8 @@
     <BuildConfigurations>
       uap101aot-Windows_NT;
       net463-Windows_NT;
-      netcoreapp;
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
       netcoreapp1.2corert;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Threading/src/Configurations.props
+++ b/src/System.Threading/src/Configurations.props
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <BuildConfigurations>
       net463-Windows_NT;
-      netcoreapp;
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Xml.ReaderWriter/src/Configurations.props
+++ b/src/System.Xml.ReaderWriter/src/Configurations.props
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <BuildConfigurations>
       net463-Windows_NT;
-      netcoreapp;
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Xml.XDocument/src/Configurations.props
+++ b/src/System.Xml.XDocument/src/Configurations.props
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <BuildConfigurations>
       net463-Windows_NT;
-      netcoreapp;
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Xml.XPath.XDocument/src/Configurations.props
+++ b/src/System.Xml.XPath.XDocument/src/Configurations.props
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <BuildConfigurations>
       net463-Windows_NT;
-      netcoreapp;
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Xml.XPath.XmlDocument/src/Configurations.props
+++ b/src/System.Xml.XPath.XmlDocument/src/Configurations.props
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <BuildConfigurations>
       net461-Windows_NT;
-      netstandard;
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Xml.XPath/src/Configurations.props
+++ b/src/System.Xml.XPath/src/Configurations.props
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <BuildConfigurations>
       net463-Windows_NT;
-      netcoreapp;
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Xml.XmlDocument/src/Configurations.props
+++ b/src/System.Xml.XmlDocument/src/Configurations.props
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <BuildConfigurations>
       net463-Windows_NT;
-      netcoreapp;
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Xml.XmlSerializer/src/Configurations.props
+++ b/src/System.Xml.XmlSerializer/src/Configurations.props
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <BuildConfigurations>
       net463-Windows_NT;
-      netcoreapp;
+      netcoreapp-Windows_NT;
+      netcoreapp-Unix;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Previously we'd always choose Configuration for P2Ps based on
BuildConfiguration.  This was incorrect and could result in netstandard
configurations building against netcoreapp references.

Fix this by doing configuration selection in the referencing project.

I had to fix a number of projects after making this change.  These were 
all cases where we were building a OS-agnostic configuration and 
referencing an OS-specific library.  Or building netstandard libraries 
referencing netcoreapp libraries.

I've also added hooks to build all configurations.  To do this from a
traversal set /p:BuildAllConfigurations=true.  To do this from a project
build with /t:BuildAll.

/cc @weshaggard @joperezr @chcosta 