### PR TITLE
Revert "Mark System.Memory and Unsafe as .NET Core App assemblies."

### DIFF
--- a/src/System.Memory/dir.props
+++ b/src/System.Memory/dir.props
@@ -3,6 +3,5 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <IsNETCoreApp>true</IsNETCoreApp>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/dir.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/dir.props
@@ -3,6 +3,5 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
-    <IsNETCoreApp>true</IsNETCoreApp>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This reverts commit 6ad53135788d9d5a1a71fcb09cedb6fda93dc182.

This is blocked on building ilproj's outside of Windows, the root cause of which is perhaps https://github.com/dotnet/coreclr/issues/9292.