### PR TITLE
Change the simulated error class to SQL Server Error Range

### DIFF
--- a/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
@@ -792,7 +792,7 @@ namespace System.Data.SqlClient.Tests
             
             if (lowerBatchText.Contains("1 / 0")) // SELECT 1/0 
             {
-                TDSErrorToken errorToken = new TDSErrorToken(8134, 1, 1, "Divide by zero error encountered.");
+                TDSErrorToken errorToken = new TDSErrorToken(8134, 1, 11, "Divide by zero error encountered.");
                 TDSMessage responseMessage = new TDSMessage(TDSMessageType.Response, errorToken);
                 return new TDSMessageCollection(responseMessage);
             }


### PR DESCRIPTION
The error class sent by the Query engine should be > 11 which is lower bound of the error class range in Sql Server.

Fixes #15419 

cc @danmosemsft 