### PR TITLE
string.Format call fixed

### DIFF
--- a/src/System.Threading.Tasks/tests/Task/TaskCancelWaitTest.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskCancelWaitTest.cs
@@ -237,7 +237,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
                     break;
 
                 default:
-                    throw new ArgumentOutOfRangeException(string.Format("unknown API_CancelWait of", _api));
+                    throw new ArgumentOutOfRangeException(string.Format("unknown API_CancelWait of {0}", _api));
             }
         }
 


### PR DESCRIPTION
Format string missed argument