### PR TITLE
Restore some comment formatting for BigInteger

### DIFF
--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.BitsBuffer.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.BitsBuffer.cs
@@ -7,14 +7,17 @@ using System.Security;
 
 namespace System.Numerics
 {
+    // ATTENTION: always pass BitsBuffer by reference,
+    // it's a structure for performance reasons. Furthermore
+    // it's a mutable one, so use it only with care!
+
     internal static partial class BigIntegerCalculator
     {
-        /// <summary>
-        /// To spare memory allocations a buffer helps reusing memory!
-        /// We just create the target array twice and switch between every
-        /// operation. In order to not compute unnecessarily with all those
-        /// leading zeros we take care of the current actual length.
-        /// </summary>
+        // To spare memory allocations a buffer helps reusing memory!
+        // We just create the target array twice and switch between every
+        // operation. In order to not compute unnecessarily with all those
+        // leading zeros we take care of the current actual length.
+
         internal struct BitsBuffer
         {
             private uint[] _bits;
@@ -92,6 +95,7 @@ namespace System.Numerics
             {
                 // Executes a modulo operation using an optimized reducer.
                 // Thus, no need of any switching here, happens in-line.
+
                 _length = reducer.Reduce(_bits, _length);
             }
 
@@ -121,6 +125,7 @@ namespace System.Numerics
             {
                 // Executes a modulo operation using the divide operation.
                 // Thus, no need of any switching here, happens in-line.
+
                 if (_length >= modulus._length)
                 {
                     fixed (uint* b = _bits, m = modulus._bits)
@@ -201,6 +206,7 @@ namespace System.Numerics
 
                 // Resets this and switches this and temp afterwards.
                 // The caller assumed an empty temp, the next will too.
+
                 Array.Clear(_bits, 0, _length);
 
                 uint[] t = temp._bits;

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.DivRem.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.DivRem.cs
@@ -40,6 +40,7 @@ namespace System.Numerics
             Debug.Assert(left.Length >= 1);
 
             // Same as above, but only computing the quotient.
+
             uint[] quotient = new uint[left.Length];
 
             ulong carry = 0UL;
@@ -60,6 +61,7 @@ namespace System.Numerics
             Debug.Assert(left.Length >= 1);
 
             // Same as above, but only computing the remainder.
+
             ulong carry = 0UL;
             for (int i = left.Length - 1; i >= 0; i--)
             {
@@ -110,7 +112,9 @@ namespace System.Numerics
             Debug.Assert(left.Length >= right.Length);
 
             // Same as above, but only returning the quotient.
+
             // NOTE: left will get overwritten, we need a local copy
+
             uint[] localLeft = CreateCopy(left);
             uint[] bits = new uint[left.Length - right.Length + 1];
 
@@ -134,7 +138,9 @@ namespace System.Numerics
             Debug.Assert(left.Length >= right.Length);
 
             // Same as above, but only returning the remainder.
+
             // NOTE: left will get overwritten, we need a local copy
+
             uint[] localLeft = CreateCopy(left);
 
             fixed (uint* l = localLeft, r = right)
@@ -243,6 +249,7 @@ namespace System.Numerics
             Debug.Assert(leftLength >= rightLength);
 
             // Repairs the dividend, if the last subtract was too much
+
             ulong carry = 0UL;
 
             for (int i = 0; i < rightLength; i++)

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs
@@ -9,12 +9,12 @@ namespace System.Numerics
 {
     internal static partial class BigIntegerCalculator
     {
-        /// <summary>
-        /// If we need to reduce by a certain modulus again and again, it's much
-        /// more efficient to do this with multiplication operations. This is
-        /// possible, if we do some pre-computations first...
-        /// see https://en.wikipedia.org/wiki/Barrett_reduction
-        /// </summary>
+        // If we need to reduce by a certain modulus again and again, it's much
+        // more efficient to do this with multiplication operations. This is
+        // possible, if we do some pre-computations first...
+
+        // see https://en.wikipedia.org/wiki/Barrett_reduction
+
         internal struct FastReducer
         {
             private readonly uint[] _modulus;

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.GcdInv.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.GcdInv.cs
@@ -11,7 +11,9 @@ namespace System.Numerics
         public static uint Gcd(uint left, uint right)
         {
             // Executes the classic Euclidean algorithm.
+
             // https://en.wikipedia.org/wiki/Euclidean_algorithm
+
             while (right != 0)
             {
                 uint temp = left % right;
@@ -25,6 +27,7 @@ namespace System.Numerics
         public static ulong Gcd(ulong left, ulong right)
         {
             // Same as above, but for 64-bit values.
+
             while (right > 0xFFFFFFFF)
             {
                 ulong temp = left % right;

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.PowMod.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.PowMod.cs
@@ -9,7 +9,7 @@ namespace System.Numerics
     internal static partial class BigIntegerCalculator
     {
         // Executes different exponentiation algorithms, which are
-        // basically based on the classic square-and-multiply method.
+        // based on the classic square-and-multiply method.
 
         // https://en.wikipedia.org/wiki/Exponentiation_by_squaring
 

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.PowMod.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.PowMod.cs
@@ -8,11 +8,11 @@ namespace System.Numerics
 {
     internal static partial class BigIntegerCalculator
     {
-        /// <summary>
-        /// Executes different exponentiation algorithms, which are
-        /// basically based on the classic square-and-multiply method.
-        /// https://en.wikipedia.org/wiki/Exponentiation_by_squaring
-        /// </summary>
+        // Executes different exponentiation algorithms, which are
+        // basically based on the classic square-and-multiply method.
+
+        // https://en.wikipedia.org/wiki/Exponentiation_by_squaring
+
         public static uint[] Pow(uint value, uint power)
         {
             // The basic pow method for a 32-bit integer.
@@ -31,6 +31,7 @@ namespace System.Numerics
             // The basic pow method for a big integer.
             // To spare memory allocations we first roughly
             // estimate an upper bound for our buffers.
+
             int size = PowBound(power, value.Length, 1);
             BitsBuffer v = new BitsBuffer(size, value);
             return PowCore(power, ref v);
@@ -39,6 +40,7 @@ namespace System.Numerics
         private static uint[] PowCore(uint power, ref BitsBuffer value)
         {
             // Executes the basic pow algorithm.
+
             int size = value.GetSize();
 
             BitsBuffer temp = new BitsBuffer(size, 0);
@@ -54,6 +56,7 @@ namespace System.Numerics
         {
             // The basic pow algorithm, but instead of squaring
             // and multiplying we just sum up the lengths.
+
             while (power != 0)
             {
                 checked
@@ -73,6 +76,7 @@ namespace System.Numerics
                                     ref BitsBuffer result, ref BitsBuffer temp)
         {
             // The basic pow algorithm using square-and-multiply.
+
             while (power != 0)
             {
                 if ((power & 1) == 1)
@@ -87,6 +91,7 @@ namespace System.Numerics
         {
             // The 32-bit modulus pow method for a 32-bit integer
             // raised by a 32-bit integer...
+
             return PowCore(power, modulus, value, 1);
         }
 
@@ -96,6 +101,7 @@ namespace System.Numerics
 
             // The 32-bit modulus pow method for a big integer
             // raised by a 32-bit integer...
+
             uint v = Remainder(value, modulus);
             return PowCore(power, modulus, v, 1);
         }
@@ -106,6 +112,7 @@ namespace System.Numerics
 
             // The 32-bit modulus pow method for a 32-bit integer
             // raised by a big integer...
+
             return PowCore(power, modulus, value, 1);
         }
 
@@ -116,6 +123,7 @@ namespace System.Numerics
 
             // The 32-bit modulus pow method for a big integer
             // raised by a big integer...
+
             uint v = Remainder(value, modulus);
             return PowCore(power, modulus, v, 1);
         }
@@ -125,6 +133,7 @@ namespace System.Numerics
         {
             // The 32-bit modulus pow algorithm for all but
             // the last power limb using square-and-multiply.
+
             for (int i = 0; i < power.Length - 1; i++)
             {
                 uint p = power[i];
@@ -145,6 +154,7 @@ namespace System.Numerics
         {
             // The 32-bit modulus pow algorithm for the last or
             // the only power limb using square-and-multiply.
+
             while (power != 0)
             {
                 if ((power & 1) == 1)
@@ -163,6 +173,7 @@ namespace System.Numerics
 
             // The big modulus pow method for a 32-bit integer
             // raised by a 32-bit integer...
+
             int size = modulus.Length + modulus.Length;
             BitsBuffer v = new BitsBuffer(size, value);
             return PowCore(power, modulus, ref v);
@@ -221,6 +232,7 @@ namespace System.Numerics
                                       ref BitsBuffer value)
         {
             // Executes the big pow algorithm.
+
             int size = value.GetSize();
 
             BitsBuffer temp = new BitsBuffer(size, 0);
@@ -243,6 +255,7 @@ namespace System.Numerics
                                       ref BitsBuffer value)
         {
             // Executes the big pow algorithm.
+
             int size = value.GetSize();
 
             BitsBuffer temp = new BitsBuffer(size, 0);
@@ -267,8 +280,10 @@ namespace System.Numerics
         {
             // The big modulus pow algorithm for all but
             // the last power limb using square-and-multiply.
+
             // NOTE: we're using an ordinary remainder here,
             // since the reducer overhead doesn't pay off.
+
             for (int i = 0; i < power.Length - 1; i++)
             {
                 uint p = power[i];
@@ -295,8 +310,10 @@ namespace System.Numerics
         {
             // The big modulus pow algorithm for the last or
             // the only power limb using square-and-multiply.
+
             // NOTE: we're using an ordinary remainder here,
             // since the reducer overhead doesn't pay off.
+
             while (power != 0)
             {
                 if ((power & 1) == 1)
@@ -313,12 +330,16 @@ namespace System.Numerics
             }
         }
 
-        private static void PowCore(uint[] power, ref FastReducer reducer, ref BitsBuffer value, ref BitsBuffer result, ref BitsBuffer temp)
+        private static void PowCore(uint[] power, ref FastReducer reducer,
+                                    ref BitsBuffer value, ref BitsBuffer result,
+                                    ref BitsBuffer temp)
         {
             // The big modulus pow algorithm for all but
             // the last power limb using square-and-multiply.
+
             // NOTE: we're using a special reducer here,
             // since it's additional overhead does pay off.
+
             for (int i = 0; i < power.Length - 1; i++)
             {
                 uint p = power[i];
@@ -345,8 +366,10 @@ namespace System.Numerics
         {
             // The big modulus pow algorithm for the last or
             // the only power limb using square-and-multiply.
+
             // NOTE: we're using a special reducer here,
             // since it's additional overhead does pay off.
+
             while (power != 0)
             {
                 if ((power & 1) == 1)
@@ -367,6 +390,7 @@ namespace System.Numerics
         {
             // Since we're reusing memory here, the actual length
             // of a given value may be less then the array's length
+
             return ActualLength(value, value.Length);
         }
 


### PR DESCRIPTION
I just noticed that some comments lost some well intended new-lines and even an important comment got lost somehow. Thus, I did a fancy git revert on those files (okay, rather trivial, but for casual git users like me...).

Why? An important comment got lost (otherwise I wouldn't have bothered). And, I generally add new-lines after "overall" comments, which apply not only to the next line of code.