### PR TITLE
Replace [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_1)]

### DIFF
--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -1650,7 +1650,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Join_ObjectArray_TestData))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp1_1)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp)]
         public static void Join_ObjectArray_WithNullIssue(string separator, object[] values, string expected)
         {
             string enumerableExpected = expected;


### PR DESCRIPTION
With versionless [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp)]

Closes #15555