### PR TITLE
Expose parameterless string.TrimEnd/TrimStart in ref

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -2101,8 +2101,10 @@ namespace System
         public string Trim() { throw null; }
         public string Trim(char trimChar) { throw null; }
         public string Trim(params char[] trimChars) { throw null; }
+        public string TrimEnd() { throw null; }
         public string TrimEnd(char trimChar) { throw null; }
         public string TrimEnd(params char[] trimChars) { throw null; }
+        public string TrimStart() { throw null; }
         public string TrimStart(char trimChar) { throw null; }
         public string TrimStart(params char[] trimChars) { throw null; }
     }


### PR DESCRIPTION
Expose the new parameterless TrimEnd/TrimStart APIs added in https://github.com/dotnet/coreclr/pull/8834.

The existing tests already cover these new APIs:
 - https://github.com/dotnet/corefx/blob/9f00738f44164150f9b31cff5c72c19ebb68bb88/src/System.Runtime/tests/System/StringTests.cs#L2338
 - https://github.com/dotnet/corefx/blob/9f00738f44164150f9b31cff5c72c19ebb68bb88/src/System.Runtime/tests/System/StringTests.cs#L2362

Fixes #6485