### PR TITLE
[WIP] Specialize Where.First, Where.Last and the First and Last overloads accepting predicates

### DIFF
--- a/src/Common/src/System/Collections/Generic/EnumerableHelpers.Linq.cs
+++ b/src/Common/src/System/Collections/Generic/EnumerableHelpers.Linq.cs
@@ -40,5 +40,197 @@ namespace System.Collections.Generic
             count = -1;
             return false;
         }
+
+        // TODO: Add XML docs for all of these.
+        internal static T TryGetElementAt<T>(int index, out bool found, IEnumerable<T> source)
+        {
+            Debug.Assert(index >= 0);
+            Debug.Assert(source != null);
+            Debug.Assert(!(source is IList<T>));
+
+            using (IEnumerator<T> e = source.GetEnumerator())
+            {
+                while (e.MoveNext())
+                {
+                    if (index == 0)
+                    {
+                        found = true;
+                        return e.Current;
+                    }
+
+                    index--;
+                }
+            }
+
+            found = false;
+            return default(T);
+        }
+
+        internal static T TryGetFirst<T>(Func<T, bool> predicate, out bool found, IEnumerable<T> source)
+        {
+            Debug.Assert(predicate != null);
+            Debug.Assert(source != null);
+            Debug.Assert(!(source is IList<T>));
+
+            foreach (T item in source)
+            {
+                if (predicate(item))
+                {
+                    found = true;
+                    return item;
+                }
+            }
+
+            found = false;
+            return default(T);
+        }
+
+        internal static T TryGetFirst<T>(Func<T, bool> predicate, out bool found, T[] array)
+        {
+            Debug.Assert(predicate != null);
+            Debug.Assert(array != null);
+
+            foreach (T item in array)
+            {
+                if (predicate(item))
+                {
+                    found = true;
+                    return item;
+                }
+            }
+
+            found = false;
+            return default(T);
+        }
+
+        internal static T TryGetFirst<T>(Func<T, bool> predicate, out bool found, List<T> list)
+        {
+            Debug.Assert(predicate != null);
+            Debug.Assert(list != null);
+
+            for (int i = 0; i < list.Count; i++)
+            {
+                T item = list[i];
+                if (predicate(item))
+                {
+                    found = true;
+                    return item;
+                }
+            }
+
+            found = false;
+            return default(T);
+        }
+
+        internal static T TryGetFirst<T>(Func<T, bool> predicate, out bool found, IList<T> ilist)
+        {
+            Debug.Assert(predicate != null);
+            Debug.Assert(ilist != null);
+            Debug.Assert(!(ilist is T[] || ilist is List<T>));
+
+            int count = ilist.Count;
+            for (int i = 0; i < count; i++)
+            {
+                T item = ilist[i];
+                if (predicate(item))
+                {
+                    found = true;
+                    return item;
+                }
+            }
+
+            found = false;
+            return default(T);
+        }
+
+        internal static T TryGetLast<T>(Func<T, bool> predicate, out bool found, IEnumerable<T> source)
+        {
+            Debug.Assert(predicate != null);
+            Debug.Assert(source != null);
+            Debug.Assert(!(source is IList<T>));
+
+            using (IEnumerator<T> e = source.GetEnumerator())
+            {
+                while (e.MoveNext())
+                {
+                    T result = e.Current;
+                    if (predicate(result))
+                    {
+                        while (e.MoveNext())
+                        {
+                            T item = e.Current;
+                            if (predicate(item))
+                            {
+                                result = item;
+                            }
+                        }
+
+                        found = true;
+                        return result;
+                    }
+                }
+            }
+
+            found = false;
+            return default(T);
+        }
+
+        internal static T TryGetLast<T>(Func<T, bool> predicate, out bool found, T[] array)
+        {
+            Debug.Assert(predicate != null);
+            Debug.Assert(array != null);
+
+            for (int i = array.Length - 1; i >= 0; i--)
+            {
+                T item = array[i];
+                if (predicate(item))
+                {
+                    found = true;
+                    return item;
+                }
+            }
+
+            found = false;
+            return default(T);
+        }
+
+        internal static T TryGetLast<T>(Func<T, bool> predicate, out bool found, List<T> list)
+        {
+            Debug.Assert(predicate != null);
+            Debug.Assert(list != null);
+
+            for (int i = list.Count - 1; i >= 0; i--)
+            {
+                T item = list[i];
+                if (predicate(item))
+                {
+                    found = true;
+                    return item;
+                }
+            }
+
+            found = false;
+            return default(T);
+        }
+
+        internal static T TryGetLast<T>(Func<T, bool> predicate, out bool found, IList<T> ilist)
+        {
+            Debug.Assert(predicate != null);
+            Debug.Assert(ilist != null);
+            Debug.Assert(!(ilist is T[] || ilist is List<T>));
+
+            for (int i = ilist.Count - 1; i >= 0; i--)
+            {
+                T item = ilist[i];
+                if (predicate(item))
+                {
+                    found = true;
+                    return item;
+                }
+            }
+
+            found = false;
+            return default(T);
+        }
     }
 }

--- a/src/Common/src/System/Collections/Generic/EnumerableHelpers.Linq.cs
+++ b/src/Common/src/System/Collections/Generic/EnumerableHelpers.Linq.cs
@@ -44,21 +44,23 @@ namespace System.Collections.Generic
         // TODO: Add XML docs for all of these.
         internal static T TryGetElementAt<T>(int index, out bool found, IEnumerable<T> source)
         {
-            Debug.Assert(index >= 0);
             Debug.Assert(source != null);
             Debug.Assert(!(source is IList<T>));
 
-            using (IEnumerator<T> e = source.GetEnumerator())
+            if (index >= 0)
             {
-                while (e.MoveNext())
+                using (IEnumerator<T> e = source.GetEnumerator())
                 {
-                    if (index == 0)
+                    while (e.MoveNext())
                     {
-                        found = true;
-                        return e.Current;
-                    }
+                        if (index == 0)
+                        {
+                            found = true;
+                            return e.Current;
+                        }
 
-                    index--;
+                        index--;
+                    }
                 }
             }
 

--- a/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
+++ b/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
@@ -96,6 +96,8 @@ namespace System.Collections.Generic
         /// </returns>
         internal static T[] ToArray<T>(IEnumerable<T> source, out int length)
         {
+            Debug.Assert(source != null);
+
             ICollection<T> ic = source as ICollection<T>;
             if (ic != null)
             {

--- a/src/System.Linq/src/System/Linq/ElementAt.cs
+++ b/src/System.Linq/src/System/Linq/ElementAt.cs
@@ -35,17 +35,11 @@ namespace System.Linq
 
                 if (index >= 0)
                 {
-                    using (IEnumerator<TSource> e = source.GetEnumerator())
+                    bool found;
+                    TSource item = EnumerableHelpers.TryGetElementAt(index, out found, source: source);
+                    if (found)
                     {
-                        while (e.MoveNext())
-                        {
-                            if (index == 0)
-                            {
-                                return e.Current;
-                            }
-
-                            index--;
-                        }
+                        return item;
                     }
                 }
             }
@@ -79,18 +73,8 @@ namespace System.Linq
                 }
                 else
                 {
-                    using (IEnumerator<TSource> e = source.GetEnumerator())
-                    {
-                        while (e.MoveNext())
-                        {
-                            if (index == 0)
-                            {
-                                return e.Current;
-                            }
-
-                            index--;
-                        }
-                    }
+                    bool found;
+                    return EnumerableHelpers.TryGetElementAt(index, out found, source: source);
                 }
             }
 

--- a/src/System.Linq/src/System/Linq/ElementAt.cs
+++ b/src/System.Linq/src/System/Linq/ElementAt.cs
@@ -33,14 +33,11 @@ namespace System.Linq
                     return list[index];
                 }
 
-                if (index >= 0)
+                bool found;
+                TSource item = EnumerableHelpers.TryGetElementAt(index, out found, source: source);
+                if (found)
                 {
-                    bool found;
-                    TSource item = EnumerableHelpers.TryGetElementAt(index, out found, source: source);
-                    if (found)
-                    {
-                        return item;
-                    }
+                    return item;
                 }
             }
 

--- a/src/System.Linq/src/System/Linq/First.cs
+++ b/src/System.Linq/src/System/Linq/First.cs
@@ -102,17 +102,25 @@ namespace System.Linq
                 return ordered.TryGetFirst(predicate, out found);
             }
 
-            foreach (TSource element in source)
+            var ilist = source as IList<TSource>;
+            if (ilist != null)
             {
-                if (predicate(element))
+                var array = source as TSource[];
+                if (array != null)
                 {
-                    found = true;
-                    return element;
+                    return EnumerableHelpers.TryGetFirst(predicate, out found, array: array);
                 }
+
+                var list = source as List<TSource>;
+                if (list != null)
+                {
+                    return EnumerableHelpers.TryGetFirst(predicate, out found, list: list);
+                }
+
+                return EnumerableHelpers.TryGetFirst(predicate, out found, ilist: ilist);
             }
 
-            found = false;
-            return default(TSource);
+            return EnumerableHelpers.TryGetFirst(predicate, out found, source: source);
         }
     }
 }

--- a/src/System.Linq/src/System/Linq/Last.cs
+++ b/src/System.Linq/src/System/Linq/Last.cs
@@ -110,46 +110,25 @@ namespace System.Linq
                 return ordered.TryGetLast(predicate, out found);
             }
 
-            IList<TSource> list = source as IList<TSource>;
-            if (list != null)
+            IList<TSource> ilist = source as IList<TSource>;
+            if (ilist != null)
             {
-                for (int i = list.Count - 1; i >= 0; --i)
+                var array = source as TSource[];
+                if (array != null)
                 {
-                    TSource result = list[i];
-                    if (predicate(result))
-                    {
-                        found = true;
-                        return result;
-                    }
+                    return EnumerableHelpers.TryGetLast(predicate, out found, array: array);
                 }
-            }
-            else
-            {
-                using (IEnumerator<TSource> e = source.GetEnumerator())
+
+                var list = source as List<TSource>;
+                if (list != null)
                 {
-                    while (e.MoveNext())
-                    {
-                        TSource result = e.Current;
-                        if (predicate(result))
-                        {
-                            while (e.MoveNext())
-                            {
-                                TSource element = e.Current;
-                                if (predicate(element))
-                                {
-                                    result = element;
-                                }
-                            }
-
-                            found = true;
-                            return result;
-                        }
-                    }
+                    return EnumerableHelpers.TryGetLast(predicate, out found, list: list);
                 }
-            }
 
-            found = false;
-            return default(TSource);
+                return EnumerableHelpers.TryGetLast(predicate, out found, ilist: ilist);
+            }
+            
+            return EnumerableHelpers.TryGetLast(predicate, out found, source: source);
         }
     }
 }

--- a/src/System.Linq/src/System/Linq/Where.cs
+++ b/src/System.Linq/src/System/Linq/Where.cs
@@ -28,18 +28,24 @@ namespace System.Linq
                 return iterator.Where(predicate);
             }
 
-            TSource[] array = source as TSource[];
-            if (array != null)
+            IList<TSource> ilist = source as IList<TSource>;
+            if (ilist != null)
             {
-                return array.Length == 0 ?
-                    (IEnumerable<TSource>)EmptyPartition<TSource>.Instance :
-                    new WhereArrayIterator<TSource>(array, predicate);
-            }
+                TSource[] array = source as TSource[];
+                if (array != null)
+                {
+                    return array.Length == 0 ?
+                        (IEnumerable<TSource>)EmptyPartition<TSource>.Instance :
+                        new WhereArrayIterator<TSource>(array, predicate);
+                }
 
-            List<TSource> list = source as List<TSource>;
-            if (list != null)
-            {
-                return new WhereListIterator<TSource>(list, predicate);
+                List<TSource> list = source as List<TSource>;
+                if (list != null)
+                {
+                    return new WhereListIterator<TSource>(list, predicate);
+                }
+
+                return new WhereIListIterator<TSource>(ilist, predicate);
             }
 
             return new WhereEnumerableIterator<TSource>(source, predicate);
@@ -57,10 +63,10 @@ namespace System.Linq
                 throw Error.ArgumentNull(nameof(predicate));
             }
 
-            return WhereIterator(source, predicate);
+            return WhereIndexIterator(source, predicate);
         }
 
-        private static IEnumerable<TSource> WhereIterator<TSource>(IEnumerable<TSource> source, Func<TSource, int, bool> predicate)
+        private static IEnumerable<TSource> WhereIndexIterator<TSource>(IEnumerable<TSource> source, Func<TSource, int, bool> predicate)
         {
             int index = -1;
             foreach (TSource element in source)
@@ -77,11 +83,32 @@ namespace System.Linq
             }
         }
 
+        internal abstract class WhereIterator<TSource> : Iterator<TSource>, IPartition<TSource>
+        {
+            public abstract int GetCount(bool onlyIfCheap);
+
+            public abstract override IEnumerable<TResult> Select<TResult>(Func<TSource, TResult> selector);
+
+            public IPartition<TSource> Skip(int count) => new EnumerablePartition<TSource>(this, count, -1);
+
+            public IPartition<TSource> Take(int count) => new EnumerablePartition<TSource>(this, 0, count - 1);
+
+            public abstract TSource[] ToArray();
+
+            public abstract List<TSource> ToList();
+
+            public TSource TryGetElementAt(int index, out bool found) => EnumerableHelpers.TryGetElementAt(index, out found, source: this);
+
+            public abstract TSource TryGetFirst(out bool found);
+
+            public abstract TSource TryGetLast(out bool found);
+        }
+
         /// <summary>
         /// An iterator that filters each item of an <see cref="IEnumerable{TSource}"/>.
         /// </summary>
         /// <typeparam name="TSource">The type of the source enumerable.</typeparam>
-        internal sealed class WhereEnumerableIterator<TSource> : Iterator<TSource>, IIListProvider<TSource>
+        internal sealed class WhereEnumerableIterator<TSource> : WhereIterator<TSource>
         {
             private readonly IEnumerable<TSource> _source;
             private readonly Func<TSource, bool> _predicate;
@@ -89,7 +116,7 @@ namespace System.Linq
 
             public WhereEnumerableIterator(IEnumerable<TSource> source, Func<TSource, bool> predicate)
             {
-                Debug.Assert(source != null);
+                Debug.Assert(source != null && !(source is IList<TSource>));
                 Debug.Assert(predicate != null);
                 _source = source;
                 _predicate = predicate;
@@ -111,7 +138,7 @@ namespace System.Linq
                 base.Dispose();
             }
 
-            public int GetCount(bool onlyIfCheap)
+            public override int GetCount(bool onlyIfCheap)
             {
                 if (onlyIfCheap)
                 {
@@ -165,7 +192,7 @@ namespace System.Linq
                 return new WhereSelectEnumerableIterator<TSource, TResult>(_source, _predicate, selector);
             }
 
-            public TSource[] ToArray()
+            public override TSource[] ToArray()
             {
                 var builder = new LargeArrayBuilder<TSource>(initialize: true);
 
@@ -180,7 +207,7 @@ namespace System.Linq
                 return builder.ToArray();
             }
 
-            public List<TSource> ToList()
+            public override List<TSource> ToList()
             {
                 var list = new List<TSource>();
 
@@ -195,6 +222,10 @@ namespace System.Linq
                 return list;
             }
 
+            public override TSource TryGetFirst(out bool found) => EnumerableHelpers.TryGetFirst(_predicate, out found, source: _source);
+
+            public override TSource TryGetLast(out bool found) => EnumerableHelpers.TryGetLast(_predicate, out found, source: _source);
+
             public override IEnumerable<TSource> Where(Func<TSource, bool> predicate)
             {
                 return new WhereEnumerableIterator<TSource>(_source, CombinePredicates(_predicate, predicate));
@@ -205,14 +236,14 @@ namespace System.Linq
         /// An iterator that filters each item of a <see cref="T:TSource[]"/>.
         /// </summary>
         /// <typeparam name="TSource">The type of the source array.</typeparam>
-        internal sealed class WhereArrayIterator<TSource> : Iterator<TSource>, IIListProvider<TSource>
+        internal sealed class WhereArrayIterator<TSource> : WhereIterator<TSource>
         {
             private readonly TSource[] _source;
             private readonly Func<TSource, bool> _predicate;
 
             public WhereArrayIterator(TSource[] source, Func<TSource, bool> predicate)
             {
-                Debug.Assert(source != null && source.Length > 0);
+                Debug.Assert(source?.Length > 0);
                 Debug.Assert(predicate != null);
                 _source = source;
                 _predicate = predicate;
@@ -223,7 +254,7 @@ namespace System.Linq
                 return new WhereArrayIterator<TSource>(_source, _predicate);
             }
 
-            public int GetCount(bool onlyIfCheap)
+            public override int GetCount(bool onlyIfCheap)
             {
                 if (onlyIfCheap)
                 {
@@ -271,7 +302,7 @@ namespace System.Linq
                 return new WhereSelectArrayIterator<TSource, TResult>(_source, _predicate, selector);
             }
 
-            public TSource[] ToArray()
+            public override TSource[] ToArray()
             {
                 var builder = new LargeArrayBuilder<TSource>(_source.Length);
 
@@ -286,7 +317,7 @@ namespace System.Linq
                 return builder.ToArray();
             }
 
-            public List<TSource> ToList()
+            public override List<TSource> ToList()
             {
                 var list = new List<TSource>();
 
@@ -301,6 +332,10 @@ namespace System.Linq
                 return list;
             }
 
+            public override TSource TryGetFirst(out bool found) => EnumerableHelpers.TryGetFirst(_predicate, out found, array: _source);
+
+            public override TSource TryGetLast(out bool found) => EnumerableHelpers.TryGetLast(_predicate, out found, array: _source);
+
             public override IEnumerable<TSource> Where(Func<TSource, bool> predicate)
             {
                 return new WhereArrayIterator<TSource>(_source, CombinePredicates(_predicate, predicate));
@@ -311,7 +346,7 @@ namespace System.Linq
         /// An iterator that filters each item of a <see cref="List{TSource}"/>.
         /// </summary>
         /// <typeparam name="TSource">The type of the source list.</typeparam>
-        internal sealed class WhereListIterator<TSource> : Iterator<TSource>, IIListProvider<TSource>
+        internal sealed class WhereListIterator<TSource> : WhereIterator<TSource>
         {
             private readonly List<TSource> _source;
             private readonly Func<TSource, bool> _predicate;
@@ -330,7 +365,7 @@ namespace System.Linq
                 return new WhereListIterator<TSource>(_source, _predicate);
             }
 
-            public int GetCount(bool onlyIfCheap)
+            public override int GetCount(bool onlyIfCheap)
             {
                 if (onlyIfCheap)
                 {
@@ -385,7 +420,7 @@ namespace System.Linq
                 return new WhereSelectListIterator<TSource, TResult>(_source, _predicate, selector);
             }
 
-            public TSource[] ToArray()
+            public override TSource[] ToArray()
             {
                 var builder = new LargeArrayBuilder<TSource>(_source.Count);
 
@@ -401,7 +436,7 @@ namespace System.Linq
                 return builder.ToArray();
             }
 
-            public List<TSource> ToList()
+            public override List<TSource> ToList()
             {
                 var list = new List<TSource>();
 
@@ -417,9 +452,143 @@ namespace System.Linq
                 return list;
             }
 
+            public override TSource TryGetFirst(out bool found) => EnumerableHelpers.TryGetFirst(_predicate, out found, list: _source);
+
+            public override TSource TryGetLast(out bool found) => EnumerableHelpers.TryGetLast(_predicate, out found, list: _source);
+
             public override IEnumerable<TSource> Where(Func<TSource, bool> predicate)
             {
                 return new WhereListIterator<TSource>(_source, CombinePredicates(_predicate, predicate));
+            }
+        }
+
+        internal sealed class WhereIListIterator<TSource> : WhereIterator<TSource>
+        {
+            private readonly IList<TSource> _source;
+            private readonly Func<TSource, bool> _predicate;
+            private IEnumerator<TSource> _enumerator;
+
+            public WhereIListIterator(IList<TSource> source, Func<TSource, bool> predicate)
+            {
+                Debug.Assert(source != null && !(source is TSource[] || source is List<TSource>));
+                Debug.Assert(predicate != null);
+                _source = source;
+                _predicate = predicate;
+            }                
+
+            public override Iterator<TSource> Clone()
+            {
+                return new WhereIListIterator<TSource>(_source, _predicate);
+            }
+
+            public override void Dispose()
+            {
+                if (_enumerator != null)
+                {
+                    _enumerator.Dispose();
+                    _enumerator = null;
+                }
+
+                base.Dispose();
+            }
+
+            public override int GetCount(bool onlyIfCheap)
+            {
+                if (onlyIfCheap)
+                {
+                    return -1;
+                }
+                
+                int count = 0;
+                int maxCount = _source.Count;
+
+                for (int i = 0; i < maxCount; i++)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        checked
+                        {
+                            count++;
+                        }
+                    }
+                }
+
+                return count;
+            }
+
+            public override bool MoveNext()
+            {
+                switch (_state)
+                {
+                    case 1:
+                        _enumerator = _source.GetEnumerator();
+                        _state = 2;
+                        goto case 2;
+                    case 2:
+                        while (_enumerator.MoveNext())
+                        {
+                            TSource item = _enumerator.Current;
+                            if (_predicate(item))
+                            {
+                                _current = item;
+                                return true;
+                            }
+                        }
+
+                        break;
+                }
+
+                Dispose();
+                return false;
+            }
+
+            public override IEnumerable<TResult> Select<TResult>(Func<TSource, TResult> selector)
+            {
+                return new WhereSelectIListIterator<TSource, TResult>(_source, _predicate, selector);
+            }
+
+            public override TSource[] ToArray()
+            {
+                int maxCount = _source.Count;
+                var builder = new LargeArrayBuilder<TSource>(maxCount);
+
+                for (int i = 0; i < maxCount; i++)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        builder.Add(item);
+                    }
+                }
+
+                return builder.ToArray();
+            }
+
+            public override List<TSource> ToList()
+            {
+                int maxCount = _source.Count;
+                var list = new List<TSource>();
+
+                for (int i = 0; i < maxCount; i++)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        list.Add(item);
+                    }
+                }
+
+                return list;
+            }
+
+            public override TSource TryGetFirst(out bool found) => EnumerableHelpers.TryGetFirst(_predicate, out found, ilist: _source);
+
+            public override TSource TryGetLast(out bool found) => EnumerableHelpers.TryGetLast(_predicate, out found, ilist: _source);
+
+            public override IEnumerable<TSource> Where(Func<TSource, bool> predicate)
+            {
+                return new WhereIListIterator<TSource>(_source, CombinePredicates(_predicate, predicate));
             }
         }
 
@@ -428,7 +597,7 @@ namespace System.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the source array.</typeparam>
         /// <typeparam name="TResult">The type of the mapped items.</typeparam>
-        internal sealed class WhereSelectArrayIterator<TSource, TResult> : Iterator<TResult>, IIListProvider<TResult>
+        internal sealed class WhereSelectArrayIterator<TSource, TResult> : WhereIterator<TResult>
         {
             private readonly TSource[] _source;
             private readonly Func<TSource, bool> _predicate;
@@ -436,7 +605,7 @@ namespace System.Linq
 
             public WhereSelectArrayIterator(TSource[] source, Func<TSource, bool> predicate, Func<TSource, TResult> selector)
             {
-                Debug.Assert(source != null && source.Length > 0);
+                Debug.Assert(source?.Length > 0);
                 Debug.Assert(predicate != null);
                 Debug.Assert(selector != null);
                 _source = source;
@@ -449,7 +618,7 @@ namespace System.Linq
                 return new WhereSelectArrayIterator<TSource, TResult>(_source, _predicate, _selector);
             }
 
-            public int GetCount(bool onlyIfCheap)
+            public override int GetCount(bool onlyIfCheap)
             {
                 // In case someone uses Count() to force evaluation of
                 // the selector, run it provided `onlyIfCheap` is false.
@@ -501,7 +670,7 @@ namespace System.Linq
                 return new WhereSelectArrayIterator<TSource, TResult2>(_source, _predicate, CombineSelectors(_selector, selector));
             }
 
-            public TResult[] ToArray()
+            public override TResult[] ToArray()
             {
                 var builder = new LargeArrayBuilder<TResult>(_source.Length);
 
@@ -516,7 +685,7 @@ namespace System.Linq
                 return builder.ToArray();
             }
 
-            public List<TResult> ToList()
+            public override List<TResult> ToList()
             {
                 var list = new List<TResult>();
 
@@ -530,6 +699,18 @@ namespace System.Linq
 
                 return list;
             }
+
+            public override TResult TryGetFirst(out bool found)
+            {
+                TSource item = EnumerableHelpers.TryGetFirst(_predicate, out found, array: _source);
+                return found ? _selector(item) : default(TResult);
+            }
+
+            public override TResult TryGetLast(out bool found)
+            {
+                TSource item = EnumerableHelpers.TryGetLast(_predicate, out found, array: _source);
+                return found ? _selector(item) : default(TResult);
+            }
         }
 
         /// <summary>
@@ -537,7 +718,7 @@ namespace System.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the source list.</typeparam>
         /// <typeparam name="TResult">The type of the mapped items.</typeparam>
-        internal sealed class WhereSelectListIterator<TSource, TResult> : Iterator<TResult>, IIListProvider<TResult>
+        internal sealed class WhereSelectListIterator<TSource, TResult> : WhereIterator<TResult>
         {
             private readonly List<TSource> _source;
             private readonly Func<TSource, bool> _predicate;
@@ -559,7 +740,7 @@ namespace System.Linq
                 return new WhereSelectListIterator<TSource, TResult>(_source, _predicate, _selector);
             }
 
-            public int GetCount(bool onlyIfCheap)
+            public override int GetCount(bool onlyIfCheap)
             {
                 // In case someone uses Count() to force evaluation of
                 // the selector, run it provided `onlyIfCheap` is false.
@@ -618,7 +799,7 @@ namespace System.Linq
                 return new WhereSelectListIterator<TSource, TResult2>(_source, _predicate, CombineSelectors(_selector, selector));
             }
 
-            public TResult[] ToArray()
+            public override TResult[] ToArray()
             {
                 var builder = new LargeArrayBuilder<TResult>(_source.Count);
 
@@ -634,7 +815,7 @@ namespace System.Linq
                 return builder.ToArray();
             }
 
-            public List<TResult> ToList()
+            public override List<TResult> ToList()
             {
                 var list = new List<TResult>();
 
@@ -649,6 +830,18 @@ namespace System.Linq
 
                 return list;
             }
+
+            public override TResult TryGetFirst(out bool found)
+            {
+                TSource item = EnumerableHelpers.TryGetFirst(_predicate, out found, list: _source);
+                return found ? _selector(item) : default(TResult);
+            }
+
+            public override TResult TryGetLast(out bool found)
+            {
+                TSource item = EnumerableHelpers.TryGetLast(_predicate, out found, list: _source);
+                return found ? _selector(item) : default(TResult);
+            }
         }
 
         /// <summary>
@@ -656,7 +849,7 @@ namespace System.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the source enumerable.</typeparam>
         /// <typeparam name="TResult">The type of the mapped items.</typeparam>
-        internal sealed class WhereSelectEnumerableIterator<TSource, TResult> : Iterator<TResult>, IIListProvider<TResult>
+        internal sealed class WhereSelectEnumerableIterator<TSource, TResult> : WhereIterator<TResult>
         {
             private readonly IEnumerable<TSource> _source;
             private readonly Func<TSource, bool> _predicate;
@@ -665,7 +858,7 @@ namespace System.Linq
 
             public WhereSelectEnumerableIterator(IEnumerable<TSource> source, Func<TSource, bool> predicate, Func<TSource, TResult> selector)
             {
-                Debug.Assert(source != null);
+                Debug.Assert(source != null && !(source is IList<TSource>));
                 Debug.Assert(predicate != null);
                 Debug.Assert(selector != null);
                 _source = source;
@@ -689,7 +882,7 @@ namespace System.Linq
                 base.Dispose();
             }
 
-            public int GetCount(bool onlyIfCheap)
+            public override int GetCount(bool onlyIfCheap)
             {
                 // In case someone uses Count() to force evaluation of
                 // the selector, run it provided `onlyIfCheap` is false.
@@ -747,7 +940,7 @@ namespace System.Linq
                 return new WhereSelectEnumerableIterator<TSource, TResult2>(_source, _predicate, CombineSelectors(_selector, selector));
             }
 
-            public TResult[] ToArray()
+            public override TResult[] ToArray()
             {
                 var builder = new LargeArrayBuilder<TResult>(initialize: true);
 
@@ -762,7 +955,7 @@ namespace System.Linq
                 return builder.ToArray();
             }
 
-            public List<TResult> ToList()
+            public override List<TResult> ToList()
             {
                 var list = new List<TResult>();
 
@@ -775,6 +968,155 @@ namespace System.Linq
                 }
 
                 return list;
+            }
+
+            public override TResult TryGetFirst(out bool found)
+            {
+                TSource item = EnumerableHelpers.TryGetFirst(_predicate, out found, source: _source);
+                return found ? _selector(item) : default(TResult);
+            }
+
+            public override TResult TryGetLast(out bool found)
+            {
+                TSource item = EnumerableHelpers.TryGetLast(_predicate, out found, source: _source);
+                return found ? _selector(item) : default(TResult);
+            }
+        }
+
+        internal sealed class WhereSelectIListIterator<TSource, TResult> : WhereIterator<TResult>
+        {
+            private readonly IList<TSource> _source;
+            private readonly Func<TSource, bool> _predicate;
+            private readonly Func<TSource, TResult> _selector;
+            private IEnumerator<TSource> _enumerator;
+
+            public WhereSelectIListIterator(IList<TSource> source, Func<TSource, bool> predicate, Func<TSource, TResult> selector)
+            {
+                Debug.Assert(source != null && !(source is TSource[] || source is List<TSource>));
+                Debug.Assert(predicate != null);
+                Debug.Assert(selector != null);
+                _source = source;
+                _predicate = predicate;
+                _selector = selector;
+            }                
+
+            public override Iterator<TResult> Clone()
+            {
+                return new WhereSelectIListIterator<TSource, TResult>(_source, _predicate, _selector);
+            }
+
+            public override void Dispose()
+            {
+                if (_enumerator != null)
+                {
+                    _enumerator.Dispose();
+                    _enumerator = null;
+                }
+
+                base.Dispose();
+            }
+
+            public override int GetCount(bool onlyIfCheap)
+            {
+                if (onlyIfCheap)
+                {
+                    return -1;
+                }
+                
+                int count = 0;
+                int maxCount = _source.Count;
+
+                for (int i = 0; i < maxCount; i++)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        _selector(item);
+                        checked
+                        {
+                            count++;
+                        }
+                    }
+                }
+
+                return count;
+            }
+
+            public override bool MoveNext()
+            {
+                switch (_state)
+                {
+                    case 1:
+                        _enumerator = _source.GetEnumerator();
+                        _state = 2;
+                        goto case 2;
+                    case 2:
+                        while (_enumerator.MoveNext())
+                        {
+                            TSource item = _enumerator.Current;
+                            if (_predicate(item))
+                            {
+                                _current = _selector(item);
+                                return true;
+                            }
+                        }
+
+                        break;
+                }
+
+                Dispose();
+                return false;
+            }
+
+            public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector)
+            {
+                return new WhereSelectIListIterator<TSource, TResult2>(_source, _predicate, CombineSelectors(_selector, selector));
+            }
+
+            public override TResult[] ToArray()
+            {
+                int maxCount = _source.Count;
+                var builder = new LargeArrayBuilder<TResult>(maxCount);
+
+                for (int i = 0; i < maxCount; i++)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        builder.Add(_selector(item));
+                    }
+                }
+
+                return builder.ToArray();
+            }
+
+            public override List<TResult> ToList()
+            {
+                int maxCount = _source.Count;
+                var list = new List<TResult>();
+
+                for (int i = 0; i < maxCount; i++)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        list.Add(_selector(item));
+                    }
+                }
+
+                return list;
+            }
+
+            public override TResult TryGetFirst(out bool found)
+            {
+                TSource item = EnumerableHelpers.TryGetFirst(_predicate, out found, ilist: _source);
+                return found ? _selector(item) : default(TResult);
+            }
+
+            public override TResult TryGetLast(out bool found)
+            {
+                TSource item = EnumerableHelpers.TryGetLast(_predicate, out found, ilist: _source);
+                return found ? _selector(item) : default(TResult);
             }
         }
     }

--- a/src/System.Linq/src/System/Linq/Where.cs
+++ b/src/System.Linq/src/System/Linq/Where.cs
@@ -97,16 +97,7 @@ namespace System.Linq
 
             public abstract List<TSource> ToList();
 
-            public TSource TryGetElementAt(int index, out bool found)
-            {
-                if (index >= 0)
-                {
-                    return EnumerableHelpers.TryGetElementAt(index, out found, source: this);
-                }
-
-                found = false;
-                return default(TSource);
-            }
+            public TSource TryGetElementAt(int index, out bool found) => EnumerableHelpers.TryGetElementAt(index, out found, source: this);
 
             public abstract TSource TryGetFirst(out bool found);
 

--- a/src/System.Linq/src/System/Linq/Where.cs
+++ b/src/System.Linq/src/System/Linq/Where.cs
@@ -97,7 +97,16 @@ namespace System.Linq
 
             public abstract List<TSource> ToList();
 
-            public TSource TryGetElementAt(int index, out bool found) => EnumerableHelpers.TryGetElementAt(index, out found, source: this);
+            public TSource TryGetElementAt(int index, out bool found)
+            {
+                if (index >= 0)
+                {
+                    return EnumerableHelpers.TryGetElementAt(index, out found, source: this);
+                }
+
+                found = false;
+                return default(TSource);
+            }
 
             public abstract TSource TryGetFirst(out bool found);
 


### PR DESCRIPTION
Changes:

- `source.Where(predicate).First()` should have the same result as `source.First(predicate)` (barring exceptions), so if we optimize for one we can optimize for the other. This PR speeds things up in both cases if `source` is an array/List/IList, avoiding double interface dispatch and an enumerator allocation.

- `source.Where(predicate).Last()` is now recognized in addition to `source.Last(predicate)`, so we don't run the predicate on every item if `source` supports random access.

- I also added code to specialize `ilist.Where(predicate)`. It makes sense because we can check for IList at little cost to existing codepaths, and there is already logic in place for `ilist.First(predicate)` and `ilist.Last(predicate)`, so we can implement `ilist.Where(predicate).First()` and `ilist.Where(predicate).Last()` for free.

Marking WIP temporarily because I need to finish adding XML docs and make sure all branches are being covered. Comments are welcome in the meantime though.

/cc @JonHanna @VSadov 

**edit:** Forgot the most important thing-- performance results. [Here they are.](https://gist.github.com/jamesqo/a9f0f37fca46481fe6d94a9dbd5c896f) There seems to be an improvement across the board for basically every pattern. The leaked memory stats can be ignored, I added that as part of https://github.com/dotnet/corefx/pull/15389.