### PR TITLE
Produce 1.1.0 prerelease packages with "servicing" label

### DIFF
--- a/Packaging.props
+++ b/Packaging.props
@@ -1,6 +1,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PreReleaseLabel>preview1</PreReleaseLabel>
+    <PreReleaseLabel>servicing</PreReleaseLabel>
     <PackageDescriptionFile>$(ProjectDir)pkg/descriptions.json</PackageDescriptionFile>
     <PackageLicenseFile>$(ProjectDir)pkg/dotnet_library_license.txt</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(ProjectDir)pkg/ThirdPartyNotices.txt</PackageThirdPartyNoticesFile>


### PR DESCRIPTION
This will make the package versions more consistent, so auto-upgrades like this one make more sense: https://github.com/dotnet/coreclr/pull/8698

@ericstj @weshaggard 
/cc @gkhanna79 @danmosemsft 