### PR TITLE
Remove test attributes only necessary for running on older CoreFX versions

### DIFF
--- a/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionary.KeysTests.cs
+++ b/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionary.KeysTests.cs
@@ -45,7 +45,6 @@ namespace System.Collections.Specialized.Tests
         protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NonZeroLowerBound(int count)
         {
@@ -64,7 +63,6 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_IndexEqualToArrayCount_ThrowsArgumentException(int count)
         {
@@ -77,7 +75,6 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NotEnoughSpaceInOffsettedArray_ThrowsArgumentException(int count)
         {
@@ -90,7 +87,6 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowsAnyArgumentException(int count)
         {

--- a/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionary.ValuesTests.cs
+++ b/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionary.ValuesTests.cs
@@ -45,7 +45,6 @@ namespace System.Collections.Specialized.Tests
         protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NonZeroLowerBound(int count)
         {
@@ -64,7 +63,6 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_IndexEqualToArrayCount_ThrowsArgumentException(int count)
         {
@@ -77,7 +75,6 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NotEnoughSpaceInOffsettedArray_ThrowsArgumentException(int count)
         {
@@ -90,7 +87,6 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowsAnyArgumentException(int count)
         {

--- a/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionaryTests.cs
+++ b/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionaryTests.cs
@@ -37,7 +37,6 @@ namespace System.Collections.Specialized.Tests
         protected override object CreateTValue(int seed) => CreateTKey(seed);
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NonZeroLowerBound(int count)
         {

--- a/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.IDictionary.Tests.cs
+++ b/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.IDictionary.Tests.cs
@@ -46,7 +46,6 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NonZeroLowerBound(int count)
         {

--- a/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.Keys.Tests.cs
+++ b/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.Keys.Tests.cs
@@ -47,7 +47,6 @@ namespace System.Collections.Specialized.Tests
         protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_IndexEqualToArrayCount_ThrowsArgumentException(int count)
         {
@@ -60,7 +59,6 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NotEnoughSpaceInOffsettedArray_ThrowsArgumentException(int count)
         {
@@ -73,7 +71,6 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowsAnyArgumentException(int count)
         {
@@ -90,7 +87,6 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NonZeroLowerBound(int count)
         {

--- a/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.Values.Tests.cs
+++ b/src/System.Collections.Specialized/tests/ListDictionary/ListDictionary.Values.Tests.cs
@@ -47,7 +47,6 @@ namespace System.Collections.Specialized.Tests
         protected override IEnumerable<ModifyEnumerable> ModifyEnumerables => new List<ModifyEnumerable>();
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_IndexEqualToArrayCount_ThrowsArgumentException(int count)
         {
@@ -60,7 +59,6 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NotEnoughSpaceInOffsettedArray_ThrowsArgumentException(int count)
         {
@@ -73,7 +71,6 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowsAnyArgumentException(int count)
         {
@@ -90,7 +87,6 @@ namespace System.Collections.Specialized.Tests
         }
 
         [Theory]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0, "dotnet/corefx#11566")]
         [MemberData(nameof(ValidCollectionSizes))]
         public override void ICollection_NonGeneric_CopyTo_NonZeroLowerBound(int count)
         {

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1627,7 +1627,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Join_ObjectArray_TestData))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.NetcoreUwp | TargetFrameworkMonikers.Netcoreapp1_0)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework | TargetFrameworkMonikers.NetcoreUwp)]
         public static void Join_ObjectArray(string separator, object[] values, string expected)
         {
             Assert.Equal(expected, string.Join(separator, values));


### PR DESCRIPTION
Remove all instances of:
```C#
[SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_0]
```
Contributes to #15555

cc @danmosemsft 