### PR TITLE
Seal virtual methods of uninherited classes in Microsoft.CSharp.

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorHandling.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorHandling.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
     // must be deferred, thus causing the error formatting/reporting subsystem to understand a 
     // whole host of types, many of which may not be relevant to the EE. 
 
-    internal class ErrorHandling
+    internal sealed class ErrorHandling
     {
         private readonly IErrorSink _errorSink;
         private readonly UserStringBuilder _userStringBuilder;
@@ -56,11 +56,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             error.Initialize(id, prgarg);
         }
 
-        public virtual void AddRelatedSymLoc(CParameterizedError err, Symbol sym)
+        public void AddRelatedSymLoc(CParameterizedError err, Symbol sym)
         {
         }
 
-        public virtual void AddRelatedTypeLoc(CParameterizedError err, CType pType)
+        public void AddRelatedTypeLoc(CParameterizedError err, CType pType)
         {
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BinOpArgInfo.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BinOpArgInfo.cs
@@ -7,9 +7,9 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal partial class ExpressionBinder
+    internal sealed partial class ExpressionBinder
     {
-        protected class BinOpArgInfo
+        private class BinOpArgInfo
         {
             public BinOpArgInfo(EXPR op1, EXPR op2)
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BinOpSig.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BinOpSig.cs
@@ -7,9 +7,9 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal partial class ExpressionBinder
+    internal sealed partial class ExpressionBinder
     {
-        protected class BinOpSig
+        private class BinOpSig
         {
             public BinOpSig()
             {
@@ -50,7 +50,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
         }
 
-        protected class BinOpFullSig : BinOpSig
+        private class BinOpFullSig : BinOpSig
         {
             private readonly LiftFlags _grflt;
             private readonly CType _type1;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/Better.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/Better.cs
@@ -9,7 +9,7 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal partial class ExpressionBinder
+    internal sealed partial class ExpressionBinder
     {
         ////////////////////////////////////////////////////////////////////////////////
         // This table is used to implement the last set of 'better' conversion rules
@@ -38,7 +38,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             new byte[] /* OBJECT*/ {0,     0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,       0,       0}
         };
 
-        protected BetterType WhichMethodIsBetterTieBreaker(
+        private BetterType WhichMethodIsBetterTieBreaker(
             CandidateFunctionMember node1,
             CandidateFunctionMember node2,
             CType pTypeThrough,
@@ -203,7 +203,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         //
         // Returns Left if m1 is better, Right if m2 is better, or Neither/Same
 
-        protected BetterType WhichMethodIsBetter(
+        private BetterType WhichMethodIsBetter(
             CandidateFunctionMember node1,
             CandidateFunctionMember node2,
             CType pTypeThrough,
@@ -318,7 +318,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return betterMethod;
         }
 
-        protected BetterType WhichConversionIsBetter(EXPR arg, CType argType,
+        private BetterType WhichConversionIsBetter(EXPR arg, CType argType,
             CType p1, CType p2)
         {
             Debug.Assert(argType != null);
@@ -419,8 +419,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         ////////////////////////////////////////////////////////////////////////////////
         // Determine best method for overload resolution. Returns null if no best 
         // method, in which case two tying methods are returned for error reporting.
-
-        protected CandidateFunctionMember FindBestMethod(
+        private CandidateFunctionMember FindBestMethod(
             List<CandidateFunctionMember> list,
             CType pTypeThrough,
             ArgInfos args,

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/ErrorReporting.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/ErrorReporting.cs
@@ -7,7 +7,7 @@ using Microsoft.CSharp.RuntimeBinder.Errors;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal partial class ExpressionBinder
+    internal sealed partial class ExpressionBinder
     {
         private static readonly ErrorCode[] s_ReadOnlyLocalErrors =
         {
@@ -15,7 +15,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             ErrorCode.ERR_AssgReadonlyLocal,
         };
 
-        protected void ReportLocalError(LocalVariableSymbol local, CheckLvalueKind kind, bool isNested)
+        private void ReportLocalError(LocalVariableSymbol local, CheckLvalueKind kind, bool isNested)
         {
             Debug.Assert(local != null);
 
@@ -43,7 +43,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             ErrorCode.ERR_AssgReadonlyStatic2
         };
 
-        protected void ReportReadOnlyError(EXPRFIELD field, CheckLvalueKind kind, bool isNested)
+        private void ReportReadOnlyError(EXPRFIELD field, CheckLvalueKind kind, bool isNested)
         {
             Debug.Assert(field != null);
 
@@ -63,7 +63,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         // Return true if we actually report a failure.
-        protected bool TryReportLvalueFailure(EXPR expr, CheckLvalueKind kind)
+        private bool TryReportLvalueFailure(EXPR expr, CheckLvalueKind kind)
         {
             Debug.Assert(expr != null);
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         Neither = 3,
     }
 
-    internal partial class ExpressionBinder
+    internal sealed partial class ExpressionBinder
     {
         private delegate bool ConversionFunc(
             EXPR pSourceExpr,

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -7,7 +7,7 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal partial class ExpressionBinder
+    internal sealed partial class ExpressionBinder
     {
         // ----------------------------------------------------------------------------
         // BindExplicitConversion

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         None
     }
 
-    internal partial class ExpressionBinder
+    internal sealed partial class ExpressionBinder
     {
         // ExpressionBinder - General Rules
         // 
@@ -261,12 +261,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // Factory method sets the "Do Children have Errors?" bit - not done manually.
         // Once constructed Expression trees are not mutated - doesn't work easily for statements unfortunately.
 
-        protected delegate EXPR PfnBindBinOp(ExpressionKind ek, EXPRFLAG flags, EXPR op1, EXPR op2);
-        protected delegate EXPR PfnBindUnaOp(ExpressionKind ek, EXPRFLAG flags, EXPR op);
+        private delegate EXPR PfnBindBinOp(ExpressionKind ek, EXPRFLAG flags, EXPR op1, EXPR op2);
+        private delegate EXPR PfnBindUnaOp(ExpressionKind ek, EXPRFLAG flags, EXPR op);
 
-        protected BindingContext Context;
+        private BindingContext Context;
         public BindingContext GetContext() { return Context; }
-        protected CNullable m_nullable;
+        private CNullable m_nullable;
 
         private static void VSFAIL(string s)
         {
@@ -325,15 +325,18 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 new UnaOpSig( PredefinedType.PT_DECIMAL,    UnaOpMask.IncDec,   0, null,            UnaOpFuncKind.None      ),
             };
         }
-        protected SymbolLoader GetSymbolLoader() { return SymbolLoader; }
-        protected SymbolLoader SymbolLoader
+
+        private SymbolLoader GetSymbolLoader() { return SymbolLoader; }
+
+        private SymbolLoader SymbolLoader
         {
             get
             {
                 return Context.SymbolLoader;
             }
         }
-        protected CSemanticChecker SemanticChecker
+
+        private CSemanticChecker SemanticChecker
         {
             get
             {
@@ -350,32 +353,42 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
         }
         private ErrorHandling GetErrorContext() { return ErrorContext; }
-        protected BSYMMGR GetGlobalSymbols()
+
+        private BSYMMGR GetGlobalSymbols()
         {
             return GetSymbolLoader().getBSymmgr();
         }
-        protected TypeManager GetTypes() { return TypeManager; }
-        protected TypeManager TypeManager { get { return SymbolLoader.TypeManager; } }
+
+        private TypeManager GetTypes() { return TypeManager; }
+
+        private TypeManager TypeManager { get { return SymbolLoader.TypeManager; } }
+
         private ExprFactory GetExprFactory() { return ExprFactory; }
+
         private ExprFactory ExprFactory { get { return Context.GetExprFactory(); } }
+
         private ConstValFactory GetExprConstants()
         {
             return GetExprFactory().GetExprConstants();
         }
-        protected AggregateType GetReqPDT(PredefinedType pt)
+
+        private AggregateType GetReqPDT(PredefinedType pt)
         {
             return GetReqPDT(pt, GetSymbolLoader());
         }
-        protected static AggregateType GetReqPDT(PredefinedType pt, SymbolLoader symbolLoader)
+
+        private static AggregateType GetReqPDT(PredefinedType pt, SymbolLoader symbolLoader)
         {
             Debug.Assert(pt != PredefinedType.PT_VOID);  // use getVoidType()
             return symbolLoader.GetReqPredefType(pt, true);
         }
-        protected AggregateType GetOptPDT(PredefinedType pt)
+
+        private AggregateType GetOptPDT(PredefinedType pt)
         {
             return GetOptPDT(pt, true);
         }
-        protected AggregateType GetOptPDT(PredefinedType pt, bool WarnIfNotFound)
+
+        private AggregateType GetOptPDT(PredefinedType pt, bool WarnIfNotFound)
         {
             Debug.Assert(pt != PredefinedType.PT_VOID);  // use getVoidType()
             if (WarnIfNotFound)
@@ -387,8 +400,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return GetSymbolLoader().GetOptPredefType(pt, true);
             }
         }
-        protected CType VoidType { get { return GetSymbolLoader().GetTypeManager().GetVoid(); } }
-        protected CType getVoidType() { return VoidType; }
+
+        private CType VoidType { get { return GetSymbolLoader().GetTypeManager().GetVoid(); } }
+
+        private CType getVoidType() { return VoidType; }
 
         public EXPR GenerateAssignmentConversion(EXPR op1, EXPR op2, bool allowExplicit)
         {
@@ -531,14 +546,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return pExpr;
         }
 
-        protected EXPRUNARYOP bindPtrToString(EXPR @string)
+        private EXPRUNARYOP bindPtrToString(EXPR @string)
         {
             CType typeRet = GetTypes().GetPointer(GetReqPDT(PredefinedType.PT_CHAR));
 
             return GetExprFactory().CreateUnaryOp(ExpressionKind.EK_ADDR, typeRet, @string);
         }
 
-        protected EXPRQUESTIONMARK BindPtrToArray(EXPRLOCAL exprLoc, EXPR array)
+        private EXPRQUESTIONMARK BindPtrToArray(EXPRLOCAL exprLoc, EXPR array)
         {
             CType typeElem = array.type.AsArrayType().GetElementType();
             CType typePtrElem = GetTypes().GetPointer(typeElem);
@@ -602,7 +617,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
 
-        protected EXPR bindIndexer(EXPR pObject, EXPR args, BindingFlag bindFlags)
+        private EXPR bindIndexer(EXPR pObject, EXPR args, BindingFlag bindFlags)
         {
             CType type = pObject.type;
 
@@ -1358,12 +1373,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
         ////////////////////////////////////////////////////////////////////////////////
         // Report a bad operator types error to the user.
-        protected EXPR BadOperatorTypesError(ExpressionKind ek, EXPR pOperand1, EXPR pOperand2)
+        private EXPR BadOperatorTypesError(ExpressionKind ek, EXPR pOperand1, EXPR pOperand2)
         {
             return BadOperatorTypesError(ek, pOperand1, pOperand2, null);
         }
 
-        protected EXPR BadOperatorTypesError(ExpressionKind ek, EXPR pOperand1, EXPR pOperand2, CType pTypeErr)
+        private EXPR BadOperatorTypesError(ExpressionKind ek, EXPR pOperand1, EXPR pOperand2, CType pTypeErr)
         {
             // This is a hack, but we need to store the operation somewhere... the first argument's as 
             // good a place as any.
@@ -1400,8 +1415,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return rval;
         }
 
-
-        protected EXPR UnwrapExpression(EXPR pExpression)
+        private EXPR UnwrapExpression(EXPR pExpression)
         {
             EXPR pExpr = pExpression;
             while (pExpr != null && pExpr.isWRAP() && pExpr.asWRAP().GetOptionalExpression() != null)
@@ -1428,7 +1442,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
         }
 
-        protected void CheckLvalueProp(EXPRPROP prop)
+        private void CheckLvalueProp(EXPRPROP prop)
         {
             Debug.Assert(prop != null);
             Debug.Assert(prop.isLvalue());
@@ -1452,7 +1466,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
         }
 
-        protected bool CheckPropertyAccess(MethWithType mwt, PropWithType pwtSlot, CType type)
+        private bool CheckPropertyAccess(MethWithType mwt, PropWithType pwtSlot, CType type)
         {
             ACCESSERROR error = SemanticChecker.CheckAccess2(mwt.Meth(), mwt.GetType(), ContextForMemberLookup(), type);
             if (error == ACCESSERROR.ACCESSERROR_NOACCESSTHRU)
@@ -1602,7 +1616,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
         }
 
-        protected void PostBindProperty(bool fBaseCall, PropWithType pwt, EXPR pObject, out MethWithType pmwtGet, out MethWithType pmwtSet)
+        private void PostBindProperty(bool fBaseCall, PropWithType pwt, EXPR pObject, out MethWithType pmwtGet, out MethWithType pmwtSet)
         {
             pmwtGet = new MethWithType();
             pmwtSet = new MethWithType();
@@ -1893,7 +1907,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
         }
 
-        protected void verifyMethodArgs(EXPR call, CType callingObjectType)
+        private void verifyMethodArgs(EXPR call, CType callingObjectType)
         {
             Debug.Assert(call.isCALL() || call.isPROP());
 
@@ -1906,7 +1920,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             call.setArgs(newArgs);
         }
 
-        protected void AdjustCallArgumentsForParams(CType callingObjectType, CType type, MethodOrPropertySymbol mp, TypeArray pTypeArgs, EXPR argsPtr, out EXPR newArgs)
+        private void AdjustCallArgumentsForParams(CType callingObjectType, CType type, MethodOrPropertySymbol mp, TypeArray pTypeArgs, EXPR argsPtr, out EXPR newArgs)
         {
             Debug.Assert(mp != null);
             Debug.Assert(mp.Params != null);
@@ -2126,7 +2140,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         ////////////////////////////////////////////////////////////////////////////////
         // Sets the isAssigned bit
 
-        protected void markFieldAssigned(EXPR expr)
+        private void markFieldAssigned(EXPR expr)
         {
             if (expr.isFIELD() && 0 != (expr.flags & EXPRFLAG.EXF_LVALUE))
             {
@@ -2142,7 +2156,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
         }
 
-        protected void SetExternalRef(CType type)
+        private void SetExternalRef(CType type)
         {
             AggregateSymbol agg = type.GetNakedAgg();
             if (null == agg || agg.HasExternReference())
@@ -2224,7 +2238,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             argInfo.types = GetGlobalSymbols().AllocParams(iarg, prgtype);
         }
 
-        protected bool TryGetExpandedParams(TypeArray @params, int count, out TypeArray ppExpandedParams)
+        private bool TryGetExpandedParams(TypeArray @params, int count, out TypeArray ppExpandedParams)
         {
             CType[] prgtype;
             if (count < @params.size - 1)
@@ -2485,7 +2499,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             PredefinedName.PN_OPRIGHTSHIFT,
         };
 
-        protected Name ekName(ExpressionKind ek)
+        private Name ekName(ExpressionKind ek)
         {
             Debug.Assert(ek >= ExpressionKind.EK_FIRSTOP && (ek - ExpressionKind.EK_FIRSTOP) < (int)s_EK2NAME.Length);
             return GetSymbolLoader().GetNameManager().GetPredefName(s_EK2NAME[ek - ExpressionKind.EK_FIRSTOP]);
@@ -2510,23 +2524,28 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 RecordUnsafeUsage();
             }
         }
-        protected bool InMethod()
+
+        private bool InMethod()
         {
             return Context.InMethod();
         }
-        protected bool InStaticMethod()
+
+        private bool InStaticMethod()
         {
             return Context.InStaticMethod();
         }
-        protected bool InConstructor()
+
+        private bool InConstructor()
         {
             return Context.InConstructor();
         }
-        protected bool InAnonymousMethod()
+
+        private bool InAnonymousMethod()
         {
             return Context.InAnonymousMethod();
         }
-        protected bool InFieldInitializer()
+
+        private bool InFieldInitializer()
         {
             return Context.InFieldInitializer();
         }
@@ -2537,36 +2556,42 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return Context.ContextForMemberLookup();
         }
 
-        protected AggregateSymbol ContainingAgg()
+        private AggregateSymbol ContainingAgg()
         {
             return Context.ContainingAgg();
         }
-        protected bool isThisPointer(EXPR expr)
+
+        private bool isThisPointer(EXPR expr)
         {
             return Context.IsThisPointer(expr);
         }
-        protected bool RespectReadonly()
+
+        private bool RespectReadonly()
         {
             return Context.RespectReadonly();
         }
-        protected bool isUnsafeContext()
+
+        private bool isUnsafeContext()
         {
             return Context.IsUnsafeContext();
         }
-        protected bool ReportUnsafeErrors()
+
+        private bool ReportUnsafeErrors()
         {
             return Context.ReportUnsafeErrors();
         }
-        protected virtual void RecordUnsafeUsage()
+
+        private void RecordUnsafeUsage()
         {
             RecordUnsafeUsage(Context);
         }
-        protected virtual EXPR WrapShortLivedExpression(EXPR expr)
+
+        private EXPR WrapShortLivedExpression(EXPR expr)
         {
             return GetExprFactory().CreateWrap(null, expr);
         }
 
-        virtual protected EXPR GenerateOptimizedAssignment(EXPR op1, EXPR op2)
+        private EXPR GenerateOptimizedAssignment(EXPR op1, EXPR op2)
         {
             return GetExprFactory().CreateAssignment(op1, op2);
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // to the best applicable method in the group.
     // ----------------------------------------------------------------------------
 
-    internal partial class ExpressionBinder
+    internal sealed partial class ExpressionBinder
     {
         internal class GroupToArgsBinder
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinderResult.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinderResult.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal partial class ExpressionBinder
+    internal sealed partial class ExpressionBinder
     {
         // ----------------------------------------------------------------------------
         // This class takes an EXPRMEMGRP and a set of arguments and binds the arguments

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -8,7 +8,7 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal partial class ExpressionBinder
+    internal sealed partial class ExpressionBinder
     {
         // ----------------------------------------------------------------------------
         // BindImplicitConversion

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Nullable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Nullable.cs
@@ -142,7 +142,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
     }
 
-    internal partial class ExpressionBinder
+    internal sealed partial class ExpressionBinder
     {
         // Create an expr for exprSrc.Value where exprSrc.type is a NullableType.
         internal EXPR BindNubValue(EXPR exprSrc)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -9,7 +9,7 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal partial class ExpressionBinder
+    internal sealed partial class ExpressionBinder
     {
         /*
             These are the predefined binary operator signatures
@@ -80,7 +80,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // When the binding method is looked up in these arrays we ASSERT
         // if the array is out of bounds of the corresponding array.
 
-        protected readonly BinOpSig[] g_binopSignatures;
+        private readonly BinOpSig[] g_binopSignatures;
 
         // We want unary minus to bind to "operator -(ulong)" and then we
         // produce an error (since there is no pfn). We can't let - bind to a floating point type,
@@ -88,9 +88,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         // Increment and decrement operators are special.
 
-        protected readonly UnaOpSig[] g_rguos;
+        private readonly UnaOpSig[] g_rguos;
 
-        protected EXPR bindUserDefinedBinOp(ExpressionKind ek, BinOpArgInfo info)
+        private EXPR bindUserDefinedBinOp(ExpressionKind ek, BinOpArgInfo info)
         {
             MethPropWithInst pmpwi = null;
             if (info.pt1 <= PredefinedType.PT_ULONG && info.pt2 <= PredefinedType.PT_ULONG)
@@ -134,7 +134,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         // Adds special signatures to the candidate list.  If we find an exact match
         // then it will be the last item on the list and we return true.
-        protected bool GetSpecialBinopSignatures(List<BinOpFullSig> prgbofs, BinOpArgInfo info)
+        private bool GetSpecialBinopSignatures(List<BinOpFullSig> prgbofs, BinOpArgInfo info)
         {
             Debug.Assert(prgbofs != null);
             if (info.pt1 <= PredefinedType.PT_ULONG && info.pt2 <= PredefinedType.PT_ULONG)
@@ -150,7 +150,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // Adds standard and lifted signatures to the candidate list.  If we find an exact match
         // then it will be the last item on the list and we return true.
 
-        protected bool GetStandardAndLiftedBinopSignatures(List<BinOpFullSig> rgbofs, BinOpArgInfo info)
+        private bool GetStandardAndLiftedBinopSignatures(List<BinOpFullSig> rgbofs, BinOpArgInfo info)
         {
             Debug.Assert(rgbofs != null);
 
@@ -350,7 +350,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         // Returns the index of the best match, or -1 if there is no best match.
-        protected int FindBestSignatureInList(
+        private int FindBestSignatureInList(
                 List<BinOpFullSig> binopSignatures,
                 BinOpArgInfo info)
         {
@@ -406,7 +406,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return bestSignature;
         }
 
-        protected EXPRBINOP bindNullEqualityComparison(ExpressionKind ek, BinOpArgInfo info)
+        private EXPRBINOP bindNullEqualityComparison(ExpressionKind ek, BinOpArgInfo info)
         {
             EXPR arg1 = info.arg1;
             EXPR arg2 = info.arg2;
@@ -517,7 +517,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return BindStandardBinopCore(info, binopSignatures[bestBinopSignature], ek, flags);
         }
 
-        protected EXPR BindStandardBinopCore(BinOpArgInfo info, BinOpFullSig bofs, ExpressionKind ek, EXPRFLAG flags)
+        private EXPR BindStandardBinopCore(BinOpArgInfo info, BinOpFullSig bofs, ExpressionKind ek, EXPRFLAG flags)
         {
             if (bofs.pfn == null)
             {
@@ -635,7 +635,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Get the special signatures when at least one of the args is a delegate instance.
             Returns true iff an exact signature match is found.
         */
-        protected bool GetDelBinOpSigs(List<BinOpFullSig> prgbofs, BinOpArgInfo info)
+        private bool GetDelBinOpSigs(List<BinOpFullSig> prgbofs, BinOpArgInfo info)
         {
             if (!info.ValidForDelegate())
             {
@@ -786,7 +786,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Get the special signatures when at least one of the args is an enum.  Return true if
             we find an exact match.
         */
-        protected bool GetEnumBinOpSigs(List<BinOpFullSig> prgbofs, BinOpArgInfo info)
+        private bool GetEnumBinOpSigs(List<BinOpFullSig> prgbofs, BinOpArgInfo info)
         {
             if (!info.typeRaw1.isEnumType() && !info.typeRaw2.isEnumType())
             {
@@ -857,7 +857,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             NOTE: We don't filter out bad operators on void pointers since BindPtrBinOp gives better
             error messages than the operator overload resolution does.
         */
-        protected bool GetPtrBinOpSigs(List<BinOpFullSig> prgbofs, BinOpArgInfo info)
+        private bool GetPtrBinOpSigs(List<BinOpFullSig> prgbofs, BinOpArgInfo info)
         {
             if (!info.type1.IsPointerType() && !info.type2.IsPointerType())
             {
@@ -952,7 +952,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             may be applicable and better (or ambiguous)! This also handles == on System.Delegate, since
             it has special rules as well.
         */
-        protected bool GetRefEqualSigs(List<BinOpFullSig> prgbofs, BinOpArgInfo info)
+        private bool GetRefEqualSigs(List<BinOpFullSig> prgbofs, BinOpArgInfo info)
         {
             if (info.mask != BinOpMask.Equal)
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
@@ -7,7 +7,7 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class ExpressionTreeRewriter : ExprVisitorBase
+    internal sealed class ExpressionTreeRewriter : ExprVisitorBase
     {
         public static EXPR Rewrite(EXPR expr, ExprFactory expressionFactory, SymbolLoader symbolLoader)
         {
@@ -16,15 +16,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return rewriter.Visit(expr);
         }
 
-        protected ExprFactory expressionFactory;
-        protected SymbolLoader symbolLoader;
-        protected EXPRBOUNDLAMBDA currentAnonMeth;
-        protected bool alwaysRewrite;
+        private ExprFactory expressionFactory;
+        private SymbolLoader symbolLoader;
+        private EXPRBOUNDLAMBDA currentAnonMeth;
+        private bool alwaysRewrite;
 
-        protected ExprFactory GetExprFactory() { return expressionFactory; }
-        protected SymbolLoader GetSymbolLoader() { return symbolLoader; }
+        private ExprFactory GetExprFactory() { return expressionFactory; }
 
-        protected ExpressionTreeRewriter(ExprFactory expressionFactory, SymbolLoader symbolLoader)
+        private SymbolLoader GetSymbolLoader() { return symbolLoader; }
+
+        private ExpressionTreeRewriter(ExprFactory expressionFactory, SymbolLoader symbolLoader)
         {
             this.expressionFactory = expressionFactory;
             this.symbolLoader = symbolLoader;
@@ -405,7 +406,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return GenerateConstant(expr);
         }
 
-        protected virtual EXPR GenerateQuestionMarkOperand(EXPR pExpr)
+        private EXPR GenerateQuestionMarkOperand(EXPR pExpr)
         {
             Debug.Assert(pExpr != null);
             // We must not optimize away compiler-generated reference casts because
@@ -416,7 +417,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             return Visit(pExpr);
         }
-        protected virtual EXPR GenerateDelegateInvoke(EXPRCALL expr)
+
+        private EXPR GenerateDelegateInvoke(EXPRCALL expr)
         {
             Debug.Assert(expr != null);
             EXPRMEMGRP memberGroup = expr.GetMemberGroup();
@@ -428,7 +430,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             EXPR Params = GenerateParamsArray(args, PredefinedType.PT_EXPRESSION);
             return GenerateCall(PREDEFMETH.PM_EXPRESSION_INVOKE, pObject, Params);
         }
-        protected virtual EXPR GenerateBuiltInBinaryOperator(EXPRBINOP expr)
+
+        private EXPR GenerateBuiltInBinaryOperator(EXPRBINOP expr)
         {
             Debug.Assert(expr != null);
             Debug.Assert(alwaysRewrite || currentAnonMeth != null);
@@ -536,7 +539,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             return call;
         }
-        protected virtual EXPR GenerateBuiltInUnaryOperator(EXPRUNARYOP expr)
+
+        private EXPR GenerateBuiltInUnaryOperator(EXPRUNARYOP expr)
         {
             Debug.Assert(expr != null);
             Debug.Assert(alwaysRewrite || currentAnonMeth != null);
@@ -557,7 +561,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             return GenerateBuiltInUnaryOperator(pdm, origOp, expr);
         }
-        protected virtual EXPR GenerateBuiltInUnaryOperator(PREDEFMETH pdm, EXPR pOriginalOperator, EXPR pOperator)
+
+        private EXPR GenerateBuiltInUnaryOperator(PREDEFMETH pdm, EXPR pOriginalOperator, EXPR pOperator)
         {
             EXPR op = Visit(pOriginalOperator);
             if (pOriginalOperator.type.IsNullableType() && pOriginalOperator.type.StripNubs().isEnumType())
@@ -575,7 +580,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             return call;
         }
-        protected virtual EXPR GenerateUserDefinedBinaryOperator(EXPRBINOP expr)
+
+        private EXPR GenerateUserDefinedBinaryOperator(EXPRBINOP expr)
         {
             Debug.Assert(expr != null);
             Debug.Assert(alwaysRewrite || currentAnonMeth != null);
@@ -652,7 +658,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             return call;
         }
-        protected virtual EXPR GenerateUserDefinedUnaryOperator(EXPRUNARYOP expr)
+
+        private EXPR GenerateUserDefinedUnaryOperator(EXPRUNARYOP expr)
         {
             Debug.Assert(expr != null);
             Debug.Assert(alwaysRewrite || currentAnonMeth != null);
@@ -702,7 +709,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             return GenerateCall(pdm, op, methodInfo);
         }
-        protected virtual EXPR GenerateUserDefinedComparisonOperator(EXPRBINOP expr)
+
+        private EXPR GenerateUserDefinedComparisonOperator(EXPRBINOP expr)
         {
             Debug.Assert(expr != null);
             Debug.Assert(alwaysRewrite || currentAnonMeth != null);
@@ -741,7 +749,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             EXPR methodInfo = GetExprFactory().CreateMethodInfo(expr.GetUserDefinedCallMethod());
             return GenerateCall(pdm, p1, p2, lift, methodInfo);
         }
-        protected EXPR RewriteLambdaBody(EXPRBOUNDLAMBDA anonmeth)
+
+        private EXPR RewriteLambdaBody(EXPRBOUNDLAMBDA anonmeth)
         {
             Debug.Assert(anonmeth != null);
             Debug.Assert(anonmeth.OptionalBody != null);
@@ -762,7 +771,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             throw Error.InternalCompilerError();
         }
-        protected EXPR RewriteLambdaParameters(EXPRBOUNDLAMBDA anonmeth)
+
+        private EXPR RewriteLambdaParameters(EXPRBOUNDLAMBDA anonmeth)
         {
             Debug.Assert(anonmeth != null);
 
@@ -787,29 +797,34 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             return GenerateParamsArray(paramArrayInitializerArgs, PredefinedType.PT_PARAMETEREXPRESSION);
         }
-        protected virtual EXPR GenerateConversion(EXPR arg, CType CType, bool bChecked)
+
+        private EXPR GenerateConversion(EXPR arg, CType CType, bool bChecked)
         {
             return GenerateConversionWithSource(Visit(arg), CType, bChecked || arg.isChecked());
         }
-        protected virtual EXPR GenerateConversionWithSource(EXPR pTarget, CType pType, bool bChecked)
+
+        private EXPR GenerateConversionWithSource(EXPR pTarget, CType pType, bool bChecked)
         {
             PREDEFMETH pdm = bChecked ? PREDEFMETH.PM_EXPRESSION_CONVERTCHECKED : PREDEFMETH.PM_EXPRESSION_CONVERT;
             EXPR pTypeOf = CreateTypeOf(pType);
             return GenerateCall(pdm, pTarget, pTypeOf);
         }
-        protected virtual EXPR GenerateValueAccessConversion(EXPR pArgument)
+
+        private EXPR GenerateValueAccessConversion(EXPR pArgument)
         {
             Debug.Assert(pArgument != null);
             CType pStrippedTypeOfArgument = pArgument.type.StripNubs();
             EXPR pStrippedTypeExpr = CreateTypeOf(pStrippedTypeOfArgument);
             return GenerateCall(PREDEFMETH.PM_EXPRESSION_CONVERT, Visit(pArgument), pStrippedTypeExpr);
         }
-        protected virtual EXPR GenerateUserDefinedConversion(EXPR arg, CType type, MethWithInst method)
+
+        private EXPR GenerateUserDefinedConversion(EXPR arg, CType type, MethWithInst method)
         {
             EXPR target = Visit(arg);
             return GenerateUserDefinedConversion(arg, type, target, method);
         }
-        protected virtual EXPR GenerateUserDefinedConversion(EXPR arg, CType CType, EXPR target, MethWithInst method)
+
+        private EXPR GenerateUserDefinedConversion(EXPR arg, CType CType, EXPR target, MethWithInst method)
         {
             // The user-defined explicit conversion from enum? to decimal or decimal? requires
             // that we convert the enum? to its nullable underlying CType.
@@ -850,7 +865,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             EXPR typeofOuter = CreateTypeOf(CType);
             return GenerateCall(pdmOuter, callUserDefinedConversion, typeofOuter);
         }
-        protected virtual EXPR GenerateUserDefinedConversion(EXPRUSERDEFINEDCONVERSION pExpr, EXPR pArgument)
+
+        private EXPR GenerateUserDefinedConversion(EXPRUSERDEFINEDCONVERSION pExpr, EXPR pArgument)
         {
             EXPR pCastCall = pExpr.UserDefinedCall;
             EXPR pCastArgument = pExpr.Argument;
@@ -893,22 +909,26 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             return GenerateUserDefinedConversion(pCastArgument, pExpr.type, pConversionSource, pExpr.UserDefinedCallMethod);
         }
-        protected virtual EXPR GenerateParameter(string name, CType CType)
+
+        private EXPR GenerateParameter(string name, CType CType)
         {
             GetSymbolLoader().GetReqPredefType(PredefinedType.PT_STRING);  // force an ensure state
             EXPRCONSTANT nameString = GetExprFactory().CreateStringConstant(name);
             EXPRTYPEOF pTypeOf = CreateTypeOf(CType);
             return GenerateCall(PREDEFMETH.PM_EXPRESSION_PARAMETER, pTypeOf, nameString);
         }
-        protected MethodSymbol GetPreDefMethod(PREDEFMETH pdm)
+
+        private MethodSymbol GetPreDefMethod(PREDEFMETH pdm)
         {
             return GetSymbolLoader().getPredefinedMembers().GetMethod(pdm);
         }
-        protected EXPRTYPEOF CreateTypeOf(CType CType)
+
+        private EXPRTYPEOF CreateTypeOf(CType CType)
         {
             return GetExprFactory().CreateTypeOf(CType);
         }
-        protected EXPR CreateWraps(EXPRBOUNDLAMBDA anonmeth)
+
+        private EXPR CreateWraps(EXPRBOUNDLAMBDA anonmeth)
         {
             EXPR sequence = null;
             for (Symbol sym = anonmeth.ArgumentScope().firstChild; sym != null; sym = sym.nextChild)
@@ -938,7 +958,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             return sequence;
         }
-        protected EXPR DestroyWraps(EXPRBOUNDLAMBDA anonmeth, EXPR sequence)
+
+        private EXPR DestroyWraps(EXPRBOUNDLAMBDA anonmeth, EXPR sequence)
         {
             for (Symbol sym = anonmeth.ArgumentScope(); sym != null; sym = sym.nextChild)
             {
@@ -958,7 +979,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             return sequence;
         }
-        protected virtual EXPR GenerateConstructor(EXPRCALL expr)
+
+        private EXPR GenerateConstructor(EXPRCALL expr)
         {
             Debug.Assert(expr != null);
             Debug.Assert(expr.mwi.Meth().IsConstructor());
@@ -983,7 +1005,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return GenerateCall(PREDEFMETH.PM_EXPRESSION_NEW, constructorInfo, Params);
             }
         }
-        protected virtual EXPR GenerateDelegateConstructor(EXPRCALL expr)
+
+        private EXPR GenerateDelegateConstructor(EXPRCALL expr)
         {
             // In:
             //
@@ -1025,7 +1048,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             EXPR pTypeOf = CreateTypeOf(expr.type);
             return GenerateCall(PREDEFMETH.PM_EXPRESSION_CONVERT, call, pTypeOf);
         }
-        protected virtual EXPR GenerateArgsList(EXPR oldArgs)
+
+        private EXPR GenerateArgsList(EXPR oldArgs)
         {
             EXPR newArgs = null;
             EXPR newArgsTail = newArgs;
@@ -1036,7 +1060,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             return newArgs;
         }
-        protected virtual EXPR GenerateIndexList(EXPR oldIndices)
+
+        private EXPR GenerateIndexList(EXPR oldIndices)
         {
             CType intType = symbolLoader.GetReqPredefType(PredefinedType.PT_INT, true);
 
@@ -1056,7 +1081,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             return newIndices;
         }
-        protected virtual EXPR GenerateConstant(EXPR expr)
+
+        private EXPR GenerateConstant(EXPR expr)
         {
             EXPRFLAG flags = 0;
 
@@ -1080,7 +1106,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             return GenerateCall(PREDEFMETH.PM_EXPRESSION_CONSTANT_OBJECT_TYPE, cast, pTypeOf2);
         }
-        protected EXPRCALL GenerateCall(PREDEFMETH pdm, EXPR arg1)
+
+        private EXPRCALL GenerateCall(PREDEFMETH pdm, EXPR arg1)
         {
             MethodSymbol method = GetPreDefMethod(pdm);
             // this should be enforced in an earlier pass and the transform pass should not 
@@ -1094,7 +1121,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             call.PredefinedMethod = pdm;
             return call;
         }
-        protected EXPRCALL GenerateCall(PREDEFMETH pdm, EXPR arg1, EXPR arg2)
+
+        private EXPRCALL GenerateCall(PREDEFMETH pdm, EXPR arg1, EXPR arg2)
         {
             MethodSymbol method = GetPreDefMethod(pdm);
             if (method == null)
@@ -1107,7 +1135,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             call.PredefinedMethod = pdm;
             return call;
         }
-        protected EXPRCALL GenerateCall(PREDEFMETH pdm, EXPR arg1, EXPR arg2, EXPR arg3)
+
+        private EXPRCALL GenerateCall(PREDEFMETH pdm, EXPR arg1, EXPR arg2, EXPR arg3)
         {
             MethodSymbol method = GetPreDefMethod(pdm);
             if (method == null)
@@ -1120,7 +1149,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             call.PredefinedMethod = pdm;
             return call;
         }
-        protected EXPRCALL GenerateCall(PREDEFMETH pdm, EXPR arg1, EXPR arg2, EXPR arg3, EXPR arg4)
+
+        private EXPRCALL GenerateCall(PREDEFMETH pdm, EXPR arg1, EXPR arg2, EXPR arg3, EXPR arg4)
         {
             MethodSymbol method = GetPreDefMethod(pdm);
             if (method == null)
@@ -1133,7 +1163,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             call.PredefinedMethod = pdm;
             return call;
         }
-        protected virtual EXPRARRINIT GenerateParamsArray(EXPR args, PredefinedType pt)
+
+        private EXPRARRINIT GenerateParamsArray(EXPR args, PredefinedType pt)
         {
             int parameterCount = ExpressionIterator.Count(args);
             AggregateType paramsArrayElementType = GetSymbolLoader().GetOptPredefTypeErr(pt, true);
@@ -1144,7 +1175,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             arrayInit.dimSizes = new int[] { arrayInit.dimSize }; // CLEANUP: Why isn't this done by the factory?
             return arrayInit;
         }
-        protected virtual EXPRARRINIT GenerateMembersArray(AggregateType anonymousType, PredefinedType pt)
+
+        private EXPRARRINIT GenerateMembersArray(AggregateType anonymousType, PredefinedType pt)
         {
             EXPR newArgs = null;
             EXPR newArgsTail = newArgs;
@@ -1173,7 +1205,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             arrayInit.dimSizes = new int[] { arrayInit.dimSize }; // CLEANUP: Why isn't this done by the factory?
             return arrayInit;
         }
-        protected void FixLiftedUserDefinedBinaryOperators(EXPRBINOP expr, ref EXPR pp1, ref EXPR pp2)
+
+        private void FixLiftedUserDefinedBinaryOperators(EXPRBINOP expr, ref EXPR pp1, ref EXPR pp2)
         {
             // If we have lifted T1 op T2 to T1? op T2?, and we have an expression T1 op T2? or T1? op T2 then
             // we need to ensure that the unlifted actual arguments are promoted to their nullable CType.
@@ -1216,7 +1249,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             pp1 = new1;
             pp2 = new2;
         }
-        protected bool IsNullableValueType(CType pType)
+
+        private bool IsNullableValueType(CType pType)
         {
             if (pType.IsNullableType())
             {
@@ -1225,12 +1259,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             return false;
         }
-        protected bool IsNullableValueAccess(EXPR pExpr, EXPR pObject)
+
+        private bool IsNullableValueAccess(EXPR pExpr, EXPR pObject)
         {
             Debug.Assert(pExpr != null);
             return pExpr.isPROP() && (pExpr.asPROP().GetMemberGroup().GetOptionalObject() == pObject) && pObject.type.IsNullableType();
         }
-        protected bool IsDelegateConstructorCall(EXPR pExpr)
+
+        private bool IsDelegateConstructorCall(EXPR pExpr)
         {
             Debug.Assert(pExpr != null);
             if (!pExpr.isCALL())

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/UnaOpSig.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/UnaOpSig.cs
@@ -7,13 +7,14 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal partial class ExpressionBinder
+    internal sealed partial class ExpressionBinder
     {
-        protected class UnaOpSig
+        private class UnaOpSig
         {
-            public UnaOpSig()
+            protected UnaOpSig()
             {
             }
+
             public UnaOpSig(PredefinedType pt, UnaOpMask grfuom, int cuosSkip, PfnBindUnaOp pfn, UnaOpFuncKind fnkind)
             {
                 this.pt = pt;
@@ -29,7 +30,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             public UnaOpFuncKind fnkind;
         }
 
-        protected class UnaOpFullSig : UnaOpSig
+        private class UnaOpFullSig : UnaOpSig
         {
             private readonly LiftFlags _grflt;
             private readonly CType _type;


### PR DESCRIPTION
May allow `call` rather than `callvirt` in some cases for a slight boost, but main benefit is simplifies understanding to know a method isn't overridden.