### PR TITLE
Increase restore verbosity in release/1.1.0 branch

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -84,9 +84,10 @@
       <Output TaskParameter="RestoreRequired" PropertyName="RestoreRequired" />
     </IsRestoreRequired>
     
-    <Exec Command="$(DnuRestoreCommand) @(DnuRestoreDir->'&quot;%(Identity)&quot;', ' ')"
+    <!-- Temporarily using diagnostic verbosity until mystery 45-minute timeouts are understood -->
+    <Exec Command="$(DnuRestoreCommand) -v diag @(DnuRestoreDir->'&quot;%(Identity)&quot;', ' ')"
           Condition="'$(RestoreRequired)' == 'true'"
-          StandardOutputImportance="Low"
+          StandardOutputImportance="Normal"
           CustomErrorRegularExpression="(^Unable to locate .*)|(^Updating the invalid lock file with .*)"
           ContinueOnError="ErrorAndContinue" />
 


### PR DESCRIPTION
As seen in https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build?_a=summary&buildId=536740, we periodically have strange dictionary-based errors from dotnet restore in this branch.  This change makes sync.log more verbose.

@dagood 