### PR TITLE
Increase timeouts for some failing Net tests

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -382,7 +382,6 @@ namespace System.Net.Http.Functional.Tests
 
         [Fact]
         [OuterLoop]
-        [ActiveIssue(12778)]
         public void Timeout_SetTo60AndGetResponseFromServerWhichTakes40_Success()
         {
             // TODO: This is a placeholder until GitHub Issue #2383 gets resolved.
@@ -390,7 +389,7 @@ namespace System.Net.Http.Functional.Tests
             
             using (var client = new HttpClient())
             {
-                client.Timeout = TimeSpan.FromSeconds(60);
+                client.Timeout = TimeSpan.FromMinutes(5);
                 var response = client.GetAsync(SlowServer).GetAwaiter().GetResult();
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             }

--- a/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
@@ -107,7 +107,7 @@ namespace System.Net.Http.Functional.Tests
                 cts.Cancel();
 
                 // Verify that the task completes successfully or is canceled.
-                Assert.True(((IAsyncResult)task).AsyncWaitHandle.WaitOne(new TimeSpan(0, 0, 3)));
+                Assert.True(((IAsyncResult)task).AsyncWaitHandle.WaitOne(new TimeSpan(0, 5, 0)));
                 Assert.True(task.Status == TaskStatus.RanToCompletion || task.Status == TaskStatus.Canceled);
             }
         }


### PR DESCRIPTION
These two tests are/were failing intermittently from hitting their timeouts. We can increase those timeouts to a significantly higher value without taking away from the test's value.

@steveharter @Priya91 

resolves https://github.com/dotnet/corefx/issues/13938
resolves https://github.com/dotnet/corefx/issues/12778