### PR TITLE
Added test for ConnectionStrings configuration section read

### DIFF
--- a/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="System\Configuration\ConfigurationPropertyTests.cs" />
     <Compile Include="System\Configuration\ConfigurationTests.cs" />
     <Compile Include="System\Configuration\BasicCustomSectionTests.cs" />
+    <Compile Include="System\Configuration\ConnectionStringsTests.cs" />
     <Compile Include="System\Configuration\ExceptionUtilTests.cs" />
     <Compile Include="System\Configuration\ImplicitMachineConfigTests.cs" />
     <Compile Include="System\Configuration\KeyValueConfigurationCollectionTests.cs" />

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ConnectionStringsTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ConnectionStringsTests.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Configuration;
+using Xunit;
+
+namespace System.ConfigurationTests
+{
+    public class ConnectionStringsTests
+    {
+        public static string SimpleConnectionStringConfiguration =
+@"<?xml version='1.0' encoding='utf-8' ?>
+<configuration>
+    <connectionStrings>
+        <add name='fooName' connectionString='fooConnectionString' providerName='fooProviderName' />
+    </connectionStrings>
+</configuration>";
+
+        [Fact]
+        public void SimpleConnectionString()
+        {
+            using (var temp = new TempConfig(SimpleConnectionStringConfiguration))
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(temp.ExePath);
+                Assert.NotNull(config.ConnectionStrings);
+                Assert.NotNull(config.ConnectionStrings.ConnectionStrings);
+                ConnectionStringSettings connection = config.ConnectionStrings.ConnectionStrings["fooName"];
+                Assert.Equal("fooName", connection.Name);
+                Assert.Equal("fooConnectionString", connection.ConnectionString);
+                Assert.Equal("fooProviderName", connection.ProviderName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Related to #15554 
Single test to get early feedback, so me and @dhoehna could move on in right direction.
Separate class was added like AppSettingsTests.cs.
Constant SimpleConnectionStringConfiguration was declared like in BasicCustomSectionTests.cs
cc @JeremyKuhne @karelz 