### PR TITLE
[No merge] Modify expected param names for Array.Copy invalid args

### DIFF
--- a/src/Common/tests/System/AssertExtensions.cs
+++ b/src/Common/tests/System/AssertExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System
@@ -13,6 +14,18 @@ namespace System
             where T : Exception
         {
             Assert.Equal(Assert.Throws<T>(action).Message, message);
+        }
+
+        public static void Throws<T>(string netCoreParamName, string netFxParamName, Action action)
+            where T : ArgumentException
+        {
+            T exception = Assert.Throws<T>(action);
+
+            string expectedParamName =
+                RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework") ?
+                netFxParamName : netCoreParamName;
+            
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
     }
 }

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -1556,20 +1556,20 @@ namespace System.Collections.Immutable.Tests
             // ImmutableArray<T>.CopyTo defers to Array.Copy for argument validation, so
             // the parameter names here come from Array.Copy.
 
-            Assert.Throws<ArgumentNullException>("dest", () => array.CopyTo(null));
-            Assert.Throws<ArgumentNullException>("dest", () => array.CopyTo(null, 0));
-            Assert.Throws<ArgumentNullException>("dest", () => array.CopyTo(0, null, 0, 0));
-            Assert.Throws<ArgumentNullException>("dest", () => array.CopyTo(-1, null, -1, -1)); // The destination should be validated first.
+            AssertExtensions.Throws<ArgumentNullException>("destinationArray", "dest", () => array.CopyTo(null));
+            AssertExtensions.Throws<ArgumentNullException>("destinationArray", "dest", () => array.CopyTo(null, 0));
+            AssertExtensions.Throws<ArgumentNullException>("destinationArray", "dest", () => array.CopyTo(0, null, 0, 0));
+            AssertExtensions.Throws<ArgumentNullException>("destinationArray", "dest", () => array.CopyTo(-1, null, -1, -1)); // The destination should be validated first.
 
             Assert.Throws<ArgumentOutOfRangeException>("length", () => array.CopyTo(-1, new int[0], -1, -1));
-            Assert.Throws<ArgumentOutOfRangeException>("srcIndex", () => array.CopyTo(-1, new int[0], -1, 0));
-            Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => array.CopyTo(0, new int[0], -1, 0));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("sourceIndex", "srcIndex", () => array.CopyTo(-1, new int[0], -1, 0));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("destinationIndex", "dstIndex", () => array.CopyTo(0, new int[0], -1, 0));
 
-            Assert.Throws<ArgumentException>(() => array.CopyTo(array.Length, new int[1], 0, 1)); // Not enough room in the source.
+            AssertExtensions.Throws<ArgumentException>("sourceArray", "", () => array.CopyTo(array.Length, new int[1], 0, 1)); // Not enough room in the source.
 
             if (array.Length > 0)
             {
-                Assert.Throws<ArgumentException>(() => array.CopyTo(array.Length - 1, new int[1], 1, 1)); // Not enough room in the destination.
+                AssertExtensions.Throws<ArgumentException>("destinationArray", "", () => array.CopyTo(array.Length - 1, new int[1], 1, 1)); // Not enough room in the destination.
             }
         }
 

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -1565,11 +1565,11 @@ namespace System.Collections.Immutable.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("sourceIndex", "srcIndex", () => array.CopyTo(-1, new int[0], -1, 0));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("destinationIndex", "dstIndex", () => array.CopyTo(0, new int[0], -1, 0));
 
-            AssertExtensions.Throws<ArgumentException>("sourceArray", "", () => array.CopyTo(array.Length, new int[1], 0, 1)); // Not enough room in the source.
+            AssertExtensions.Throws<ArgumentException>("sourceArray", string.Empty, () => array.CopyTo(array.Length, new int[1], 0, 1)); // Not enough room in the source.
 
             if (array.Length > 0)
             {
-                AssertExtensions.Throws<ArgumentException>("destinationArray", "", () => array.CopyTo(array.Length - 1, new int[1], 1, 1)); // Not enough room in the destination.
+                AssertExtensions.Throws<ArgumentException>("destinationArray", string.Empty, () => array.CopyTo(array.Length - 1, new int[1], 1, 1)); // Not enough room in the destination.
             }
         }
 

--- a/src/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
+++ b/src/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
@@ -39,6 +39,9 @@
     <Compile Include="RequiresTests.cs" />
     <Compile Include="SimpleElementImmutablesTestBase.cs" />
     <Compile Include="TestExtensionsMethods.cs" />
+    <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
+      <Link>Common\System\AssertExtensions.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>

--- a/src/System.Collections.NonGeneric/tests/CollectionBaseTests.cs
+++ b/src/System.Collections.NonGeneric/tests/CollectionBaseTests.cs
@@ -242,8 +242,10 @@ namespace System.Collections.Tests
         {
             MyCollection collBase = CreateCollection(100);
             var fooArr = new Foo[100];
-            Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => collBase.CopyTo(fooArr, -1)); // Index < 0
-            Assert.Throws<ArgumentException>(string.Empty, () => collBase.CopyTo(fooArr, 50)); // Index + fooArray.Length > collBase.Count
+            // Index < 0
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("destinationIndex", "dstIndex", () => collBase.CopyTo(fooArr, -1));
+            // Index + fooArray.Length > collBase.Count
+            AssertExtensions.Throws<ArgumentException>("destinationArray", string.Empty, () => collBase.CopyTo(fooArr, 50));
         }
 
         [Fact]

--- a/src/System.Collections.NonGeneric/tests/ReadOnlyCollectionBaseTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ReadOnlyCollectionBaseTests.cs
@@ -71,10 +71,10 @@ namespace System.Collections.Tests
         {
             MyReadOnlyCollectionBase collection = CreateCollection();
 
-            Assert.Throws<ArgumentNullException>("dest", () => collection.CopyTo(null, 0)); // Array is null
+            AssertExtensions.Throws<ArgumentNullException>("destinationArray", "dest", () => collection.CopyTo(null, 0)); // Array is null
 
-            Assert.Throws<ArgumentException>(string.Empty, () => collection.CopyTo(new Foo[100], 50)); // Index + collection.Count > array.Length
-            Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => collection.CopyTo(new Foo[100], -1)); // Index < 0
+            AssertExtensions.Throws<ArgumentException>("destinationArray", string.Empty, () => collection.CopyTo(new Foo[100], 50)); // Index + collection.Count > array.Length
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("destinationIndex", "dstIndex", () => collection.CopyTo(new Foo[100], -1)); // Index < 0
         }
 
         [Fact]

--- a/src/System.Collections.NonGeneric/tests/SortedListTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedListTests.cs
@@ -755,11 +755,13 @@ namespace System.Collections.Tests
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
                 IList keys = sortList2.GetKeyList();
-                Assert.Throws<ArgumentNullException>("dest", () => keys.CopyTo(null, 0)); // Array is null
-                Assert.Throws<ArgumentException>(() => keys.CopyTo(new object[10, 10], 0)); // Array is multidimensional
+                AssertExtensions.Throws<ArgumentNullException>("destinationArray", "dest", () => keys.CopyTo(null, 0)); // Array is null
+                Assert.Throws<ArgumentException>("array", () => keys.CopyTo(new object[10, 10], 0)); // Array is multidimensional
 
-                Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => keys.CopyTo(new object[100], -1)); // Index < 0
-                Assert.Throws<ArgumentException>(string.Empty, () => keys.CopyTo(new object[150], 51)); // Index + list.Count > array.Count
+                // Index < 0
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("destinationIndex", "dstIndex", () => keys.CopyTo(new object[100], -1));
+                // Index + list.Count > array.Count
+                AssertExtensions.Throws<ArgumentException>("destinationArray", string.Empty, () => keys.CopyTo(new object[150], 51));
             });
         }
 
@@ -995,11 +997,11 @@ namespace System.Collections.Tests
             Helpers.PerformActionOnAllSortedListWrappers(sortList1, sortList2 =>
             {
                 IList values = sortList2.GetValueList();
-                Assert.Throws<ArgumentNullException>("dest", () => values.CopyTo(null, 0)); // Array is null
-                Assert.Throws<ArgumentException>(() => values.CopyTo(new object[10, 10], 0)); // Array is multidimensional
+                AssertExtensions.Throws<ArgumentNullException>("destinationArray", "dest", () => values.CopyTo(null, 0)); // Array is null
+                Assert.Throws<ArgumentException>("array", () => values.CopyTo(new object[10, 10], 0)); // Array is multidimensional
 
-                Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => values.CopyTo(new object[100], -1)); // Index < 0
-                Assert.Throws<ArgumentException>(string.Empty, () => values.CopyTo(new object[150], 51)); // Index + list.Count > array.Count
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("destinationIndex", "dstIndex", () => values.CopyTo(new object[100], -1)); // Index < 0
+                AssertExtensions.Throws<ArgumentException>("destinationArray", string.Empty, () => values.CopyTo(new object[150], 51)); // Index + list.Count > array.Count
             });
         }
 

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -11,6 +11,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
+      <Link>Common\System\AssertExtensions.cs</Link>
+    </Compile>
     <!-- Common Collections tests -->
     <Compile Include="$(CommonTestPath)\System\Collections\ICollection.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\ICollection.NonGeneric.Tests.cs</Link>

--- a/src/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.CopyToTests.cs
+++ b/src/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.CopyToTests.cs
@@ -59,7 +59,7 @@ namespace System.Collections.Specialized.Tests
         {
             NameValueCollection nameValueCollection = Helpers.CreateNameValueCollection(count);
             Assert.Throws<ArgumentNullException>("dest", () => nameValueCollection.CopyTo(null, 0));
-            Assert.Throws<ArgumentException>(null, () => nameValueCollection.CopyTo(new string[count, count], 0));
+            Assert.Throws<ArgumentException>("dest", () => nameValueCollection.CopyTo(new string[count, count], 0));
 
             Assert.Throws<ArgumentOutOfRangeException>("index", () => nameValueCollection.CopyTo(new string[count], -1));
 

--- a/src/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.CopyToTests.cs
+++ b/src/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.CopyToTests.cs
@@ -59,7 +59,7 @@ namespace System.Collections.Specialized.Tests
         {
             NameValueCollection nameValueCollection = Helpers.CreateNameValueCollection(count);
             Assert.Throws<ArgumentNullException>("dest", () => nameValueCollection.CopyTo(null, 0));
-            Assert.Throws<ArgumentException>(() => nameValueCollection.CopyTo(new string[count, count], 0));
+            Assert.Throws<ArgumentException>(null, () => nameValueCollection.CopyTo(new string[count, count], 0));
 
             Assert.Throws<ArgumentOutOfRangeException>("index", () => nameValueCollection.CopyTo(new string[count], -1));
 

--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -320,7 +320,14 @@ namespace System.Collections.Tests
             ICollection bitArray = new BitArray(bits);
             T[] array = (T[])Array.CreateInstance(typeof(T), arraySize);
             Assert.Throws<ArgumentOutOfRangeException>("index", () => bitArray.CopyTo(array, -1));
-            Assert.Throws<ArgumentException>(def is int ? string.Empty : null, () => bitArray.CopyTo(array, index));
+            if (def is int)
+            {
+                AssertExtensions.Throws<ArgumentException>("destinationArray", string.Empty, () => bitArray.CopyTo(array, index));
+            }
+            else
+            {
+                Assert.Throws<ArgumentException>(null, () => bitArray.CopyTo(array, index));
+            }
         }
 
         [Fact]

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -13,6 +13,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
+      <Link>Common\System\AssertExtensions.cs</Link>
+    </Compile>
     <!-- Common Collections tests -->
     <Compile Include="$(CommonTestPath)\System\Collections\CollectionAsserts.cs">
       <Link>Common\System\Collections\CollectionAsserts.cs</Link>

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -19,6 +19,9 @@
     <Compile Include="$(CommonTestPath)\System\TypeBuilderExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
+      <Link>Common\System\AssertExtensions.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\EnumTypes.cs">
       <Link>Common\System\EnumTypes.cs</Link>
     </Compile>

--- a/src/System.Runtime/tests/System/ArrayTests.cs
+++ b/src/System.Runtime/tests/System/ArrayTests.cs
@@ -975,18 +975,20 @@ namespace System.Tests
         public static void Copy_NullSourceArray_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("sourceArray", () => Array.Copy(null, new string[10], 0));
-            Assert.Throws<ArgumentNullException>("source", () => Array.Copy(null, 0, new string[10], 0, 0));
-            Assert.Throws<ArgumentNullException>("source", () => Array.ConstrainedCopy(null, 0, new string[10], 0, 0));
+
+            AssertExtensions.Throws<ArgumentNullException>("sourceArray", "source", () => Array.Copy(null, 0, new string[10], 0, 0));
+            AssertExtensions.Throws<ArgumentNullException>("sourceArray", "source", () => Array.ConstrainedCopy(null, 0, new string[10], 0, 0));
         }
 
         [Fact]
         public static void Copy_NullDestinationArray_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("destinationArray", () => Array.Copy(new string[10], null, 0));
-            Assert.Throws<ArgumentNullException>("dest", () => Array.Copy(new string[10], 0, null, 0, 0));
-            Assert.Throws<ArgumentNullException>("dest", () => Array.ConstrainedCopy(new string[10], 0, null, 0, 0));
 
-            Assert.Throws<ArgumentNullException>("dest", () => new string[10].CopyTo(null, 0));
+            AssertExtensions.Throws<ArgumentNullException>("destinationArray", "dest", () => Array.Copy(new string[10], 0, null, 0, 0));
+            AssertExtensions.Throws<ArgumentNullException>("destinationArray", "dest", () => Array.ConstrainedCopy(new string[10], 0, null, 0, 0));
+
+            AssertExtensions.Throws<ArgumentNullException>("destinationArray", "dest", () => new string[10].CopyTo(null, 0));
         }
 
         [Fact]
@@ -1265,33 +1267,43 @@ namespace System.Tests
         [InlineData(8, 0, 10, 0, 9)]
         [InlineData(8, 8, 10, 0, 1)]
         [InlineData(8, 9, 10, 0, 0)]
-        [InlineData(10, 0, 8, 0, 9)]
-        [InlineData(10, 0, 8, 8, 1)]
-        [InlineData(10, 0, 8, 9, 0)]
-        public static void Copy_IndexPlusLengthGreaterThanArrayLength_ThrowsArgumentException(int sourceCount, int sourceIndex, int destinationCount, int destinationIndex, int count)
+        public static void Copy_IndexPlusLengthGreaterThanSourceArrayLength_ThrowsArgumentException(int sourceCount, int sourceIndex, int destinationCount, int destinationIndex, int count)
         {
             if (sourceIndex == 0 && destinationIndex == 0)
             {
-                Assert.Throws<ArgumentException>("", () => Array.Copy(new string[sourceCount], new string[destinationCount], count));
+                AssertExtensions.Throws<ArgumentException>("sourceArray", "", () => Array.Copy(new string[sourceCount], new string[destinationCount], count));
             }
-            Assert.Throws<ArgumentException>("", () => Array.Copy(new string[sourceCount], sourceIndex, new string[destinationCount], destinationIndex, count));
-            Assert.Throws<ArgumentException>("", () => Array.ConstrainedCopy(new string[sourceCount], sourceIndex, new string[destinationCount], destinationIndex, count));
+            AssertExtensions.Throws<ArgumentException>("sourceArray", "", () => Array.Copy(new string[sourceCount], sourceIndex, new string[destinationCount], destinationIndex, count));
+            AssertExtensions.Throws<ArgumentException>("sourceArray", "", () => Array.ConstrainedCopy(new string[sourceCount], sourceIndex, new string[destinationCount], destinationIndex, count));
+        }
+
+        [Theory]
+        [InlineData(10, 0, 8, 0, 9)]
+        [InlineData(10, 0, 8, 8, 1)]
+        [InlineData(10, 0, 8, 9, 0)]
+        public static void Copy_IndexPlusLengthGreaterThanDestinationArrayLength_ThrowsArgumentException(int sourceCount, int sourceIndex, int destinationCount, int destinationIndex, int count)
+        {
+            if (sourceIndex == 0 && destinationIndex == 0)
+            {
+                AssertExtensions.Throws<ArgumentException>("destinationArray", "", () => Array.Copy(new string[sourceCount], new string[destinationCount], count));
+            }
+            AssertExtensions.Throws<ArgumentException>("destinationArray", "", () => Array.Copy(new string[sourceCount], sourceIndex, new string[destinationCount], destinationIndex, count));
+            AssertExtensions.Throws<ArgumentException>("destinationArray", "", () => Array.ConstrainedCopy(new string[sourceCount], sourceIndex, new string[destinationCount], destinationIndex, count));
         }
 
         [Fact]
         public static void Copy_StartIndexNegative_ThrowsArgumentOutOfRangeException()
         {
-            Assert.Throws<ArgumentOutOfRangeException>("srcIndex", () => Array.Copy(new string[10], -1, new string[10], 0, 0));
-            Assert.Throws<ArgumentOutOfRangeException>("srcIndex", () => Array.ConstrainedCopy(new string[10], -1, new string[10], 0, 0));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("sourceIndex", "srcIndex", () => Array.Copy(new string[10], -1, new string[10], 0, 0));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("sourceIndex", "srcIndex", () => Array.ConstrainedCopy(new string[10], -1, new string[10], 0, 0));
         }
 
         [Fact]
         public static void Copy_DestinationIndexNegative_ThrowsArgumentOutOfRangeException()
         {
-            Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => Array.Copy(new string[10], 0, new string[10], -1, 0));
-            Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => Array.ConstrainedCopy(new string[10], 0, new string[10], -1, 0));
-
-            Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => new string[10].CopyTo(new string[10], -1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("destinationIndex", "dstIndex", () => Array.Copy(new string[10], 0, new string[10], -1, 0));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("destinationIndex", "dstIndex", () => Array.ConstrainedCopy(new string[10], 0, new string[10], -1, 0));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("destinationIndex", "dstIndex", () => new string[10].CopyTo(new string[10], -1));
         }
 
         [Fact]
@@ -1309,7 +1321,8 @@ namespace System.Tests
         [Fact]
         public static void CopyTo_IndexInvalid_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>("", () => new int[3].CopyTo(new int[10], 10)); // Index > destination.Length
+            // Index > destination.Length
+            AssertExtensions.Throws<ArgumentException>("destinationArray", "", () => new int[3].CopyTo(new int[10], 10));
         }
 
         public static unsafe IEnumerable<object[]> CreateInstance_TestData()
@@ -3294,10 +3307,10 @@ namespace System.Tests
         public static void IList_CopyTo_Invalid()
         {
             IList iList = new int[] { 7, 8, 9, 10, 11, 12, 13 };
-            Assert.Throws<ArgumentNullException>("dest", () => iList.CopyTo(null, 0)); // Destination array is null
+            AssertExtensions.Throws<ArgumentNullException>("destinationArray", "dest", () => iList.CopyTo(null, 0)); // Destination array is null
 
-            Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => iList.CopyTo(new int[7], -1)); // Index < 0
-            Assert.Throws<ArgumentException>("", () => iList.CopyTo(new int[7], 8)); // Index > destinationArray.Length
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("destinationIndex", "dstIndex", () => iList.CopyTo(new int[7], -1)); // Index < 0
+            AssertExtensions.Throws<ArgumentException>("destinationArray", "", () => iList.CopyTo(new int[7], 8)); // Index > destinationArray.Length
         }
 
         private static void VerifyArray(Array array, Type elementType, int[] lengths, int[] lowerBounds, object repeatedValue)

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
@@ -234,7 +234,7 @@ namespace System.Text.RegularExpressions
 
             internal Enumerator(MatchCollection collection)
             {
-                Debug.Assert(collection != null, "collection cannot be null.");
+                Debug.Assert(collection != null);
 
                 _collection = collection;
                 _index = -1;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchCollection.cs
@@ -234,7 +234,7 @@ namespace System.Text.RegularExpressions
 
             internal Enumerator(MatchCollection collection)
             {
-                Debug.Assert(collection != null);
+                Debug.Assert(collection != null, "collection cannot be null.");
 
                 _collection = collection;
                 _index = -1;

--- a/src/System.Text.RegularExpressions/tests/MatchCollectionTests.cs
+++ b/src/System.Text.RegularExpressions/tests/MatchCollectionTests.cs
@@ -105,21 +105,21 @@ namespace System.Text.RegularExpressions.Tests
             ICollection collection = regex.Matches("dotnet");
 
             // Array is null
-            Assert.Throws<ArgumentNullException>("dest", () => collection.CopyTo(null, 0));
+            AssertExtensions.Throws<ArgumentNullException>("destinationArray", "dest", () => collection.CopyTo(null, 0));
 
             // Array is multidimensional
             Assert.Throws<ArgumentException>(null, () => collection.CopyTo(new object[10, 10], 0));
 
             // Array has a non-zero lower bound
             Array o = Array.CreateInstance(typeof(object), new int[] { 10 }, new int[] { 10 });
-            Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => collection.CopyTo(o, 0));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("destinationIndex", "dstIndex", () => collection.CopyTo(o, 0));
 
             // Index < 0
-            Assert.Throws<ArgumentOutOfRangeException>("dstIndex", () => collection.CopyTo(new object[collection.Count], -1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("destinationIndex", "dstIndex", () => collection.CopyTo(new object[collection.Count], -1));
 
             // Invalid index + length
-            Assert.Throws<ArgumentException>("", () => collection.CopyTo(new object[collection.Count], 1));
-            Assert.Throws<ArgumentException>("", () => collection.CopyTo(new object[collection.Count + 1], 2));
+            AssertExtensions.Throws<ArgumentException>("destinationArray", "", () => collection.CopyTo(new object[collection.Count], 1));
+            AssertExtensions.Throws<ArgumentException>("destinationArray", "", () => collection.CopyTo(new object[collection.Count + 1], 2));
         }
 
         private static MatchCollection CreateCollection() => new Regex("t").Matches("dotnet");

--- a/src/System.Text.RegularExpressions/tests/MatchCollectionTests.cs
+++ b/src/System.Text.RegularExpressions/tests/MatchCollectionTests.cs
@@ -118,8 +118,8 @@ namespace System.Text.RegularExpressions.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("destinationIndex", "dstIndex", () => collection.CopyTo(new object[collection.Count], -1));
 
             // Invalid index + length
-            AssertExtensions.Throws<ArgumentException>("destinationArray", "", () => collection.CopyTo(new object[collection.Count], 1));
-            AssertExtensions.Throws<ArgumentException>("destinationArray", "", () => collection.CopyTo(new object[collection.Count + 1], 2));
+            AssertExtensions.Throws<ArgumentException>("destinationArray", string.Empty, () => collection.CopyTo(new object[collection.Count], 1));
+            AssertExtensions.Throws<ArgumentException>("destinationArray", string.Empty, () => collection.CopyTo(new object[collection.Count + 1], 2));
         }
 
         private static MatchCollection CreateCollection() => new Regex("t").Matches("dotnet");

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -27,6 +27,9 @@
     <Compile Include="Regex.Split.Tests.cs" />
     <Compile Include="Regex.Match.Tests.cs" />
     <Compile Include="Regex.Tests.Common.cs" />
+    <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
+      <Link>Common\System\AssertExtensions.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="PrecompiledRegexScenarioTest.cs" />


### PR DESCRIPTION
**edit:** This can be cherry-picked whenever the version of coreclr that corefx builds against is updated. I've run tests against my change in coreclr locally and can confirm that all of these tests pass on .NET Core against the new build.

Corresponding PR for https://github.com/dotnet/coreclr/pull/9117. Do not merge this yet, it will fail until the version of coreclr with the fix is taken in. Also I might have to amend my coreclr PR to fix the names in more throw-sites, and I may not have covered all of the affected tests in my initial commit here.