### PR TITLE
Catch divide-by-constant-zero in Microsoft.CSharp.RuntimeBinder

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -2734,14 +2734,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     {
                         uRes = u1 / u2;
                     }
-                    else if (u2 != 0)
-                    {
-                        uRes = (uint)((int)u1 / (int)u2);
-                    }
                     else
                     {
-                        uRes = (uint)-(int)u1;
-                        EnsureChecked(u1 != uSign);
+                        uRes = (uint)((int)u1 / (int)u2);
                     }
                     break;
 
@@ -2751,13 +2746,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     {
                         uRes = u1 % u2;
                     }
-                    else if (u2 != 0)
-                    {
-                        uRes = (uint)((int)u1 % (int)u2);
-                    }
                     else
                     {
-                        uRes = 0;
+                        uRes = (uint)((int)u1 % (int)u2);
                     }
                     break;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -2504,8 +2504,26 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return true;
         }
 
-        private static bool isDivByZero(ExpressionKind kind, EXPR op2)
+        private static bool IsDivByZero(ExpressionKind kind, EXPR op2, PredefinedType ptOp)
         {
+            switch (kind)
+            {
+                case ExpressionKind.EK_DIV:
+                case ExpressionKind.EK_MOD:
+                    EXPRCONSTANT opConst2 = op2?.GetConst().asCONSTANT();
+                    if (opConst2 != null)
+                    {
+                        if (ptOp == PredefinedType.PT_LONG)
+                        {
+                            return opConst2.getVal().longVal == 0;
+                        }
+
+                        return opConst2.getVal().ulongVal == 0;
+                    }
+
+                    break;
+            }
+
             return false;
         }
 
@@ -2553,7 +2571,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(op2 == null || op2.type == typeOp);
             Debug.Assert((op2 == null) == (kind == ExpressionKind.EK_NEG || kind == ExpressionKind.EK_UPLUS || kind == ExpressionKind.EK_BITNOT));
 
-            if (isDivByZero(kind, op2))
+            if (IsDivByZero(kind, op2, ptOp))
             {
                 GetErrorContext().Error(ErrorCode.ERR_IntDivByZero);
                 EXPR rval = GetExprFactory().CreateBinop(kind, typeOp, op1, op2);

--- a/src/Microsoft.CSharp/tests/IntegerBindingTests.cs
+++ b/src/Microsoft.CSharp/tests/IntegerBindingTests.cs
@@ -1,0 +1,100 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Microsoft.CSharp.RuntimeBinder.Tests
+{
+    public class IntegerBindingTests
+    {
+        private static readonly IEnumerable<ExpressionType> DivisionExpressionTypes = new[]
+        {
+            ExpressionType.Divide, ExpressionType.DivideAssign, ExpressionType.Modulo, ExpressionType.ModuloAssign
+        };
+
+        private static IEnumerable<object[]> DivisionOperations()
+        {
+            foreach (ExpressionType type in DivisionExpressionTypes)
+            {
+                yield return new object[] {type, true};
+                yield return new object[] {type, false};
+            }
+        }
+
+        private static CallSite<Func<CallSite, T, T, object>> GetZeroConstantDivisionCallSite<T>(ExpressionType operation, bool constantDividend)
+        {
+            CSharpArgumentInfo x = CSharpArgumentInfo.Create(constantDividend ? CSharpArgumentInfoFlags.Constant : CSharpArgumentInfoFlags.None, null);
+            CSharpArgumentInfo y = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.Constant, null);
+            CallSiteBinder binder = Binder.BinaryOperation(CSharpBinderFlags.None, operation, typeof(IntegerBindingTests), new[] { x, y });
+            return CallSite<Func<CallSite, T, T, object>>.Create(binder);
+        }
+
+        [Theory, MemberData(nameof(DivisionOperations))]
+        public void DivConstantZeroSByte(ExpressionType operation, bool constantDividend)
+        {
+            CallSite<Func<CallSite, sbyte, sbyte, object>> callsite = GetZeroConstantDivisionCallSite<sbyte>(operation, constantDividend);
+            Assert.Throws<RuntimeBinderException>(() => callsite.Target(callsite, 8, 0));
+        }
+
+        [Theory, MemberData(nameof(DivisionOperations))]
+        public void DivConstantZeroByte(ExpressionType operation, bool constantDividend)
+        {
+            CallSite<Func<CallSite, byte, byte, object>> callsite = GetZeroConstantDivisionCallSite<byte>(operation, constantDividend);
+            Assert.Throws<RuntimeBinderException>(() => callsite.Target(callsite, 8, 0));
+        }
+
+        [Theory, MemberData(nameof(DivisionOperations))]
+        public void DivConstantZeroInt16(ExpressionType operation, bool constantDividend)
+        {
+            CallSite<Func<CallSite, short, short, object>> callsite = GetZeroConstantDivisionCallSite<short>(operation, constantDividend);
+            Assert.Throws<RuntimeBinderException>(() => callsite.Target(callsite, 8, 0));
+        }
+
+        [Theory, MemberData(nameof(DivisionOperations))]
+        public void DivConstantZeroUInt16(ExpressionType operation, bool constantDividend)
+        {
+            CallSite<Func<CallSite, ushort, ushort, object>> callsite = GetZeroConstantDivisionCallSite<ushort>(operation, constantDividend);
+            Assert.Throws<RuntimeBinderException>(() => callsite.Target(callsite, 8, 0));
+        }
+
+        [Theory, MemberData(nameof(DivisionOperations))]
+        public void DivConstantZeroChar(ExpressionType operation, bool constantDividend)
+        {
+            CallSite<Func<CallSite, char, char, object>> callsite = GetZeroConstantDivisionCallSite<char>(operation, constantDividend);
+            Assert.Throws<RuntimeBinderException>(() => callsite.Target(callsite, '\b', '\0'));
+        }
+
+        [Theory, MemberData(nameof(DivisionOperations))]
+        public void DivConstantZeroInt32(ExpressionType operation, bool constantDividend)
+        {
+            CallSite<Func<CallSite, int, int, object>> callsite = GetZeroConstantDivisionCallSite<int>(operation, constantDividend);
+            Assert.Throws<RuntimeBinderException>(() => callsite.Target(callsite, 8, 0));
+        }
+
+        [Theory, MemberData(nameof(DivisionOperations))]
+        public void DivConstantZeroUInt32(ExpressionType operation, bool constantDividend)
+        {
+            CallSite<Func<CallSite, uint, uint, object>> callsite = GetZeroConstantDivisionCallSite<uint>(operation, constantDividend);
+            Assert.Throws<RuntimeBinderException>(() => callsite.Target(callsite, 8, 0));
+        }
+
+        [Theory, MemberData(nameof(DivisionOperations))]
+        public void DivConstantZeroInt64(ExpressionType operation, bool constantDividend)
+        {
+            CallSite<Func<CallSite, long, long, object>> callsite = GetZeroConstantDivisionCallSite<long>(operation, constantDividend);
+            Assert.Throws<RuntimeBinderException>(() => callsite.Target(callsite, 8, 0));
+        }
+
+        [Theory, MemberData(nameof(DivisionOperations))]
+        public void DivConstantZeroUInt64(ExpressionType operation, bool constantDividend)
+        {
+            CallSite<Func<CallSite, ulong, ulong, object>> callsite = GetZeroConstantDivisionCallSite<ulong>(operation, constantDividend);
+            Assert.Throws<RuntimeBinderException>(() => callsite.Target(callsite, 8, 0));
+        }
+    }
+}

--- a/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
+++ b/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -8,6 +8,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="CSharpArgumentInfoTests.cs" />
+    <Compile Include="IntegerBindingTests.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Fixes #15464