### PR TITLE
Add dotnet/versions subscriptions for SNI

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -31,6 +31,7 @@
     <ExternalExpectedPrerelease>beta-24727-00</ExternalExpectedPrerelease>
     <ProjectNTfsExpectedPrerelease>beta-24927-00</ProjectNTfsExpectedPrerelease>
     <StandardExpectedPrerelease>beta-24919-01</StandardExpectedPrerelease>
+    <!-- Use the SNI runtime package -->
     <SniPackageVersion>4.4.0-beta-24926-02</SniPackageVersion>
   </PropertyGroup>
 
@@ -96,6 +97,7 @@
     <XmlUpdateStep Include="Sni">
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>SniPackageVersion</ElementName>
+      <!-- Pick any of the SNI runtime packages. All the runtime packages of sni will have the same version -->
       <PackageId>runtime.win7-x64.runtime.native.System.Data.SqlClient.sni</PackageId>
     </XmlUpdateStep>
   </ItemGroup>

--- a/dependencies.props
+++ b/dependencies.props
@@ -31,7 +31,7 @@
     <ExternalExpectedPrerelease>beta-24727-00</ExternalExpectedPrerelease>
     <ProjectNTfsExpectedPrerelease>beta-24927-00</ProjectNTfsExpectedPrerelease>
     <StandardExpectedPrerelease>beta-24919-01</StandardExpectedPrerelease>
-    <SniExpectedPrerelease>beta-24926-02</SniExpectedPrerelease>
+    <SniPackageVersion>4.4.0-beta-24926-02</SniPackageVersion>
   </PropertyGroup>
 
   <!-- Full package version strings that are used in other parts of the build. -->
@@ -92,6 +92,11 @@
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>ProjectNTfsExpectedPrerelease</ElementName>
       <BuildInfoName>ProjectNTfs</BuildInfoName>
+    </XmlUpdateStep>
+    <XmlUpdateStep Include="Sni">
+      <Path>$(MSBuildThisFileFullPath)</Path>
+      <ElementName>SniPackageVersion</ElementName>
+      <PackageId>runtime.win7-x64.runtime.native.System.Data.SqlClient.sni</PackageId>
     </XmlUpdateStep>
   </ItemGroup>
 

--- a/dependencies.props
+++ b/dependencies.props
@@ -21,6 +21,7 @@
     <CoreClrCurrentRef>4120995e04ae4696f3e9398fa78bf65f53a933a7</CoreClrCurrentRef>
     <ExternalCurrentRef>4e2952b5114bfa90cc45eef908204006a771a62b</ExternalCurrentRef>
     <ProjectNTfsCurrentRef>8281edc1401dbea7074563526d760f2090abcc79</ProjectNTfsCurrentRef>
+    <SniCurrentRef>99a2e18954382a654e66aed649af70c1c61a47c3</SniCurrentRef>
   </PropertyGroup>
 
   <!-- Auto-upgraded properties for each build info dependency. -->
@@ -30,6 +31,7 @@
     <ExternalExpectedPrerelease>beta-24727-00</ExternalExpectedPrerelease>
     <ProjectNTfsExpectedPrerelease>beta-24927-00</ProjectNTfsExpectedPrerelease>
     <StandardExpectedPrerelease>beta-24919-01</StandardExpectedPrerelease>
+    <SniExpectedPrerelease>beta-24926-02</SniExpectedPrerelease>
   </PropertyGroup>
 
   <!-- Full package version strings that are used in other parts of the build. -->
@@ -57,6 +59,10 @@
     <RemoteDependencyBuildInfo Include="External">
       <BuildInfoPath>$(BaseDotNetBuildInfo)projectk-tfs/$(DependencyBranch)</BuildInfoPath>
       <CurrentRef>$(ExternalCurrentRef)</CurrentRef>
+    </RemoteDependencyBuildInfo>
+    <RemoteDependencyBuildInfo Include="Sni">
+      <BuildInfoPath>$(BaseDotNetBuildInfo)sni/$(DependencyBranch)</BuildInfoPath>
+      <CurrentRef>$(SniCurrentRef)</CurrentRef>
     </RemoteDependencyBuildInfo>
     <RemoteDependencyBuildInfo Condition="'$(DisableProjectNTfsAutoUpgrade)' != 'true'" Include="ProjectNTfs">
       <BuildInfoPath>$(BaseDotNetBuildInfo)projectn-tfs/$(DependencyBranch)</BuildInfoPath>

--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Dependency Include="runtime.win7-x64.runtime.native.System.Data.SqlClient.sni">
-      <Version>$(PackageVersion)-$(SniExpectedPrerelease)</Version>
+      <Version>$(SniPackageVersion)</Version>
     </Dependency>
     <Dependency Include="runtime.win7-x86.runtime.native.System.Data.SqlClient.sni">
-      <Version>$(PackageVersion)-$(SniExpectedPrerelease)</Version>
+      <Version>$(SniPackageVersion)</Version>
     </Dependency>
     <Dependency Include="runtime.win10-arm64.runtime.native.System.Data.SqlClient.sni">
-      <Version>$(PackageVersion)-$(SniExpectedPrerelease)</Version>
+      <Version>$(SniPackageVersion)</Version>
     </Dependency>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
@@ -4,18 +4,16 @@
   <PropertyGroup>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>
-    <!-- replace with $(PackageVersion) once we have a new TFS build -->
-    <RuntimePackageVersion>4.3.0</RuntimePackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Dependency Include="runtime.win7-x64.runtime.native.System.Data.SqlClient.sni">
-      <Version>$(RuntimePackageVersion)-$(ExternalExpectedPrerelease)</Version>
+      <Version>$(PackageVersion)-$(SniExpectedPrerelease)</Version>
     </Dependency>
     <Dependency Include="runtime.win7-x86.runtime.native.System.Data.SqlClient.sni">
-      <Version>$(RuntimePackageVersion)-$(ExternalExpectedPrerelease)</Version>
+      <Version>$(PackageVersion)-$(SniExpectedPrerelease)</Version>
     </Dependency>
     <Dependency Include="runtime.win10-arm64.runtime.native.System.Data.SqlClient.sni">
-      <Version>$(RuntimePackageVersion)-$(ExternalExpectedPrerelease)</Version>
+      <Version>$(PackageVersion)-$(SniExpectedPrerelease)</Version>
     </Dependency>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
Added the dotnet/versions subscription to sni packages. 
Consume the package version in .Net Core sni identity package.

@dagood @gkhanna79 @ajlam