### PR TITLE
Replace GetTypeCode extension with call to Type.GetTypeCode() 

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
@@ -881,7 +881,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                     underlyingType = underlyingType.getAggregate().GetUnderlyingType();
                 }
 
-                switch (underlyingType.AssociatedSystemType.GetTypeCode())
+                switch (Type.GetTypeCode(underlyingType.AssociatedSystemType))
                 {
                     case TypeCode.Boolean:
                         objval = val.boolVal;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinderExtensions.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinderExtensions.cs
@@ -22,46 +22,6 @@ namespace Microsoft.CSharp.RuntimeBinder
             return type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
         }
 
-        public static TypeCode GetTypeCode(this Type type)
-        {
-            if (type == null)
-                return TypeCode.Empty;
-            else if (type == typeof(bool))
-                return TypeCode.Boolean;
-            else if (type == typeof(char))
-                return TypeCode.Char;
-            else if (type == typeof(sbyte))
-                return TypeCode.SByte;
-            else if (type == typeof(byte))
-                return TypeCode.Byte;
-            else if (type == typeof(short))
-                return TypeCode.Int16;
-            else if (type == typeof(ushort))
-                return TypeCode.UInt16;
-            else if (type == typeof(int))
-                return TypeCode.Int32;
-            else if (type == typeof(uint))
-                return TypeCode.UInt32;
-            else if (type == typeof(long))
-                return TypeCode.Int64;
-            else if (type == typeof(ulong))
-                return TypeCode.UInt64;
-            else if (type == typeof(float))
-                return TypeCode.Single;
-            else if (type == typeof(double))
-                return TypeCode.Double;
-            else if (type == typeof(decimal))
-                return TypeCode.Decimal;
-            else if (type == typeof(DateTime))
-                return TypeCode.DateTime;
-            else if (type == typeof(string))
-                return TypeCode.String;
-            else if (type.GetTypeInfo().IsEnum)
-                return GetTypeCode(Enum.GetUnderlyingType(type));
-            else
-                return TypeCode.Object;
-        }
-
         // This method is intended as a means to detect when MemberInfos are the same,
         // modulo the fact that they can appear to have different but equivalent local
         // No-PIA types. It is by the symbol table to determine whether

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ConstVal.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ConstVal.cs
@@ -167,8 +167,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             if (o == null)
                 return true;
 
-            TypeCode code = o.GetType().GetTypeCode();
-            switch (code)
+            switch (Type.GetTypeCode(o.GetType()))
             {
                 case TypeCode.Boolean:
                     return default(bool).Equals(o);


### PR DESCRIPTION
Wasn't available once. Now it is, and it caches, too.