### PR TITLE
Typo in build variable name

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux.json
@@ -442,7 +442,7 @@
       "value": null,
       "isSecret": true
     },
-    "PB_VsoRepoName": {
+    "PB_VsoRepositoryName": {
       "value": "DotNet-CoreFX-Trusted",
       "allowOverride": true
     },


### PR DESCRIPTION
Should be PB_VsoRepositoryName, matching with other repos.  No effective different in execution since VsoRepoName was unused.

/cc @chcosta 