### PR TITLE
Remove ActiveIssue attributes for #3838

### DIFF
--- a/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -107,7 +107,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => rethrowFinally.Compile(useInterpreter));
         }
 
-        [Theory, InlineData(true)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void CannotRethrowWithinFaultWithinCatch(bool useInterpreter)
         {
             LambdaExpression rethrowFinally = Expression.Lambda<Action>(
@@ -123,12 +123,6 @@ namespace System.Linq.Expressions.Tests
                     )
                 );
             Assert.Throws<InvalidOperationException>(() => rethrowFinally.Compile(useInterpreter));
-        }
-
-        [Fact, ActiveIssue(3838)]
-        public void CannotRethrowWithinFaultWithinCatchCompiled()
-        {
-            CannotRethrowWithinFaultWithinCatch(false);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
@@ -481,7 +475,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(1, Expression.Lambda<Func<int>>(block).Compile(useInterpreter)());
         }
 
-        [Theory, InlineData(true)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void FaultNotTriggeredOnNoThrowNonVoid(bool useInterpreter)
         {
             Func<int> func = Expression.Lambda<Func<int>>(
@@ -493,13 +487,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(42, func());
         }
 
-        [Fact, ActiveIssue(3838)]
-        public void FaultNotTriggeredOnNoThrowNonVoidCompiled()
-        {
-            FaultNotTriggeredOnNoThrowNonVoid(false);
-        }
-
-        [Theory, InlineData(true)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void FaultTriggeredOnThrow(bool useInterpreter)
         {
             ParameterExpression variable = Expression.Parameter(typeof(int));
@@ -518,12 +506,6 @@ namespace System.Linq.Expressions.Tests
                 Expression.Label(target, Expression.Default(typeof(int)))
                 );
             Assert.Equal(2, Expression.Lambda<Func<int>>(block).Compile(useInterpreter)());
-        }
-
-        [Fact, ActiveIssue(3838)]
-        public void FaultTriggeredOnThrowCompiled()
-        {
-            FaultTriggeredOnThrow(false);
         }
 
         [Theory, InlineData(true)]
@@ -585,7 +567,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<TestException>(act);
         }
 
-        [Theory, InlineData(true)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void ExceptionInFaultReplacesException(bool useInterpreter)
         {
             Action act = Expression.Lambda<Action>(
@@ -595,12 +577,6 @@ namespace System.Linq.Expressions.Tests
                     )
                 ).Compile(useInterpreter);
             Assert.Throws<TestException>(act);
-        }
-
-        [Fact, ActiveIssue(3838)]
-        public void ExceptionInFaultReplacesExceptionCompiled()
-        {
-            ExceptionInFaultReplacesException(false);
         }
 
         [Theory]
@@ -764,8 +740,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentException>("filter", () => Expression.Catch(Expression.Parameter(typeof(Exception)), Expression.Empty(), Expression.Constant(42)));
         }
 
-        [Theory]
-        [InlineData(true)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void FilterOnCatch(bool useInterpreter)
         {
             TryExpression tryExp = Expression.TryCatch(
@@ -777,15 +752,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(2, Expression.Lambda<Func<int>>(tryExp).Compile(useInterpreter)());
         }
 
-        [Fact]
-        [ActiveIssue(3838)]
-        public void FilterOnCatchCompiled(bool useInterpreter)
-        {
-            FilterOnCatch(false);
-        }
-
-        [Theory]
-        [InlineData(true)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void FilterCanAccessException(bool useInterpreter)
         {
             ParameterExpression exception = Expression.Variable(typeof(TestException));
@@ -798,15 +765,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(2, Expression.Lambda<Func<int>>(tryExp).Compile(useInterpreter)());
         }
 
-        [Fact]
-        [ActiveIssue(3838)]
-        public void FilterCanAccessExceptionCompiled(bool useInterpreter)
-        {
-            FilterCanAccessException(false);
-        }
-
-        [Theory]
-        [InlineData(true)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void FilterOverwiteExceptionVisibleToHandler(bool useInterpreter)
         {
             ParameterExpression exception = Expression.Variable(typeof(TestException));
@@ -824,15 +783,7 @@ namespace System.Linq.Expressions.Tests
             Assert.True(Expression.Lambda<Func<bool>>(tryExp).Compile(useInterpreter)());
         }
 
-        [Fact]
-        [ActiveIssue(3838)]
-        public void FilterOverwiteExceptionVisibleToHandlerCompiler()
-        {
-            FilterOverwiteExceptionVisibleToHandler(false);
-        }
-
-        [Theory]
-        [InlineData(true)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void FilterOverwriteExceptionNotVisibleToNextFilterOrHandler(bool useInterpreter)
         {
             ParameterExpression exception = Expression.Variable(typeof(TestException));
@@ -855,15 +806,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(24, Expression.Lambda<Func<int>>(tryExp).Compile(useInterpreter)());
         }
 
-        [Fact]
-        [ActiveIssue(3838)]
-        public void FilterOverwriteExceptionNotVisibleToNextFilterOrHandlerCompiler()
-        {
-            FilterOverwriteExceptionNotVisibleToNextFilterOrHandler(false);
-        }
-
-        [Theory]
-        [InlineData(true)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void FilterBeforeInnerFinally(bool useInterpreter)
         {
             StringBuilder sb = new StringBuilder();
@@ -911,14 +854,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal("ACBD", func().ToString());
         }
 
-        [Fact]
-        [ActiveIssue(3838)]
-        public void FilterBeforeInnerFinallyCompiled()
-        {
-            FilterBeforeInnerFinally(false);
-        }
-
-        [Theory, InlineData(true)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void FilterBeforeInnerFault(bool useInterpreter)
         {
             StringBuilder sb = new StringBuilder();
@@ -942,14 +878,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal("ACBD", func().ToString());
         }
 
-        [Fact, ActiveIssue(3838)]
-        public void FilterBeforeInnerFaultCompiled()
-        {
-            FilterBeforeInnerFault(false);
-        }
-
-        [Theory]
-        [InlineData(true)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void ExceptionThrownInFilter(bool useInterpreter)
         {
             // An exception in a filter should be eaten and the filter fail.
@@ -970,13 +899,6 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(9, func());
         }
 
-        [Fact]
-        [ActiveIssue(3838)]
-        public void ExceptionThrownInFilterCompiled()
-        {
-            ExceptionThrownInFilter(false);
-        }
-
         private bool MethodWithManyArguments(
             int x, int y, int z,
             int α, int β, int γ, int δ,
@@ -987,8 +909,7 @@ namespace System.Linq.Expressions.Tests
             return returnBack;
         }
 
-        [Theory]
-        [InlineData(true)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void DeepExceptionFilter(bool useInterpreter)
         {
             // An expression where the deepest use of the stack is within filters.
@@ -1051,15 +972,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(2, func());
         }
 
-        [Fact]
-        [ActiveIssue(3838)]
-        public void DeepExceptionFilterCompiled()
-        {
-            DeepExceptionFilter(false);
-        }
-
-        [Theory]
-        [InlineData(true)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void JumpOutOfExceptionFilter(bool useInterpreter)
         {
             LabelTarget target = Expression.Label();
@@ -1080,13 +993,6 @@ namespace System.Linq.Expressions.Tests
                     )
                 );
             Assert.Throws<InvalidOperationException>(() => tryExp.Compile(useInterpreter));
-        }
-
-        [Fact]
-        [ActiveIssue(3838)]
-        public void JumpOutOfExceptionFilterCompiled()
-        {
-            JumpOutOfExceptionFilter(false);
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]


### PR DESCRIPTION
This issue was caused by dotnet/coreclr#1764 which was fixed by dotnet/coreclr#8438 and so the attribute can be removed.

Closes #3838