### PR TITLE
Flags attribute added for ErrArgFlags enum

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFmt.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFmt.cs
@@ -33,6 +33,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         Lim
     }
 
+    [Flags]
     internal enum ErrArgFlags
     {
         None = 0x0000,


### PR DESCRIPTION
Enum ErrArgFlags is used in bitwise operation, so it should be marked by [Flags] attribute.