### PR TITLE
Stop bin placing facade assemblies to the refs for netfx builds

### DIFF
--- a/binplace.targets
+++ b/binplace.targets
@@ -7,8 +7,18 @@
          https://github.com/dotnet/corefx/issues/14291 is tracking cleaning this up -->
     <IsRuntimeAndReferenceAssembly Condition="'$(IsRuntimeAndReferenceAssembly)' == '' and '$(IsRuntimeAssembly)' == 'true' and Exists('$(SourceDir)/$(AssemblyName)') and !Exists('$(SourceDir)/$(AssemblyName)/ref') and !$(AssemblyName.StartsWith('System.Private'))">true</IsRuntimeAndReferenceAssembly>
     <IsNETCoreAppRef Condition="'$(IsNETCoreAppRef)' == ''">$(IsNETCoreApp)</IsNETCoreAppRef>
-    <BinPlaceStuffDependsOn Condition="'$(IsReferenceAssembly)' == 'true' OR '$(IsRuntimeAndReferenceAssembly)' == 'true'">$(BinPlaceStuffDependsOn);BinPlaceReferenceAssembly</BinPlaceStuffDependsOn>
-    <BinPlaceStuffDependsOn Condition="'$(IsRuntimeAssembly)' == 'true' OR '$(IsRuntimeAndReferenceAssembly)' == 'true'">$(BinPlaceStuffDependsOn);BinPlaceRuntimeAssembly</BinPlaceStuffDependsOn>
+
+    <BuildingDesktopFacade Condition="'$(IsDesktopFacade)' == 'true' And ('$(TargetGroup)' == 'netfx' Or $(TargetGroup.StartsWith('net4')))" >true</BuildingDesktopFacade>
+
+    <!-- if building desktop facade, we don't bin place the refs -->
+    <BinPlaceRef Condition="'$(BuildingDesktopFacade)' != 'true' And ('$(IsReferenceAssembly)' == 'true' OR '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRef>
+    <BinPlaceRuntime Condition="'$(IsRuntimeAssembly)' == 'true' OR '$(IsRuntimeAndReferenceAssembly)' == 'true'">true</BinPlaceRuntime>
+
+    <!-- if building desktop facade and bin placing the runtime, then we need to bin place the refs too -->
+    <BinPlaceRef Condition="'$(BuildingDesktopFacade)' == 'true' And '$(BinPlaceRuntime)' == 'true'">true</BinPlaceRef>
+
+    <BinPlaceStuffDependsOn Condition="'$(BinPlaceRef)' == 'true'">$(BinPlaceStuffDependsOn);BinPlaceReferenceAssembly</BinPlaceStuffDependsOn>
+    <BinPlaceStuffDependsOn Condition="'$(BinPlaceRuntime)' == 'true'">$(BinPlaceStuffDependsOn);BinPlaceRuntimeAssembly</BinPlaceStuffDependsOn>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Microsoft.Win32.Registry.AccessControl/dir.props
+++ b/src/Microsoft.Win32.Registry.AccessControl/dir.props
@@ -3,5 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Win32.Registry/dir.props
+++ b/src/Microsoft.Win32.Registry/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.CodeDom/dir.props
+++ b/src/System.CodeDom/dir.props
@@ -1,7 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>
-

--- a/src/System.ComponentModel.Annotations/dir.props
+++ b/src/System.ComponentModel.Annotations/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.Data.Common/dir.props
+++ b/src/System.Data.Common/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.Diagnostics.StackTrace/dir.props
+++ b/src/System.Diagnostics.StackTrace/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Compression/dir.props
+++ b/src/System.IO.Compression/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.FileSystem.AccessControl/dir.props
+++ b/src/System.IO.FileSystem.AccessControl/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Packaging/dir.props
+++ b/src/System.IO.Packaging/dir.props
@@ -3,5 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Pipes.AccessControl/dir.props
+++ b/src/System.IO.Pipes.AccessControl/dir.props
@@ -3,5 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Http/src/Configurations.props
+++ b/src/System.Net.Http/src/Configurations.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <BuildConfigurations>
       uap-Windows_NT;
-      net46-Windows_NT;
       netcoreapp-Unix;
       netcoreapp-Windows_NT;
       net46-Windows_NT;

--- a/src/System.Numerics.Vectors/dir.props
+++ b/src/System.Numerics.Vectors/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.3.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.TypeExtensions/dir.props
+++ b/src/System.Reflection.TypeExtensions/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Serialization.Primitives/dir.props
+++ b/src/System.Runtime.Serialization.Primitives/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Serialization.Xml/dir.props
+++ b/src/System.Runtime.Serialization.Xml/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.3.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.AccessControl/dir.props
+++ b/src/System.Security.AccessControl/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Cng/dir.props
+++ b/src/System.Security.Cryptography.Cng/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.3.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Pkcs/dir.props
+++ b/src/System.Security.Cryptography.Pkcs/dir.props
@@ -3,5 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.ProtectedData/dir.props
+++ b/src/System.Security.Cryptography.ProtectedData/dir.props
@@ -3,5 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Permissions/dir.props
+++ b/src/System.Security.Permissions/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Principal.Windows/dir.props
+++ b/src/System.Security.Principal.Windows/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.ServiceProcess.ServiceController/dir.props
+++ b/src/System.ServiceProcess.ServiceController/dir.props
@@ -3,5 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.Threading.AccessControl/dir.props
+++ b/src/System.Threading.AccessControl/dir.props
@@ -3,5 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.Threading.Overlapped/dir.props
+++ b/src/System.Threading.Overlapped/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.Xml.XPath.XDocument/dir.props
+++ b/src/System.Xml.XPath.XDocument/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
we were bin placing the facade assemblies to the ref folder during netfx build. this was causing a problem while building the tests as we'll get some types defined in the referenced facade assemblies and core libs.