### PR TITLE
Fix signature of CFArrayCreate.

### DIFF
--- a/src/Common/src/Interop/OSX/Interop.CoreFoundation.cs
+++ b/src/Common/src/Interop/OSX/Interop.CoreFoundation.cs
@@ -74,7 +74,7 @@ internal static partial class Interop
             IntPtr allocator,
             [MarshalAs(UnmanagedType.LPArray)]
             IntPtr[] values,
-            ulong numValues,
+            UIntPtr numValues,
             IntPtr callbacks);
 
         /// <summary>
@@ -83,7 +83,7 @@ internal static partial class Interop
         /// <param name="values">The values to put in the array</param>
         /// <param name="numValues">The number of values in the array</param>
         /// <returns>Returns a valid SafeCreateHandle to a CFArray on success; otherwise, returns an invalid SafeCreateHandle</returns>
-        internal static SafeCreateHandle CFArrayCreate(IntPtr[] values, ulong numValues)
+        internal static SafeCreateHandle CFArrayCreate(IntPtr[] values, UIntPtr numValues)
         {
             return CFArrayCreate(IntPtr.Zero, values, numValues, IntPtr.Zero);
         }

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -212,7 +212,7 @@ namespace System.IO
                 }
 
                 // Take the CFStringRef and put it into an array to pass to the EventStream
-                SafeCreateHandle arrPaths = Interop.CoreFoundation.CFArrayCreate(new CFStringRef[1] { path.DangerousGetHandle() }, 1);
+                SafeCreateHandle arrPaths = Interop.CoreFoundation.CFArrayCreate(new CFStringRef[1] { path.DangerousGetHandle() }, (UIntPtr)1);
                 if (arrPaths.IsInvalid)
                 {
                     path.Dispose();

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
@@ -153,7 +153,7 @@ namespace System.Net.NetworkInformation
                         {
                             ipv4Pattern.DangerousGetHandle(),
                             ipv6Pattern.DangerousGetHandle()
-                        }, 2))
+                        }, (UIntPtr)2))
                 {
                     // Try to register our pattern strings with the dynamic store instance.
                     if (patterns.IsInvalid || !Interop.SystemConfiguration.SCDynamicStoreSetNotificationKeys(


### PR DESCRIPTION
CFIndex is a C long, therefore UIntPtr should be used

This should fix the binding for 32bit OS X. There are no API changes.