### PR TITLE
Fix networking test activeissues in System.Net.Http

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -23,6 +23,8 @@ namespace System
             File.Exists(Path.Combine(Environment.GetEnvironmentVariable("windir"), "regedit.exe")));
         public static bool IsWindows10Version1607OrGreater { get; } = IsWindows &&
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14393;
+        public static bool IsWindows10VersionInsiderPreviewOrGreater { get; } = IsWindows &&
+            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14917;
         // Windows OneCoreUAP SKU doesn't have httpapi.dll
         public static bool HasHttpApi { get; } = (IsWindows &&
             File.Exists(Path.Combine(Environment.GetEnvironmentVariable("windir"), "System32", "httpapi.dll")));

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -71,7 +71,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [ActiveIssue(9543, TestPlatforms.Windows)] // reuseClient==false fails in debug/release, reuseClient==true fails sporadically in release
         [ConditionalTheory(nameof(BackendSupportsCustomCertificateHandling))]
         [InlineData(6, false)]
         [InlineData(3, true)]
@@ -80,58 +79,62 @@ namespace System.Net.Http.Functional.Tests
             bool reuseClient) // validate behavior with and without connection pooling, which impacts client cert usage
         {
             var options = new LoopbackServer.Options { UseSsl = true };
-            using (X509Certificate2 cert = Configuration.Certificates.GetClientCertificate())
+
+            Func<X509Certificate2, HttpClient> createClient = (cert) =>
             {
-                Func<HttpClient> createClient = () =>
-                {
-                    var handler = new HttpClientHandler() { ServerCertificateCustomValidationCallback = delegate { return true; } };
-                    handler.ClientCertificates.Add(cert);
-                    return new HttpClient(handler);
-                };
+                var handler = new HttpClientHandler() { ServerCertificateCustomValidationCallback = delegate { return true; } };
+                handler.ClientCertificates.Add(cert);
+                return new HttpClient(handler);
+            };
 
-                Func<HttpClient, Socket, Uri, Task> makeAndValidateRequest = async (client, server, url) =>
-                {
-                    await TestHelper.WhenAllCompletedOrAnyFailed(
-                        client.GetStringAsync(url),
-                        LoopbackServer.AcceptSocketAsync(server, async (socket, stream, reader, writer) =>
-                        {
-                            SslStream sslStream = Assert.IsType<SslStream>(stream);
-                            Assert.Equal(cert, sslStream.RemoteCertificate);
-                            await LoopbackServer.ReadWriteAcceptedAsync(socket, reader, writer);
-                            return null;
-                        }, options));
-                };
-
-                await LoopbackServer.CreateServerAsync(async (server, url) =>
-                {
-                    if (reuseClient)
+            Func<HttpClient, Socket, Uri, X509Certificate2, Task> makeAndValidateRequest = async (client, server, url, cert) =>
+            {
+                await TestHelper.WhenAllCompletedOrAnyFailed(
+                    client.GetStringAsync(url),
+                    LoopbackServer.AcceptSocketAsync(server, async (socket, stream, reader, writer) =>
                     {
-                        using (HttpClient client = createClient())
+                        SslStream sslStream = Assert.IsType<SslStream>(stream);
+                        Assert.Equal(cert, sslStream.RemoteCertificate);
+                        await LoopbackServer.ReadWriteAcceptedAsync(socket, reader, writer);
+                        return null;
+                    }, options));
+            };
+
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                if (reuseClient)
+                {
+                    using (X509Certificate2 cert = Configuration.Certificates.GetClientCertificate())
+                    {
+                        using (HttpClient client = createClient(cert))
                         {
                             for (int i = 0; i < numberOfRequests; i++)
                             {
-                                await makeAndValidateRequest(client, server, url);
+                                await makeAndValidateRequest(client, server, url, cert);
 
                                 GC.Collect();
                                 GC.WaitForPendingFinalizers();
                             }
                         }
                     }
-                    else
+                }
+                else
+                {
+                    for (int i = 0; i < numberOfRequests; i++)
                     {
-                        for (int i = 0; i < numberOfRequests; i++)
+                        using (X509Certificate2 cert = Configuration.Certificates.GetClientCertificate())
                         {
-                            using (HttpClient client = createClient())
+                            using (HttpClient client = createClient(cert))
                             {
-                                await makeAndValidateRequest(client, server, url);
+                                await makeAndValidateRequest(client, server, url, cert);
                             }
-
-                            GC.Collect();
-                            GC.WaitForPendingFinalizers();
                         }
+
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
                     }
-                }, options);
-            }
+                }
+            }, options);
         }
 
         private static bool BackendSupportsCustomCertificateHandling =>

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -88,7 +88,7 @@ namespace System.Net.Http.Functional.Tests
         {
             _output = output;
         }
-
+        
         [Fact]
         public void Ctor_ExpectedDefaultPropertyValues()
         {
@@ -110,7 +110,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.True(handler.UseCookies);
                 Assert.False(handler.UseDefaultCredentials);
                 Assert.True(handler.UseProxy);
-                
+
                 // Changes from .NET Framework (Desktop).
                 Assert.Equal(DecompressionMethods.GZip | DecompressionMethods.Deflate, handler.AutomaticDecompression);
                 Assert.Equal(0, handler.MaxRequestContentBufferSize);
@@ -146,7 +146,7 @@ namespace System.Net.Http.Functional.Tests
             handler.UseDefaultCredentials = false;
             using (var client = new HttpClient(handler))
             {
-                Uri uri = Configuration.Http.NegotiateAuthUriForDefaultCreds(secure:false);
+                Uri uri = Configuration.Http.NegotiateAuthUriForDefaultCreds(secure: false);
                 _output.WriteLine("Uri: {0}", uri);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
@@ -316,7 +316,7 @@ namespace System.Net.Http.Functional.Tests
             handler.Credentials = CredentialCache.DefaultCredentials;
             using (var client = new HttpClient(handler))
             {
-                Uri uri = Configuration.Http.BasicAuthUriForCreds(secure:false, userName:Username, password:Password);
+                Uri uri = Configuration.Http.BasicAuthUriForCreds(secure: false, userName: Username, password: Password);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
                     Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -332,7 +332,7 @@ namespace System.Net.Http.Functional.Tests
             handler.Credentials = _credential;
             using (var client = new HttpClient(handler))
             {
-                Uri uri = Configuration.Http.BasicAuthUriForCreds(secure:false, userName:Username, password:Password);
+                Uri uri = Configuration.Http.BasicAuthUriForCreds(secure: false, userName: Username, password: Password);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -346,7 +346,7 @@ namespace System.Net.Http.Functional.Tests
         {
             using (var client = new HttpClient())
             {
-                Uri uri = Configuration.Http.BasicAuthUriForCreds(secure:false, userName:Username, password:Password);
+                Uri uri = Configuration.Http.BasicAuthUriForCreds(secure: false, userName: Username, password: Password);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
                     Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -390,10 +390,10 @@ namespace System.Net.Http.Functional.Tests
             using (var client = new HttpClient(handler))
             {
                 Uri uri = Configuration.Http.RedirectUriForDestinationUri(
-                    secure:false,
-                    statusCode:statusCode,
-                    destinationUri:Configuration.Http.RemoteEchoServer,
-                    hops:1);
+                    secure: false,
+                    statusCode: statusCode,
+                    destinationUri: Configuration.Http.RemoteEchoServer,
+                    hops: 1);
                 _output.WriteLine("Uri: {0}", uri);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
@@ -412,10 +412,10 @@ namespace System.Net.Http.Functional.Tests
             using (var client = new HttpClient(handler))
             {
                 Uri uri = Configuration.Http.RedirectUriForDestinationUri(
-                    secure:false,
-                    statusCode:statusCode,
-                    destinationUri:Configuration.Http.RemoteEchoServer,
-                    hops:1);
+                    secure: false,
+                    statusCode: statusCode,
+                    destinationUri: Configuration.Http.RemoteEchoServer,
+                    hops: 1);
                 _output.WriteLine("Uri: {0}", uri);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
@@ -434,10 +434,10 @@ namespace System.Net.Http.Functional.Tests
             using (var client = new HttpClient(handler))
             {
                 Uri uri = Configuration.Http.RedirectUriForDestinationUri(
-                    secure:false,
-                    statusCode:302,
-                    destinationUri:Configuration.Http.SecureRemoteEchoServer,
-                    hops:1);
+                    secure: false,
+                    statusCode: 302,
+                    destinationUri: Configuration.Http.SecureRemoteEchoServer,
+                    hops: 1);
                 _output.WriteLine("Uri: {0}", uri);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
@@ -456,10 +456,10 @@ namespace System.Net.Http.Functional.Tests
             using (var client = new HttpClient(handler))
             {
                 Uri uri = Configuration.Http.RedirectUriForDestinationUri(
-                    secure:true,
-                    statusCode:302,
-                    destinationUri:Configuration.Http.RemoteEchoServer,
-                    hops:1);
+                    secure: true,
+                    statusCode: 302,
+                    destinationUri: Configuration.Http.RemoteEchoServer,
+                    hops: 1);
                 _output.WriteLine("Uri: {0}", uri);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
@@ -475,14 +475,14 @@ namespace System.Net.Http.Functional.Tests
         {
             var handler = new HttpClientHandler();
             handler.AllowAutoRedirect = true;
-            Uri targetUri = Configuration.Http.BasicAuthUriForCreds(secure:false, userName:Username, password:Password);
+            Uri targetUri = Configuration.Http.BasicAuthUriForCreds(secure: false, userName: Username, password: Password);
             using (var client = new HttpClient(handler))
             {
                 Uri uri = Configuration.Http.RedirectUriForDestinationUri(
-                    secure:false,
-                    statusCode:302,
-                    destinationUri:targetUri,
-                    hops:1);
+                    secure: false,
+                    statusCode: 302,
+                    destinationUri: targetUri,
+                    hops: 1);
                 _output.WriteLine("Uri: {0}", uri);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
@@ -493,13 +493,18 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [ActiveIssue(8945, TestPlatforms.Windows)]
         [Theory]
         [InlineData(3, 2)]
         [InlineData(3, 3)]
         [InlineData(3, 4)]
         public async Task GetAsync_MaxAutomaticRedirectionsNServerHops_ThrowsIfTooMany(int maxHops, int hops)
         {
+            if (PlatformDetection.IsWindows && !PlatformDetection.IsWindows10VersionInsiderPreviewOrGreater)
+            {
+                // Run this test only on windows10 build greater than 14917.
+                return;
+            }
+
             using (var client = new HttpClient(new HttpClientHandler() { MaxAutomaticRedirections = maxHops }))
             {
                 Task<HttpResponseMessage> t = client.GetAsync(Configuration.Http.RedirectUriForDestinationUri(
@@ -635,27 +640,27 @@ namespace System.Net.Http.Functional.Tests
             using (var client = new HttpClient(handler))
             {
                 Uri redirectUri = Configuration.Http.RedirectUriForCreds(
-                    secure:false,
-                    statusCode:302,
-                    userName:Username,
-                    password:Password);
+                    secure: false,
+                    statusCode: 302,
+                    userName: Username,
+                    password: Password);
                 using (HttpResponseMessage unAuthResponse = await client.GetAsync(redirectUri))
                 {
                     Assert.Equal(HttpStatusCode.Unauthorized, unAuthResponse.StatusCode);
                 }
             }
-       }
+        }
 
         [OuterLoop] // TODO: Issue #11345
         [Theory, MemberData(nameof(RedirectStatusCodes))]
         public async Task GetAsync_CredentialIsCredentialCacheUriRedirect_StatusCodeOK(int statusCode)
         {
-            Uri uri = Configuration.Http.BasicAuthUriForCreds(secure:false, userName:Username, password:Password);
+            Uri uri = Configuration.Http.BasicAuthUriForCreds(secure: false, userName: Username, password: Password);
             Uri redirectUri = Configuration.Http.RedirectUriForCreds(
-                secure:false,
-                statusCode:statusCode,
-                userName:Username,
-                password:Password);
+                secure: false,
+                statusCode: statusCode,
+                userName: Username,
+                password: Password);
             _output.WriteLine(uri.AbsoluteUri);
             _output.WriteLine(redirectUri.AbsoluteUri);
             var credentialCache = new CredentialCache();
@@ -715,10 +720,10 @@ namespace System.Net.Http.Functional.Tests
         public async Task GetAsync_RedirectResponseHasCookie_CookieSentToFinalUri(string cookieName, string cookieValue)
         {
             Uri uri = Configuration.Http.RedirectUriForDestinationUri(
-                secure:false,
-                statusCode:302,
-                destinationUri:Configuration.Http.RemoteEchoServer,
-                hops:1);
+                secure: false,
+                statusCode: 302,
+                destinationUri: Configuration.Http.RemoteEchoServer,
+                hops: 1);
             using (HttpClient client = new HttpClient())
             {
                 client.DefaultRequestHeaders.Add(
@@ -730,7 +735,7 @@ namespace System.Net.Http.Functional.Tests
                     _output.WriteLine(responseText);
                     Assert.True(TestHelper.JsonMessageContainsKeyValue(responseText, cookieName, cookieValue));
                 }
-            }            
+            }
         }
 
         [OuterLoop] // TODO: Issue #11345
@@ -846,13 +851,13 @@ namespace System.Net.Http.Functional.Tests
                     using (HttpResponseMessage response = await responseTasks[i])
                     {
                         string responseContent = await response.Content.ReadAsStringAsync();
-                        _output.WriteLine(responseContent);                    
+                        _output.WriteLine(responseContent);
                         TestHelper.VerifyResponseBody(
                             responseContent,
                             response.Content.Headers.ContentMD5,
                             false,
-                            null);                    
-                   }
+                            null);
+                    }
                 }
             }
         }
@@ -867,12 +872,12 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpResponseMessage response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead))
                 {
                     string responseContent = await response.Content.ReadAsStringAsync();
-                    _output.WriteLine(responseContent);                    
+                    _output.WriteLine(responseContent);
                     TestHelper.VerifyResponseBody(
                         responseContent,
                         response.Content.Headers.ContentMD5,
                         false,
-                        null);                    
+                        null);
                 }
             }
         }
@@ -907,7 +912,7 @@ namespace System.Net.Http.Functional.Tests
                                 Assert.True(bytesRead < buffer.Length, "bytesRead should be less than buffer.Length");
                             }
                         }
-                        
+
                         return null;
                     });
                 }
@@ -1062,7 +1067,7 @@ namespace System.Net.Http.Functional.Tests
                 string data = "\ub4f1\uffc7\u4e82\u67ab4\uc6d4\ud1a0\uc694\uc77c\uffda3\u3155\uc218\uffdb";
                 var content = new StringContent(data, Encoding.UTF8);
                 content.Headers.ContentMD5 = TestHelper.ComputeMD5Hash(data);
-                
+
                 using (HttpResponseMessage response = await client.PostAsync(remoteServer, content))
                 {
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1120,94 +1125,94 @@ namespace System.Net.Http.Functional.Tests
             get
             {
                 foreach (object[] serverArr in VerifyUploadServers) // target server
-                foreach (bool syncCopy in new[] { true, false }) // force the content copy to happen via Read/Write or ReadAsync/WriteAsync
-                {
-                    Uri server = (Uri)serverArr[0];
-
-                    byte[] data = new byte[1234];
-                    new Random(42).NextBytes(data);
-
-                    // A MemoryStream
+                    foreach (bool syncCopy in new[] { true, false }) // force the content copy to happen via Read/Write or ReadAsync/WriteAsync
                     {
-                        var memStream = new MemoryStream(data, writable: false);
-                        yield return new object[] { server, new StreamContentWithSyncAsyncCopy(memStream, syncCopy: syncCopy), data };
-                    }
+                        Uri server = (Uri)serverArr[0];
 
-                    // A multipart content that provides its own stream from CreateContentReadStreamAsync
-                    {
-                        var mc = new MultipartContent();
-                        mc.Add(new ByteArrayContent(data));
-                        var memStream = new MemoryStream();
-                        mc.CopyToAsync(memStream).GetAwaiter().GetResult();
-                        yield return new object[] { server, mc, memStream.ToArray() };
-                    }
+                        byte[] data = new byte[1234];
+                        new Random(42).NextBytes(data);
 
-                    // A stream that provides the data synchronously and has a known length
-                    {
-                        var wrappedMemStream = new MemoryStream(data, writable: false);
-                        var syncKnownLengthStream = new DelegateStream(
-                            canReadFunc: () => wrappedMemStream.CanRead,
-                            canSeekFunc: () => wrappedMemStream.CanSeek,
-                            lengthFunc: () => wrappedMemStream.Length,
-                            positionGetFunc: () => wrappedMemStream.Position,
-                            positionSetFunc: p => wrappedMemStream.Position = p,
-                            readFunc: (buffer, offset, count) => wrappedMemStream.Read(buffer, offset, count),
-                            readAsyncFunc: (buffer, offset, count, token) => wrappedMemStream.ReadAsync(buffer, offset, count, token));
-                        yield return new object[] { server, new StreamContentWithSyncAsyncCopy(syncKnownLengthStream, syncCopy: syncCopy), data };
-                    }
-
-                    // A stream that provides the data synchronously and has an unknown length
-                    {
-                        int syncUnknownLengthStreamOffset = 0;
-
-                        Func<byte[], int, int, int> readFunc = (buffer, offset, count) =>
+                        // A MemoryStream
                         {
-                            int bytesRemaining = data.Length - syncUnknownLengthStreamOffset;
-                            int bytesToCopy = Math.Min(bytesRemaining, count);
-                            Array.Copy(data, syncUnknownLengthStreamOffset, buffer, offset, bytesToCopy);
-                            syncUnknownLengthStreamOffset += bytesToCopy;
-                            return bytesToCopy;
-                        };
+                            var memStream = new MemoryStream(data, writable: false);
+                            yield return new object[] { server, new StreamContentWithSyncAsyncCopy(memStream, syncCopy: syncCopy), data };
+                        }
 
-                        var syncUnknownLengthStream = new DelegateStream(
-                            canReadFunc: () => true,
-                            canSeekFunc: () => false,
-                            readFunc: readFunc,
-                            readAsyncFunc: (buffer, offset, count, token) => Task.FromResult(readFunc(buffer, offset, count)));
-                        yield return new object[] { server, new StreamContentWithSyncAsyncCopy(syncUnknownLengthStream, syncCopy: syncCopy), data };
-                    }
-
-                    // A stream that provides the data asynchronously
-                    {
-                        int asyncStreamOffset = 0, maxDataPerRead = 100;
-
-                        Func<byte[], int, int, int> readFunc = (buffer, offset, count) =>
+                        // A multipart content that provides its own stream from CreateContentReadStreamAsync
                         {
-                            int bytesRemaining = data.Length - asyncStreamOffset;
-                            int bytesToCopy = Math.Min(bytesRemaining, Math.Min(maxDataPerRead, count));
-                            Array.Copy(data, asyncStreamOffset, buffer, offset, bytesToCopy);
-                            asyncStreamOffset += bytesToCopy;
-                            return bytesToCopy;
-                        };
+                            var mc = new MultipartContent();
+                            mc.Add(new ByteArrayContent(data));
+                            var memStream = new MemoryStream();
+                            mc.CopyToAsync(memStream).GetAwaiter().GetResult();
+                            yield return new object[] { server, mc, memStream.ToArray() };
+                        }
 
-                        var asyncStream = new DelegateStream(
-                            canReadFunc: () => true,
-                            canSeekFunc: () => false,
-                            readFunc: readFunc,
-                            readAsyncFunc: async (buffer, offset, count, token) =>
+                        // A stream that provides the data synchronously and has a known length
+                        {
+                            var wrappedMemStream = new MemoryStream(data, writable: false);
+                            var syncKnownLengthStream = new DelegateStream(
+                                canReadFunc: () => wrappedMemStream.CanRead,
+                                canSeekFunc: () => wrappedMemStream.CanSeek,
+                                lengthFunc: () => wrappedMemStream.Length,
+                                positionGetFunc: () => wrappedMemStream.Position,
+                                positionSetFunc: p => wrappedMemStream.Position = p,
+                                readFunc: (buffer, offset, count) => wrappedMemStream.Read(buffer, offset, count),
+                                readAsyncFunc: (buffer, offset, count, token) => wrappedMemStream.ReadAsync(buffer, offset, count, token));
+                            yield return new object[] { server, new StreamContentWithSyncAsyncCopy(syncKnownLengthStream, syncCopy: syncCopy), data };
+                        }
+
+                        // A stream that provides the data synchronously and has an unknown length
+                        {
+                            int syncUnknownLengthStreamOffset = 0;
+
+                            Func<byte[], int, int, int> readFunc = (buffer, offset, count) =>
                             {
-                                await Task.Delay(1).ConfigureAwait(false);
-                                return readFunc(buffer, offset, count);
-                            });
-                        yield return new object[] { server, new StreamContentWithSyncAsyncCopy(asyncStream, syncCopy: syncCopy), data };
-                    }
+                                int bytesRemaining = data.Length - syncUnknownLengthStreamOffset;
+                                int bytesToCopy = Math.Min(bytesRemaining, count);
+                                Array.Copy(data, syncUnknownLengthStreamOffset, buffer, offset, bytesToCopy);
+                                syncUnknownLengthStreamOffset += bytesToCopy;
+                                return bytesToCopy;
+                            };
 
-                    // Providing data from a FormUrlEncodedContent's stream
-                    {
-                        var formContent = new FormUrlEncodedContent(new[] { new KeyValuePair<string, string>("key", "val") });
-                        yield return new object[] { server, formContent, Encoding.GetEncoding("iso-8859-1").GetBytes("key=val") };
+                            var syncUnknownLengthStream = new DelegateStream(
+                                canReadFunc: () => true,
+                                canSeekFunc: () => false,
+                                readFunc: readFunc,
+                                readAsyncFunc: (buffer, offset, count, token) => Task.FromResult(readFunc(buffer, offset, count)));
+                            yield return new object[] { server, new StreamContentWithSyncAsyncCopy(syncUnknownLengthStream, syncCopy: syncCopy), data };
+                        }
+
+                        // A stream that provides the data asynchronously
+                        {
+                            int asyncStreamOffset = 0, maxDataPerRead = 100;
+
+                            Func<byte[], int, int, int> readFunc = (buffer, offset, count) =>
+                            {
+                                int bytesRemaining = data.Length - asyncStreamOffset;
+                                int bytesToCopy = Math.Min(bytesRemaining, Math.Min(maxDataPerRead, count));
+                                Array.Copy(data, asyncStreamOffset, buffer, offset, bytesToCopy);
+                                asyncStreamOffset += bytesToCopy;
+                                return bytesToCopy;
+                            };
+
+                            var asyncStream = new DelegateStream(
+                                canReadFunc: () => true,
+                                canSeekFunc: () => false,
+                                readFunc: readFunc,
+                                readAsyncFunc: async (buffer, offset, count, token) =>
+                                {
+                                    await Task.Delay(1).ConfigureAwait(false);
+                                    return readFunc(buffer, offset, count);
+                                });
+                            yield return new object[] { server, new StreamContentWithSyncAsyncCopy(asyncStream, syncCopy: syncCopy), data };
+                        }
+
+                        // Providing data from a FormUrlEncodedContent's stream
+                        {
+                            var formContent = new FormUrlEncodedContent(new[] { new KeyValuePair<string, string>("key", "val") });
+                            yield return new object[] { server, formContent, Encoding.GetEncoding("iso-8859-1").GetBytes("key=val") };
+                        }
                     }
-                }
             }
         }
 
@@ -1220,14 +1225,14 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpResponseMessage response = await client.PostAsync(remoteServer, null))
                 {
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                    
+
                     string responseContent = await response.Content.ReadAsStringAsync();
-                    _output.WriteLine(responseContent);                    
+                    _output.WriteLine(responseContent);
                     TestHelper.VerifyResponseBody(
                         responseContent,
                         response.Content.Headers.ContentMD5,
                         false,
-                        string.Empty);                    
+                        string.Empty);
                 }
             }
         }
@@ -1242,14 +1247,14 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpResponseMessage response = await client.PostAsync(remoteServer, content))
                 {
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                    
+
                     string responseContent = await response.Content.ReadAsStringAsync();
-                    _output.WriteLine(responseContent);                    
+                    _output.WriteLine(responseContent);
                     TestHelper.VerifyResponseBody(
                         responseContent,
                         response.Content.Headers.ContentMD5,
                         false,
-                        string.Empty);                  
+                        string.Empty);
                 }
             }
         }
@@ -1348,7 +1353,7 @@ namespace System.Net.Http.Functional.Tests
                             Assert.True(contentDisposed, "Expected request content to be disposed");
                             Assert.Equal("abcdefghij", await response.Content.ReadAsStringAsync());
                         }
-                        
+
                         return null;
                     });
                 });
@@ -1412,7 +1417,7 @@ namespace System.Net.Http.Functional.Tests
                             Assert.True(contentDisposed, "Expected request content to be disposed");
                             Assert.Equal("abcdefghij", await response.Content.ReadAsStringAsync());
                         }
-                        
+
                         return null;
                     });
                 });
@@ -1501,14 +1506,14 @@ namespace System.Net.Http.Functional.Tests
             using (var client = new HttpClient())
             {
                 var request = new HttpRequestMessage(
-                    new HttpMethod(method), 
+                    new HttpMethod(method),
                     secureServer ? Configuration.Http.SecureRemoteEchoServer : Configuration.Http.RemoteEchoServer);
                 using (HttpResponseMessage response = await client.SendAsync(request))
                 {
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                     TestHelper.VerifyRequestMethod(response, method);
                 }
-            }        
+            }
         }
 
         [OuterLoop] // TODO: Issue #11345
@@ -1520,7 +1525,7 @@ namespace System.Net.Http.Functional.Tests
             using (var client = new HttpClient())
             {
                 var request = new HttpRequestMessage(
-                    new HttpMethod(method), 
+                    new HttpMethod(method),
                     secureServer ? Configuration.Http.SecureRemoteEchoServer : Configuration.Http.RemoteEchoServer);
                 request.Content = new StringContent(ExpectedContent);
                 using (HttpResponseMessage response = await client.SendAsync(request))
@@ -1535,9 +1540,9 @@ namespace System.Net.Http.Functional.Tests
                         responseContent,
                         response.Content.Headers.ContentMD5,
                         false,
-                        ExpectedContent);                    
+                        ExpectedContent);
                 }
-            }        
+            }
         }
 
         [OuterLoop] // TODO: Issue #11345
@@ -1575,7 +1580,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [ActiveIssue(10702)]
         [Theory, MemberData(nameof(HttpMethodsThatDontAllowContent))]
         public async Task SendAsync_SendRequestUsingNoBodyMethodToEchoServerWithContent_NoBodySent(
             string method,
@@ -1632,15 +1636,21 @@ namespace System.Net.Http.Functional.Tests
         {
             // The default value for HttpRequestMessage.Version is Version(1,1).
             // So, we need to set something different (0,0), to test the "unknown" version.
-            Version receivedRequestVersion = await SendRequestAndGetRequestVersionAsync(new Version(0,0));
+            Version receivedRequestVersion = await SendRequestAndGetRequestVersionAsync(new Version(0, 0));
             Assert.Equal(new Version(1, 1), receivedRequestVersion);
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [Theory, MemberData(nameof(Http2Servers))]
-        [ActiveIssue(10958, TestPlatforms.Windows)]
+        [Theory]
+        [MemberData(nameof(Http2Servers))]
         public async Task SendAsync_RequestVersion20_ResponseVersion20IfHttp2Supported(Uri server)
         {
+            if (PlatformDetection.IsWindows && !PlatformDetection.IsWindows10VersionInsiderPreviewOrGreater)
+            {
+                // Run this test only on windows10 build greater than 14917.
+                return;
+            }
+
             // We don't currently have a good way to test whether HTTP/2 is supported without
             // using the same mechanism we're trying to test, so for now we allow both 2.0 and 1.1 responses.
             var request = new HttpRequestMessage(HttpMethod.Get, server);
@@ -1734,16 +1744,15 @@ namespace System.Net.Http.Functional.Tests
                     {
                         Assert.True(false, "Invalid HTTP request version");
                     }
-                    
+
                 }
             });
-            
+
             return receivedRequestVersion;
         }
         #endregion
-        
+
         #region Proxy tests
-        [ActiveIssue(13188)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(CredentialsForProxy))]
@@ -1824,7 +1833,7 @@ namespace System.Net.Http.Functional.Tests
                     Assert.Equal(HttpStatusCode.ProxyAuthenticationRequired, responseTask.Result.StatusCode);
                 }
             }
-        }        
+        }
 
         private static IEnumerable<object[]> BypassedProxies()
         {


### PR DESCRIPTION
addresses #9543 #8945 #10958 #10702 #13188

cc @steveharter @ianhays @karelz 

#9543 Ensure the certificate is not disposed before next client reuses it.
#8945 #10958 Make the test run only on windows version greater than insider preview.
#10702 #13188 Not able to repro these locally, and the stack trace is from very old CI or different branch. Re-enabling the test for latest CI.