### PR TITLE
Show a more helpful description in the debugger for Grouping/Lookup

### DIFF
--- a/src/Common/tests/System/Diagnostics/DebuggerAttributes.cs
+++ b/src/Common/tests/System/Diagnostics/DebuggerAttributes.cs
@@ -40,8 +40,8 @@ namespace System.Diagnostics
         public static DebuggerBrowsableState? GetDebuggerBrowsableState(MemberInfo info)
         {
             CustomAttributeData debuggerBrowsableAttribute = info.CustomAttributes
-                .SingleOrDefault(a => a.AttributeType == typeof(DebuggerTypeProxyAttribute));
-            return (DebuggerBrowsableState?)debuggerBrowsableAttribute?.ConstructorArguments.Single().Value;
+                .SingleOrDefault(a => a.AttributeType == typeof(DebuggerBrowsableAttribute));
+            return (DebuggerBrowsableState?)(int?)debuggerBrowsableAttribute?.ConstructorArguments.Single().Value;
         }
 
         public static IDictionary<string, FieldInfo> GetDebuggerVisibleFields(object obj)

--- a/src/Common/tests/System/Diagnostics/DebuggerAttributes.cs
+++ b/src/Common/tests/System/Diagnostics/DebuggerAttributes.cs
@@ -41,6 +41,7 @@ namespace System.Diagnostics
         {
             CustomAttributeData debuggerBrowsableAttribute = info.CustomAttributes
                 .SingleOrDefault(a => a.AttributeType == typeof(DebuggerBrowsableAttribute));
+            // Enums in attribute constructors are boxed as ints, so cast to int? first.
             return (DebuggerBrowsableState?)(int?)debuggerBrowsableAttribute?.ConstructorArguments.Single().Value;
         }
 
@@ -48,6 +49,7 @@ namespace System.Diagnostics
         {
             TypeInfo typeInfo = obj.GetType().GetTypeInfo();
             IEnumerable<FieldInfo> visibleFields = typeInfo.DeclaredFields
+                // The debugger doesn't evaluate non-public members of type proxies.
                 .Where(fi => fi.IsPublic && GetDebuggerBrowsableState(fi) != DebuggerBrowsableState.Never);
             return visibleFields.ToDictionary(fi => fi.Name, fi => fi);
         }
@@ -56,6 +58,7 @@ namespace System.Diagnostics
         {
             TypeInfo typeInfo = obj.GetType().GetTypeInfo();
             IEnumerable<PropertyInfo> visibleProperties = typeInfo.DeclaredProperties
+                // The debugger doesn't evaluate non-public members of type proxies. GetGetMethod returns null if the getter is non-public.
                 .Where(pi => pi.GetGetMethod() != null && GetDebuggerBrowsableState(pi) != DebuggerBrowsableState.Never);
             return visibleProperties.ToDictionary(pi => pi.Name, pi => pi);
         }

--- a/src/System.Linq/src/System/Linq/DebugView.cs
+++ b/src/System.Linq/src/System/Linq/DebugView.cs
@@ -110,16 +110,14 @@ namespace System.Linq
         public TKey Key => _grouping.Key;
 
         // The name of this property must alphabetically follow `Key` so the elements appear last in the display.
-        // TODO: Does it matter if the contents are cached here? AFAICT Groupings are immutable after they are populated,
-        // so we could save the debugger some work if the Grouping contains a huge number of elements, right? Same for the
-        // Lookup proxy.
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public TElement[] Values => _grouping.ToArray();
+        public TElement[] Values => _grouping._elements;
     }
 
     internal sealed class LookupDebuggerProxy<TKey, TElement>
     {
         private readonly Lookup<TKey, TElement> _lookup;
+        private IGrouping<TKey, TElement>[] _cachedGroupings;
 
         public LookupDebuggerProxy(Lookup<TKey, TElement> lookup)
         {
@@ -127,6 +125,6 @@ namespace System.Linq
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public IGrouping<TKey, TElement>[] Groupings => _lookup.ToArray();
+        public IGrouping<TKey, TElement>[] Groupings => _cachedGroupings ?? (_cachedGroupings = _lookup.ToArray());
     }
 }

--- a/src/System.Linq/src/System/Linq/DebugView.cs
+++ b/src/System.Linq/src/System/Linq/DebugView.cs
@@ -98,12 +98,12 @@ namespace System.Linq
         private IEnumerable _enumerable;
     }
 
-    internal sealed class GroupingDebuggerProxy<TKey, TElement>
+    internal sealed class SystemLinq_GroupingDebugView<TKey, TElement>
     {
         private readonly Grouping<TKey, TElement> _grouping;
         private TElement[] _cachedValues;
 
-        public GroupingDebuggerProxy(Grouping<TKey, TElement> grouping)
+        public SystemLinq_GroupingDebugView(Grouping<TKey, TElement> grouping)
         {
             _grouping = grouping;
         }
@@ -115,12 +115,12 @@ namespace System.Linq
         public TElement[] Values => _cachedValues ?? (_cachedValues = _grouping.ToArray());
     }
 
-    internal sealed class LookupDebuggerProxy<TKey, TElement>
+    internal sealed class SystemLinq_LookupDebugView<TKey, TElement>
     {
         private readonly Lookup<TKey, TElement> _lookup;
         private IGrouping<TKey, TElement>[] _cachedGroupings;
 
-        public LookupDebuggerProxy(Lookup<TKey, TElement> lookup)
+        public SystemLinq_LookupDebugView(Lookup<TKey, TElement> lookup)
         {
             _lookup = lookup;
         }

--- a/src/System.Linq/src/System/Linq/DebugView.cs
+++ b/src/System.Linq/src/System/Linq/DebugView.cs
@@ -97,4 +97,20 @@ namespace System.Linq
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private IEnumerable _enumerable;
     }
+
+    internal sealed class GroupingDebuggerProxy<TKey, TElement>
+    {
+        private readonly Grouping<TKey, TElement> _grouping;
+
+        public GroupingDebuggerProxy(Grouping<TKey, TElement> grouping)
+        {
+            _grouping = grouping;
+        }
+
+        public TKey Key => _grouping.Key;
+
+        // The name of this property must alphabetically follow others so the elements appear last in the display.
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public TElement[] Values => _grouping.ToArray();
+    }
 }

--- a/src/System.Linq/src/System/Linq/DebugView.cs
+++ b/src/System.Linq/src/System/Linq/DebugView.cs
@@ -109,8 +109,24 @@ namespace System.Linq
 
         public TKey Key => _grouping.Key;
 
-        // The name of this property must alphabetically follow others so the elements appear last in the display.
+        // The name of this property must alphabetically follow `Key` so the elements appear last in the display.
+        // TODO: Does it matter if the contents are cached here? AFAICT Groupings are immutable after they are populated,
+        // so we could save the debugger some work if the Grouping contains a huge number of elements, right? Same for the
+        // Lookup proxy.
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         public TElement[] Values => _grouping.ToArray();
+    }
+
+    internal sealed class LookupDebuggerProxy<TKey, TElement>
+    {
+        private readonly Lookup<TKey, TElement> _lookup;
+
+        public LookupDebuggerProxy(Lookup<TKey, TElement> lookup)
+        {
+            _lookup = lookup;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public IGrouping<TKey, TElement>[] Groupings => _lookup.ToArray();
     }
 }

--- a/src/System.Linq/src/System/Linq/DebugView.cs
+++ b/src/System.Linq/src/System/Linq/DebugView.cs
@@ -101,6 +101,7 @@ namespace System.Linq
     internal sealed class GroupingDebuggerProxy<TKey, TElement>
     {
         private readonly Grouping<TKey, TElement> _grouping;
+        private TElement[] _cachedValues;
 
         public GroupingDebuggerProxy(Grouping<TKey, TElement> grouping)
         {
@@ -111,7 +112,7 @@ namespace System.Linq
 
         // The name of this property must alphabetically follow `Key` so the elements appear last in the display.
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public TElement[] Values => _grouping._elements;
+        public TElement[] Values => _cachedValues ?? (_cachedValues = _grouping.ToArray());
     }
 
     internal sealed class LookupDebuggerProxy<TKey, TElement>

--- a/src/System.Linq/src/System/Linq/Grouping.cs
+++ b/src/System.Linq/src/System/Linq/Grouping.cs
@@ -62,7 +62,7 @@ namespace System.Linq
     //
     // To limit the damage, the toolchain makes this type appear in a hidden assembly.
     // (This is also why it is no longer a nested type of Lookup<,>).
-    [DebuggerDisplay("{Key}")]
+    [DebuggerDisplay("Key = {Key}")]
     [DebuggerTypeProxy(typeof(SystemLinq_GroupingDebugView<,>))]
     public class Grouping<TKey, TElement> : IGrouping<TKey, TElement>, IList<TElement>
     {

--- a/src/System.Linq/src/System/Linq/Grouping.cs
+++ b/src/System.Linq/src/System/Linq/Grouping.cs
@@ -4,6 +4,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System.Linq
 {
@@ -61,6 +62,8 @@ namespace System.Linq
     //
     // To limit the damage, the toolchain makes this type appear in a hidden assembly.
     // (This is also why it is no longer a nested type of Lookup<,>).
+    [DebuggerDisplay("{Key}")]
+    [DebuggerTypeProxy(typeof(GroupingDebuggerTypeProxy<,>))]
     public class Grouping<TKey, TElement> : IGrouping<TKey, TElement>, IList<TElement>
     {
         internal TKey _key;

--- a/src/System.Linq/src/System/Linq/Grouping.cs
+++ b/src/System.Linq/src/System/Linq/Grouping.cs
@@ -63,7 +63,7 @@ namespace System.Linq
     // To limit the damage, the toolchain makes this type appear in a hidden assembly.
     // (This is also why it is no longer a nested type of Lookup<,>).
     [DebuggerDisplay("{Key}")]
-    [DebuggerTypeProxy(typeof(GroupingDebuggerTypeProxy<,>))]
+    [DebuggerTypeProxy(typeof(GroupingDebuggerProxy<,>))]
     public class Grouping<TKey, TElement> : IGrouping<TKey, TElement>, IList<TElement>
     {
         internal TKey _key;

--- a/src/System.Linq/src/System/Linq/Grouping.cs
+++ b/src/System.Linq/src/System/Linq/Grouping.cs
@@ -63,7 +63,7 @@ namespace System.Linq
     // To limit the damage, the toolchain makes this type appear in a hidden assembly.
     // (This is also why it is no longer a nested type of Lookup<,>).
     [DebuggerDisplay("{Key}")]
-    [DebuggerTypeProxy(typeof(GroupingDebuggerProxy<,>))]
+    [DebuggerTypeProxy(typeof(SystemLinq_GroupingDebugView<,>))]
     public class Grouping<TKey, TElement> : IGrouping<TKey, TElement>, IList<TElement>
     {
         internal TKey _key;

--- a/src/System.Linq/src/System/Linq/Lookup.cs
+++ b/src/System.Linq/src/System/Linq/Lookup.cs
@@ -65,6 +65,8 @@ namespace System.Linq
         bool Contains(TKey key);
     }
 
+    [DebuggerDisplay("Count = {Count}")]
+    [DebuggerTypeProxy(typeof(LookupDebuggerProxy<,>))]
     public class Lookup<TKey, TElement> : ILookup<TKey, TElement>, IIListProvider<IGrouping<TKey, TElement>>
     {
         private readonly IEqualityComparer<TKey> _comparer;

--- a/src/System.Linq/src/System/Linq/Lookup.cs
+++ b/src/System.Linq/src/System/Linq/Lookup.cs
@@ -66,7 +66,7 @@ namespace System.Linq
     }
 
     [DebuggerDisplay("Count = {Count}")]
-    [DebuggerTypeProxy(typeof(LookupDebuggerProxy<,>))]
+    [DebuggerTypeProxy(typeof(SystemLinq_LookupDebugView<,>))]
     public class Lookup<TKey, TElement> : ILookup<TKey, TElement>, IIListProvider<IGrouping<TKey, TElement>>
     {
         private readonly IEqualityComparer<TKey> _comparer;

--- a/src/System.Linq/tests/GroupByTests.cs
+++ b/src/System.Linq/tests/GroupByTests.cs
@@ -884,12 +884,12 @@ namespace System.Linq.Tests
             TKey key = (TKey)properties["Key"].GetValue(proxyObject);
             Assert.Equal(grouping.Key, key);
 
-            PropertyInfo elementsProperty = properties["Elements"];
-            Assert.Equal(DebuggerBrowsableState.RootHidden, DebuggerAttributes.GetDebuggerBrowsableState(elementsProperty));
-            TElement[] elements = (TElement[])elementsProperty.GetValue(proxyObject);
-            Assert.IsType<TElement[]>(elements); // Arrays can be covariant / of assignment-compatible types
-            Assert.Equal(grouping, elements);
-            Assert.Same(elements, elementsProperty.GetValue(proxyObject)); // The result should be cached, as Grouping is immutable.
+            PropertyInfo valuesProperty = properties["Values"];
+            Assert.Equal(DebuggerBrowsableState.RootHidden, DebuggerAttributes.GetDebuggerBrowsableState(valuesProperty));
+            TElement[] values = (TElement[])valuesProperty.GetValue(proxyObject);
+            Assert.IsType<TElement[]>(values); // Arrays can be covariant / of assignment-compatible types
+            Assert.Equal(grouping, values);
+            Assert.Same(values, valuesProperty.GetValue(proxyObject)); // The result should be cached, as Grouping is immutable.
         }
 
         public static IEnumerable<object[]> DebuggerAttributesValid_Data()

--- a/src/System.Linq/tests/GroupByTests.cs
+++ b/src/System.Linq/tests/GroupByTests.cs
@@ -881,9 +881,11 @@ namespace System.Linq.Tests
             IDictionary<string, PropertyInfo> properties = DebuggerAttributes.GetDebuggerVisibleProperties(proxyObject);
             Assert.Equal(2, properties.Count);
             
+            // Key
             TKey key = (TKey)properties["Key"].GetValue(proxyObject);
             Assert.Equal(grouping.Key, key);
 
+            // Values
             PropertyInfo valuesProperty = properties["Values"];
             Assert.Equal(DebuggerBrowsableState.RootHidden, DebuggerAttributes.GetDebuggerBrowsableState(valuesProperty));
             TElement[] values = (TElement[])valuesProperty.GetValue(proxyObject);

--- a/src/System.Linq/tests/GroupByTests.cs
+++ b/src/System.Linq/tests/GroupByTests.cs
@@ -867,10 +867,10 @@ namespace System.Linq.Tests
 
         [Theory]
         [MemberData(nameof(DebuggerAttributesValid_Data))]
-        public void DebuggerAttributesValid<TKey, TElement>(IGrouping<TKey, TElement> grouping, string expected, TKey dummy1, TElement dummy2)
+        public void DebuggerAttributesValid<TKey, TElement>(IGrouping<TKey, TElement> grouping, string keyString, TKey dummy1, TElement dummy2)
         {
             // The dummy parameters can be removed once https://github.com/dotnet/buildtools/pull/1300 is brought in.
-            Assert.Equal(expected, DebuggerAttributes.ValidateDebuggerDisplayReferences(grouping));
+            Assert.Equal($"Key = {keyString}", DebuggerAttributes.ValidateDebuggerDisplayReferences(grouping));
             
             object proxyObject = DebuggerAttributes.GetProxyObject(grouping);
             

--- a/src/System.Linq/tests/GroupByTests.cs
+++ b/src/System.Linq/tests/GroupByTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
 using Xunit;
 
@@ -850,6 +851,7 @@ namespace System.Linq.Tests
         {
             Assert.Equal(0, Enumerable.Empty<int>().GroupBy(i => i, (x, y) => x + y.Count()).Count());
         }
+
         [Fact]
         public static void GroupingKeyIsPublic()
         {
@@ -861,6 +863,29 @@ namespace System.Linq.Tests
             Type grouptype = group.GetType();
             PropertyInfo key = grouptype.GetProperty("Key", BindingFlags.Instance | BindingFlags.Public);
             Assert.NotNull(key);
+        }
+
+        [Theory]
+        [MemberData(nameof(DebuggerAttributesValid_Data))]
+        public void DebuggerAttributesValid<TKey, TElement>(IGrouping<TKey, TElement> grouping, string expected, TKey dummy1, TElement dummy2)
+        {
+            // The dummy parameters can be removed once https://github.com/dotnet/buildtools/pull/1300 is brought in.
+            Assert.Equal(expected, DebuggerAttributes.ValidateDebuggerDisplayReferences(grouping));
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(grouping);
+        }
+
+        public static IEnumerable<object[]> DebuggerAttributesValid_Data()
+        {
+            IEnumerable<int> source = new[] { 1 };
+            yield return new object[] { source.GroupBy(i => i).Single(), "1", 0, 0 };
+            yield return new object[] { source.GroupBy(i => i.ToString(), i => i).Single(), @"""1""", string.Empty, 0 };
+            yield return new object[] { source.GroupBy(i => TimeSpan.FromSeconds(i), i => i).Single(), "{00:00:01}", TimeSpan.Zero, 0 };
+
+            yield return new object[] { new string[] { null }.GroupBy(x => x).Single(), "null", string.Empty, string.Empty };
+            // This test won't even work with the work-around because nullables lose their type once boxed, so xUnit sees an `int` and thinks
+            // we're trying to pass an IGrouping<int, int> rather than an IGrouping<int?, int?>.
+            // However, it should also be fixed once that PR is brought in, so leaving in this comment.
+            // yield return new object[] { new int?[] { null }.GroupBy(x => x).Single(), "null", new int?(0), new int?(0) };
         }
     }
 }

--- a/src/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/System.Linq/tests/System.Linq.Tests.csproj
@@ -75,6 +75,9 @@
     <Compile Include="UnionTests.cs" />
     <Compile Include="WhereTests.cs" />
     <Compile Include="ZipTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+      <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\PlatformDetection.cs">
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>

--- a/src/System.Linq/tests/ToLookupTests.cs
+++ b/src/System.Linq/tests/ToLookupTests.cs
@@ -306,6 +306,7 @@ namespace System.Linq.Tests
             IDictionary<string, PropertyInfo> properties = DebuggerAttributes.GetDebuggerVisibleProperties(proxyObject);
             Assert.Equal(1, properties.Count);
 
+            // Groupings
             PropertyInfo groupingsProperty = properties["Groupings"];
             Assert.Equal(DebuggerBrowsableState.RootHidden, DebuggerAttributes.GetDebuggerBrowsableState(groupingsProperty));
             var groupings = (IGrouping<TKey, TElement>[])groupingsProperty.GetValue(proxyObject);


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/14790. Another thing: I changed a test function that before was just making sure the display string could be parsed correctly, to actually handing back the display string so we can assert it's equal to some format. [All of the other references to that function](https://github.com/dotnet/corefx/search?utf8=%E2%9C%93&q=ValidateDebuggerDisplayReferences) would probably be better off if they actually used its return value now instead of just calling it, so I'll open up a tracking issue for that.

/cc @JonHanna @VSadov @stephentoub 