### PR TITLE
ClientWebSocket(Managed): Allow user code to control the HTTP Host header

### DIFF
--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
@@ -214,7 +214,7 @@ namespace System.Net.WebSockets
                 builder.Append("Host: ");
                 if (string.IsNullOrEmpty(hostHeader))
                 {
-                    builder.Append(uri.IdnHost).Append(":").Append(uri.Port).Append("\r\n");
+                    builder.Append(uri.IdnHost).Append(':').Append(uri.Port).Append("\r\n");
                 }
                 else
                 {
@@ -294,7 +294,7 @@ namespace System.Net.WebSockets
         /// Given a "Host:Port" string return only the "Host"
         /// </summary>
         /// <param name="hostAndPort">The host and optional port value (e.g. "Host:Port").</param>
-        /// <returns>The the "Host" portion</returns>
+        /// <returns>The "Host" portion</returns>
         private static string ExtractHost(string hostAndPort)
         {
             string host = hostAndPort;

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
@@ -291,24 +291,19 @@ namespace System.Net.WebSockets
         }
 
         /// <summary>
-        /// Given a &quot;Host:Port&quot; string return only the &quot;Host&quot;
+        /// Given a "Host:Port" string return only the "Host"
         /// </summary>
-        /// <param name="hostAndPort">The host and optional port value (e.g. &quot;Host:Port&quot;).</param>
-        /// <returns>The the &quot;Host&quot; portion</returns>
+        /// <param name="hostAndPort">The host and optional port value (e.g. "Host:Port").</param>
+        /// <returns>The the "Host" portion</returns>
         private static string ExtractHost(string hostAndPort)
         {
             string host = hostAndPort;
             if (!string.IsNullOrEmpty(hostAndPort))
             {
                 int colonIndex = hostAndPort.IndexOf(':');
-                if (colonIndex == -1)
-                {
-                    host = hostAndPort;
-                }
-                else
-                {
-                    host = hostHeader.Substring(0, colonIndex);
-                }
+                host = colonIndex == -1 ? 
+                    hostAndPort :
+                    hostHeader.Substring(0, colonIndex);
             }
 
             return host;

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
@@ -303,7 +303,7 @@ namespace System.Net.WebSockets
                 int colonIndex = hostAndPort.IndexOf(':');
                 host = colonIndex == -1 ? 
                     hostAndPort :
-                    hostHeader.Substring(0, colonIndex);
+                    hostAndPort.Substring(0, colonIndex);
             }
 
             return host;


### PR DESCRIPTION
Allow user code to control the HTTP Host header by calling ClientWebSocketOptions.SetRequestHeader:

``` C#
clientWebSocket.Options.SetRequestHeader("Host", "contoso.servicebus.windows.net");
await clientWebSocket.ConnectAsync("wss://gateway63.servicebus.windows.net/someresource", ...);
```