### PR TITLE
Improve BinderHelper.Bind

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             BindingRestrictions restrictions = BindingRestrictions.Empty;
             ICSharpInvokeOrInvokeMemberBinder callPayload = action as ICSharpInvokeOrInvokeMemberBinder;
             ParameterExpression tempForIncrement = null;
-            IEnumerator<CSharpArgumentInfo> arginfosEnum = arginfos == null ? null : arginfos.GetEnumerator();
+            IEnumerator<CSharpArgumentInfo> arginfosEnum = (arginfos ?? Array.Empty<CSharpArgumentInfo>()).GetEnumerator();
 
             for (int index = 0; index < args.Length; ++index)
             {
@@ -42,9 +42,8 @@ namespace Microsoft.CSharp.RuntimeBinder
                     Debug.Assert(false, "The runtime binder is being asked to bind a metaobject without a value");
                     throw Error.InternalCompilerError();
                 }
-                CSharpArgumentInfo info = null;
-                if (arginfosEnum != null && arginfosEnum.MoveNext())
-                    info = arginfosEnum.Current;
+
+                CSharpArgumentInfo info = arginfosEnum.MoveNext() ? arginfosEnum.Current : null;
 
                 if (index == 0 && IsIncrementOrDecrementActionOnLocal(action))
                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
@@ -15,22 +15,25 @@ namespace Microsoft.CSharp.RuntimeBinder
 {
     internal static class BinderHelper
     {
+        private static MethodInfo s_DoubleIsNaN;
+        private static MethodInfo s_SingleIsNaN;
+
         internal static DynamicMetaObject Bind(
                 DynamicMetaObjectBinder action,
                 RuntimeBinder binder,
-                IEnumerable<DynamicMetaObject> args,
+                DynamicMetaObject[] args,
                 IEnumerable<CSharpArgumentInfo> arginfos,
                 DynamicMetaObject onBindingError)
         {
-            List<Expression> parameters = new List<Expression>();
+            Expression[] parameters = new Expression[args.Length];
             BindingRestrictions restrictions = BindingRestrictions.Empty;
             ICSharpInvokeOrInvokeMemberBinder callPayload = action as ICSharpInvokeOrInvokeMemberBinder;
             ParameterExpression tempForIncrement = null;
             IEnumerator<CSharpArgumentInfo> arginfosEnum = arginfos == null ? null : arginfos.GetEnumerator();
 
-            int index = 0;
-            foreach (DynamicMetaObject o in args)
+            for (int index = 0; index < args.Length; ++index)
             {
+                DynamicMetaObject o = args[index];
                 // Our contract with the DLR is such that we will not enter a bind unless we have
                 // values for the meta-objects involved.
 
@@ -50,12 +53,13 @@ namespace Microsoft.CSharp.RuntimeBinder
                     // We need to do this because for value types, the object will come 
                     // in boxed, and we'd need to unbox it to get the original type in order
                     // to increment. The only way to do that is to create a new temporary.
-                    tempForIncrement = Expression.Variable(o.Value != null ? o.Value.GetType() : typeof(object), "t0");
-                    parameters.Add(tempForIncrement);
+                    object value = o.Value;
+                    tempForIncrement = Expression.Variable(value != null ? value.GetType() : typeof(object), "t0");
+                    parameters[0] = tempForIncrement;
                 }
                 else
                 {
-                    parameters.Add(o.Expression);
+                    parameters[index] = o.Expression;
                 }
 
                 BindingRestrictions r = DeduceArgumentRestriction(index, callPayload, o, info);
@@ -66,11 +70,17 @@ namespace Microsoft.CSharp.RuntimeBinder
                 // the constant.
                 if (info != null && info.LiteralConstant)
                 {
-                    if ((o.Value is float && float.IsNaN((float)o.Value))
-                      || o.Value is double && double.IsNaN((double)o.Value))
+                    if (o.Value is double && double.IsNaN((double)o.Value))
                     {
-                        // We cannot create an equality restriction for NaN, because equality is implemented
-                        // in such a way that NaN != NaN and the rule we make would be unsatisfiable.
+                        MethodInfo isNaN = s_DoubleIsNaN ?? (s_DoubleIsNaN = typeof(double).GetMethod("IsNaN"));
+                        Expression e = Expression.Call(null, isNaN, o.Expression);
+                        restrictions = restrictions.Merge(BindingRestrictions.GetExpressionRestriction(e));
+                    }
+                    else if (o.Value is float && float.IsNaN((float)o.Value))
+                    {
+                        MethodInfo isNaN = s_SingleIsNaN ?? (s_SingleIsNaN = typeof(float).GetMethod("IsNaN"));
+                        Expression e = Expression.Call(null, isNaN, o.Expression);
+                        restrictions = restrictions.Merge(BindingRestrictions.GetExpressionRestriction(e));
                     }
                     else
                     {
@@ -79,15 +89,13 @@ namespace Microsoft.CSharp.RuntimeBinder
                         restrictions = restrictions.Merge(r);
                     }
                 }
-
-                ++index;
             }
 
             // Get the bound expression.
             try
             {
                 DynamicMetaObject deferredBinding;
-                Expression expression = binder.Bind(action, parameters, args.ToArray(), out deferredBinding);
+                Expression expression = binder.Bind(action, parameters, args, out deferredBinding);
 
                 if (deferredBinding != null)
                 {
@@ -106,21 +114,13 @@ namespace Microsoft.CSharp.RuntimeBinder
                     // o = temp;
                     // return o;
 
-                    DynamicMetaObject arg0 = Enumerable.First(args);
+                    DynamicMetaObject arg0 = args[0];
 
-                    Expression assignTemp = Expression.Assign(
-                        tempForIncrement,
-                        Expression.Convert(arg0.Expression, arg0.Value.GetType()));
-                    Expression assignResult = Expression.Assign(
-                        arg0.Expression,
-                        Expression.Convert(tempForIncrement, arg0.Expression.Type));
-                    List<Expression> expressions = new List<Expression>();
-
-                    expressions.Add(assignTemp);
-                    expressions.Add(expression);
-                    expressions.Add(assignResult);
-
-                    expression = Expression.Block(new ParameterExpression[] { tempForIncrement }, expressions);
+                    expression = Expression.Block(
+                        new[] {tempForIncrement},
+                        Expression.Assign(tempForIncrement, Expression.Convert(arg0.Expression, arg0.Value.GetType())),
+                        expression,
+                        Expression.Assign(arg0.Expression, Expression.Convert(tempForIncrement, arg0.Expression.Type)));
                 }
 
                 expression = ConvertResult(expression, action);
@@ -140,7 +140,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                             typeof(RuntimeBinderException).GetConstructor(new Type[] { typeof(string) }),
                             Expression.Constant(e.Message)
                         ),
-                        GetTypeForErrorMetaObject(action, args.FirstOrDefault())
+                        GetTypeForErrorMetaObject(action, args.Length == 0 ? null : args[0])
                     ),
                     restrictions
                 );
@@ -338,32 +338,31 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         /////////////////////////////////////////////////////////////////////////////////
 
-        internal static IEnumerable<T> Cons<T>(T sourceHead, IEnumerable<T> sourceTail)
+        internal static T[] Cons<T>(T sourceHead, T[] sourceTail)
         {
-            yield return sourceHead;
-
-            if (sourceTail != null)
+            if (sourceTail?.Length != 0)
             {
-                foreach (T x in sourceTail)
-                {
-                    yield return x;
-                }
+                T[] array = new T[sourceTail.Length + 1];
+                array[0] = sourceHead;
+                sourceTail.CopyTo(array, 1);
+                return array;
             }
+
+            return new[] { sourceHead };
         }
 
-        internal static IEnumerable<T> Cons<T>(T sourceHead, IEnumerable<T> sourceMiddle, T sourceLast)
+        internal static T[] Cons<T>(T sourceHead, T[] sourceMiddle, T sourceLast)
         {
-            yield return sourceHead;
-
-            if (sourceMiddle != null)
+            if (sourceMiddle?.Length != 0)
             {
-                foreach (T x in sourceMiddle)
-                {
-                    yield return x;
-                }
+                T[] array = new T[sourceMiddle.Length + 2];
+                array[0] = sourceHead;
+                array[array.Length - 1] = sourceLast;
+                sourceMiddle.CopyTo(array, 1);
+                return array;
             }
 
-            yield return sourceLast;
+            return new[] {sourceHead, sourceLast};
         }
 
         /////////////////////////////////////////////////////////////////////////////////

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpBinaryOperationBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpBinaryOperationBinder.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CSharp.RuntimeBinder
         /// <returns>The <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public sealed override DynamicMetaObject FallbackBinaryOperation(DynamicMetaObject target, DynamicMetaObject arg, DynamicMetaObject errorSuggestion)
         {
-            return BinderHelper.Bind(this, _binder, BinderHelper.Cons(target, null, arg), _argumentInfo, errorSuggestion);
+            return BinderHelper.Bind(this, _binder, new [] {target, arg}, _argumentInfo, errorSuggestion);
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpUnaryOperationBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpUnaryOperationBinder.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CSharp.RuntimeBinder
         /// <returns>The <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public sealed override DynamicMetaObject FallbackUnaryOperation(DynamicMetaObject target, DynamicMetaObject errorSuggestion)
         {
-            return BinderHelper.Bind(this, _binder, BinderHelper.Cons(target, null), _argumentInfo, errorSuggestion);
+            return BinderHelper.Bind(this, _binder, new[] {target}, _argumentInfo, errorSuggestion);
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Dynamic/BinaryOperationTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/BinaryOperationTests.cs
@@ -700,6 +700,26 @@ namespace System.Dynamic.Tests
             Assert.Throws<RuntimeBinderException>(() => dX && dY);
         }
 
+        [Fact]
+        public void LiteralDoubleNaN()
+        {
+            dynamic d = double.NaN;
+            Assert.False(d == double.NaN);
+            Assert.True(d != double.NaN);
+            d = 3.0;
+            Assert.True(double.IsNaN(d + double.NaN));
+        }
+
+        [Fact]
+        public void LiteralSingleNaN()
+        {
+            dynamic d = float.NaN;
+            Assert.False(d == float.NaN);
+            Assert.True(d != float.NaN);
+            d = 3.0F;
+            Assert.True(float.IsNaN(d + float.NaN));
+        }
+
         [Theory]
         [ClassData(typeof(CompilationTypes))]
         public void BinaryCallSiteBinder_DynamicExpression(bool useInterpreter)


### PR DESCRIPTION
`args` will be turned into an array and its sources all have determinable sizes, so create an array to pass in immediately, avoiding repeated enumerator allocation and allowing array access.

An index is incremented with each pass through `args`, so now it's an array just use `for(;;)` access with it as the index.

`parameters` will always end up as the same size as `args`, so preallocate an array rather than growing a `List<T>`.

Use direct indexing rather than Linq's `First` and `FirstOrDefault`.

Allow for binding restrictions with literal `NaN` (we can't use `==` as the previous comment said, but we can call `IsNaN`).

Create block for increment/decrement writeback directly, rather than growing a `List<T>`. Inline the expressions (IMO clearer resulting expression for those who are often reading code with explicit expression creation).