### PR TITLE
Attempt to make UDP socket tests more reliable on Linux

### DIFF
--- a/src/Common/tests/System/Net/Sockets/TestSettings.cs
+++ b/src/Common/tests/System/Net/Sockets/TestSettings.cs
@@ -11,6 +11,11 @@ namespace System.Net.Sockets.Tests
         public const int FailingTestTimeout = 100;
 
         // Number of redundant UDP packets to send to increase test reliability
-        public const int UDPRedundancy = 10;
+        // Update: was 10, changing to 1 to measure impact of random test failures occurring on *nix.
+        // Certain random failures appear to be caused by a UDP client sending in a loop (based on UDPRedundancy)
+        // to a server which was closed but another server created (on a different thread \ test) that happens to
+        // have the same port #.
+        // This occurs on *nix but not Windows because *nix uses random values (1024-65535) while Windows increments.
+        public const int UDPRedundancy = 1;
     }
 }


### PR DESCRIPTION
Currently some of the UDP tests are sending to a given server multiple times due to potential 'packet loss' problems, which apparently is causing side effects with other tests running in parallel. This PR changes the tests to only send once; I will measure the test impact over several days and determine whether to keep it like this, or if new failures start occurring due to packet loss we'll need to refactor the tests in some manner to accommodate multiple sends without side effecting other tests running in parallel.

Also I'm not sure if packet loss should ever occur on loopback \ localhost, assuming that various send\receive buffers do not get overloaded when our tests run, and in that case sending multiple times may make the problem worse.

I believe the problem is the extra sends that would normally just get lost actually go to the wrong server if another test running in parallel happens to create a server with the same port number. UDP is connectionless so the client doesn't know if the original server has been closed. This causes things like expected timeouts not occurring because a receive succeeds when there shouldn't be a client sending (https://github.com/dotnet/corefx/blob/master/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs#L557) or other failures because received messages are coming from the wrong client(https://github.com/dotnet/corefx/blob/master/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs#L2347)

Here's some examples of recent test failures affected by this issue (roughly 1 per day on CI runs):
````
Assert.Throws() Failure\nExpected: typeof(System.Net.Sockets.SocketException)\nActual: (No exception was thrown)
at System.Net.Sockets.Tests.DualModeConnectAsync.ConnectAsyncV4IPEndPointToV6Host_Fails() in /mnt/j/workspace/dotnet_corefx/master/ubuntu16.10_debug/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs:line 516

Assert.Throws() Failure\nExpected: typeof(System.TimeoutException)\nActual: typeof(Xunit.Sdk.EqualException): Assert.Equal() Failure\nExpected: ::1\nActual: ::ffff:127.0.0.1
at System.Net.Sockets.Tests.DualModeConnectionlessReceiveMessageFrom.ReceiveMessageFromAsync_Helper(IPAddress listenOn, IPAddress connectTo, Boolean expectedToTimeout) in /mnt/resource/j/workspace/dotnet_corefx/master/opensuse42.1_release/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs:line 2347

Assert.Throws() Failure\nExpected: typeof(System.Net.Sockets.SocketException)\nActual: typeof(Xunit.Sdk.ThrowsException): Assert.Throws() Failure\nExpected: typeof(System.Exception)\nActual: (No exception was thrown)
at System.Net.Sockets.Tests.DualModeConnectionlessReceiveMessageFrom.ReceiveMessageFrom_Helper(IPAddress listenOn, IPAddress connectTo, Boolean expectedToTimeout) in /mnt/j/workspace/dotnet_corefx/master/ubuntu14.04_debug/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs:line 1988 at System.Net.Sockets.Tests.DualModeConnectionlessReceiveMessageFrom.<ReceiveMessageFromV6BoundToAnyV4_NotReceived>b__13_0() in /mnt/j/workspace/dotnet_corefx/master/ubuntu14.04_debug/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs:line 1946

Assert.Throws() Failure\nExpected: typeof(System.Net.Sockets.SocketException)\nActual: typeof(Xunit.Sdk.EqualException): Assert.Equal() Failure\nExpected: ::1\nActual: ::ffff:127.0.0.1
at System.Net.Sockets.Tests.DualModeBase.ReceiveFrom_Helper(IPAddress listenOn, IPAddress connectTo) in /mnt/j/workspace/dotnet_corefx/master/ubuntu16.10_debug/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs:line 2709 at System.Net.Sockets.Tests.DualModeConnectionlessReceiveFrom.<ReceiveFromV6BoundToSpecificV4_NotReceived>b__6_0() in /mnt/j/workspace/dotnet_corefx/master/ubuntu16.10_debug/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs:line 1401
````
cc @ianhays 
cc @Priya91 
cc @davidsh
cc @ericeil

In reference to issue #14519 