### PR TITLE
Extra Encoding tests

### DIFF
--- a/src/System.Text.Encoding/tests/Encoder/EncoderConvert2.cs
+++ b/src/System.Text.Encoding/tests/Encoder/EncoderConvert2.cs
@@ -38,7 +38,7 @@ namespace System.Text.Tests
         #endregion
 
         #region Positive Test Cases
-        // PosTest1: Call Convert to convert a arbitrary character array with ASCII encoder
+        // PosTest1: Call Convert to convert a arbitrary character array with UTF8 encoder
         [Fact]
         public void PosTest1()
         {
@@ -82,7 +82,7 @@ namespace System.Text.Tests
             encoder.Convert(chars, 0, chars.Length, bytes, 0, bytes.Length, true, out charsUsed, out bytesUsed, out completed);
         }
 
-        // PosTest3: Call Convert to convert a ASCII character array with ASCII encoder
+        // PosTest3: Call Convert to convert a ASCII character array with UTF8 encoder
         [Fact]
         public void PosTest3()
         {
@@ -107,7 +107,7 @@ namespace System.Text.Tests
             VerificationHelper(encoder, chars, 0, chars.Length, bytes, 0, bytes.Length, true, chars.Length, chars.Length, true, "004.2");
         }
 
-        // PosTest5: Call Convert to convert partial of a ASCII character array with ASCII encoder
+        // PosTest5: Call Convert to convert partial of a ASCII character array with UTF8 encoder
         [Fact]
         public void PosTest5()
         {
@@ -187,6 +187,145 @@ namespace System.Text.Tests
 
             VerificationHelper(encoder, chars, 0, 1, bytes, 0, bytes.Length, false, 1, 2, true, "009.3");
             VerificationHelper(encoder, chars, 0, 1, bytes, 0, bytes.Length, true, 1, 2, true, "009.4");
+        }
+        
+        // PosTest10: Call Convert to convert a arbitrary character array with ASCII encoder
+        [Fact]
+        public void PosTest10()
+        {
+            char[] chars = new char[c_SIZE_OF_ARRAY];
+            byte[] bytes = new byte[c_SIZE_OF_ARRAY];
+            Encoder encoder = Encoding.ASCII.GetEncoder();
+
+            for (int i = 0; i < chars.Length; ++i)
+            {
+                chars[i] = _generator.GetChar(-55);
+            }
+
+            int charsUsed;
+            int bytesUsed;
+            bool completed;
+            encoder.Convert(chars, 0, chars.Length, bytes, 0, bytes.Length, false, out charsUsed, out bytesUsed, out completed);
+
+            // set flush to true and try again
+            encoder.Convert(chars, 0, chars.Length, bytes, 0, bytes.Length, true, out charsUsed, out bytesUsed, out completed);
+        }
+        
+        // PosTest11: Call Convert to convert a ASCII character array with ASCII encoder
+        [Fact]
+        public void PosTest11()
+        {
+            char[] chars = "TestLibrary.TestFramework.BeginScenario".ToCharArray();
+            byte[] bytes = new byte[chars.Length];
+            Encoder encoder = Encoding.ASCII.GetEncoder();
+
+            VerificationHelper(encoder, chars, 0, chars.Length, bytes, 0, bytes.Length, false, chars.Length, chars.Length, true, "011.1");
+            VerificationHelper(encoder, chars, 0, chars.Length, bytes, 0, bytes.Length, true, chars.Length, chars.Length, true, "011.2");
+            VerificationHelper(encoder, chars, 0, 0, bytes, 0, 0, true, 0, 0, true, "011.3");
+        }
+        
+        // PosTest12: Call Convert to convert partial of a ASCII character array with ASCII encoder
+        [Fact]
+        public void PosTest12()
+        {
+            char[] chars = "TestLibrary.TestFramework.BeginScenario".ToCharArray();
+            byte[] bytes = new byte[chars.Length];
+            Encoder encoder = Encoding.ASCII.GetEncoder();
+
+            VerificationHelper(encoder, chars, 0, 1, bytes, 0, 1, false, 1, 1, true, "012.1");
+            VerificationHelper(encoder, chars, 0, 1, bytes, 0, 1, true, 1, 1, true, "012.2");
+            VerificationHelper(encoder, chars, 1, 1, bytes, 0, 1, false, 1, 1, true, "012.3");
+            VerificationHelper(encoder, chars, 1, 1, bytes, 0, 1, true, 1, 1, true, "012.4");
+            VerificationHelper(encoder, chars, 1, 1, bytes, 1, 1, false, 1, 1, true, "012.5");
+            VerificationHelper(encoder, chars, 1, 1, bytes, 1, 1, true, 1, 1, true, "012.6");
+
+            // Verify maxBytes is large than character count
+            VerificationHelper(encoder, chars, 0, chars.Length - 1, bytes, 0, bytes.Length, false, chars.Length - 1, chars.Length - 1, true, "012.7");
+            VerificationHelper(encoder, chars, 1, chars.Length - 1, bytes, 0, bytes.Length, true, chars.Length - 1, chars.Length - 1, true, "012.8");
+        }
+        
+        // PosTest13: Call Convert to convert partial of a Unicode character array with ASCII encoder
+        [Fact]
+        public void PosTest13()
+        {
+            char[] chars = "😁Test".ToCharArray();
+            byte[] bytes = new byte[chars.Length * 2];
+            Encoder encoder = Encoding.ASCII.GetEncoder();
+
+            VerificationHelper(encoder, chars, 0, 1, bytes, 0, 1, true, 1, 1, true, "013.1");
+            VerificationHelper(encoder, chars, 0, 1, bytes, 0, 1, false, 1, 1, true, "013.2");
+            VerificationHelper(encoder, chars, 0, 2, bytes, 0, 2, false, 2, 2, true, "013.3");
+            VerificationHelper(encoder, chars, 0, 4, bytes, 0, 4, false, 4, 4, true, "013.4");
+            VerificationHelper(encoder, chars, 0, 4, bytes, 0, 4, true, 4, 4, true, "013.5");
+            VerificationHelper(encoder, chars, 2, 2, bytes, 0, 2, true, 2, 2, true, "013.6");
+            VerificationHelper(encoder, chars, 1, 3, bytes, 1, 3, false, 3, 3, true, "013.7");
+            VerificationHelper(encoder, chars, 1, 3, bytes, 1, 5, true, 3, 3, true, "013.8");
+
+            VerificationHelper(encoder, chars, 0, 1, bytes, 0, bytes.Length, false, 1, 1, true, "013.9");
+            VerificationHelper(encoder, chars, 1, 1, bytes, 0, bytes.Length, true, 1, 1, true, "013.10");
+        }
+        
+        // PosTest14: Call Convert to convert partial of a Unicode character array with UTF8 encoder
+        [Fact]
+        public void PosTest14()
+        {
+            char[] chars = "😁Test".ToCharArray();
+            byte[] bytes = new byte[chars.Length * 2];
+            Encoder encoder = Encoding.UTF8.GetEncoder();
+
+            VerificationHelper(encoder, chars, 0, 1, bytes, 0, 0, true, 1, 0, true, "014.1");
+            VerificationHelper(encoder, chars, 0, 1, bytes, 0, 3, false, 1, 3, true, "014.2");
+            VerificationHelper(encoder, chars, 0, 2, bytes, 0, 7, false, 2, 7, true, "014.3");
+            VerificationHelper(encoder, chars, 0, 4, bytes, 0, 6, false, 4, 6, true, "014.4");
+            VerificationHelper(encoder, chars, 0, 4, bytes, 0, 6, true, 4, 6, true, "014.5");
+            VerificationHelper(encoder, chars, 2, 2, bytes, 0, 2, true, 2, 2, true, "014.6");
+            VerificationHelper(encoder, chars, 1, 3, bytes, 1, 3, false, 1, 3, false, "014.7");
+            VerificationHelper(encoder, chars, 1, 3, bytes, 1, 5, true, 3, 5, true, "014.8");
+
+            VerificationHelper(encoder, chars, 0, 1, bytes, 0, bytes.Length, false, 1, 0, true, "014.9");
+            VerificationHelper(encoder, chars, 1, 1, bytes, 0, bytes.Length, true, 1, 4, true, "014.10");
+        }
+ 
+        // PosTest15: Call Convert to convert partial of a ASCII+Unicode character array with ASCII encoder
+        [Fact]
+        public void PosTest15()
+        {
+            char[] chars = "T😁est".ToCharArray();
+            byte[] bytes = new byte[chars.Length * 2];
+            Encoder encoder = Encoding.ASCII.GetEncoder();
+
+            VerificationHelper(encoder, chars, 0, 1, bytes, 0, 1, true, 1, 1, true, "015.1");
+            VerificationHelper(encoder, chars, 0, 2, bytes, 0, 1, false, 1, 1, false, "015.2");
+            VerificationHelper(encoder, chars, 1, 2, bytes, 0, 2, false, 2, 2, true, "015.3");
+            VerificationHelper(encoder, chars, 0, 5, bytes, 0, 5, false, 5, 5, true, "015.4");
+            VerificationHelper(encoder, chars, 0, 4, bytes, 0, 4, true, 4, 4, true, "015.5");
+            VerificationHelper(encoder, chars, 2, 2, bytes, 0, 2, true, 2, 2, true, "015.6");
+            VerificationHelper(encoder, chars, 1, 3, bytes, 1, 5, false, 3, 3, true, "015.7");
+            VerificationHelper(encoder, chars, 1, 3, bytes, 1, 3, true, 3, 3, true, "015.8");
+
+            VerificationHelper(encoder, chars, 0, 2, bytes, 0, bytes.Length, false, 2, 2, true, "015.9");
+            VerificationHelper(encoder, chars, 1, 1, bytes, 0, bytes.Length, true, 1, 1, true, "015.10");
+        }
+        
+        // PosTest16: Call Convert to convert partial of a ASCII+Unicode character array with UTF8 encoder
+        [Fact]
+        public void PosTest16()
+        {
+            char[] chars = "T😁est".ToCharArray();
+            byte[] bytes = new byte[chars.Length * 2];
+            Encoder encoder = Encoding.UTF8.GetEncoder();
+
+            VerificationHelper(encoder, chars, 0, 1, bytes, 0, 1, true, 1, 1, true, "016.1");
+            VerificationHelper(encoder, chars, 0, 2, bytes, 0, 1, false, 2, 1, true, "016.2");
+            VerificationHelper(encoder, chars, 1, 2, bytes, 0, 7, false, 2, 7, true, "016.3");
+            VerificationHelper(encoder, chars, 0, 5, bytes, 0, 7, false, 5, 7, true, "016.4");
+            VerificationHelper(encoder, chars, 0, 4, bytes, 0, 6, true, 4, 6, true, "016.5");
+            VerificationHelper(encoder, chars, 2, 2, bytes, 0, 3, true, 1, 3, false, "016.6");
+            VerificationHelper(encoder, chars, 1, 3, bytes, 1, 5, false, 3, 5, true, "016.7");
+            VerificationHelper(encoder, chars, 1, 3, bytes, 1, 5, true, 3, 5, true, "016.8");
+
+            VerificationHelper(encoder, chars, 0, 2, bytes, 0, bytes.Length, false, 2, 1, true, "016.9");
+            VerificationHelper(encoder, chars, 1, 1, bytes, 0, bytes.Length, true, 1, 3, true, "016.10");
         }
         #endregion
 

--- a/src/System.Text.Encoding/tests/Encoder/EncoderGetBytes2.cs
+++ b/src/System.Text.Encoding/tests/Encoder/EncoderGetBytes2.cs
@@ -17,7 +17,7 @@ namespace System.Text.Tests
         #endregion
 
         #region Positive Test Cases
-        // PosTest1: Call GetBytes to convert an arbitrary character array by using ASCII encoder
+        // PosTest1: Call GetBytes to convert an arbitrary character array by using UTF8 encoder
         [Fact]
         public void PosTest1()
         {
@@ -81,7 +81,7 @@ namespace System.Text.Tests
             Assert.Equal(0, ret1);
         }
 
-        // PosTest3: Call GetBytes to convert an ASCII character array by using ASCII encoder
+        // PosTest3: Call GetBytes to convert an ASCII character array by using UTF8 encoder
         [Fact]
         public void PosTest3()
         {
@@ -119,15 +119,93 @@ namespace System.Text.Tests
             char[] chars = "\u8FD9\u4E2A\u4E00\u4E2AABC\u6D4B\u8BD5".ToCharArray();
             byte[] bytes = new byte[chars.Length * 2];
             Encoder encoder = Encoding.Unicode.GetEncoder();
-            VerificationHelper(encoder, chars, 0, chars.Length, bytes, 0, true, chars.Length * 2, "006.1");
-            VerificationHelper(encoder, chars, 0, chars.Length, bytes, 0, false, chars.Length * 2, "006.2");
+            VerificationHelper(encoder, chars, 0, chars.Length, bytes, 0, true, chars.Length * 2, "005.1");
+            VerificationHelper(encoder, chars, 0, chars.Length, bytes, 0, false, chars.Length * 2, "005.2");
 
             // partial conversion
-            VerificationHelper(encoder, chars, 1, chars.Length - 1, bytes, 1, true, (chars.Length - 1) * 2, "006.3");
-            VerificationHelper(encoder, chars, 1, 1, bytes, 1, false, 2, "006.4");
+            VerificationHelper(encoder, chars, 1, chars.Length - 1, bytes, 1, true, (chars.Length - 1) * 2, "005.3");
+            VerificationHelper(encoder, chars, 1, 1, bytes, 1, false, 2, "005.4");
+        }
+        
+        // PosTest6: Call GetBytes to convert an arbitrary character array by using ASCII encoder
+        [Fact]
+        public void PosTest6()
+        {
+            char[] chars = new char[c_SIZE_OF_ARRAY];
+            byte[] bytes = new byte[c_SIZE_OF_ARRAY * 4];
+            for (int i = 0; i < chars.Length; ++i)
+            {
+                chars[i] = _generator.GetChar(-55);
+            }
+            Encoder encoder = Encoding.ASCII.GetEncoder();
+
+            int ret1 = encoder.GetBytes(chars, 0, chars.Length, bytes, 0, true);
+            int ret2 = encoder.GetBytes(chars, 0, chars.Length, bytes, 0, false);
+
+            // If the last character is a surrogate and the encoder is flushing its state, it will return a fallback character. 
+            // When the encoder isn't flushing its state then it holds on to the remnant bytes between calls so that if the next
+            // bytes passed in form a valid character you'd get that char as a result.
+            // The difference in length of a low surrogate flushed vs non-flushed is 1 
+            if (IsHighSurrogate(chars[chars.Length - 1]))
+            {
+                ret2 += 3;
+                encoder.GetBytes(chars, 0, chars.Length, bytes, 0, true);
+            }
+            Assert.Equal(ret2, ret1);
+
+            ret1 = encoder.GetBytes(chars, 0, 0, bytes, 0, true);
+            ret2 = encoder.GetBytes(chars, 0, 0, bytes, 0, false);
+            Assert.Equal(ret2, ret1);
+            Assert.Equal(0, ret1);
+        }
+        
+        // PosTest7: Call GetBytes to convert an ASCII character array by using ASCII encoder
+        [Fact]
+        public void PosTest7()
+        {
+            char[] chars = "abcdefghijklmnopqrstuvwxyz1234567890!@#$%^&*()_+-=\\|/?<>  ,.`~".ToCharArray();
+            byte[] bytes = new byte[chars.Length];
+            Encoder encoder = Encoding.ASCII.GetEncoder();
+
+            VerificationHelper(encoder, chars, 0, chars.Length, bytes, 0, true, chars.Length, "007.1");
+            VerificationHelper(encoder, chars, 0, chars.Length, bytes, 0, false, chars.Length, "007.2");
+
+            // partial conversion
+            VerificationHelper(encoder, chars, 1, chars.Length - 1, bytes, 0, true, chars.Length - 1, "007.3");
+            VerificationHelper(encoder, chars, 0, 1, bytes, 1, false, 1, "007.4");
         }
         #endregion
 
+        // NegTest7: Call GetBytes to convert an ASCIIUnicode character array by using UTF8 encoder
+        [Fact]
+        public void NegTest1()
+        {
+            Encoder encoder = Encoding.UTF8.GetEncoder();
+            // Bytes does not have enough capacity to accomodate result
+            string s = "T😁est";
+            char[] c = s.ToCharArray();           
+            Assert.Throws<ArgumentException>("bytes", () => encoder.GetBytes(c, 0, 2, new byte[3], 0, true));
+            Assert.Throws<ArgumentException>("bytes", () => encoder.GetBytes(c, 0, 3, new byte[4], 0, true));
+            Assert.Throws<ArgumentException>("bytes", () => encoder.GetBytes(c, 0, 4, new byte[5], 0, true));
+            Assert.Throws<ArgumentException>("bytes", () => encoder.GetBytes(c, 0, 5, new byte[6], 0, true));
+
+            byte[] b = new byte[8];
+            Assert.Throws<ArgumentException>("bytes", () => FixedEncodingHelper(c, 2, b, 3));
+            Assert.Throws<ArgumentException>("bytes", () => FixedEncodingHelper(c, 3, b, 4));
+            Assert.Throws<ArgumentException>("bytes", () => FixedEncodingHelper(c, 4, b, 5));
+            Assert.Throws<ArgumentException>("bytes", () => FixedEncodingHelper(c, 5, b, 6));
+        }
+        
+        private static unsafe void FixedEncodingHelper(char[] c, int charCount, byte[] b, int byteCount)
+        {
+            Encoder encoder = Encoding.UTF8.GetEncoder();
+            fixed(char* pChar = c)
+            fixed(byte* pByte = b)
+            {
+                encoder.GetBytes(pChar, charCount, pByte, byteCount, true);
+            }
+        }
+        
         private void VerificationHelper(Encoder encoder, char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex,
             bool flush, int expectedRetVal, string errorno)
         {


### PR DESCRIPTION
Add extra ASCII encoding tests (were using UTF8 by commented as ASCII)
Add Unicode start tests for ASCII and UTF8
Add ASCII start followed by Unicode for ASCII and UTF8 to cover ASCII fast-path with Unicode fallback
Added extra length verification exception tests when split (ascii followed by unicode) for UTF8

/cc @tarekgh @stephentoub 