### PR TITLE
Avoid unnecessary branches when fixing non-null/empty arrays

### DIFF
--- a/src/Common/src/Interop/OSX/Interop.libproc.cs
+++ b/src/Common/src/Interop/OSX/Interop.libproc.cs
@@ -199,7 +199,7 @@ internal static partial class Interop
                 // To make sure it isn't #2, when the result == size, increase the buffer and try again
                 processes = new int[(int)(numProcesses * 1.10)];
 
-                fixed (int* pBuffer = processes)
+                fixed (int* pBuffer = &processes[0])
                 {
                     numProcesses = proc_listallpids(pBuffer, processes.Length * Marshal.SizeOf<int>());
                     if (numProcesses <= 0)
@@ -371,7 +371,7 @@ internal static partial class Interop
             do
             {
                 threadIds = new ulong[size];
-                fixed (ulong* pBuffer = threadIds)
+                fixed (ulong* pBuffer = &threadIds[0])
                 {
                     result = proc_pidinfo(pid, PROC_PIDLISTTHREADS, 0, pBuffer, Marshal.SizeOf<ulong>() * threadIds.Length);
                 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetCwd.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetCwd.cs
@@ -34,7 +34,7 @@ internal static partial class Interop
                 {
                     checked { bufferSize *= 2; }
                     var buf = new byte[Math.Min(bufferSize, maxPath)];
-                    fixed (byte* ptr = buf)
+                    fixed (byte* ptr = &buf[0])
                     {
                         result = GetCwdHelper(ptr, buf.Length);
                         if (result != null)

--- a/src/Common/src/Interop/Unix/System.Native/Interop.IPAddress.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.IPAddress.cs
@@ -90,7 +90,7 @@ internal static partial class Interop
             Debug.Assert((address.Length == IPv4AddressBytes) || (address.Length == IPv6AddressBytes), $"Unexpected address length: {address.Length}");
 
             int err;
-            fixed (byte* rawAddress = address)
+            fixed (byte* rawAddress = &address[0])
             {
                 int bufferLength = isIPv6 ? INET6_ADDRSTRLEN : INET_ADDRSTRLEN;
                 byte* buffer = stackalloc byte[bufferLength];

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
@@ -93,7 +93,7 @@ internal static partial class Interop
             // so make sure to leave room for it.
             int initialBytesNeeded = bytesNeeded;
             byte[] bufHeap = new byte[bytesNeeded + 1];
-            fixed (byte* buf = bufHeap)
+            fixed (byte* buf = &bufHeap[0])
             {
                 bytesNeeded = ObjObj2Txt(buf, bufHeap.Length, asn1ObjectPtr);
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
@@ -30,7 +30,7 @@ internal static partial class Interop
         private static unsafe string ErrErrorStringN(ulong error)
         {
             var buffer = new byte[1024];
-            fixed (byte* buf = buffer)
+            fixed (byte* buf = &buffer[0])
             {
                 ErrErrorStringN(error, buf, buffer.Length);
                 return Marshal.PtrToStringAnsi((IntPtr)buf);

--- a/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
@@ -514,7 +514,7 @@ namespace System.Net
                     case Interop.SspiCli.ContextAttribute.SECPKG_ATTR_NEGOTIATION_INFO:
                         unsafe
                         {
-                            fixed (void* ptr = nativeBuffer)
+                            fixed (void* ptr = &nativeBuffer[0])
                             {
                                 attribute = new NegotiationInfoClass(sspiHandle, Marshal.ReadInt32(new IntPtr(ptr), SecPkgContext_NegotiationInfoW.NegotiationStateOffest));
                             }

--- a/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
@@ -563,7 +563,7 @@ namespace System.Net.Security
                     }
 
                     Interop.SspiCli.SecBuffer[] outUnmanagedBuffer = new Interop.SspiCli.SecBuffer[1];
-                    fixed (void* outUnmanagedBufferPtr = outUnmanagedBuffer)
+                    fixed (void* outUnmanagedBufferPtr = &outUnmanagedBuffer[0])
                     {
                         // Fix Descriptor pointer that points to unmanaged SecurityBuffers.
                         outSecurityBufferDescriptor.pBuffers = outUnmanagedBufferPtr;
@@ -854,7 +854,7 @@ namespace System.Net.Security
                     }
 
                     var outUnmanagedBuffer = new Interop.SspiCli.SecBuffer[1];
-                    fixed (void* outUnmanagedBufferPtr = outUnmanagedBuffer)
+                    fixed (void* outUnmanagedBufferPtr = &outUnmanagedBuffer[0])
                     {
                         // Fix Descriptor pointer that points to unmanaged SecurityBuffers.
                         outSecurityBufferDescriptor.pBuffers = outUnmanagedBufferPtr;

--- a/src/Common/src/System/IO/PersistedFiles.Unix.cs
+++ b/src/Common/src/System/IO/PersistedFiles.Unix.cs
@@ -109,7 +109,7 @@ namespace System.IO
                 {
                     lastBufLen *= 2;
                     byte[] heapBuf = new byte[lastBufLen];
-                    fixed (byte* buf = heapBuf)
+                    fixed (byte* buf = &heapBuf[0])
                     {
                         if (TryGetHomeDirectoryFromPasswd(buf, heapBuf.Length, out userHomeDirectory))
                             return userHomeDirectory;

--- a/src/Common/src/System/Security/Cryptography/DSACng.ImportExport.cs
+++ b/src/Common/src/System/Security/Cryptography/DSACng.ImportExport.cs
@@ -83,7 +83,7 @@ namespace System.Security.Cryptography
                     }
 
                     blob = new byte[blobSize];
-                    fixed (byte* pDsaBlob = blob)
+                    fixed (byte* pDsaBlob = &blob[0])
                     {
                         // Build the header
                         BCRYPT_DSA_KEY_BLOB* pBcryptBlob = (BCRYPT_DSA_KEY_BLOB*)pDsaBlob;
@@ -154,7 +154,7 @@ namespace System.Security.Cryptography
                         (includePrivateParameters ? parameters.X.Length : 0);
 
                     blob = new byte[blobSize];
-                    fixed (byte* pDsaBlob = blob)
+                    fixed (byte* pDsaBlob = &blob[0])
                     {
                         // Build the header
                         BCRYPT_DSA_KEY_BLOB_V2* pBcryptBlob = (BCRYPT_DSA_KEY_BLOB_V2*)pDsaBlob;

--- a/src/Common/src/System/Security/Cryptography/ECCng.ImportExport.cs
+++ b/src/Common/src/System/Security/Cryptography/ECCng.ImportExport.cs
@@ -42,7 +42,7 @@ namespace System.Security.Cryptography
                 }
 
                 blob = new byte[blobSize];
-                fixed (byte* pBlob = blob)
+                fixed (byte* pBlob = &blob[0])
                 {
                     // Build the header
                     BCRYPT_ECCKEY_BLOB* pBcryptBlob = (BCRYPT_ECCKEY_BLOB*)pBlob;
@@ -107,7 +107,7 @@ namespace System.Security.Cryptography
                 }
 
                 blob = new byte[blobSize];
-                fixed (byte* pBlob = blob)
+                fixed (byte* pBlob = &blob[0])
                 {
                     // Build the header
                     BCRYPT_ECCFULLKEY_BLOB* pBcryptBlob = (BCRYPT_ECCFULLKEY_BLOB*)pBlob;
@@ -171,7 +171,7 @@ namespace System.Security.Cryptography
                 if (ecBlob.Length < sizeof(BCRYPT_ECCKEY_BLOB))
                     throw ErrorCode.E_FAIL.ToCryptographicException();
 
-                fixed (byte* pEcBlob = ecBlob)
+                fixed (byte* pEcBlob = &ecBlob[0])
                 {
                     BCRYPT_ECCKEY_BLOB* pBcryptBlob = (BCRYPT_ECCKEY_BLOB*)pEcBlob;
 
@@ -220,7 +220,7 @@ namespace System.Security.Cryptography
                 if (ecBlob.Length < sizeof(BCRYPT_ECCFULLKEY_BLOB))
                     throw ErrorCode.E_FAIL.ToCryptographicException();
 
-                fixed (byte* pEcBlob = ecBlob)
+                fixed (byte* pEcBlob = &ecBlob[0])
                 {
                     BCRYPT_ECCFULLKEY_BLOB* pBcryptBlob = (BCRYPT_ECCFULLKEY_BLOB*)pEcBlob;
 
@@ -286,7 +286,7 @@ namespace System.Security.Cryptography
                     (curve.Seed == null ? 0 : curve.Seed.Length);
 
                 byte[] blob = new byte[blobSize];
-                fixed (byte* pBlob = blob)
+                fixed (byte* pBlob = &blob[0])
                 {
                     // Build the header
                     BCRYPT_ECC_PARAMETER_HEADER* pBcryptBlob = (BCRYPT_ECC_PARAMETER_HEADER*)pBlob;

--- a/src/Common/src/System/Security/Cryptography/RSACng.ImportExport.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.ImportExport.cs
@@ -76,7 +76,7 @@ namespace System.Security.Cryptography
                 }
 
                 byte[] rsaBlob = new byte[blobSize];
-                fixed (byte* pRsaBlob = rsaBlob)
+                fixed (byte* pRsaBlob = &rsaBlob[0])
                 {
                     // Build the header
                     BCRYPT_RSAKEY_BLOB* pBcryptBlob = (BCRYPT_RSAKEY_BLOB*)pRsaBlob;
@@ -148,7 +148,7 @@ namespace System.Security.Cryptography
                 if (rsaBlob.Length < sizeof(BCRYPT_RSAKEY_BLOB))
                     throw ErrorCode.E_FAIL.ToCryptographicException();
 
-                fixed (byte* pRsaBlob = rsaBlob)
+                fixed (byte* pRsaBlob = &rsaBlob[0])
                 {
                     BCRYPT_RSAKEY_BLOB* pBcryptBlob = (BCRYPT_RSAKEY_BLOB*)pRsaBlob;
 

--- a/src/Common/src/System/Text/DBCSDecoder.cs
+++ b/src/Common/src/System/Text/DBCSDecoder.cs
@@ -150,7 +150,7 @@ namespace System.Text
             if (byteCount == 0 && (_leftOverLeadByte == 0 || !flush))
                 return 0;
             
-            fixed (char* pChars = chars)
+            fixed (char* pChars = &chars[0])
             fixed (byte* pBytes = bytes)
             {
                 byte dummyByte;
@@ -225,7 +225,7 @@ namespace System.Text
                 return;
             }
 
-            fixed (char* pChars = chars)
+            fixed (char* pChars = &chars[0])
             fixed (byte* pBytes = bytes)
             {
                 byte dummyByte;

--- a/src/Common/src/System/Text/OSEncoder.cs
+++ b/src/Common/src/System/Text/OSEncoder.cs
@@ -125,7 +125,7 @@ namespace System.Text
                 return 0;
             
             fixed (char* pChars = chars)
-            fixed (byte* pBytes = bytes)
+            fixed (byte* pBytes = &bytes[0])
             {
                 char dummyChar;
                 char* pBuffer = pChars == null ? &dummyChar : pChars + charIndex;
@@ -200,7 +200,7 @@ namespace System.Text
             }
 
             fixed (char* pChars = chars)
-            fixed (byte* pBytes = bytes)
+            fixed (byte* pBytes = &bytes[0])
             {
                 char dummyChar;
                 char* pBuffer = pChars == null ? &dummyChar : pChars + charIndex;

--- a/src/Common/src/System/Text/OSEncoding.Windows.cs
+++ b/src/Common/src/System/Text/OSEncoding.Windows.cs
@@ -78,7 +78,7 @@ namespace System.Text
             }
             
             fixed (char* pChars = s)
-            fixed (byte *pBytes = bytes)
+            fixed (byte *pBytes = &bytes[0])
             {
                 return WideCharToMultiByte(_codePage, pChars+charIndex, charCount, pBytes+byteIndex, bytes.Length - byteIndex);
             }
@@ -107,7 +107,7 @@ namespace System.Text
             }
             
             fixed (char* pChars = chars)
-            fixed (byte *pBytes = bytes)
+            fixed (byte *pBytes = &bytes[0])
             {
                 return WideCharToMultiByte(_codePage, pChars+charIndex, charCount, pBytes+byteIndex, bytes.Length - byteIndex);
             }
@@ -154,7 +154,7 @@ namespace System.Text
                 throw new ArgumentOutOfRangeException(SR.Argument_EncodingConversionOverflowChars);
 
             fixed (byte* pBytes = bytes)
-            fixed (char* pChars = chars)
+            fixed (char* pChars = &chars[0])
             {
                 return MultiByteToWideChar(_codePage, pBytes+byteIndex, byteCount, pChars+charIndex, chars.Length - charIndex);
             }

--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -1189,7 +1189,7 @@ namespace System
                 }
 
                 bool readSuccess;
-                fixed (byte* p = bytes)
+                fixed (byte* p = &bytes[0])
                 {
                     if (useFileAPIs)
                     {
@@ -1227,7 +1227,7 @@ namespace System
                     return Interop.Errors.ERROR_SUCCESS;
 
                 bool writeSuccess;
-                fixed (byte* p = bytes)
+                fixed (byte* p = &bytes[0])
                 {
                     if (useFileAPIs)
                     {

--- a/src/System.Console/src/System/TermInfo.cs
+++ b/src/System.Console/src/System/TermInfo.cs
@@ -857,7 +857,7 @@ namespace System
 
                 // Allocate the needed space, format into it, and return the data as a string.
                 byte[] bytes = new byte[neededLength + 1]; // extra byte for the null terminator
-                fixed (byte* ptr = bytes)
+                fixed (byte* ptr = &bytes[0])
                 {
                     int length = stringArg != null ?
                         Interop.Sys.SNPrintF(ptr, bytes.Length, format, stringArg) :

--- a/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Windows.cs
+++ b/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Windows.cs
@@ -21,7 +21,7 @@ namespace System.Diagnostics
             if (infoSize != 0)
             {
                 byte[] mem = new byte[infoSize];
-                fixed (byte* memPtr = mem)
+                fixed (byte* memPtr = &mem[0])
                 {
                     IntPtr memIntPtr = new IntPtr((void*)memPtr);
                     if (Interop.Version.GetFileVersionInfoEx(

--- a/src/System.IO.Compression/src/Interop/Interop.zlib.Windows.cs
+++ b/src/System.IO.Compression/src/Interop/Interop.zlib.Windows.cs
@@ -41,7 +41,7 @@ internal static partial class Interop
                                             int memLevel,
                                             ZLibNative.CompressionStrategy strategy)
         {
-            fixed (byte* versionString = ZLibVersion)
+            fixed (byte* versionString = &ZLibVersion[0])
             fixed (ZLibNative.ZStream* streamBytes = &stream)
             {
                 byte* pBytes = (byte*)streamBytes;
@@ -77,7 +77,7 @@ internal static partial class Interop
                                             ref ZLibNative.ZStream stream,
                                             int windowBits)
         {
-            fixed (byte* versionString = ZLibVersion)
+            fixed (byte* versionString = &ZLibVersion[0])
             fixed (ZLibNative.ZStream* streamBytes = &stream)
             {
                 byte* pBytes = (byte*)streamBytes;

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Deflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Deflater.cs
@@ -134,8 +134,7 @@ namespace System.IO.Compression
 
         private unsafe ZErrorCode ReadDeflateOutput(byte[] outputBuffer, ZFlushCode flushCode, out int bytesRead)
         {
-            Debug.Assert(null != outputBuffer, "Can't pass in a null output buffer!");
-            Debug.Assert(outputBuffer.Length > 0, "Can't pass in an empty output buffer!");
+            Debug.Assert(outputBuffer?.Length > 0);
         
             lock (SyncLock)
             {

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Deflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Deflater.cs
@@ -134,9 +134,12 @@ namespace System.IO.Compression
 
         private unsafe ZErrorCode ReadDeflateOutput(byte[] outputBuffer, ZFlushCode flushCode, out int bytesRead)
         {
+            Debug.Assert(null != outputBuffer, "Can't pass in a null output buffer!");
+            Debug.Assert(outputBuffer.Length > 0, "Can't pass in an empty output buffer!");
+        
             lock (SyncLock)
             {
-                fixed (byte* bufPtr = outputBuffer)
+                fixed (byte* bufPtr = &outputBuffer[0])
                 {
                     _zlibStream.NextOut = (IntPtr)bufPtr;
                     _zlibStream.AvailOut = (uint)outputBuffer.Length;

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -742,6 +742,7 @@ namespace System.IO
             private bool TryReadEvent(out NotifyEvent notifyEvent)
             {
                 Debug.Assert(_buffer != null);
+                Debug.Assert(_buffer.Length > 0);
                 Debug.Assert(_bufferAvailable >= 0 && _bufferAvailable <= _buffer.Length);
                 Debug.Assert(_bufferPos >= 0 && _bufferPos <= _bufferAvailable);
 
@@ -754,7 +755,7 @@ namespace System.IO
                     {
                         try
                         {
-                            fixed (byte* buf = this._buffer)
+                            fixed (byte* buf = &_buffer[0])
                             {
                                 _bufferAvailable = Interop.CheckIo(Interop.Sys.Read(_inotifyHandle, buf, this._buffer.Length), 
                                     isDirectory: true);

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
@@ -246,6 +246,9 @@ namespace System.IO
 
         private void ParseEventBufferAndNotifyForEach(byte[] buffer)
         {
+            Debug.Assert(buffer != null);
+            Debug.Assert(buffer.Length > 0);
+
             // Parse each event from the buffer and notify appropriate delegates
 
             /******
@@ -273,7 +276,7 @@ namespace System.IO
             {
                 unsafe
                 {
-                    fixed (byte* buffPtr = buffer)
+                    fixed (byte* buffPtr = &buffer[0])
                     {
                         // Get next offset:
                         nextOffset = *((int*)(buffPtr + offset));
@@ -370,6 +373,7 @@ namespace System.IO
             internal AsyncReadState(int session, byte[] buffer, SafeFileHandle handle, ThreadPoolBoundHandle binding)
             {
                 Debug.Assert(buffer != null);
+                Debug.Assert(buffer.Length > 0);
                 Debug.Assert(handle != null);
                 Debug.Assert(binding != null);
 

--- a/src/System.IO.FileSystem/src/System/IO/FileStream.Win32.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileStream.Win32.cs
@@ -1277,7 +1277,7 @@ namespace System.IO
             int r = 0;
             int numBytesRead = 0;
 
-            fixed (byte* p = bytes)
+            fixed (byte* p = &bytes[0])
             {
                 if (_useAsyncIO)
                     r = Interop.Kernel32.ReadFile(handle, p + offset, count, IntPtr.Zero, overlapped);
@@ -1322,7 +1322,7 @@ namespace System.IO
             int numBytesWritten = 0;
             int r = 0;
 
-            fixed (byte* p = bytes)
+            fixed (byte* p = &bytes[0])
             {
                 if (_useAsyncIO)
                     r = Interop.Kernel32.WriteFile(handle, p + offset, count, IntPtr.Zero, overlapped);

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
@@ -353,7 +353,7 @@ namespace System.IO.Pipes
             int r = 0;
             int numBytesRead = 0;
 
-            fixed (byte* p = buffer)
+            fixed (byte* p = &buffer[0])
             {
                 if (_isAsync)
                 {
@@ -403,7 +403,7 @@ namespace System.IO.Pipes
             int numBytesWritten = 0;
             int r = 0;
 
-            fixed (byte* p = buffer)
+            fixed (byte* p = &buffer[0])
             {
                 if (_isAsync)
                 {

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -160,7 +160,7 @@ namespace System.Net.Http
             else
             {
                 bufferLength = buffer.Length;
-                fixed (char* pBuffer = buffer)
+                fixed (char* pBuffer = &buffer[0])
                 {
                     if (QueryHeaders(requestHandle, infoLevel, pBuffer, ref bufferLength, ref index))
                     {
@@ -203,7 +203,7 @@ namespace System.Net.Http
             int bufferLength = buffer.Length;
             uint index = 0;
 
-            fixed (char* pBuffer = buffer)
+            fixed (char* pBuffer = &buffer[0])
             {
                 if (!QueryHeaders(requestHandle, infoLevel, pBuffer, ref bufferLength, ref index))
                 {

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -2006,7 +2006,7 @@ namespace System.Net
             // is >128 we will get ERROR_MORE_DATA and call again
             int size = s_requestChannelBindStatusSize + 128;
 
-            Debug.Assert(size >= 0);
+            Debug.Assert(size > 0);
 
             byte[] blob = null;
             Interop.HttpApi.SafeLocalFreeChannelBinding token = null;

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -1901,7 +1901,7 @@ namespace System.Net
                 httpResponse.ReasonLength = (ushort)byteReason.Length;
 
                 byte[] byteContentLength = Encoding.Default.GetBytes("0");
-                fixed (byte* pContentLength = byteContentLength)
+                fixed (byte* pContentLength = &byteContentLength[0])
                 {
                     (&httpResponse.Headers.KnownHeaders)[(int)HttpResponseHeader.ContentLength].pRawValue = (sbyte*)pContentLength;
                     (&httpResponse.Headers.KnownHeaders)[(int)HttpResponseHeader.ContentLength].RawValueLength = (ushort)byteContentLength.Length;
@@ -2017,7 +2017,7 @@ namespace System.Net
             do
             {
                 blob = new byte[size];
-                fixed (byte* blobPtr = blob)
+                fixed (byte* blobPtr = &blob[0])
                 {
                     // Http.sys team: ServiceName will always be null if 
                     // HTTP_RECEIVE_SECURE_CHANNEL_TOKEN flag is set.

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerRequest.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerRequest.Windows.cs
@@ -822,7 +822,7 @@ namespace System.Net
                 while (true)
                 {
                     byte[] clientCertInfoBlob = new byte[checked((int)size)];
-                    fixed (byte* pClientCertInfoBlob = clientCertInfoBlob)
+                    fixed (byte* pClientCertInfoBlob = &clientCertInfoBlob[0])
                     {
                         Interop.HttpApi.HTTP_SSL_CLIENT_CERT_INFO* pClientCertInfo = (Interop.HttpApi.HTTP_SSL_CLIENT_CERT_INFO*)pClientCertInfoBlob;
 

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
@@ -549,7 +549,7 @@ namespace System.Net
                 if (StatusDescription.Length > 0)
                 {
                     byte[] statusDescriptionBytes = new byte[WebHeaderEncoding.GetByteCount(StatusDescription)];
-                    fixed (byte* pStatusDescription = statusDescriptionBytes)
+                    fixed (byte* pStatusDescription = &statusDescriptionBytes[0])
                     {
                         _nativeResponse.ReasonLength = (ushort)statusDescriptionBytes.Length;
                         WebHeaderEncoding.GetBytes(StatusDescription, 0, statusDescriptionBytes.Length, statusDescriptionBytes, 0);

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpResponseStream.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpResponseStream.Windows.cs
@@ -427,7 +427,7 @@ namespace System.Net
                         {
                             flags |= Interop.HttpApi.HTTP_FLAGS.HTTP_SEND_RESPONSE_FLAG_DISCONNECT;
                         }
-                        fixed (void* pBuffer = s_chunkTerminator)
+                        fixed (void* pBuffer = &s_chunkTerminator[0])
                         {
                             Interop.HttpApi.HTTP_DATA_CHUNK* pDataChunk = null;
                             if (_httpContext.Response.BoundaryType == BoundaryType.Chunked)

--- a/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Unix.cs
+++ b/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Unix.cs
@@ -190,7 +190,7 @@ namespace System.Net
             byte[] addressBuffer = addr.GetAddressBytes();
 
             int error;
-            fixed (byte* rawAddress = addressBuffer)
+            fixed (byte* rawAddress = &addressBuffer[0])
             {
                 error = Interop.Sys.GetNameInfo(
                     rawAddress,

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPAddressUtil.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPAddressUtil.cs
@@ -34,7 +34,7 @@ namespace System.Net.NetworkInformation
         public static unsafe IPAddress GetIPAddressFromNativeInfo(Interop.Sys.IpAddressInfo* addressInfo)
         {
             byte[] ipBytes = new byte[addressInfo->NumAddressBytes];
-            fixed (byte* ipArrayPtr = &ipBytes[0])
+            fixed (byte* ipArrayPtr = ipBytes)
             {
                 Buffer.MemoryCopy(addressInfo->AddressBytes, ipArrayPtr, ipBytes.Length, ipBytes.Length);
             }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPAddressUtil.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPAddressUtil.cs
@@ -34,7 +34,7 @@ namespace System.Net.NetworkInformation
         public static unsafe IPAddress GetIPAddressFromNativeInfo(Interop.Sys.IpAddressInfo* addressInfo)
         {
             byte[] ipBytes = new byte[addressInfo->NumAddressBytes];
-            fixed (byte* ipArrayPtr = ipBytes)
+            fixed (byte* ipArrayPtr = &ipBytes[0])
             {
                 Buffer.MemoryCopy(addressInfo->AddressBytes, ipArrayPtr, ipBytes.Length, ipBytes.Length);
             }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxIPGlobalProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxIPGlobalProperties.cs
@@ -26,7 +26,7 @@ namespace System.Net.NetworkInformation
                 TcpState state = nativeInfo.State;
 
                 byte[] localBytes = new byte[nativeInfo.LocalEndPoint.NumAddressBytes];
-                fixed (byte* localBytesPtr = &localBytes[0])
+                fixed (byte* localBytesPtr = localBytes)
                 {
                     Buffer.MemoryCopy(nativeInfo.LocalEndPoint.AddressBytes, localBytesPtr, localBytes.Length, localBytes.Length);
                 }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxIPGlobalProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxIPGlobalProperties.cs
@@ -26,7 +26,7 @@ namespace System.Net.NetworkInformation
                 TcpState state = nativeInfo.State;
 
                 byte[] localBytes = new byte[nativeInfo.LocalEndPoint.NumAddressBytes];
-                fixed (byte* localBytesPtr = localBytes)
+                fixed (byte* localBytesPtr = &localBytes[0])
                 {
                     Buffer.MemoryCopy(nativeInfo.LocalEndPoint.AddressBytes, localBytesPtr, localBytes.Length, localBytes.Length);
                 }
@@ -41,7 +41,7 @@ namespace System.Net.NetworkInformation
                 else
                 {
                     byte[] remoteBytes = new byte[nativeInfo.RemoteEndPoint.NumAddressBytes];
-                    fixed (byte* remoteBytesPtr = remoteBytes)
+                    fixed (byte* remoteBytesPtr = &remoteBytes[0])
                     {
                         Buffer.MemoryCopy(nativeInfo.RemoteEndPoint.AddressBytes, remoteBytesPtr, remoteBytes.Length, remoteBytes.Length);
                     }
@@ -84,7 +84,7 @@ namespace System.Net.NetworkInformation
                 else
                 {
                     byte[] bytes = new byte[endPointInfo.NumAddressBytes];
-                    fixed (byte* bytesPtr = bytes)
+                    fixed (byte* bytesPtr = &bytes[0])
                     {
                         Buffer.MemoryCopy(endPointInfo.AddressBytes, bytesPtr, bytes.Length, bytes.Length);
                     }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxIpInterfaceProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxIpInterfaceProperties.cs
@@ -49,7 +49,7 @@ namespace System.Net.NetworkInformation
                 (gatewayAddressInfo) =>
                 {
                     byte[] ipBytes = new byte[gatewayAddressInfo->NumAddressBytes];
-                    fixed (byte* ipArrayPtr = &ipBytes[0])
+                    fixed (byte* ipArrayPtr = ipBytes)
                     {
                         Buffer.MemoryCopy(gatewayAddressInfo->AddressBytes, ipArrayPtr, ipBytes.Length, ipBytes.Length);
                     }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxIpInterfaceProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxIpInterfaceProperties.cs
@@ -49,7 +49,7 @@ namespace System.Net.NetworkInformation
                 (gatewayAddressInfo) =>
                 {
                     byte[] ipBytes = new byte[gatewayAddressInfo->NumAddressBytes];
-                    fixed (byte* ipArrayPtr = ipBytes)
+                    fixed (byte* ipArrayPtr = &ipBytes[0])
                     {
                         Buffer.MemoryCopy(gatewayAddressInfo->AddressBytes, ipArrayPtr, ipBytes.Length, ipBytes.Length);
                     }

--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
@@ -103,7 +103,7 @@ namespace System.Net.NetworkInformation
                     byte type, code;
                     unsafe
                     {
-                        fixed (byte* bytesPtr = receiveBuffer)
+                        fixed (byte* bytesPtr = &receiveBuffer[0])
                         {
                             int icmpHeaderOffset = ipHeaderLength;
                             IcmpHeader receivedHeader = *((IcmpHeader*)(bytesPtr + icmpHeaderOffset)); // Skip IP header.

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -951,7 +951,7 @@ namespace System.Net.Sockets
             }
             else
             {
-                fixed (byte* pinnedValue = optionValue)
+                fixed (byte* pinnedValue = &optionValue[0])
                 {
                     err = Interop.Sys.SetSockOpt(handle, optionLevel, optionName, pinnedValue, optionValue.Length);
                 }
@@ -1071,7 +1071,7 @@ namespace System.Net.Sockets
                 SocketError returnError = GetSockOpt(handle, optionLevel, optionName, out outError);
                 if (returnError == SocketError.Success)
                 {
-                    fixed (byte* pinnedValue = optionValue)
+                    fixed (byte* pinnedValue = &optionValue[0])
                     {
                         Debug.Assert(BitConverter.IsLittleEndian, "Expected little endian");
                         *((int*)pinnedValue) = outError;
@@ -1082,7 +1082,7 @@ namespace System.Net.Sockets
             }
             else
             {
-                fixed (byte* pinnedValue = optionValue)
+                fixed (byte* pinnedValue = &optionValue[0])
                 {
                     err = Interop.Sys.GetSockOpt(handle, optionLevel, optionName, pinnedValue, &optLen);
                 }
@@ -1213,7 +1213,7 @@ namespace System.Net.Sockets
             else
             {
                 var eventsOnHeap = new Interop.Sys.PollEvent[count];
-                fixed (Interop.Sys.PollEvent* eventsOnHeapPtr = eventsOnHeap)
+                fixed (Interop.Sys.PollEvent* eventsOnHeapPtr = &eventsOnHeap[0])
                 {
                     return SelectViaPoll(
                         checkRead, checkReadInitialCount,

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -189,7 +189,7 @@ namespace System.Net.Sockets
             }
             else
             {
-                fixed (byte* pinnedBuffer = buffer)
+                fixed (byte* pinnedBuffer = &buffer[0])
                 {
                     bytesSent = Interop.Winsock.send(
                         handle.DangerousGetHandle(),
@@ -234,7 +234,7 @@ namespace System.Net.Sockets
             }
             else
             {
-                fixed (byte* pinnedBuffer = buffer)
+                fixed (byte* pinnedBuffer = &buffer[0])
                 {
                     bytesSent = Interop.Winsock.sendto(
                         handle.DangerousGetHandle(),
@@ -440,7 +440,7 @@ namespace System.Net.Sockets
             }
             else
             {
-                fixed (byte* pinnedBuffer = buffer)
+                fixed (byte* pinnedBuffer = &buffer[0])
                 {
                     bytesReceived = Interop.Winsock.recvfrom(handle.DangerousGetHandle(), pinnedBuffer + offset, size, socketFlags, socketAddress, ref addressLength);
                 }

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocket.cs
@@ -676,7 +676,7 @@ namespace System.Net.WebSockets
             else
             {
                 bufferLength = buffer.Length;
-                fixed (char* pBuffer = buffer)
+                fixed (char* pBuffer = &buffer[0])
                 {
                     if (QueryHeaders(headerName, pBuffer, ref bufferLength))
                     {

--- a/src/System.Private.DataContractSerialization/src/System/Text/Base64Encoding.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Text/Base64Encoding.cs
@@ -11,7 +11,7 @@ namespace System.Text
 {
     internal class Base64Encoding : Encoding
     {
-        private static byte[] s_char2val = new byte[128]
+        private static readonly byte[] s_char2val = new byte[128]
         {
             /*    0-15 */ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
             /*   16-31 */ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
@@ -23,8 +23,8 @@ namespace System.Text
             /* 112-127 */   41,   42,   43,   44,   45,   46,   47,   48,   49,   50,   51, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
         };
 
-        private static string s_val2char = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-        private static byte[] s_val2byte = new byte[]
+        private static readonly string s_val2char = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        private static readonly byte[] s_val2byte = new byte[]
         {
             (byte)'A',(byte)'B',(byte)'C',(byte)'D',(byte)'E',(byte)'F',(byte)'G',(byte)'H',(byte)'I',(byte)'J',(byte)'K',(byte)'L',(byte)'M',(byte)'N',(byte)'O',(byte)'P',
             (byte)'Q',(byte)'R',(byte)'S',(byte)'T',(byte)'U',(byte)'V',(byte)'W',(byte)'X',(byte)'Y',(byte)'Z',(byte)'a',(byte)'b',(byte)'c',(byte)'d',(byte)'e',(byte)'f',
@@ -70,7 +70,7 @@ namespace System.Text
                 return 0;
             if ((count % 4) != 0)
                 throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new FormatException(SR.Format(SR.XmlInvalidBase64Length, count.ToString(NumberFormatInfo.CurrentInfo))));
-            fixed (byte* _char2val = s_char2val)
+            fixed (byte* _char2val = &s_char2val[0])
             {
                 fixed (char* _chars = &chars[index])
                 {
@@ -133,7 +133,7 @@ namespace System.Text
                 return 0;
             if ((charCount % 4) != 0)
                 throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new FormatException(SR.Format(SR.XmlInvalidBase64Length, charCount.ToString(NumberFormatInfo.CurrentInfo))));
-            fixed (byte* _char2val = s_char2val)
+            fixed (byte* _char2val = &s_char2val[0])
             {
                 fixed (char* _chars = &chars[charIndex])
                 {
@@ -211,7 +211,7 @@ namespace System.Text
                 return 0;
             if ((charCount % 4) != 0)
                 throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new FormatException(SR.Format(SR.XmlInvalidBase64Length, charCount.ToString(NumberFormatInfo.CurrentInfo))));
-            fixed (byte* _char2val = s_char2val)
+            fixed (byte* _char2val = &s_char2val[0])
             {
                 fixed (byte* _chars = &chars[charIndex])
                 {
@@ -393,7 +393,7 @@ namespace System.Text
 
             if (byteCount > 0)
             {
-                fixed (byte* _val2byte = s_val2byte)
+                fixed (byte* _val2byte = &s_val2byte[0])
                 {
                     fixed (byte* _bytes = &bytes[byteIndex])
                     {

--- a/src/System.Private.DataContractSerialization/src/System/Text/Base64Encoding.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Text/Base64Encoding.cs
@@ -23,7 +23,8 @@ namespace System.Text
             /* 112-127 */   41,   42,   43,   44,   45,   46,   47,   48,   49,   50,   51, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
         };
 
-        private static readonly string s_val2char = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        private const string Val2Char = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        
         private static readonly byte[] s_val2byte = new byte[]
         {
             (byte)'A',(byte)'B',(byte)'C',(byte)'D',(byte)'E',(byte)'F',(byte)'G',(byte)'H',(byte)'I',(byte)'J',(byte)'K',(byte)'L',(byte)'M',(byte)'N',(byte)'O',(byte)'P',
@@ -303,7 +304,7 @@ namespace System.Text
 
             if (byteCount > 0)
             {
-                fixed (char* _val2char = s_val2char)
+                fixed (char* _val2char = Val2Char)
                 {
                     fixed (byte* _bytes = &bytes[byteIndex])
                     {

--- a/src/System.Private.DataContractSerialization/src/System/Text/BinHexEncoding.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Text/BinHexEncoding.cs
@@ -29,7 +29,7 @@ namespace System.Text
                               0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
         };
 
-        private static readonly string s_val2char = "0123456789ABCDEF";
+        private const string Val2Char = "0123456789ABCDEF";
 
         public override int GetMaxByteCount(int charCount)
         {
@@ -138,7 +138,7 @@ namespace System.Text
                 throw new ArgumentException(SR.XmlArrayTooSmall, nameof(chars));
             if (byteCount > 0)
             {
-                fixed (char* _val2char = s_val2char)
+                fixed (char* _val2char = Val2Char)
                 {
                     fixed (byte* _bytes = &bytes[byteIndex])
                     {

--- a/src/System.Private.DataContractSerialization/src/System/Text/BinHexEncoding.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Text/BinHexEncoding.cs
@@ -9,7 +9,7 @@ namespace System.Text
 {
     internal class BinHexEncoding : Encoding
     {
-        private static byte[] s_char2val = new byte[128]
+        private static readonly byte[] s_char2val = new byte[128]
         {
             /*    0-15 */
                               0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
@@ -29,7 +29,7 @@ namespace System.Text
                               0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
         };
 
-        private static string s_val2char = "0123456789ABCDEF";
+        private static readonly string s_val2char = "0123456789ABCDEF";
 
         public override int GetMaxByteCount(int charCount)
         {
@@ -68,7 +68,7 @@ namespace System.Text
                 throw new ArgumentException(SR.XmlArrayTooSmall, nameof(bytes));
             if (charCount > 0)
             {
-                fixed (byte* _char2val = s_char2val)
+                fixed (byte* _char2val = &s_char2val[0])
                 {
                     fixed (byte* _bytes = &bytes[byteIndex])
                     {

--- a/src/System.Private.DataContractSerialization/src/System/Xml/UniqueId.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/UniqueId.cs
@@ -12,7 +12,7 @@ namespace System.Xml
         private const int guidLength = 16;
         private const int uuidLength = 45;
 
-        private static short[] s_char2val = new short[256]
+        private static readonly short[] s_char2val = new short[256]
         {
             /*    0-15 */
                               0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100, 0x100,
@@ -163,7 +163,7 @@ namespace System.Xml
 
             int i = 0;
             int j = 0;
-            fixed (short* ps = s_char2val)
+            fixed (short* ps = &s_char2val[0])
             {
                 short* _char2val = ps;
 

--- a/src/System.Private.Uri/src/System/IriHelper.cs
+++ b/src/System.Private.Uri/src/System/IriHelper.cs
@@ -307,9 +307,9 @@ namespace System
 
                 if (escape)
                 {
-                    const int maxNumberOfBytesEncoded = 4;
+                    const int MaxNumberOfBytesEncoded = 4;
 
-                    if (bufferRemaining < maxNumberOfBytesEncoded * percentEncodingLen)
+                    if (bufferRemaining < MaxNumberOfBytesEncoded * percentEncodingLen)
                     {
                         int newBufferLength = 0;
 
@@ -339,11 +339,11 @@ namespace System
                         pDest = (char*)destHandle.AddrOfPinnedObject();
                     }
 
-                    byte[] encodedBytes = new byte[maxNumberOfBytesEncoded];
+                    byte[] encodedBytes = new byte[MaxNumberOfBytesEncoded];
                     fixed (byte* pEncodedBytes = &encodedBytes[0])
                     {
-                        int encodedBytesCount = Encoding.UTF8.GetBytes(pInput + next, surrogatePair ? 2 : 1, pEncodedBytes, maxNumberOfBytesEncoded);
-                        Debug.Assert(encodedBytesCount <= maxNumberOfBytesEncoded, "UTF8 encoder should not exceed specified byteCount");
+                        int encodedBytesCount = Encoding.UTF8.GetBytes(pInput + next, surrogatePair ? 2 : 1, pEncodedBytes, MaxNumberOfBytesEncoded);
+                        Debug.Assert(encodedBytesCount <= MaxNumberOfBytesEncoded, "UTF8 encoder should not exceed specified byteCount");
 
                         bufferRemaining -= encodedBytesCount * percentEncodingLen;
 

--- a/src/System.Private.Uri/src/System/IriHelper.cs
+++ b/src/System.Private.Uri/src/System/IriHelper.cs
@@ -340,7 +340,7 @@ namespace System
                     }
 
                     byte[] encodedBytes = new byte[maxNumberOfBytesEncoded];
-                    fixed (byte* pEncodedBytes = encodedBytes)
+                    fixed (byte* pEncodedBytes = &encodedBytes[0])
                     {
                         int encodedBytesCount = Encoding.UTF8.GetBytes(pInput + next, surrogatePair ? 2 : 1, pEncodedBytes, maxNumberOfBytesEncoded);
                         Debug.Assert(encodedBytesCount <= maxNumberOfBytesEncoded, "UTF8 encoder should not exceed specified byteCount");

--- a/src/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/System.Private.Uri/src/System/UriHelper.cs
@@ -412,7 +412,7 @@ namespace System
                                 {
                                     escapedReallocations = 30;
                                     char[] newDest = new char[dest.Length + escapedReallocations * 3];
-                                    fixed (char* pNewDest = newDest)
+                                    fixed (char* pNewDest = &newDest[0])
                                     {
                                         for (int i = 0; i < destPosition; ++i)
                                             pNewDest[i] = pDest[i];

--- a/src/System.Private.Xml/src/System/Xml/Core/HtmlUtf8RawTextWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/HtmlUtf8RawTextWriter.cs
@@ -711,6 +711,7 @@ namespace System.Xml
                             break;
                         default:
                             const string hexDigits = "0123456789ABCDEF";
+                            Debug.Assert(_uriEscapingBuffer?.Length > 0);
                             fixed (byte* pUriEscapingBuffer = &_uriEscapingBuffer[0])
                             {
                                 byte* pByte = pUriEscapingBuffer;

--- a/src/System.Private.Xml/src/System/Xml/Core/HtmlUtf8RawTextWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/HtmlUtf8RawTextWriter.cs
@@ -711,7 +711,7 @@ namespace System.Xml
                             break;
                         default:
                             const string hexDigits = "0123456789ABCDEF";
-                            fixed (byte* pUriEscapingBuffer = _uriEscapingBuffer)
+                            fixed (byte* pUriEscapingBuffer = &_uriEscapingBuffer[0])
                             {
                                 byte* pByte = pUriEscapingBuffer;
                                 byte* pEnd = pByte;

--- a/src/System.Private.Xml/src/System/Xml/Xsl/XPathConvert.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/XPathConvert.cs
@@ -3188,7 +3188,7 @@ namespace System.Xml.Xsl
                     dec.Sign = sign;
                     dec.MantissaSize = numDig;
 
-                    fixed (byte* pin = dec.Mantissa)
+                    fixed (byte* pin = &dec.Mantissa[0])
                     {
                         byte* mantissa = pin;
                         while (pchFirstDig < pch)

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/EncodingHelper.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/EncodingHelper.cs
@@ -92,7 +92,7 @@ namespace System.Reflection.Internal
             Marshal.Copy((IntPtr)bytes, buffer, prefix.Length, byteCount);
 
             string result;
-            fixed (byte* prefixedBytes = buffer)
+            fixed (byte* prefixedBytes = &buffer[0])
             {
                 result = utf8Decoder.GetString(prefixedBytes, prefixedByteCount);
             }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
@@ -774,7 +774,7 @@ namespace System.Reflection.Metadata
                 return;
             }
 
-            fixed (byte* ptr = buffer)
+            fixed (byte* ptr = &buffer[0])
             {
                 WriteBytesUnchecked(ptr + start, byteCount);
             }
@@ -954,7 +954,7 @@ namespace System.Reflection.Metadata
                 return;
             }
 
-            fixed (char* ptr = value)
+            fixed (char* ptr = &value[0])
             {
                 WriteBytesUnchecked((byte*)ptr, value.Length * sizeof(char));
             }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobContentId.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobContentId.cs
@@ -38,7 +38,7 @@ namespace System.Reflection.Metadata
                 throw new ArgumentException(SR.Format(SR.UnexpectedArrayLength, Size), nameof(id));
             }
 
-            fixed (byte* ptr = id)
+            fixed (byte* ptr = &id[0])
             {
                 var reader = new BlobReader(ptr, id.Length);
                 Guid = reader.ReadGuid();

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
@@ -231,7 +231,7 @@ namespace System.Reflection.Metadata
                 return;
             }
 
-            fixed (byte* ptr = buffer)
+            fixed (byte* ptr = &buffer[0])
             {
                 WriteBytes(ptr + start, byteCount);
             }
@@ -384,7 +384,7 @@ namespace System.Reflection.Metadata
                 return;
             }
 
-            fixed (char* ptr = value)
+            fixed (char* ptr = &value[0])
             {
                 WriteBytesUnchecked((byte*)ptr, value.Length * sizeof(char));
             }

--- a/src/System.Runtime.Extensions/src/System/BitConverter.cs
+++ b/src/System.Runtime.Extensions/src/System/BitConverter.cs
@@ -51,7 +51,7 @@ namespace System
             Contract.Ensures(Contract.Result<byte[]>().Length == 2);
 
             byte[] bytes = new byte[2];
-            fixed (byte* b = bytes)
+            fixed (byte* b = &bytes[0])
                 *((short*)b) = value;
             return bytes;
         }
@@ -65,7 +65,7 @@ namespace System
             Contract.Ensures(Contract.Result<byte[]>().Length == 4);
 
             byte[] bytes = new byte[4];
-            fixed (byte* b = bytes)
+            fixed (byte* b = &bytes[0])
                 *((int*)b) = value;
             return bytes;
         }
@@ -79,7 +79,7 @@ namespace System
             Contract.Ensures(Contract.Result<byte[]>().Length == 8);
 
             byte[] bytes = new byte[8];
-            fixed (byte* b = bytes)
+            fixed (byte* b = &bytes[0])
                 *((long*)b) = value;
             return bytes;
         }
@@ -374,7 +374,8 @@ namespace System
                 }
                 else
                 {
-                    fixed (char* chArrayPtr = new char[chArrayLength])
+                    char[] chArray = new char[chArrayLength];
+                    fixed (char* chArrayPtr = &chArray[0])
                         return ToString(value, startIndex, length, chArrayPtr, chArrayLength);
                 }
             }

--- a/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
@@ -382,7 +382,7 @@ namespace System
                 {
                     lastBufLen *= 2;
                     byte[] heapBuf = new byte[lastBufLen];
-                    fixed (byte* buf = heapBuf)
+                    fixed (byte* buf = &heapBuf[0])
                     {
                         if (TryGetUserNameFromPasswd(buf, heapBuf.Length, out username))
                         {

--- a/src/System.Runtime.Extensions/src/System/Environment.Win32.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Win32.cs
@@ -288,7 +288,7 @@ namespace System
                 // Allocate that much space
                 Debug.Assert(len > 0);
                 var buffer = new byte[len];
-                fixed (byte* bufferPtr = &buffer[0])
+                fixed (byte* bufferPtr = buffer)
                 {
                     // Call GetLogicalProcessorInformationEx with the allocated buffer
                     if (Interop.Kernel32.GetLogicalProcessorInformationEx(Interop.Kernel32.LOGICAL_PROCESSOR_RELATIONSHIP.RelationGroup, (IntPtr)bufferPtr, ref len))

--- a/src/System.Runtime.Extensions/src/System/Environment.Win32.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Win32.cs
@@ -288,7 +288,7 @@ namespace System
                 // Allocate that much space
                 Debug.Assert(len > 0);
                 var buffer = new byte[len];
-                fixed (byte* bufferPtr = buffer)
+                fixed (byte* bufferPtr = &buffer[0])
                 {
                     // Call GetLogicalProcessorInformationEx with the allocated buffer
                     if (Interop.Kernel32.GetLogicalProcessorInformationEx(Interop.Kernel32.LOGICAL_PROCESSOR_RELATIONSHIP.RelationGroup, (IntPtr)bufferPtr, ref len))

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.AddSub.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.AddSub.cs
@@ -47,7 +47,7 @@ namespace System.Numerics
 
             uint[] bits = new uint[left.Length + 1];
 
-            fixed (uint* l = left, r = right, b = bits)
+            fixed (uint* l = left, r = right, b = &bits[0])
             {
                 Add(l, left.Length,
                     r, right.Length,

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.DivRem.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.DivRem.cs
@@ -88,7 +88,7 @@ namespace System.Numerics
             uint[] localLeft = CreateCopy(left);
             uint[] bits = new uint[left.Length - right.Length + 1];
 
-            fixed (uint* l = localLeft, r = right, b = bits)
+            fixed (uint* l = &localLeft[0], r = &right[0], b = &bits[0])
             {
                 Divide(l, localLeft.Length,
                        r, right.Length,
@@ -114,7 +114,7 @@ namespace System.Numerics
             uint[] localLeft = CreateCopy(left);
             uint[] bits = new uint[left.Length - right.Length + 1];
 
-            fixed (uint* l = localLeft, r = right, b = bits)
+            fixed (uint* l = &localLeft[0], r = &right[0], b = &bits[0])
             {
                 Divide(l, localLeft.Length,
                        r, right.Length,
@@ -137,7 +137,7 @@ namespace System.Numerics
             // NOTE: left will get overwritten, we need a local copy
             uint[] localLeft = CreateCopy(left);
 
-            fixed (uint* l = localLeft, r = right)
+            fixed (uint* l = &localLeft[0], r = &right[0])
             {
                 Divide(l, localLeft.Length,
                        r, right.Length,

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AppleCCCryptor.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AppleCCCryptor.cs
@@ -77,7 +77,7 @@ namespace Internal.Cryptography
             int ret;
             int errorCode;
 
-            fixed (byte* outputStart = output)
+            fixed (byte* outputStart = &output[0])
             {
                 byte* outputCurrent = outputStart + outputBytes;
                 int bytesWritten;

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CngKeyLite.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CngKeyLite.cs
@@ -338,7 +338,7 @@ namespace System.Security.Cryptography
 
             unsafe
             {
-                fixed (byte* pValue = value)
+                fixed (byte* pValue = &value[0])
                 {
                     string valueAsString = Marshal.PtrToStringUni((IntPtr)pValue);
                     return valueAsString;

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
@@ -123,7 +123,7 @@ namespace Internal.Cryptography
                 return string.Empty; // Desktop compat: return empty if property value is 0-length.
             unsafe
             {
-                fixed (byte* pValue = value)
+                fixed (byte* pValue = &value[0])
                 {
                     string valueAsString = Marshal.PtrToStringUni((IntPtr)pValue);
                     return valueAsString;

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.StandardProperties.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.StandardProperties.cs
@@ -285,7 +285,7 @@ namespace System.Security.Cryptography
                         // ! We must keep this byte array pinned until NCryptGetProperty() has returned *and* we've marshaled all of the inner native strings into managed String
                         // ! objects. Otherwise, a badly timed GC will move the native strings in memory and invalidate the pointers to them before we dereference them. 
                         byte[] ncryptUiPolicyAndStrings = new byte[numBytesNeeded];
-                        fixed (byte* pNcryptUiPolicyAndStrings = ncryptUiPolicyAndStrings)
+                        fixed (byte* pNcryptUiPolicyAndStrings = &ncryptUiPolicyAndStrings[0])
                         {
                             errorCode = Interop.NCrypt.NCryptGetProperty(_keyHandle, KeyPropertyName.UIPolicy, pNcryptUiPolicyAndStrings, ncryptUiPolicyAndStrings.Length, out numBytesNeeded, CngPropertyOptions.None);
                             if (errorCode != ErrorCode.ERROR_SUCCESS)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.PublicKey.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.PublicKey.cs
@@ -175,7 +175,7 @@ namespace Internal.Cryptography.Pal
             {
                 Debug.Assert(ecBlob.Length >= sizeof(Interop.BCrypt.BCRYPT_ECCKEY_BLOB));
 
-                fixed (byte* pEcBlob = ecBlob)
+                fixed (byte* pEcBlob = &ecBlob[0])
                 {
                     Interop.BCrypt.BCRYPT_ECCKEY_BLOB* pBcryptBlob = (Interop.BCrypt.BCRYPT_ECCKEY_BLOB*)pEcBlob;
 
@@ -341,7 +341,7 @@ namespace Internal.Cryptography.Pal
 
             unsafe
             {
-                fixed (byte* pValue = value)
+                fixed (byte* pValue = &value[0])
                 {
                     string valueAsString = Marshal.PtrToStringUni((IntPtr)pValue);
                     return valueAsString;

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
@@ -183,11 +183,12 @@ namespace System.Security.Principal
 
         private static int LookupAuthenticationPackage(SafeLsaHandle lsaHandle, string packageName)
         {
+            Debug.Assert(!string.IsNullOrEmpty(packageName));
             unsafe
             {
                 int packageId;
                 byte[] asciiPackageName = Encoding.ASCII.GetBytes(packageName);
-                fixed (byte* pAsciiPackageName = asciiPackageName)
+                fixed (byte* pAsciiPackageName = &asciiPackageName[0])
                 {
                     LSA_STRING lsaPackageName = new LSA_STRING((IntPtr)pAsciiPackageName, checked((ushort)(asciiPackageName.Length)));
                     int ntStatus = Interop.SspiCli.LsaLookupAuthenticationPackage(lsaHandle, ref lsaPackageName, out packageId);

--- a/src/System.Text.Encoding.CodePages/src/System/Text/BaseCodePageEncoding.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/BaseCodePageEncoding.cs
@@ -211,13 +211,13 @@ namespace System.Text
                 s_codePagesEncodingDataStream.Seek(CODEPAGE_DATA_FILE_HEADER_SIZE, SeekOrigin.Begin);
 
                 int codePagesCount;
-                fixed (byte* pBytes = s_codePagesDataHeader)
+                fixed (byte* pBytes = &s_codePagesDataHeader[0])
                 {
                     CodePageDataFileHeader* pDataHeader = (CodePageDataFileHeader*)pBytes;
                     codePagesCount = pDataHeader->CodePageCount;
                 }
 
-                fixed (byte* pBytes = codePageIndex)
+                fixed (byte* pBytes = &codePageIndex[0])
                 {
                     CodePageIndex* pCodePageIndex = (CodePageIndex*)pBytes;
                     for (int i = 0; i < codePagesCount; i++)
@@ -268,13 +268,13 @@ namespace System.Text
                 s_codePagesEncodingDataStream.Seek(CODEPAGE_DATA_FILE_HEADER_SIZE, SeekOrigin.Begin);
 
                 int codePagesCount;
-                fixed (byte* pBytes = s_codePagesDataHeader)
+                fixed (byte* pBytes = &s_codePagesDataHeader[0])
                 {
                     CodePageDataFileHeader* pDataHeader = (CodePageDataFileHeader*)pBytes;
                     codePagesCount = pDataHeader->CodePageCount;
                 }
 
-                fixed (byte* pBytes = codePageIndex)
+                fixed (byte* pBytes = &codePageIndex[0])
                 {
                     CodePageIndex* pCodePageIndex = (CodePageIndex*)pBytes;
                     for (int i = 0; i < codePagesCount; i++)

--- a/src/System.Text.Encoding.CodePages/src/System/Text/DBCSCodePageEncoding.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/DBCSCodePageEncoding.cs
@@ -79,7 +79,9 @@ namespace System.Text
         [System.Security.SecurityCritical]  // auto-generated
         protected override unsafe void LoadManagedCodePage()
         {
-            fixed (byte* pBytes = m_codePageHeader)
+            Debug.Assert(m_codePageHeader?.Length > 0);
+
+            fixed (byte* pBytes = &m_codePageHeader[0])
             {
                 CodePageHeader* pCodePage = (CodePageHeader*)pBytes;
 

--- a/src/System.Text.Encoding.CodePages/src/System/Text/DecoderNLS.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/DecoderNLS.cs
@@ -149,7 +149,7 @@ namespace System.Text
                 bytes = new byte[1];
 
             // Just call pointer version
-            fixed (byte* pBytes = bytes)
+            fixed (byte* pBytes = &bytes[0])
                 return GetCharCount(pBytes + index, count, flush);
         }
 
@@ -206,8 +206,8 @@ namespace System.Text
                 chars = new char[1];
 
             // Just call pointer version
-            fixed (byte* pBytes = bytes)
-                fixed (char* pChars = chars)
+            fixed (byte* pBytes = &bytes[0])
+                fixed (char* pChars = &chars[0])
                     // Remember that charCount is # to decode, not size of array
                     return GetChars(pBytes + byteIndex, byteCount,
                                     pChars + charIndex, charCount, flush);
@@ -265,9 +265,9 @@ namespace System.Text
                 chars = new char[1];
 
             // Just call the pointer version (public overrides can't do this)
-            fixed (byte* pBytes = bytes)
+            fixed (byte* pBytes = &bytes[0])
             {
-                fixed (char* pChars = chars)
+                fixed (char* pChars = &chars[0])
                 {
                     Convert(pBytes + byteIndex, byteCount, pChars + charIndex, charCount, flush,
                         out bytesUsed, out charsUsed, out completed);

--- a/src/System.Text.Encoding.CodePages/src/System/Text/EncoderNLS.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/EncoderNLS.cs
@@ -159,7 +159,7 @@ namespace System.Text
 
             // Just call the pointer version
             int result = -1;
-            fixed (char* pChars = chars)
+            fixed (char* pChars = &chars[0])
             {
                 result = GetByteCount(pChars + index, count, flush);
             }
@@ -208,8 +208,8 @@ namespace System.Text
                 bytes = new byte[1];
 
             // Just call pointer version
-            fixed (char* pChars = chars)
-                fixed (byte* pBytes = bytes)
+            fixed (char* pChars = &chars[0])
+                fixed (byte* pBytes = &bytes[0])
 
                     // Remember that charCount is # to decode, not size of array.
                     return GetBytes(pChars + charIndex, charCount,
@@ -264,9 +264,9 @@ namespace System.Text
                 bytes = new byte[1];
 
             // Just call the pointer version (can't do this for non-msft encoders)
-            fixed (char* pChars = chars)
+            fixed (char* pChars = &chars[0])
             {
-                fixed (byte* pBytes = bytes)
+                fixed (byte* pBytes = &bytes[0])
                 {
                     Convert(pChars + charIndex, charCount, pBytes + byteIndex, byteCount, flush,
                         out charsUsed, out bytesUsed, out completed);

--- a/src/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
@@ -66,7 +66,7 @@ namespace System.Text
                 return 0;
 
             // Just call the pointer version
-            fixed (char* pChars = chars)
+            fixed (char* pChars = &chars[0])
                 return GetByteCount(pChars + index, count, null);
         }
 
@@ -130,7 +130,7 @@ namespace System.Text
                 bytes = new byte[1];
 
             fixed (char* pChars = s)
-                fixed (byte* pBytes = bytes)
+                fixed (byte* pBytes = &bytes[0])
                     return GetBytes(pChars + charIndex, charCount,
                                     pBytes + byteIndex, byteCount, null);
         }
@@ -176,8 +176,8 @@ namespace System.Text
             if (bytes.Length == 0)
                 bytes = new byte[1];
 
-            fixed (char* pChars = chars)
-                fixed (byte* pBytes = bytes)
+            fixed (char* pChars = &chars[0])
+                fixed (byte* pBytes = &bytes[0])
                     // Remember that byteCount is # to decode, not size of array.
                     return GetBytes(pChars + charIndex, charCount,
                                     pBytes + byteIndex, byteCount, null);
@@ -224,7 +224,7 @@ namespace System.Text
                 return 0;
 
             // Just call pointer version
-            fixed (byte* pBytes = bytes)
+            fixed (byte* pBytes = &bytes[0])
                 return GetCharCount(pBytes + index, count, null);
         }
 
@@ -276,8 +276,8 @@ namespace System.Text
             if (chars.Length == 0)
                 chars = new char[1];
 
-            fixed (byte* pBytes = bytes)
-                fixed (char* pChars = chars)
+            fixed (byte* pBytes = &bytes[0])
+                fixed (char* pChars = &chars[0])
                     // Remember that charCount is # to decode, not size of array
                     return GetChars(pBytes + byteIndex, byteCount,
                                     pChars + charIndex, charCount, null);
@@ -322,7 +322,7 @@ namespace System.Text
             // Avoid problems with empty input buffer
             if (bytes.Length == 0) return String.Empty;
 
-            fixed (byte* pBytes = bytes)
+            fixed (byte* pBytes = &bytes[0])
                 return GetString(pBytes + index, count);
         }
 

--- a/src/System.Text.Encoding.CodePages/src/System/Text/SBCSCodePageEncoding.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/SBCSCodePageEncoding.cs
@@ -75,7 +75,9 @@ namespace System.Text
         [System.Security.SecurityCritical]  // auto-generated
         protected override unsafe void LoadManagedCodePage()
         {
-            fixed (byte* pBytes = m_codePageHeader)
+            Debug.Assert(m_codePageHeader?.Length > 0);
+
+            fixed (byte* pBytes = &m_codePageHeader[0])
             {
                 CodePageHeader* pCodePage = (CodePageHeader*)pBytes;
                 // Should be loading OUR code page
@@ -116,7 +118,7 @@ namespace System.Text
                     s_codePagesEncodingDataStream.Read(buffer, 0, buffer.Length);
                 }
 
-                fixed (byte* pBuffer = buffer)
+                fixed (byte* pBuffer = &buffer[0])
                 {
                     char* pTemp = (char*)pBuffer;
                     for (int b = 0; b < 256; b++)

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
@@ -109,7 +109,7 @@ namespace System.Text.Encodings.Web
                     else
                     {
                         char[] wholebuffer = new char[bufferSize];
-                        fixed(char* buffer = wholebuffer)
+                        fixed(char* buffer = &wholebuffer[0])
                         {
                             int totalWritten = EncodeIntoBuffer(buffer, bufferSize, valuePointer, value.Length, firstCharacterToEncode);
                             result = new string(wholebuffer, 0, totalWritten);                            


### PR DESCRIPTION
When we know an array is not null or empty at the point where `fixed` is used, we can reduce the number of branches (and IL size of the method body) by using the address of the first element.

Based on the discussion here: https://github.com/dotnet/corefx/pull/15432#discussion_r97684916

Related:
 - https://github.com/dotnet/coreclr/pull/9115
 - https://github.com/dotnet/coreclr/pull/9188