### PR TITLE
Add support multiple BuildConfigurations

### DIFF
--- a/buildvertical.targets
+++ b/buildvertical.targets
@@ -8,56 +8,64 @@
   <!-- Import configuration data model -->
   <Import Project="$(MSBuildThisFileDirectory)src/Tools/GenerateProps/properties.props" />
 
-  <!-- Runs during traversal to select which projects and configurations of those projects to build -->
-  <Target Name="FilterProjects">
-
-    <!-- find the best configuration for each project, projects that shouldn't build for this configuration
-         return an empty item.  -->
-    <MSBuild Targets="FindBestConfiguration"
-             Projects="@(Project)"
-             Condition="'$(BuildAllConfigurations)' != 'true'">
-      <Output TaskParameter="TargetOutputs"
-              ItemName="_ProjectBestConfigurations" />
-    </MSBuild>
+  <!-- Runs during traversal when BuildAllConfigurations is set to expand each project
+       to a seperate instance for each of its BuildConfigurations -->
+  <Target Name="ExpandAllBuildConfigurations" 
+          Condition="'$(BuildAllConfigurations)' == 'true'">
     <MSBuild Targets="GetBuildConfigurations"
              Projects="@(Project)"
              Condition="'$(BuildAllConfigurations)' == 'true'">
       <Output TaskParameter="TargetOutputs"
-              ItemName="_ProjectBestConfigurations" />
+              ItemName="_projectBuildConfigurations" />
     </MSBuild>
 
     <ItemGroup>
       <!-- transform back to project -->
-      <ProjectWithConfiguration Include="@(_ProjectBestConfigurations->'%(OriginalItemSpec)')">
+      <_ProjectWithConfiguration Include="@(_projectBuildConfigurations->'%(OriginalItemSpec)')">
         <AdditionalProperties>Configuration=%(Identity);%(_ProjectBestConfigurations.AdditionalProperties)</AdditionalProperties>
-      </ProjectWithConfiguration>
+      </_ProjectWithConfiguration>
     </ItemGroup>
 
     <ItemGroup>
       <Project Remove="@(Project)" />
-      <Project Include="@(ProjectWithConfiguration)" />
+      <Project Include="@(_ProjectWithConfiguration)" />
     </ItemGroup>
   </Target>
 
-  <!-- Runs in a leaf project (eg: csproj) to determine best configuration if one exists for purposes of filtering -->
-  <Target Name="FindBestConfiguration"
-          Returns="$(_BestConfiguration)">
+  <!-- Runs during traversal to select which projects and configurations of those projects to build 
+       Batches over the projects because we need to treat BuildConfigurations as a Property
+       as well as copy the Project based on results of FindBestConfigurations. -->
+  <Target Name="FilterBuildConfiguration"
+          Condition="'$(BuildAllConfigurations)' != 'true'"
+          Inputs="%(Project.Identity)"
+          Outputs="unused">
 
-    <!-- if BuildConfigurations is defined, find the best one -->
-    <FindBestConfigurations Condition="'$(BuildConfigurations)' != ''"
-                            Properties="@(Property)"
+    <MSBuild Targets="GetBuildConfigurations"
+             Projects="@(Project)">
+      <Output TaskParameter="TargetOutputs"
+              PropertyName="_projectBuildConfigurations" />
+    </MSBuild>
+
+    <FindBestConfigurations Properties="@(Property)"
                             PropertyValues="@(PropertyValue)"
-                            SupportedConfigurations="$(BuildConfigurations)"
+                            SupportedConfigurations="$(_projectBuildConfigurations)"
                             Configurations="$(BuildConfiguration)">
-      <Output TaskParameter="BestConfigurations" PropertyName="_BestConfiguration" />
+      <Output TaskParameter="BestConfigurations" ItemName="_projectBestConfigurations" />
     </FindBestConfigurations>
 
-    <!-- if BuildConfigurations is not defined, use BuildConfiguration -->
-    <PropertyGroup>
-      <_BestConfiguration Condition="'$(BuildConfigurations)' == ''">$(BuildConfiguration)</_BestConfiguration>
-    </PropertyGroup>
+    <ItemGroup>
+      <!-- Apply configuration, this does a catesian product between @(Project) and @(_projectBestConfigurations) -->
+      <_projectWithConfiguration Include="@(Project)" Condition="'@(_projectBestConfigurations)' != ''">
+        <AdditionalProperties>Configuration=%(_projectBestConfigurations.Identity);%(_projectWithConfiguration.AdditionalProperties)</AdditionalProperties>
+      </_projectWithConfiguration>
+      <Project Remove="@(Project)"/>
+      <Project Include="@(_projectWithConfiguration)"/>
+    </ItemGroup>
   </Target>
-  
+
+  <Target Name="FilterProjects"
+          DependsOnTargets="ExpandAllBuildConfigurations;FilterBuildConfiguration" />
+
   <!-- Runs in a leaf project (eg: csproj) to determine all configurations -->
   <Target Name="GetBuildConfigurations"
           Returns="$(_AllBuildConfigurations)">
@@ -74,10 +82,6 @@
           Inputs="%(ProjectReference.Identity)"
           Outputs="unused">
 
-    <!-- Get all configurations for each ProjectReference.  We use this 
-         rather than the FindBestConfiguration target since we need to 
-         choose the best configuration for the referencing project's 
-         configuration, not the BuildConfiguration.  -->
     <MSBuild Targets="GetBuildConfigurations"
              Projects="@(ProjectReference)">
       <Output TaskParameter="TargetOutputs" PropertyName="_projectReferenceBuildConfigurations" />

--- a/src/System.ValueTuple/ref/Configurations.props
+++ b/src/System.ValueTuple/ref/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netcoreapp;
       uap;
+      netstandard;
       netstandard1.0;
       <!-- portable_net40+sl4+win8+wp8-Windows_NT; Looks like our filtering mechanism doesn't understand this targetgroup. Do we even need it? -->
     </BuildConfigurations>

--- a/src/System.ValueTuple/ref/System.ValueTuple.csproj
+++ b/src/System.ValueTuple/ref/System.ValueTuple.csproj
@@ -22,6 +22,9 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' Or '$(TargetGroup)' == 'uap'">
     <Compile Include="System.ValueTuple.TypeForwards.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
+    <Reference Include="netstandard" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'portable-net40+sl4+win8+wp8'">
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System" />

--- a/src/Tools/CoreFx.Tools/FindBestConfigurations.cs
+++ b/src/Tools/CoreFx.Tools/FindBestConfigurations.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
                 if (bestConfiguration == null)
                 {
-                    Log.LogMessage($"Could not find any applicable configuration for '{buildConfiguration}' among projectConfigurations {string.Join(", ", supportedProjectConfigurations.Select(c => c.ToString()))}");
+                    Log.LogMessage(MessageImportance.Low, $"Could not find any applicable configuration for '{buildConfiguration}' among projectConfigurations {string.Join(", ", supportedProjectConfigurations.Select(c => c.ToString()))}");
                     Log.LogMessage(MessageImportance.Low, $"Compatible configurations: {string.Join(", ", compatibleConfigurations.Select(c => c.ToString()))}");
                 }
                 else

--- a/src/ref.builds
+++ b/src/ref.builds
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <NETStandardBuildConfiguration Condition="'$(NETStandardBuildConfiguration)' == ''">netstandard-$(OSGroup)-$(ConfigurationGroup)-$(ArchGroup)</NETStandardBuildConfiguration>
+    <BuildConfiguration>$(BuildConfiguration);$(NETStandardBuildConfiguration)</BuildConfiguration>
+  </PropertyGroup>
+
   <ItemGroup>
     <Project Include="$(MSBuildThisFileDirectory)*\ref\*.*proj">
       <AdditionalMetadata>ConfigurationGroup=$(ConfigurationGroup)</AdditionalMetadata>


### PR DESCRIPTION
This enables building more than one BuildConfiguration at a time.

I enabled this in the references to ensure we build netstandard references in addition to
the current BuildConfiguration.

/cc @weshaggard @joperezr @chcosta @mellinoe