### PR TITLE
Disable failing WellKnownSidTypeTests

### DIFF
--- a/src/System.Security.Principal.Windows/tests/WellKnownSidTypeTests.cs
+++ b/src/System.Security.Principal.Windows/tests/WellKnownSidTypeTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 public class WellKnownSidTypeTests
 {
+    [ActiveIssue(15436)]
     [Theory]
     [InlineData(WellKnownSidType.NullSid)]
     [InlineData(WellKnownSidType.WorldSid)]


### PR DESCRIPTION
Our outerloop Windows runs are failing due to this.
https://github.com/dotnet/corefx/issues/15436
cc: @weshaggard, @danmosemsft 