### PR TITLE
Correctly compile Expression.Default(typeof(DBNull))

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
@@ -71,6 +71,14 @@ namespace System.Linq.Expressions
                                  s_Closure_Locals ??
                                 (s_Closure_Locals = typeof(Closure).GetField(nameof(Closure.Locals)));
 
+        private static FieldInfo s_Decimal_Zero;
+        public static FieldInfo Decimal_Zero
+            => s_Decimal_Zero ?? (s_Decimal_Zero = typeof(decimal).GetField(nameof(decimal.Zero)));
+
+        private static FieldInfo s_DateTime_MinValue;
+        public static FieldInfo DateTime_MinValue
+            => s_DateTime_MinValue ?? (s_DateTime_MinValue = typeof(DateTime).GetField(nameof(DateTime.MinValue)));
+
         private static MethodInfo s_MethodBase_GetMethodFromHandle_RuntimeMethodHandle;
         public  static MethodInfo   MethodBase_GetMethodFromHandle_RuntimeMethodHandle =>
                                   s_MethodBase_GetMethodFromHandle_RuntimeMethodHandle ??

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -1087,7 +1087,7 @@ namespace System.Linq.Expressions.Compiler
                                 il.Emit(OpCodes.Ldsfld, Decimal_MinusOne);
                                 return;
                             case 0:
-                                il.EmitDefault(typeof(decimal));
+                                il.EmitDefault(typeof(decimal), locals: null); // locals won't be used.
                                 return;
                             case 1:
                                 il.Emit(OpCodes.Ldsfld, Decimal_One);
@@ -1152,8 +1152,11 @@ namespace System.Linq.Expressions.Compiler
         {
             switch (type.GetTypeCode())
             {
-                case TypeCode.Object:
                 case TypeCode.DateTime:
+                    il.Emit(OpCodes.Ldsfld, DateTime_MinValue);
+                    break;
+
+                case TypeCode.Object:
                     if (type.GetTypeInfo().IsValueType)
                     {
                         // Type.GetTypeCode on an enum returns the underlying
@@ -1168,12 +1171,10 @@ namespace System.Linq.Expressions.Compiler
                         il.Emit(OpCodes.Initobj, type);
                         il.Emit(OpCodes.Ldloc, lb);
                         locals.FreeLocal(lb);
+                        break;
                     }
-                    else
-                    {
-                        il.Emit(OpCodes.Ldnull);
-                    }
-                    break;
+
+                    goto case TypeCode.Empty;
 
                 case TypeCode.Empty:
                 case TypeCode.String:
@@ -1207,8 +1208,7 @@ namespace System.Linq.Expressions.Compiler
                     break;
 
                 case TypeCode.Decimal:
-                    il.Emit(OpCodes.Ldc_I4_0);
-                    il.Emit(OpCodes.Newobj, Decimal_Ctor_Int32);
+                    il.Emit(OpCodes.Ldsfld, Decimal_Zero);
                     break;
 
                 default:

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -1177,6 +1177,7 @@ namespace System.Linq.Expressions.Compiler
 
                 case TypeCode.Empty:
                 case TypeCode.String:
+                case TypeCode.DBNull:
                     il.Emit(OpCodes.Ldnull);
                     break;
 

--- a/src/System.Linq.Expressions/tests/Default/DefaultTests.cs
+++ b/src/System.Linq.Expressions/tests/Default/DefaultTests.cs
@@ -75,5 +75,13 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentException>("type", () => Expression.Default(typeof(List<>.Enumerator)));
             Assert.Throws<ArgumentException>("type", () => Expression.Default(typeof(List<>).MakeGenericType(typeof(List<>))));
         }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void DbNull(bool useInterpreter)
+        {
+            Expression<Func<DBNull>> lambda = Expression.Lambda<Func<DBNull>>(Expression.Default(typeof(DBNull)));
+            Func<DBNull> func = lambda.Compile(useInterpreter);
+            Assert.Null(func());
+        }
     }
 }


### PR DESCRIPTION
Fixes #15790

While at it, reduce IL produced for default of `decimal` and `DateTime`.

Load `decimal.Zero` for decimal; lighter IL without a method call, and closer to current C# compiler behaviour.

Load `DateTime.MinValue` for `DateTime`; lighter IL, and skips `IsValueType` check.