### PR TITLE
Fix uap Configurations for a few libraries

### DIFF
--- a/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.csproj
+++ b/src/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.csproj
@@ -14,7 +14,6 @@
     <ProjectReference Include="..\..\System.Resources.Writer\ref\System.Resources.Writer.csproj" />
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Runtime.Extensions\ref\System.Runtime.Extensions.csproj" />
-    <ProjectReference Include="..\..\System.Security.Permissions\ref\System.Security.Permissions.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Configuration.ConfigurationManager/ref/Configurations.props
+++ b/src/System.Configuration.ConfigurationManager/ref/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp;
+      uap;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Permissions/ref/Configurations.props
+++ b/src/System.Security.Permissions/ref/Configurations.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp;
-      uap;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/Tools/GenerateProps/targetgroups.props
+++ b/src/Tools/GenerateProps/targetgroups.props
@@ -33,6 +33,7 @@
       <PackageTargetRuntime>aot</PackageTargetRuntime>
       <NuGetTargetMoniker>UAP,Version=v10.1</NuGetTargetMoniker>
       <Imports>uap101aot</Imports>
+      <CompatibleWith>uap;netstandard</CompatibleWith>
     </TargetGroups>
     <TargetGroups Include="netstandard1.0">
       <NuGetTargetMoniker>.NETStandard,Version=v1.0</NuGetTargetMoniker>


### PR DESCRIPTION
With this few changes the TargetingPack that we produce for uap (and uapaot) will match the set of reference assemblies we had supported on uap10.1 before the dev/eng merge

cc: @weshaggard @ericstj

Next, I'll do the src configs.