### PR TITLE
Remove AccessControl OOM tests

### DIFF
--- a/src/System.Security.AccessControl/tests/DiscretionaryAcl/DiscretionaryAcl_Constructor1.cs
+++ b/src/System.Security.AccessControl/tests/DiscretionaryAcl/DiscretionaryAcl_Constructor1.cs
@@ -73,39 +73,11 @@ namespace System.Security.AccessControl.Tests
             return result;
         }
 
+
         [Fact]
-        public static void Constructor1_AdditionalTestCases()
+        public static void Constructor1_NegativeCapacity()
         {
-            DiscretionaryAcl discretionaryAcl = null;
-            bool isContainer = false;
-            bool isDS = false;
-            int capacity = 0;
-            //case 1, capacity = -1
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-            {
-                capacity = -1;
-                discretionaryAcl = new DiscretionaryAcl(isContainer, isDS, capacity);
-            });
-
-            //case 2, capacity = Int32.MaxValue/2
-            Assert.Throws<OutOfMemoryException>(() =>
-            {
-                isContainer = true;
-                isDS = false;
-                capacity = Int32.MaxValue / 2;
-                Assert.True(Constructor1(isContainer, isDS, capacity));
-
-            });
-
-            //case 3, capacity = Int32.MaxValue
-            Assert.Throws<OutOfMemoryException>(() =>
-            {
-                isContainer = true;
-                isDS = true;
-                capacity = Int32.MaxValue;
-                Assert.True(Constructor1(isContainer, isDS, capacity));
-
-            });
+            Assert.Throws<ArgumentOutOfRangeException>(() => new DiscretionaryAcl(false, false, -1));
         }
     }
 }

--- a/src/System.Security.AccessControl/tests/DiscretionaryAcl/DiscretionaryAcl_Constructor2.cs
+++ b/src/System.Security.AccessControl/tests/DiscretionaryAcl/DiscretionaryAcl_Constructor2.cs
@@ -70,40 +70,9 @@ namespace System.Security.AccessControl.Tests
         }
 
         [Fact]
-        public static void Constructor2_AdditionalTestCases()
+        public static void Constructor2_NegativeCapacity()
         {
-            DiscretionaryAcl discretionaryAcl = null;
-            bool isContainer = false;
-            bool isDS = false;
-            byte revision = 0;
-            int capacity = 0;
-
-            //case 1, capacity = -1
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-            {
-                capacity = -1;
-                discretionaryAcl = new DiscretionaryAcl(isContainer, isDS, revision, capacity);
-            });
-
-            //case 2, capacity = Int32.MaxValue/2
-            Assert.Throws<OutOfMemoryException>(() =>
-            {
-                isContainer = true;
-                isDS = false;
-                revision = 0;
-                capacity = Int32.MaxValue / 2;
-                Assert.True(Constructor2(isContainer, isDS, revision, capacity));
-            });
-
-            //case 3, capacity = Int32.MaxValue
-            Assert.Throws<OutOfMemoryException>(() =>
-            {
-                isContainer = true;
-                isDS = true;
-                revision = 255;
-                capacity = Int32.MaxValue;
-                Assert.True(Constructor2(isContainer, isDS, revision, capacity));
-            });
+            Assert.Throws<ArgumentOutOfRangeException>(() => new DiscretionaryAcl(false, false, 0, -1));
         }
     }
 }

--- a/src/System.Security.AccessControl/tests/RawAcl/RawAcl_Constructor.cs
+++ b/src/System.Security.AccessControl/tests/RawAcl/RawAcl_Constructor.cs
@@ -26,36 +26,9 @@ namespace System.Security.AccessControl.Tests
         }
 
         [Fact]
-        public static void AdditionalTestCases()
+        public static void NegativeCapacity()
         {
-            RawAcl rawAcl = null;
-            byte revision = 0;
-            int capacity = 0;
-
-            //case 1, capacity = -1
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-            {
-                revision = 0;
-                capacity = -1;
-                rawAcl = new RawAcl(revision, capacity);
-            });
-
-            //case 2, capacity = Int32.MaxValue/2 
-            Assert.Throws<OutOfMemoryException>(() =>
-            {
-                revision = 0;
-                capacity = Int32.MaxValue / 2;
-                TestConstructor(revision, capacity);
-            });
-
-            //case 3, capacity = Int32.MaxValue
-            Assert.Throws<OutOfMemoryException>(() =>
-            {
-                revision = 0;
-                capacity = Int32.MaxValue;
-                TestConstructor(revision, capacity);
-            });
+            Assert.Throws<ArgumentOutOfRangeException>(() => new RawAcl(0, -1));
         }
-
     }
 }

--- a/src/System.Security.AccessControl/tests/SystemAcl/SystemAcl_Constructor1.cs
+++ b/src/System.Security.AccessControl/tests/SystemAcl/SystemAcl_Constructor1.cs
@@ -23,37 +23,9 @@ namespace System.Security.AccessControl.Tests
         }
 
         [Fact]
-        public static void AdditionalTestCases()
+        public static void NegativeCapacity()
         {
-            SystemAcl systemAcl = null;
-            bool isContainer = false;
-            bool isDS = false;
-            int capacity = 0;
-
-            //case 1, capacity = -1
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-            {
-                capacity = -1;
-                systemAcl = new SystemAcl(isContainer, isDS, capacity);
-            });
-
-            //case 2, capacity = Int32.MaxValue/2
-            Assert.Throws<OutOfMemoryException>(() =>
-            {
-                isContainer = true;
-                isDS = false;
-                capacity = Int32.MaxValue / 2;
-                TestConstructor(isContainer, isDS, capacity);
-            });
-
-            //case 3, capacity = Int32.MaxValue
-            Assert.Throws<OutOfMemoryException>(() =>
-            {
-                isContainer = true;
-                isDS = true;
-                capacity = Int32.MaxValue;
-                TestConstructor(isContainer, isDS, capacity);
-            });
+            Assert.Throws<ArgumentOutOfRangeException>(() => new SystemAcl(false, false, -1));
         }
 
         [Theory]

--- a/src/System.Security.AccessControl/tests/SystemAcl/SystemAcl_Constructor2.cs
+++ b/src/System.Security.AccessControl/tests/SystemAcl/SystemAcl_Constructor2.cs
@@ -23,40 +23,9 @@ namespace System.Security.AccessControl.Tests
         }
 
         [Fact]
-        public static void AdditionalTestCases()
+        public static void NegativeCapacity()
         {
-            SystemAcl systemAcl = null;
-            bool isContainer = false;
-            bool isDS = false;
-            byte revision = 0;
-            int capacity = 0;
-
-            //case 1, capacity = -1
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-            {
-                capacity = -1;
-                systemAcl = new SystemAcl(isContainer, isDS, revision, capacity);
-            });
-
-            //case 2, capacity = Int32.MaxValue/2
-            Assert.Throws<OutOfMemoryException>(() =>
-            {
-                isContainer = true;
-                isDS = false;
-                revision = 0;
-                capacity = Int32.MaxValue / 2;
-                TestConstructor(isContainer, isDS, revision, capacity);
-            });
-
-            //case 3, capacity = Int32.MaxValue
-            Assert.Throws<OutOfMemoryException>(() =>
-            {
-                isContainer = true;
-                isDS = true;
-                revision = 255;
-                capacity = Int32.MaxValue;
-                TestConstructor(isContainer, isDS, revision, capacity);
-            });
+            Assert.Throws<ArgumentOutOfRangeException>(() => new SystemAcl(false, false, 0, -1));
         }
 
         [Theory]


### PR DESCRIPTION
An OOM from the constructor isn't something we should even be testing in this case, especially not in an innerloop test. Better just to remove it.

resolves https://github.com/dotnet/corefx/issues/15502