### PR TITLE
Mark System.Memory and Unsafe as .NET Core App assemblies.

### DIFF
--- a/src/System.Memory/dir.props
+++ b/src/System.Memory/dir.props
@@ -3,5 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsNETCoreApp>true</IsNETCoreApp>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/dir.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/dir.props
@@ -3,5 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <IsNETCoreApp>true</IsNETCoreApp>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This should include both System.Memory and System.Runtime.CompilerServices.Unsafe in the .NET Core package.

@ericstj 