### PR TITLE
Include StringBuilderCache.cs under ProductionCode dir in HttpClient unit tests

### DIFF
--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -27,7 +27,7 @@
       <Link>ProductionCode\Common\System\StringExtensions.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
-      <Link>Common\System\IO\StringBuilderCache.cs</Link>
+      <Link>ProductionCode\Common\System\IO\StringBuilderCache.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\IO\StreamHelpers.CopyValidation.cs">
       <Link>ProductionCode\Common\System\IO\StreamHelpers.CopyValidation.cs</Link>


### PR DESCRIPTION
A minor nit I noticed from #15432 

cc: @stephentoub