### PR TITLE
Update xunit dependencies to beta4

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -122,7 +122,7 @@
     <XUnitDependency Include="xunit.runner.utility"/>
     <XUnitDependency Include="xunit.runner.console"/>
     <StaticDependency Include="@(XUnitDependency)">
-      <Version>2.2.0-beta2-build3300</Version>
+      <Version>2.2.0-beta4-build3444</Version>
     </StaticDependency>
 
     <StaticDependency Include="Microsoft.xunit.netcore.extensions;Microsoft.DotNet.BuildTools.TestSuite">

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -7,7 +7,7 @@
     -->
     <NugetRuntimeIdentifier>win7-x64</NugetRuntimeIdentifier>
     <OutputPath>$(RuntimePath)</OutputPath>
-    <XUnitConsoleRunnerVersion>2.2.0-beta2-build3300</XUnitConsoleRunnerVersion>
+    <XUnitConsoleRunnerVersion>2.2.0-beta4-build3444</XUnitConsoleRunnerVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/external/test-runtime/project.json
+++ b/external/test-runtime/project.json
@@ -22,7 +22,7 @@
     "netstandard2.0": {},
     "net463": {
       "dependencies": {
-        "xunit.runner.console": "2.2.0-beta2-build3300"
+        "xunit.runner.console": "2.2.0-beta4-build3444"
       }
     }
   },


### PR DESCRIPTION
I don't think this relies on https://github.com/dotnet/buildtools/pull/1300

However, both this and that PR have to be merged in any order to get the workaround fixed (which will be done in another PR)


@jamesqo FYI 