### PR TITLE
Avoid InternalGetCookies costs when there are no cookies

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -727,6 +727,11 @@ namespace System.Net
 
         internal CookieCollection InternalGetCookies(Uri uri)
         {
+            if (_count == 0)
+            {
+                return null;
+            }
+
             bool isSecure = (uri.Scheme == UriScheme.Https);
             int port = uri.Port;
             CookieCollection cookies = null;


### PR DESCRIPTION
Calling CookieContainer.GetCookieHeader results in a bunch of work and allocations, including a list, an array, several strings, etc., but none of that is necessary if there aren't any cookies in the container anyway. This commit just special cases an empty container to avoid those.  This is showing up in traces of HttpClient.

cc: @davidsh, @cipop, @geoffkizer, @mikeharder, @cesarbs 