### PR TITLE
Port System.IO.Ports

### DIFF
--- a/src/Common/src/Interop/Windows/Interop.Errors.cs
+++ b/src/Common/src/Interop/Windows/Interop.Errors.cs
@@ -4,6 +4,7 @@
 
 internal partial class Interop
 {
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382.aspx
     internal partial class Errors
     {
         internal const int ERROR_SUCCESS = 0x0;
@@ -17,6 +18,7 @@ internal partial class Interop
         internal const int ERROR_INVALID_DRIVE = 0xF;
         internal const int ERROR_NO_MORE_FILES = 0x12;
         internal const int ERROR_NOT_READY = 0x15;
+        internal const int ERROR_BAD_COMMAND = 0x16;
         internal const int ERROR_BAD_LENGTH = 0x18;
         internal const int ERROR_SHARING_VIOLATION = 0x20;
         internal const int ERROR_LOCK_VIOLATION = 0x21;
@@ -46,9 +48,11 @@ internal partial class Interop
         internal const int ERROR_PIPE_CONNECTED = 0x217;
         internal const int ERROR_PIPE_LISTENING = 0x218;
         internal const int ERROR_OPERATION_ABORTED = 0x3E3;
+        internal const int ERROR_IO_INCOMPLETE = 0x3E4;
         internal const int ERROR_IO_PENDING = 0x3E5;
         internal const int ERROR_NO_TOKEN = 0x3f0;
         internal const int ERROR_DLL_INIT_FAILED = 0x45A;
+        internal const int ERROR_COUNTER_TIMEOUT = 0x461;
         internal const int ERROR_NOT_FOUND = 0x490;
         internal const int ERROR_NON_ACCOUNT_SID = 0x4E9;
         internal const int ERROR_NOT_ALL_ASSIGNED = 0x514;

--- a/src/Common/src/Interop/Windows/kernel32/Interop.COMMPROP.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.COMMPROP.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        // Declaration for C# representation of Win32 COMMPROP
+        // structure associated with a file handle to a serial communications resource.
+        // Currently the only fields used are dwMaxTxQueue, dwMaxRxQueue, and dwMaxBaud
+        // to ensure that users provide appropriate settings to the SerialStream constructor.
+        //
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/aa363189.aspx
+        internal struct COMMPROP
+        {
+            public ushort  wPacketLength;
+            public ushort  wPacketVersion;
+            public int dwServiceMask;
+            public int dwReserved1;
+            public int dwMaxTxQueue;
+            public int dwMaxRxQueue;
+            public int dwMaxBaud;
+            public int dwProvSubType;
+            public int dwProvCapabilities;
+            public int dwSettableParams;
+            public int dwSettableBaud;
+            public ushort wSettableData;
+            public ushort  wSettableStopParity;
+            public int dwCurrentTxQueue;
+            public int dwCurrentRxQueue;
+            public int dwProvSpec1;
+            public int dwProvSpec2;
+            public char wcProvChar;
+        }
+
+    }
+}

--- a/src/Common/src/Interop/Windows/kernel32/Interop.COMMTIMEOUTS.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.COMMTIMEOUTS.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        // Declaration for C# representation of Win32 COMMTIMEOUTS
+        // structure associated with a file handle to a serial communications resource.
+        //
+        // Currently the only set fields are ReadTotalTimeoutConstant
+        // and WriteTotalTimeoutConstant.
+        //
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/aa363190.aspx
+        internal struct COMMTIMEOUTS
+        {
+            public int ReadIntervalTimeout;
+            public int ReadTotalTimeoutMultiplier;
+            public int ReadTotalTimeoutConstant;
+            public int WriteTotalTimeoutMultiplier;
+            public int WriteTotalTimeoutConstant;
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/kernel32/Interop.COMSTAT.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.COMSTAT.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        // Declaration for C# representation of Win32 COMSTAT structure associated with
+        // a file handle to a serial communications resource.  SerialStream's
+        // InBufferBytes and OutBufferBytes directly expose cbInQue and cbOutQue to reading, respectively.
+        //
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/aa363200.aspx
+        internal struct COMSTAT
+        {
+            public uint Flags;
+            public uint cbInQue;
+            public uint cbOutQue;
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/kernel32/Interop.ClearCommBreak.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.ClearCommBreak.cs
@@ -2,19 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct SECURITY_ATTRIBUTES
-        {
-            internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
-            internal BOOL bInheritHandle;
-        }
+        [DllImport(Libraries.Kernel32, SetLastError=true, CharSet=CharSet.Auto)]
+        internal static extern bool ClearCommBreak(
+            SafeFileHandle hFile);
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.ClearCommError.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.ClearCommError.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, SetLastError=true, CharSet=CharSet.Auto)]
+        internal static extern bool ClearCommError(
+            SafeFileHandle hFile,
+            ref int lpErrors,
+            ref COMSTAT lpStat);
+
+        [DllImport(Libraries.Kernel32, SetLastError = true, CharSet = CharSet.Auto)]
+        internal static extern bool ClearCommError(
+            SafeFileHandle hFile,
+            ref int lpErrors,
+            IntPtr lpStat);
+    }
+}

--- a/src/Common/src/Interop/Windows/kernel32/Interop.CreateFile.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.CreateFile.cs
@@ -12,29 +12,41 @@ internal partial class Interop
     internal partial class Kernel32
     {
         /// <summary>
-        /// WARNING: This method does not implicitly handle long paths. Use CreateFile.
+        /// WARNING: The private methods do not implicitly handle long paths. Use CreateFile.
         /// </summary>
         [DllImport(Libraries.Kernel32, EntryPoint = "CreateFileW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
         private static extern SafeFileHandle CreateFilePrivate(
             string lpFileName,
             int dwDesiredAccess,
-            System.IO.FileShare dwShareMode,
+            FileShare dwShareMode,
             [In] ref SECURITY_ATTRIBUTES securityAttrs,
-            System.IO.FileMode dwCreationDisposition,
+            FileMode dwCreationDisposition,
             int dwFlagsAndAttributes,
             IntPtr hTemplateFile);
 
         internal static SafeFileHandle CreateFile(
             string lpFileName,
             int dwDesiredAccess,
-            System.IO.FileShare dwShareMode,
+            FileShare dwShareMode,
             [In] ref SECURITY_ATTRIBUTES securityAttrs,
-            System.IO.FileMode dwCreationDisposition,
+            FileMode dwCreationDisposition,
             int dwFlagsAndAttributes,
             IntPtr hTemplateFile)
         {
             lpFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(lpFileName);
             return CreateFilePrivate(lpFileName, dwDesiredAccess, dwShareMode, ref securityAttrs, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+        }
+
+        internal static SafeFileHandle CreateFileDefaultSecurity(
+            string lpFileName,
+            int dwDesiredAccess,
+            FileShare dwShareMode,
+            FileMode dwCreationDisposition,
+            int dwFlagsAndAttributes)
+        {
+            // This is technically equivalent to passing a null SECURITY_ATTRIBUTES
+            SECURITY_ATTRIBUTES security = new SECURITY_ATTRIBUTES();
+            return CreateFilePrivate(lpFileName, dwDesiredAccess, dwShareMode, ref security, dwCreationDisposition, dwFlagsAndAttributes, IntPtr.Zero);
         }
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.DCB.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.DCB.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        // Declaration for C# representation of Win32 Device Control Block (DCB)
+        // structure.  Note that all flag properties are encapsulated in the Flags field here,
+        // and accessed/set through SerialStream's GetDcbFlag(...) and SetDcbFlag(...) methods.
+        //
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/aa363214.aspx
+        internal struct DCB
+        {
+            public uint DCBlength;
+            public uint BaudRate;
+            public uint Flags;
+            public ushort wReserved;
+            public ushort XonLim;
+            public ushort XoffLim;
+            public byte ByteSize;
+            public byte Parity;
+            public byte StopBits;
+            public byte XonChar;
+            public byte XoffChar;
+            public byte ErrorChar;
+            public byte EofChar;
+            public byte EvtChar;
+            public ushort wReserved1;
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/kernel32/Interop.EscapeCommFunction.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.EscapeCommFunction.cs
@@ -2,19 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct SECURITY_ATTRIBUTES
-        {
-            internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
-            internal BOOL bInheritHandle;
-        }
+        [DllImport(Libraries.Kernel32, SetLastError=true, CharSet=CharSet.Auto)]
+        internal static extern bool EscapeCommFunction(
+            SafeFileHandle hFile,
+            int dwFunc);
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.FileTypes.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.FileTypes.cs
@@ -8,6 +8,7 @@ internal partial class Interop
     {
         internal partial class FileTypes
         {
+            internal const int FILE_TYPE_UNKNOWN = 0x0000;
             internal const int FILE_TYPE_DISK = 0x0001;
             internal const int FILE_TYPE_CHAR = 0x0002;
             internal const int FILE_TYPE_PIPE = 0x0003;

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetCommModemStatus.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetCommModemStatus.cs
@@ -2,19 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct SECURITY_ATTRIBUTES
-        {
-            internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
-            internal BOOL bInheritHandle;
-        }
+        [DllImport(Libraries.Kernel32, SetLastError=true, CharSet=CharSet.Auto)]
+        internal static extern bool GetCommModemStatus(
+            SafeFileHandle hFile,
+            ref int lpModemStat);
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetCommProperties.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetCommProperties.cs
@@ -2,19 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct SECURITY_ATTRIBUTES
-        {
-            internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
-            internal BOOL bInheritHandle;
-        }
+        [DllImport(Libraries.Kernel32, SetLastError=true, CharSet=CharSet.Auto)]
+        internal static extern bool GetCommProperties(
+            SafeFileHandle hFile,
+            ref COMMPROP lpCommProp);
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetCommState.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetCommState.cs
@@ -2,19 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct SECURITY_ATTRIBUTES
-        {
-            internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
-            internal BOOL bInheritHandle;
-        }
+        [DllImport(Libraries.Kernel32, SetLastError=true, CharSet=CharSet.Auto)]
+        internal static extern bool GetCommState(
+            SafeFileHandle hFile,
+            ref DCB lpDCB);
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetFileType_SafeHandle.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetFileType_SafeHandle.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
 
 internal partial class Interop

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetOverlappedResult.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetOverlappedResult.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, SetLastError=true, CharSet=CharSet.Auto)]
+        unsafe internal static extern bool GetOverlappedResult(
+            SafeFileHandle hFile,
+            NativeOverlapped* lpOverlapped,
+            ref int lpNumberOfBytesTransferred,
+            bool bWait);
+    }
+}

--- a/src/Common/src/Interop/Windows/kernel32/Interop.PurgeComm.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.PurgeComm.cs
@@ -2,19 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct SECURITY_ATTRIBUTES
-        {
-            internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
-            internal BOOL bInheritHandle;
-        }
+        [DllImport(Libraries.Kernel32, SetLastError=true, CharSet=CharSet.Auto)]
+        internal static extern bool PurgeComm(
+            SafeFileHandle hFile,
+            uint dwFlags);
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.SetCommBreak.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.SetCommBreak.cs
@@ -2,19 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct SECURITY_ATTRIBUTES
-        {
-            internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
-            internal BOOL bInheritHandle;
-        }
+        [DllImport(Libraries.Kernel32, SetLastError=true, CharSet=CharSet.Auto)]
+        internal static extern bool SetCommBreak(
+            SafeFileHandle hFile);
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.SetCommMask.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.SetCommMask.cs
@@ -2,19 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct SECURITY_ATTRIBUTES
-        {
-            internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
-            internal BOOL bInheritHandle;
-        }
+        [DllImport(Libraries.Kernel32, SetLastError=true, CharSet=CharSet.Auto)]
+        internal static extern bool SetCommMask(
+            SafeFileHandle hFile,
+            int dwEvtMask
+        );
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.SetCommState.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.SetCommState.cs
@@ -2,19 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct SECURITY_ATTRIBUTES
-        {
-            internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
-            internal BOOL bInheritHandle;
-        }
+        [DllImport(Libraries.Kernel32, SetLastError=true, CharSet=CharSet.Auto)]
+        internal static extern bool SetCommState(
+            SafeFileHandle hFile,
+            ref DCB lpDCB);
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.SetCommTimeouts.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.SetCommTimeouts.cs
@@ -2,19 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct SECURITY_ATTRIBUTES
-        {
-            internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
-            internal BOOL bInheritHandle;
-        }
+        [DllImport(Libraries.Kernel32, SetLastError=true, CharSet=CharSet.Auto)]
+        internal static extern bool SetCommTimeouts(
+            SafeFileHandle hFile,
+            ref COMMTIMEOUTS lpCommTimeouts);
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.SetupComm.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.SetupComm.cs
@@ -2,19 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct SECURITY_ATTRIBUTES
-        {
-            internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
-            internal BOOL bInheritHandle;
-        }
+        [DllImport(Libraries.Kernel32, SetLastError=true, CharSet=CharSet.Auto)]
+        internal static extern bool SetupComm(
+            SafeFileHandle hFile,
+            int dwInQueue,
+            int dwOutQueue);
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.WaitCommEvent.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.WaitCommEvent.cs
@@ -2,19 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct SECURITY_ATTRIBUTES
-        {
-            internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
-            internal BOOL bInheritHandle;
-        }
+        [DllImport(Libraries.Kernel32, SetLastError=true, CharSet=CharSet.Auto)]
+        unsafe internal static extern bool WaitCommEvent(
+            SafeFileHandle hFile,
+            int* lpEvtMask,
+            NativeOverlapped* lpOverlapped);
     }
 }

--- a/src/System.IO.Ports/System.IO.Ports.sln
+++ b/src/System.IO.Ports/System.IO.Ports.sln
@@ -1,0 +1,67 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26127.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Ports", "src\System.IO.Ports.csproj", "{187503F4-BEF9-4369-A1B2-E3DC5D564E4E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{CFF63FA4-95A1-4048-B1CE-74F3F38361D2}"
+	ProjectSection(SolutionItems) = preProject
+		ref\Configurations.props = ref\Configurations.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2DE17EC6-726E-4CF1-A0AE-7B2C35B8FCF8}"
+	ProjectSection(SolutionItems) = preProject
+		src\Configurations.props = src\Configurations.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{8A2DC1F0-EC43-4B84-88DF-5D2FBF3EADC8}"
+	ProjectSection(SolutionItems) = preProject
+		tests\Configurations.props = tests\Configurations.props
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Ports", "ref\System.IO.Ports.csproj", "{16BA89AC-D2BC-452B-845B-7B2BF2344111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Ports.Tests", "tests\System.IO.Ports.Tests.csproj", "{4259DCE9-3480-40BB-B08A-64A2D446264B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "pkg", "pkg", "{73710F6E-9783-475F-B240-17E2BDC34985}"
+	ProjectSection(SolutionItems) = preProject
+		pkg\System.IO.Ports.builds = pkg\System.IO.Ports.builds
+		pkg\System.IO.Ports.pkgproj = pkg\System.IO.Ports.pkgproj
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		netstandard-Debug|Any CPU = netstandard-Debug|Any CPU
+		netstandard-Release|Any CPU = netstandard-Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{187503F4-BEF9-4369-A1B2-E3DC5D564E4E}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{187503F4-BEF9-4369-A1B2-E3DC5D564E4E}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{187503F4-BEF9-4369-A1B2-E3DC5D564E4E}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{187503F4-BEF9-4369-A1B2-E3DC5D564E4E}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{187503F4-BEF9-4369-A1B2-E3DC5D564E4E}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{187503F4-BEF9-4369-A1B2-E3DC5D564E4E}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{16BA89AC-D2BC-452B-845B-7B2BF2344111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{16BA89AC-D2BC-452B-845B-7B2BF2344111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{16BA89AC-D2BC-452B-845B-7B2BF2344111}.netstandard-Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{16BA89AC-D2BC-452B-845B-7B2BF2344111}.netstandard-Debug|Any CPU.Build.0 = Debug|Any CPU
+		{16BA89AC-D2BC-452B-845B-7B2BF2344111}.netstandard-Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{16BA89AC-D2BC-452B-845B-7B2BF2344111}.netstandard-Release|Any CPU.Build.0 = Debug|Any CPU
+		{4259DCE9-3480-40BB-B08A-64A2D446264B}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{4259DCE9-3480-40BB-B08A-64A2D446264B}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{4259DCE9-3480-40BB-B08A-64A2D446264B}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{4259DCE9-3480-40BB-B08A-64A2D446264B}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{4259DCE9-3480-40BB-B08A-64A2D446264B}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{4259DCE9-3480-40BB-B08A-64A2D446264B}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{187503F4-BEF9-4369-A1B2-E3DC5D564E4E} = {2DE17EC6-726E-4CF1-A0AE-7B2C35B8FCF8}
+		{16BA89AC-D2BC-452B-845B-7B2BF2344111} = {CFF63FA4-95A1-4048-B1CE-74F3F38361D2}
+		{4259DCE9-3480-40BB-B08A-64A2D446264B} = {8A2DC1F0-EC43-4B84-88DF-5D2FBF3EADC8}
+	EndGlobalSection
+EndGlobal

--- a/src/System.IO.Ports/dir.props
+++ b/src/System.IO.Ports/dir.props
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/System.IO.Ports/pkg/System.IO.Ports.builds
+++ b/src/System.IO.Ports/pkg/System.IO.Ports.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.IO.Ports.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.IO.Ports/pkg/System.IO.Ports.pkgproj
+++ b/src/System.IO.Ports/pkg/System.IO.Ports.pkgproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.IO.Ports.csproj">
+      <SupportedFramework>net463;netcoreapp2.0</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.IO.Ports.builds" />
+    <NotSupportedOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>win</PackageTargetRuntime>
+    </NotSupportedOnTargetFramework>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO.Ports/ref/Configurations.props
+++ b/src/System.IO.Ports/ref/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.IO.Ports/ref/System.IO.Ports.cs
+++ b/src/System.IO.Ports/ref/System.IO.Ports.cs
@@ -1,0 +1,124 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Ports
+{
+    public enum Handshake
+    {
+        None = 0,
+        RequestToSend = 2,
+        RequestToSendXOnXOff = 3,
+        XOnXOff = 1,
+    }
+    public enum Parity
+    {
+        Even = 2,
+        Mark = 3,
+        None = 0,
+        Odd = 1,
+        Space = 4,
+    }
+    public enum SerialData
+    {
+        Chars = 1,
+        Eof = 2,
+    }
+    public partial class SerialDataReceivedEventArgs : System.EventArgs
+    {
+        internal SerialDataReceivedEventArgs() { }
+        public System.IO.Ports.SerialData EventType { get { throw null; } }
+    }
+    public delegate void SerialDataReceivedEventHandler(object sender, System.IO.Ports.SerialDataReceivedEventArgs e);
+    public enum SerialError
+    {
+        Frame = 8,
+        Overrun = 2,
+        RXOver = 1,
+        RXParity = 4,
+        TXFull = 256,
+    }
+    public partial class SerialErrorReceivedEventArgs : System.EventArgs
+    {
+        internal SerialErrorReceivedEventArgs() { }
+        public System.IO.Ports.SerialError EventType { get { throw null; } }
+    }
+    public delegate void SerialErrorReceivedEventHandler(object sender, System.IO.Ports.SerialErrorReceivedEventArgs e);
+    public enum SerialPinChange
+    {
+        Break = 64,
+        CDChanged = 32,
+        CtsChanged = 8,
+        DsrChanged = 16,
+        Ring = 256,
+    }
+    public partial class SerialPinChangedEventArgs : System.EventArgs
+    {
+        internal SerialPinChangedEventArgs() { }
+        public System.IO.Ports.SerialPinChange EventType { get { throw null; } }
+    }
+    public delegate void SerialPinChangedEventHandler(object sender, System.IO.Ports.SerialPinChangedEventArgs e);
+    public partial class SerialPort : System.ComponentModel.Component
+    {
+        public const int InfiniteTimeout = -1;
+        public SerialPort() { }
+        public SerialPort(System.ComponentModel.IContainer container) { }
+        public SerialPort(string portName) { }
+        public SerialPort(string portName, int baudRate) { }
+        public SerialPort(string portName, int baudRate, System.IO.Ports.Parity parity) { }
+        public SerialPort(string portName, int baudRate, System.IO.Ports.Parity parity, int dataBits) { }
+        public SerialPort(string portName, int baudRate, System.IO.Ports.Parity parity, int dataBits, System.IO.Ports.StopBits stopBits) { }
+        public System.IO.Stream BaseStream { get { throw null; } }
+        public int BaudRate { get { throw null; } set { } }
+        public bool BreakState { get { throw null; } set { } }
+        public int BytesToRead { get { throw null; } }
+        public int BytesToWrite { get { throw null; } }
+        public bool CDHolding { get { throw null; } }
+        public bool CtsHolding { get { throw null; } }
+        public int DataBits { get { throw null; } set { } }
+        public bool DiscardNull { get { throw null; } set { } }
+        public bool DsrHolding { get { throw null; } }
+        public bool DtrEnable { get { throw null; } set { } }
+        public System.Text.Encoding Encoding { get { throw null; } set { } }
+        public System.IO.Ports.Handshake Handshake { get { throw null; } set { } }
+        public bool IsOpen { get { throw null; } }
+        public string NewLine { get { throw null; } set { } }
+        public System.IO.Ports.Parity Parity { get { throw null; } set { } }
+        public byte ParityReplace { get { throw null; } set { } }
+        public string PortName { get { throw null; } set { } }
+        public int ReadBufferSize { get { throw null; } set { } }
+        public int ReadTimeout { get { throw null; } set { } }
+        public int ReceivedBytesThreshold { get { throw null; } set { } }
+        public bool RtsEnable { get { throw null; } set { } }
+        public System.IO.Ports.StopBits StopBits { get { throw null; } set { } }
+        public int WriteBufferSize { get { throw null; } set { } }
+        public int WriteTimeout { get { throw null; } set { } }
+        public event System.IO.Ports.SerialDataReceivedEventHandler DataReceived { add { } remove { } }
+        public event System.IO.Ports.SerialErrorReceivedEventHandler ErrorReceived { add { } remove { } }
+        public event System.IO.Ports.SerialPinChangedEventHandler PinChanged { add { } remove { } }
+        public void Close() { }
+        public void DiscardInBuffer() { }
+        public void DiscardOutBuffer() { }
+        protected override void Dispose(bool disposing) { }
+        public static string[] GetPortNames() { throw null; }
+        public void Open() { }
+        public int Read(byte[] buffer, int offset, int count) { throw null; }
+        public int Read(char[] buffer, int offset, int count) { throw null; }
+        public int ReadByte() { throw null; }
+        public int ReadChar() { throw null; }
+        public string ReadExisting() { throw null; }
+        public string ReadLine() { throw null; }
+        public string ReadTo(string value) { throw null; }
+        public void Write(byte[] buffer, int offset, int count) { }
+        public void Write(char[] buffer, int offset, int count) { }
+        public void Write(string text) { }
+        public void WriteLine(string text) { }
+    }
+    public enum StopBits
+    {
+        None = 0,
+        One = 1,
+        OnePointFive = 3,
+        Two = 2,
+    }
+}

--- a/src/System.IO.Ports/ref/System.IO.Ports.csproj
+++ b/src/System.IO.Ports/ref/System.IO.Ports.csproj
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Compile Include="System.IO.Ports.cs" />
+    <Reference Include="netstandard" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO.Ports/src/Configurations.props
+++ b/src/System.IO.Ports/src/Configurations.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard-Windows_NT;
+      net463-AnyOS;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.IO.Ports/src/Resources/Strings.resx
+++ b/src/System.IO.Ports/src/Resources/Strings.resx
@@ -1,0 +1,249 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Parameter_Invalid" xml:space="preserve">
+    <value>The parameter '{0}' is invalid.</value>
+  </data>
+  <data name="IO_EOF_ReadBeyondEOF" xml:space="preserve">
+    <value>Unable to read beyond the end of the stream.</value>
+  </data>
+  <data name="IO_UnknownError" xml:space="preserve">
+    <value>Unknown Error '{0}'.</value>
+  </data>
+  <data name="BaseStream_Invalid_Not_Open" xml:space="preserve">
+    <value>The BaseStream is only available when the port is open.</value>
+  </data>
+  <data name="PortNameEmpty_String" xml:space="preserve">
+    <value>The PortName cannot be empty.</value>
+  </data>
+  <data name="Port_not_open" xml:space="preserve">
+    <value>The port is closed.</value>
+  </data>
+  <data name="Port_already_open" xml:space="preserve">
+    <value>The port is already open.</value>
+  </data>
+  <data name="Cant_be_set_when_open" xml:space="preserve">
+    <value>'{0}' cannot be set while the port is open.</value>
+  </data>
+  <data name="Max_Baud" xml:space="preserve">
+    <value>The maximum baud rate for the device is {0}.</value>
+  </data>
+  <data name="In_Break_State" xml:space="preserve">
+    <value>The port is in the break state and cannot be written to.</value>
+  </data>
+  <data name="Write_timed_out" xml:space="preserve">
+    <value>The write timed out.</value>
+  </data>
+  <data name="CantSetRtsWithHandshaking" xml:space="preserve">
+    <value>RtsEnable cannot be accessed if Handshake is set to RequestToSend or RequestToSendXOnXOff.</value>
+  </data>
+  <data name="NotSupportedEncoding" xml:space="preserve">
+    <value>SerialPort does not support encoding '{0}'.  The supported encodings include ASCIIEncoding, UTF8Encoding, UnicodeEncoding, UTF32Encoding, and most single or double byte code pages.  For a complete list please see the documentation.</value>
+  </data>
+  <data name="Arg_InvalidSerialPort" xml:space="preserve">
+    <value>The given port name does not start with COM/com or does not resolve to a valid serial port.</value>
+  </data>
+  <data name="Arg_InvalidSerialPortExtended" xml:space="preserve">
+    <value>The given port name is invalid.  It may be a valid port, but not a serial port.</value>
+  </data>
+  <data name="Arg_SecurityException" xml:space="preserve">
+    <value>The port name cannot start with '\\'.</value>
+  </data>
+  <data name="Argument_InvalidOffLen" xml:space="preserve">
+    <value>Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.</value>
+  </data>
+  <data name="ArgumentNull_Array" xml:space="preserve">
+    <value>Array cannot be null.</value>
+  </data>
+  <data name="ArgumentNull_Buffer" xml:space="preserve">
+    <value>Buffer cannot be null.</value>
+  </data>
+  <data name="ArgumentOutOfRange_Bounds_Lower_Upper" xml:space="preserve">
+    <value>Argument must be between {0} and {1}.</value>
+  </data>
+  <data name="ArgumentOutOfRange_Enum" xml:space="preserve">
+    <value>Enum value was out of legal range.</value>
+  </data>
+  <data name="ArgumentOutOfRange_NeedNonNegNumRequired" xml:space="preserve">
+    <value>Non-negative number required.</value>
+  </data>
+  <data name="ArgumentOutOfRange_NeedPosNum" xml:space="preserve">
+    <value>Positive number required."</value>
+  </data>
+  <data name="ArgumentOutOfRange_Timeout" xml:space="preserve">
+    <value>The timeout must be greater than or equal to -1.</value>
+  </data>
+  <data name="ArgumentOutOfRange_WriteTimeout" xml:space="preserve">
+    <value>The timeout must be either a positive number or -1.</value>
+  </data>
+  <data name="ArgumentOutOfRange_OffsetOut" xml:space="preserve">
+    <value>Either offset did not refer to a position in the string, or there is an insufficient length of destination character array."</value>
+  </data>
+  <data name="IndexOutOfRange_IORaceCondition" xml:space="preserve">
+    <value>Probable I/O race condition detected while copying memory.  The I/O package is not thread safe by default.  In multithreaded applications, a stream must be accessed in a thread-safe way, such as a thread-safe wrapper returned by TextReader's or TextWriter's Synchronized methods.  This also applies to classes like StreamWriter and StreamReader.</value>
+  </data>
+  <data name="IO_BindHandleFailed" xml:space="preserve">
+    <value>BindHandle for ThreadPool failed on this handle.</value>
+  </data>
+  <data name="IO_OperationAborted" xml:space="preserve">
+    <value>The I/O operation has been aborted because of either a thread exit or an application request.</value>
+  </data>
+  <data name="NotSupported_UnseekableStream" xml:space="preserve">
+    <value>Stream does not support seeking.</value>
+  </data>
+  <data name="IO_EOF_ReadBeyondEOF" xml:space="preserve">
+    <value>Unable to read beyond the end of the stream.</value>
+  </data>
+  <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
+    <value>Can not access a closed Stream."</value>
+  </data>
+  <data name="InvalidNullEmptyArgument" xml:space="preserve">
+    <value>Argument {0} cannot be null or zero-length."</value>
+  </data>
+  <data name="Arg_WrongAsyncResult" xml:space="preserve">
+    <value>IAsyncResult object did not come from the corresponding async method on this type.</value>
+  </data>
+  <data name="InvalidOperation_EndReadCalledMultiple" xml:space="preserve">
+    <value>EndRead can only be called once for each asynchronous operation.</value>
+  </data>
+  <data name="InvalidOperation_EndWriteCalledMultiple" xml:space="preserve">
+    <value>EndWrite can only be called once for each asynchronous operation."</value>
+  </data>
+  <data name="IO_PortNotFound" xml:space="preserve">
+    <value>The specified port does not exist.</value>
+  </data>
+  <data name="IO_PortNotFoundFileName" xml:space="preserve">
+    <value>The port '{0}' does not exist.</value>
+  </data>
+  <data name="UnauthorizedAccess_IODenied_NoPathName" xml:space="preserve">
+    <value>Access to the port is denied.</value>
+  </data>
+  <data name="IO_PathTooLong" xml:space="preserve">
+    <value>The specified port name is too long.  The port name must be less than 260 characters.</value>
+  </data>
+  <data name="IO_SharingViolation_NoFileName" xml:space="preserve">
+    <value>The process cannot access the port because it is being used by another process.</value>
+  </data>
+  <data name="IO_SharingViolation_File" xml:space="preserve">
+    <value>The process cannot access the port '{0}' because it is being used by another process."</value>
+  </data>
+  <data name="UnauthorizedAccess_IODenied_Path" xml:space="preserve">
+    <value>Access to the port '{0}' is denied."</value>
+  </data>
+</root>

--- a/src/System.IO.Ports/src/System.IO.Ports.csproj
+++ b/src/System.IO.Ports/src/System.IO.Ports.csproj
@@ -120,6 +120,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.BOOL.cs">
+      <Link>Common\Interop\Windows\Interop.BOOL.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="netstandard" />

--- a/src/System.IO.Ports/src/System.IO.Ports.csproj
+++ b/src/System.IO.Ports/src/System.IO.Ports.csproj
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{187503F4-BEF9-4369-A1B2-E3DC5D564E4E}</ProjectGuid>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the options -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="System\IO\Ports\Handshake.cs" />
+    <Compile Include="System\IO\Ports\InternalResources.cs" />
+    <Compile Include="System\IO\Ports\NativeMethods.cs" />
+    <Compile Include="System\IO\Ports\Parity.cs" />
+    <Compile Include="System\IO\Ports\SerialData.cs" />
+    <Compile Include="System\IO\Ports\SerialDataReceivedEventHandler.cs" />
+    <Compile Include="System\IO\Ports\SerialError.cs" />
+    <Compile Include="System\IO\Ports\SerialErrorReceivedEventArgs.cs" />
+    <Compile Include="System\IO\Ports\SerialErrorReceivedEventHandler.cs" />
+    <Compile Include="System\IO\Ports\SerialPinChange.cs" />
+    <Compile Include="System\IO\Ports\SerialPinChangedEventArgs.cs" />
+    <Compile Include="System\IO\Ports\SerialPinChangedEventHandler.cs" />
+    <Compile Include="System\IO\Ports\SerialPort.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="System\IO\Ports\SerialDataReceivedEventArgs.cs" />
+    <Compile Include="System\IO\Ports\SerialStream.cs" />
+    <Compile Include="System\IO\Ports\StopBits.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.DCB.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.DCB.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.COMMPROP.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.COMMPROP.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.COMMTIMEOUTS.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.COMMTIMEOUTS.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.COMSTAT.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.COMSTAT.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetCommState.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.SetCommState.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetCommBreak.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.SetCommBreak.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.ClearCommBreak.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.ClearCommBreak.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.EscapeCommFunction.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.EscapeCommFunction.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetCommTimeouts.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.SetCommTimeouts.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetCommModemStatus.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.GetCommModemStatus.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.ClearCommError.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.ClearCommError.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetCommProperties.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.GetCommProperties.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetCommMask.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.SetCommMask.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.PurgeComm.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.PurgeComm.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SetupComm.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.SetupComm.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetCommState.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.GetCommState.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.WaitCommEvent.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.WaitCommEvent.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.CreateFile.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.CreateFile.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.ReadFile_SafeHandle_IntPtr.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.ReadFile_SafeHandle_IntPtr.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.ReadFile_SafeHandle_NativeOverlapped.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.ReadFile_SafeHandle_NativeOverlapped.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.WriteFile_SafeHandle_IntPtr.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.WriteFile_SafeHandle_IntPtr.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.WriteFile_SafeHandle_NativeOverlapped.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.WriteFile_SafeHandle_NativeOverlapped.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetOverlappedResult.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.GetOverlappedResult.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.FlushFileBuffers.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.FlushFileBuffers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GenericOperations.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.GenericOperations.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.SECURITY_ATTRIBUTES.cs">
+      <Link>Common\Interop\Windows\Interop.SECURITY_ATTRIBUTES.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.FileTypes.cs">
+      <Link>Common\Interop\Windows\Interop.FileTypes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\IO\PathInternal.Windows.cs">
+      <Link>Common\System\IO\PathInternal.Windows.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetFileType_SafeHandle.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.GetFileType_SafeHandle.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+      <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+      <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="netstandard" />
+    <Reference Include="Microsoft.Win32.Registry" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO.Ports/src/System/IO/Ports/Handshake.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/Handshake.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Ports
+{
+    public enum Handshake
+    {
+        None,
+        XOnXOff,
+        RequestToSend,
+        RequestToSendXOnXOff
+    };
+}

--- a/src/System.IO.Ports/src/System/IO/Ports/InternalResources.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/InternalResources.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using Marshal = System.Runtime.InteropServices.Marshal;
+
+namespace System.IO.Ports
+{
+    internal static class InternalResources
+    {
+        // Beginning of static Error methods
+        internal static void EndOfFile()
+        {
+            throw new EndOfStreamException(SR.IO_EOF_ReadBeyondEOF);
+        }
+
+        internal static String GetMessage(int errorCode)
+        {
+            return new Win32Exception(errorCode).Message;
+        }
+
+        internal static void FileNotOpen()
+        {
+            throw new ObjectDisposedException(null, SR.Port_not_open);
+        }
+
+        internal static void WrongAsyncResult()
+        {
+            throw new ArgumentException(SR.Arg_WrongAsyncResult);
+        }
+
+        internal static void EndReadCalledTwice()
+        {
+            // Should ideally be InvalidOperationExc but we can't maintain parity with Stream and SerialStream without some work
+            throw new ArgumentException(SR.InvalidOperation_EndReadCalledMultiple);
+        }
+
+        internal static void EndWriteCalledTwice()
+        {
+            // Should ideally be InvalidOperationExc but we can't maintain parity with Stream and SerialStream without some work
+            throw new ArgumentException(SR.InvalidOperation_EndWriteCalledMultiple);
+        }
+
+        internal static void WinIOError()
+        {
+            int errorCode = Marshal.GetLastWin32Error();
+            WinIOError(errorCode, String.Empty);
+        }
+
+        internal static void WinIOError(string str)
+        {
+            int errorCode = Marshal.GetLastWin32Error();
+            WinIOError(errorCode, str);
+        }
+
+        // After calling GetLastWin32Error(), it clears the last error field,
+        // so you must save the HResult and pass it to this method.  This method
+        // will determine the appropriate exception to throw dependent on your 
+        // error, and depending on the error, insert a string into the message 
+        // gotten from the ResourceManager.
+        internal static void WinIOError(int errorCode, String str)
+        {
+            switch (errorCode)
+            {
+                case Interop.Errors.ERROR_FILE_NOT_FOUND:
+                case Interop.Errors.ERROR_PATH_NOT_FOUND:
+                    if (str.Length == 0)
+                        throw new IOException(SR.IO_PortNotFound);
+                    else
+                        throw new IOException(string.Format(SR.IO_PortNotFoundFileName, str));
+
+                case Interop.Errors.ERROR_ACCESS_DENIED:
+                    if (str.Length == 0)
+                        throw new UnauthorizedAccessException(SR.UnauthorizedAccess_IODenied_NoPathName);
+                    else
+                        throw new UnauthorizedAccessException(string.Format(SR.UnauthorizedAccess_IODenied_Path, str));
+
+                case Interop.Errors.ERROR_FILENAME_EXCED_RANGE:
+                    throw new PathTooLongException(SR.IO_PathTooLong);
+
+                case Interop.Errors.ERROR_SHARING_VIOLATION:
+                    // error message.
+                    if (str.Length == 0)
+                        throw new IOException(SR.IO_SharingViolation_NoFileName);
+                    else
+                        throw new IOException(string.Format(SR.IO_SharingViolation_File, str));
+
+                default:
+                    throw new IOException(GetMessage(errorCode), MakeHRFromErrorCode(errorCode));
+            }
+        }
+
+        // Use this to translate error codes like the above into HRESULTs like
+        // 0x80070006 for ERROR_INVALID_HANDLE
+        internal static int MakeHRFromErrorCode(int errorCode)
+        {
+            return unchecked(((int)0x80070000) | errorCode);
+        }
+    }
+}
+

--- a/src/System.IO.Ports/src/System/IO/Ports/NativeMethods.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/NativeMethods.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Ports
+{
+    // TODO: These should be put in Common\Interop in classes like GenericOperations
+    internal class NativeMethods
+    {
+        internal const int FILE_ATTRIBUTE_NORMAL = 0x00000080;
+        internal const int FILE_FLAG_OVERLAPPED = 0x40000000;
+
+        // The following are unique to the SerialPort/SerialStream classes
+        internal const byte ONESTOPBIT = 0;
+        internal const byte ONE5STOPBITS = 1;
+        internal const byte TWOSTOPBITS = 2;
+
+        internal const int DTR_CONTROL_DISABLE = 0x00;
+        internal const int DTR_CONTROL_ENABLE = 0x01;
+        internal const int DTR_CONTROL_HANDSHAKE = 0x02;
+
+        internal const int RTS_CONTROL_DISABLE = 0x00;
+        internal const int RTS_CONTROL_ENABLE = 0x01;
+        internal const int RTS_CONTROL_HANDSHAKE = 0x02;
+        internal const int RTS_CONTROL_TOGGLE = 0x03;
+
+        internal const int MS_CTS_ON = 0x10;
+        internal const int MS_DSR_ON = 0x20;
+        internal const int MS_RING_ON = 0x40;
+        internal const int MS_RLSD_ON = 0x80;
+
+        internal const byte EOFCHAR = 26;
+
+        // Since C# does not provide access to bitfields and the native DCB structure contains
+        // a very necessary one, these are the positional offsets (from the right) of areas
+        // of the 32-bit integer used in SerialStream's SetDcbFlag() and GetDcbFlag() methods.
+        internal const int FBINARY = 0;
+        internal const int FPARITY = 1;
+        internal const int FOUTXCTSFLOW = 2;
+        internal const int FOUTXDSRFLOW = 3;
+        internal const int FDTRCONTROL = 4;
+        internal const int FDSRSENSITIVITY = 6;
+        internal const int FTXCONTINUEONXOFF = 7;
+        internal const int FOUTX = 8;
+        internal const int FINX = 9;
+        internal const int FERRORCHAR = 10;
+        internal const int FNULL = 11;
+        internal const int FRTSCONTROL = 12;
+        internal const int FABORTONOERROR = 14;
+        internal const int FDUMMY2 = 15;
+
+        internal const int PURGE_TXABORT = 0x0001;  // Kill the pending/current writes to the comm port.
+        internal const int PURGE_RXABORT = 0x0002;  // Kill the pending/current reads to the comm port.
+        internal const int PURGE_TXCLEAR = 0x0004;  // Kill the transmit queue if there.
+        internal const int PURGE_RXCLEAR = 0x0008;  // Kill the typeahead buffer if there.
+
+        internal const byte DEFAULTXONCHAR = (byte)17;
+        internal const byte DEFAULTXOFFCHAR = (byte)19;
+
+        internal const int SETRTS = 3;       // Set RTS high
+        internal const int CLRRTS = 4;       // Set RTS low
+        internal const int SETDTR = 5;       // Set DTR high
+        internal const int CLRDTR = 6;
+
+        internal const int EV_RXCHAR = 0x01;
+        internal const int EV_RXFLAG = 0x02;
+        internal const int EV_CTS = 0x08;
+        internal const int EV_DSR = 0x10;
+        internal const int EV_RLSD = 0x20;
+        internal const int EV_BREAK = 0x40;
+        internal const int EV_ERR = 0x80;
+        internal const int EV_RING = 0x100;
+        internal const int ALL_EVENTS = 0x1fb;  // don't use EV_TXEMPTY
+
+        internal const int CE_RXOVER = 0x01;
+        internal const int CE_OVERRUN = 0x02;
+        internal const int CE_PARITY = 0x04;
+        internal const int CE_FRAME = 0x08;
+        internal const int CE_BREAK = 0x10;
+        internal const int CE_TXFULL = 0x100;
+
+        internal const int MAXDWORD = -1;   // note this is 0xfffffff, or UInt32.MaxValue, here used as an int
+
+        internal const int NOPARITY = 0;
+        internal const int ODDPARITY = 1;
+        internal const int EVENPARITY = 2;
+        internal const int MARKPARITY = 3;
+        internal const int SPACEPARITY = 4;
+    }
+}

--- a/src/System.IO.Ports/src/System/IO/Ports/Parity.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/Parity.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Ports
+{
+    public enum Parity
+    {
+        None = NativeMethods.NOPARITY,
+        Odd = NativeMethods.ODDPARITY,
+        Even = NativeMethods.EVENPARITY,
+        Mark = NativeMethods.MARKPARITY,
+        Space = NativeMethods.SPACEPARITY
+    };
+}
+

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialData.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialData.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Ports
+{
+    public enum SerialData
+    {
+        // EV_RXCHAR
+        Chars = 0x01,
+
+        // EV_RXFLAG
+        Eof = 0x02
+    }
+}

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialDataReceivedEventArgs.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialDataReceivedEventArgs.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Ports
+{
+    public class SerialDataReceivedEventArgs : EventArgs
+    {
+        internal SerialDataReceivedEventArgs(SerialData eventCode)
+        {
+            EventType = eventCode;
+        }
+
+        public SerialData EventType { get; private set; }
+    }
+}
+

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialDataReceivedEventHandler.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialDataReceivedEventHandler.cs
@@ -1,0 +1,8 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Ports
+{
+    public delegate void SerialDataReceivedEventHandler(object sender, SerialDataReceivedEventArgs e);
+}

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialError.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialError.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Ports
+{
+    public enum SerialError
+    {
+        TXFull = NativeMethods.CE_TXFULL,
+        RXOver = NativeMethods.CE_RXOVER,
+        Overrun = NativeMethods.CE_OVERRUN,
+        RXParity = NativeMethods.CE_PARITY,
+        Frame = NativeMethods.CE_FRAME,
+    }
+}

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialErrorReceivedEventArgs.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialErrorReceivedEventArgs.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Ports
+{
+    public class SerialErrorReceivedEventArgs : EventArgs
+    {
+        internal SerialErrorReceivedEventArgs(SerialError eventCode)
+        {
+            EventType = eventCode;
+        }
+
+        public SerialError EventType { get; private set; }
+    }
+}

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialErrorReceivedEventHandler.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialErrorReceivedEventHandler.cs
@@ -1,0 +1,8 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Ports
+{
+    public delegate void SerialErrorReceivedEventHandler(object sender, SerialErrorReceivedEventArgs e);
+}

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialPinChange.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialPinChange.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Ports
+{
+    public enum SerialPinChange
+    {
+        CtsChanged = NativeMethods.EV_CTS,
+        DsrChanged = NativeMethods.EV_DSR,
+        CDChanged = NativeMethods.EV_RLSD,
+        Ring = NativeMethods.EV_RING,
+        Break = NativeMethods.EV_BREAK
+    }
+}

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialPinChangedEventArgs.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialPinChangedEventArgs.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Ports
+{
+    public class SerialPinChangedEventArgs : EventArgs
+    {
+        internal SerialPinChangedEventArgs(SerialPinChange eventCode)
+        {
+            EventType = eventCode;
+        }
+
+        public SerialPinChange EventType { get; private set; }
+    }
+}
+

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialPinChangedEventHandler.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialPinChangedEventHandler.cs
@@ -1,0 +1,8 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Ports
+{
+    public delegate void SerialPinChangedEventHandler(object sender, SerialPinChangedEventArgs e);
+}

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialPort.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialPort.cs
@@ -242,12 +242,10 @@ namespace System.IO.Ports
                     throw new ArgumentNullException(nameof(Encoding));
 
                 // Limit the encodings we support to some known ones.  The code pages < 50000 represent all of the single-byte
-                // and double-byte code pages.  Code page 54936 is GB18030.  Finally we check that the encoding's assembly
-                // is mscorlib, so we don't get any weird user encodings that happen to set a code page less than 50000. 
+                // and double-byte code pages.  Code page 54936 is GB18030.
                 if (!(value is ASCIIEncoding || value is UTF8Encoding || value is UnicodeEncoding || value is UTF32Encoding ||
-                      ((value.CodePage < 50000 || value.CodePage == 54936) && value.GetType().Assembly == typeof(String).Assembly)))
+                      value.CodePage < 50000 || value.CodePage == 54936))
                 {
-
                     throw new ArgumentException(string.Format(SR.NotSupportedEncoding, value.WebName), nameof(Encoding));
                 }
 

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialPort.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialPort.cs
@@ -1,0 +1,1307 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text;
+
+namespace System.IO.Ports
+{
+    public class SerialPort : Component
+    {
+        public const int InfiniteTimeout = -1;
+
+        // ---------- default values -------------*
+
+        private const int DefaultDataBits = 8;
+        private const Parity DefaultParity = Parity.None;
+        private const StopBits DefaultStopBits = StopBits.One;
+        private const Handshake DefaultHandshake = Handshake.None;
+        private const int DefaultBufferSize = 1024;
+        private const string DefaultPortName = "COM1";
+        private const int DefaultBaudRate = 9600;
+        private const bool DefaultDtrEnable = false;
+        private const bool DefaultRtsEnable = false;
+        private const bool DefaultDiscardNull = false;
+        private const byte DefaultParityReplace = (byte)'?';
+        private const int DefaultReceivedBytesThreshold = 1;
+        private const int DefaultReadTimeout = InfiniteTimeout;
+        private const int DefaultWriteTimeout = InfiniteTimeout;
+        private const int DefaultReadBufferSize = 4096;
+        private const int DefaultWriteBufferSize = 2048;
+        private const int MaxDataBits = 8;
+        private const int MinDataBits = 5;
+        private const string DefaultNewLine = "\n";
+
+        private const string SERIAL_NAME = @"\Device\Serial";
+
+        // --------- members supporting exposed properties ------------*
+        private int _baudRate = DefaultBaudRate;
+        private int _dataBits = DefaultDataBits;
+        private Parity _parity = DefaultParity;
+        private StopBits _stopBits = DefaultStopBits;
+        private string _portName = DefaultPortName;
+        private Encoding _encoding = Encoding.ASCII; // ASCII is default encoding for modem communication, etc.
+        private Decoder _decoder = Encoding.ASCII.GetDecoder();
+        private int _maxByteCountForSingleChar = Encoding.ASCII.GetMaxByteCount(1);
+        private Handshake _handshake = DefaultHandshake;
+        private int _readTimeout = DefaultReadTimeout;
+        private int _writeTimeout = DefaultWriteTimeout;
+        private int _receivedBytesThreshold = DefaultReceivedBytesThreshold;
+        private bool _discardNull = DefaultDiscardNull;
+        private bool _dtrEnable = DefaultDtrEnable;
+        private bool _rtsEnable = DefaultRtsEnable;
+        private byte _parityReplace = DefaultParityReplace;
+        private string _newLine = DefaultNewLine;
+        private int _readBufferSize = DefaultReadBufferSize;
+        private int _writeBufferSize = DefaultWriteBufferSize;
+
+        // ---------- members for internal support ---------*
+        private SerialStream _internalSerialStream = null;
+        private byte[] _inBuffer = new byte[DefaultBufferSize];
+        private int _readPos = 0;    // position of next byte to read in the read buffer.  readPos <= readLen
+        private int _readLen = 0;    // position of first unreadable byte => CachedBytesToRead is the number of readable bytes left.
+        private char[] _oneChar = new char[1];
+        private char[] _singleCharBuffer = null;
+
+        public event SerialErrorReceivedEventHandler ErrorReceived;
+        public event SerialPinChangedEventHandler PinChanged;
+        public event SerialDataReceivedEventHandler DataReceived;
+
+        //--- component properties---------------*
+
+        // ---- SECTION: public properties --------------*
+        // Note: information about port properties passes in ONE direction: from SerialPort to
+        // its underlying Stream.  No changes are able to be made in the important properties of
+        // the stream and its behavior, so no reflection back to SerialPort is necessary.
+
+        // Gets the internal SerialStream object.  Used to pass essence of SerialPort to another Stream wrapper.
+        public Stream BaseStream
+        {
+            get
+            {
+                if (!IsOpen)
+                    throw new InvalidOperationException(SR.BaseStream_Invalid_Not_Open);
+
+                return _internalSerialStream;
+            }
+        }
+
+        public int BaudRate
+        {
+            get { return _baudRate; }
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentOutOfRangeException(nameof(BaudRate), SR.ArgumentOutOfRange_NeedPosNum);
+
+                if (IsOpen)
+                    _internalSerialStream.BaudRate = value;
+                _baudRate = value;
+            }
+        }
+
+        public bool BreakState
+        {
+            get
+            {
+                if (!IsOpen)
+                    throw new InvalidOperationException(SR.Port_not_open);
+
+                return _internalSerialStream.BreakState;
+            }
+            set
+            {
+                if (!IsOpen)
+                    throw new InvalidOperationException(SR.Port_not_open);
+
+                _internalSerialStream.BreakState = value;
+            }
+        }
+
+        // includes all bytes available on serial driver's output buffer.  Note that we do not internally buffer output bytes in SerialPort.
+        public int BytesToWrite
+        {
+            get
+            {
+                if (!IsOpen)
+                    throw new InvalidOperationException(SR.Port_not_open);
+                return _internalSerialStream.BytesToWrite;
+            }
+        }
+
+        // includes all bytes available on serial driver's input buffer as well as bytes internally buffered int the SerialPort class.
+        public int BytesToRead
+        {
+            get
+            {
+                if (!IsOpen)
+                    throw new InvalidOperationException(SR.Port_not_open);
+                return _internalSerialStream.BytesToRead + CachedBytesToRead; // count the number of bytes we have in the internal buffer too.
+            }
+        }
+
+        private int CachedBytesToRead
+        {
+            get
+            {
+                return _readLen - _readPos;
+            }
+        }
+
+        public bool CDHolding
+        {
+            get
+            {
+                if (!IsOpen)
+                    throw new InvalidOperationException(SR.Port_not_open);
+                return _internalSerialStream.CDHolding;
+            }
+        }
+
+        public bool CtsHolding
+        {
+            get
+            {
+                if (!IsOpen)
+                    throw new InvalidOperationException(SR.Port_not_open);
+                return _internalSerialStream.CtsHolding;
+            }
+        }
+
+        public int DataBits
+        {
+            get
+            { return _dataBits; }
+            set
+            {
+                if (value < MinDataBits || value > MaxDataBits)
+                    throw new ArgumentOutOfRangeException(nameof(DataBits), string.Format(SR.ArgumentOutOfRange_Bounds_Lower_Upper, MinDataBits, MaxDataBits));
+
+                if (IsOpen)
+                    _internalSerialStream.DataBits = value;
+                _dataBits = value;
+            }
+        }
+
+        public bool DiscardNull
+        {
+            get
+            {
+                return _discardNull;
+            }
+            set
+            {
+                if (IsOpen)
+                    _internalSerialStream.DiscardNull = value;
+                _discardNull = value;
+            }
+        }
+
+        public bool DsrHolding
+        {
+            get
+            {
+                if (!IsOpen)
+                    throw new InvalidOperationException(SR.Port_not_open);
+                return _internalSerialStream.DsrHolding;
+            }
+        }
+
+        public bool DtrEnable
+        {
+            get
+            {
+                if (IsOpen)
+                    _dtrEnable = _internalSerialStream.DtrEnable;
+
+                return _dtrEnable;
+            }
+            set
+            {
+                if (IsOpen)
+                    _internalSerialStream.DtrEnable = value;
+                _dtrEnable = value;
+            }
+        }
+
+        // Allows specification of an arbitrary encoding for the reading and writing functions of the port
+        // which deal with chars and strings.  Set by default in the code to System.Text.ASCIIEncoding(), which
+        // is the standard text encoding for modem commands and most of serial communication.
+        public Encoding Encoding
+        {
+            get
+            {
+                return _encoding;
+            }
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(Encoding));
+
+                // Limit the encodings we support to some known ones.  The code pages < 50000 represent all of the single-byte
+                // and double-byte code pages.  Code page 54936 is GB18030.  Finally we check that the encoding's assembly
+                // is mscorlib, so we don't get any weird user encodings that happen to set a code page less than 50000. 
+                if (!(value is ASCIIEncoding || value is UTF8Encoding || value is UnicodeEncoding || value is UTF32Encoding ||
+                      ((value.CodePage < 50000 || value.CodePage == 54936) && value.GetType().Assembly == typeof(String).Assembly)))
+                {
+
+                    throw new ArgumentException(string.Format(SR.NotSupportedEncoding, value.WebName), nameof(Encoding));
+                }
+
+                _encoding = value;
+                _decoder = _encoding.GetDecoder();
+
+                // This is somewhat of an approximate guesstimate to get the max char[] size needed to encode a single character
+                _maxByteCountForSingleChar = _encoding.GetMaxByteCount(1);
+                _singleCharBuffer = null;
+            }
+        }
+
+        public Handshake Handshake
+        {
+            get
+            {
+                return _handshake;
+            }
+            set
+            {
+                if (value < Handshake.None || value > Handshake.RequestToSendXOnXOff)
+                    throw new ArgumentOutOfRangeException(nameof(Handshake), SR.ArgumentOutOfRange_Enum);
+
+                if (IsOpen)
+                    _internalSerialStream.Handshake = value;
+                _handshake = value;
+            }
+        }
+
+        public bool IsOpen
+        {
+            // true only if the Open() method successfully called on this SerialPort object, without Close() being called more recently.
+            get { return (_internalSerialStream != null && _internalSerialStream.IsOpen); }
+        }
+
+        public string NewLine
+        {
+            get { return _newLine; }
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException();
+                if (value.Length == 0)
+                    throw new ArgumentException(string.Format(SR.InvalidNullEmptyArgument, nameof(NewLine)));
+
+                _newLine = value;
+            }
+        }
+
+        public Parity Parity
+        {
+            get
+            {
+                return _parity;
+            }
+            set
+            {
+                if (value < Parity.None || value > Parity.Space)
+                    throw new ArgumentOutOfRangeException(nameof(Parity), SR.ArgumentOutOfRange_Enum);
+
+                if (IsOpen)
+                    _internalSerialStream.Parity = value;
+                _parity = value;
+            }
+        }
+
+        public byte ParityReplace
+        {
+            get { return _parityReplace; }
+            set
+            {
+                if (IsOpen)
+                    _internalSerialStream.ParityReplace = value;
+                _parityReplace = value;
+            }
+        }
+
+        // Note that the communications port cannot be meaningfully re-set when the port is open,
+        // and so once set by the constructor becomes read-only.
+        public string PortName
+        {
+            get
+            {
+                return _portName;
+            }
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(PortName));
+                if (value.Length == 0)
+                    throw new ArgumentException(SR.PortNameEmpty_String, nameof(PortName));
+
+                if (IsOpen)
+                    throw new InvalidOperationException(String.Format(SR.Cant_be_set_when_open, nameof(PortName)));
+                _portName = value;
+            }
+        }
+
+        public int ReadBufferSize
+        {
+            get
+            {
+                return _readBufferSize;
+            }
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentOutOfRangeException(nameof(ReadBufferSize));
+
+                if (IsOpen)
+                    throw new InvalidOperationException(string.Format(SR.Cant_be_set_when_open, nameof(ReadBufferSize)));
+
+                _readBufferSize = value;
+            }
+        }
+
+        // timeout for all read operations.  May be set to SerialPort.InfiniteTimeout, 0, or any positive value
+        public int ReadTimeout
+        {
+            get
+            {
+                return _readTimeout;
+            }
+            set
+            {
+                if (value < 0 && value != InfiniteTimeout)
+                    throw new ArgumentOutOfRangeException(nameof(ReadTimeout), SR.ArgumentOutOfRange_Timeout);
+
+                if (IsOpen)
+                    _internalSerialStream.ReadTimeout = value;
+                _readTimeout = value;
+            }
+        }
+
+        // If we have the SerialData.Chars event set, this property indicates the number of bytes necessary
+        // to exist in our buffers before the event is thrown.  This is useful if we expect to receive n-byte
+        // packets and can only act when we have this many, etc.
+        public int ReceivedBytesThreshold
+        {
+            get
+            {
+                return _receivedBytesThreshold;
+            }
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentOutOfRangeException(nameof(ReceivedBytesThreshold), SR.ArgumentOutOfRange_NeedPosNum);
+
+                _receivedBytesThreshold = value;
+
+                if (IsOpen)
+                {
+                    // fake the call to our event handler in case the threshold has been set lower
+                    // than how many bytes we currently have.
+                    SerialDataReceivedEventArgs args = new SerialDataReceivedEventArgs(SerialData.Chars);
+                    CatchReceivedEvents(this, args);
+                }
+            }
+        }
+
+        public bool RtsEnable
+        {
+            get
+            {
+                if (IsOpen)
+                    _rtsEnable = _internalSerialStream.RtsEnable;
+
+                return _rtsEnable;
+            }
+            set
+            {
+                if (IsOpen)
+                    _internalSerialStream.RtsEnable = value;
+                _rtsEnable = value;
+            }
+        }
+
+        // StopBits represented in C# as StopBits enum type and in Win32 as an integer 1, 2, or 3.
+        public StopBits StopBits
+        {
+            get
+            {
+                return _stopBits;
+            }
+            set
+            {
+                // this range check looks wrong, but it really is correct.  One = 1, Two = 2, and OnePointFive = 3
+                if (value < StopBits.One || value > StopBits.OnePointFive)
+                    throw new ArgumentOutOfRangeException(nameof(StopBits), SR.ArgumentOutOfRange_Enum);
+
+                if (IsOpen)
+                    _internalSerialStream.StopBits = value;
+                _stopBits = value;
+            }
+        }
+
+        public int WriteBufferSize
+        {
+            get
+            {
+                return _writeBufferSize;
+            }
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentOutOfRangeException(nameof(WriteBufferSize));
+
+                if (IsOpen)
+                    throw new InvalidOperationException(string.Format(SR.Cant_be_set_when_open, nameof(WriteBufferSize)));
+
+                _writeBufferSize = value;
+            }
+        }
+
+        // timeout for all write operations.  May be set to SerialPort.InfiniteTimeout or any positive value
+        public int WriteTimeout
+        {
+            get
+            {
+                return _writeTimeout;
+            }
+            set
+            {
+                if (value <= 0 && value != InfiniteTimeout)
+                    throw new ArgumentOutOfRangeException(nameof(WriteTimeout), SR.ArgumentOutOfRange_WriteTimeout);
+
+                if (IsOpen)
+                    _internalSerialStream.WriteTimeout = value;
+                _writeTimeout = value;
+            }
+        }
+
+        // -------- SECTION: constructors -----------------*
+        public SerialPort(IContainer container)
+        {
+            // Required for Windows.Forms Class Composition Designer support
+            container.Add(this);
+        }
+
+        public SerialPort()
+        {
+        }
+
+        // Non-design SerialPort constructors here chain, using default values for members left unspecified by parameters
+        // Note: Calling SerialPort() does not open a port connection but merely instantiates an object.
+        //     : A connection must be made using SerialPort's Open() method.
+        public SerialPort(string portName) : this(portName, DefaultBaudRate, DefaultParity, DefaultDataBits, DefaultStopBits)
+        {
+        }
+
+        public SerialPort(string portName, int baudRate) : this(portName, baudRate, DefaultParity, DefaultDataBits, DefaultStopBits)
+        {
+        }
+
+        public SerialPort(string portName, int baudRate, Parity parity) : this(portName, baudRate, parity, DefaultDataBits, DefaultStopBits)
+        {
+        }
+
+        public SerialPort(string portName, int baudRate, Parity parity, int dataBits) : this(portName, baudRate, parity, dataBits, DefaultStopBits)
+        {
+        }
+
+        // all the magic happens in the call to the instance's .Open() method.
+        // Internally, the SerialStream constructor opens the file handle, sets the device
+        // control block and associated Win32 structures, and begins the event-watching cycle.
+        public SerialPort(string portName, int baudRate, Parity parity, int dataBits, StopBits stopBits)
+        {
+            PortName = portName;
+            BaudRate = baudRate;
+            Parity = parity;
+            DataBits = dataBits;
+            StopBits = stopBits;
+        }
+
+        // Calls internal Serial Stream's Close() method on the internal Serial Stream.
+        public void Close()
+        {
+            Dispose();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (IsOpen)
+                {
+                    _internalSerialStream.Flush();
+                    _internalSerialStream.Close();
+                    _internalSerialStream = null;
+                }
+            }
+            base.Dispose(disposing);
+        }
+
+        public void DiscardInBuffer()
+        {
+            if (!IsOpen)
+                throw new InvalidOperationException(SR.Port_not_open);
+            _internalSerialStream.DiscardInBuffer();
+            _readPos = _readLen = 0;
+        }
+
+        public void DiscardOutBuffer()
+        {
+            if (!IsOpen)
+                throw new InvalidOperationException(SR.Port_not_open);
+            _internalSerialStream.DiscardOutBuffer();
+        }
+
+        public static string[] GetPortNames()
+        {
+            // Hitting the registry for this isn't the only way to get the ports.
+            // 
+            // WMI: https://msdn.microsoft.com/en-us/library/aa394413.aspx
+            // QueryDosDevice: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365461.aspx
+            //
+            // QueryDosDevice involves finding any ports that map to \Device\Serialx (call with null to get all, then iterate to get the actual device name)
+
+            RegistryKey baseKey = null;
+            RegistryKey serialKey = null;
+
+            String[] portNames = null;
+
+            try
+            {
+                baseKey = Registry.LocalMachine;
+                serialKey = baseKey.OpenSubKey(@"HARDWARE\DEVICEMAP\SERIALCOMM", false);
+
+                if (serialKey != null)
+                {
+
+                    string[] deviceNames = serialKey.GetValueNames();
+                    portNames = new String[deviceNames.Length];
+
+                    for (int i = 0; i < deviceNames.Length; i++)
+                        portNames[i] = (string)serialKey.GetValue(deviceNames[i]);
+                }
+            }
+            finally
+            {
+                baseKey?.Dispose();
+                serialKey?.Dispose();
+            }
+
+            // If serialKey didn't exist for some reason
+            if (portNames == null)
+                portNames = new String[0];
+
+            return portNames;
+        }
+
+        // SerialPort is open <=> SerialPort has an associated SerialStream.
+        // The two statements are functionally equivalent here, so this method basically calls underlying Stream's
+        // constructor from the main properties specified in SerialPort: baud, stopBits, parity, dataBits,
+        // comm portName, handshaking, and timeouts.
+        public void Open()
+        {
+            if (IsOpen)
+                throw new InvalidOperationException(SR.Port_already_open);
+
+            _internalSerialStream = new SerialStream(_portName, _baudRate, _parity, _dataBits, _stopBits, _readTimeout,
+                _writeTimeout, _handshake, _dtrEnable, _rtsEnable, _discardNull, _parityReplace);
+
+            _internalSerialStream.SetBufferSizes(_readBufferSize, _writeBufferSize);
+
+            _internalSerialStream.ErrorReceived += new SerialErrorReceivedEventHandler(CatchErrorEvents);
+            _internalSerialStream.PinChanged += new SerialPinChangedEventHandler(CatchPinChangedEvents);
+            _internalSerialStream.DataReceived += new SerialDataReceivedEventHandler(CatchReceivedEvents);
+        }
+
+        // Read Design pattern:
+        //  : ReadChar() returns the first available full char if found before, throws TimeoutExc if timeout.
+        //  : Read(byte[] buffer..., int count) returns all data available before read timeout expires up to *count* bytes
+        //  : Read(char[] buffer..., int count) returns all data available before read timeout expires up to *count* chars.
+        //  :                                   Note, this does not return "half-characters".
+        //  : ReadByte() is the binary analogue of the first one.
+        //  : ReadLine(): returns null string on timeout, saves received data in buffer
+        //  : ReadAvailable(): returns all full characters which are IMMEDIATELY available.
+
+        public int Read(byte[] buffer, int offset, int count)
+        {
+            if (!IsOpen)
+                throw new InvalidOperationException(SR.Port_not_open);
+            if (buffer == null)
+                throw new ArgumentNullException("buffer", SR.ArgumentNull_Buffer);
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException("offset", SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+            if (count < 0)
+                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+            if (buffer.Length - offset < count)
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+            int bytesReadToBuffer = 0;
+
+            // if any bytes available in internal buffer, return those without calling any read ops.
+            if (CachedBytesToRead >= 1)
+            {
+                bytesReadToBuffer = Math.Min(CachedBytesToRead, count);
+                Buffer.BlockCopy(_inBuffer, _readPos, buffer, offset, bytesReadToBuffer);
+                _readPos += bytesReadToBuffer;
+                if (bytesReadToBuffer == count)
+                {
+                    if (_readPos == _readLen) _readPos = _readLen = 0;  // just a check to see if we can reset buffer
+                    return count;
+                }
+
+                // if we have read some bytes but there's none immediately available, return.
+                if (BytesToRead == 0)
+                    return bytesReadToBuffer;
+            }
+
+            Debug.Assert(CachedBytesToRead == 0, "there should be nothing left in our internal buffer");
+            _readLen = _readPos = 0;
+
+            int bytesLeftToRead = count - bytesReadToBuffer;
+
+            // request to read the requested number of bytes to fulfill the contract,
+            // doesn't matter if we time out.  We still return all the data we have available.
+            bytesReadToBuffer += _internalSerialStream.Read(buffer, offset + bytesReadToBuffer, bytesLeftToRead);
+
+            _decoder.Reset();
+            return bytesReadToBuffer;
+        }
+
+        // publicly exposed "ReadOneChar"-type: Read()
+        // reads one full character from the stream
+        public int ReadChar()
+        {
+            if (!IsOpen)
+                throw new InvalidOperationException(SR.Port_not_open);
+
+            return ReadOneChar(_readTimeout);
+        }
+
+        // gets next available full character, which may be from the buffer, the stream, or both.
+        // this takes size^2 time at most, where *size* is the maximum size of any one character in an encoding.
+        // The user can call Read(1) to mimic this functionality.
+
+        // We can replace ReadOneChar with Read at some point
+        private int ReadOneChar(int timeout)
+        {
+            int nextByte;
+            int timeUsed = 0;
+            Debug.Assert(IsOpen, "ReadOneChar - port not open");
+
+            // case 1: we have >= 1 character in the internal buffer.
+            if (_decoder.GetCharCount(_inBuffer, _readPos, CachedBytesToRead) != 0)
+            {
+                int beginReadPos = _readPos;
+                // get characters from buffer.
+                do
+                {
+                    _readPos++;
+                } while (_decoder.GetCharCount(_inBuffer, beginReadPos, _readPos - beginReadPos) < 1);
+
+                try
+                {
+                    _decoder.GetChars(_inBuffer, beginReadPos, _readPos - beginReadPos, _oneChar, 0);
+                }
+                catch
+                {
+
+                    // Handle surrogate chars correctly, restore readPos
+                    _readPos = beginReadPos;
+                    throw;
+                }
+                return _oneChar[0];
+            }
+            else
+            {
+
+                // need to return immediately.
+                if (timeout == 0)
+                {
+                    // read all bytes in the serial driver in here.  Make sure we ask for at least 1 byte
+                    // so that we get the proper timeout behavior
+                    int bytesInStream = _internalSerialStream.BytesToRead;
+                    if (bytesInStream == 0)
+                        bytesInStream = 1;
+                    MaybeResizeBuffer(bytesInStream);
+                    _readLen += _internalSerialStream.Read(_inBuffer, _readLen, bytesInStream); // read all immediately avail.
+
+                    // If what we have in the buffer is not enough, throw TimeoutExc
+                    // if we are reading surrogate char then ReadBufferIntoChars 
+                    // will throw argexc and that is okay as readPos is not altered
+                    if (ReadBufferIntoChars(_oneChar, 0, 1, false) == 0)
+                        throw new TimeoutException();
+                    else
+                        return _oneChar[0];
+                }
+
+                // case 2: we need to read from outside to find this.
+                // timeout is either infinite or positive.
+                int startTicks = Environment.TickCount;
+                do
+                {
+                    if (timeout == InfiniteTimeout)
+                        nextByte = _internalSerialStream.ReadByte(InfiniteTimeout);
+                    else if (timeout - timeUsed >= 0)
+                    {
+                        nextByte = _internalSerialStream.ReadByte(timeout - timeUsed);
+                        timeUsed = Environment.TickCount - startTicks;
+                    }
+                    else
+                        throw new TimeoutException();
+
+                    MaybeResizeBuffer(1);
+                    _inBuffer[_readLen++] = (byte)nextByte;  // we must add to the end of the buffer
+                } while (_decoder.GetCharCount(_inBuffer, _readPos, _readLen - _readPos) < 1);
+            }
+
+            // If we are reading surrogate char then this will throw argexc 
+            // we need not deal with that exc because we have not altered readPos yet.
+            _decoder.GetChars(_inBuffer, _readPos, _readLen - _readPos, _oneChar, 0);
+
+            // Everything should be out of inBuffer now.  We'll just reset the pointers. 
+            _readLen = _readPos = 0;
+            return _oneChar[0];
+        }
+
+        // Will return 'n' (1 < n < count) characters (or) TimeoutExc
+        public int Read(char[] buffer, int offset, int count)
+        {
+            if (!IsOpen)
+                throw new InvalidOperationException(SR.Port_not_open);
+            if (buffer == null)
+                throw new ArgumentNullException("buffer", SR.ArgumentNull_Buffer);
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException("offset", SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+            if (count < 0)
+                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+            if (buffer.Length - offset < count)
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+
+            return InternalRead(buffer, offset, count, _readTimeout, false);
+        }
+
+        private int InternalRead(char[] buffer, int offset, int count, int timeout, bool countMultiByteCharsAsOne)
+        {
+            Debug.Assert(IsOpen, "port not open!");
+            Debug.Assert(buffer != null, "invalid buffer!");
+            Debug.Assert(offset >= 0, "invalid offset!");
+            Debug.Assert(count >= 0, "invalid count!");
+            Debug.Assert(buffer.Length - offset >= count, "invalid offset/count!");
+
+            if (count == 0) return 0;   // immediately return on zero chars desired.  This simplifies things later.
+
+            // Get the startticks before we read the underlying stream
+            int startTicks = Environment.TickCount;
+
+            // read everything else into internal buffer, which we know we can do instantly, and see if we NOW have enough.
+            int bytesInStream = _internalSerialStream.BytesToRead;
+            MaybeResizeBuffer(bytesInStream);
+            _readLen += _internalSerialStream.Read(_inBuffer, _readLen, bytesInStream);    // should execute instantaneously.
+
+            int charsWeAlreadyHave = _decoder.GetCharCount(_inBuffer, _readPos, CachedBytesToRead); // full chars already in our buffer
+            if (charsWeAlreadyHave > 0)
+            {
+                // we found some chars after reading everything the SerialStream had to offer.  We'll return what we have
+                // rather than wait for more. 
+                return ReadBufferIntoChars(buffer, offset, count, countMultiByteCharsAsOne);
+            }
+
+            if (timeout == 0)
+                throw new TimeoutException();
+
+            // else: we need to do incremental reads from the stream.
+            // -----
+            // our internal algorithm for finding exactly n characters is a bit complicated, but must overcome the
+            // hurdle of NEVER READING TOO MANY BYTES from the Stream, since we can time out.  A variable-length encoding
+            // allows anywhere between minimum and maximum bytes per char times number of chars to be the exactly correct
+            // target, and we have to take care not to overuse GetCharCount().  The problem is that GetCharCount() will never tell
+            // us if we've read "half" a character in our current set of collected bytes; it underestimates.
+            // size = maximum bytes per character in the encoding.  n = number of characters requested.
+            // Solution I: Use ReadOneChar() to read successive characters until we get to n.
+            // Read calls: size * n; GetCharCount calls: size * n; each byte "counted": size times.
+            // Solution II: Use a binary reduction and backtracking to reduce the number of calls.
+            // Read calls: size * log n; GetCharCount calls: size * log n; each byte "counted": size * (log n) / n times.
+            // We use the second, more complicated solution here.  Note log is actually log_(size/size - 1)...
+
+
+            // we need to read some from the stream
+            // read *up to* the maximum number of bytes from the stream
+            // we can read more since we receive everything instantaneously, and we don't have enough,
+            // so when we do receive any data, it will be necessary and sufficient.
+
+            int justRead;
+            int maxReadSize = Encoding.GetMaxByteCount(count);
+            do
+            {
+                MaybeResizeBuffer(maxReadSize);
+
+                _readLen += _internalSerialStream.Read(_inBuffer, _readLen, maxReadSize);
+                justRead = ReadBufferIntoChars(buffer, offset, count, countMultiByteCharsAsOne);
+                if (justRead > 0)
+                {
+                    return justRead;
+                }
+            } while (timeout == InfiniteTimeout || (timeout - GetElapsedTime(Environment.TickCount, startTicks) > 0));
+
+            // must've timed out w/o getting a character.
+            throw new TimeoutException();
+        }
+
+        // ReadBufferIntoChars reads from Serial Port's inBuffer up to *count* chars and
+        // places them in *buffer* starting at *offset*.
+        // This does not call any stream Reads, and so takes "no time".
+        // If the buffer specified is insufficient to accommodate surrogate characters
+        // the call to underlying Decoder.GetChars will throw argexc. 
+        private int ReadBufferIntoChars(char[] buffer, int offset, int count, bool countMultiByteCharsAsOne)
+        {
+            Debug.Assert(count != 0, "Count should never be zero.  We will probably see bugs further down if count is 0.");
+
+            int bytesToRead = Math.Min(count, CachedBytesToRead);
+
+            // There are lots of checks to determine if this really is a single byte encoding with no
+            // funky fallbacks that would make it not single byte
+            DecoderReplacementFallback fallback = _encoding.DecoderFallback as DecoderReplacementFallback;
+            if (_encoding.IsSingleByte && _encoding.GetMaxCharCount(bytesToRead) == bytesToRead &&
+                fallback != null && fallback.MaxCharCount == 1)
+            {
+                // kill ASCII/ANSI encoding easily.
+                // read at least one and at most *count* characters
+                _decoder.GetChars(_inBuffer, _readPos, bytesToRead, buffer, offset);
+
+                _readPos += bytesToRead;
+                if (_readPos == _readLen) _readPos = _readLen = 0;
+                return bytesToRead;
+            }
+            else
+            {
+                // We want to turn inBuffer into at most count chars.  This algorithm basically works like this:
+                //
+                // 1) Take the largest step possible that won't give us too many chars
+                // 2) If we find some chars, walk backwards until we find exactly how many bytes
+                //    they occupy.  lastFullCharPos points to the end of the full chars.
+                // 3) if we don't have enough chars for the buffer, goto #1
+
+                int totalBytesExamined = 0;     // total number of Bytes in inBuffer we've looked at
+                int totalCharsFound = 0;        // total number of chars we've found in inBuffer, totalCharsFound <= totalBytesExamined
+                int currentBytesToExamine;      // the number of additional bytes to examine for characters
+                int currentCharsFound;          // the number of additional chars found after examining currentBytesToExamine extra bytes
+                int lastFullCharPos = _readPos; // first index AFTER last full char read, capped at ReadLen.
+                do
+                {
+                    currentBytesToExamine = Math.Min(count - totalCharsFound, _readLen - _readPos - totalBytesExamined);
+                    if (currentBytesToExamine <= 0)
+                        break;
+
+                    totalBytesExamined += currentBytesToExamine;
+
+                    // recalculate currentBytesToExamine so that it includes leftover bytes from the last iteration. 
+                    currentBytesToExamine = _readPos + totalBytesExamined - lastFullCharPos;
+
+                    // make sure we don't go beyond the end of the valid data that we have. 
+                    Debug.Assert((lastFullCharPos + currentBytesToExamine) <= _readLen, "We should never be attempting to read more bytes than we have");
+
+                    currentCharsFound = _decoder.GetCharCount(_inBuffer, lastFullCharPos, currentBytesToExamine);
+
+                    if (currentCharsFound > 0)
+                    {
+                        if ((totalCharsFound + currentCharsFound) > count)
+                        {
+                            // Multibyte unicode sequence (possibly surrogate chars) 
+                            // at the end of the buffer. We should not split the sequence, 
+                            // instead return with less chars now and defer reading them 
+                            // until next time
+                            if (!countMultiByteCharsAsOne)
+                                break;
+
+                            // If we are here it is from ReadTo which attempts to read one logical character 
+                            // at a time. The supplied singleCharBuffer should be large enough to accommodate 
+                            // this multi-byte char
+                            Debug.Assert((buffer.Length - offset - totalCharsFound) >= currentCharsFound, "internal buffer to read one full unicode char sequence is not sufficient!");
+                        }
+
+                        // go backwards until we know we have a full set of currentCharsFound bytes with no extra lead-bytes.
+                        int foundCharsByteLength = currentBytesToExamine;
+                        do
+                        {
+                            foundCharsByteLength--;
+                        } while (_decoder.GetCharCount(_inBuffer, lastFullCharPos, foundCharsByteLength) == currentCharsFound);
+
+                        // Fill into destination buffer all the COMPLETE characters we've read.
+                        // If the buffer specified is insufficient to accommodate surrogate character
+                        // the call to underlying Decoder.GetChars will throw argexc. We need not 
+                        // deal with this exc because we have not altered readPos yet.
+                        _decoder.GetChars(_inBuffer, lastFullCharPos, foundCharsByteLength + 1, buffer, offset + totalCharsFound);
+                        lastFullCharPos = lastFullCharPos + foundCharsByteLength + 1; // update the end position of last known char.
+                    }
+
+                    totalCharsFound += currentCharsFound;
+                } while ((totalCharsFound < count) && (totalBytesExamined < CachedBytesToRead));
+
+                _readPos = lastFullCharPos;
+
+                if (_readPos == _readLen) _readPos = _readLen = 0;
+                return totalCharsFound;
+            }
+        }
+
+        public int ReadByte()
+        {
+            if (!IsOpen)
+                throw new InvalidOperationException(SR.Port_not_open);
+            if (_readLen != _readPos)                // stuff left in buffer, so we can read from it
+                return _inBuffer[_readPos++];
+
+            _decoder.Reset();
+            return _internalSerialStream.ReadByte(); // otherwise, ask the stream.
+        }
+
+        public string ReadExisting()
+        {
+            if (!IsOpen)
+                throw new InvalidOperationException(SR.Port_not_open);
+
+            byte[] bytesReceived = new byte[BytesToRead];
+
+            if (_readPos < _readLen)
+            {
+                // stuff in internal buffer
+                Buffer.BlockCopy(_inBuffer, _readPos, bytesReceived, 0, CachedBytesToRead);
+            }
+
+            _internalSerialStream.Read(bytesReceived, CachedBytesToRead, bytesReceived.Length - (CachedBytesToRead));    // get everything
+            
+            // Read full characters and leave partial input in the buffer. Encoding.GetCharCount doesn't work because
+            // it returns fallback characters on partial input, meaning that it overcounts. Instead, we use 
+            // GetCharCount from the decoder and tell it to preserve state, so that it returns the count of full 
+            // characters. Note that we don't actually want it to preserve state, so we call the decoder as if it's 
+            // preserving state and then call Reset in between calls. This uses a local decoder instead of the class 
+            // member decoder because that one may preserve state across SerialPort method calls.
+            Decoder localDecoder = Encoding.GetDecoder();
+            int numCharsReceived = localDecoder.GetCharCount(bytesReceived, 0, bytesReceived.Length);
+            int lastFullCharIndex = bytesReceived.Length;
+
+            if (numCharsReceived == 0)
+            {
+                Buffer.BlockCopy(bytesReceived, 0, _inBuffer, 0, bytesReceived.Length); // put it all back!
+                // don't change readPos. --> readPos == 0?
+                _readPos = 0;
+                _readLen = bytesReceived.Length;
+                return "";
+            }
+
+            do
+            {
+                localDecoder.Reset();
+                lastFullCharIndex--;
+            } while (localDecoder.GetCharCount(bytesReceived, 0, lastFullCharIndex) == numCharsReceived);
+
+            _readPos = 0;
+            _readLen = bytesReceived.Length - (lastFullCharIndex + 1);
+
+            Buffer.BlockCopy(bytesReceived, lastFullCharIndex + 1, _inBuffer, 0, bytesReceived.Length - (lastFullCharIndex + 1));
+            return Encoding.GetString(bytesReceived, 0, lastFullCharIndex + 1);
+        }
+
+        public string ReadLine()
+        {
+            return ReadTo(NewLine);
+        }
+
+        public string ReadTo(string value)
+        {
+            if (!IsOpen)
+                throw new InvalidOperationException(SR.Port_not_open);
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            if (value.Length == 0)
+                throw new ArgumentException(string.Format(SR.InvalidNullEmptyArgument, nameof(value)));
+
+            int startTicks = Environment.TickCount;
+            int numCharsRead;
+            int timeUsed = 0;
+            int timeNow;
+            StringBuilder currentLine = new StringBuilder();
+            char lastValueChar = value[value.Length - 1];
+
+            // for timeout issues, best to read everything already on the stream into our buffers.
+            // first make sure inBuffer is big enough
+            int bytesInStream = _internalSerialStream.BytesToRead;
+            MaybeResizeBuffer(bytesInStream);
+
+            _readLen += _internalSerialStream.Read(_inBuffer, _readLen, bytesInStream);
+            int beginReadPos = _readPos;
+
+            if (_singleCharBuffer == null)
+            {
+                // This is somewhat of an approximate guesstimate to get the max char[] size needed to encode a single character
+                _singleCharBuffer = new char[_maxByteCountForSingleChar];
+            }
+
+            try
+            {
+                while (true)
+                {
+                    if (_readTimeout == InfiniteTimeout)
+                    {
+                        numCharsRead = InternalRead(_singleCharBuffer, 0, 1, _readTimeout, true);
+                    }
+                    else if (_readTimeout - timeUsed >= 0)
+                    {
+                        timeNow = Environment.TickCount;
+                        numCharsRead = InternalRead(_singleCharBuffer, 0, 1, _readTimeout - timeUsed, true);
+                        timeUsed += Environment.TickCount - timeNow;
+                    }
+                    else
+                        throw new TimeoutException();
+
+#if DEBUG
+                    if (numCharsRead > 1)
+                    {
+                        for (int i = 0; i < numCharsRead; i++)
+                            Debug.Assert((Char.IsSurrogate(_singleCharBuffer[i])), "number of chars read should be more than one only for surrogate characters!");
+                    }
+#endif
+                    Debug.Assert((numCharsRead > 0), "possible bug in ReadBufferIntoChars, reading surrogate char?");
+                    currentLine.Append(_singleCharBuffer, 0, numCharsRead);
+
+                    if (lastValueChar == (char)_singleCharBuffer[numCharsRead - 1] && (currentLine.Length >= value.Length))
+                    {
+                        // we found the last char in the value string.  See if the rest is there.  No need to
+                        // recompare the last char of the value string.
+                        bool found = true;
+                        for (int i = 2; i <= value.Length; i++)
+                        {
+                            if (value[value.Length - i] != currentLine[currentLine.Length - i])
+                            {
+                                found = false;
+                                break;
+                            }
+                        }
+
+                        if (found)
+                        {
+                            // we found the search string.  Exclude it from the return string.
+                            string ret = currentLine.ToString(0, currentLine.Length - value.Length);
+                            if (_readPos == _readLen) _readPos = _readLen = 0;
+                            return ret;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // We probably got here due to timeout. 
+                // We will try our best to restore the internal states, it's tricky!
+
+                // 0) Save any existing data
+                // 1) Restore readPos to the original position upon entering ReadTo 
+                // 2) Set readLen to the number of bytes read since entering ReadTo
+                // 3) Restore inBuffer so that it contains the bytes from currentLine, resizing if necessary.
+                // 4) Append the buffer with any saved data from 0) 
+
+                byte[] readBuffer = _encoding.GetBytes(currentLine.ToString());
+
+                // We will compact the data by default
+                if (readBuffer.Length > 0)
+                {
+                    int bytesToSave = CachedBytesToRead;
+                    byte[] savBuffer = new byte[bytesToSave];
+
+                    if (bytesToSave > 0)
+                        Buffer.BlockCopy(_inBuffer, _readPos, savBuffer, 0, bytesToSave);
+
+                    _readPos = 0;
+                    _readLen = 0;
+
+                    MaybeResizeBuffer(readBuffer.Length + bytesToSave);
+
+                    Buffer.BlockCopy(readBuffer, 0, _inBuffer, _readLen, readBuffer.Length);
+                    _readLen += readBuffer.Length;
+
+                    if (bytesToSave > 0)
+                    {
+                        Buffer.BlockCopy(savBuffer, 0, _inBuffer, _readLen, bytesToSave);
+                        _readLen += bytesToSave;
+                    }
+                }
+
+                throw;
+            }
+        }
+
+        // Writes string to output, no matter string's length.
+        public void Write(string text)
+        {
+            if (!IsOpen)
+                throw new InvalidOperationException(SR.Port_not_open);
+            if (text == null)
+                throw new ArgumentNullException(nameof(text));
+            if (text.Length == 0) return;
+            byte[] bytesToWrite;
+
+            bytesToWrite = _encoding.GetBytes(text);
+
+            _internalSerialStream.Write(bytesToWrite, 0, bytesToWrite.Length, _writeTimeout);
+        }
+
+        // encoding-dependent Write-chars method.
+        // Probably as performant as direct conversion from ASCII to bytes, since we have to cast anyway (we can just call GetBytes)
+        public void Write(char[] buffer, int offset, int count)
+        {
+            if (!IsOpen)
+                throw new InvalidOperationException(SR.Port_not_open);
+            if (buffer == null)
+                throw new ArgumentNullException(nameof(buffer));
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset), SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+            if (buffer.Length - offset < count)
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+
+            if (buffer.Length == 0) return;
+
+            byte[] byteArray = Encoding.GetBytes(buffer, offset, count);
+            Write(byteArray, 0, byteArray.Length);
+        }
+
+        // Writes a specified section of a byte buffer to output.
+        public void Write(byte[] buffer, int offset, int count)
+        {
+            if (!IsOpen)
+                throw new InvalidOperationException(SR.Port_not_open);
+            if (buffer == null)
+                throw new ArgumentNullException(nameof(buffer), SR.ArgumentNull_Buffer);
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset), SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+            if (buffer.Length - offset < count)
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+            if (buffer.Length == 0) return;
+
+            _internalSerialStream.Write(buffer, offset, count, _writeTimeout);
+        }
+
+        public void WriteLine(string text)
+        {
+            Write(text + NewLine);
+        }
+
+#pragma warning disable CA2002
+        // ----- SECTION: internal utility methods ----------------*
+
+        // included here just to use the event filter to block unwanted invocations of the Serial Port's events.
+        // Plus, this enforces the requirement on the received event that the number of buffered bytes >= receivedBytesThreshold
+        private void CatchErrorEvents(object src, SerialErrorReceivedEventArgs e)
+        {
+            SerialErrorReceivedEventHandler eventHandler = ErrorReceived;
+            SerialStream stream = _internalSerialStream;
+
+            if ((eventHandler != null) && (stream != null))
+            {
+                lock (stream)
+                {
+                    if (stream.IsOpen)
+                        eventHandler(this, e);
+                }
+            }
+        }
+
+        private void CatchPinChangedEvents(object src, SerialPinChangedEventArgs e)
+        {
+            SerialPinChangedEventHandler eventHandler = PinChanged;
+            SerialStream stream = _internalSerialStream;
+
+            if ((eventHandler != null) && (stream != null))
+            {
+                lock (stream)
+                {
+                    if (stream.IsOpen)
+                        eventHandler(this, e);
+                }
+            }
+        }
+
+        private void CatchReceivedEvents(object src, SerialDataReceivedEventArgs e)
+        {
+            SerialDataReceivedEventHandler eventHandler = DataReceived;
+            SerialStream stream = _internalSerialStream;
+
+            if ((eventHandler != null) && (stream != null))
+            {
+                lock (stream)
+                {
+                    // SerialStream might be closed between the time the event runner
+                    // pumped this event and the time the threadpool thread end up 
+                    // invoking this event handler. The above lock and IsOpen check 
+                    // ensures that we raise the event only when the port is open
+
+                    bool raiseEvent = false;
+                    try
+                    {
+                        raiseEvent = stream.IsOpen && (SerialData.Eof == e.EventType || BytesToRead >= _receivedBytesThreshold);
+                    }
+                    catch
+                    {
+                        // Ignore and continue. SerialPort might have been closed already! 
+                    }
+                    finally
+                    {
+                        if (raiseEvent)
+                            eventHandler(this, e);  // here, do your reading, etc. 
+                    }
+                }
+            }
+        }
+#pragma warning restore CA2002
+
+        private void CompactBuffer()
+        {
+            Buffer.BlockCopy(_inBuffer, _readPos, _inBuffer, 0, CachedBytesToRead);
+            _readLen = CachedBytesToRead;
+            _readPos = 0;
+        }
+
+        // This method guarantees that our inBuffer is big enough.  The parameter passed in is
+        // the number of bytes that our code is going to add to inBuffer.  MaybeResizeBuffer will 
+        // do one of three things depending on how much data is already in the buffer and how 
+        // much will be added:
+        // 1) Nothing.  The current buffer is big enough to hold it all
+        // 2) Compact the existing data and keep the current buffer. 
+        // 3) Create a new, larger buffer and compact the existing data into it.
+        private void MaybeResizeBuffer(int additionalByteLength)
+        {
+            // Case 1.  No action needed
+            if (additionalByteLength + _readLen <= _inBuffer.Length)
+                return;
+
+            // Case 2.  Compact
+            if (CachedBytesToRead + additionalByteLength <= _inBuffer.Length / 2)
+                CompactBuffer();
+            else
+            {
+                // Case 3.  Create a new buffer
+                int newLength = Math.Max(CachedBytesToRead + additionalByteLength, _inBuffer.Length * 2);
+
+                Debug.Assert(_inBuffer.Length >= _readLen, "ResizeBuffer - readLen > inBuffer.Length");
+                byte[] newBuffer = new byte[newLength];
+                // only copy the valid data from inBuffer, and put it at the beginning of newBuffer.
+                Buffer.BlockCopy(_inBuffer, _readPos, newBuffer, 0, CachedBytesToRead);
+                _readLen = CachedBytesToRead;
+                _readPos = 0;
+                _inBuffer = newBuffer;
+            }
+        }
+
+        private static int GetElapsedTime(int currentTickCount, int startTickCount)
+        {
+            int elapsedTime = unchecked(currentTickCount - startTickCount);
+            return (elapsedTime >= 0) ? (int)elapsedTime : Int32.MaxValue;
+        }
+    }
+}

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.cs
@@ -1,0 +1,1997 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+// Notes about the SerialStream:
+//  * The stream is always opened via the SerialStream constructor.
+//  * Lifetime of the COM port's handle is controlled via a SafeHandle.  Thus, all properties are available
+//  * only when the SerialStream is open and not disposed.
+//  * Handles to serial communications resources here always:
+//  * 1) own the handle
+//  * 2) are opened for asynchronous operation
+//  * 3) set access at the level of FileAccess.ReadWrite
+//  * 4) Allow for reading AND writing
+//  * 5) Disallow seeking, since they encapsulate a file of type FILE_TYPE_CHAR
+
+namespace System.IO.Ports
+{
+    internal sealed class SerialStream : Stream
+    {
+        private const int ErrorEvents = (int)(SerialError.Frame | SerialError.Overrun |
+                                 SerialError.RXOver | SerialError.RXParity | SerialError.TXFull);
+        private const int ReceivedEvents = (int)(SerialData.Chars | SerialData.Eof);
+        private const int PinChangedEvents = (int)(SerialPinChange.Break | SerialPinChange.CDChanged | SerialPinChange.CtsChanged |
+                                      SerialPinChange.Ring | SerialPinChange.DsrChanged);
+
+        private const int infiniteTimeoutConst = -2;
+        private const int MaxDataBits = 8;
+        private const int MinDataBits = 5;
+
+        // members supporting properties exposed to SerialPort
+        private string _portName;
+        private byte _parityReplace = (byte)'?';
+        private bool _inBreak = false;               // port is initially in non-break state
+        private bool _isAsync = true;
+        private Handshake _handshake;
+        private bool _rtsEnable = false;
+
+        // The internal C# representations of Win32 structures necessary for communication
+        // hold most of the internal "fields" maintaining information about the port.
+        private Interop.Kernel32.DCB _dcb;
+        private Interop.Kernel32.COMMTIMEOUTS _commTimeouts;
+        private Interop.Kernel32.COMSTAT _comStat;
+        private Interop.Kernel32.COMMPROP _commProp;
+
+        // internal-use members
+        internal SafeFileHandle _handle = null;
+        internal EventLoopRunner _eventRunner;
+
+        private byte[] _tempBuf;                 // used to avoid multiple array allocations in ReadByte()
+
+        // called whenever any async i/o operation completes.
+        private unsafe static readonly IOCompletionCallback s_IOCallback = new IOCompletionCallback(AsyncFSCallback);
+
+        // three different events, also wrapped by SerialPort.
+        internal event SerialDataReceivedEventHandler DataReceived;      // called when one character is received.
+        internal event SerialPinChangedEventHandler PinChanged;    // called when any of the pin/ring-related triggers occurs
+        internal event SerialErrorReceivedEventHandler ErrorReceived;         // called when any runtime error occurs on the port (frame, overrun, parity, etc.)
+
+
+        // ----SECTION: inherited properties from Stream class ------------*
+
+        // These six properites are required for SerialStream to inherit from the abstract Stream class.
+        // Note four of them are always true or false, and two of them throw exceptions, so these
+        // are not usefully queried by applications which know they have a SerialStream, etc...
+        public override bool CanRead
+        {
+            get { return (_handle != null); }
+        }
+
+        public override bool CanSeek
+        {
+            get { return false; }
+        }
+
+        public override bool CanTimeout
+        {
+            get { return (_handle != null); }
+        }
+
+        public override bool CanWrite
+        {
+            get { return (_handle != null); }
+        }
+
+        public override long Length
+        {
+            get { throw new NotSupportedException(SR.NotSupported_UnseekableStream); }
+        }
+
+        public override long Position
+        {
+            get { throw new NotSupportedException(SR.NotSupported_UnseekableStream); }
+            set { throw new NotSupportedException(SR.NotSupported_UnseekableStream); }
+        }
+
+        // ----- new get-set properties -----------------*
+
+        // Standard port properties, also called from SerialPort
+        // BaudRate may not be settable to an arbitrary integer between dwMinBaud and dwMaxBaud,
+        // and is limited only by the serial driver.  Typically about twelve values such
+        // as Winbase.h's CBR_110 through CBR_256000 are used.
+        internal int BaudRate
+        {
+            set
+            {
+                if (value <= 0 || (value > _commProp.dwMaxBaud && _commProp.dwMaxBaud > 0))
+                {
+                    // if no upper bound on baud rate imposed by serial driver, note that argument must be positive
+                    if (_commProp.dwMaxBaud == 0)
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(BaudRate), SR.ArgumentOutOfRange_NeedPosNum);
+                    }
+                    else
+                    {
+                        // otherwise, we can present the bounds on the baud rate for this driver
+                        throw new ArgumentOutOfRangeException(nameof(BaudRate), string.Format(SR.ArgumentOutOfRange_Bounds_Lower_Upper, 0, _commProp.dwMaxBaud));
+                    }
+                }
+                // Set only if it's different.  Rollback to previous values if setting fails.
+                //  This pattern occurs through most of the other properties in this class.
+                if (value != _dcb.BaudRate)
+                {
+                    int baudRateOld = (int)_dcb.BaudRate;
+                    _dcb.BaudRate = (uint)value;
+
+                    if (Interop.Kernel32.SetCommState(_handle, ref _dcb) == false)
+                    {
+                        _dcb.BaudRate = (uint)baudRateOld;
+                        InternalResources.WinIOError();
+                    }
+                }
+            }
+        }
+
+        public bool BreakState
+        {
+            get { return _inBreak; }
+            set
+            {
+                if (value)
+                {
+                    if (Interop.Kernel32.SetCommBreak(_handle) == false)
+                        InternalResources.WinIOError();
+                    _inBreak = true;
+                }
+                else
+                {
+                    if (Interop.Kernel32.ClearCommBreak(_handle) == false)
+                        InternalResources.WinIOError();
+                    _inBreak = false;
+                }
+            }
+        }
+
+        internal int DataBits
+        {
+            set
+            {
+                Debug.Assert(!(value < MinDataBits || value > MaxDataBits), "An invalid value was passed to DataBits");
+                if (value != _dcb.ByteSize)
+                {
+                    byte byteSizeOld = _dcb.ByteSize;
+                    _dcb.ByteSize = (byte)value;
+
+                    if (Interop.Kernel32.SetCommState(_handle, ref _dcb) == false)
+                    {
+                        _dcb.ByteSize = byteSizeOld;
+                        InternalResources.WinIOError();
+                    }
+                }
+            }
+        }
+
+        internal bool DiscardNull
+        {
+            set
+            {
+                int fNullFlag = GetDcbFlag(NativeMethods.FNULL);
+                if (value == true && fNullFlag == 0 || value == false && fNullFlag == 1)
+                {
+                    int fNullOld = fNullFlag;
+                    SetDcbFlag(NativeMethods.FNULL, value ? 1 : 0);
+
+                    if (Interop.Kernel32.SetCommState(_handle, ref _dcb) == false)
+                    {
+                        SetDcbFlag(NativeMethods.FNULL, fNullOld);
+                        InternalResources.WinIOError();
+                    }
+                }
+            }
+        }
+
+        internal bool DtrEnable
+        {
+            get
+            {
+                int fDtrControl = GetDcbFlag(NativeMethods.FDTRCONTROL);
+
+                return (fDtrControl == NativeMethods.DTR_CONTROL_ENABLE);
+            }
+            set
+            {
+                // first set the FDTRCONTROL field in the DCB struct
+                int fDtrControlOld = GetDcbFlag(NativeMethods.FDTRCONTROL);
+
+                SetDcbFlag(NativeMethods.FDTRCONTROL, value ? NativeMethods.DTR_CONTROL_ENABLE : NativeMethods.DTR_CONTROL_DISABLE);
+                if (Interop.Kernel32.SetCommState(_handle, ref _dcb) == false)
+                {
+                    SetDcbFlag(NativeMethods.FDTRCONTROL, fDtrControlOld);
+                    InternalResources.WinIOError();
+                }
+
+                // then set the actual pin 
+                if (!Interop.Kernel32.EscapeCommFunction(_handle, value ? NativeMethods.SETDTR : NativeMethods.CLRDTR))
+                    InternalResources.WinIOError();
+            }
+        }
+
+        internal Handshake Handshake
+        {
+            set
+            {
+                Debug.Assert(!(value < Handshake.None || value > Handshake.RequestToSendXOnXOff),
+                    "An invalid value was passed to Handshake");
+
+                if (value != _handshake)
+                {
+                    // in the DCB, handshake affects the fRtsControl, fOutxCtsFlow, and fInX, fOutX fields,
+                    // so we must save everything in that closure before making any changes.
+                    Handshake handshakeOld = _handshake;
+                    int fInOutXOld = GetDcbFlag(NativeMethods.FINX);
+                    int fOutxCtsFlowOld = GetDcbFlag(NativeMethods.FOUTXCTSFLOW);
+                    int fRtsControlOld = GetDcbFlag(NativeMethods.FRTSCONTROL);
+
+                    _handshake = value;
+                    int fInXOutXFlag = (_handshake == Handshake.XOnXOff || _handshake == Handshake.RequestToSendXOnXOff) ? 1 : 0;
+                    SetDcbFlag(NativeMethods.FINX, fInXOutXFlag);
+                    SetDcbFlag(NativeMethods.FOUTX, fInXOutXFlag);
+
+                    SetDcbFlag(NativeMethods.FOUTXCTSFLOW, (_handshake == Handshake.RequestToSend ||
+                        _handshake == Handshake.RequestToSendXOnXOff) ? 1 : 0);
+
+                    if ((_handshake == Handshake.RequestToSend ||
+                        _handshake == Handshake.RequestToSendXOnXOff))
+                    {
+                        SetDcbFlag(NativeMethods.FRTSCONTROL, NativeMethods.RTS_CONTROL_HANDSHAKE);
+                    }
+                    else if (_rtsEnable)
+                    {
+                        SetDcbFlag(NativeMethods.FRTSCONTROL, NativeMethods.RTS_CONTROL_ENABLE);
+                    }
+                    else
+                    {
+                        SetDcbFlag(NativeMethods.FRTSCONTROL, NativeMethods.RTS_CONTROL_DISABLE);
+                    }
+
+                    if (Interop.Kernel32.SetCommState(_handle, ref _dcb) == false)
+                    {
+                        _handshake = handshakeOld;
+                        SetDcbFlag(NativeMethods.FINX, fInOutXOld);
+                        SetDcbFlag(NativeMethods.FOUTX, fInOutXOld);
+                        SetDcbFlag(NativeMethods.FOUTXCTSFLOW, fOutxCtsFlowOld);
+                        SetDcbFlag(NativeMethods.FRTSCONTROL, fRtsControlOld);
+                        InternalResources.WinIOError();
+                    }
+
+                }
+            }
+        }
+
+        internal bool IsOpen => _handle != null && !_eventRunner.ShutdownLoop;
+
+        internal Parity Parity
+        {
+            set
+            {
+                Debug.Assert(!(value < Parity.None || value > Parity.Space), "An invalid value was passed to Parity");
+
+                if ((byte)value != _dcb.Parity)
+                {
+                    byte parityOld = _dcb.Parity;
+
+                    // in the DCB structure, the parity setting also potentially effects:
+                    // fParity, fErrorChar, ErrorChar
+                    // so these must be saved as well.
+                    int fParityOld = GetDcbFlag(NativeMethods.FPARITY);
+                    byte ErrorCharOld = _dcb.ErrorChar;
+                    int fErrorCharOld = GetDcbFlag(NativeMethods.FERRORCHAR);
+                    _dcb.Parity = (byte)value;
+
+                    int parityFlag = (_dcb.Parity == (byte)Parity.None) ? 0 : 1;
+                    SetDcbFlag(NativeMethods.FPARITY, parityFlag);
+                    if (parityFlag == 1)
+                    {
+                        SetDcbFlag(NativeMethods.FERRORCHAR, (_parityReplace != '\0') ? 1 : 0);
+                        _dcb.ErrorChar = _parityReplace;
+                    }
+                    else
+                    {
+                        SetDcbFlag(NativeMethods.FERRORCHAR, 0);
+                        _dcb.ErrorChar = (byte)'\0';
+                    }
+                    if (Interop.Kernel32.SetCommState(_handle, ref _dcb) == false)
+                    {
+                        _dcb.Parity = parityOld;
+                        SetDcbFlag(NativeMethods.FPARITY, fParityOld);
+
+                        _dcb.ErrorChar = ErrorCharOld;
+                        SetDcbFlag(NativeMethods.FERRORCHAR, fErrorCharOld);
+
+                        InternalResources.WinIOError();
+                    }
+                }
+            }
+        }
+
+        // ParityReplace is the eight-bit character which replaces any bytes which
+        // ParityReplace affects the equivalent field in the DCB structure: ErrorChar, and
+        // the DCB flag fErrorChar.
+        internal byte ParityReplace
+        {
+            set
+            {
+                if (value != _parityReplace)
+                {
+                    byte parityReplaceOld = _parityReplace;
+                    byte errorCharOld = _dcb.ErrorChar;
+                    int fErrorCharOld = GetDcbFlag(NativeMethods.FERRORCHAR);
+
+                    _parityReplace = value;
+                    if (GetDcbFlag(NativeMethods.FPARITY) == 1)
+                    {
+                        SetDcbFlag(NativeMethods.FERRORCHAR, (_parityReplace != '\0') ? 1 : 0);
+                        _dcb.ErrorChar = _parityReplace;
+                    }
+                    else
+                    {
+                        SetDcbFlag(NativeMethods.FERRORCHAR, 0);
+                        _dcb.ErrorChar = (byte)'\0';
+                    }
+
+                    if (Interop.Kernel32.SetCommState(_handle, ref _dcb) == false)
+                    {
+                        _parityReplace = parityReplaceOld;
+                        SetDcbFlag(NativeMethods.FERRORCHAR, fErrorCharOld);
+                        _dcb.ErrorChar = errorCharOld;
+                        InternalResources.WinIOError();
+                    }
+                }
+            }
+        }
+
+        // Timeouts are considered to be TOTAL time for the Read/Write operation and to be in milliseconds.
+        // Timeouts are translated into DCB structure as follows:
+        //
+        //  Desired timeout      =>  ReadTotalTimeoutConstant    ReadTotalTimeoutMultiplier  ReadIntervalTimeout
+        //   0                                   0                           0               MAXDWORD
+        //   0 < n < infinity                    n                       MAXDWORD            MAXDWORD
+        //  infinity                             infiniteTimeoutConst    MAXDWORD            MAXDWORD
+        //
+        // rationale for "infinity": There does not exist in the COMMTIMEOUTS structure a way to
+        // *wait indefinitely for any byte, return when found*.  Instead, if we set ReadTimeout
+        // to infinity, SerialStream's EndRead loops if infiniteTimeoutConst mills have elapsed
+        // without a byte received.  Note that this is approximately 24 days, so essentially
+        // most practical purposes effectively equate 24 days with an infinite amount of time
+        // on a serial port connection.
+        public override int ReadTimeout
+        {
+            get
+            {
+                int constant = _commTimeouts.ReadTotalTimeoutConstant;
+
+                if (constant == infiniteTimeoutConst) return SerialPort.InfiniteTimeout;
+                else return constant;
+            }
+            set
+            {
+                if (value < 0 && value != SerialPort.InfiniteTimeout)
+                    throw new ArgumentOutOfRangeException(nameof(ReadTimeout), SR.ArgumentOutOfRange_Timeout);
+                if (_handle == null) InternalResources.FileNotOpen();
+
+                int oldReadConstant = _commTimeouts.ReadTotalTimeoutConstant;
+                int oldReadInterval = _commTimeouts.ReadIntervalTimeout;
+                int oldReadMultipler = _commTimeouts.ReadTotalTimeoutMultiplier;
+
+                // NOTE: this logic should match what is in the constructor
+                if (value == 0)
+                {
+                    _commTimeouts.ReadTotalTimeoutConstant = 0;
+                    _commTimeouts.ReadTotalTimeoutMultiplier = 0;
+                    _commTimeouts.ReadIntervalTimeout = NativeMethods.MAXDWORD;
+                }
+                else if (value == SerialPort.InfiniteTimeout)
+                {
+                    // SetCommTimeouts doesn't like a value of -1 for some reason, so
+                    // we'll use -2(infiniteTimeoutConst) to represent infinite. 
+                    _commTimeouts.ReadTotalTimeoutConstant = infiniteTimeoutConst;
+                    _commTimeouts.ReadTotalTimeoutMultiplier = NativeMethods.MAXDWORD;
+                    _commTimeouts.ReadIntervalTimeout = NativeMethods.MAXDWORD;
+                }
+                else
+                {
+                    _commTimeouts.ReadTotalTimeoutConstant = value;
+                    _commTimeouts.ReadTotalTimeoutMultiplier = NativeMethods.MAXDWORD;
+                    _commTimeouts.ReadIntervalTimeout = NativeMethods.MAXDWORD;
+                }
+
+                if (Interop.Kernel32.SetCommTimeouts(_handle, ref _commTimeouts) == false)
+                {
+                    _commTimeouts.ReadTotalTimeoutConstant = oldReadConstant;
+                    _commTimeouts.ReadTotalTimeoutMultiplier = oldReadMultipler;
+                    _commTimeouts.ReadIntervalTimeout = oldReadInterval;
+                    InternalResources.WinIOError();
+                }
+            }
+        }
+
+        internal bool RtsEnable
+        {
+            get
+            {
+                int fRtsControl = GetDcbFlag(NativeMethods.FRTSCONTROL);
+                if (fRtsControl == NativeMethods.RTS_CONTROL_HANDSHAKE)
+                    throw new InvalidOperationException(SR.CantSetRtsWithHandshaking);
+
+                return (fRtsControl == NativeMethods.RTS_CONTROL_ENABLE);
+            }
+            set
+            {
+                if ((_handshake == Handshake.RequestToSend || _handshake == Handshake.RequestToSendXOnXOff))
+                    throw new InvalidOperationException(SR.CantSetRtsWithHandshaking);
+
+                if (value != _rtsEnable)
+                {
+                    int fRtsControlOld = GetDcbFlag(NativeMethods.FRTSCONTROL);
+
+                    _rtsEnable = value;
+                    if (value)
+                        SetDcbFlag(NativeMethods.FRTSCONTROL, NativeMethods.RTS_CONTROL_ENABLE);
+                    else
+                        SetDcbFlag(NativeMethods.FRTSCONTROL, NativeMethods.RTS_CONTROL_DISABLE);
+
+                    if (Interop.Kernel32.SetCommState(_handle, ref _dcb) == false)
+                    {
+                        SetDcbFlag(NativeMethods.FRTSCONTROL, fRtsControlOld);
+                        // set it back to the old value on a failure
+                        _rtsEnable = !_rtsEnable;
+                        InternalResources.WinIOError();
+                    }
+
+                    if (!Interop.Kernel32.EscapeCommFunction(_handle, value ? NativeMethods.SETRTS : NativeMethods.CLRRTS))
+                        InternalResources.WinIOError();
+                }
+            }
+        }
+
+        // StopBits represented in C# as StopBits enum type and in Win32 as an integer 1, 2, or 3.
+        internal StopBits StopBits
+        {
+            set
+            {
+                Debug.Assert(!(value < StopBits.One || value > StopBits.OnePointFive), "An invalid value was passed to StopBits");
+
+                byte nativeValue = 0;
+                if (value == StopBits.One) nativeValue = NativeMethods.ONESTOPBIT;
+                else if (value == StopBits.OnePointFive) nativeValue = NativeMethods.ONE5STOPBITS;
+                else nativeValue = NativeMethods.TWOSTOPBITS;
+
+                if (nativeValue != _dcb.StopBits)
+                {
+                    byte stopBitsOld = _dcb.StopBits;
+                    _dcb.StopBits = nativeValue;
+
+                    if (Interop.Kernel32.SetCommState(_handle, ref _dcb) == false)
+                    {
+                        _dcb.StopBits = stopBitsOld;
+                        InternalResources.WinIOError();
+                    }
+                }
+            }
+        }
+
+        // note: WriteTimeout must be either SerialPort.InfiniteTimeout or POSITIVE.
+        // a timeout of zero implies that every Write call throws an exception.
+        public override int WriteTimeout
+        {
+            get
+            {
+                int timeout = _commTimeouts.WriteTotalTimeoutConstant;
+                return (timeout == 0) ? SerialPort.InfiniteTimeout : timeout;
+            }
+            set
+            {
+                if (value <= 0 && value != SerialPort.InfiniteTimeout)
+                    throw new ArgumentOutOfRangeException("WriteTimeout", SR.ArgumentOutOfRange_WriteTimeout);
+                if (_handle == null) InternalResources.FileNotOpen();
+
+                int oldWriteConstant = _commTimeouts.WriteTotalTimeoutConstant;
+                _commTimeouts.WriteTotalTimeoutConstant = ((value == SerialPort.InfiniteTimeout) ? 0 : value);
+
+                if (Interop.Kernel32.SetCommTimeouts(_handle, ref _commTimeouts) == false)
+                {
+                    _commTimeouts.WriteTotalTimeoutConstant = oldWriteConstant;
+                    InternalResources.WinIOError();
+                }
+            }
+        }
+
+        // CDHolding, CtsHolding, DsrHolding query the current state of each of the carrier, the CTS pin,
+        // and the DSR pin, respectively. Read-only.
+        // All will throw exceptions if the port is not open.
+        internal bool CDHolding
+        {
+            get
+            {
+                int pinStatus = 0;
+                if (Interop.Kernel32.GetCommModemStatus(_handle, ref pinStatus) == false)
+                    InternalResources.WinIOError();
+
+                return (NativeMethods.MS_RLSD_ON & pinStatus) != 0;
+            }
+        }
+
+        internal bool CtsHolding
+        {
+            get
+            {
+                int pinStatus = 0;
+                if (Interop.Kernel32.GetCommModemStatus(_handle, ref pinStatus) == false)
+                    InternalResources.WinIOError();
+                return (NativeMethods.MS_CTS_ON & pinStatus) != 0;
+            }
+
+        }
+
+        internal bool DsrHolding
+        {
+            get
+            {
+                int pinStatus = 0;
+                if (Interop.Kernel32.GetCommModemStatus(_handle, ref pinStatus) == false)
+                    InternalResources.WinIOError();
+
+                return (NativeMethods.MS_DSR_ON & pinStatus) != 0;
+            }
+        }
+
+
+        // Fills comStat structure from an unmanaged function
+        // to determine the number of bytes waiting in the serial driver's internal receive buffer.
+        internal int BytesToRead
+        {
+            get
+            {
+                int errorCode = 0; // "ref" arguments need to have values, as opposed to "out" arguments
+                if (Interop.Kernel32.ClearCommError(_handle, ref errorCode, ref _comStat) == false)
+                {
+                    InternalResources.WinIOError();
+                }
+                return (int)_comStat.cbInQue;
+            }
+        }
+
+        // Fills comStat structure from an unmanaged function
+        // to determine the number of bytes waiting in the serial driver's internal transmit buffer.
+        internal int BytesToWrite
+        {
+            get
+            {
+                int errorCode = 0; // "ref" arguments need to be set before method invocation, as opposed to "out" arguments
+                if (Interop.Kernel32.ClearCommError(_handle, ref errorCode, ref _comStat) == false)
+                    InternalResources.WinIOError();
+                return (int)_comStat.cbOutQue;
+
+            }
+        }
+
+        // -----------SECTION: constructor --------------------------*
+
+        // this method is used by SerialPort upon SerialStream's creation
+        internal SerialStream(string portName, int baudRate, Parity parity, int dataBits, StopBits stopBits, int readTimeout, int writeTimeout, Handshake handshake,
+            bool dtrEnable, bool rtsEnable, bool discardNull, byte parityReplace)
+        {
+            int flags = NativeMethods.FILE_FLAG_OVERLAPPED;
+
+            // disable async on win9x
+            if (Environment.OSVersion.Platform == PlatformID.Win32Windows)
+            {
+                flags = NativeMethods.FILE_ATTRIBUTE_NORMAL;
+                _isAsync = false;
+            }
+
+            if ((portName == null) || !portName.StartsWith("COM", StringComparison.OrdinalIgnoreCase))
+                throw new ArgumentException(SR.Arg_InvalidSerialPort, nameof(portName));
+
+            // Error checking done in SerialPort.
+
+            SafeFileHandle tempHandle = Interop.Kernel32.CreateFileDefaultSecurity(@"\\\\?\\" + portName,
+                Interop.Kernel32.GenericOperations.GENERIC_READ | Interop.Kernel32.GenericOperations.GENERIC_WRITE,
+                0,              // comm devices must be opened w/exclusive-access
+                FileMode.Open,  // comm devices must use OPEN_EXISTING
+                flags);
+
+            if (tempHandle.IsInvalid)
+            {
+                InternalResources.WinIOError(portName);
+            }
+
+            try
+            {
+                int fileType = Interop.Kernel32.GetFileType(tempHandle);
+
+                // Allowing FILE_TYPE_UNKNOWN for legitimate serial device such as USB to serial adapter device 
+                if ((fileType != Interop.Kernel32.FileTypes.FILE_TYPE_CHAR) && (fileType != Interop.Kernel32.FileTypes.FILE_TYPE_UNKNOWN))
+                    throw new ArgumentException(SR.Arg_InvalidSerialPort, nameof(portName));
+
+                _handle = tempHandle;
+
+                // set properties of the stream that exist as members in SerialStream
+                _portName = portName;
+                _handshake = handshake;
+                _parityReplace = parityReplace;
+
+                _tempBuf = new byte[1];          // used in ReadByte()
+
+                // Fill COMMPROPERTIES struct, which has our maximum allowed baud rate.
+                // Call a serial specific API such as GetCommModemStatus which would fail
+                // in case the device is not a legitimate serial device. For instance, 
+                // some illegal FILE_TYPE_UNKNOWN device (or) "LPT1" on Win9x 
+                // trying to pass for serial will be caught here. GetCommProperties works
+                // fine for "LPT1" on Win9x, so that alone can't be relied here to
+                // detect non serial devices.
+
+                _commProp = new Interop.Kernel32.COMMPROP();
+                int pinStatus = 0;
+
+                if (!Interop.Kernel32.GetCommProperties(_handle, ref _commProp)
+                    || !Interop.Kernel32.GetCommModemStatus(_handle, ref pinStatus))
+                {
+                    // If the portName they have passed in is a FILE_TYPE_CHAR but not a serial port,
+                    // for example "LPT1", this API will fail.  For this reason we handle the error message specially. 
+                    int errorCode = Marshal.GetLastWin32Error();
+                    if ((errorCode == Interop.Errors.ERROR_INVALID_PARAMETER) || (errorCode == Interop.Errors.ERROR_INVALID_HANDLE))
+                        throw new ArgumentException(SR.Arg_InvalidSerialPortExtended, nameof(portName));
+                    else
+                        InternalResources.WinIOError(errorCode, string.Empty);
+                }
+
+                if (_commProp.dwMaxBaud != 0 && baudRate > _commProp.dwMaxBaud)
+                    throw new ArgumentOutOfRangeException(nameof(baudRate), string.Format(SR.Max_Baud, _commProp.dwMaxBaud));
+
+                _comStat = new Interop.Kernel32.COMSTAT();
+                // create internal DCB structure, initialize according to Platform SDK
+                // standard: ms-help://MS.MSNDNQTR.2002APR.1003/hardware/commun_965u.htm
+                _dcb = new Interop.Kernel32.DCB();
+
+                // set constant properties of the DCB
+                InitializeDCB(baudRate, parity, dataBits, stopBits, discardNull);
+
+                DtrEnable = dtrEnable;
+
+                // query and cache the initial RtsEnable value 
+                // so that set_RtsEnable can do the (value != rtsEnable) optimization
+                _rtsEnable = (GetDcbFlag(NativeMethods.FRTSCONTROL) == NativeMethods.RTS_CONTROL_ENABLE);
+
+                // now set this.RtsEnable to the specified value.
+                // Handshake takes precedence, this will be a nop if 
+                // handshake is either RequestToSend or RequestToSendXOnXOff 
+                if ((handshake != Handshake.RequestToSend && handshake != Handshake.RequestToSendXOnXOff))
+                    RtsEnable = rtsEnable;
+
+                // NOTE: this logic should match what is in the ReadTimeout property
+                if (readTimeout == 0)
+                {
+                    _commTimeouts.ReadTotalTimeoutConstant = 0;
+                    _commTimeouts.ReadTotalTimeoutMultiplier = 0;
+                    _commTimeouts.ReadIntervalTimeout = NativeMethods.MAXDWORD;
+                }
+                else if (readTimeout == SerialPort.InfiniteTimeout)
+                {
+                    // SetCommTimeouts doesn't like a value of -1 for some reason, so
+                    // we'll use -2(infiniteTimeoutConst) to represent infinite. 
+                    _commTimeouts.ReadTotalTimeoutConstant = infiniteTimeoutConst;
+                    _commTimeouts.ReadTotalTimeoutMultiplier = NativeMethods.MAXDWORD;
+                    _commTimeouts.ReadIntervalTimeout = NativeMethods.MAXDWORD;
+                }
+                else
+                {
+                    _commTimeouts.ReadTotalTimeoutConstant = readTimeout;
+                    _commTimeouts.ReadTotalTimeoutMultiplier = NativeMethods.MAXDWORD;
+                    _commTimeouts.ReadIntervalTimeout = NativeMethods.MAXDWORD;
+                }
+
+                _commTimeouts.WriteTotalTimeoutMultiplier = 0;
+                _commTimeouts.WriteTotalTimeoutConstant = ((writeTimeout == SerialPort.InfiniteTimeout) ? 0 : writeTimeout);
+
+                // set unmanaged timeout structure
+                if (Interop.Kernel32.SetCommTimeouts(_handle, ref _commTimeouts) == false)
+                {
+                    InternalResources.WinIOError();
+                }
+
+                if (_isAsync)
+                {
+                    if (!ThreadPool.BindHandle(_handle))
+                    {
+                        throw new IOException(SR.IO_BindHandleFailed);
+                    }
+                }
+
+                // monitor all events except TXEMPTY
+                Interop.Kernel32.SetCommMask(_handle, NativeMethods.ALL_EVENTS);
+
+                // prep. for starting event cycle.
+                _eventRunner = new EventLoopRunner(this);
+                Thread eventLoopThread = new Thread(new ThreadStart(_eventRunner.WaitForCommEvent));
+                eventLoopThread.IsBackground = true;
+                eventLoopThread.Start();
+
+            }
+            catch
+            {
+                // if there are any exceptions after the call to CreateFile, we need to be sure to close the
+                // handle before we let them continue up.
+                tempHandle.Close();
+                _handle = null;
+                throw;
+            }
+        }
+
+        ~SerialStream()
+        {
+            Dispose(false);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            // Signal the other side that we're closing.  Should do regardless of whether we've called
+            // Close() or not Dispose() 
+            if (_handle != null && !_handle.IsInvalid)
+            {
+                try
+                {
+
+                    _eventRunner.endEventLoop = true;
+
+                    Thread.MemoryBarrier();
+
+                    bool skipSPAccess = false;
+
+                    // turn off all events and signal WaitCommEvent
+                    Interop.Kernel32.SetCommMask(_handle, 0);
+                    if (!Interop.Kernel32.EscapeCommFunction(_handle, NativeMethods.CLRDTR))
+                    {
+                        int hr = Marshal.GetLastWin32Error();
+
+                        // access denied can happen if USB is yanked out. If that happens, we
+                        // want to at least allow finalize to succeed and clean up everything 
+                        // we can. To achieve this, we need to avoid further attempts to access
+                        // the SerialPort.  A customer also reported seeing ERROR_BAD_COMMAND here.
+                        // Do not throw an exception on the finalizer thread - that's just rude,
+                        // since apps can't catch it and we may tear down the app.
+                        const int ERROR_DEVICE_REMOVED = 1617;
+                        if ((hr == Interop.Errors.ERROR_ACCESS_DENIED || hr == Interop.Errors.ERROR_BAD_COMMAND || hr == ERROR_DEVICE_REMOVED) && !disposing)
+                        {
+                            skipSPAccess = true;
+                        }
+                        else
+                        {
+                            // should not happen
+                            Debug.Fail(string.Format("Unexpected error code from EscapeCommFunction in SerialPort.Dispose(bool)  Error code: 0x{0:x}", (uint)hr));
+
+                            // Do not throw an exception from the finalizer here.
+                            if (disposing)
+                                InternalResources.WinIOError();
+                        }
+                    }
+
+                    if (!skipSPAccess && !_handle.IsClosed)
+                    {
+                        Flush();
+                    }
+
+                    _eventRunner.waitCommEventWaitHandle.Set();
+
+                    if (!skipSPAccess)
+                    {
+                        DiscardInBuffer();
+                        DiscardOutBuffer();
+                    }
+
+                    if (disposing && _eventRunner != null)
+                    {
+                        // now we need to wait for the event loop to tell us it's done.  Without this we could get into a race where the
+                        // event loop kept the port open even after Dispose ended.
+                        _eventRunner.eventLoopEndedSignal.WaitOne();
+                        _eventRunner.eventLoopEndedSignal.Close();
+                        _eventRunner.waitCommEventWaitHandle.Close();
+                    }
+                }
+                finally
+                {
+                    // If we are disposing synchronize closing with raising SerialPort events
+                    if (disposing)
+                    {
+#pragma warning disable CA2002
+                        lock (this)
+                        {
+                            _handle.Close();
+                            _handle = null;
+                        }
+#pragma warning restore CA2002
+                    }
+                    else
+                    {
+                        _handle.Close();
+                        _handle = null;
+                    }
+                    base.Dispose(disposing);
+                }
+
+            }
+        }
+
+        // -----SECTION: all public methods ------------------*
+
+        // User-accessible async read method.  Returns SerialStreamAsyncResult : IAsyncResult
+        public override IAsyncResult BeginRead(byte[] array, int offset, int numBytes, AsyncCallback userCallback, object stateObject)
+        {
+            if (array == null)
+                throw new ArgumentNullException(nameof(array));
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset), SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+            if (numBytes < 0)
+                throw new ArgumentOutOfRangeException(nameof(numBytes), SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+            if (array.Length - offset < numBytes)
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+            if (_handle == null) InternalResources.FileNotOpen();
+
+            int oldtimeout = ReadTimeout;
+            ReadTimeout = SerialPort.InfiniteTimeout;
+            IAsyncResult result;
+            try
+            {
+                if (!_isAsync)
+                    result = base.BeginRead(array, offset, numBytes, userCallback, stateObject);
+                else
+                    result = BeginReadCore(array, offset, numBytes, userCallback, stateObject);
+            }
+            finally
+            {
+                ReadTimeout = oldtimeout;
+            }
+            return result;
+        }
+
+        // User-accessible async write method.  Returns SerialStreamAsyncResult : IAsyncResult
+        // Throws an exception if port is in break state.
+        public override IAsyncResult BeginWrite(byte[] array, int offset, int numBytes,
+            AsyncCallback userCallback, object stateObject)
+        {
+            if (_inBreak)
+                throw new InvalidOperationException(SR.In_Break_State);
+            if (array == null)
+                throw new ArgumentNullException(nameof(array));
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset), SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+            if (numBytes < 0)
+                throw new ArgumentOutOfRangeException(nameof(numBytes), SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+            if (array.Length - offset < numBytes)
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+            if (_handle == null) InternalResources.FileNotOpen();
+
+            int oldtimeout = WriteTimeout;
+            WriteTimeout = SerialPort.InfiniteTimeout;
+            IAsyncResult result;
+            try
+            {
+                if (!_isAsync)
+                    result = base.BeginWrite(array, offset, numBytes, userCallback, stateObject);
+                else
+                    result = BeginWriteCore(array, offset, numBytes, userCallback, stateObject);
+            }
+            finally
+            {
+                WriteTimeout = oldtimeout;
+            }
+            return result;
+        }
+
+        // Uses Win32 method to dump out the receive buffer; analagous to MSComm's "InBufferCount = 0"
+        internal void DiscardInBuffer()
+        {
+
+            if (Interop.Kernel32.PurgeComm(_handle, NativeMethods.PURGE_RXCLEAR | NativeMethods.PURGE_RXABORT) == false)
+                InternalResources.WinIOError();
+        }
+
+        // Uses Win32 method to dump out the xmit buffer; analagous to MSComm's "OutBufferCount = 0"
+        internal void DiscardOutBuffer()
+        {
+            if (Interop.Kernel32.PurgeComm(_handle, NativeMethods.PURGE_TXCLEAR | NativeMethods.PURGE_TXABORT) == false)
+                InternalResources.WinIOError();
+        }
+
+        // Async companion to BeginRead.
+        // Note, assumed IAsyncResult argument is of derived type SerialStreamAsyncResult,
+        // and throws an exception if untrue.
+        public unsafe override int EndRead(IAsyncResult asyncResult)
+        {
+            if (!_isAsync)
+                return base.EndRead(asyncResult);
+
+            if (asyncResult == null)
+                throw new ArgumentNullException(nameof(asyncResult));
+
+            SerialStreamAsyncResult afsar = asyncResult as SerialStreamAsyncResult;
+            if (afsar == null || afsar._isWrite)
+                InternalResources.WrongAsyncResult();
+
+            // This sidesteps race conditions, avoids memory corruption after freeing the
+            // NativeOverlapped class or GCHandle twice.
+            if (1 == Interlocked.CompareExchange(ref afsar._EndXxxCalled, 1, 0))
+                InternalResources.EndReadCalledTwice();
+
+            bool failed = false;
+
+            // Obtain the WaitHandle, but don't use public property in case we
+            // delay initialize the manual reset event in the future.
+            WaitHandle wh = afsar._waitHandle;
+            if (wh != null)
+            {
+                // We must block to ensure that AsyncFSCallback has completed,
+                // and we should close the WaitHandle in here.  
+                try
+                {
+                    wh.WaitOne();
+                    Debug.Assert(afsar._isComplete == true, "SerialStream::EndRead - AsyncFSCallback didn't set _isComplete to true!");
+
+                    // InfiniteTimeout is not something native to the underlying serial device, 
+                    // we specify the timeout to be a very large value (MAXWORD-1) to achieve 
+                    // an infinite timeout illusion. 
+
+                    // I'm not sure what we can do here after an asyn operation with infinite 
+                    // timeout returns with no data. From a purist point of view we should 
+                    // somehow restart the read operation but we are not in a position to do so
+                    // (and frankly that may not necessarily be the right thing to do here) 
+                    // I think the best option in this (almost impossible to run into) situation 
+                    // is to throw some sort of IOException.
+
+                    if ((afsar._numBytes == 0) && (ReadTimeout == SerialPort.InfiniteTimeout) && (afsar._errorCode == 0))
+                        failed = true;
+                }
+                finally
+                {
+                    wh.Close();
+                }
+            }
+
+            // Free memory, GC handles.
+            NativeOverlapped* overlappedPtr = afsar._overlapped;
+            if (overlappedPtr != null)
+                Overlapped.Free(overlappedPtr);
+
+            // Check for non-timeout errors during the read.
+            if (afsar._errorCode != 0)
+                InternalResources.WinIOError(afsar._errorCode, _portName);
+
+            if (failed)
+                throw new IOException(SR.IO_OperationAborted);
+
+            return afsar._numBytes;
+        }
+
+        // Async companion to BeginWrite.
+        // Note, assumed IAsyncResult argument is of derived type SerialStreamAsyncResult,
+        // and throws an exception if untrue.
+        // Also fails if called in port's break state.
+        public unsafe override void EndWrite(IAsyncResult asyncResult)
+        {
+            if (!_isAsync)
+            {
+                base.EndWrite(asyncResult);
+                return;
+            }
+
+            if (_inBreak)
+                throw new InvalidOperationException(SR.In_Break_State);
+            if (asyncResult == null)
+                throw new ArgumentNullException(nameof(asyncResult));
+
+            SerialStreamAsyncResult afsar = asyncResult as SerialStreamAsyncResult;
+            if (afsar == null || !afsar._isWrite)
+                InternalResources.WrongAsyncResult();
+
+            // This sidesteps race conditions, avoids memory corruption after freeing the
+            // NativeOverlapped class or GCHandle twice.
+            if (1 == Interlocked.CompareExchange(ref afsar._EndXxxCalled, 1, 0))
+                InternalResources.EndWriteCalledTwice();
+
+            // Obtain the WaitHandle, but don't use public property in case we
+            // delay initialize the manual reset event in the future.
+            WaitHandle wh = afsar._waitHandle;
+            if (wh != null)
+            {
+                // We must block to ensure that AsyncFSCallback has completed,
+                // and we should close the WaitHandle in here.  
+                try
+                {
+                    wh.WaitOne();
+                    Debug.Assert(afsar._isComplete == true, "SerialStream::EndWrite - AsyncFSCallback didn't set _isComplete to true!");
+                }
+                finally
+                {
+                    wh.Close();
+                }
+            }
+
+            // Free memory, GC handles.
+            NativeOverlapped* overlappedPtr = afsar._overlapped;
+            if (overlappedPtr != null)
+                Overlapped.Free(overlappedPtr);
+
+            // Now check for any error during the write.
+            if (afsar._errorCode != 0)
+                InternalResources.WinIOError(afsar._errorCode, _portName);
+
+            // Number of bytes written is afsar._numBytes.
+        }
+
+        // Flush dumps the contents of the serial driver's internal read and write buffers.
+        // We actually expose the functionality for each, but fulfilling Stream's contract
+        // requires a Flush() method.  Fails if handle closed.
+        // Note: Serial driver's write buffer is *already* attempting to write it, so we can only wait until it finishes.
+        public override void Flush()
+        {
+            if (_handle == null) throw new ObjectDisposedException(SR.Port_not_open);
+            Interop.Kernel32.FlushFileBuffers(_handle);
+        }
+
+        // Blocking read operation, returning the number of bytes read from the stream.
+
+        public override int Read([In, Out] byte[] array, int offset, int count)
+        {
+            return Read(array, offset, count, ReadTimeout);
+        }
+
+        internal unsafe int Read([In, Out] byte[] array, int offset, int count, int timeout)
+        {
+            if (array == null)
+                throw new ArgumentNullException(nameof(array), SR.ArgumentNull_Buffer);
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset), SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+            if (array.Length - offset < count)
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+            if (count == 0) return 0; // return immediately if no bytes requested; no need for overhead.
+
+            Debug.Assert(timeout == SerialPort.InfiniteTimeout || timeout >= 0, "Serial Stream Read - called with timeout " + timeout);
+
+            // Check to see we have no handle-related error, since the port's always supposed to be open.
+            if (_handle == null) InternalResources.FileNotOpen();
+
+            int numBytes = 0;
+            if (_isAsync)
+            {
+                IAsyncResult result = BeginReadCore(array, offset, count, null, null);
+                numBytes = EndRead(result);
+            }
+            else
+            {
+                int hr;
+                numBytes = ReadFileNative(array, offset, count, null, out hr);
+                if (numBytes == -1)
+                {
+                    InternalResources.WinIOError();
+                }
+            }
+
+            if (numBytes == 0)
+                throw new TimeoutException();
+
+            return numBytes;
+        }
+
+        public override int ReadByte()
+        {
+            return ReadByte(ReadTimeout);
+        }
+
+        internal unsafe int ReadByte(int timeout)
+        {
+            if (_handle == null) InternalResources.FileNotOpen();
+
+            int numBytes = 0;
+            if (_isAsync)
+            {
+                IAsyncResult result = BeginReadCore(_tempBuf, 0, 1, null, null);
+                numBytes = EndRead(result);
+            }
+            else
+            {
+                int hr;
+                numBytes = ReadFileNative(_tempBuf, 0, 1, null, out hr);
+                if (numBytes == -1)
+                {
+                    InternalResources.WinIOError();
+                }
+            }
+
+            if (numBytes == 0)
+                throw new TimeoutException();
+            else
+                return _tempBuf[0];
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException(SR.NotSupported_UnseekableStream);
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException(SR.NotSupported_UnseekableStream);
+        }
+
+        internal void SetBufferSizes(int readBufferSize, int writeBufferSize)
+        {
+            if (_handle == null) InternalResources.FileNotOpen();
+
+            if (!Interop.Kernel32.SetupComm(_handle, readBufferSize, writeBufferSize))
+                InternalResources.WinIOError();
+        }
+
+        public override void Write(byte[] array, int offset, int count)
+        {
+            Write(array, offset, count, WriteTimeout);
+        }
+
+        internal unsafe void Write(byte[] array, int offset, int count, int timeout)
+        {
+
+            if (_inBreak)
+                throw new InvalidOperationException(SR.In_Break_State);
+            if (array == null)
+                throw new ArgumentNullException(nameof(array), SR.ArgumentNull_Array);
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset), SR.ArgumentOutOfRange_NeedPosNum);
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedPosNum);
+            if (count == 0) return; // no need to expend overhead in creating asyncResult, etc.
+            if (array.Length - offset < count)
+                throw new ArgumentException(nameof(count), SR.ArgumentOutOfRange_OffsetOut);
+            Debug.Assert(timeout == SerialPort.InfiniteTimeout || timeout >= 0, "Serial Stream Write - write timeout is " + timeout);
+
+            // check for open handle, though the port is always supposed to be open
+            if (_handle == null) InternalResources.FileNotOpen();
+
+            int numBytes;
+            if (_isAsync)
+            {
+                IAsyncResult result = BeginWriteCore(array, offset, count, null, null);
+                EndWrite(result);
+
+                SerialStreamAsyncResult afsar = result as SerialStreamAsyncResult;
+                Debug.Assert(afsar != null, "afsar should be a SerialStreamAsyncResult and should not be null");
+                numBytes = afsar._numBytes;
+            }
+            else
+            {
+                int hr;
+                numBytes = WriteFileNative(array, offset, count, null, out hr);
+                if (numBytes == -1)
+                {
+
+                    // This is how writes timeout on Win9x. 
+                    if (hr == Interop.Errors.ERROR_COUNTER_TIMEOUT)
+                        throw new TimeoutException(SR.Write_timed_out);
+
+                    InternalResources.WinIOError();
+                }
+            }
+
+            if (numBytes == 0)
+                throw new TimeoutException(SR.Write_timed_out);
+        }
+
+        // use default timeout as argument to WriteByte override with timeout arg
+        public override void WriteByte(byte value)
+        {
+            WriteByte(value, WriteTimeout);
+        }
+
+        internal unsafe void WriteByte(byte value, int timeout)
+        {
+            if (_inBreak)
+                throw new InvalidOperationException(SR.In_Break_State);
+
+            if (_handle == null) InternalResources.FileNotOpen();
+            _tempBuf[0] = value;
+
+
+            int numBytes;
+            int hr;
+            if (_isAsync)
+            {
+                IAsyncResult result = BeginWriteCore(_tempBuf, 0, 1, null, null);
+                EndWrite(result);
+
+                SerialStreamAsyncResult afsar = result as SerialStreamAsyncResult;
+                Debug.Assert(afsar != null, "afsar should be a SerialStreamAsyncResult and should not be null");
+                numBytes = afsar._numBytes;
+            }
+            else
+            {
+                numBytes = WriteFileNative(_tempBuf, 0, 1, null, out hr);
+                if (numBytes == -1)
+                {
+                    // This is how writes timeout on Win9x. 
+                    if (Marshal.GetLastWin32Error() == Interop.Errors.ERROR_COUNTER_TIMEOUT)
+                        throw new TimeoutException(SR.Write_timed_out);
+
+                    InternalResources.WinIOError();
+                }
+            }
+
+            if (numBytes == 0)
+                throw new TimeoutException(SR.Write_timed_out);
+
+            return;
+        }
+
+        // --------SUBSECTION: internal-use methods ----------------------*
+        // ------ internal DCB-supporting methods ------- *
+
+        // Initializes unmananged DCB struct, to be called after opening communications resource.
+        // assumes we have already: baudRate, parity, dataBits, stopBits
+        // should only be called in SerialStream(...)
+        private void InitializeDCB(int baudRate, Parity parity, int dataBits, StopBits stopBits, bool discardNull)
+        {
+            // first get the current dcb structure setup
+            if (Interop.Kernel32.GetCommState(_handle, ref _dcb) == false)
+            {
+                InternalResources.WinIOError();
+            }
+            _dcb.DCBlength = (uint)Marshal.SizeOf(_dcb);
+
+            // set parameterized properties
+            _dcb.BaudRate = (uint)baudRate;
+            _dcb.ByteSize = (byte)dataBits;
+
+
+            switch (stopBits)
+            {
+                case StopBits.One:
+                    _dcb.StopBits = NativeMethods.ONESTOPBIT;
+                    break;
+                case StopBits.OnePointFive:
+                    _dcb.StopBits = NativeMethods.ONE5STOPBITS;
+                    break;
+                case StopBits.Two:
+                    _dcb.StopBits = NativeMethods.TWOSTOPBITS;
+                    break;
+                default:
+                    Debug.Assert(false, "Invalid value for stopBits");
+                    break;
+            }
+
+            _dcb.Parity = (byte)parity;
+            // SetDcbFlag, GetDcbFlag expose access to each of the relevant bits of the 32-bit integer
+            // storing all flags of the DCB.  C# provides no direct means of manipulating bit fields, so
+            // this is the solution.
+            SetDcbFlag(NativeMethods.FPARITY, ((parity == Parity.None) ? 0 : 1));
+
+            SetDcbFlag(NativeMethods.FBINARY, 1);   // always true for communications resources
+
+            // set DCB fields implied by default and the arguments given.
+            // Boolean fields in C# must become 1, 0 to properly set the bit flags in the unmanaged DCB struct
+
+            SetDcbFlag(NativeMethods.FOUTXCTSFLOW, ((_handshake == Handshake.RequestToSend ||
+                _handshake == Handshake.RequestToSendXOnXOff) ? 1 : 0));
+            // SetDcbFlag(NativeMethods.FOUTXDSRFLOW, (dsrTimeout != 0L) ? 1 : 0);
+            SetDcbFlag(NativeMethods.FOUTXDSRFLOW, 0); // dsrTimeout is always set to 0.
+            SetDcbFlag(NativeMethods.FDTRCONTROL, NativeMethods.DTR_CONTROL_DISABLE);
+            SetDcbFlag(NativeMethods.FDSRSENSITIVITY, 0); // this should remain off
+            SetDcbFlag(NativeMethods.FINX, (_handshake == Handshake.XOnXOff || _handshake == Handshake.RequestToSendXOnXOff) ? 1 : 0);
+            SetDcbFlag(NativeMethods.FOUTX, (_handshake == Handshake.XOnXOff || _handshake == Handshake.RequestToSendXOnXOff) ? 1 : 0);
+
+            // if no parity, we have no error character (i.e. ErrorChar = '\0' or null character)
+            if (parity != Parity.None)
+            {
+                SetDcbFlag(NativeMethods.FERRORCHAR, (_parityReplace != '\0') ? 1 : 0);
+                _dcb.ErrorChar = _parityReplace;
+            }
+            else
+            {
+                SetDcbFlag(NativeMethods.FERRORCHAR, 0);
+                _dcb.ErrorChar = (byte)'\0';
+            }
+
+            // this method only runs once in the constructor, so we only have the default value to use.
+            // Later the user may change this via the NullDiscard property.
+            SetDcbFlag(NativeMethods.FNULL, discardNull ? 1 : 0);
+
+
+            // Setting RTS control, which is RTS_CONTROL_HANDSHAKE if RTS / RTS-XOnXOff handshaking
+            // used, RTS_ENABLE (RTS pin used during operation) if rtsEnable true but XOnXoff / No handshaking
+            // used, and disabled otherwise.
+            if ((_handshake == Handshake.RequestToSend ||
+                _handshake == Handshake.RequestToSendXOnXOff))
+            {
+                SetDcbFlag(NativeMethods.FRTSCONTROL, NativeMethods.RTS_CONTROL_HANDSHAKE);
+            }
+            else if (GetDcbFlag(NativeMethods.FRTSCONTROL) == NativeMethods.RTS_CONTROL_HANDSHAKE)
+            {
+                SetDcbFlag(NativeMethods.FRTSCONTROL, NativeMethods.RTS_CONTROL_DISABLE);
+            }
+
+            _dcb.XonChar = NativeMethods.DEFAULTXONCHAR;             // may be exposed later but for now, constant
+            _dcb.XoffChar = NativeMethods.DEFAULTXOFFCHAR;
+
+            // minimum number of bytes allowed in each buffer before flow control activated
+            // heuristically, this has been set at 1/4 of the buffer size
+            _dcb.XonLim = _dcb.XoffLim = (ushort)(_commProp.dwCurrentRxQueue / 4);
+
+            _dcb.EofChar = NativeMethods.EOFCHAR;
+
+            //OLD MSCOMM: dcb.EvtChar = (byte) 0;
+            // now changed to make use of RXFlag WaitCommEvent event => Eof WaitForCommEvent event
+            _dcb.EvtChar = NativeMethods.EOFCHAR;
+
+            // set DCB structure
+            if (Interop.Kernel32.SetCommState(_handle, ref _dcb) == false)
+            {
+                InternalResources.WinIOError();
+            }
+        }
+
+        // Here we provide a method for getting the flags of the Device Control Block structure dcb
+        // associated with each instance of SerialStream, i.e. this method gets myStream.dcb.Flags
+        // Flags are any of the constants in NativeMethods such as FBINARY, FDTRCONTROL, etc.
+        internal int GetDcbFlag(int whichFlag)
+        {
+            uint mask;
+
+            Debug.Assert(whichFlag >= NativeMethods.FBINARY && whichFlag <= NativeMethods.FDUMMY2, "GetDcbFlag needs to fit into enum!");
+
+            if (whichFlag == NativeMethods.FDTRCONTROL || whichFlag == NativeMethods.FRTSCONTROL)
+            {
+                mask = 0x3;
+            }
+            else if (whichFlag == NativeMethods.FDUMMY2)
+            {
+                mask = 0x1FFFF;
+            }
+            else
+            {
+                mask = 0x1;
+            }
+            uint result = _dcb.Flags & (mask << whichFlag);
+            return (int)(result >> whichFlag);
+        }
+
+        // Since C# applications have to provide a workaround for accessing and setting bitfields in unmanaged code,
+        // here we provide methods for getting and setting the Flags field of the Device Control Block structure dcb
+        // associated with each instance of SerialStream, i.e. this method sets myStream.dcb.Flags
+        // Flags are any of the constants in NativeMethods such as FBINARY, FDTRCONTROL, etc.
+        internal void SetDcbFlag(int whichFlag, int setting)
+        {
+            uint mask;
+            setting = setting << whichFlag;
+
+            Debug.Assert(whichFlag >= NativeMethods.FBINARY && whichFlag <= NativeMethods.FDUMMY2, "SetDcbFlag needs to fit into enum!");
+
+            if (whichFlag == NativeMethods.FDTRCONTROL || whichFlag == NativeMethods.FRTSCONTROL)
+            {
+                mask = 0x3;
+            }
+            else if (whichFlag == NativeMethods.FDUMMY2)
+            {
+                mask = 0x1FFFF;
+            }
+            else
+            {
+                mask = 0x1;
+            }
+
+            // clear the region
+            _dcb.Flags &= ~(mask << whichFlag);
+
+            // set the region
+            _dcb.Flags |= ((uint)setting);
+        }
+
+        // ----SUBSECTION: internal methods supporting public read/write methods-------*
+
+        unsafe private SerialStreamAsyncResult BeginReadCore(byte[] array, int offset, int numBytes, AsyncCallback userCallback, Object stateObject)
+        {
+
+            // Create and store async stream class library specific data in the
+            // async result
+            SerialStreamAsyncResult asyncResult = new SerialStreamAsyncResult();
+            asyncResult._userCallback = userCallback;
+            asyncResult._userStateObject = stateObject;
+            asyncResult._isWrite = false;
+
+            // For Synchronous IO, I could go with either a callback and using
+            // the managed Monitor class, or I could create a handle and wait on it.
+            ManualResetEvent waitHandle = new ManualResetEvent(false);
+            asyncResult._waitHandle = waitHandle;
+
+            // Create a managed overlapped class
+            // We will set the file offsets later
+            Overlapped overlapped = new Overlapped(0, 0, IntPtr.Zero, asyncResult);
+
+            // Pack the Overlapped class, and store it in the async result
+            NativeOverlapped* intOverlapped = overlapped.Pack(s_IOCallback, array);
+
+            asyncResult._overlapped = intOverlapped;
+
+            // queue an async ReadFile operation and pass in a packed overlapped
+            //int r = ReadFile(_handle, array, numBytes, null, intOverlapped);
+            int hr = 0;
+            int r = ReadFileNative(array, offset, numBytes,
+             intOverlapped, out hr);
+
+            // ReadFile, the OS version, will return 0 on failure.  But
+            // my ReadFileNative wrapper returns -1.  My wrapper will return
+            // the following:
+            // On error, r==-1.
+            // On async requests that are still pending, r==-1 w/ hr==ERROR_IO_PENDING
+            // on async requests that completed sequentially, r==0
+            // Note that you will NEVER RELIABLY be able to get the number of bytes
+            // read back from this call when using overlapped structures!  You must
+            // not pass in a non-null lpNumBytesRead to ReadFile when using
+            // overlapped structures!
+            if (r == -1)
+            {
+                if (hr != Interop.Errors.ERROR_IO_PENDING)
+                {
+                    if (hr == Interop.Errors.ERROR_HANDLE_EOF)
+                        InternalResources.EndOfFile();
+                    else
+                        InternalResources.WinIOError(hr, String.Empty);
+                }
+            }
+
+            return asyncResult;
+        }
+
+        unsafe private SerialStreamAsyncResult BeginWriteCore(byte[] array, int offset, int numBytes, AsyncCallback userCallback, Object stateObject)
+        {
+            // Create and store async stream class library specific data in the
+            // async result
+            SerialStreamAsyncResult asyncResult = new SerialStreamAsyncResult();
+            asyncResult._userCallback = userCallback;
+            asyncResult._userStateObject = stateObject;
+            asyncResult._isWrite = true;
+
+            // For Synchronous IO, I could go with either a callback and using
+            // the managed Monitor class, or I could create a handle and wait on it.
+            ManualResetEvent waitHandle = new ManualResetEvent(false);
+            asyncResult._waitHandle = waitHandle;
+
+            // Create a managed overlapped class
+            // We will set the file offsets later
+            Overlapped overlapped = new Overlapped(0, 0, IntPtr.Zero, asyncResult);
+
+            // Pack the Overlapped class, and store it in the async result
+            NativeOverlapped* intOverlapped = overlapped.Pack(s_IOCallback, array);
+
+            asyncResult._overlapped = intOverlapped;
+
+            int hr = 0;
+            // queue an async WriteFile operation and pass in a packed overlapped
+            int r = WriteFileNative(array, offset, numBytes, intOverlapped, out hr);
+
+            // WriteFile, the OS version, will return 0 on failure.  But
+            // my WriteFileNative wrapper returns -1.  My wrapper will return
+            // the following:
+            // On error, r==-1.
+            // On async requests that are still pending, r==-1 w/ hr==ERROR_IO_PENDING
+            // On async requests that completed sequentially, r==0
+            // Note that you will NEVER RELIABLY be able to get the number of bytes
+            // written back from this call when using overlapped IO!  You must
+            // not pass in a non-null lpNumBytesWritten to WriteFile when using
+            // overlapped structures!
+            if (r == -1)
+            {
+                if (hr != Interop.Errors.ERROR_IO_PENDING)
+                {
+
+                    if (hr == Interop.Errors.ERROR_HANDLE_EOF)
+                        InternalResources.EndOfFile();
+                    else
+                        InternalResources.WinIOError(hr, String.Empty);
+                }
+            }
+            return asyncResult;
+        }
+
+
+        // Internal method, wrapping the PInvoke to ReadFile().
+        private unsafe int ReadFileNative(byte[] bytes, int offset, int count, NativeOverlapped* overlapped, out int hr)
+        {
+
+            // Don't corrupt memory when multiple threads are erroneously writing
+            // to this stream simultaneously.
+            if (bytes.Length - offset < count)
+                throw new IndexOutOfRangeException(SR.IndexOutOfRange_IORaceCondition);
+
+            // You can't use the fixed statement on an array of length 0.
+            if (bytes.Length == 0)
+            {
+                hr = 0;
+                return 0;
+            }
+
+            int r = 0;
+            int numBytesRead = 0;
+
+            fixed (byte* p = bytes)
+            {
+                if (_isAsync)
+                    r = Interop.Kernel32.ReadFile(_handle, p + offset, count, IntPtr.Zero, overlapped);
+                else
+                    r = Interop.Kernel32.ReadFile(_handle, p + offset, count, out numBytesRead, IntPtr.Zero);
+            }
+
+            if (r == 0)
+            {
+                hr = Marshal.GetLastWin32Error();
+
+                // Note: we should never silently ignore an error here without some
+                // extra work.  We must make sure that BeginReadCore won't return an
+                // IAsyncResult that will cause EndRead to block, since the OS won't
+                // call AsyncFSCallback for us.
+
+                // For invalid handles, detect the error and mark our handle
+                // as closed to give slightly better error messages.  Also
+                // help ensure we avoid handle recycling bugs.
+                if (hr == Interop.Errors.ERROR_INVALID_HANDLE)
+                    _handle.SetHandleAsInvalid();
+
+                return -1;
+            }
+            else
+                hr = 0;
+            return numBytesRead;
+        }
+
+        private unsafe int WriteFileNative(byte[] bytes, int offset, int count, NativeOverlapped* overlapped, out int hr)
+        {
+
+            // Don't corrupt memory when multiple threads are erroneously writing
+            // to this stream simultaneously.  (Note that the OS is reading from
+            // the array we pass to WriteFile, but if we read beyond the end and
+            // that memory isn't allocated, we could get an AV.)
+            if (bytes.Length - offset < count)
+                throw new IndexOutOfRangeException(SR.IndexOutOfRange_IORaceCondition);
+
+            // You can't use the fixed statement on an array of length 0.
+            if (bytes.Length == 0)
+            {
+                hr = 0;
+                return 0;
+            }
+
+            int numBytesWritten = 0;
+            int r = 0;
+
+            fixed (byte* p = bytes)
+            {
+                if (_isAsync)
+                    r = Interop.Kernel32.WriteFile(_handle, p + offset, count, IntPtr.Zero, overlapped);
+                else
+                    r = Interop.Kernel32.WriteFile(_handle, p + offset, count, out numBytesWritten, IntPtr.Zero);
+            }
+
+            if (r == 0)
+            {
+                hr = Marshal.GetLastWin32Error();
+                // Note: we should never silently ignore an error here without some
+                // extra work.  We must make sure that BeginWriteCore won't return an
+                // IAsyncResult that will cause EndWrite to block, since the OS won't
+                // call AsyncFSCallback for us.
+
+                // For invalid handles, detect the error and mark our handle
+                // as closed to give slightly better error messages.  Also
+                // help ensure we avoid handle recycling bugs.
+                if (hr == Interop.Errors.ERROR_INVALID_HANDLE)
+                    _handle.SetHandleAsInvalid();
+
+                return -1;
+            }
+            else
+                hr = 0;
+            return numBytesWritten;
+        }
+
+        // ----SUBSECTION: internal methods supporting events/async operation------*
+
+        // This is a the callback prompted when a thread completes any async I/O operation.
+        unsafe private static void AsyncFSCallback(uint errorCode, uint numBytes, NativeOverlapped* pOverlapped)
+        {
+            // Unpack overlapped
+            Overlapped overlapped = Overlapped.Unpack(pOverlapped);
+
+            // Extract async the result from overlapped structure
+            SerialStreamAsyncResult asyncResult =
+                (SerialStreamAsyncResult)overlapped.AsyncResult;
+            asyncResult._numBytes = (int)numBytes;
+
+            asyncResult._errorCode = (int)errorCode;
+
+            // Call the user-provided callback.  Note that it can and often should
+            // call EndRead or EndWrite.  There's no reason to use an async
+            // delegate here - we're already on a threadpool thread.
+            // Note the IAsyncResult's completedSynchronously property must return
+            // false here, saying the user callback was called on another thread.
+            asyncResult._completedSynchronously = false;
+            asyncResult._isComplete = true;
+
+            // The OS does not signal this event.  We must do it ourselves.
+            // But don't close it if the user callback called EndXxx, 
+            // which then closed the manual reset event already.
+            ManualResetEvent wh = asyncResult._waitHandle;
+            if (wh != null)
+            {
+                bool r = wh.Set();
+                if (!r) InternalResources.WinIOError();
+            }
+
+            asyncResult._userCallback?.Invoke(asyncResult);
+        }
+
+
+        // ----SECTION: internal classes --------*
+
+        internal sealed class EventLoopRunner
+        {
+            private WeakReference streamWeakReference;
+            internal ManualResetEvent eventLoopEndedSignal = new ManualResetEvent(false);
+            internal ManualResetEvent waitCommEventWaitHandle = new ManualResetEvent(false);
+            private SafeFileHandle handle = null;
+            private bool isAsync;
+            internal bool endEventLoop;
+            private int eventsOccurred;
+
+            WaitCallback callErrorEvents;
+            WaitCallback callReceiveEvents;
+            WaitCallback callPinEvents;
+            IOCompletionCallback freeNativeOverlappedCallback;
+
+#if DEBUG 
+            private readonly string portName;
+#endif
+
+            internal unsafe EventLoopRunner(SerialStream stream)
+            {
+                handle = stream._handle;
+                streamWeakReference = new WeakReference(stream);
+
+                callErrorEvents = new WaitCallback(CallErrorEvents);
+                callReceiveEvents = new WaitCallback(CallReceiveEvents);
+                callPinEvents = new WaitCallback(CallPinEvents);
+                freeNativeOverlappedCallback = new IOCompletionCallback(FreeNativeOverlappedCallback);
+                isAsync = stream._isAsync;
+#if DEBUG 
+                portName = stream._portName;
+#endif
+            }
+
+            internal bool ShutdownLoop
+            {
+                get
+                {
+                    return endEventLoop;
+                }
+            }
+
+            // This is the blocking method that waits for an event to occur.  It wraps the SDK's WaitCommEvent function.
+            [SuppressMessage("Microsoft.Interoperability", "CA1404:CallGetLastErrorImmediatelyAfterPInvoke", Justification = "this is debug-only code")]
+            internal unsafe void WaitForCommEvent()
+            {
+                int unused = 0;
+                bool doCleanup = false;
+                NativeOverlapped* intOverlapped = null;
+                while (!ShutdownLoop)
+                {
+                    SerialStreamAsyncResult asyncResult = null;
+                    if (isAsync)
+                    {
+                        asyncResult = new SerialStreamAsyncResult();
+                        asyncResult._userCallback = null;
+                        asyncResult._userStateObject = null;
+                        asyncResult._isWrite = false;
+
+                        // we're going to use _numBytes for something different in this loop.  In this case, both 
+                        // freeNativeOverlappedCallback and this thread will decrement that value.  Whichever one decrements it
+                        // to zero will be the one to free the native overlapped.  This guarantees the overlapped gets freed
+                        // after both the callback and GetOverlappedResult have had a chance to use it. 
+                        asyncResult._numBytes = 2;
+                        asyncResult._waitHandle = waitCommEventWaitHandle;
+
+                        waitCommEventWaitHandle.Reset();
+                        Overlapped overlapped = new Overlapped(0, 0, waitCommEventWaitHandle.SafeWaitHandle.DangerousGetHandle(), asyncResult);
+                        // Pack the Overlapped class, and store it in the async result
+                        intOverlapped = overlapped.Pack(freeNativeOverlappedCallback, null);
+                    }
+
+                    fixed (int* eventsOccurredPtr = &eventsOccurred)
+                    {
+                        if (Interop.Kernel32.WaitCommEvent(handle, eventsOccurredPtr, intOverlapped) == false)
+                        {
+                            int hr = Marshal.GetLastWin32Error();
+
+                            // When a device is disconnected unexpectedly from a serial port, there appear to be
+                            // at least three error codes Windows or drivers may return.
+                            const int ERROR_DEVICE_REMOVED = 1617;
+                            if (hr == Interop.Errors.ERROR_ACCESS_DENIED || hr == Interop.Errors.ERROR_BAD_COMMAND || hr == ERROR_DEVICE_REMOVED)
+                            {
+                                doCleanup = true;
+                                break;
+                            }
+                            if (hr == Interop.Errors.ERROR_IO_PENDING)
+                            {
+                                Debug.Assert(isAsync, "The port is not open for async, so we should not get ERROR_IO_PENDING from WaitCommEvent");
+                                int error;
+
+                                // if we get IO pending, MSDN says we should wait on the WaitHandle, then call GetOverlappedResult
+                                // to get the results of WaitCommEvent. 
+                                bool success = waitCommEventWaitHandle.WaitOne();
+                                Debug.Assert(success, "waitCommEventWaitHandle.WaitOne() returned error " + Marshal.GetLastWin32Error());
+
+                                do
+                                {
+                                    // NOTE: GetOverlappedResult will modify the original pointer passed into WaitCommEvent.
+                                    success = Interop.Kernel32.GetOverlappedResult(handle, intOverlapped, ref unused, false);
+                                    error = Marshal.GetLastWin32Error();
+                                }
+                                while (error == Interop.Errors.ERROR_IO_INCOMPLETE && !ShutdownLoop && !success);
+
+                                if (!success)
+                                {
+                                    // Ignore ERROR_IO_INCOMPLETE and ERROR_INVALID_PARAMETER, because there's a chance we'll get
+                                    // one of those while shutting down 
+                                    if (!((error == Interop.Errors.ERROR_IO_INCOMPLETE || error == Interop.Errors.ERROR_INVALID_PARAMETER) && ShutdownLoop))
+                                        Debug.Assert(false, "GetOverlappedResult returned error, we might leak intOverlapped memory" + error.ToString(CultureInfo.InvariantCulture));
+                                }
+                            }
+                            else if (hr != Interop.Errors.ERROR_INVALID_PARAMETER)
+                            {
+                                // ignore ERROR_INVALID_PARAMETER errors.  WaitCommError seems to return this
+                                // when SetCommMask is changed while it's blocking (like we do in Dispose())
+                                Debug.Assert(false, "WaitCommEvent returned error " + hr);
+                            }
+                        }
+                    }
+
+                    if (!ShutdownLoop)
+                        CallEvents(eventsOccurred);
+
+                    if (isAsync)
+                    {
+                        if (Interlocked.Decrement(ref asyncResult._numBytes) == 0)
+                            Overlapped.Free(intOverlapped);
+                    }
+                } // while (!ShutdownLoop)
+
+                if (doCleanup)
+                {
+                    // the rest will be handled in Dispose()
+                    endEventLoop = true;
+                    Overlapped.Free(intOverlapped);
+                }
+                eventLoopEndedSignal.Set();
+            }
+
+            private unsafe void FreeNativeOverlappedCallback(uint errorCode, uint numBytes, NativeOverlapped* pOverlapped)
+            {
+                // Unpack overlapped
+                Overlapped overlapped = Overlapped.Unpack(pOverlapped);
+
+                // Extract the async result from overlapped structure
+                SerialStreamAsyncResult asyncResult =
+                    (SerialStreamAsyncResult)overlapped.AsyncResult;
+
+                if (Interlocked.Decrement(ref asyncResult._numBytes) == 0)
+                    Overlapped.Free(pOverlapped);
+            }
+
+            private void CallEvents(int nativeEvents)
+            {
+                // EV_ERR includes only CE_FRAME, CE_OVERRUN, and CE_RXPARITY
+                // To catch errors such as CE_RXOVER, we need to call CleanCommErrors bit more regularly. 
+                // EV_RXCHAR is perhaps too loose an event to look for overflow errors but a safe side to err...
+                if ((nativeEvents & (NativeMethods.EV_ERR | NativeMethods.EV_RXCHAR)) != 0)
+                {
+                    int errors = 0;
+                    if (Interop.Kernel32.ClearCommError(handle, ref errors, IntPtr.Zero) == false)
+                    {
+
+                        //InternalResources.WinIOError();
+
+                        // We don't want to throw an exception from the background thread which is un-catchable and hence tear down the process.
+                        // At present we don't have a first class event that we can raise for this class of fatal errors. One possibility is 
+                        // to overload SeralErrors event to include another enum (perhaps CE_IOE) that we can use for this purpose. 
+                        // In the absene of that, it is better to eat this error silently than tearing down the process (lesser of the evil). 
+                        // This uncleared comm error will most likely blow up when the device is accessed by other APIs (such as Read) on the 
+                        // main thread and hence become known. It is bit roundabout but acceptable.  
+                        //  
+                        // Shutdown the event runner loop (probably bit drastic but we did come across a fatal error). 
+                        // Defer actual dispose chores until finalization though. 
+                        endEventLoop = true;
+                        Thread.MemoryBarrier();
+                        return;
+                    }
+
+                    errors = errors & ErrorEvents;
+                    // TODO: what about CE_BREAK?  Is this the same as EV_BREAK?  EV_BREAK happens as one of the pin events,
+                    //       but CE_BREAK is returned from ClreaCommError.
+                    // TODO: what about other error conditions not covered by the enum?  Should those produce some other error?
+
+                    if (errors != 0)
+                    {
+                        ThreadPool.QueueUserWorkItem(callErrorEvents, errors);
+                    }
+                }
+
+                // now look for pin changed and received events.
+                if ((nativeEvents & PinChangedEvents) != 0)
+                {
+                    ThreadPool.QueueUserWorkItem(callPinEvents, nativeEvents);
+                }
+
+                if ((nativeEvents & ReceivedEvents) != 0)
+                {
+                    ThreadPool.QueueUserWorkItem(callReceiveEvents, nativeEvents);
+                }
+            }
+
+
+            private void CallErrorEvents(object state)
+            {
+                int errors = (int)state;
+                SerialStream stream = (SerialStream)streamWeakReference.Target;
+                if (stream == null)
+                    return;
+
+                if (stream.ErrorReceived != null)
+                {
+                    if ((errors & (int)SerialError.TXFull) != 0)
+                        stream.ErrorReceived(stream, new SerialErrorReceivedEventArgs(SerialError.TXFull));
+
+                    if ((errors & (int)SerialError.RXOver) != 0)
+                        stream.ErrorReceived(stream, new SerialErrorReceivedEventArgs(SerialError.RXOver));
+
+                    if ((errors & (int)SerialError.Overrun) != 0)
+                        stream.ErrorReceived(stream, new SerialErrorReceivedEventArgs(SerialError.Overrun));
+
+                    if ((errors & (int)SerialError.RXParity) != 0)
+                        stream.ErrorReceived(stream, new SerialErrorReceivedEventArgs(SerialError.RXParity));
+
+                    if ((errors & (int)SerialError.Frame) != 0)
+                        stream.ErrorReceived(stream, new SerialErrorReceivedEventArgs(SerialError.Frame));
+                }
+
+                stream = null;
+            }
+
+            private void CallReceiveEvents(object state)
+            {
+                int nativeEvents = (int)state;
+                SerialStream stream = (SerialStream)streamWeakReference.Target;
+                if (stream == null)
+                    return;
+
+                if (stream.DataReceived != null)
+                {
+                    if ((nativeEvents & (int)SerialData.Chars) != 0)
+                        stream.DataReceived(stream, new SerialDataReceivedEventArgs(SerialData.Chars));
+                    if ((nativeEvents & (int)SerialData.Eof) != 0)
+                        stream.DataReceived(stream, new SerialDataReceivedEventArgs(SerialData.Eof));
+                }
+
+                stream = null;
+            }
+
+            private void CallPinEvents(object state)
+            {
+                int nativeEvents = (int)state;
+
+                SerialStream stream = (SerialStream)streamWeakReference.Target;
+                if (stream == null)
+                    return;
+
+                if (stream.PinChanged != null)
+                {
+                    if ((nativeEvents & (int)SerialPinChange.CtsChanged) != 0)
+                        stream.PinChanged(stream, new SerialPinChangedEventArgs(SerialPinChange.CtsChanged));
+
+                    if ((nativeEvents & (int)SerialPinChange.DsrChanged) != 0)
+                        stream.PinChanged(stream, new SerialPinChangedEventArgs(SerialPinChange.DsrChanged));
+
+                    if ((nativeEvents & (int)SerialPinChange.CDChanged) != 0)
+                        stream.PinChanged(stream, new SerialPinChangedEventArgs(SerialPinChange.CDChanged));
+
+                    if ((nativeEvents & (int)SerialPinChange.Ring) != 0)
+                        stream.PinChanged(stream, new SerialPinChangedEventArgs(SerialPinChange.Ring));
+
+                    if ((nativeEvents & (int)SerialPinChange.Break) != 0)
+                        stream.PinChanged(stream, new SerialPinChangedEventArgs(SerialPinChange.Break));
+                }
+
+                stream = null;
+            }
+
+        }
+
+
+        // This is an internal object implementing IAsyncResult with fields
+        // for all of the relevant data necessary to complete the IO operation.
+        // This is used by AsyncFSCallback and all async methods.
+        unsafe internal sealed class SerialStreamAsyncResult : IAsyncResult
+        {
+            // User code callback
+            internal AsyncCallback _userCallback;
+
+            internal Object _userStateObject;
+
+            internal bool _isWrite;     // Whether this is a read or a write
+            internal bool _isComplete;
+            internal bool _completedSynchronously;  // Which thread called callback
+
+            internal ManualResetEvent _waitHandle;
+            internal int _EndXxxCalled;   // Whether we've called EndXxx already.
+            internal int _numBytes;     // number of bytes read OR written
+            internal int _errorCode;
+            internal NativeOverlapped* _overlapped;
+
+            public Object AsyncState
+            {
+                get { return _userStateObject; }
+            }
+
+            public bool IsCompleted
+            {
+                get { return _isComplete; }
+            }
+
+            public WaitHandle AsyncWaitHandle
+            {
+                get
+                {
+                    /*
+                      // Consider uncommenting this someday soon - the EventHandle 
+                      // in the Overlapped struct is really useless half of the 
+                      // time today since the OS doesn't signal it.  If users call
+                      // EndXxx after the OS call happened to complete, there's no
+                      // reason to create a synchronization primitive here.  Fixing
+                      // this will save us some perf, assuming we can correctly
+                      // initialize the ManualResetEvent. 
+                    if (_waitHandle == null) {
+                        ManualResetEvent mre = new ManualResetEvent(false);
+                        if (_overlapped != null && _overlapped->EventHandle != IntPtr.Zero)
+                            mre.Handle = _overlapped->EventHandle;
+                        if (_isComplete)
+                            mre.Set();
+                        _waitHandle = mre;
+                    }
+                    */
+                    return _waitHandle;
+                }
+            }
+
+            // Returns true if the user callback was called by the thread that
+            // called BeginRead or BeginWrite.  If we use an async delegate or
+            // threadpool thread internally, this will be false.  This is used
+            // by code to determine whether a successive call to BeginRead needs
+            // to be done on their main thread or in their callback to avoid a
+            // stack overflow on many reads or writes.
+            public bool CompletedSynchronously
+            {
+                get { return _completedSynchronously; }
+            }
+        }
+    }
+}

--- a/src/System.IO.Ports/src/System/IO/Ports/StopBits.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/StopBits.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Ports
+{
+    public enum StopBits
+    {
+        None = 0,
+        One = 1,
+        Two = 2,
+        OnePointFive = 3
+    };
+}

--- a/src/System.IO.Ports/tests/Configurations.props
+++ b/src/System.IO.Ports/tests/Configurations.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard-Windows_NT;
+      net463-AnyOS;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.IO.Ports/tests/System.IO.Ports.Tests.csproj
+++ b/src/System.IO.Ports/tests/System.IO.Ports.Tests.csproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{4259DCE9-3480-40BB-B08A-64A2D446264B}</ProjectGuid>
+    <TestCategories>InnerLoop;OuterLoop</TestCategories>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the options -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="System\IO\Ports\SmokeTest.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO.Ports/tests/System/IO/Ports/SmokeTest.cs
+++ b/src/System.IO.Ports/tests/System/IO/Ports/SmokeTest.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO.Ports;
+using Xunit;
+
+namespace System.IO.PortsTests
+{
+    public class SmokeTest
+    {
+        [Fact]
+        public void EnumeratePorts()
+        {
+            Assert.NotNull(SerialPort.GetPortNames());
+        }
+    }
+}


### PR DESCRIPTION
- Ports SerialPort code
- Stubs out test project and adds smoke test

The NativeMethods class (which only contains defines) should
be broken out into Common/src/Interop files.

Tests need added. I'll try and round up what we currently have.

@ianhays, @joperezr, @weshaggard, @ericstj, @danmosemsft, @SWY1985, @willdean, @karelz 