### PR TITLE
Fix some misc failing desktop IO tests

### DIFF
--- a/src/System.IO.Compression/tests/DeflateStreamTests.cs
+++ b/src/System.IO.Compression/tests/DeflateStreamTests.cs
@@ -421,6 +421,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full Framework Flush is a no-op.")]
         public void Precancellation()
         {
             var ms = new MemoryStream();
@@ -443,6 +444,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full Framework Flush is a no-op.")]
         public async Task RoundTripWithFlush()
         {
             await RoundTripWithFlush(useAsync: false, useGzip: false, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
@@ -450,6 +452,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full Framework Flush is a no-op.")]
         public async Task WriteAfterFlushing()
         {
             await WriteAfterFlushing(useAsync: false, useGzip: false, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
@@ -457,6 +460,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full Framework Flush is a no-op.")]
         public async Task FlushBeforeFirstWrites()
         {
             await FlushBeforeFirstWrites(useAsync: false, useGzip: false, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
@@ -510,6 +514,7 @@ namespace System.IO.Compression.Tests
         [OuterLoop]
         [Theory]
         [MemberData(nameof(RoundtripCompressDecompressOuterData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full Framework Flush is a no-op.")]
         public async Task RoundTripWithFlush(bool useAsync, bool useGzip, int chunkSize, int totalSize, CompressionLevel level)
         {
             byte[] data = new byte[totalSize];
@@ -539,6 +544,7 @@ namespace System.IO.Compression.Tests
         [OuterLoop]
         [Theory]
         [MemberData(nameof(RoundtripCompressDecompressOuterData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full Framework Flush is a no-op.")]
         public async Task WriteAfterFlushing(bool useAsync, bool useGzip, int chunkSize, int totalSize, CompressionLevel level)
         {
             byte[] data = new byte[totalSize];
@@ -574,6 +580,7 @@ namespace System.IO.Compression.Tests
         [OuterLoop]
         [Theory]
         [MemberData(nameof(RoundtripCompressDecompressOuterData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full Framework Flush is a no-op.")]
         public async Task FlushBeforeFirstWrites(bool useAsync, bool useGzip, int chunkSize, int totalSize, CompressionLevel level)
         {
             byte[] data = new byte[totalSize];
@@ -679,6 +686,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full Framework Flush is a no-op.")]
         public async Task WrapNullReturningTasksStream()
         {
             using (var ds = new DeflateStream(new BadWrappedStream(BadWrappedStream.Mode.ReturnNullTasks), CompressionMode.Decompress))
@@ -686,6 +694,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full Framework Flush is a no-op.")]
         public async Task WrapStreamReturningBadReadValues()
         {
             using (var ds = new DeflateStream(new BadWrappedStream(BadWrappedStream.Mode.ReturnTooLargeCounts), CompressionMode.Decompress))
@@ -862,6 +871,7 @@ namespace System.IO.Compression.Tests
         protected static string gzTestFile(string fileName) { return Path.Combine("GZTestData", fileName); }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full Framework Flush is a no-op.")]
         public async Task OverlappingFlushAsync_DuringFlushAsync()
         {
             byte[] buffer = null;
@@ -896,6 +906,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full Framework Flush is a no-op.")]
         public async Task OverlappingFlushAsync_DuringWriteAsync()
         {
             byte[] buffer = null;
@@ -926,6 +937,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full Framework Flush is a no-op.")]
         public async Task OverlappingWriteAsync()
         {
             byte[] buffer = null;
@@ -956,6 +968,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full Framework Flush is a no-op.")]
         public async Task OverlappingReadAsync()
         {
             byte[] buffer = new byte[32];

--- a/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -53,38 +53,62 @@ namespace System.IO.Compression.Tests
         }
 
         [Theory]
-        [InlineData("small", true)]
-        [InlineData("small", false)]
-        [InlineData("normal", true)]
-        [InlineData("normal", false)]
-        [InlineData("empty", true)]
-        [InlineData("empty", false)]
-        [InlineData("emptydir", true)]
-        [InlineData("emptydir", false)]
-        public static async Task CreateNormal(string folder, bool seekable)
+        [InlineData("small")]
+        [InlineData("normal")]
+        [InlineData("empty")]
+        [InlineData("emptydir")]
+        public static async Task CreateNormal_Seekable(string folder)
         {
             using (var s = new MemoryStream())
             {
-                var testStream = new WrappedStream(s, false, true, seekable, null);
+                var testStream = new WrappedStream(s, false, true, true, null);
                 await CreateFromDir(zfolder(folder), testStream, ZipArchiveMode.Create);
 
                 IsZipSameAsDir(s, zfolder(folder), ZipArchiveMode.Read, requireExplicit: true, checkTimes: true);
             }
         }
 
-
         [Theory]
-        [InlineData("unicode", true)]
-        [InlineData("unicode", false)]
-        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Jenkins fails with unicode characters [JENKINS-12610]
-        public static async Task CreateNormal_Unicode(string folder, bool seekable)
+        [InlineData("small")]
+        [InlineData("normal")]
+        [InlineData("empty")]
+        [InlineData("emptydir")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full Framework does not allow unseekable streams.")]
+        public static async Task CreateNormal_Unseekable(string folder)
         {
             using (var s = new MemoryStream())
             {
-                var testStream = new WrappedStream(s, false, true, seekable, null);
+                var testStream = new WrappedStream(s, false, true, false, null);
                 await CreateFromDir(zfolder(folder), testStream, ZipArchiveMode.Create);
 
                 IsZipSameAsDir(s, zfolder(folder), ZipArchiveMode.Read, requireExplicit: true, checkTimes: true);
+            }
+        }
+
+        [Fact]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Jenkins fails with unicode characters [JENKINS-12610]
+        public static async Task CreateNormal_Unicode_Seekable(string folder)
+        {
+            using (var s = new MemoryStream())
+            {
+                var testStream = new WrappedStream(s, false, true, true, null);
+                await CreateFromDir(zfolder("unicode"), testStream, ZipArchiveMode.Create);
+
+                IsZipSameAsDir(s, zfolder("unicode"), ZipArchiveMode.Read, requireExplicit: true, checkTimes: true);
+            }
+        }
+
+        [Fact]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Jenkins fails with unicode characters [JENKINS-12610]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full Framework does not allow unseekable streams.")]
+        public static async Task CreateNormal_Unicode_Unseekable(string folder)
+        {
+            using (var s = new MemoryStream())
+            {
+                var testStream = new WrappedStream(s, false, true, false, null);
+                await CreateFromDir(zfolder("unicode"), testStream, ZipArchiveMode.Create);
+
+                IsZipSameAsDir(s, zfolder("unicode"), ZipArchiveMode.Read, requireExplicit: true, checkTimes: true);
             }
         }
     }

--- a/src/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
@@ -9,6 +9,7 @@ namespace System.IO.Tests
     public class RenamedEventArgsTests
     {
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "OldFullPath on Desktop demands FileIOPermissions which causes failures for invalid paths.")]
         [InlineData(WatcherChangeTypes.Changed, "C:", "foo.txt", "bar.txt")]
         [InlineData(WatcherChangeTypes.All, "C:", "foo.txt", "bar.txt")]
         [InlineData(0, "", "", "")]


### PR DESCRIPTION
These tests are failing on the full framework test runs for misc reasons explained in the comment section of the attributes. Most of them are because of lack of DeflateStream Flush support.

resolves https://github.com/dotnet/corefx/issues/13249