### PR TITLE
Throw ArgumentNullException on CallSite<T>.Create() with null binder

### DIFF
--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
@@ -186,6 +186,7 @@ namespace System.Runtime.CompilerServices
         public static CallSite<T> Create(CallSiteBinder binder)
         {
             if (!typeof(T).IsSubclassOf(typeof(MulticastDelegate))) throw System.Linq.Expressions.Error.TypeMustBeDerivedFromSystemDelegate();
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             return new CallSite<T>(binder);
         }
 

--- a/src/System.Linq.Expressions/tests/Dynamic/CallSiteTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/CallSiteTests.cs
@@ -30,5 +30,11 @@ namespace System.Runtime.CompilerServices.Tests
         {
             Assert.Throws<ArgumentNullException>("binder", () => CallSite.Create(typeof(Func<string>), null));
         }
+
+        [Fact]
+        public void NullBinder()
+        {
+            Assert.Throws<ArgumentNullException>("binder", () => CallSite<Func<CallSite, object, object>>.Create(null));
+        }
     }
 }


### PR DESCRIPTION
Fixes #15613