### PR TITLE
Null propagation and merging of null-checks in Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
@@ -11,129 +11,350 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
     {
         public static string GetMessage(ErrorCode code)
         {
-            string codeStr = null;
+            string codeStr;
             switch (code)
             {
-                case ErrorCode.ERR_BadBinaryOps: codeStr = SR.BadBinaryOps; break;
-                case ErrorCode.ERR_IntDivByZero: codeStr = SR.IntDivByZero; break;
-                case ErrorCode.ERR_BadIndexLHS: codeStr = SR.BadIndexLHS; break;
-                case ErrorCode.ERR_BadIndexCount: codeStr = SR.BadIndexCount; break;
-                case ErrorCode.ERR_BadUnaryOp: codeStr = SR.BadUnaryOp; break;
-                case ErrorCode.ERR_NoImplicitConv: codeStr = SR.NoImplicitConv; break;
-                case ErrorCode.ERR_NoExplicitConv: codeStr = SR.NoExplicitConv; break;
-                case ErrorCode.ERR_ConstOutOfRange: codeStr = SR.ConstOutOfRange; break;
-                case ErrorCode.ERR_AmbigBinaryOps: codeStr = SR.AmbigBinaryOps; break;
-                case ErrorCode.ERR_AmbigUnaryOp: codeStr = SR.AmbigUnaryOp; break;
-                case ErrorCode.ERR_ValueCantBeNull: codeStr = SR.ValueCantBeNull; break;
-                case ErrorCode.ERR_WrongNestedThis: codeStr = SR.WrongNestedThis; break;
-                case ErrorCode.ERR_NoSuchMember: codeStr = SR.NoSuchMember; break;
-                case ErrorCode.ERR_ObjectRequired: codeStr = SR.ObjectRequired; break;
-                case ErrorCode.ERR_AmbigCall: codeStr = SR.AmbigCall; break;
-                case ErrorCode.ERR_BadAccess: codeStr = SR.BadAccess; break;
-                case ErrorCode.ERR_MethDelegateMismatch: codeStr = SR.MethDelegateMismatch; break;
-                case ErrorCode.ERR_AssgLvalueExpected: codeStr = SR.AssgLvalueExpected; break;
-                case ErrorCode.ERR_NoConstructors: codeStr = SR.NoConstructors; break;
-                case ErrorCode.ERR_BadDelegateConstructor: codeStr = SR.BadDelegateConstructor; break;
-                case ErrorCode.ERR_PropertyLacksGet: codeStr = SR.PropertyLacksGet; break;
-                case ErrorCode.ERR_ObjectProhibited: codeStr = SR.ObjectProhibited; break;
-                case ErrorCode.ERR_AssgReadonly: codeStr = SR.AssgReadonly; break;
-                case ErrorCode.ERR_RefReadonly: codeStr = SR.RefReadonly; break;
-                case ErrorCode.ERR_AssgReadonlyStatic: codeStr = SR.AssgReadonlyStatic; break;
-                case ErrorCode.ERR_RefReadonlyStatic: codeStr = SR.RefReadonlyStatic; break;
-                case ErrorCode.ERR_AssgReadonlyProp: codeStr = SR.AssgReadonlyProp; break;
-                case ErrorCode.ERR_AbstractBaseCall: codeStr = SR.AbstractBaseCall; break;
-                case ErrorCode.ERR_RefProperty: codeStr = SR.RefProperty; break;
-                case ErrorCode.ERR_ManagedAddr: codeStr = SR.ManagedAddr; break;
-                case ErrorCode.ERR_FixedNotNeeded: codeStr = SR.FixedNotNeeded; break;
-                case ErrorCode.ERR_UnsafeNeeded: codeStr = SR.UnsafeNeeded; break;
-                case ErrorCode.ERR_BadBoolOp: codeStr = SR.BadBoolOp; break;
-                case ErrorCode.ERR_MustHaveOpTF: codeStr = SR.MustHaveOpTF; break;
-                case ErrorCode.ERR_CheckedOverflow: codeStr = SR.CheckedOverflow; break;
-                case ErrorCode.ERR_ConstOutOfRangeChecked: codeStr = SR.ConstOutOfRangeChecked; break;
-                case ErrorCode.ERR_AmbigMember: codeStr = SR.AmbigMember; break;
-                case ErrorCode.ERR_SizeofUnsafe: codeStr = SR.SizeofUnsafe; break;
-                case ErrorCode.ERR_FieldInitRefNonstatic: codeStr = SR.FieldInitRefNonstatic; break;
-                case ErrorCode.ERR_CallingFinalizeDepracated: codeStr = SR.CallingFinalizeDepracated; break;
-                case ErrorCode.ERR_CallingBaseFinalizeDeprecated: codeStr = SR.CallingBaseFinalizeDeprecated; break;
-                case ErrorCode.ERR_BadCastInFixed: codeStr = SR.BadCastInFixed; break;
-                case ErrorCode.ERR_NoImplicitConvCast: codeStr = SR.NoImplicitConvCast; break;
-                case ErrorCode.ERR_InaccessibleGetter: codeStr = SR.InaccessibleGetter; break;
-                case ErrorCode.ERR_InaccessibleSetter: codeStr = SR.InaccessibleSetter; break;
-                case ErrorCode.ERR_BadArity: codeStr = SR.BadArity; break;
-                case ErrorCode.ERR_BadTypeArgument: codeStr = SR.BadTypeArgument; break;
-                case ErrorCode.ERR_TypeArgsNotAllowed: codeStr = SR.TypeArgsNotAllowed; break;
-                case ErrorCode.ERR_HasNoTypeVars: codeStr = SR.HasNoTypeVars; break;
-                case ErrorCode.ERR_NewConstraintNotSatisfied: codeStr = SR.NewConstraintNotSatisfied; break;
-                case ErrorCode.ERR_GenericConstraintNotSatisfiedRefType: codeStr = SR.GenericConstraintNotSatisfiedRefType; break;
-                case ErrorCode.ERR_GenericConstraintNotSatisfiedNullableEnum: codeStr = SR.GenericConstraintNotSatisfiedNullableEnum; break;
-                case ErrorCode.ERR_GenericConstraintNotSatisfiedNullableInterface: codeStr = SR.GenericConstraintNotSatisfiedNullableInterface; break;
-                case ErrorCode.ERR_GenericConstraintNotSatisfiedTyVar: codeStr = SR.GenericConstraintNotSatisfiedTyVar; break;
-                case ErrorCode.ERR_GenericConstraintNotSatisfiedValType: codeStr = SR.GenericConstraintNotSatisfiedValType; break;
-                case ErrorCode.ERR_TypeVarCantBeNull: codeStr = SR.TypeVarCantBeNull; break;
-                case ErrorCode.ERR_BadRetType: codeStr = SR.BadRetType; break;
-                case ErrorCode.ERR_CantInferMethTypeArgs: codeStr = SR.CantInferMethTypeArgs; break;
-                case ErrorCode.ERR_MethGrpToNonDel: codeStr = SR.MethGrpToNonDel; break;
-                case ErrorCode.ERR_RefConstraintNotSatisfied: codeStr = SR.RefConstraintNotSatisfied; break;
-                case ErrorCode.ERR_ValConstraintNotSatisfied: codeStr = SR.ValConstraintNotSatisfied; break;
-                case ErrorCode.ERR_CircularConstraint: codeStr = SR.CircularConstraint; break;
-                case ErrorCode.ERR_BaseConstraintConflict: codeStr = SR.BaseConstraintConflict; break;
-                case ErrorCode.ERR_ConWithValCon: codeStr = SR.ConWithValCon; break;
-                case ErrorCode.ERR_AmbigUDConv: codeStr = SR.AmbigUDConv; break;
-                case ErrorCode.ERR_PredefinedTypeNotFound: codeStr = SR.PredefinedTypeNotFound; break;
-                case ErrorCode.ERR_PredefinedTypeBadType: codeStr = SR.PredefinedTypeBadType; break;
-                case ErrorCode.ERR_BindToBogus: codeStr = SR.BindToBogus; break;
-                case ErrorCode.ERR_CantCallSpecialMethod: codeStr = SR.CantCallSpecialMethod; break;
-                case ErrorCode.ERR_BogusType: codeStr = SR.BogusType; break;
-                case ErrorCode.ERR_MissingPredefinedMember: codeStr = SR.MissingPredefinedMember; break;
-                case ErrorCode.ERR_LiteralDoubleCast: codeStr = SR.LiteralDoubleCast; break;
-                case ErrorCode.ERR_UnifyingInterfaceInstantiations: codeStr = SR.UnifyingInterfaceInstantiations; break;
-                case ErrorCode.ERR_ConvertToStaticClass: codeStr = SR.ConvertToStaticClass; break;
-                case ErrorCode.ERR_GenericArgIsStaticClass: codeStr = SR.GenericArgIsStaticClass; break;
-                case ErrorCode.ERR_PartialMethodToDelegate: codeStr = SR.PartialMethodToDelegate; break;
-                case ErrorCode.ERR_IncrementLvalueExpected: codeStr = SR.IncrementLvalueExpected; break;
-                case ErrorCode.ERR_NoSuchMemberOrExtension: codeStr = SR.NoSuchMemberOrExtension; break;
-                case ErrorCode.ERR_ValueTypeExtDelegate: codeStr = SR.ValueTypeExtDelegate; break;
-                case ErrorCode.ERR_BadArgCount: codeStr = SR.BadArgCount; break;
-                case ErrorCode.ERR_BadArgTypes: codeStr = SR.BadArgTypes; break;
-                case ErrorCode.ERR_BadArgType: codeStr = SR.BadArgType; break;
-                case ErrorCode.ERR_RefLvalueExpected: codeStr = SR.RefLvalueExpected; break;
-                case ErrorCode.ERR_BadProtectedAccess: codeStr = SR.BadProtectedAccess; break;
-                case ErrorCode.ERR_BindToBogusProp2: codeStr = SR.BindToBogusProp2; break;
-                case ErrorCode.ERR_BindToBogusProp1: codeStr = SR.BindToBogusProp1; break;
-                case ErrorCode.ERR_BadDelArgCount: codeStr = SR.BadDelArgCount; break;
-                case ErrorCode.ERR_BadDelArgTypes: codeStr = SR.BadDelArgTypes; break;
-                case ErrorCode.ERR_AssgReadonlyLocal: codeStr = SR.AssgReadonlyLocal; break;
-                case ErrorCode.ERR_RefReadonlyLocal: codeStr = SR.RefReadonlyLocal; break;
-                case ErrorCode.ERR_ReturnNotLValue: codeStr = SR.ReturnNotLValue; break;
-                case ErrorCode.ERR_BadArgExtraRef: codeStr = SR.BadArgExtraRef; break;
-                case ErrorCode.ERR_BadArgRef: codeStr = SR.BadArgRef; break;
-                case ErrorCode.ERR_AssgReadonly2: codeStr = SR.AssgReadonly2; break;
-                case ErrorCode.ERR_RefReadonly2: codeStr = SR.RefReadonly2; break;
-                case ErrorCode.ERR_AssgReadonlyStatic2: codeStr = SR.AssgReadonlyStatic2; break;
-                case ErrorCode.ERR_RefReadonlyStatic2: codeStr = SR.RefReadonlyStatic2; break;
-                case ErrorCode.ERR_AssgReadonlyLocalCause: codeStr = SR.AssgReadonlyLocalCause; break;
-                case ErrorCode.ERR_RefReadonlyLocalCause: codeStr = SR.RefReadonlyLocalCause; break;
-                case ErrorCode.ERR_ThisStructNotInAnonMeth: codeStr = SR.ThisStructNotInAnonMeth; break;
-                case ErrorCode.ERR_DelegateOnNullable: codeStr = SR.DelegateOnNullable; break;
-                case ErrorCode.ERR_BadCtorArgCount: codeStr = SR.BadCtorArgCount; break;
-                case ErrorCode.ERR_BadExtensionArgTypes: codeStr = SR.BadExtensionArgTypes; break;
-                case ErrorCode.ERR_BadInstanceArgType: codeStr = SR.BadInstanceArgType; break;
-                case ErrorCode.ERR_BadArgTypesForCollectionAdd: codeStr = SR.BadArgTypesForCollectionAdd; break;
-                case ErrorCode.ERR_InitializerAddHasParamModifiers: codeStr = SR.InitializerAddHasParamModifiers; break;
-                case ErrorCode.ERR_NonInvocableMemberCalled: codeStr = SR.NonInvocableMemberCalled; break;
-                case ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument: codeStr = SR.NamedArgumentSpecificationBeforeFixedArgument; break;
-                case ErrorCode.ERR_BadNamedArgument: codeStr = SR.BadNamedArgument; break;
-                case ErrorCode.ERR_BadNamedArgumentForDelegateInvoke: codeStr = SR.BadNamedArgumentForDelegateInvoke; break;
-                case ErrorCode.ERR_DuplicateNamedArgument: codeStr = SR.DuplicateNamedArgument; break;
-                case ErrorCode.ERR_NamedArgumentUsedInPositional: codeStr = SR.NamedArgumentUsedInPositional; break;
-                default:
-                    Debug.Assert(false, "Missing resources for the error " + code.ToString()); // means missing resources match the code entry
+                case ErrorCode.ERR_BadBinaryOps:
+                    codeStr = SR.BadBinaryOps;
                     break;
-            }
-
-            if (codeStr == null)
-            {
-                return null;
+                case ErrorCode.ERR_IntDivByZero:
+                    codeStr = SR.IntDivByZero;
+                    break;
+                case ErrorCode.ERR_BadIndexLHS:
+                    codeStr = SR.BadIndexLHS;
+                    break;
+                case ErrorCode.ERR_BadIndexCount:
+                    codeStr = SR.BadIndexCount;
+                    break;
+                case ErrorCode.ERR_BadUnaryOp:
+                    codeStr = SR.BadUnaryOp;
+                    break;
+                case ErrorCode.ERR_NoImplicitConv:
+                    codeStr = SR.NoImplicitConv;
+                    break;
+                case ErrorCode.ERR_NoExplicitConv:
+                    codeStr = SR.NoExplicitConv;
+                    break;
+                case ErrorCode.ERR_ConstOutOfRange:
+                    codeStr = SR.ConstOutOfRange;
+                    break;
+                case ErrorCode.ERR_AmbigBinaryOps:
+                    codeStr = SR.AmbigBinaryOps;
+                    break;
+                case ErrorCode.ERR_AmbigUnaryOp:
+                    codeStr = SR.AmbigUnaryOp;
+                    break;
+                case ErrorCode.ERR_ValueCantBeNull:
+                    codeStr = SR.ValueCantBeNull;
+                    break;
+                case ErrorCode.ERR_WrongNestedThis:
+                    codeStr = SR.WrongNestedThis;
+                    break;
+                case ErrorCode.ERR_NoSuchMember:
+                    codeStr = SR.NoSuchMember;
+                    break;
+                case ErrorCode.ERR_ObjectRequired:
+                    codeStr = SR.ObjectRequired;
+                    break;
+                case ErrorCode.ERR_AmbigCall:
+                    codeStr = SR.AmbigCall;
+                    break;
+                case ErrorCode.ERR_BadAccess:
+                    codeStr = SR.BadAccess;
+                    break;
+                case ErrorCode.ERR_MethDelegateMismatch:
+                    codeStr = SR.MethDelegateMismatch;
+                    break;
+                case ErrorCode.ERR_AssgLvalueExpected:
+                    codeStr = SR.AssgLvalueExpected;
+                    break;
+                case ErrorCode.ERR_NoConstructors:
+                    codeStr = SR.NoConstructors;
+                    break;
+                case ErrorCode.ERR_BadDelegateConstructor:
+                    codeStr = SR.BadDelegateConstructor;
+                    break;
+                case ErrorCode.ERR_PropertyLacksGet:
+                    codeStr = SR.PropertyLacksGet;
+                    break;
+                case ErrorCode.ERR_ObjectProhibited:
+                    codeStr = SR.ObjectProhibited;
+                    break;
+                case ErrorCode.ERR_AssgReadonly:
+                    codeStr = SR.AssgReadonly;
+                    break;
+                case ErrorCode.ERR_RefReadonly:
+                    codeStr = SR.RefReadonly;
+                    break;
+                case ErrorCode.ERR_AssgReadonlyStatic:
+                    codeStr = SR.AssgReadonlyStatic;
+                    break;
+                case ErrorCode.ERR_RefReadonlyStatic:
+                    codeStr = SR.RefReadonlyStatic;
+                    break;
+                case ErrorCode.ERR_AssgReadonlyProp:
+                    codeStr = SR.AssgReadonlyProp;
+                    break;
+                case ErrorCode.ERR_AbstractBaseCall:
+                    codeStr = SR.AbstractBaseCall;
+                    break;
+                case ErrorCode.ERR_RefProperty:
+                    codeStr = SR.RefProperty;
+                    break;
+                case ErrorCode.ERR_ManagedAddr:
+                    codeStr = SR.ManagedAddr;
+                    break;
+                case ErrorCode.ERR_FixedNotNeeded:
+                    codeStr = SR.FixedNotNeeded;
+                    break;
+                case ErrorCode.ERR_UnsafeNeeded:
+                    codeStr = SR.UnsafeNeeded;
+                    break;
+                case ErrorCode.ERR_BadBoolOp:
+                    codeStr = SR.BadBoolOp;
+                    break;
+                case ErrorCode.ERR_MustHaveOpTF:
+                    codeStr = SR.MustHaveOpTF;
+                    break;
+                case ErrorCode.ERR_CheckedOverflow:
+                    codeStr = SR.CheckedOverflow;
+                    break;
+                case ErrorCode.ERR_ConstOutOfRangeChecked:
+                    codeStr = SR.ConstOutOfRangeChecked;
+                    break;
+                case ErrorCode.ERR_AmbigMember:
+                    codeStr = SR.AmbigMember;
+                    break;
+                case ErrorCode.ERR_SizeofUnsafe:
+                    codeStr = SR.SizeofUnsafe;
+                    break;
+                case ErrorCode.ERR_FieldInitRefNonstatic:
+                    codeStr = SR.FieldInitRefNonstatic;
+                    break;
+                case ErrorCode.ERR_CallingFinalizeDepracated:
+                    codeStr = SR.CallingFinalizeDepracated;
+                    break;
+                case ErrorCode.ERR_CallingBaseFinalizeDeprecated:
+                    codeStr = SR.CallingBaseFinalizeDeprecated;
+                    break;
+                case ErrorCode.ERR_BadCastInFixed:
+                    codeStr = SR.BadCastInFixed;
+                    break;
+                case ErrorCode.ERR_NoImplicitConvCast:
+                    codeStr = SR.NoImplicitConvCast;
+                    break;
+                case ErrorCode.ERR_InaccessibleGetter:
+                    codeStr = SR.InaccessibleGetter;
+                    break;
+                case ErrorCode.ERR_InaccessibleSetter:
+                    codeStr = SR.InaccessibleSetter;
+                    break;
+                case ErrorCode.ERR_BadArity:
+                    codeStr = SR.BadArity;
+                    break;
+                case ErrorCode.ERR_BadTypeArgument:
+                    codeStr = SR.BadTypeArgument;
+                    break;
+                case ErrorCode.ERR_TypeArgsNotAllowed:
+                    codeStr = SR.TypeArgsNotAllowed;
+                    break;
+                case ErrorCode.ERR_HasNoTypeVars:
+                    codeStr = SR.HasNoTypeVars;
+                    break;
+                case ErrorCode.ERR_NewConstraintNotSatisfied:
+                    codeStr = SR.NewConstraintNotSatisfied;
+                    break;
+                case ErrorCode.ERR_GenericConstraintNotSatisfiedRefType:
+                    codeStr = SR.GenericConstraintNotSatisfiedRefType;
+                    break;
+                case ErrorCode.ERR_GenericConstraintNotSatisfiedNullableEnum:
+                    codeStr = SR.GenericConstraintNotSatisfiedNullableEnum;
+                    break;
+                case ErrorCode.ERR_GenericConstraintNotSatisfiedNullableInterface:
+                    codeStr = SR.GenericConstraintNotSatisfiedNullableInterface;
+                    break;
+                case ErrorCode.ERR_GenericConstraintNotSatisfiedTyVar:
+                    codeStr = SR.GenericConstraintNotSatisfiedTyVar;
+                    break;
+                case ErrorCode.ERR_GenericConstraintNotSatisfiedValType:
+                    codeStr = SR.GenericConstraintNotSatisfiedValType;
+                    break;
+                case ErrorCode.ERR_TypeVarCantBeNull:
+                    codeStr = SR.TypeVarCantBeNull;
+                    break;
+                case ErrorCode.ERR_BadRetType:
+                    codeStr = SR.BadRetType;
+                    break;
+                case ErrorCode.ERR_CantInferMethTypeArgs:
+                    codeStr = SR.CantInferMethTypeArgs;
+                    break;
+                case ErrorCode.ERR_MethGrpToNonDel:
+                    codeStr = SR.MethGrpToNonDel;
+                    break;
+                case ErrorCode.ERR_RefConstraintNotSatisfied:
+                    codeStr = SR.RefConstraintNotSatisfied;
+                    break;
+                case ErrorCode.ERR_ValConstraintNotSatisfied:
+                    codeStr = SR.ValConstraintNotSatisfied;
+                    break;
+                case ErrorCode.ERR_CircularConstraint:
+                    codeStr = SR.CircularConstraint;
+                    break;
+                case ErrorCode.ERR_BaseConstraintConflict:
+                    codeStr = SR.BaseConstraintConflict;
+                    break;
+                case ErrorCode.ERR_ConWithValCon:
+                    codeStr = SR.ConWithValCon;
+                    break;
+                case ErrorCode.ERR_AmbigUDConv:
+                    codeStr = SR.AmbigUDConv;
+                    break;
+                case ErrorCode.ERR_PredefinedTypeNotFound:
+                    codeStr = SR.PredefinedTypeNotFound;
+                    break;
+                case ErrorCode.ERR_PredefinedTypeBadType:
+                    codeStr = SR.PredefinedTypeBadType;
+                    break;
+                case ErrorCode.ERR_BindToBogus:
+                    codeStr = SR.BindToBogus;
+                    break;
+                case ErrorCode.ERR_CantCallSpecialMethod:
+                    codeStr = SR.CantCallSpecialMethod;
+                    break;
+                case ErrorCode.ERR_BogusType:
+                    codeStr = SR.BogusType;
+                    break;
+                case ErrorCode.ERR_MissingPredefinedMember:
+                    codeStr = SR.MissingPredefinedMember;
+                    break;
+                case ErrorCode.ERR_LiteralDoubleCast:
+                    codeStr = SR.LiteralDoubleCast;
+                    break;
+                case ErrorCode.ERR_UnifyingInterfaceInstantiations:
+                    codeStr = SR.UnifyingInterfaceInstantiations;
+                    break;
+                case ErrorCode.ERR_ConvertToStaticClass:
+                    codeStr = SR.ConvertToStaticClass;
+                    break;
+                case ErrorCode.ERR_GenericArgIsStaticClass:
+                    codeStr = SR.GenericArgIsStaticClass;
+                    break;
+                case ErrorCode.ERR_PartialMethodToDelegate:
+                    codeStr = SR.PartialMethodToDelegate;
+                    break;
+                case ErrorCode.ERR_IncrementLvalueExpected:
+                    codeStr = SR.IncrementLvalueExpected;
+                    break;
+                case ErrorCode.ERR_NoSuchMemberOrExtension:
+                    codeStr = SR.NoSuchMemberOrExtension;
+                    break;
+                case ErrorCode.ERR_ValueTypeExtDelegate:
+                    codeStr = SR.ValueTypeExtDelegate;
+                    break;
+                case ErrorCode.ERR_BadArgCount:
+                    codeStr = SR.BadArgCount;
+                    break;
+                case ErrorCode.ERR_BadArgTypes:
+                    codeStr = SR.BadArgTypes;
+                    break;
+                case ErrorCode.ERR_BadArgType:
+                    codeStr = SR.BadArgType;
+                    break;
+                case ErrorCode.ERR_RefLvalueExpected:
+                    codeStr = SR.RefLvalueExpected;
+                    break;
+                case ErrorCode.ERR_BadProtectedAccess:
+                    codeStr = SR.BadProtectedAccess;
+                    break;
+                case ErrorCode.ERR_BindToBogusProp2:
+                    codeStr = SR.BindToBogusProp2;
+                    break;
+                case ErrorCode.ERR_BindToBogusProp1:
+                    codeStr = SR.BindToBogusProp1;
+                    break;
+                case ErrorCode.ERR_BadDelArgCount:
+                    codeStr = SR.BadDelArgCount;
+                    break;
+                case ErrorCode.ERR_BadDelArgTypes:
+                    codeStr = SR.BadDelArgTypes;
+                    break;
+                case ErrorCode.ERR_AssgReadonlyLocal:
+                    codeStr = SR.AssgReadonlyLocal;
+                    break;
+                case ErrorCode.ERR_RefReadonlyLocal:
+                    codeStr = SR.RefReadonlyLocal;
+                    break;
+                case ErrorCode.ERR_ReturnNotLValue:
+                    codeStr = SR.ReturnNotLValue;
+                    break;
+                case ErrorCode.ERR_BadArgExtraRef:
+                    codeStr = SR.BadArgExtraRef;
+                    break;
+                case ErrorCode.ERR_BadArgRef:
+                    codeStr = SR.BadArgRef;
+                    break;
+                case ErrorCode.ERR_AssgReadonly2:
+                    codeStr = SR.AssgReadonly2;
+                    break;
+                case ErrorCode.ERR_RefReadonly2:
+                    codeStr = SR.RefReadonly2;
+                    break;
+                case ErrorCode.ERR_AssgReadonlyStatic2:
+                    codeStr = SR.AssgReadonlyStatic2;
+                    break;
+                case ErrorCode.ERR_RefReadonlyStatic2:
+                    codeStr = SR.RefReadonlyStatic2;
+                    break;
+                case ErrorCode.ERR_AssgReadonlyLocalCause:
+                    codeStr = SR.AssgReadonlyLocalCause;
+                    break;
+                case ErrorCode.ERR_RefReadonlyLocalCause:
+                    codeStr = SR.RefReadonlyLocalCause;
+                    break;
+                case ErrorCode.ERR_ThisStructNotInAnonMeth:
+                    codeStr = SR.ThisStructNotInAnonMeth;
+                    break;
+                case ErrorCode.ERR_DelegateOnNullable:
+                    codeStr = SR.DelegateOnNullable;
+                    break;
+                case ErrorCode.ERR_BadCtorArgCount:
+                    codeStr = SR.BadCtorArgCount;
+                    break;
+                case ErrorCode.ERR_BadExtensionArgTypes:
+                    codeStr = SR.BadExtensionArgTypes;
+                    break;
+                case ErrorCode.ERR_BadInstanceArgType:
+                    codeStr = SR.BadInstanceArgType;
+                    break;
+                case ErrorCode.ERR_BadArgTypesForCollectionAdd:
+                    codeStr = SR.BadArgTypesForCollectionAdd;
+                    break;
+                case ErrorCode.ERR_InitializerAddHasParamModifiers:
+                    codeStr = SR.InitializerAddHasParamModifiers;
+                    break;
+                case ErrorCode.ERR_NonInvocableMemberCalled:
+                    codeStr = SR.NonInvocableMemberCalled;
+                    break;
+                case ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument:
+                    codeStr = SR.NamedArgumentSpecificationBeforeFixedArgument;
+                    break;
+                case ErrorCode.ERR_BadNamedArgument:
+                    codeStr = SR.BadNamedArgument;
+                    break;
+                case ErrorCode.ERR_BadNamedArgumentForDelegateInvoke:
+                    codeStr = SR.BadNamedArgumentForDelegateInvoke;
+                    break;
+                case ErrorCode.ERR_DuplicateNamedArgument:
+                    codeStr = SR.DuplicateNamedArgument;
+                    break;
+                case ErrorCode.ERR_NamedArgumentUsedInPositional:
+                    codeStr = SR.NamedArgumentUsedInPositional;
+                    break;
+                default:
+                    // means missing resources match the code entry
+                    Debug.Assert(false, "Missing resources for the error " + code.ToString());
+                    codeStr = null;
+                    break;
             }
 
             return codeStr;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorHandling.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorHandling.cs
@@ -44,10 +44,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
 
         public void SubmitError(CParameterizedError error)
         {
-            if (_errorSink != null)
-            {
-                _errorSink.SubmitError(error);
-            }
+            _errorSink?.SubmitError(error);
         }
 
         private void MakeErrorLocArgs(out CParameterizedError error, ErrorCode id, ErrArg[] prgarg)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
@@ -1034,7 +1034,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 {
                     if (m.IsGenericMethod)
                     {
-                        int size = methinfo.Method.TypeArgs != null ? methinfo.Method.TypeArgs.size : 0;
+                        int size = methinfo.Method.TypeArgs?.size ?? 0;
                         Type[] typeArgs = new Type[size];
                         if (size > 0)
                         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -269,7 +269,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             if (payload is CSharpInvokeMemberBinder)
             {
                 ICSharpInvokeOrInvokeMemberBinder callPayload = payload as ICSharpInvokeOrInvokeMemberBinder;
-                int arity = callPayload.TypeArguments != null ? callPayload.TypeArguments.Count : 0;
+                int arity = callPayload.TypeArguments?.Count ?? 0;
                 MemberLookup mem = new MemberLookup();
                 EXPR callingObject = CreateCallingObjectForCall(callPayload, arguments, dictionary);
 
@@ -532,12 +532,12 @@ namespace Microsoft.CSharp.RuntimeBinder
 
                 if (callOrInvoke.StaticCall)
                 {
-                    if (arguments[0].Value == null || !(arguments[0].Value is Type))
+                    type = arguments[0].Value as Type;
+                    if (type == null)
                     {
                         Debug.Assert(false, "Cannot make static call without specifying a type");
                         throw Error.InternalCompilerError();
                     }
-                    type = arguments[0].Value as Type;
                 }
                 else
                 {
@@ -1129,12 +1129,13 @@ namespace Microsoft.CSharp.RuntimeBinder
             EXPR callingObject;
             if (payload.StaticCall)
             {
-                if (arguments[0].Value == null || !(arguments[0].Value is Type))
+                Type t = arguments[0].Value as Type;
+                if (t == null)
                 {
                     Debug.Assert(false, "Cannot make static call without specifying a type");
                     throw Error.InternalCompilerError();
                 }
-                Type t = arguments[0].Value as Type;
+
                 callingObject = _exprFactory.CreateClass(_symbolTable.GetCTypeFromType(t), null, t.GetTypeInfo().ContainsGenericParameters ?
                         _exprFactory.CreateTypeArguments(SymbolLoader.getBSymmgr().AllocParams(_symbolTable.GetCTypeArrayFromTypes(t.GetGenericArguments())), null) : null);
             }
@@ -1173,7 +1174,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             }
 
             EXPR pResult = null;
-            int arity = payload.TypeArguments != null ? payload.TypeArguments.Count : 0;
+            int arity = payload.TypeArguments?.Count ?? 0;
             MemberLookup mem = new MemberLookup();
 
             Debug.Assert(_bindingContext.ContextForMemberLookup() != null);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -819,11 +819,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
          */
         private bool canConvertInstanceParamForExtension(EXPR exprSrc, CType typeDest)
         {
-            if (exprSrc == null || exprSrc.type == null)
-            {
-                return false;
-            }
-            return canConvertInstanceParamForExtension(exprSrc.type, typeDest);
+            CType typeSrc = exprSrc?.type;
+            return typeSrc != null && canConvertInstanceParamForExtension(typeSrc, typeDest);
         }
 
         private bool canConvertInstanceParamForExtension(CType typeSrc, CType typeDest)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -726,7 +726,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         }
                         else
                         {
-                            _binder.bindSimpleCast(_exprSrc, _exprTypeDest, out _exprDest, EXPRFLAG.EXF_REFCHECK | (_exprSrc != null ? (_exprSrc.flags & EXPRFLAG.EXF_CANTBENULL) : 0));
+                            _binder.bindSimpleCast(_exprSrc, _exprTypeDest, out _exprDest, EXPRFLAG.EXF_REFCHECK | (_exprSrc?.flags & EXPRFLAG.EXF_CANTBENULL ?? 0));
                         }
                     }
                     return AggCastResult.Success;
@@ -738,7 +738,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     CConversions.HasGenericDelegateExplicitReferenceConversion(GetSymbolLoader(), _typeSrc, aggTypeDest))
                 {
                     if (_needsExprDest)
-                        _binder.bindSimpleCast(_exprSrc, _exprTypeDest, out _exprDest, EXPRFLAG.EXF_REFCHECK | (_exprSrc != null ? (_exprSrc.flags & EXPRFLAG.EXF_CANTBENULL) : 0));
+                        _binder.bindSimpleCast(_exprSrc, _exprTypeDest, out _exprDest, EXPRFLAG.EXF_REFCHECK | (_exprSrc?.flags & EXPRFLAG.EXF_CANTBENULL ?? 0));
                     return AggCastResult.Success;
                 }
                 return AggCastResult.Failure;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             rval.SetOptionalArguments(pOptionalArguments);
             rval.SetOptionalArgumentDimensions(pOptionalArgumentDimensions);
             rval.dimSizes = pDimSizes;
-            rval.dimSize = pDimSizes != null ? pDimSizes.Length : 0;
+            rval.dimSize = pDimSizes?.Length ?? 0;
             Debug.Assert(rval != null);
             return (rval);
         }
@@ -174,7 +174,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 EXPR pObject,
                 MethPropWithInst mwi)
         {
-            Name pName = mwi.Sym != null ? mwi.Sym.name : null;
+            Name pName = mwi.Sym?.name;
             MethodOrPropertySymbol methProp = mwi.MethProp();
 
             CType pType = mwi.GetType();
@@ -183,7 +183,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 pType = GetTypes().GetErrorSym();
             }
 
-            return CreateMemGroup(0, pName, mwi.TypeArgs, methProp != null ? methProp.getKind() : SYMKIND.SK_MethodSymbol, mwi.GetType(), methProp, pObject, new CMemberLookupResults(GetGlobalSymbols().AllocParams(1, new CType[] { pType }), pName));
+            return CreateMemGroup(0, pName, mwi.TypeArgs, methProp?.getKind() ?? SYMKIND.SK_MethodSymbol, mwi.GetType(), methProp, pObject, new CMemberLookupResults(GetGlobalSymbols().AllocParams(1, new CType[] { pType }), pName));
         }
 
         public EXPRUSERDEFINEDCONVERSION CreateUserDefinedConversion(EXPR arg, EXPR call, MethWithInst mwi)
@@ -432,8 +432,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public EXPRCONCAT CreateConcat(EXPR op1, EXPR op2)
         {
-            Debug.Assert(op1 != null && op1.type != null);
-            Debug.Assert(op2 != null && op2.type != null);
+            Debug.Assert(op1?.type != null);
+            Debug.Assert(op2?.type != null);
             Debug.Assert(op1.type.isPredefType(PredefinedType.PT_STRING) || op2.type.isPredefType(PredefinedType.PT_STRING));
 
             CType type = op1.type;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -748,7 +748,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             bool fConstrained;
             bool bIsMatchingStatic;
             EXPR pObject = pMemGroup.GetOptionalObject();
-            CType callingObjectType = pObject != null ? pObject.type : null;
+            CType callingObjectType = pObject?.type;
             PostBindMethod((flags & MemLookFlags.BaseCall) != 0, ref mwi, pObject);
             pObject = AdjustMemberObject(mwi, pObject, out fConstrained, out bIsMatchingStatic);
             pMemGroup.SetOptionalObject(pObject);
@@ -1051,7 +1051,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (result.GetOptionalArguments() != null)
             {
-                verifyMethodArgs(result, pObjectThrough != null ? pObjectThrough.type : null);
+                verifyMethodArgs(result, pObjectThrough?.type);
             }
 
             if (mwtSet && objectIsLvalue(result.GetMemberGroup().GetOptionalObject()))

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -679,7 +679,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     MethodOrPropertySymbol pMethProp,
                     EXPR pObject)
             {
-                return FindMostDerivedMethod(GetSymbolLoader(), pMethProp, pObject != null ? pObject.type : null);
+                return FindMostDerivedMethod(GetSymbolLoader(), pMethProp, pObject?.type);
             }
 
             /////////////////////////////////////////////////////////////////////////////////
@@ -719,9 +719,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
 
                 // Now get the slot method.
-                if (method.swtSlot != null && method.swtSlot.Meth() != null)
+                var slotMethod = method.swtSlot?.Meth();
+                if (slotMethod != null)
                 {
-                    method = method.swtSlot.Meth();
+                    method = slotMethod;
                 }
 
                 if (!pType.IsAggregateType())
@@ -772,7 +773,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             private bool HasOptionalParameters()
             {
                 MethodOrPropertySymbol methprop = FindMostDerivedMethod(_pCurrentSym, _pGroup.GetOptionalObject());
-                return methprop != null ? methprop.HasOptionalParameters() : false;
+                return methprop != null && methprop.HasOptionalParameters();
             }
 
             /////////////////////////////////////////////////////////////////////////////////

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -233,10 +233,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 //
                 // Every incoming dynamic operand should be implicitly convertible
                 // to any type that it is an instance of.
-
-                if (_exprSrc != null
-                    && _exprSrc.RuntimeObject != null
-                    && _typeDest.AssociatedSystemType.IsInstanceOfType(_exprSrc.RuntimeObject)
+                object srcRuntimeObject = _exprSrc?.RuntimeObject;
+                if (srcRuntimeObject != null
+                    && _typeDest.AssociatedSystemType.IsInstanceOfType(srcRuntimeObject)
                     && _binder.GetSemanticChecker().CheckTypeAccess(_typeDest, _binder.Context.ContextForMemberLookup()))
                 {
                     if (_needsExprDest)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Nullable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Nullable.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             PropWithType pwt = new PropWithType(prop, ats);
-            MethWithType mwt = new MethWithType(prop != null ? prop.methGet : null, ats);
+            MethWithType mwt = new MethWithType(prop?.methGet, ats);
             MethPropWithInst mpwi = new MethPropWithInst(prop, ats);
             EXPRMEMGRP pMemGroup = GetExprFactory().CreateMemGroup(exprSrc, mpwi);
             EXPRPROP exprRes = GetExprFactory().CreateProperty(typeBase, null, null, pMemGroup, pwt, mwt, null);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -1590,7 +1590,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private EXPR BindLiftedStandardUnop(ExpressionKind ek, EXPRFLAG flags, EXPR arg, UnaOpFullSig uofs)
         {
             NullableType type = uofs.GetType().AsNullableType();
-            Debug.Assert(arg != null && arg.type != null);
+            Debug.Assert(arg?.type != null);
             if (arg.type.IsNullType())
             {
                 return BadOperatorTypesError(ek, arg, null, type);
@@ -3022,14 +3022,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             EXPR exprRes;
             EXPR opConst1 = op1.GetConst();
-            EXPR opConst2 = op2 != null ? op2.GetConst() : null;
+            EXPR opConst2 = op2?.GetConst();
 
             // Check for constants and fold them.
             if (opConst1 != null && (op2 == null || opConst2 != null))
             {
                 // Get the operands
                 double d1 = opConst1.asCONSTANT().getVal().doubleVal;
-                double d2 = opConst2 != null ? opConst2.asCONSTANT().getVal().doubleVal : 0.0;
+                double d2 = opConst2?.asCONSTANT().getVal().doubleVal ?? 0.0;
                 double result = 0;      // if isBoolResult is false
                 bool result_b = false;  // if isBoolResult is true
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
@@ -352,10 +352,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
             }
 
-            if (setter != null)
-            {
-                setter.SetMethKind(MethodKindEnum.PropAccessor);
-            }
+            setter?.SetMethKind(MethodKindEnum.PropAccessor);
 
             PropertySymbol property = null;
             if (getter != null)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private SubstContext(AggregateType type, TypeArray typeArgsMeth, SubstTypeFlags grfst)
         {
-            Init(type != null ? type.GetTypeArgsAll() : null, typeArgsMeth, grfst);
+            Init(type?.GetTypeArgsAll(), typeArgsMeth, grfst);
         }
 
         public SubstContext(CType[] prgtypeCls, int ctypeCls, CType[] prgtypeMeth, int ctypeMeth)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AggregateSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AggregateSymbol.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public AggregateSymbol GetBaseAgg()
         {
-            return _pBaseClass == null ? null : _pBaseClass.getAggregate();
+            return _pBaseClass?.getAggregate();
         }
 
         public AggregateType getThisType()

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/NamespaceOrAggregateSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/NamespaceOrAggregateSymbol.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 #if DEBUG
                 // Validate our chain.
                 Declaration pdecl;
-                for (pdecl = _declFirst; pdecl != null && pdecl.declNext != null; pdecl = pdecl.declNext)
+                for (pdecl = _declFirst; pdecl?.declNext != null; pdecl = pdecl.declNext)
                 { }
                 Debug.Assert(pdecl == null || (pdecl == _declLast && pdecl.declNext == null));
 #endif

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/ParentSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/ParentSymbol.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // Validate our chain.
                 Symbol psym;
                 int count = 400; // Limited the length of chain that we'll run - so debug perf isn't too bad.
-                for (psym = this.firstChild; psym != null && psym.nextChild != null && --count > 0;)
+                for (psym = this.firstChild; psym?.nextChild != null && --count > 0;)
                     psym = psym.nextChild;
                 Debug.Assert(_lastChild == psym || count == 0);
 #endif

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
@@ -74,10 +74,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // DECLSYMs are not parented like named symbols.
             AggregateDeclaration sym = newBasicSym(SYMKIND.SK_AggregateDeclaration, agg.name, null).AsAggregateDeclaration();
 
-            if (declOuter != null)
-            {
-                declOuter.AddToChildList(sym);
-            }
+            declOuter?.AddToChildList(sym);
             agg.AddDecl(sym);
 
             Debug.Assert(sym != null);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolTable.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             if (_dictionary.TryGetValue(k, out sym))
             {
                 // Link onto the end of the symbol chain here.
-                while (sym != null && sym.nextSameName != null)
+                while (sym?.nextSameName != null)
                 {
                     sym = sym.nextSameName;
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExprVisitorBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExprVisitorBase.cs
@@ -55,11 +55,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 if (pexpr == first)
                 {
-                    first = (result == null) ? null : result.asSTMT();
+                    first = result?.asSTMT();
                 }
                 else
                 {
-                    pexpr.SetOptionalNextStatement((result == null) ? null : result.asSTMT());
+                    pexpr.SetOptionalNextStatement(result?.asSTMT());
                 }
 
                 // A transformation may return back a list of statements (or

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -267,13 +267,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // class. This is so that if we have a base type that's generic, we'll be
                 // getting the correctly instantiated base type.
 
-                if (pAggregate.AssociatedSystemType != null &&
-                    pAggregate.AssociatedSystemType.GetTypeInfo().BaseType != null)
+                var baseType = pAggregate.AssociatedSystemType?.GetTypeInfo().BaseType;
+                if (baseType != null)
                 {
                     // Store the old base class.
 
                     AggregateType oldBaseType = agg.GetBaseClass();
-                    agg.SetBaseClass(_symbolTable.GetCTypeFromType(pAggregate.AssociatedSystemType.GetTypeInfo().BaseType).AsAggregateType());
+                    agg.SetBaseClass(_symbolTable.GetCTypeFromType(baseType).AsAggregateType());
                     pAggregate.GetBaseClass(); // Get the base type for the new agg type we're making.
 
                     agg.SetBaseClass(oldBaseType);
@@ -1033,7 +1033,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public CType SubstType(CType typeSrc, AggregateType atsCls, TypeArray typeArgsMeth)
         {
-            return SubstType(typeSrc, atsCls != null ? atsCls.GetTypeArgsAll() : null, typeArgsMeth);
+            return SubstType(typeSrc, atsCls?.GetTypeArgsAll(), typeArgsMeth);
         }
 
         public CType SubstType(CType typeSrc, CType typeCls, TypeArray typeArgsMeth)
@@ -1043,7 +1043,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public TypeArray SubstTypeArray(TypeArray taSrc, AggregateType atsCls, TypeArray typeArgsMeth)
         {
-            return SubstTypeArray(taSrc, atsCls != null ? atsCls.GetTypeArgsAll() : null, typeArgsMeth);
+            return SubstTypeArray(taSrc, atsCls?.GetTypeArgsAll(), typeArgsMeth);
         }
 
         public TypeArray SubstTypeArray(TypeArray taSrc, AggregateType atsCls)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/WithType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/WithType.cs
@@ -100,8 +100,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public override int GetHashCode()
         {
-            return (Sym != null ? Sym.GetHashCode() : 0) +
-                (Ats != null ? Ats.GetHashCode() : 0);
+            return (Sym?.GetHashCode() ?? 0) + (Ats?.GetHashCode() ?? 0);
         }
 
         // The SymWithType is considered NULL iff the Symbol is NULL.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -556,7 +556,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                     nextParent = nextParent.GetTypeInfo().GetGenericTypeDefinition();
                 }
 
-                if (nextParent != null && nextParent.GetGenericArguments() != null && nextParent.GetGenericArguments().Length > pos)
+                if (nextParent?.GetGenericArguments()?.Length > pos)
                 {
                     parentType = nextParent;
                 }
@@ -703,7 +703,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                     // similarly named types, but we are not going to try to solve that
                     // scenario here.
 
-                    if (next != null && next is AggregateSymbol)
+                    if (next != null)
                     {
                         Type existingType = (next as AggregateSymbol).AssociatedSystemType;
                         Type newType = t.GetTypeInfo().IsGenericType ? t.GetTypeInfo().GetGenericTypeDefinition() : t;
@@ -1322,17 +1322,23 @@ namespace Microsoft.CSharp.RuntimeBinder
             // we mark it as such. This is used for the CSharpIsEventBinder.
             // In the case of a WindowsRuntime event, the field will be of type
             // EventRegistrationTokenTable<delegateType>.
-            Type eventRegistrationTokenTableType;
-            if (addedField != null && addedField.GetType() != null &&
-                (addedField.GetType() == ev.type ||
-                (
-                    addedField.GetType().AssociatedSystemType.IsConstructedGenericType &&
-                    (object)(eventRegistrationTokenTableType = EventRegistrationTokenTableType) != null &&
-                    addedField.GetType().AssociatedSystemType.GetGenericTypeDefinition() == eventRegistrationTokenTableType &&
-                    addedField.GetType().AssociatedSystemType.GenericTypeArguments[0] == ev.type.AssociatedSystemType)
-                ))
+            CType addedFieldType = addedField?.GetType();
+            if (addedFieldType != null)
             {
-                addedField.isEvent = true;
+                if (addedFieldType == ev.type)
+                {
+                    addedField.isEvent = true;
+                }
+                else
+                {
+                    Type associated = addedFieldType.AssociatedSystemType;
+                    if (associated.IsConstructedGenericType
+                        && associated.GetGenericTypeDefinition() == EventRegistrationTokenTableType
+                        && associated.GenericTypeArguments[0] == ev.type.AssociatedSystemType)
+                    {
+                        addedField.isEvent = true;
+                    }
+                }
             }
 
             return ev;


### PR DESCRIPTION
Some avoid repeated field access or method calls. Some just make it easier to grep for the cases that avoid repeated field access or method calls.