### PR TITLE
Add tests for Thread constructor with stack size argument

### DIFF
--- a/src/System.Threading.Thread/tests/System.Threading.Thread.Tests.csproj
+++ b/src/System.Threading.Thread/tests/System.Threading.Thread.Tests.csproj
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{33F5A50E-B823-4FDD-8571-365C909ACEAE}</ProjectGuid>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Debug|AnyCPU'" />

--- a/src/System.Threading.Thread/tests/ThreadTests.netstandard.cs
+++ b/src/System.Threading.Thread/tests/ThreadTests.netstandard.cs
@@ -36,8 +36,8 @@ namespace System.Threading.Threads.Tests
                     unsafe
                     {
                         byte* buffer = stackalloc byte[bufferSizeBytes];
-                        buffer[0] = 0xff;
-                        buffer[bufferSizeBytes - 1] = 0xff;
+                        Volatile.Write(ref buffer[0], 0xff);
+                        Volatile.Write(ref buffer[bufferSizeBytes - 1], 0xff);
                     }
                 };
             startThreadAndJoin(new Thread(() => verifyStackSize(0)));


### PR DESCRIPTION
Fixes dotnet/coreclr#9158
Fixes dotnet/coreclr#9167

Part of https://github.com/dotnet/coreclr/pull/9186
Forked from https://github.com/dotnet/corefx/pull/15576