### PR TITLE
Restrict access or overridability of private MS.CSharp classes

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/CError.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/CError.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
     // This object is the implementation of ICSError for all compiler errors,
     // including lexer, parser, and compiler errors.
 
-    internal class CError
+    internal sealed class CError
     {
         private string _text;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/CErrorFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/CErrorFactory.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Errors
 {
-    internal class CErrorFactory
+    internal sealed class CErrorFactory
     {
         public CError CreateError(ErrorCode iErrorIndex, params string[] args)
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/CParameterizedError.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/CParameterizedError.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
     // This object is the unrealized error that is generated prior to
     // becoming a CError.  It only has the spans, error number, and parameters.
 
-    internal class CParameterizedError
+    internal sealed class CParameterizedError
     {
         private ErrorCode _errorNumber;
         private ErrArg[] _arguments;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFmt.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFmt.cs
@@ -43,13 +43,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         UseGetErrorInfo = 0x0008,
     }
 
-    internal class SymWithTypeMemo
+    internal sealed class SymWithTypeMemo
     {
         public Symbol sym;
         public AggregateType ats;
     }
 
-    internal class MethPropWithInstMemo
+    internal sealed class MethPropWithInstMemo
     {
         public Symbol sym;
         public AggregateType ats;
@@ -74,13 +74,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         public ErrArg()
         {
         }
+
         public ErrArg(int n)
         {
             this.eak = ErrArgKind.Int;
             this.eaf = ErrArgFlags.None;
             this.n = n;
         }
-        public ErrArg(SYMKIND sk)
+
+        private ErrArg(SYMKIND sk)
         {
             Debug.Assert(sk != SYMKIND.SK_AssemblyQualifiedNamespaceSymbol);
             this.eaf = ErrArgFlags.None;
@@ -94,7 +96,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             this.eaf = ErrArgFlags.None;
             this.name = name;
         }
-        public ErrArg(PredefinedName pdn)
+        private ErrArg(PredefinedName pdn)
         {
             this.eak = ErrArgKind.PredefName;
             this.eaf = ErrArgFlags.None;
@@ -107,21 +109,25 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             this.eaf = ErrArgFlags.None;
             this.psz = psz;
         }
+
         public ErrArg(CType pType)
             : this(pType, ErrArgFlags.None)
         {
         }
+
         public ErrArg(CType pType, ErrArgFlags eaf)
         {
             this.eak = ErrArgKind.Type;
             this.eaf = eaf;
             this.pType = pType;
         }
+
         public ErrArg(Symbol pSym)
             : this(pSym, ErrArgFlags.None)
         {
         }
-        public ErrArg(Symbol pSym, ErrArgFlags eaf)
+
+        private ErrArg(Symbol pSym, ErrArgFlags eaf)
         {
             this.eak = ErrArgKind.Sym;
             this.eaf = eaf;
@@ -182,22 +188,24 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         }
     }
 
-
     internal class ErrArgRef : ErrArg
     {
-        public ErrArgRef()
+        protected ErrArgRef()
         {
         }
-        public ErrArgRef(int n)
+
+        private ErrArgRef(int n)
             : base(n)
         {
         }
-        public ErrArgRef(Name name)
+
+        private ErrArgRef(Name name)
             : base(name)
         {
             this.eaf = ErrArgFlags.Ref;
         }
-        public ErrArgRef(string psz)
+
+        private ErrArgRef(string psz)
             : base(psz)
         {
             this.eaf = ErrArgFlags.Ref;
@@ -207,17 +215,19 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         {
             this.eaf = ErrArgFlags.Ref;
         }
-        public ErrArgRef(CType pType)
+
+        private ErrArgRef(CType pType)
             : base(pType)
         {
             this.eaf = ErrArgFlags.Ref;
         }
-        public ErrArgRef(SymWithType swt)
+
+        private ErrArgRef(SymWithType swt)
             : base(swt)
         {
             this.eaf = ErrArgFlags.Ref;
         }
-        public ErrArgRef(MethPropWithInst mpwi)
+        private ErrArgRef(MethPropWithInst mpwi)
             : base(mpwi)
         {
             this.eaf = ErrArgFlags.Ref;
@@ -257,7 +267,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         }
     }
 
-    internal class ErrArgRefOnly : ErrArgRef
+    internal sealed class ErrArgRefOnly : ErrArgRef
     {
         public ErrArgRefOnly(Symbol sym)
             : base(sym)
@@ -267,7 +277,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
     }
 
     // This is used with COMPILER_BASE::ErrorRef to indicate no reference.
-    internal class ErrArgNoRef : ErrArgRef
+    internal sealed class ErrArgNoRef : ErrArgRef
     {
         public ErrArgNoRef(CType pType)
         {
@@ -277,7 +287,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         }
     }
 
-    internal class ErrArgIds : ErrArgRef
+    internal sealed class ErrArgIds : ErrArgRef
     {
         public ErrArgIds(MessageID ids)
         {
@@ -287,7 +297,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         }
     }
 
-    sealed internal class ErrArgSymKind : ErrArgRef
+    internal sealed class ErrArgSymKind : ErrArgRef
     {
         public ErrArgSymKind(Symbol sym)
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorHandling.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorHandling.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             }
         }
 
-        public void MakeErrorLocArgs(out CParameterizedError error, ErrorCode id, ErrArg[] prgarg)
+        private void MakeErrorLocArgs(out CParameterizedError error, ErrorCode id, ErrArg[] prgarg)
         {
             error = new CParameterizedError();
             error.Initialize(id, prgarg);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -11,12 +11,12 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Errors
 {
-    internal class UserStringBuilder
+    internal sealed class UserStringBuilder
     {
-        protected bool fHadUndisplayableStringInError;
-        protected bool m_buildingInProgress;
-        protected GlobalSymbolContext m_globalSymbols;
-        protected StringBuilder m_strBuilder;
+        private bool fHadUndisplayableStringInError;
+        private bool m_buildingInProgress;
+        private GlobalSymbolContext m_globalSymbols;
+        private StringBuilder m_strBuilder;
 
         public UserStringBuilder(
             GlobalSymbolContext globalSymbols)
@@ -27,13 +27,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             m_globalSymbols = globalSymbols;
         }
 
-        protected void BeginString()
+        private void BeginString()
         {
             Debug.Assert(!m_buildingInProgress);
             m_buildingInProgress = true;
             m_strBuilder = new StringBuilder();
         }
-        protected void EndString(out string s)
+
+        private void EndString(out string s)
         {
             Debug.Assert(m_buildingInProgress);
             m_buildingInProgress = false;
@@ -52,7 +53,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             fHadUndisplayableStringInError = false;
         }
 
-        protected void ErrSK(out string psz, SYMKIND sk)
+        private void ErrSK(out string psz, SYMKIND sk)
         {
             MessageID id;
             switch (sk)
@@ -97,7 +98,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
          * Create a fill-in string describing a parameter list.
          * Does NOT include ()
          */
-        protected void ErrAppendParamList(TypeArray @params, bool isVarargs, bool isParamArray)
+
+        private void ErrAppendParamList(TypeArray @params, bool isVarargs, bool isParamArray)
         {
             if (null == @params)
                 return;
@@ -129,20 +131,21 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             }
         }
 
-        public void ErrAppendString(string str)
+        private void ErrAppendString(string str)
         {
             m_strBuilder.Append(str);
         }
-        public void ErrAppendChar(char ch)
+
+        private void ErrAppendChar(char ch)
         {
             m_strBuilder.Append(ch);
         }
 
-        public void ErrAppendPrintf(string format, params object[] args)
+        private void ErrAppendPrintf(string format, params object[] args)
         {
             ErrAppendString(String.Format(CultureInfo.InvariantCulture, format, args));
         }
-        public void ErrAppendName(Name name)
+        private void ErrAppendName(Name name)
         {
             CheckDisplayableName(name);
 
@@ -156,17 +159,18 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             }
         }
 
-        protected void ErrAppendMethodParentSym(MethodSymbol sym, SubstContext pcxt, out TypeArray substMethTyParams)
+        private void ErrAppendMethodParentSym(MethodSymbol sym, SubstContext pcxt, out TypeArray substMethTyParams)
         {
             substMethTyParams = null;
             ErrAppendParentSym(sym, pcxt);
         }
 
-        protected void ErrAppendParentSym(Symbol sym, SubstContext pctx)
+        private void ErrAppendParentSym(Symbol sym, SubstContext pctx)
         {
             ErrAppendParentCore(sym.parent, pctx);
         }
-        protected void ErrAppendParentType(CType pType, SubstContext pctx)
+
+        private void ErrAppendParentType(CType pType, SubstContext pctx)
         {
             if (pType.IsErrorType())
             {
@@ -190,7 +194,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 ErrAppendChar('.');
             }
         }
-        protected void ErrAppendParentCore(Symbol parent, SubstContext pctx)
+
+        private void ErrAppendParentCore(Symbol parent, SubstContext pctx)
         {
             if (null == parent)
                 return;
@@ -209,7 +214,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             }
             ErrAppendChar('.');
         }
-        protected void ErrAppendTypeParameters(TypeArray @params, SubstContext pctx, bool forClass)
+
+        private void ErrAppendTypeParameters(TypeArray @params, SubstContext pctx, bool forClass)
         {
             if (@params != null && @params.size != 0)
             {
@@ -223,7 +229,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 ErrAppendChar('>');
             }
         }
-        protected void ErrAppendMethod(MethodSymbol meth, SubstContext pctx, bool fArgs)
+
+        private void ErrAppendMethod(MethodSymbol meth, SubstContext pctx, bool fArgs)
         {
             if (meth.IsExpImpl() && meth.swtSlot)
             {
@@ -364,13 +371,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 ErrAppendChar(')');
             }
         }
-        protected void ErrAppendIndexer(IndexerSymbol indexer, SubstContext pctx)
+        private void ErrAppendIndexer(IndexerSymbol indexer, SubstContext pctx)
         {
             ErrAppendString("this[");
             ErrAppendParamList(GetTypeManager().SubstTypeArray(indexer.Params, pctx), false, indexer.isParamArray);
             ErrAppendChar(']');
         }
-        protected void ErrAppendProperty(PropertySymbol prop, SubstContext pctx)
+        private void ErrAppendProperty(PropertySymbol prop, SubstContext pctx)
         {
             ErrAppendParentSym(prop, pctx);
             if (prop.IsExpImpl() && prop.swtSlot.Sym != null)
@@ -397,10 +404,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 ErrAppendName(prop.name);
             }
         }
-        protected void ErrAppendEvent(EventSymbol @event, SubstContext pctx)
+
+        private void ErrAppendEvent(EventSymbol @event, SubstContext pctx)
         {
         }
-        public void ErrAppendId(MessageID id)
+
+        private void ErrAppendId(MessageID id)
         {
             string str;
             ErrId(out str, id);
@@ -410,11 +419,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         /*
          * Create a fill-in string describing a symbol.
          */
-        public void ErrAppendSym(Symbol sym, SubstContext pctx)
+        private void ErrAppendSym(Symbol sym, SubstContext pctx)
         {
             ErrAppendSym(sym, pctx, true);
         }
-        public void ErrAppendSym(Symbol sym, SubstContext pctx, bool fArgs)
+
+        private void ErrAppendSym(Symbol sym, SubstContext pctx, bool fArgs)
         {
             switch (sym.getKind())
             {
@@ -514,12 +524,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             }
         }
 
-        public void ErrAppendType(CType pType, SubstContext pCtx)
+        private void ErrAppendType(CType pType, SubstContext pCtx)
         {
             ErrAppendType(pType, pCtx, true);
         }
 
-        public void ErrAppendType(CType pType, SubstContext pctx, bool fArgs)
+        private void ErrAppendType(CType pType, SubstContext pctx, bool fArgs)
         {
             if (pctx != null)
             {
@@ -775,11 +785,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
 
             return result;
         }
-        protected bool IsDisplayableName(Name name)
+
+        private bool IsDisplayableName(Name name)
         {
             return name != GetNameManager().GetPredefName(PredefinedName.PN_MISSING);
         }
-        protected void CheckDisplayableName(Name name)
+
+        private void CheckDisplayableName(Name name)
         {
             if (!IsDisplayableName(name))
             {
@@ -787,23 +799,27 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             }
         }
 
-        protected NameManager GetNameManager()
+        private NameManager GetNameManager()
         {
             return m_globalSymbols.GetNameManager();
         }
-        protected TypeManager GetTypeManager()
+
+        private TypeManager GetTypeManager()
         {
             return m_globalSymbols.GetTypes();
         }
-        protected BSYMMGR getBSymmgr()
+
+        private BSYMMGR getBSymmgr()
         {
             return m_globalSymbols.GetGlobalSymbols();
         }
-        protected int GetTypeID(CType type)
+
+        private int GetTypeID(CType type)
         {
             return 0;
         }
-        public void ErrId(out string s, MessageID id)
+
+        private void ErrId(out string s, MessageID id)
         {
             s = ErrorFacts.GetMessage(id);
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
@@ -12,12 +12,12 @@ using Microsoft.CSharp.RuntimeBinder.Semantics;
 
 namespace Microsoft.CSharp.RuntimeBinder
 {
-    internal class ExpressionTreeCallRewriter : ExprVisitorBase
+    internal sealed class ExpressionTreeCallRewriter : ExprVisitorBase
     {
         /////////////////////////////////////////////////////////////////////////////////
         // Members
 
-        private class ExpressionEXPR : EXPR
+        private sealed class ExpressionEXPR : EXPR
         {
             public readonly Expression Expression;
             public ExpressionEXPR(Expression e)
@@ -35,7 +35,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         /////////////////////////////////////////////////////////////////////////////////
 
-        protected ExpressionTreeCallRewriter(TypeManager typeManager, IEnumerable<Expression> listOfParameters)
+        private ExpressionTreeCallRewriter(TypeManager typeManager, IEnumerable<Expression> listOfParameters)
         {
             _typeManager = typeManager;
             _DictionaryOfParameters = new Dictionary<EXPRCALL, Expression>();

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -14,7 +14,7 @@ using System.Reflection;
 
 namespace Microsoft.CSharp.RuntimeBinder
 {
-    internal class RuntimeBinder
+    internal sealed class RuntimeBinder
     {
         #region Singleton Implementation
 
@@ -64,7 +64,7 @@ namespace Microsoft.CSharp.RuntimeBinder
         // value's type because unless the static time type was dynamic, we want to use the
         // static time type. Also, we may have null values, in which case we would not be 
         // able to get the type.
-        private class ArgumentObject
+        private sealed class ArgumentObject
         {
             internal Type Type;
             internal object Value;
@@ -75,7 +75,7 @@ namespace Microsoft.CSharp.RuntimeBinder
         // Methods
 
         #region BookKeeping
-        public RuntimeBinder()
+        private RuntimeBinder()
         {
             Reset();
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinderController.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinderController.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CSharp.RuntimeBinder
     // This class merely wraps a controller and throws a runtime binder exception
     // whenever we get an error during binding.
 
-    internal class RuntimeBinderController : CController
+    internal sealed class RuntimeBinderController : CController
     {
         public override void SubmitError(CError pError)
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BinOpArgInfo.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BinOpArgInfo.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     internal sealed partial class ExpressionBinder
     {
-        private class BinOpArgInfo
+        private sealed class BinOpArgInfo
         {
             public BinOpArgInfo(EXPR op1, EXPR op2)
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BinOpSig.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BinOpSig.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     {
         private class BinOpSig
         {
-            public BinOpSig()
+            protected BinOpSig()
             {
             }
 
@@ -50,7 +50,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
         }
 
-        private class BinOpFullSig : BinOpSig
+        private sealed class BinOpFullSig : BinOpSig
         {
             private readonly LiftFlags _grflt;
             private readonly CType _type1;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/Better.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/Better.cs
@@ -352,7 +352,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return WhichConversionIsBetter(argType, p1, p2);
         }
 
-        public BetterType WhichConversionIsBetter(CType argType,
+        private BetterType WhichConversionIsBetter(CType argType,
             CType p1, CType p2)
         {
             // 7.4.2.4 Better conversion from type

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BindingContextBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BindingContextBase.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // consumed by the StatementBinder.
     // ----------------------------------------------------------------------------
 
-    internal class OutputContext
+    internal sealed class OutputContext
     {
         public LocalVariableSymbol m_pThisPointer;
         public MethodSymbol m_pCurrentMethodSymbol;
@@ -56,7 +56,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 bInRefactoring,
                 aidLookupContext);
         }
-        protected BindingContext(
+
+        private BindingContext(
             CSemanticChecker pSemanticChecker,
             ExprFactory exprFactory,
             OutputContext outputContext,
@@ -239,17 +240,17 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return m_UnsafeState;
         }
 
-        public KAID m_aidExternAliasLookupContext { get; }
+        private KAID m_aidExternAliasLookupContext { get; }
 
         // Members.
 
-        protected ExprFactory m_ExprFactory;
-        protected OutputContext m_outputContext;
-        protected NameGenerator m_pNameGenerator;
+        private ExprFactory m_ExprFactory;
+        private OutputContext m_outputContext;
+        private NameGenerator m_pNameGenerator;
 
         // Methods.
 
-        protected InputFile m_pInputFile;
+        private InputFile m_pInputFile;
 
         // symbols.
 
@@ -260,27 +261,27 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // are used, because the using clauses in effect may be different and 
         // unsafe state may be different.  
 
-        protected AggregateSymbol m_pContainingAgg;
-        protected CType m_pCurrentSwitchType;
-        protected FieldSymbol m_pOriginalConstantField;
-        protected FieldSymbol m_pCurrentFieldSymbol;
+        private AggregateSymbol m_pContainingAgg;
+        private CType m_pCurrentSwitchType;
+        private FieldSymbol m_pOriginalConstantField;
+        private FieldSymbol m_pCurrentFieldSymbol;
 
         // If we are in a context where we are binding the right hand side of a declaration
         // like var y = (y=5), we need to keep track of what local we are attempting to
         // infer the type of, so that we can give an error if that local is used on the
         // right hand side.
-        protected LocalVariableSymbol m_pImplicitlyTypedLocal;
+        private LocalVariableSymbol m_pImplicitlyTypedLocal;
 
         // Scopes.
 
-        protected Scope m_pOuterScope;
-        protected Scope m_pFinallyScope; // innermost finally, or pOuterScope if none...
-        protected Scope m_pTryScope;     // innermost try, or pOuterScope if none...
-        protected Scope m_pCatchScope;   // innermost catch, or null if none
-        protected Scope m_pCurrentScope; // current scope
-        protected Scope m_pSwitchScope;  // innermost switch, or null if none
+        private Scope m_pOuterScope;
+        private Scope m_pFinallyScope; // innermost finally, or pOuterScope if none...
+        private Scope m_pTryScope;     // innermost try, or pOuterScope if none...
+        private Scope m_pCatchScope;   // innermost catch, or null if none
+        private Scope m_pCurrentScope; // current scope
+        private Scope m_pSwitchScope;  // innermost switch, or null if none
 
-        protected EXPRBLOCK m_pCurrentBlock;
+        private EXPRBLOCK m_pCurrentBlock;
 
         // m_ppamis points to the list of child anonymous methods of the current context.
         // That is, m_ppamis is where we will add an anonymous method should we find a
@@ -289,38 +290,38 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // anonymous method then it points to m_pamiCurrent.pamis.  If we are presently
         // in a context in which anonymous methods cannot occur (eg, binding an attribute)
         // then it is null.
-        protected List<EXPRBOUNDLAMBDA> m_ppamis;
+        private List<EXPRBOUNDLAMBDA> m_ppamis;
         // If we are presently binding an anonymous method body then m_pamiCurrent points
         // to the anon meth info.  If we are binding either a method body or some other
         // statement context (eg, binding an attribute, etc) then m_pamiCurrent is null.
-        protected EXPRBOUNDLAMBDA m_pamiCurrent;
+        private EXPRBOUNDLAMBDA m_pamiCurrent;
 
         // Unsafe states.
 
-        protected UNSAFESTATES m_UnsafeState;
+        private UNSAFESTATES m_UnsafeState;
 
         // Variable Counters.
 
-        protected int m_FinallyNestingCount;
+        private int m_FinallyNestingCount;
 
         // The rest of the members.
 
-        protected bool m_bInsideTryOfCatch;
-        protected bool m_bInFieldInitializer;
-        protected bool m_bInBaseConstructorCall;
-        protected bool m_bAllowUnsafeBlocks;
-        protected bool m_bIsOptimizingSwitchAndArrayInit;
-        protected bool m_bShowReachability;
-        protected bool m_bWrapNonExceptionThrows;
-        protected bool m_bInRefactoring;
-        protected bool m_bInAttribute;
+        private bool m_bInsideTryOfCatch;
+        private bool m_bInFieldInitializer;
+        private bool m_bInBaseConstructorCall;
+        private bool m_bAllowUnsafeBlocks;
+        private bool m_bIsOptimizingSwitchAndArrayInit;
+        private bool m_bShowReachability;
+        private bool m_bWrapNonExceptionThrows;
+        private bool m_bInRefactoring;
+        private bool m_bInAttribute;
 
-        protected bool m_bflushLocalVariableTypesForEachStatement;
-        protected bool m_bRespectSemanticsAndReportErrors; // False if we're in the EE.
+        private bool m_bflushLocalVariableTypesForEachStatement;
+        private bool m_bRespectSemanticsAndReportErrors; // False if we're in the EE.
 
-        protected CType m_pInitType;
+        private CType m_pInitType;
 
-        protected IErrorSink m_returnErrorSink;
+        private IErrorSink m_returnErrorSink;
 
         public CSemanticChecker SemanticChecker { get; }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BindingContexts.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/BindingContexts.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // from the current one, but push on some new state.
     // ----------------------------------------------------------------------------
 
-    internal class CheckedContext : BindingContext
+    internal sealed class CheckedContext : BindingContext
     {
         public static CheckedContext CreateInstance(
             BindingContext parentCtx,
@@ -19,7 +19,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return new CheckedContext(parentCtx, checkedNormal, checkedConstant);
         }
 
-        protected CheckedContext(
+        private CheckedContext(
                 BindingContext parentCtx,
                 bool checkedNormal,
                 bool checkedConstant

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/COperators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/COperators.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     internal static class Operators
     {
-        private class OPINFO
+        private sealed class OPINFO
         {
             public OPINFO(TokenKind t, PredefinedName pn, ExpressionKind e, int c)
             {
@@ -115,21 +115,25 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             return OperatorKind.OP_NONE;
         }
-        public static bool HasMethodName(OperatorKind op)
+
+        private static bool HasMethodName(OperatorKind op)
         {
             //Debug.Assert(IsValid(op));
             return GetMethodName(op) != PredefinedName.PN_COUNT;
         }
-        public static PredefinedName GetMethodName(OperatorKind op)
+
+        private static PredefinedName GetMethodName(OperatorKind op)
         {
             //Debug.Assert(IsValid(op));
             return GetInfo(op).methodName;
         }
-        public static Name GetMethodName(NameManager namemgr, OperatorKind op)
+
+        private static Name GetMethodName(NameManager namemgr, OperatorKind op)
         {
             Debug.Assert(HasMethodName(op));
             return namemgr.GetPredefName(GetMethodName(op));
         }
+
         public static bool HasDisplayName(OperatorKind op)
         {
             //Debug.Assert(IsValid(op));

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/CandidateFunctionMember.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/CandidateFunctionMember.cs
@@ -5,7 +5,7 @@
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     // Used to string together methods in the pool of available methods...
-    internal class CandidateFunctionMember
+    internal sealed class CandidateFunctionMember
     {
         public CandidateFunctionMember(MethPropWithInst mpwi, TypeArray @params, byte ctypeLift, bool fExpanded)
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -339,7 +339,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         // returns true if an implicit conversion exists from source type to dest type. flags is an optional parameter.
-        public bool canConvert(CType src, CType dest, CONVERTTYPE flags)
+        private bool canConvert(CType src, CType dest, CONVERTTYPE flags)
         {
             EXPRCLASS exprDest = ExprFactory.MakeClass(dest);
             return BindImplicitConversion(null, src, exprDest, dest, flags);
@@ -351,12 +351,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         // returns true if a implicit conversion exists from source expr to dest type. flags is an optional parameter.
-        public bool canConvert(EXPR expr, CType dest)
+        private bool canConvert(EXPR expr, CType dest)
         {
             return canConvert(expr, dest, 0);
         }
 
-        public bool canConvert(EXPR expr, CType dest, CONVERTTYPE flags)
+        private bool canConvert(EXPR expr, CType dest, CONVERTTYPE flags)
         {
             EXPRCLASS exprDest = ExprFactory.MakeClass(dest);
             return BindImplicitConversion(expr, expr.type, exprDest, dest, flags);
@@ -364,12 +364,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         // performs an implicit conversion if it's possible. otherwise displays an error. flags is an optional parameter.
 
-        public EXPR mustConvertCore(EXPR expr, EXPRTYPEORNAMESPACE destExpr)
+        private EXPR mustConvertCore(EXPR expr, EXPRTYPEORNAMESPACE destExpr)
         {
             return mustConvertCore(expr, destExpr, 0);
         }
 
-        public EXPR mustConvertCore(EXPR expr, EXPRTYPEORNAMESPACE destExpr, CONVERTTYPE flags)
+        private EXPR mustConvertCore(EXPR expr, EXPRTYPEORNAMESPACE destExpr, CONVERTTYPE flags)
         {
             EXPR exprResult;
             CType dest = destExpr.TypeOrNamespace as CType;
@@ -452,7 +452,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return tryConvert(expr, dest, 0);
         }
 
-        public EXPR tryConvert(EXPR expr, CType dest, CONVERTTYPE flags)
+        private EXPR tryConvert(EXPR expr, CType dest, CONVERTTYPE flags)
         {
             EXPR exprResult;
             EXPRCLASS exprDest = ExprFactory.MakeClass(dest);
@@ -469,12 +469,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             return mustConvert(expr, dest, (CONVERTTYPE)0);
         }
-        public EXPR mustConvert(EXPR expr, CType dest, CONVERTTYPE flags)
+
+        private EXPR mustConvert(EXPR expr, CType dest, CONVERTTYPE flags)
         {
             EXPRCLASS exprClass = ExprFactory.MakeClass(dest);
             return mustConvert(expr, exprClass, flags);
         }
-        public EXPR mustConvert(EXPR expr, EXPRTYPEORNAMESPACE dest, CONVERTTYPE flags)
+        private EXPR mustConvert(EXPR expr, EXPRTYPEORNAMESPACE dest, CONVERTTYPE flags)
         {
             return mustConvertCore(expr, dest, flags);
         }
@@ -651,13 +652,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
  
             We currently implement (1). The spec needs to be tightened up.
         ***************************************************************************************************/
-        public bool BindGrpConversion(EXPRMEMGRP grp, CType typeDst, bool fReportErrors)
+        private bool BindGrpConversion(EXPRMEMGRP grp, CType typeDst, bool fReportErrors)
         {
             EXPRCALL dummy;
             return BindGrpConversion(grp, typeDst, false, out dummy, fReportErrors);
         }
 
-        public bool BindGrpConversion(EXPRMEMGRP grp, CType typeDst, bool needDest, out EXPRCALL pexprDst, bool fReportErrors)
+        private bool BindGrpConversion(EXPRMEMGRP grp, CType typeDst, bool needDest, out EXPRCALL pexprDst, bool fReportErrors)
         {
             pexprDst = null;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Declarations/AggregateDeclaration.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Declarations/AggregateDeclaration.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // ----------------------------------------------------------------------------
 
     // Either a ClassNode or a DelegateNode
-    internal class AggregateDeclaration : Declaration
+    internal sealed class AggregateDeclaration : Declaration
     {
         public AggregateSymbol Agg()
         {
@@ -30,7 +30,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return null;
         }
 
-        public new Assembly GetAssembly()
+        public Assembly GetAssembly()
         {
             return Agg().AssociatedAssembly;
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Declarations/Declaration.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Declarations/Declaration.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // Children are DECLs.
     // ----------------------------------------------------------------------------
 
-    internal class Declaration : ParentSymbol
+    internal abstract class Declaration : ParentSymbol
     {
         public NamespaceOrAggregateSymbol bag;
         public Declaration declNext;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Declarations/NamespaceDeclaration.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Declarations/NamespaceDeclaration.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // DeclNext() is the next declaration for the same namespace.
     // ----------------------------------------------------------------------------
 
-    internal class NamespaceDeclaration : Declaration
+    internal sealed class NamespaceDeclaration : Declaration
     {
         public NamespaceSymbol Bag()
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/EXPRExtensions.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/EXPRExtensions.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return (expr.isCONSTANT_OK()) && (expr.asCONSTANT().isZero());
         }
 
-        public static EXPR GetSeqVal(this EXPR expr)
+        private static EXPR GetSeqVal(this EXPR expr)
         {
             // Scan through EK_SEQUENCE and EK_SEQREV exprs to get the real value.
             if (expr == null)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // BindExplicitConversion
         // ----------------------------------------------------------------------------
 
-        private class ExplicitConversion
+        private sealed class ExplicitConversion
         {
             private readonly ExpressionBinder _binder;
             private EXPR _exprSrc;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExprFactory.cs
@@ -230,7 +230,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return CreateReturn(nFlags, pCurrentScope, pOptionalObject, pOptionalObject);
         }
 
-        public EXPRRETURN CreateReturn(EXPRFLAG nFlags, Scope pCurrentScope, EXPR pOptionalObject, EXPR pOptionalOriginalObject)
+        private EXPRRETURN CreateReturn(EXPRFLAG nFlags, Scope pCurrentScope, EXPR pOptionalObject, EXPR pOptionalOriginalObject)
         {
             Debug.Assert(0 == (nFlags &
                        ~(EXPRFLAG.EXF_ASLEAVE | EXPRFLAG.EXF_FINALLYBLOCKED | EXPRFLAG.EXF_RETURNISYIELD |
@@ -382,7 +382,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return rval;
         }
 
-        public EXPRTYPEOF CreateTypeOf(EXPRTYPEORNAMESPACE pSourceType)
+        private EXPRTYPEOF CreateTypeOf(EXPRTYPEORNAMESPACE pSourceType)
         {
             EXPRTYPEOF rval = new EXPRTYPEOF();
             rval.kind = ExpressionKind.EK_TYPEOF;
@@ -501,7 +501,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return CreateZeroInit(exprClass);
         }
 
-        public EXPR CreateZeroInit(EXPRTYPEORNAMESPACE pTypeExpr)
+        private EXPR CreateZeroInit(EXPRTYPEORNAMESPACE pTypeExpr)
         {
             return CreateZeroInit(pTypeExpr, null, false);
         }
@@ -598,7 +598,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return CreateConstant(pType, constVal, null);
         }
 
-        public EXPRCONSTANT CreateConstant(CType pType, CONSTVAL constVal, EXPR pOriginal)
+        private EXPRCONSTANT CreateConstant(CType pType, CONSTVAL constVal, EXPR pOriginal)
         {
             EXPRCONSTANT rval = CreateConstant(pType);
             rval.setVal(constVal);
@@ -606,7 +606,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return (rval);
         }
 
-        public EXPRCONSTANT CreateConstant(CType pType)
+        private EXPRCONSTANT CreateConstant(CType pType)
         {
             EXPRCONSTANT rval = new EXPRCONSTANT();
             rval.kind = ExpressionKind.EK_CONSTANT;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -11,7 +11,7 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     // Used by bindUserDefinedConversion
-    internal class UdConvInfo
+    internal sealed class UdConvInfo
     {
         public MethWithType mwt;
         public bool fSrcImplicit;
@@ -22,7 +22,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // Small wrapper for passing around argument information for the various BindGrpTo methods
     // It is used because most things only need the type, but in the case of METHGRPs and ANONMETHs
     // the expr is also needed to determine if a conversion is possible
-    internal class ArgInfos
+    internal sealed class ArgInfos
     {
         public int carg;
         public TypeArray types;
@@ -405,7 +405,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private CType getVoidType() { return VoidType; }
 
-        public EXPR GenerateAssignmentConversion(EXPR op1, EXPR op2, bool allowExplicit)
+        private EXPR GenerateAssignmentConversion(EXPR op1, EXPR op2, bool allowExplicit)
         {
             if (allowExplicit)
             {
@@ -688,11 +688,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         ////////////////////////////////////////////////////////////////////////////////
         // Create a cast node with the given expression flags. 
-        public void bindSimpleCast(EXPR exprSrc, EXPRTYPEORNAMESPACE typeDest, out EXPR pexprDest)
+        private void bindSimpleCast(EXPR exprSrc, EXPRTYPEORNAMESPACE typeDest, out EXPR pexprDest)
         {
             bindSimpleCast(exprSrc, typeDest, out pexprDest, 0);
         }
-        public void bindSimpleCast(EXPR exprSrc, EXPRTYPEORNAMESPACE exprTypeDest, out EXPR pexprDest, EXPRFLAG exprFlags)
+
+        private void bindSimpleCast(EXPR exprSrc, EXPRTYPEORNAMESPACE exprTypeDest, out EXPR pexprDest, EXPRFLAG exprFlags)
         {
             Debug.Assert(exprTypeDest != null);
             Debug.Assert(exprTypeDest.TypeOrNamespace != null);
@@ -739,7 +740,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // args      - arguments
         // exprFlags - Flags to put on the generated expr
 
-        internal EXPRCALL BindToMethod(MethWithInst mwi, EXPR pArguments, EXPRMEMGRP pMemGroup, MemLookFlags flags)
+        private EXPRCALL BindToMethod(MethWithInst mwi, EXPR pArguments, EXPRMEMGRP pMemGroup, MemLookFlags flags)
         {
             Debug.Assert(mwi.Sym != null && mwi.Sym.IsMethodSymbol() && (!mwi.Meth().isOverride || mwi.Meth().isHideByName));
             Debug.Assert(pMemGroup != null);
@@ -812,7 +813,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         ////////////////////////////////////////////////////////////////////////////////
 
-        internal EXPR BindToField(EXPR pOptionalObject, FieldWithType fwt, BindingFlag bindFlags, EXPR pOptionalLHS)
+        private EXPR BindToField(EXPR pOptionalObject, FieldWithType fwt, BindingFlag bindFlags, EXPR pOptionalLHS)
         {
             Debug.Assert(fwt.GetType() != null && fwt.Field().getClass() == fwt.GetType().getAggregate());
 
@@ -1345,7 +1346,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         ////////////////////////////////////////////////////////////////////////////////
         // This finds a method  and binds it to the args provided.
 
-        internal EXPRCALL BindPredefMethToArgs(PREDEFMETH predefMethod, EXPR obj, EXPR args, TypeArray clsTypeArgs, TypeArray methTypeArgs)
+        private EXPRCALL BindPredefMethToArgs(PREDEFMETH predefMethod, EXPR obj, EXPR args, TypeArray clsTypeArgs, TypeArray methTypeArgs)
         {
             MethodSymbol methSym = GetSymbolLoader().getPredefinedMembers().GetMethod(predefMethod);
             if (methSym == null)
@@ -1485,7 +1486,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         ////////////////////////////////////////////////////////////////////////////////
         // A false return means not to process the expr any further - it's totally out
         // of place. For example - a method group or an anonymous method.
-        internal bool checkLvalue(EXPR expr, CheckLvalueKind kind)
+        private bool checkLvalue(EXPR expr, CheckLvalueKind kind)
         {
             if (!expr.isOK())
                 return false;
@@ -1569,7 +1570,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return !TryReportLvalueFailure(expr, kind);
         }
 
-        internal void PostBindMethod(bool fBaseCall, ref MethWithInst pMWI, EXPR pObject)
+        private void PostBindMethod(bool fBaseCall, ref MethWithInst pMWI, EXPR pObject)
         {
             MethWithInst mwiOrig = pMWI;
 
@@ -1862,7 +1863,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // removed.... We start searching from "typeObj" up the superclass hierarchy 
         // until we find a method with an exact signature match.
 
-        public static void RemapToOverride(SymbolLoader symbolLoader, SymWithType pswt, CType typeObj)
+        private static void RemapToOverride(SymbolLoader symbolLoader, SymWithType pswt, CType typeObj)
         {
             // For a property/indexer we remap the accessors, not the property/indexer.
             // Since every event has both accessors we remap the event instead of the accessors.
@@ -2304,12 +2305,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         ////////////////////////////////////////////////////////////////////////////////
         // Check to see if an integral constant is within range of a integral 
         // destination type.
-        public static bool isConstantInRange(EXPRCONSTANT exprSrc, CType typeDest)
+        private static bool isConstantInRange(EXPRCONSTANT exprSrc, CType typeDest)
         {
             return isConstantInRange(exprSrc, typeDest, false);
         }
 
-        public static bool isConstantInRange(EXPRCONSTANT exprSrc, CType typeDest, bool realsOk)
+        private static bool isConstantInRange(EXPRCONSTANT exprSrc, CType typeDest, bool realsOk)
         {
             FUNDTYPE ftSrc = exprSrc.type.fundType();
             FUNDTYPE ftDest = typeDest.fundType();
@@ -2505,11 +2506,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return GetSymbolLoader().GetNameManager().GetPredefName(s_EK2NAME[ek - ExpressionKind.EK_FIRSTOP]);
         }
 
-        public void checkUnsafe(CType type)
+        private void checkUnsafe(CType type)
         {
             checkUnsafe(type, ErrorCode.ERR_UnsafeNeeded, null);
         }
-        public void checkUnsafe(CType type, ErrorCode errCode, ErrArg pArg)
+
+        private void checkUnsafe(CType type, ErrorCode errCode, ErrArg pArg)
         {
             Debug.Assert((errCode != ErrorCode.ERR_SizeofUnsafe) || pArg != null);
             if (type == null || type.isUnsafe())
@@ -2596,7 +2598,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return GetExprFactory().CreateAssignment(op1, op2);
         }
 
-        public static void RecordUnsafeUsage(BindingContext context)
+        private static void RecordUnsafeUsage(BindingContext context)
         {
             if (!(context.GetUnsafeState() == UNSAFESTATES.UNSAFESTATES_Unsafe) &&
                     !context.GetOutputContext().m_bUnsafeErrorGiven)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/FileRecord.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/FileRecord.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class FileRecord
+    internal abstract class FileRecord
     {
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GlobalSymbolContext.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GlobalSymbolContext.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     This includes symbols, types, declarations.
     *****************************************************************************/
 
-    internal class GlobalSymbolContext
+    internal sealed class GlobalSymbolContext
     {
         private readonly PredefinedTypes _predefTypes;
         private readonly NameManager _nameManager;
@@ -29,7 +29,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public TypeManager TypeManager { get; }
         public TypeManager GetTypes() { return TypeManager; }
-        public BSYMMGR GlobalSymbols { get; }
+        private BSYMMGR GlobalSymbols { get; }
         public BSYMMGR GetGlobalSymbols() { return GlobalSymbols; }
         public NameManager GetNameManager() { return _nameManager; }
         public PredefinedTypes GetPredefTypes() { return _predefTypes; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
     internal sealed partial class ExpressionBinder
     {
-        internal class GroupToArgsBinder
+        internal sealed class GroupToArgsBinder
         {
             private enum Result
             {
@@ -139,7 +139,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 return _pExprBinder.GetErrorContext();
             }
-            public static CType GetTypeQualifier(EXPRMEMGRP pGroup)
+            private static CType GetTypeQualifier(EXPRMEMGRP pGroup)
             {
                 Debug.Assert(pGroup != null);
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinderResult.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinderResult.cs
@@ -13,17 +13,17 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // to the best applicable method in the group.
         // ----------------------------------------------------------------------------
 
-        internal class GroupToArgsBinderResult
+        internal sealed class GroupToArgsBinderResult
         {
             public MethPropWithInst BestResult;
             public MethPropWithInst GetBestResult() { return BestResult; }
             public MethPropWithInst AmbiguousResult;
             public MethPropWithInst GetAmbiguousResult() { return AmbiguousResult; }
-            public MethPropWithInst InaccessibleResult;
+            private MethPropWithInst InaccessibleResult;
             public MethPropWithInst GetInaccessibleResult() { return InaccessibleResult; }
-            public MethPropWithInst UninferableResult;
+            private MethPropWithInst UninferableResult;
             public MethPropWithInst GetUninferableResult() { return UninferableResult; }
-            public MethPropWithInst InconvertibleResult;
+            private MethPropWithInst InconvertibleResult;
             public GroupToArgsBinderResult()
             {
                 BestResult = new MethPropWithInst();

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // BindImplicitConversion
         // ----------------------------------------------------------------------------
 
-        private class ImplicitConversion
+        private sealed class ImplicitConversion
         {
             public ImplicitConversion(ExpressionBinder binder, EXPR exprSrc, CType typeSrc, EXPRTYPEORNAMESPACE typeDest, bool needsExprDest, CONVERTTYPE flags)
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/InputFile.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/InputFile.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // and another for source files.
     // ----------------------------------------------------------------------------
 
-    internal class InputFile : FileRecord
+    internal sealed class InputFile : FileRecord
     {
         // Which aliases this INFILE is in. For source INFILESYMs, only bits kaidThisAssembly and kaidGlobal
         // should be set.

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/LangCompiler.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/LangCompiler.cs
@@ -8,7 +8,7 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class LangCompiler :
+    internal sealed class LangCompiler :
          CSemanticChecker,
          IErrorSink
     {
@@ -30,7 +30,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _symbolLoader = new SymbolLoader(globalSymbolContext, null, _errorContext);
         }
 
-        public new ErrorHandling GetErrorContext()
+        private new ErrorHandling GetErrorContext()
         {
             return _errorContext;
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // 
     // Lookup must be called before any other methods.
 
-    internal class MemberLookup
+    internal sealed class MemberLookup
     {
         // The inputs to Lookup.
         private CSemanticChecker _pSemanticChecker;
@@ -712,7 +712,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         // Whether there were errors.
-        public bool FError()
+        private bool FError()
         {
             return !_swtFirst || _swtAmbig;
         }
@@ -747,7 +747,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         // Put all the types in a type array.
-        public TypeArray GetAllTypes()
+        private TypeArray GetAllTypes()
         {
             return GetSymbolLoader().getBSymmgr().AllocParams(_prgtype.Count, _prgtype.ToArray());
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookupResults.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookupResults.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
     internal partial class CMemberLookupResults
     {
-        public TypeArray ContainingTypes { get; }// Types that contain the member we're looking for.
+        private TypeArray ContainingTypes { get; }// Types that contain the member we're looking for.
 
         private readonly Name _pName; // The name that we're looking for.
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -8,7 +8,7 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class MethodTypeInferrer
+    internal sealed class MethodTypeInferrer
     {
         private enum NewInferenceResult
         {
@@ -376,7 +376,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // dynamic operands enter method type inference with their
                 // actual runtime type, and in this way can infer implemented
                 // types that are not visible on more public types. (for ex.,
-                // private classes that implement IEnumerable, as in iterators).
+                // private sealed classes that implement IEnumerable, as in iterators).
 
                 CType pSource = pExpr.RuntimeObjectActualType != null
                     ? pExpr.RuntimeObjectActualType

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Nullable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Nullable.cs
@@ -7,7 +7,7 @@ using Microsoft.CSharp.RuntimeBinder.Errors;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class CNullable
+    internal sealed class CNullable
     {
         private readonly SymbolLoader _pSymbolLoader;
         private readonly ExprFactory _exprFactory;
@@ -25,7 +25,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             return _pErrorContext;
         }
-        public static bool IsNullableConstructor(EXPR expr)
+        private static bool IsNullableConstructor(EXPR expr)
         {
             Debug.Assert(expr != null);
 
@@ -145,7 +145,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     internal sealed partial class ExpressionBinder
     {
         // Create an expr for exprSrc.Value where exprSrc.type is a NullableType.
-        internal EXPR BindNubValue(EXPR exprSrc)
+        private EXPR BindNubValue(EXPR exprSrc)
         {
             return m_nullable.BindValue(exprSrc);
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     }
 
     // A description of a method the compiler uses while compiling.
-    internal class PredefinedMethodInfo
+    internal sealed class PredefinedMethodInfo
     {
         public PREDEFMETH method;
         public PredefinedType type;
@@ -220,7 +220,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
 
     // A description of a method the compiler uses while compiling.
-    internal class PredefinedPropertyInfo
+    internal sealed class PredefinedPropertyInfo
     {
         public PREDEFPROP property;
         public PredefinedName name;
@@ -238,9 +238,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
     // Loads and caches predefined members.
     // Also finds constructors on delegate types.
-    internal class PredefinedMembers
+    internal sealed class PredefinedMembers
     {
-        protected static void RETAILVERIFY(bool f)
+        private static void RETAILVERIFY(bool f)
         {
             if (!f)
                 Debug.Assert(false, "panic!");
@@ -560,7 +560,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return result;
         }
 
-        public MethodSymbol GetOptionalMethod(PREDEFMETH method)
+        private MethodSymbol GetOptionalMethod(PREDEFMETH method)
         {
             return EnsureMethod(method);
         }
@@ -712,7 +712,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             new PredefinedPropertyInfo(   PREDEFPROP.PP_G_OPTIONAL_VALUE,                                MethodRequiredEnum.Optional,   PredefinedName.PN_CAP_VALUE,               PREDEFMETH.PM_G_OPTIONAL_GETVALUE,                             PREDEFMETH.PM_COUNT  ),
         };
 
-        public static PredefinedPropertyInfo GetPropInfo(PREDEFPROP property)
+        private static PredefinedPropertyInfo GetPropInfo(PREDEFPROP property)
         {
             RETAILVERIFY(property > PREDEFPROP.PP_FIRST && property < PREDEFPROP.PP_COUNT);
             RETAILVERIFY(s_predefinedProperties[(int)property].property == property);
@@ -720,7 +720,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return s_predefinedProperties[(int)property];
         }
 
-        public static PredefinedMethodInfo GetMethInfo(PREDEFMETH method)
+        private static PredefinedMethodInfo GetMethInfo(PREDEFMETH method)
         {
             RETAILVERIFY(method > PREDEFMETH.PM_FIRST && method < PREDEFMETH.PM_COUNT);
             RETAILVERIFY(s_predefinedMethods[(int)method].method == method);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
@@ -161,7 +161,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         //
         // Utility methods
         //
-        protected ACCESSERROR CheckAccessCore(Symbol symCheck, AggregateType atsCheck, Symbol symWhere, CType typeThru)
+        private ACCESSERROR CheckAccessCore(Symbol symCheck, AggregateType atsCheck, Symbol symWhere, CType typeThru)
         {
             Debug.Assert(symCheck != null);
             Debug.Assert(atsCheck == null || symCheck.parent == atsCheck.getAggregate());

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         NoRefOutDifference = 0x10
     }
 
-    internal class SubstContext
+    internal sealed class SubstContext
     {
         public CType[] prgtypeCls;
         public int ctypeCls;
@@ -43,7 +43,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
         }
 
-        public SubstContext(AggregateType type, TypeArray typeArgsMeth, SubstTypeFlags grfst)
+        private SubstContext(AggregateType type, TypeArray typeArgsMeth, SubstTypeFlags grfst)
         {
             Init(type != null ? type.GetTypeArgsAll() : null, typeArgsMeth, grfst);
         }
@@ -52,7 +52,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             : this(prgtypeCls, ctypeCls, prgtypeMeth, ctypeMeth, SubstTypeFlags.NormNone)
         {
         }
-        public SubstContext(CType[] prgtypeCls, int ctypeCls, CType[] prgtypeMeth, int ctypeMeth, SubstTypeFlags grfst)
+
+        private SubstContext(CType[] prgtypeCls, int ctypeCls, CType[] prgtypeMeth, int ctypeMeth, SubstTypeFlags grfst)
         {
             this.prgtypeCls = prgtypeCls;
             this.ctypeCls = ctypeCls;
@@ -67,7 +68,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
 
         // Initializes a substitution context. Returns false iff no substitutions will ever be performed.
-        public void Init(TypeArray typeArgsCls, TypeArray typeArgsMeth, SubstTypeFlags grfst)
+        private void Init(TypeArray typeArgsCls, TypeArray typeArgsMeth, SubstTypeFlags grfst)
         {
             if (typeArgsCls != null)
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AggregateSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AggregateSymbol.cs
@@ -136,7 +136,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             get { return parent.AsNamespaceOrAggregateSymbol(); }
         }
 
-        public new AggregateDeclaration DeclFirst()
+        private new AggregateDeclaration DeclFirst()
         {
             return (AggregateDeclaration)base.DeclFirst();
         }
@@ -157,7 +157,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return (aid == GetModuleID());
         }
 
-        public KAID GetModuleID()
+        private KAID GetModuleID()
         {
             return 0;
         }
@@ -341,9 +341,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         ////////////////////////////////////////////////////////////////////////////////
 
-        public bool IsUnmanagedStruct()
+        private bool IsUnmanagedStruct()
         {
-            return _isUnmanagedStruct == true;
+            return _isUnmanagedStruct;
         }
 
         public void SetUnmanagedStruct(bool unmanagedStruct)
@@ -506,7 +506,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _pConvFirst = conv;
         }
 
-        public new bool InternalsVisibleTo(Assembly assembly)
+        public bool InternalsVisibleTo(Assembly assembly)
         {
             return _pTypeManager.InternalsVisibleTo(AssociatedAssembly, assembly);
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AssemblyQualifiedNamespaceSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/AssemblyQualifiedNamespaceSymbol.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // The name is a form of the aid.
     // ----------------------------------------------------------------------------
 
-    internal class AssemblyQualifiedNamespaceSymbol : ParentSymbol, ITypeOrNamespace
+    internal sealed class AssemblyQualifiedNamespaceSymbol : ParentSymbol, ITypeOrNamespace
     {
         // ----------------------------------------------------------------------------
         // AssemblyQualifiedNamespaceSymbol

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/EventSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/EventSymbol.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // private.
     // ----------------------------------------------------------------------------
 
-    internal class EventSymbol : Symbol
+    internal sealed class EventSymbol : Symbol
     {
         public EventInfo AssociatedEventInfo;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/IndexerSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/IndexerSymbol.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class IndexerSymbol : PropertySymbol
+    internal sealed class IndexerSymbol : PropertySymbol
     {
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/LabelSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/LabelSymbol.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class LabelSymbol : Symbol
+    internal sealed class LabelSymbol : Symbol
     {
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/LocalVariableSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/LocalVariableSymbol.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class LocalVariableSymbol : VariableSymbol
+    internal sealed class LocalVariableSymbol : VariableSymbol
     {
         // To do expression tree rewriting we need to keep a map between a
         // local in an expression tree and the result of a ParameterExpression

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodOrPropertySymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodOrPropertySymbol.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // variables.
     // ----------------------------------------------------------------------------
 
-    internal class MethodOrPropertySymbol : ParentSymbol
+    internal abstract class MethodOrPropertySymbol : ParentSymbol
     {
         public uint modOptCount;              // number of CMOD_OPTs in signature and return type
 
@@ -142,7 +142,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return _defaultParameterConstValTypes[index];
         }
 
-        public bool IsMarshalAsParameter(int index)
+        private bool IsMarshalAsParameter(int index)
         {
             return _marshalAsIndex[index];
         }
@@ -153,7 +153,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _marshalAsBuffer[index] = umt;
         }
 
-        public UnmanagedType GetMarshalAsParameterValue(int index)
+        private UnmanagedType GetMarshalAsParameterValue(int index)
         {
             Debug.Assert(IsMarshalAsParameter(index));
             return _marshalAsBuffer[index];

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodSymbol.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return _methKind == MethodKindEnum.EventAccessor;
         }
 
-        public bool isExplicit()          // is user defined explicit conversion operator
+        private bool isExplicit()          // is user defined explicit conversion operator
         {
             return _methKind == MethodKindEnum.ExplicitConv;
         }
@@ -171,7 +171,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return !isOperator && !isAnyAccessor();
         }
 
-        public bool isAnyAccessor()
+        private bool isAnyAccessor()
         {
             return isPropertyAccessor() || isEventAccessor();
         }
@@ -206,11 +206,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // used for CMOD_OPT interop
     // ----------------------------------------------------------------------------
 
-    internal class InterfaceImplementationMethodSymbol : MethodSymbol
+    internal sealed class InterfaceImplementationMethodSymbol : MethodSymbol
     {
     }
 
-    internal class IteratorFinallyMethodSymbol : MethodSymbol
+    internal sealed class IteratorFinallyMethodSymbol : MethodSymbol
     {
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MiscSymFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MiscSymFactory.cs
@@ -8,7 +8,7 @@ using mdAssemblyRef = Microsoft.CSharp.RuntimeBinder.Semantics.mdToken;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class MiscSymFactory : SymFactoryBase
+    internal sealed class MiscSymFactory : SymFactoryBase
     {
         // Constructor.
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/NamespaceSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/NamespaceSymbol.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // parent is the containing namespace.
     // ----------------------------------------------------------------------------
 
-    internal class NamespaceSymbol : NamespaceOrAggregateSymbol
+    internal sealed class NamespaceSymbol : NamespaceOrAggregateSymbol
     {
         // Which assemblies and extern aliases contain this namespace.
         private HashSet<KAID> _bsetFilter;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Scope.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Scope.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class Scope : ParentSymbol
+    internal sealed class Scope : ParentSymbol
     {
         public uint nestingOrder;  // the nesting order of this scopes. outermost == 0
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactory.cs
@@ -7,7 +7,7 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class SymFactory : SymFactoryBase
+    internal sealed class SymFactory : SymFactoryBase
     {
         public SymFactory(
             SYMTBL symtable,
@@ -84,7 +84,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return (sym);
         }
 
-        public AggregateSymbol CreateUnresolvedAggregate(Name name, ParentSymbol parent, TypeManager typeManager)
+        private AggregateSymbol CreateUnresolvedAggregate(Name name, ParentSymbol parent, TypeManager typeManager)
         {
             Debug.Assert(name != null);
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactoryBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymFactoryBase.cs
@@ -10,12 +10,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // SymFactory, TypeFactory and MiscSymFactory. This provides a common
     // way of creating syms that all three classes use.
 
-    internal class SymFactoryBase
+    internal abstract class SymFactoryBase
     {
         // Members.
-        protected SYMTBL m_pSymTable;
-        protected Name m_pMissingNameNode;
-        protected Name m_pMissingNameSym;
+        private SYMTBL m_pSymTable;
+        private Name m_pMissingNameNode;
+        private Name m_pMissingNameSym;
 
         protected Symbol newBasicSym(
             SYMKIND kind,

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     //
     // ----------------------------------------------------------------------------
 
-    internal class Symbol
+    internal abstract class Symbol
     {
         private SYMKIND _kind;     // the symbol kind
         private bool _isBogus;     // can't be used in our language -- unsupported type(s)
@@ -326,7 +326,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
         }
 
-        public Assembly GetAssembly()
+        private Assembly GetAssembly()
         {
             switch (_kind)
             {
@@ -354,7 +354,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         /*
          * returns the assembly id for the declaration of this symbol
          */
-        public bool InternalsVisibleTo(Assembly assembly)
+        private bool InternalsVisibleTo(Assembly assembly)
         {
             switch (_kind)
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
@@ -8,12 +8,12 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class SymbolLoader
+    internal sealed class SymbolLoader
     {
         private readonly NameManager _nameManager;
 
         public PredefinedMembers PredefinedMembers { get; }
-        public GlobalSymbolContext GlobalSymbolContext { get; }
+        private GlobalSymbolContext GlobalSymbolContext { get; }
         public ErrorHandling ErrorContext { get; }
         public SymbolTable RuntimeBinderSymbolTable { get; private set; }
 
@@ -117,7 +117,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return GetOptPredefAgg(pt, true);
         }
 
-        public AggregateSymbol GetOptPredefAgg(PredefinedType pt, bool fEnsureState)
+        private AggregateSymbol GetOptPredefAgg(PredefinedType pt, bool fEnsureState)
         {
             AggregateSymbol agg = GetTypeManager().GetOptPredefAgg(pt);
             return agg;
@@ -189,7 +189,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return null;
         }
 
-        public bool IsBaseInterface(CType pDerived, CType pBase)
+        private bool IsBaseInterface(CType pDerived, CType pBase)
         {
             Debug.Assert(pDerived != null);
             Debug.Assert(pBase != null);
@@ -231,7 +231,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return IsBaseClass(pDerived, pBase);
         }
 
-        public bool IsBaseClass(CType pDerived, CType pBase)
+        private bool IsBaseClass(CType pDerived, CType pBase)
         {
             Debug.Assert(pDerived != null);
             Debug.Assert(pBase != null);
@@ -292,7 +292,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return HasImplicitReferenceConversion(pSource, pDest);
         }
 
-        protected bool AreTypesEqualForConversion(CType pType1, CType pType2)
+        private bool AreTypesEqualForConversion(CType pType1, CType pType2)
         {
             return pType1.Equals(pType2);
         }
@@ -344,7 +344,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return HasIdentityOrImplicitReferenceConversion(pSourceElement, pDestTypeArgument);
         }
 
-        public bool HasImplicitReferenceConversion(CType pSource, CType pDest)
+        private bool HasImplicitReferenceConversion(CType pSource, CType pDest)
         {
             Debug.Assert(pSource != null);
             Debug.Assert(pDest != null);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
@@ -29,9 +29,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
     }
 
-    internal class BSYMMGR
+    internal sealed class BSYMMGR
     {
-        internal HashSet<KAID> bsetGlobalAssemblies; // Assemblies in the global alias.
+        private HashSet<KAID> bsetGlobalAssemblies; // Assemblies in the global alias.
 
         // Special nullable members.
         public PropertySymbol propNubValue;
@@ -43,14 +43,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private readonly NamespaceSymbol _rootNS;         // The "root" (unnamed) namespace.
 
         // Map from aids to INFILESYMs and EXTERNALIASSYMs
-        protected List<AidContainer> ssetAssembly;
+        private List<AidContainer> ssetAssembly;
         // Map from aids to MODULESYMs and OUTFILESYMs
 
-        protected NameManager m_nameTable;
-        protected SYMTBL tableGlobal;
+        private NameManager m_nameTable;
+        private SYMTBL tableGlobal;
 
         // The hash table for type arrays.
-        protected Dictionary<TypeArrayKey, TypeArray> tableTypeArrays;
+        private Dictionary<TypeArrayKey, TypeArray> tableTypeArrays;
 
         private const int LOG2_SYMTBL_INITIAL_BUCKET_CNT = 13;    // Initial local size: 8192 buckets.
 
@@ -291,7 +291,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
         }
 
-        public AssemblyQualifiedNamespaceSymbol GetNsAid(NamespaceSymbol ns, KAID aid)
+        private AssemblyQualifiedNamespaceSymbol GetNsAid(NamespaceSymbol ns, KAID aid)
         {
             Name name = GetNameFromPtrs(aid, 0);
             Debug.Assert(name != null);
@@ -317,7 +317,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // 2) Make it so parameter lists can be compared by a simple pointer comparison
         // 3) Allow us to associate a token with each signature for faster metadata emit
 
-        protected struct TypeArrayKey : IEquatable<TypeArrayKey>
+        private struct TypeArrayKey : IEquatable<TypeArrayKey>
         {
             private readonly CType[] _types;
             private readonly int _hashCode;
@@ -394,7 +394,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return result;
         }
 
-        public TypeArray ConcatParams(CType[] prgtype1, CType[] prgtype2)
+        private TypeArray ConcatParams(CType[] prgtype1, CType[] prgtype2)
         {
             CType[] combined = new CType[prgtype1.Length + prgtype2.Length];
             Array.Copy(prgtype1, 0, combined, 0, prgtype1.Length);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolTable.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // A symbol table is a helper class used by the symbol manager. There are
     // two symbol tables; a global and a local.
 
-    internal class SYMTBL
+    internal sealed class SYMTBL
     {
         /////////////////////////////////////////////////////////////////////////////////
         // Public

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/TransparentIdentifierMemberSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/TransparentIdentifierMemberSymbol.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class TransparentIdentifierMemberSymbol : Symbol
+    internal sealed class TransparentIdentifierMemberSymbol : Symbol
     {
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/TypeParameterSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/TypeParameterSymbol.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class TypeParameterSymbol : Symbol
+    internal sealed class TypeParameterSymbol : Symbol
     {
         private bool _bIsMethodTypeParameter;
         private bool _bHasRefBound;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/UnresolvedAggregateSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/UnresolvedAggregateSymbol.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     //
     // ----------------------------------------------------------------------------
 
-    internal class UnresolvedAggregateSymbol : AggregateSymbol
+    internal sealed class UnresolvedAggregateSymbol : AggregateSymbol
     {
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/VariableSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/VariableSymbol.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // and formal parameters, 
     // ----------------------------------------------------------------------------
 
-    internal class VariableSymbol : Symbol
+    internal abstract class VariableSymbol : Symbol
     {
         protected CType type;                       // CType of the field.
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ArrayIndex.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ArrayIndex.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRARRAYINDEX : EXPR
+    internal sealed class EXPRARRAYINDEX : EXPR
     {
         private EXPR _Array;
         public EXPR GetArray() { return _Array; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ArrayInitialization.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ArrayInitialization.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRARRINIT : EXPR
+    internal sealed class EXPRARRINIT : EXPR
     {
         private EXPR _OptionalArguments;
         public EXPR GetOptionalArguments() { return _OptionalArguments; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ArrayLength.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ArrayLength.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRARRAYLENGTH : EXPR
+    internal sealed class EXPRARRAYLENGTH : EXPR
     {
         private EXPR _Array;
         public EXPR GetArray() { return _Array; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Assignment.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Assignment.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRASSIGNMENT : EXPR
+    internal sealed class EXPRASSIGNMENT : EXPR
     {
         private EXPR _LHS;
         public EXPR GetLHS() { return _LHS; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/BinaryOperator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/BinaryOperator.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRBINOP : EXPR
+    internal sealed class EXPRBINOP : EXPR
     {
         private EXPR _OptionalLeftChild;
         public EXPR GetOptionalLeftChild() { return _OptionalLeftChild; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Block.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Block.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRBLOCK : EXPRSTMT
+    internal sealed class EXPRBLOCK : EXPRSTMT
     {
         private EXPRSTMT _OptionalStatements;
         public EXPRSTMT GetOptionalStatements() { return _OptionalStatements; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/BoundAnonymousFunction.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/BoundAnonymousFunction.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRBOUNDLAMBDA : EXPR
+    internal sealed class EXPRBOUNDLAMBDA : EXPR
     {
         public EXPRBLOCK OptionalBody;
         private Scope _argumentScope;            // The scope containing the names of the parameters

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Call.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Call.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRCALL : EXPR
+    internal sealed class EXPRCALL : EXPR
     {
         private EXPR _OptionalArguments;
         public EXPR GetOptionalArguments() { return _OptionalArguments; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Cast.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Cast.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRCAST : EXPR
+    internal sealed class EXPRCAST : EXPR
     {
         public EXPR Argument;
         public EXPR GetArgument() { return Argument; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Class.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Class.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRCLASS : EXPRTYPEORNAMESPACE
+    internal sealed class EXPRCLASS : EXPRTYPEORNAMESPACE
     {
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/CompoundOperator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/CompoundOperator.cs
@@ -4,14 +4,14 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRMULTIGET : EXPR
+    internal sealed class EXPRMULTIGET : EXPR
     {
-        public EXPRMULTI OptionalMulti;
+        private EXPRMULTI OptionalMulti;
         public EXPRMULTI GetOptionalMulti() { return OptionalMulti; }
         public void SetOptionalMulti(EXPRMULTI value) { OptionalMulti = value; }
     }
 
-    internal class EXPRMULTI : EXPR
+    internal sealed class EXPRMULTI : EXPR
     {
         public EXPR Left;
         public EXPR GetLeft() { return Left; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Concatenate.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Concatenate.cs
@@ -4,12 +4,12 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRCONCAT : EXPR
+    internal sealed class EXPRCONCAT : EXPR
     {
-        public EXPR FirstArgument;
+        private EXPR FirstArgument;
         public EXPR GetFirstArgument() { return FirstArgument; }
         public void SetFirstArgument(EXPR value) { FirstArgument = value; }
-        public EXPR SecondArgument;
+        private EXPR SecondArgument;
         public EXPR GetSecondArgument() { return SecondArgument; }
         public void SetSecondArgument(EXPR value) { SecondArgument = value; }
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ConditionalOperator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ConditionalOperator.cs
@@ -4,12 +4,12 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRQUESTIONMARK : EXPR
+    internal sealed class EXPRQUESTIONMARK : EXPR
     {
-        public EXPR TestExpression;
+        private EXPR TestExpression;
         public EXPR GetTestExpression() { return TestExpression; }
         public void SetTestExpression(EXPR value) { TestExpression = value; }
-        public EXPRBINOP Consequence;
+        private EXPRBINOP Consequence;
         public EXPRBINOP GetConsequence() { return Consequence; }
         public void SetConsequence(EXPRBINOP value) { Consequence = value; }
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Constant.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Constant.cs
@@ -7,15 +7,15 @@ using System.Text;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRCONSTANT : EXPR
+    internal sealed class EXPRCONSTANT : EXPR
     {
-        public EXPR OptionalConstructorCall;
+        private EXPR OptionalConstructorCall;
         public EXPR GetOptionalConstructorCall() { return OptionalConstructorCall; }
         public void SetOptionalConstructorCall(EXPR value) { OptionalConstructorCall = value; }
 
         private CONSTVAL _val;
 
-        public bool IsZero
+        private bool IsZero
         {
             get
             {
@@ -30,8 +30,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             get
             {
                 return _val;
-            }
-            set
+            } 
+            private set
             {
                 _val = value;
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/EXPR.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/EXPR.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     internal abstract class EXPR
     {
-        protected static void RETAILVERIFY(bool f)
+        private static void RETAILVERIFY(bool f)
         {
             //if (!f)
             //Debug.Assert(false, "panic!");
@@ -19,7 +19,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public ExpressionKind kind;
         public EXPRFLAG flags;
-        public bool IsError;
+        private bool IsError;
         public bool IsOptionalArgument;
         public void SetInaccessibleBit()
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Event.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Event.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPREVENT : EXPR
+    internal sealed class EXPREVENT : EXPR
     {
         public EXPR OptionalObject;
         public EventWithType ewt;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ExpressionIterator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ExpressionIterator.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     //
     //     int n = ExpressionIterator::Count(list);
 
-    internal class ExpressionIterator
+    internal sealed class ExpressionIterator
     {
         public ExpressionIterator(EXPR pExpr) { Init(pExpr); }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Field.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Field.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRFIELD : EXPR
+    internal sealed class EXPRFIELD : EXPR
     {
         public EXPR OptionalObject;
         public EXPR GetOptionalObject() { return OptionalObject; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/FieldInfo.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/FieldInfo.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRFIELDINFO : EXPR
+    internal sealed class EXPRFIELDINFO : EXPR
     {
         public FieldSymbol Field()
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/HoistedLocal.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/HoistedLocal.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRHOISTEDLOCALEXPR : EXPR
+    internal sealed class EXPRHOISTEDLOCALEXPR : EXPR
     {
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/List.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/List.cs
@@ -4,9 +4,9 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRLIST : EXPR
+    internal sealed class EXPRLIST : EXPR
     {
-        public EXPR OptionalElement;
+        private EXPR OptionalElement;
         public EXPR GetOptionalElement() { return OptionalElement; }
         public void SetOptionalElement(EXPR value) { OptionalElement = value; }
         public EXPR OptionalNextListNode;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/MemberGroup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/MemberGroup.cs
@@ -6,7 +6,7 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRMEMGRP : EXPR
+    internal sealed class EXPRMEMGRP : EXPR
     {
         public Name name;
         public TypeArray typeArgs;
@@ -24,16 +24,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // The lhs that was bound to resolve this invocation. Set for static invocations only.
         // We don't use the regular defines because we don't want to visit this guy in regular visitors,
         // just in the visitors that create the node maps for LAF and refactoring.
-        public EXPR OptionalLHS;
+        private EXPR OptionalLHS;
         public EXPR GetOptionalLHS() { return OptionalLHS; }
         public void SetOptionalLHS(EXPR lhs) { OptionalLHS = lhs; }
         // The owning call of this member group. NEVER visit this thing.
         // The list of the methods that the memgroup is binding to. This list is formulated after binding
         // the name of the method. When we've attempted to bind the arguments, we populate the MethPropWithInst list.
-        public CMemberLookupResults MemberLookupResults;
+        private CMemberLookupResults MemberLookupResults;
         public CMemberLookupResults GetMemberLookupResults() { return MemberLookupResults; }
         public void SetMemberLookupResults(CMemberLookupResults results) { MemberLookupResults = results; }
-        public CType ParentType;
+        private CType ParentType;
         public CType GetParentType() { return ParentType; }
         public void SetParentType(CType type) { ParentType = type; }
         public bool isDelegate() { return (flags & EXPRFLAG.EXF_DELEGATE) != 0; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/MethodInfo.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/MethodInfo.cs
@@ -8,7 +8,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRMETHODINFO : EXPR
+    internal sealed class EXPRMETHODINFO : EXPR
     {
         public MethWithInst Method;
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/MethodReference.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/MethodReference.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRFUNCPTR : EXPR
+    internal sealed class EXPRFUNCPTR : EXPR
     {
         public MethWithInst mwi;
         public EXPR OptionalObject;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/NamedArgumentSpecification.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/NamedArgumentSpecification.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRNamedArgumentSpecification : EXPR
+    internal sealed class EXPRNamedArgumentSpecification : EXPR
     {
         public Syntax.Name Name;
         public EXPR Value;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Property.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Property.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRPROP : EXPR
+    internal sealed class EXPRPROP : EXPR
     {
         // If we have this.prop = 123, but the implementation of the property is in the
         // base class, then the object is of the base class type. Note that to get
@@ -14,13 +14,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // of the type we are actually calling through.  (We need to know the
         // "through" type to ensure that protected semantics are correctly enforced.)
 
-        public EXPR OptionalArguments;
+        private EXPR OptionalArguments;
         public EXPR GetOptionalArguments() { return OptionalArguments; }
         public void SetOptionalArguments(EXPR value) { OptionalArguments = value; }
-        public EXPRMEMGRP MemberGroup;
+        private EXPRMEMGRP MemberGroup;
         public EXPRMEMGRP GetMemberGroup() { return MemberGroup; }
         public void SetMemberGroup(EXPRMEMGRP value) { MemberGroup = value; }
-        public EXPR OptionalObjectThrough;
+        private EXPR OptionalObjectThrough;
         public EXPR GetOptionalObjectThrough() { return OptionalObjectThrough; }
         public void SetOptionalObjectThrough(EXPR value) { OptionalObjectThrough = value; }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/PropertyInfo.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/PropertyInfo.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRPropertyInfo : EXPR
+    internal sealed class EXPRPropertyInfo : EXPR
     {
         public PropWithType Property;
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Return.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Return.cs
@@ -8,10 +8,10 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRRETURN : EXPRSTMT
+    internal sealed class EXPRRETURN : EXPRSTMT
     {
         // Return object is optional because of void returns.
-        public EXPR OptionalObject;
+        private EXPR OptionalObject;
         public EXPR GetOptionalObject() { return OptionalObject; }
         public void SetOptionalObject(EXPR value) { OptionalObject = value; }
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Temporary.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Temporary.cs
@@ -4,9 +4,9 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRWRAP : EXPR
+    internal sealed class EXPRWRAP : EXPR
     {
-        public EXPR OptionalExpression;
+        private EXPR OptionalExpression;
         public EXPR GetOptionalExpression() { return OptionalExpression; }
         public void SetOptionalExpression(EXPR value) { OptionalExpression = value; }
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/This.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/This.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRTHISPOINTER : EXPRLOCAL
+    internal sealed class EXPRTHISPOINTER : EXPRLOCAL
     {
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/TypeArguments.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/TypeArguments.cs
@@ -9,9 +9,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         associated with the AggregateType for the instantiation of the class. 
     *************************************************************************************************/
 
-    internal class EXPRTYPEARGUMENTS : EXPR
+    internal sealed class EXPRTYPEARGUMENTS : EXPR
     {
-        public EXPR OptionalElements;
+        private EXPR OptionalElements;
         public EXPR GetOptionalElements() { return OptionalElements; }
         public void SetOptionalElements(EXPR value) { OptionalElements = value; }
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/TypeOf.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/TypeOf.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRTYPEOF : EXPR
+    internal sealed class EXPRTYPEOF : EXPR
     {
         public EXPRTYPEORNAMESPACE SourceType;
         public EXPRTYPEORNAMESPACE GetSourceType() { return SourceType; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/TypeOrNamespace.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/TypeOrNamespace.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
          must be a type or a namespace. This EXPR encapsulates that fact. The lhs member is the EXPR 
          tree that was bound to resolve the type or namespace.
      *************************************************************************************************/
-    internal class EXPRTYPEORNAMESPACE : EXPR
+    internal abstract class EXPRTYPEORNAMESPACE : EXPR
     {
         public ITypeOrNamespace TypeOrNamespace;
     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/UnaryOperator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/UnaryOperator.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRUNARYOP : EXPR
+    internal sealed class EXPRUNARYOP : EXPR
     {
         public EXPR Child;
         public EXPR OptionalUserDefinedCall;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/UnboundAnonymousFunction.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/UnboundAnonymousFunction.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRUNBOUNDLAMBDA : EXPR
+    internal sealed class EXPRUNBOUNDLAMBDA : EXPR
     {
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/UserDefinedConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/UserDefinedConversion.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRUSERDEFINEDCONVERSION : EXPR
+    internal sealed class EXPRUSERDEFINEDCONVERSION : EXPR
     {
         public EXPR Argument;
         public EXPR UserDefinedCall;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/UserDefinedLogicalOperator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/UserDefinedLogicalOperator.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRUSERLOGOP : EXPR
+    internal sealed class EXPRUSERLOGOP : EXPR
     {
         public EXPR TrueFalseCall;
         public EXPRCALL OperatorCall;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExprVisitorBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExprVisitorBase.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class ExprVisitorBase
+    internal abstract class ExprVisitorBase
     {
         public EXPR Visit(EXPR pExpr)
         {
@@ -31,7 +31,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         /////////////////////////////////////////////////////////////////////////////////
 
-        protected EXPRSTMT DispatchStatementList(EXPRSTMT expr)
+        private EXPRSTMT DispatchStatementList(EXPRSTMT expr)
         {
             Debug.Assert(expr != null);
 
@@ -82,7 +82,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         /////////////////////////////////////////////////////////////////////////////////
 
-        protected bool IsCachedExpr(EXPR pExpr, out EXPR pTransformedExpr)
+        private bool IsCachedExpr(EXPR pExpr, out EXPR pTransformedExpr)
         {
             pTransformedExpr = null;
             return false;
@@ -90,7 +90,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         /////////////////////////////////////////////////////////////////////////////////
 
-        protected EXPR CacheExprMapping(EXPR pExpr, EXPR pTransformedExpr)
+        private EXPR CacheExprMapping(EXPR pExpr, EXPR pTransformedExpr)
         {
             return pTransformedExpr;
         }
@@ -265,7 +265,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     throw Error.InternalCompilerError();
             }
         }
-        protected void VisitChildren(EXPR pExpr)
+        private void VisitChildren(EXPR pExpr)
         {
             Debug.Assert(pExpr != null);
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ZeroInitialize.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/ZeroInitialize.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class EXPRZEROINIT : EXPR
+    internal sealed class EXPRZEROINIT : EXPR
     {
         public EXPR OptionalArgument;
         public EXPR OptionalConstructorCall;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             SetTypeArgsAll(pOuterTypeArgs);
         }
 
-        public void SetTypeArgsAll(TypeArray outerTypeArgs)
+        private void SetTypeArgsAll(TypeArray outerTypeArgs)
         {
             Debug.Assert(_pTypeArgsThis != null);
 
@@ -133,7 +133,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _pTypeArgsAll = pTypeManager.ConcatenateTypeArrays(pCheckedOuterTypeArgs, _pTypeArgsThis);
         }
 
-        public bool AreAllTypeArgumentsUnitTypes(TypeArray typeArray)
+        private bool AreAllTypeArgumentsUnitTypes(TypeArray typeArray)
         {
             if (typeArray.Size == 0)
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ArgumentListType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ArgumentListType.cs
@@ -9,6 +9,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // There is exactly one of these.
     // ----------------------------------------------------------------------------
 
-    internal class ArgumentListType : CType
+    internal sealed class ArgumentListType : CType
     { };
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ArrayType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ArrayType.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // ArrayType - a symbol representing an array.
     // ----------------------------------------------------------------------------
 
-    internal class ArrayType : CType
+    internal sealed class ArrayType : CType
     {
         // rank of the array. zero means unknown rank int [?].
         public int rank;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/BoundLambdaType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/BoundLambdaType.cs
@@ -9,6 +9,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // method expression. There is exactly one of these.
     // ----------------------------------------------------------------------------
 
-    internal class BoundLambdaType : CType
+    internal sealed class BoundLambdaType : CType
     { };
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ErrorType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ErrorType.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // ErrorType - a symbol representing an error that has been reported.
     // ----------------------------------------------------------------------------
 
-    internal class ErrorType : CType
+    internal sealed class ErrorType : CType
     {
         public Name nameText;
         public TypeArray typeArgs;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/MethodGroupType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/MethodGroupType.cs
@@ -9,6 +9,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // group expression.  There is exactly one of these.
     // ----------------------------------------------------------------------------
 
-    internal class MethodGroupType : CType
+    internal sealed class MethodGroupType : CType
     { };
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/NullType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/NullType.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // NullType - represents the null type -- the type of the "null constant".
     // ----------------------------------------------------------------------------
 
-    internal class NullType : CType
+    internal sealed class NullType : CType
     {
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/NullableType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/NullableType.cs
@@ -14,9 +14,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     //
     // ----------------------------------------------------------------------------
 
-    internal class NullableType : CType
+    internal sealed class NullableType : CType
     {
-        public AggregateType ats;
+        private AggregateType ats;
         public BSYMMGR symmgr;
         public TypeManager typeManager;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/OpenTypePlaceholderType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/OpenTypePlaceholderType.cs
@@ -9,6 +9,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // types. There is exactly one of these.
     // ----------------------------------------------------------------------------
 
-    internal class OpenTypePlaceholderType : CType
+    internal sealed class OpenTypePlaceholderType : CType
     { }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ParameterModifierType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/ParameterModifierType.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     //
     // ----------------------------------------------------------------------------
 
-    internal class ParameterModifierType : CType
+    internal sealed class ParameterModifierType : CType
     {
         public bool isOut;            // True for out parameter, false for ref parameter.
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/PointerType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/PointerType.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class PointerType : CType
+    internal sealed class PointerType : CType
     {
         public CType GetReferentType() { return _pReferentType; }
         public void SetReferentType(CType pType) { _pReferentType = pType; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/PredefinedTypes.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/PredefinedTypes.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     }
 
 
-    internal class PredefinedTypes
+    internal sealed class PredefinedTypes
     {
         private SymbolTable _runtimeBinderSymbolTable;
         private readonly BSYMMGR _pBSymmgr;
@@ -265,7 +265,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         // "object". This return the nice name if one exists; otherwise null is 
         // returned.
 
-        public static string GetNiceName(PredefinedType pt)
+        private static string GetNiceName(PredefinedType pt)
         {
             return PredefinedTypeFacts.GetNiceName(pt);
         }
@@ -404,7 +404,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return s_pdTypeNames[name];
         }
 
-        private class PredefinedTypeInfo
+        private sealed class PredefinedTypeInfo
         {
             internal readonly PredefinedType type;
             internal readonly string name;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -10,7 +10,7 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class CType : ITypeOrNamespace
+    internal abstract class CType : ITypeOrNamespace
     {
         private TypeKind _typeKind;
         private Name _pName;
@@ -469,7 +469,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             return GetNakedAgg(false);
         }
-        public AggregateSymbol GetNakedAgg(bool fStripNub)
+
+        private AggregateSymbol GetNakedAgg(bool fStripNub)
         {
             CType type = GetNakedType(fStripNub);
             if (type != null && type.IsAggregateType())
@@ -521,7 +522,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return isSimpleType() || isPredefType(PredefinedType.PT_STRING) || isEnumType();
         }
 
-        public bool isPointerLike()
+        private bool isPointerLike()
         {
             return IsPointerType() || isPredefType(PredefinedType.PT_INTPTR) || isPredefType(PredefinedType.PT_UINTPTR);
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeArray.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeArray.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     /////////////////////////////////////////////////////////////////////////////////
     // Encapsulates a type list, including its size and metadata token.
 
-    internal class TypeArray
+    internal sealed class TypeArray
     {
         private readonly CType[] _items;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeFactory.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeFactory.cs
@@ -7,7 +7,7 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class TypeFactory
+    internal sealed class TypeFactory
     {
         // Aggregate
         public AggregateType CreateAggregateType(

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -14,7 +14,7 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
-    internal class TypeManager
+    internal sealed class TypeManager
     {
         private BSYMMGR _BSymmgr;
         private PredefinedTypes _predefTypes;
@@ -126,9 +126,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
         }
 
-        private class StdTypeVarColl
+        private sealed class StdTypeVarColl
         {
-            public readonly List<TypeParameterType> prgptvs;
+            private readonly List<TypeParameterType> prgptvs;
 
             public StdTypeVarColl()
             {
@@ -451,7 +451,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return _nullType;
         }
 
-        public OpenTypePlaceholderType GetUnitType()
+        private OpenTypePlaceholderType GetUnitType()
         {
             return _typeUnit;
         }
@@ -481,7 +481,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return this.GetOptPredefAgg(PredefinedType.PT_G_OPTIONAL);
         }
 
-        public CType SubstType(CType typeSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth, SubstTypeFlags grfst)
+        private CType SubstType(CType typeSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth, SubstTypeFlags grfst)
         {
             if (typeSrc == null)
                 return null;
@@ -495,7 +495,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return SubstType(typeSrc, typeArgsCls, null, SubstTypeFlags.NormNone);
         }
 
-        public CType SubstType(CType typeSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth)
+        private CType SubstType(CType typeSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth)
         {
             return SubstType(typeSrc, typeArgsCls, typeArgsMeth, SubstTypeFlags.NormNone);
         }
@@ -513,7 +513,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return _BSymmgr.AllocParams(taSrc.size, prgpts);
         }
 
-        public TypeArray SubstTypeArray(TypeArray taSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth, SubstTypeFlags grfst)
+        private TypeArray SubstTypeArray(TypeArray taSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth, SubstTypeFlags grfst)
         {
             if (taSrc == null || taSrc.Size == 0)
                 return taSrc;
@@ -681,7 +681,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return true;
         }
 
-        public bool SubstEqualTypesCore(CType typeDst, CType typeSrc, SubstContext pctx)
+        private bool SubstEqualTypesCore(CType typeDst, CType typeSrc, SubstContext pctx)
         {
         LRecurse:  // Label used for "tail" recursion.
 
@@ -1051,7 +1051,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return this.SubstTypeArray(taSrc, atsCls, (TypeArray)null);
         }
 
-        public bool SubstEqualTypes(CType typeDst, CType typeSrc, CType typeCls, TypeArray typeArgsMeth)
+        private bool SubstEqualTypes(CType typeDst, CType typeSrc, CType typeCls, TypeArray typeArgsMeth)
         {
             return SubstEqualTypes(typeDst, typeSrc, typeCls.IsAggregateType() ? typeCls.AsAggregateType().GetTypeArgsAll() : null, typeArgsMeth, SubstTypeFlags.NormNone);
         }
@@ -1071,7 +1071,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return _stvcMethod.GetTypeVarSym(iv, this, true);
         }
 
-        public TypeParameterType GetStdClsTypeVar(int iv)
+        private TypeParameterType GetStdClsTypeVar(int iv)
         {
             return _stvcClass.GetTypeVarSym(iv, this, false);
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeParameterType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeParameterType.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     /////////////////////////////////////////////////////////////////////////////////
 
-    internal class TypeParameterType : CType
+    internal sealed class TypeParameterType : CType
     {
         public TypeParameterSymbol GetTypeParameterSymbol() { return _pTypeParameterSymbol; }
         public void SetTypeParameterSymbol(TypeParameterSymbol pTypePArameterSymbol) { _pTypeParameterSymbol = pTypePArameterSymbol; }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeTable.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
     }
 
-    internal class TypeTable
+    internal sealed class TypeTable
     {
         // Two way hashes
         private readonly Dictionary<KeyPair<AggregateSymbol, Name>, AggregateType> _pAggregateTable;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/VoidType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/VoidType.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
     // VoidType - represents the type "void".
     // ----------------------------------------------------------------------------
 
-    internal class VoidType : CType
+    internal sealed class VoidType : CType
     {
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/UnaOpSig.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/UnaOpSig.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             public UnaOpFuncKind fnkind;
         }
 
-        private class UnaOpFullSig : UnaOpSig
+        private sealed class UnaOpFullSig : UnaOpSig
         {
             private readonly LiftFlags _grflt;
             private readonly CType _type;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/UtilityTypeExtensions.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/UtilityTypeExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     internal static class UtilityTypeExtensions
     {
-        public static IEnumerable<AggregateType> InterfaceAndBases(this AggregateType type)
+        private static IEnumerable<AggregateType> InterfaceAndBases(this AggregateType type)
         {
             Debug.Assert(type != null);
             yield return type;
@@ -17,7 +17,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 yield return t;
         }
 
-        public static IEnumerable<AggregateType> AllConstraintInterfaces(this TypeArray constraints)
+        private static IEnumerable<AggregateType> AllConstraintInterfaces(this TypeArray constraints)
         {
             Debug.Assert(constraints != null);
             foreach (AggregateType c in constraints.ToArray())
@@ -25,7 +25,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     yield return t;
         }
 
-        public static IEnumerable<AggregateType> TypeAndBaseClasses(this AggregateType type)
+        private static IEnumerable<AggregateType> TypeAndBaseClasses(this AggregateType type)
         {
             Debug.Assert(type != null);
             AggregateType t = type;
@@ -36,7 +36,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
         }
 
-        public static IEnumerable<AggregateType> TypeAndBaseClassInterfaces(this AggregateType type)
+        private static IEnumerable<AggregateType> TypeAndBaseClassInterfaces(this AggregateType type)
         {
             Debug.Assert(type != null);
             foreach (AggregateType b in type.TypeAndBaseClasses())

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/WithType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/WithType.cs
@@ -158,7 +158,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
     }
 
-    internal class MethWithType : MethPropWithType
+    internal sealed class MethWithType : MethPropWithType
     {
         public MethWithType()
         {
@@ -170,7 +170,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
     }
 
-    internal class PropWithType : MethPropWithType
+    internal sealed class PropWithType : MethPropWithType
     {
         public PropWithType()
         { }
@@ -186,7 +186,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
     }
 
-    internal class EventWithType : SymWithType
+    internal sealed class EventWithType : SymWithType
     {
         public EventWithType()
         {
@@ -198,7 +198,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
     }
 
-    internal class FieldWithType : SymWithType
+    internal sealed class FieldWithType : SymWithType
     {
         public FieldWithType()
         {
@@ -259,7 +259,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         }
     }
 
-    internal class MethWithInst : MethPropWithInst
+    internal sealed class MethWithInst : MethPropWithInst
     {
         public MethWithInst()
         {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -14,7 +14,7 @@ using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder
 {
-    internal class SymbolTable
+    internal sealed class SymbolTable
     {
         /////////////////////////////////////////////////////////////////////////////////
         // Members
@@ -81,7 +81,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         /////////////////////////////////////////////////////////////////////////////////
 
-        internal void ClearCache()
+        private void ClearCache()
         {
             _typesWithConversionsLoaded = new HashSet<Type>();
             _namesLoadedForEachType = new HashSet<NameHashKey>();

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/KnownName.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/KnownName.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Syntax
 {
     internal partial class NameManager
     {
-        internal class KnownName : Name
+        private sealed class KnownName : Name
         {
             public KnownName(string text)
                 : base(text)
@@ -22,7 +22,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Syntax
                 PredefinedName = id;
             }
 
-            public override PredefinedName PredefinedName { get; } = PredefinedName.PN_COUNT;
+            public PredefinedName PredefinedName { get; } = PredefinedName.PN_COUNT;
         }
 
         private static NameTable s_knownNames;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/NameManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/NameManager.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Syntax
         {
         }
 
-        internal NameManager(NameTable nameTable)
+        private NameManager(NameTable nameTable)
         {
             _names = nameTable;
             InitKnownNames();

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/NameTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/NameTable.cs
@@ -4,9 +4,9 @@
 
 namespace Microsoft.CSharp.RuntimeBinder.Syntax
 {
-    internal class NameTable
+    internal sealed class NameTable
     {
-        private class Entry
+        private sealed class Entry
         {
             internal readonly Name name;
             internal readonly int hashCode;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/Names.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/Names.cs
@@ -18,11 +18,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Syntax
             get { return _text; }
         }
 
-        public virtual PredefinedName PredefinedName
-        {
-            get { return PredefinedName.PN_COUNT; }
-        }
-
         public override string ToString()
         {
             return _text;


### PR DESCRIPTION
Seal internal classes that aren't derived from.

Make internal classes that aren't instantiated abstract.

Make init-only fields readonly

Make access of members to private or otherwise reduced.