### PR TITLE
Enable the building of VB project from all platforms

### DIFF
--- a/src/Microsoft.VisualBasic/pkg/Microsoft.VisualBasic.builds
+++ b/src/Microsoft.VisualBasic/pkg/Microsoft.VisualBasic.builds
@@ -2,8 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <!-- Temporary workaround, VisualBasic projects cannot be built on non-Windows platforms. See issue #5230. -->
-    <Project Include="Microsoft.VisualBasic.pkgproj" Condition="'$(OS)'=='Windows_NT'" />
+    <Project Include="Microsoft.VisualBasic.pkgproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>


### PR DESCRIPTION
Microsoft.VisualBasic.dll is a component of NETCore.App, so NETCore.App is not resolved if Microsoft.VisualBasic.dll is absent. 

```
PM> Install-Package Microsoft.NETCore.App.1.2.0-beta-001291-00.nupkg
Install-Package : Unable to resolve 'Microsoft.VisualBasic (>= 10.2.0-beta-24909-02)' for '.NETCoreApp,Version=v1.1'.At line:1 char:1
+ Install-Package Microsoft.NETCore.App.1.2.0-beta-001291-00.nupkg
```
Related issues : #5230, #13444, #7472