### PR TITLE
Modify reflection only tests 

### DIFF
--- a/src/System.Runtime/tests/System/Reflection/AssemblyTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/AssemblyTests.cs
@@ -163,38 +163,25 @@ namespace System.Reflection.Tests
             Assert.Equal(assembly.FullName, loadedAssembly.FullName);
         }
 
-        [Fact]
         public static void AssemblyReflectionOnlyLoadFromString()
         {
             AssemblyName an = typeof(AssemblyTests).Assembly.GetName();
-
-            Assembly a1 = Assembly.ReflectionOnlyLoad(an.FullName);
-            Assert.NotNull(a1);
-            Assert.Equal(an.FullName, a1.GetName().FullName);
+            Assert.Throws<NotSupportedException>(() => Assembly.ReflectionOnlyLoad(an.FullName));
         }
 
-        [Fact]
         public static void AssemblyReflectionOnlyLoadFromBytes()
         {
             Assembly assembly = typeof(AssemblyTests).Assembly;
             byte[] aBytes = System.IO.File.ReadAllBytes(assembly.Location);
-
-            Assembly a1 = Assembly.ReflectionOnlyLoad(aBytes);
-            Assert.NotNull(a1);
-            Assert.Equal(assembly.FullName, a1.GetName().FullName);
+            Assert.Throws<NotSupportedException>(() => Assembly.ReflectionOnlyLoad(aBytes));
         }
 
-        [Fact]
         public static void AssemblyReflectionOnlyLoadFromNeg()
         {
             Assert.Throws<ArgumentNullException>(() => Assembly.ReflectionOnlyLoad((string)null));
             Assert.Throws<ArgumentException>(() => Assembly.ReflectionOnlyLoad(string.Empty));
 
-            string emptyCName = new string('\0', 1);
-            Assert.Throws<ArgumentException>(() => Assembly.ReflectionOnlyLoad(emptyCName));
-
             Assert.Throws<ArgumentNullException>(() => Assembly.ReflectionOnlyLoad((byte[])null));
-            Assert.Throws<BadImageFormatException>(() => Assembly.ReflectionOnlyLoad(new byte[0]));
         }
 
         public static IEnumerable<object[]> GetModules_TestData()

--- a/src/System.Runtime/tests/System/TypeTests.cs
+++ b/src/System.Runtime/tests/System/TypeTests.cs
@@ -286,5 +286,12 @@ namespace System.Tests
         {
             Assert.Equal(typeCode, Type.GetTypeCode(t));
         }
+
+        public static void ReflectionOnlyGetType()
+        {
+            Assert.Throws<ArgumentNullException>("typeName", () => Type.ReflectionOnlyGetType(null, true, false));
+            Assert.Throws<TypeLoadException>(() => Type.ReflectionOnlyGetType("", true, true));
+            Assert.Throws<NotSupportedException>(() => Type.ReflectionOnlyGetType("System.Tests.TypeTests", false, true));
+        }
     }
 }


### PR DESCRIPTION
modify reflectiononly tests as their implementation is being changed to NotSupported in coreclr repo.
Disable the tests for now till new changes are pulled in.