### PR TITLE
Add ExcludeFromCodeCoverage attributes to System.Linq.Parallel unreachables

### DIFF
--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/ParallelQuery.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/ParallelQuery.cs
@@ -13,6 +13,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq.Parallel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Linq
 {
@@ -46,6 +47,7 @@ namespace System.Linq
         // is thrown.
         //
 
+        [ExcludeFromCodeCoverage]
         internal virtual ParallelQuery<TCastTo> Cast<TCastTo>()
         {
             Debug.Fail("The derived class must override this method.");
@@ -58,6 +60,7 @@ namespace System.Linq
         // the results.
         //
 
+        [ExcludeFromCodeCoverage]
         internal virtual ParallelQuery<TCastTo> OfType<TCastTo>()
         {
             Debug.Fail("The derived class must override this method.");
@@ -70,6 +73,7 @@ namespace System.Linq
         // IEnumerable<T>.
         //
 
+        [ExcludeFromCodeCoverage]
         internal virtual IEnumerator GetEnumeratorUntyped()
         {
             Debug.Fail("The derived class must override this method.");

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Merging/ArrayMergeHelper.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Merging/ArrayMergeHelper.cs
@@ -15,6 +15,7 @@ using System.Text;
 using System.Linq.Parallel;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Linq.Parallel
 {
@@ -70,6 +71,7 @@ namespace System.Linq.Parallel
         /// We never expect this method to be called. ArrayMergeHelper is intended to be used when we want
         /// to consume the results using GetResultsAsArray().
         /// </summary>
+        [ExcludeFromCodeCoverage]
         public IEnumerator<TInputOutput> GetEnumerator()
         {
             Debug.Fail("ArrayMergeHelper<>.GetEnumerator() is not intended to be used. Call GetResultsAsArray() instead.");

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Merging/OrderPreservingPipeliningMergeHelper.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Merging/OrderPreservingPipeliningMergeHelper.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -166,6 +167,7 @@ namespace System.Linq.Parallel
         // Returns the results as an array.
         //
 
+        [ExcludeFromCodeCoverage]
         public TOutput[] GetResultsAsArray()
         {
             Debug.Fail("An ordered pipelining merge is not intended to be used this way.");

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/AssociativeAggregationOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/AssociativeAggregationOperator.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace System.Linq.Parallel
@@ -212,6 +213,7 @@ namespace System.Linq.Parallel
         // Returns an enumerable that represents the query executing sequentially.
         //
 
+        [ExcludeFromCodeCoverage]
         internal override IEnumerable<TIntermediate> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("This method should never be called. Associative aggregation can always be parallelized.");

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Inlined/InlinedAggregationOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Inlined/InlinedAggregationOperator.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace System.Linq.Parallel
@@ -142,6 +143,7 @@ namespace System.Linq.Parallel
         protected abstract QueryOperatorEnumerator<TIntermediate, int> CreateEnumerator<TKey>(
             int index, int count, QueryOperatorEnumerator<TSource, TKey> source, object sharedData, CancellationToken cancellationToken);
 
+        [ExcludeFromCodeCoverage]
         internal override IEnumerable<TIntermediate> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("This method should never be called. Associative aggregation can always be parallelized.");

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/AnyAllSearchOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/AnyAllSearchOperator.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace System.Linq.Parallel
@@ -123,6 +124,7 @@ namespace System.Linq.Parallel
         // Returns an enumerable that represents the query executing sequentially.
         //
 
+        [ExcludeFromCodeCoverage]
         internal override IEnumerable<bool> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("This method should never be called as it is an ending operator with LimitsParallelism=false.");

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ContainsSearchOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ContainsSearchOperator.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace System.Linq.Parallel
@@ -109,6 +110,7 @@ namespace System.Linq.Parallel
         // Returns an enumerable that represents the query executing sequentially.
         //
 
+        [ExcludeFromCodeCoverage]
         internal override IEnumerable<bool> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("This method should never be called as it is an ending operator with LimitsParallelism=false.");

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ElementAtQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ElementAtQueryOperator.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace System.Linq.Parallel
@@ -97,6 +98,7 @@ namespace System.Linq.Parallel
         // Returns an enumerable that represents the query executing sequentially.
         //
 
+        [ExcludeFromCodeCoverage]
         internal override IEnumerable<TSource> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("This method should never be called as fallback to sequential is handled in Aggregate().");

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/FirstQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/FirstQueryOperator.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace System.Linq.Parallel
@@ -95,6 +96,7 @@ namespace System.Linq.Parallel
         // Returns an enumerable that represents the query executing sequentially.
         //
 
+        [ExcludeFromCodeCoverage]
         internal override IEnumerable<TSource> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("This method should never be called as fallback to sequential is handled in ParallelEnumerable.First().");

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ForAllOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ForAllOperator.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Linq.Parallel
 {
@@ -99,6 +100,7 @@ namespace System.Linq.Parallel
         // Returns an enumerable that represents the query executing sequentially.
         //
 
+        [ExcludeFromCodeCoverage]
         internal override IEnumerable<TInput> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("AsSequentialQuery is not supported on ForAllOperator");

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/LastQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/LastQueryOperator.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Linq.Parallel
 {
@@ -91,6 +92,7 @@ namespace System.Linq.Parallel
         //---------------------------------------------------------------------------------------
         // Returns an enumerable that represents the query executing sequentially.
         //
+        [ExcludeFromCodeCoverage]
         internal override IEnumerable<TSource> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("This method should never be called as fallback to sequential is handled in ParallelEnumerable.First().");

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SingleQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SingleQueryOperator.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Linq.Parallel
 {
@@ -72,6 +73,7 @@ namespace System.Linq.Parallel
         // Returns an enumerable that represents the query executing sequentially.
         //
 
+        [ExcludeFromCodeCoverage]
         internal override IEnumerable<TSource> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("This method should never be called as it is an ending operator with LimitsParallelism=false.");


### PR DESCRIPTION
Each method has a message like

> This method should never be called as ...
