### PR TITLE
In SNITcpHandle.Dispose(), null _stream so that it releases any object references.

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -63,6 +63,9 @@ namespace System.Data.SqlClient.SNI
                     _tcpStream.Dispose();
                     _tcpStream = null;
                 }
+
+                //Release any references held by _stream.
+                _stream = null;
             }
         }
 


### PR DESCRIPTION
Porting change in https://github.com/dotnet/corefx/pull/15431/commits/4893f2f89032b5d2c39d619ae0961fa491aaf8d9 to current release branch.