### PR TITLE
Update Code of Conduct link per latest guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Want to chat with other members of the CoreFX community?
 
 [.NET Foundation forums]: http://forums.dotnetfoundation.org/
 
-This project has adopted the code of conduct defined by the [Contributor Covenant](http://contributor-covenant.org/)
+This project has adopted the code of conduct defined by the Contributor Covenant
 to clarify expected behavior in our community. For more information, see the [.NET Foundation Code of Conduct](http://www.dotnetfoundation.org/code-of-conduct).
 
 ### Reporting security issues and security bugs


### PR DESCRIPTION
People were getting confused about which code of conduct link to click
on and not realising there was a contact email address provided to
report concerns. Updating README as per latest foundation guidance
here https://github.com/dotnet/home/blob/master/guidance/readme-guide.md