### PR TITLE
Clean up dir.traversal.targets

### DIFF
--- a/Tools-Override/depProj.targets
+++ b/Tools-Override/depProj.targets
@@ -61,23 +61,27 @@ See the LICENSE file in the project root for more information.
       <!-- Don't set IntermediateAssembly since this is not produced -->
       <IntermediateAssembly Remove="@(IntermediateAssembly)" />
 
-      <NuGetDeploy Include="@($(NuGetDeploySourceItem))" />
+      <NuGetDeploy Include="@($(NuGetDeploySourceItem))"/>
+
       <!-- filter to only items that came from packages -->
       <!-- the following condition must be applied after the include because msbuild doesn't seem
            to support property-defined-item-names in a metadata statement -->
-      <NuGetDeploy Remove="@(NuGetDeploy)" Condition="'%(NugetDeploy.NuGetPackageId)' == ''" />
+      <NuGetDeploy Remove="@(NuGetDeploy)" Condition="'%(NuGetDeploy.NuGetPackageId)' == ''" />
 
       <!-- remove all existing items from NuGet packages we'll be defining these in our own item -->
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' != ''"/>
       <Reference Remove="@(Reference)" Condition="'%(Reference.NuGetPackageId)' != ''"/>
       <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.NuGetPackageId)' != ''"/>
 
-      <!-- add items defined by NuGetDeployItem property to ReferenceCopyLocalPaths -->
-      <ReferenceCopyLocalPaths Include="@(NuGetDeploy)" />
+      <!-- add items defined by NuGetDeployItem property to Content so that we get clean behavior -->
+      <ContentWithTargetPath Include="@(NuGetDeploy)">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <TargetPath>%(FileName)%(Extension)</TargetPath>
+      </ContentWithTargetPath>
     </ItemGroup>
 
     <Error Condition="'@(NuGetDeploy)' == ''" Text="Error no assets were resolved from NuGet packages." />
-    <Message Importance="High" Text="%(FullPath) (%(NuGetPackageId).%(NuGetPackageVersion)) -&gt; @(NuGetDeploy->'%(FileName)%(Extension)')" />
+    <Message Importance="High" Text="%(FullPath) (%(NuGetPackageId).%(NuGetPackageVersion)) -&gt; @(NuGetDeploy->'$(TargetDir)%(FileName)%(Extension)')" />
 
     <!-- Include marker files if an extension has been provided -->
     <!-- internal builds use this to distinguish files which have already been signed -->

--- a/buildvertical.targets
+++ b/buildvertical.targets
@@ -9,8 +9,7 @@
   <Import Project="$(MSBuildThisFileDirectory)src/Tools/GenerateProps/properties.props" />
 
   <!-- Runs during traversal to select which projects and configurations of those projects to build -->
-  <Target Name="AnnotateAndFilterProjects"
-          BeforeTargets="BuildAllProjects;TestAllProjects">
+  <Target Name="FilterProjects">
 
     <!-- find the best configuration for each project, projects that shouldn't build for this configuration
          return an empty item.  -->
@@ -101,13 +100,13 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="BuildAll">
+  <Target Name="BuildAllConfigurations">
     <ItemGroup>
       <_buildConfigurations Include="$(BuildConfigurations)" />
       <_buildConfigurations Condition="'@(_buildConfigurations)' == ''" Include="$(BuildConfiguration)" />
     </ItemGroup>
 
     <MSBuild Projects="$(MSBuildProjectFullPath)"
-             Properties="Configuration=%(_buildConfigurations.Identity)" />
+             Properties="Configuration=%(_buildConfigurations.Identity);BuildAllConfigurations=true" />
   </Target>
 </Project>

--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -27,10 +27,9 @@
     <Message Text="%(PackageIds.Identity)" Importance="High" />
   </Target>
 
-  <!-- build vertical requires the FindBestConfiguration task which is currently in CoreFx.Tools.dll -->
-  <Import Project="buildvertical.targets" Condition="'$(ImportedBuildVerticalTargets)' != 'true' and Exists('$(CoreFxToolsTaskDir)CoreFx.Tools.dll')" />
+  <Import Project="buildvertical.targets" Condition="'$(ImportedBuildVerticalTargets)' != 'true'" />
 
-  <Target Name="BuildAllProjects">
+  <Target Name="BuildAllProjects" DependsOnTargets="FilterProjects">
     <PropertyGroup>
       <DefaultBuildAllTarget Condition="'$(DefaultBuildAllTarget)'==''">$(MSBuildProjectDefaultTargets)</DefaultBuildAllTarget>
     </PropertyGroup>
@@ -78,7 +77,8 @@
     <Error Condition="'$(MSBuildLastTaskResult)'=='false'" />
   </Target>
 
-  <Target Name="GetFilesToPackage" DependsOnTargets="FilterProjects"
+  <Target Name="GetFilesToPackage" 
+          DependsOnTargets="FilterProjects" 
           Returns="@(FilesToPackage)">
     <MSBuild Targets="GetFilesToPackage"
              Projects="@(Project)"
@@ -143,36 +143,6 @@
     <Error Condition="'$(MSBuildLastTaskResult)'=='false'" />
   </Target>
 
-  <Target Name="GenerateAllTestProjectJsons">
-    <PropertyGroup>
-      <DefaultGenerateAllTestProjectJsonsTarget Condition="'$(DefaultGenerateAllTestProjectJsonsTarget)' == ''">GenerateAllTestProjectJsons</DefaultGenerateAllTestProjectJsonsTarget>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <GeneratedProject Include="@(Project)">
-        <AdditionalProperties>GeneratedTargetGroup=%(Project.TargetGroup);GeneratedOSGroup=%(Project.OSGroup);%(Project.AdditionalProperties)</AdditionalProperties>
-      </GeneratedProject>
-    </ItemGroup>
-
-    <!-- To Serialize we use msbuild's batching functionality '%' to force it to batch all similar projects with the same identity
-         however since the project names are unique it will essentially force each to run in its own batch -->
-    <MSBuild Targets="$(DefaultGenerateAllTestProjectJsonsTarget)"
-             Projects="@(GeneratedProject)"
-             Condition="'$(SerializeProjects)' != 'true'"
-             Properties="GenerateAllTestProjectJsons=$(DefaultGenerateAllTestProjectJsonsTarget)"
-             BuildInParallel="true"
-             ContinueOnError="ErrorAndContinue" />
-
-    <MSBuild Targets="$(DefaultGenerateAllTestProjectJsonsTarget)"
-             Projects="@(GeneratedProject)"
-             Condition="'$(SerializeProjects)' == 'true' AND '%(Identity)' != ''"
-             Properties="GenerateAllTestProjectJsons=$(DefaultGenerateAllTestProjectJsonsTarget)"
-             ContinueOnError="ErrorAndContinue" />
-
-    <!-- Given we ErrorAndContinue we need to propagate the error if the overall task failed -->
-    <Error Condition="'$(MSBuildLastTaskResult)'=='false'" />
-  </Target>
-
   <PropertyGroup>
     <TraversalBuildDependsOn>
       BuildAllProjects;
@@ -184,18 +154,8 @@
       $(TraversalCleanDependsOn);
     </TraversalCleanDependsOn>
 
-    <TraversalGenerateTestProjectJsonsDependsOn>
-      GenerateAllTestProjectJsons;
-      $(TraversalGenerateTestProjectJsonsDependsOn)
-    </TraversalGenerateTestProjectJsonsDependsOn>
-
     <TraversalRestorePackagesDependsOn>
       RestoreAllProjectPackages;
-      $(TraversalRestorePackagesDependsOn)
-    </TraversalRestorePackagesDependsOn>
-
-    <TraversalRestorePackagesDependsOn Condition="'$(_BuildAgainstPackages)' == 'true'">
-      $(TraversalGenerateTestProjectJsonsDependsOn);
       $(TraversalRestorePackagesDependsOn)
     </TraversalRestorePackagesDependsOn>
   </PropertyGroup>
@@ -210,8 +170,5 @@
   <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />
   <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" />
   <Target Name="Test" />
-
-  <!-- Target will be overridden if buildagainstpackages.targets is imported. -->
-  <Target Name="GenerateTestProjectJson" />
  <Import Condition="'$(_BuildAgainstPackages)' == 'true'" Project="$(ToolsDir)/buildagainstpackages.targets" />
 </Project>


### PR DESCRIPTION
Remove some unused targets in dir.traversal.targets and fix Clean.

Update the name of BuildAll to BuildAllConfigurations and make it
work with traversal projects too.

Fix clean for depproj's.

/cc @weshaggard @chcosta 