### PR TITLE
macOS: fix interop to proc_pid_rusage

### DIFF
--- a/src/Common/src/Interop/OSX/Interop.libproc.cs
+++ b/src/Common/src/Interop/OSX/Interop.libproc.cs
@@ -26,7 +26,7 @@ internal static partial class Interop
         private static int PROC_PIDLISTTHREADS_SIZE = (Marshal.SizeOf<uint>() * 2);
 
         // Constants from sys\resource.h
-        private const int RUSAGE_SELF = 0;
+        private const int RUSAGE_INFO_V3 = 3;
 
         // Defines from proc_info.h
         internal enum ThreadRunState
@@ -449,18 +449,14 @@ internal static partial class Interop
         /// Gets the rusage information for the process identified by the PID
         /// </summary>
         /// <param name="pid">The process to retrieve the rusage for</param>
-        /// <param name="flavor">Should be RUSAGE_SELF to specify getting the info for the specified process</param>
-        /// <param name="rusage_info_t">A buffer to be filled with rusage_info data</param>
+        /// <param name="flavor">Specifies the type of struct that is passed in to <paramref>buffer</paramref>. Should be RUSAGE_INFO_V3 to specify a rusage_info_v3 struct.</param>
+        /// <param name="buffer">A buffer to be filled with rusage_info data</param>
         /// <returns>Returns 0 on success; on fail, -1 and errno is set with the error code</returns>
-        /// <remarks>
-        /// We need to use IntPtr here for the buffer since the function signature uses 
-        /// void* and not a strong type even though it returns a rusage_info struct
-        /// </remarks>
         [DllImport(Interop.Libraries.libproc, SetLastError = true)]
         private static extern unsafe int proc_pid_rusage(
             int pid,
             int flavor,
-            rusage_info_v3* rusage_info_t);
+            rusage_info_v3* buffer);
 
         /// <summary>
         /// Gets the rusage information for the process identified by the PID
@@ -480,7 +476,7 @@ internal static partial class Interop
             rusage_info_v3 info = new rusage_info_v3();
 
             // Get the PIDs rusage info
-            int result = proc_pid_rusage(pid, RUSAGE_SELF, &info);
+            int result = proc_pid_rusage(pid, RUSAGE_INFO_V3, &info);
             if (result < 0)
             {
                 throw new InvalidOperationException(SR.RUsageFailure);


### PR DESCRIPTION
It appears that `proc_pid_rusage` is supposed to be used as follows:

```
rusage_info_current info;
int result = proc_pid_rusage(pid, RUSAGE_INFO_CURRENT, &info);
assert(result >= 0); // or do error checking
// use `info`.
```

The preprocessor macros in `<sys/resource.h>` would therefore transform it into one of the following, depending on which SDK the code is compiled against:

```
int result;

struct rusage_info_v0 info0;
result = proc_pid_rusage(pid, RUSAGE_INFO_V0, &info0);
assert(result >= 0); // or do error checking
// use `info0`.


struct rusage_info_v1 info1;
result = proc_pid_rusage(pid, RUSAGE_INFO_V1, &info1);
assert(result >= 0); // or do error checking
// use `info1`.


struct rusage_info_v2 info2;
result = proc_pid_rusage(pid, RUSAGE_INFO_V2, &info2);
assert(result >= 2); // or do error checking
// use `info0`.


struct rusage_info_v3 info3;
result = proc_pid_rusage(pid, RUSAGE_INFO_V3, &info3);
assert(result >= 0); // or do error checking
// use `info3`.
```

Since we're using v3 in corefx, it would be better to use `RUSAGE_INFO_V3` explicitly, rather than using the incorrect constant `RUSAGE_SELF` which gets interpreted as `RUSAGE_INFO_V0` for an `rusage_info_v3` struct.