### PR TITLE
Several changes to improve Socket stress

### DIFF
--- a/src/Common/tests/System/Net/Sockets/Performance/SocketPerformanceTests.cs
+++ b/src/Common/tests/System/Net/Sockets/Performance/SocketPerformanceTests.cs
@@ -50,8 +50,7 @@ namespace System.Net.Sockets.Performance.Tests
             {
                 milliseconds = RunClient(
                     clientType,
-                    "localhost",
-                    port,
+                    new IPEndPoint(address, port),
                     iterations,
                     bufferSize,
                     socketInstances);
@@ -79,8 +78,7 @@ namespace System.Net.Sockets.Performance.Tests
 
         public long RunClient(
             SocketImplementationType testType,
-            string server,
-            int port,
+            EndPoint endpoint,
             int iterations,
             int bufferSize,
             int socketInstances)
@@ -122,8 +120,7 @@ namespace System.Net.Sockets.Performance.Tests
                     var test = SocketTestClient.SocketTestClientFactory(
                         _log,
                         testType,
-                        server,
-                        port,
+                        endpoint,
                         iterations,
                         message,
                         timeProgramStart);

--- a/src/Common/tests/System/Net/Sockets/Performance/SocketTestClient.cs
+++ b/src/Common/tests/System/Net/Sockets/Performance/SocketTestClient.cs
@@ -126,8 +126,8 @@ namespace System.Net.Sockets.Performance.Tests
                 // IMPORTANT: The code currently assumes one outstanding Send and one Receive. Interlocked operations
                 //            are required to handle re-entrancy.
 
-                Task t1 = Task.Run(async () => { await DoSend(); });
-                Task t2 = Task.Run(async () => { await DoReceive(); });
+                Task t1 = Task.Run(() => DoSend());
+                Task t2 = Task.Run(() => DoReceive());
 
                 await t1;
                 await t2;

--- a/src/Common/tests/System/Net/Sockets/Performance/SocketTestClient.cs
+++ b/src/Common/tests/System/Net/Sockets/Performance/SocketTestClient.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
+using Xunit;
 using Xunit.Abstractions;
 
 namespace System.Net.Sockets.Performance.Tests
@@ -16,8 +17,6 @@ namespace System.Net.Sockets.Performance.Tests
     {
         protected readonly ITestOutputHelper _log;
 
-        protected string _server;
-        protected int _port;
         protected EndPoint _endpoint;
 
         protected Socket _s;
@@ -36,8 +35,7 @@ namespace System.Net.Sockets.Performance.Tests
         private const string _format = "{0, -20}, {1, -25}, {2, 15}, {3, 15}, {4, 15}, {5, 15}, {6, 15}, {7, 15}, {8, 15}";
         private int _bufferLen;
 
-        private int _send_iterations = 0;
-        private int _receive_iterations = 0;
+        private int _current_bytes;
 
         private Stopwatch _timeConnect = new Stopwatch();
         private Stopwatch _timeSendRecv = new Stopwatch();
@@ -45,19 +43,18 @@ namespace System.Net.Sockets.Performance.Tests
 
         private TaskCompletionSource<long> _tcs = new TaskCompletionSource<long>();
 
+        private Random _random = new Random();
+
         public SocketTestClient(
             ITestOutputHelper log,
-            string server,
-            int port,
+            EndPoint endpoint,
             int iterations,
             string message,
             Stopwatch timeProgramStart)
         {
             _log = log;
 
-            _server = server;
-            _port = port;
-            _endpoint = new DnsEndPoint(server, _port);
+            _endpoint = endpoint;
 
             _sendString = message;
             _sendBuffer = Encoding.UTF8.GetBytes(_sendString);
@@ -67,21 +64,13 @@ namespace System.Net.Sockets.Performance.Tests
 
             _timeProgramStart = timeProgramStart;
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // on Unix, socket will be created in Socket.ConnectAsync
-            {
-                _timeInit.Start();
-                _s = new Socket(SocketType.Stream, ProtocolType.Tcp);
-                _timeInit.Stop();
-            }
-
             _iterations = iterations;
         }
 
         public static SocketTestClient SocketTestClientFactory(
             ITestOutputHelper log,
             SocketImplementationType type,
-            string server,
-            int port,
+            EndPoint endpoint,
             int iterations,
             string message,
             Stopwatch timeProgramStart)
@@ -89,11 +78,11 @@ namespace System.Net.Sockets.Performance.Tests
             switch (type)
             {
                 case SocketImplementationType.APM:
-                    var socketAPM = new SocketTestClientAPM(log, server, port, iterations, message, timeProgramStart);
+                    var socketAPM = new SocketTestClientAPM(log, endpoint, iterations, message, timeProgramStart);
                     log.WriteLine(socketAPM.GetHashCode() + " SocketTestClientAPM(..)");
                     return socketAPM;
                 case SocketImplementationType.Async:
-                    var socketAsync = new SocketTestClientAsync(log, server, port, iterations, message, timeProgramStart);
+                    var socketAsync = new SocketTestClientAsync(log, endpoint, iterations, message, timeProgramStart);
                     log.WriteLine(socketAsync.GetHashCode() + " SocketTestClientAsync(..)");
                     return socketAsync;
 
@@ -104,58 +93,109 @@ namespace System.Net.Sockets.Performance.Tests
 
         public abstract void Connect(Action<SocketError> onConnectCallback);
 
-        private void OnConnect(SocketError error)
+        private async void OnConnect(SocketError error)
         {
             _timeConnect.Stop();
             _log.WriteLine(this.GetHashCode() + " OnConnect({0}) _timeConnect={1}", error, _timeConnect.ElapsedMilliseconds);
 
-            // TODO: an error should fail the test.
-            if (error != SocketError.Success)
-            {
-                _timeClose.Start();
-                Close(OnClose);
-                return;
-            }
+            Assert.Equal(SocketError.Success, error);
 
             _timeSendRecv.Start();
 
-            // TODO: It might be more efficient to have more than one outstanding Send/Receive.
-
-            // IMPORTANT: The code currently assumes one outstanding Send and one Receive. Interlocked operations
-            //            are required to handle re-entrancy.
-
-            int bytesTransferred;
-            SocketError socketError;
-
-            if (!Send(out bytesTransferred, out socketError, OnSend))
+            // Loop over iterations, doing sends and receives
+            for (int i = 0; i < _iterations; i++)
             {
-                OnSend(bytesTransferred, socketError);
+                // Kick off another iteration.
+                // First, we pick a random # of Sends to perform.
+
+                // Generate a random floating point number between 0 and 10
+                double d = ((double)_random.Next()) / int.MaxValue * 10;
+
+                // Use this as the base 2 exponent to determine # of Sends to do.
+                // In other words, this scales exponentially from 1 (2^0) to 1024 (2^10),
+                // with a median of 32 (2^5).
+                int sends = (int) Math.Floor(Math.Pow(2.0, d));
+
+                // We actually track bytes overall, since the receives are not
+                // necessarily always on buffer length boundaries.
+                _current_bytes = sends * _bufferLen;
+
+                // 
+                // TODO: It might be more efficient to have more than one outstanding Send/Receive.
+
+                // IMPORTANT: The code currently assumes one outstanding Send and one Receive. Interlocked operations
+                //            are required to handle re-entrancy.
+
+                Task t1 = Task.Run(async () => { await DoSend(); });
+                Task t2 = Task.Run(async () => { await DoReceive(); });
+
+                await t1;
+                await t2;
             }
 
-            if (!Receive(out bytesTransferred, out socketError, OnReceive))
-            {
-                OnReceive(bytesTransferred, socketError);
-            }
+            Close(OnClose);
         }
 
         public abstract bool Send(out int bytesTransferred, out SocketError socketError, Action<int, SocketError> onSendCallback);
 
-        // Called when the entire _sendBuffer has been sent.
-        private void OnSend(int bytesSent, SocketError error)
+        private Task<int> SendHelper()
         {
-            // Keep sending until pending
-            bool pending;
-            do
-            {
-                _log.WriteLine(this.GetHashCode() + " OnSend({0}, {1})", bytesSent, error);
+            TaskCompletionSource<int> tcs = new TaskCompletionSource<int>();
 
-                // TODO: an error should fail the test.
-                if (error != SocketError.Success)
+            Action<int, SocketError> onSend = (bytesTransferred, socketError) => {
+                if (socketError == SocketError.Success)
                 {
-                    _timeClose.Start();
-                    Close(OnClose);
-                    return;
+                    tcs.SetResult(bytesTransferred);
                 }
+                else
+                {
+                    tcs.SetException(new SocketException((int)socketError));
+                }
+            };
+
+            int bytes;
+            SocketError error;
+            bool pending = Send(out bytes, out error, onSend);
+            if (!pending)
+            {
+                onSend(bytes, error);
+            }
+
+            return tcs.Task;
+        }
+
+        private Task<int> ReceiveHelper()
+        {
+            TaskCompletionSource<int> tcs = new TaskCompletionSource<int>();
+
+            Action<int, SocketError> onReceive = (bytesTransferred, socketError) => {
+                if (socketError == SocketError.Success)
+                {
+                    tcs.SetResult(bytesTransferred);
+                }
+                else
+                {
+                    tcs.SetException(new SocketException((int)socketError));
+                }
+            };
+
+            int bytes;
+            SocketError error;
+            bool pending = Receive(out bytes, out error, onReceive);
+            if (!pending)
+            {
+                onReceive(bytes, error);
+            }
+
+            return tcs.Task;
+        }
+
+        private async Task DoSend()
+        {
+            int total_bytes_sent = 0;
+            while (total_bytes_sent < _current_bytes)
+            {
+                int bytesSent = await SendHelper();
 
                 if (bytesSent != _sendBuffer.Length)
                 {
@@ -163,77 +203,48 @@ namespace System.Net.Sockets.Performance.Tests
                         "OnSend: Unexpected bytesSent={0}, expected {1}",
                         bytesSent,
                         _sendBuffer.Length);
-                    return;
+                    throw new Exception("Unexpected bytesSent");
                 }
 
-                _send_iterations++;
-                _log.WriteLine(this.GetHashCode() + " OnSendMessage() _send_iterations={0}", _send_iterations);
-
-                if (_send_iterations == _iterations)
-                {
-                    //TODO: _s.Shutdown(SocketShutdown.Send);
-                    return;
-                }
-
-                pending = Send(out bytesSent, out error, OnSend);
-            } while (!pending);
+                total_bytes_sent += bytesSent;
+                Assert.True(total_bytes_sent <= _current_bytes);
+            }
         }
 
         public abstract bool Receive(out int bytesTransferred, out SocketError socketError, Action<int, SocketError> onSendCallback);
 
-        // Called when the entire _recvBuffer has been received.
-        private void OnReceive(int receivedBytes, SocketError error)
+        private async Task DoReceive()
         {
-            bool pending;
-            do
+            int total_bytes_received = 0;
+            while (total_bytes_received < _current_bytes)
             {
-                _log.WriteLine(this.GetHashCode() + " OnSend({0}, {1})", receivedBytes, error);
-                _recvBufferIndex += receivedBytes;
-
-                // TODO: an error should fail the test.
-                if (error != SocketError.Success)
+                int receivedBytes = await ReceiveHelper();
+                if (receivedBytes == 0)
                 {
-                    _timeClose.Start();
-                    Close(OnClose);
-                    return;
+                    _log.WriteLine("Socket unexpectedly closed.");
+                    throw new Exception("Socket unexpectedly closed");
                 }
 
-                if (_recvBufferIndex == _recvBuffer.Length)
-                {
-                    _receive_iterations++;
-                    _log.WriteLine(this.GetHashCode() + " OnReceiveMessage() _receive_iterations={0}", _receive_iterations);
+                total_bytes_received += receivedBytes;
+                Assert.True(total_bytes_received <= _current_bytes);
 
+                _recvBufferIndex += receivedBytes;
+                Assert.True(_recvBufferIndex <= _bufferLen);
+                if (_recvBufferIndex == _bufferLen)
+                {
                     _recvBufferIndex = 0;
 
-                    // Expect echo server.
+                    // Compare the bytes we sent to the bytes we received;
+                    // They should be the same since the server is an echo server.
                     if (!SocketTestMemcmp.Compare(_sendBuffer, _recvBuffer))
                     {
                         _log.WriteLine("Received different data from echo server");
+                        throw new Exception("Received different data from echo server");
                     }
 
-                    if (_receive_iterations >= _iterations)
-                    {
-                        _timeSendRecv.Stop();
-                        _timeClose.Start();
-                        Close(OnClose);
-                        return;
-                    }
-                    else
-                    {
-                        Array.Clear(_recvBuffer, 0, _recvBuffer.Length);
-                        pending = Receive(out receivedBytes, out error, OnReceive);
-                    }
+                    Array.Clear(_recvBuffer, 0, _bufferLen);
                 }
-                else if (receivedBytes == 0)
-                {
-                    _log.WriteLine("Socket unexpectedly closed.");
-                    return;
-                }
-                else
-                {
-                    pending = Receive(out receivedBytes, out error, OnReceive);
-                }
-            } while (!pending);
+            }
         }
 
         public abstract void Close(Action onCloseCallback);
@@ -241,30 +252,6 @@ namespace System.Net.Sockets.Performance.Tests
         private void OnClose()
         {
             _timeClose.Stop();
-            _log.WriteLine(this.GetHashCode() + " OnClose() _timeClose={0}", _timeClose.ElapsedMilliseconds);
-
-            try
-            {
-                _log.WriteLine(
-                    _format,
-                    "Socket",
-                    ImplementationName(),
-                    _bufferLen,
-                    _receive_iterations,
-                    _timeInit.ElapsedMilliseconds, // only relevant on Windows
-                    _timeConnect.ElapsedMilliseconds, // on Unix this includes socket creation time
-                    _timeSendRecv.ElapsedMilliseconds,
-                    _timeClose.ElapsedMilliseconds,
-                    _timeProgramStart.ElapsedMilliseconds);
-            }
-            catch (Exception ex)
-            {
-                _log.WriteLine("Exception while writing the report: {0}", ex);
-            }
-
-            _log.WriteLine(
-                this.GetHashCode() + " OnClose() setting tcs result : {0}",
-                _timeSendRecv.ElapsedMilliseconds);
 
             _tcs.TrySetResult(_timeSendRecv.ElapsedMilliseconds);
         }

--- a/src/Common/tests/System/Net/Sockets/Performance/SocketTestClient.cs
+++ b/src/Common/tests/System/Net/Sockets/Performance/SocketTestClient.cs
@@ -41,8 +41,6 @@ namespace System.Net.Sockets.Performance.Tests
         private Stopwatch _timeSendRecv = new Stopwatch();
         private Stopwatch _timeClose = new Stopwatch();
 
-        private TaskCompletionSource<long> _tcs = new TaskCompletionSource<long>();
-
         private Random _random = new Random();
 
         public SocketTestClient(
@@ -93,12 +91,59 @@ namespace System.Net.Sockets.Performance.Tests
 
         public abstract void Connect(Action<SocketError> onConnectCallback);
 
-        private async void OnConnect(SocketError error)
+        private Task ConnectHelper()
         {
-            _timeConnect.Stop();
-            _log.WriteLine(this.GetHashCode() + " OnConnect({0}) _timeConnect={1}", error, _timeConnect.ElapsedMilliseconds);
+            TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();
 
-            Assert.Equal(SocketError.Success, error);
+            Connect(socketError => {
+                if (socketError == SocketError.Success)
+                {
+                    tcs.SetResult(true);
+                }
+                else
+                {
+                    tcs.SetException(new SocketException((int)socketError));
+                }
+            });
+
+            return tcs.Task;
+        }
+
+        public async Task RunTest()
+        {
+            int connectionAttempts = 0;
+            while (true)
+            {
+                try 
+                {
+                    await ConnectHelper();
+
+                    // Success, break out of loop
+                    break;
+                }
+                catch (SocketException e)
+                {
+                    // If we got ConnectionRefused, we want to fall through and retry
+                    // Otherwise, rethrow
+                    if (e.SocketErrorCode != SocketError.ConnectionRefused)
+                    {
+                        throw;
+                    }
+
+                    // Limit connection attempts
+                    if (connectionAttempts == 3)
+                    {
+                        throw;
+                    }
+                }
+
+                // Connection was refused.  
+                // The server may be temporarily overloaded, and the server OS is rejecting connections.
+                // Wait a bit and then retry.
+                await Task.Delay(200);
+
+                connectionAttempts++;
+            }
 
             _timeSendRecv.Start();
 
@@ -133,7 +178,7 @@ namespace System.Net.Sockets.Performance.Tests
                 await t2;
             }
 
-            Close(OnClose);
+            await CloseHelper();
         }
 
         public abstract bool Send(out int bytesTransferred, out SocketError socketError, Action<int, SocketError> onSendCallback);
@@ -249,19 +294,13 @@ namespace System.Net.Sockets.Performance.Tests
 
         public abstract void Close(Action onCloseCallback);
 
-        private void OnClose()
+        private Task CloseHelper()
         {
-            _timeClose.Stop();
+            TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();
 
-            _tcs.TrySetResult(_timeSendRecv.ElapsedMilliseconds);
-        }
+            Close(() => { tcs.SetResult(true); });
 
-        public Task<long> RunTest()
-        {
-            _timeConnect.Start();
-            Connect(OnConnect);
-
-            return _tcs.Task;
+            return tcs.Task;
         }
 
         protected abstract string ImplementationName();

--- a/src/Common/tests/System/Net/Sockets/Performance/SocketTestClientAsync.cs
+++ b/src/Common/tests/System/Net/Sockets/Performance/SocketTestClientAsync.cs
@@ -15,11 +15,10 @@ namespace System.Net.Sockets.Performance.Tests
 
         public SocketTestClientAsync(
             ITestOutputHelper log,
-            string server,
-            int port,
+            EndPoint endpoint,
             int iterations,
             string message,
-            Stopwatch timeProgramStart) : base(log, server, port, iterations, message, timeProgramStart)
+            Stopwatch timeProgramStart) : base(log, endpoint, iterations, message, timeProgramStart)
         {
             _sendEventArgs.Completed += IO_Complete;
             _recvEventArgs.Completed += IO_Complete;
@@ -32,9 +31,7 @@ namespace System.Net.Sockets.Performance.Tests
             connectEventArgs.UserToken = onConnectCallback;
             connectEventArgs.Completed += OnConnect;
 
-            bool willRaiseEvent = _s != null ?
-                _s.ConnectAsync(connectEventArgs) :
-                Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, connectEventArgs);
+            bool willRaiseEvent = Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, connectEventArgs);
             if (!willRaiseEvent)
             {
                 ProcessConnect(connectEventArgs);
@@ -48,10 +45,7 @@ namespace System.Net.Sockets.Performance.Tests
 
         private void ProcessConnect(SocketAsyncEventArgs e)
         {
-            if (_s == null)
-            {
-                _s = e.ConnectSocket;
-            }
+            _s = e.ConnectSocket;
             Action<SocketError> callback = (Action<SocketError>)e.UserToken;
             callback(e.SocketError);
         }

--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Net.Sockets.Tests;
 using System.Net.Test.Common;
 
@@ -14,32 +15,17 @@ namespace System.Net.Sockets.Performance.Tests
     public class SocketPerformanceAsyncTests
     {
         private readonly ITestOutputHelper _log;
+        private readonly int _iterations = 1;
 
         public SocketPerformanceAsyncTests(ITestOutputHelper output)
         {
             _log = TestLogging.GetInstance();
-        }
 
-        [ActiveIssue(13349, TestPlatforms.OSX)]
-        [OuterLoop]
-        [Fact]
-        public void SocketPerformance_SingleSocketClientAsync_LocalHostServerAsync()
-        {
-            SocketImplementationType serverType = SocketImplementationType.Async;
-            SocketImplementationType clientType = SocketImplementationType.Async;
-            int iterations = 10000;
-            int bufferSize = 256;
-            int socket_instances = 1;
-
-            var test = new SocketPerformanceTests(_log);
-
-            // Run in Stress mode no expected time to complete.
-            test.ClientServerTest(
-                serverType,
-                clientType,
-                iterations,
-                bufferSize,
-                socket_instances);
+            string env = Environment.GetEnvironmentVariable("SOCKETSTRESS_ITERATIONS");
+            if (env != null)
+            {
+                _iterations = int.Parse(env);
+            }
         }
 
         [ActiveIssue(13349, TestPlatforms.OSX)]
@@ -49,9 +35,9 @@ namespace System.Net.Sockets.Performance.Tests
         {
             SocketImplementationType serverType = SocketImplementationType.Async;
             SocketImplementationType clientType = SocketImplementationType.Async;
-            int iterations = 2000;
+            int iterations = 200 * _iterations;
             int bufferSize = 256;
-            int socket_instances = 500;
+            int socket_instances = 200;
 
             var test = new SocketPerformanceTests(_log);
 

--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketTestClientAPMMock.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketTestClientAPMMock.cs
@@ -12,11 +12,10 @@ namespace System.Net.Sockets.Performance.Tests
     {
         public SocketTestClientAPM(
             ITestOutputHelper log,
-            string server,
-            int port,
+            EndPoint endpoint,
             int iterations,
             string message,
-            Stopwatch timeProgramStart) : base(log, server, port, iterations, message, timeProgramStart)
+            Stopwatch timeProgramStart) : base(log, endpoint, iterations, message, timeProgramStart)
         {
         }
 


### PR DESCRIPTION
Existing Socket stress test ignores most failures, such as connection failure, send failure, receive failure, etc.  I am adding checks for these failures.

When adding these checks, I noticed several other problems:
(1) On Linux, all connections were silently failing due to the way we were trying to connect.  The server was listening on IPv6Loopback, but the client was trying to connect via DNS resolution to "localhost".  On Windows, "localhost" resolves to both IPv6Loopback and IPv4Loopback, so this works.  On Linux, it only resolves to IPv4Loopback, thus all client connections fail.

Fix is to make the client explicitly connect to IPv6Loopback instead of using the "localhost" name.

(2) On Windows, the host OS would start rejecting connections at around the 150th connection or so.  This seemed to be due to the way the test works; it was connecting and immediately performing lots and lots of sends to the server.

The fix is to rework the test to do sends and receives in a slightly less aggressive way, and make sure that the client is processing receives at the same time as sends by spawning separate tasks for them.

Also, a couple related changes:
(1) Randomly vary the size of the amount of data sent before the client stops sending and waits for all data to be received from the server.
(2) Add the SOCKETSTRESS_ITERATIONS env variable to enable longer stress runs.
(3) Rework some code to use Tasks, to make the code easier to implement
(4) Have just one stress test instead of multiple.  (The second variation wasn't really providing any additional coverage anyway.)

This stress test should take around 30s to run, compared to 3s previously.
