### PR TITLE
Fix Globalization test on Sierra

### DIFF
--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
@@ -29,7 +29,7 @@ namespace System.Globalization.Tests
 
         public static string[] FrFRDayNames()
         {
-            if (PlatformDetection.IsOSX)
+            if (PlatformDetection.IsOSX && PlatformDetection.OSXKernelVersion < new Version(16, 0))
             {
                 return new string[] { "Dimanche", "Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi" };
             }
@@ -38,7 +38,7 @@ namespace System.Globalization.Tests
 
         public static string[] FrFRAbbreviatedDayNames()
         {
-            if (PlatformDetection.IsOSX)
+            if (PlatformDetection.IsOSX  && PlatformDetection.OSXKernelVersion < new Version(16, 0))
             {
                 return new string[] { "Dim.", "Lun.", "Mar.", "Mer.", "Jeu.", "Ven.", "Sam." };
             }


### PR DESCRIPTION
Sierra Mac OS has some changes in the globalization data. actually they have fixed some data. this fix break the test as the test was checking the old values.