### PR TITLE
Tests for UnaryExpressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
@@ -189,7 +189,7 @@ namespace System.Linq.Expressions.Compiler
                         }
                         return;
                     default:
-                        throw Error.UnhandledUnary(op);
+                        throw Error.UnhandledUnary(op, nameof(op));
                 }
             }
             else
@@ -248,7 +248,7 @@ namespace System.Linq.Expressions.Compiler
                         _ilg.Emit(OpCodes.Sub);
                         break;
                     default:
-                        throw Error.UnhandledUnary(op);
+                        throw Error.UnhandledUnary(op, nameof(op));
                 }
 
                 EmitConvertArithmeticResult(op, resultType);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -982,9 +982,9 @@ namespace System.Linq.Expressions
         /// <summary>
         /// ArgumentException with message like "Unhandled unary: {0}"
         /// </summary>
-        internal static Exception UnhandledUnary(object p0)
+        internal static Exception UnhandledUnary(object p0, string paramName)
         {
-            return new ArgumentException(Strings.UnhandledUnary(p0));
+            return new ArgumentException(Strings.UnhandledUnary(p0), paramName);
         }
         /// <summary>
         /// ArgumentException with message like "Unknown binding type"

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -361,7 +361,7 @@ namespace System.Linq.Expressions
                 case ExpressionType.PostDecrementAssign:
                     return PostDecrementAssign(operand, method);
                 default:
-                    throw Error.UnhandledUnary(unaryType);
+                    throw Error.UnhandledUnary(unaryType, nameof(unaryType));
             }
         }
 

--- a/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -1594,6 +1595,18 @@ namespace System.Linq.Expressions.Tests
         {
             Expression array = Expression.Property(null, typeof(Unreadable<int[]>), nameof(Unreadable<int>.WriteOnly));
             Assert.Throws<ArgumentException>(() => Expression.ArrayLength(array));
+        }
+
+        private static IEnumerable<object[]> TestArrays()
+            => Enumerable.Range(0, 6).Select(i => new object[] {new int[i * i]});
+
+        [Theory, PerCompilationType(nameof(TestArrays))]
+        public static void MakeUnaryArrayLength(int[] array, bool useInterpreter)
+        {
+            Expression<Func<int>> lambda = Expression.Lambda<Func<int>>(
+                Expression.MakeUnary(ExpressionType.ArrayLength, Expression.Constant(array), null));
+            Func<int> func = lambda.Compile(useInterpreter);
+            Assert.Equal(array.Length, func());
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Conditional/ConditionalTests.cs
+++ b/src/System.Linq.Expressions/tests/Conditional/ConditionalTests.cs
@@ -255,24 +255,6 @@ namespace System.Linq.Expressions.Tests
             yield return new object[] { false, ce, be, be, typeof(Expression) };
         }
 
-        private class Truthiness
-        {
-            private bool Value { get; }
-
-            public Truthiness(bool value)
-            {
-                Value = value;
-            }
-
-            public static implicit operator bool(Truthiness truth) => truth.Value;
-
-            public static bool operator true(Truthiness truth) => truth.Value;
-
-            public static bool operator false(Truthiness truth) => !truth.Value;
-
-            public static Truthiness operator !(Truthiness truth) => new Truthiness(!truth.Value);
-        }
-
         private static class Unreadable<T>
         {
             public static T WriteOnly

--- a/src/System.Linq.Expressions/tests/Convert/ConvertCheckedTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertCheckedTests.cs
@@ -18423,5 +18423,24 @@ namespace System.Linq.Expressions.Tests
         {
             Assert.Throws<ArgumentException>("type", () => Expression.ConvertChecked(Expression.Constant(null), typeof(int*)));
         }
+
+        public static IEnumerable<object[]> Conversions()
+        {
+            yield return new object[] { 3, 3 };
+            yield return new object[] { (byte)3, 3 };
+            yield return new object[] { 3, 3.0 };
+            yield return new object[] { 3.0, 3 };
+            yield return new object[] { 24910, (short)24910 };
+        }
+
+        [Theory, PerCompilationType(nameof(Conversions))]
+        public static void ConvertCheckedMakeUnary(object source, object result, bool useInterpreter)
+        {
+            LambdaExpression lambda = Expression.Lambda(
+                Expression.MakeUnary(ExpressionType.ConvertChecked, Expression.Constant(source), result.GetType())
+                );
+            Delegate del = lambda.Compile(useInterpreter);
+            Assert.Equal(result, del.DynamicInvoke());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -474,4 +474,22 @@ namespace System.Linq.Expressions.Tests
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
+
+    public class Truthiness
+    {
+        private bool Value { get; }
+
+        public Truthiness(bool value)
+        {
+            Value = value;
+        }
+
+        public static implicit operator bool(Truthiness truth) => truth.Value;
+
+        public static bool operator true(Truthiness truth) => truth.Value;
+
+        public static bool operator false(Truthiness truth) => !truth.Value;
+
+        public static Truthiness operator !(Truthiness truth) => new Truthiness(!truth.Value);
+    }
 }

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -204,6 +204,7 @@
     <Compile Include="Unary\IncDecAssign\PreDecrementAssignTests.cs" />
     <Compile Include="Unary\IncDecAssign\PreIncrementAssignTests.cs" />
     <Compile Include="Unary\IncrementDecrementTests.cs" />
+    <Compile Include="Unary\MakeUnaryTests.cs" />
     <Compile Include="Unary\UnaryArithmeticNegateNullableOneOffTests.cs" />
     <Compile Include="Unary\UnaryArithmeticNegateCheckedNullableTests.cs" />
     <Compile Include="Unary\UnaryArithmeticNegateNullableTests.cs" />

--- a/src/System.Linq.Expressions/tests/Unary/MakeUnaryTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/MakeUnaryTests.cs
@@ -1,0 +1,88 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class MakeUnaryTests
+    {
+        public static readonly object[][] NonUnaryExpressionTypes =
+        {
+            new object[] {ExpressionType.Add},
+            new object[] {ExpressionType.AddChecked},
+            new object[] {ExpressionType.And},
+            new object[] {ExpressionType.AndAlso},
+            new object[] {ExpressionType.ArrayIndex},
+            new object[] {ExpressionType.Call},
+            new object[] {ExpressionType.Coalesce},
+            new object[] {ExpressionType.Conditional},
+            new object[] {ExpressionType.Constant},
+            new object[] {ExpressionType.Divide},
+            new object[] {ExpressionType.Equal},
+            new object[] {ExpressionType.ExclusiveOr},
+            new object[] {ExpressionType.GreaterThan},
+            new object[] {ExpressionType.GreaterThanOrEqual},
+            new object[] {ExpressionType.Invoke},
+            new object[] {ExpressionType.Lambda},
+            new object[] {ExpressionType.LeftShift},
+            new object[] {ExpressionType.LessThan},
+            new object[] {ExpressionType.LessThanOrEqual},
+            new object[] {ExpressionType.ListInit},
+            new object[] {ExpressionType.MemberAccess},
+            new object[] {ExpressionType.MemberInit},
+            new object[] {ExpressionType.Modulo},
+            new object[] {ExpressionType.Multiply},
+            new object[] {ExpressionType.MultiplyChecked},
+            new object[] {ExpressionType.New},
+            new object[] {ExpressionType.NewArrayInit},
+            new object[] {ExpressionType.NewArrayBounds},
+            new object[] {ExpressionType.NotEqual},
+            new object[] {ExpressionType.Or},
+            new object[] {ExpressionType.OrElse},
+            new object[] {ExpressionType.Parameter},
+            new object[] {ExpressionType.Power},
+            new object[] {ExpressionType.RightShift},
+            new object[] {ExpressionType.Subtract},
+            new object[] {ExpressionType.SubtractChecked},
+            new object[] {ExpressionType.TypeIs},
+            new object[] {ExpressionType.Assign},
+            new object[] {ExpressionType.Block},
+            new object[] {ExpressionType.DebugInfo},
+            new object[] {ExpressionType.Dynamic},
+            new object[] {ExpressionType.Default},
+            new object[] {ExpressionType.Extension},
+            new object[] {ExpressionType.Goto},
+            new object[] {ExpressionType.Index},
+            new object[] {ExpressionType.Label},
+            new object[] {ExpressionType.RuntimeVariables},
+            new object[] {ExpressionType.Loop},
+            new object[] {ExpressionType.Switch},
+            new object[] {ExpressionType.Try},
+            new object[] {ExpressionType.AddAssign},
+            new object[] {ExpressionType.AndAssign},
+            new object[] {ExpressionType.DivideAssign},
+            new object[] {ExpressionType.ExclusiveOrAssign},
+            new object[] {ExpressionType.LeftShiftAssign},
+            new object[] {ExpressionType.ModuloAssign},
+            new object[] {ExpressionType.MultiplyAssign},
+            new object[] {ExpressionType.OrAssign},
+            new object[] {ExpressionType.PowerAssign},
+            new object[] {ExpressionType.RightShiftAssign},
+            new object[] {ExpressionType.SubtractAssign},
+            new object[] {ExpressionType.AddAssignChecked},
+            new object[] {ExpressionType.MultiplyAssignChecked},
+            new object[] {ExpressionType.SubtractAssignChecked},
+            new object[] {ExpressionType.TypeEqual},
+            new object[] {(ExpressionType)(-1)},
+            new object[] {(ExpressionType)int.MaxValue}
+        };
+
+        [Theory, MemberData(nameof(NonUnaryExpressionTypes))]
+        public void MakeUnaryExpressionNonUnary(ExpressionType type)
+        {
+            Assert.Throws<ArgumentException>("unaryType", () => Expression.MakeUnary(type, null, null));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/Unary/UnaryDecrementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryDecrementTests.cs
@@ -39,6 +39,7 @@ namespace System.Linq.Expressions.Tests
             for (int i = 0; i < values.Length; i++)
             {
                 VerifyDecrementInt(values[i], useInterpreter);
+                VerifyDecrementIntMakeUnary(values[i], useInterpreter);
             }
         }
 
@@ -177,6 +178,16 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile(useInterpreter);
             Assert.Equal((int)(--value), f());
+        }
+
+        private static void VerifyDecrementIntMakeUnary(int value, bool useInterpreter)
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.MakeUnary(ExpressionType.Decrement, Expression.Constant(value), null),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile(useInterpreter);
+            Assert.Equal(--value, f());
         }
 
         private static void VerifyDecrementUInt(uint value, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIncrementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIncrementTests.cs
@@ -39,6 +39,7 @@ namespace System.Linq.Expressions.Tests
             for (int i = 0; i < values.Length; i++)
             {
                 VerifyIncrementInt(values[i], useInterpreter);
+                VerifyIncrementIntMakeUnary(values[i], useInterpreter);
             }
         }
 
@@ -179,6 +180,15 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal((int)(++value), f());
         }
 
+        private static void VerifyIncrementIntMakeUnary(int value, bool useInterpreter)
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.MakeUnary(ExpressionType.Increment, Expression.Constant(value), null),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile(useInterpreter);
+            Assert.Equal(++value, f());
+        }
         private static void VerifyIncrementUInt(uint value, bool useInterpreter)
         {
             Expression<Func<uint>> e =

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -41,7 +42,34 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal((bool)(value == false), f());
         }
 
-
         #endregion
+
+        private static IEnumerable<object[]> Truthinesses()
+        {
+            yield return new object[] { new Truthiness(true), false };
+            yield return new object[] { new Truthiness(false), true };
+        }
+
+        [Theory, PerCompilationType(nameof(Truthinesses))]
+        private static void VerifyMakeUnaryExplicitMethodIsFalseBool(Truthiness argument, bool expected, bool useInterpreter)
+        {
+            Expression<Func<bool>> e =
+                Expression.Lambda<Func<bool>>(
+                    Expression.MakeUnary(
+                        ExpressionType.IsFalse, Expression.Constant(argument), null, typeof(Truthiness).GetMethod("op_False")));
+            Func<bool> f = e.Compile(useInterpreter);
+            Assert.Equal(expected, f());
+        }
+
+        [Theory, PerCompilationType(nameof(Truthinesses))]
+        private static void VerifyMakeUnaryDeduceMethodIsFalseBool(Truthiness argument, bool expected, bool useInterpreter)
+        {
+            Expression<Func<bool>> e =
+                Expression.Lambda<Func<bool>>(
+                    Expression.MakeUnary(
+                        ExpressionType.IsFalse, Expression.Constant(argument), null, null));
+            Func<bool> f = e.Compile(useInterpreter);
+            Assert.Equal(expected, f());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -41,7 +42,34 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal((bool)(value == true), f());
         }
 
-
         #endregion
+
+        private static IEnumerable<object[]> Truthinesses()
+        {
+            yield return new object[] {new Truthiness(true), true};
+            yield return new object[] {new Truthiness(false), false};
+        }
+
+        [Theory, PerCompilationType(nameof(Truthinesses))]
+        private static void VerifyMakeUnaryExplicitMethodIsTrueBool(Truthiness argument, bool expected, bool useInterpreter)
+        {
+            Expression<Func<bool>> e =
+                Expression.Lambda<Func<bool>>(
+                    Expression.MakeUnary(
+                        ExpressionType.IsTrue, Expression.Constant(argument), null, typeof(Truthiness).GetMethod("op_True")));
+            Func<bool> f = e.Compile(useInterpreter);
+            Assert.Equal(expected, f());
+        }
+
+        [Theory, PerCompilationType(nameof(Truthinesses))]
+        private static void VerifyMakeUnaryDeduceMethodIsTrueBool(Truthiness argument, bool expected, bool useInterpreter)
+        {
+            Expression<Func<bool>> e =
+                Expression.Lambda<Func<bool>>(
+                    Expression.MakeUnary(
+                        ExpressionType.IsTrue, Expression.Constant(argument), null, null));
+            Func<bool> f = e.Compile(useInterpreter);
+            Assert.Equal(expected, f());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Unary/UnaryQuoteTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryQuoteTests.cs
@@ -64,6 +64,22 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
+        public void Quote_Lambda_Action_MakeUnary(bool useInterpreter)
+        {
+            Expression<Action> e = () => Nop();
+            UnaryExpression q = MakeUnary(ExpressionType.Quote, e, null);
+            Expression<Func<LambdaExpression>> f = Lambda<Func<LambdaExpression>>(q);
+
+            var quote = f.Compile(useInterpreter)();
+
+            Assert.Equal(0, quote.Parameters.Count);
+            Assert.Equal(ExpressionType.Call, quote.Body.NodeType);
+
+            var call = (MethodCallExpression)quote.Body;
+            Assert.Equal(typeof(UnaryQuoteTests).GetMethod(nameof(Nop)), call.Method);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void Quote_Lambda_IdentityFunc(bool useInterpreter)
         {
             Expression<Func<LambdaExpression>> f = () => GetQuote<Func<int, int>>(x => x);

--- a/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusTests.cs
@@ -37,6 +37,7 @@ namespace System.Linq.Expressions.Tests
             for (int i = 0; i < values.Length; i++)
             {
                 VerifyArithmeticUnaryPlusInt(values[i], useInterpreter);
+                VerifyArithmeticMakeUnaryPlusInt(values[i], useInterpreter);
             }
         }
 
@@ -136,6 +137,16 @@ namespace System.Linq.Expressions.Tests
             Expression<Func<int>> e =
                 Expression.Lambda<Func<int>>(
                     Expression.UnaryPlus(Expression.Constant(value, typeof(int))),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile(useInterpreter);
+            Assert.Equal((int)(+value), f());
+        }
+
+        private static void VerifyArithmeticMakeUnaryPlusInt(int value, bool useInterpreter)
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.MakeUnary(ExpressionType.UnaryPlus, Expression.Constant(value), null),
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile(useInterpreter);
             Assert.Equal((int)(+value), f());


### PR DESCRIPTION
Fills remaining gaps in coverage for these factories.

Also adds parameter name to the "Unhandled unary" `ArgumentException`.