### PR TITLE
Change HttpClient timeout test to use loopback server

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -381,17 +381,19 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [OuterLoop]
-        public void Timeout_SetTo60AndGetResponseFromServerWhichTakes40_Success()
+        [OuterLoop("One second delay in getting server's response")]
+        public async Task Timeout_SetTo30AndGetResponseFromLoopbackQuickly_Success()
         {
-            // TODO: This is a placeholder until GitHub Issue #2383 gets resolved.
-            const string SlowServer = "http://httpbin.org/drip?numbytes=1&duration=1&delay=40&code=200";
-            
-            using (var client = new HttpClient())
+            using (var client = new HttpClient() { Timeout = TimeSpan.FromSeconds(30) })
             {
-                client.Timeout = TimeSpan.FromMinutes(5);
-                var response = client.GetAsync(SlowServer).GetAwaiter().GetResult();
-                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                await LoopbackServer.CreateServerAsync(async (server, url) =>
+                {
+                    Task getTask = client.GetStringAsync(url);
+                    await Task.Delay(TimeSpan.FromSeconds(.5));
+                    await TestHelper.WhenAllCompletedOrAnyFailed(
+                        getTask,
+                        LoopbackServer.ReadRequestAndSendResponseAsync(server));
+                });
             }
         }
 


### PR DESCRIPTION
Shorten test duration from 40 seconds to .5 seconds, as discussed at https://github.com/dotnet/corefx/pull/15481/files#r97910075

cc: @ianhays, @davidsh