### PR TITLE
S.L.Expressions Lighter IL for known decimal values.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
@@ -30,6 +30,22 @@ namespace System.Linq.Expressions
                                        s_Decimal_Ctor_Int32_Int32_Int32_Bool_Byte ??
                                       (s_Decimal_Ctor_Int32_Int32_Int32_Bool_Byte = typeof(decimal).GetConstructor(new[] { typeof(int), typeof(int), typeof(int), typeof(bool), typeof(byte) }));
 
+        private static FieldInfo s_Decimal_One;
+        public static FieldInfo Decimal_One
+            => s_Decimal_One ?? (s_Decimal_One = typeof(decimal).GetField(nameof(decimal.One)));
+
+        private static FieldInfo s_Decimal_MinusOne;
+        public static FieldInfo Decimal_MinusOne
+            => s_Decimal_MinusOne ?? (s_Decimal_MinusOne = typeof(decimal).GetField(nameof(decimal.MinusOne)));
+
+        private static FieldInfo s_Decimal_MinValue;
+        public static FieldInfo Decimal_MinValue
+            => s_Decimal_MinValue ?? (s_Decimal_MinValue = typeof(decimal).GetField(nameof(decimal.MinValue)));
+
+        private static FieldInfo s_Decimal_MaxValue;
+        public static FieldInfo Decimal_MaxValue
+            => s_Decimal_MaxValue ?? (s_Decimal_MaxValue = typeof(decimal).GetField(nameof(decimal.MaxValue)));
+
         private static ConstructorInfo s_Closure_ObjectArray_ObjectArray;
         public  static ConstructorInfo   Closure_ObjectArray_ObjectArray =>
                                        s_Closure_ObjectArray_ObjectArray ??

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
@@ -25,6 +25,11 @@ namespace System.Linq.Expressions
                                        s_Decimal_Ctor_Int64 ??
                                       (s_Decimal_Ctor_Int64 = typeof(decimal).GetConstructor(new[] { typeof(long) }));
 
+        private static ConstructorInfo s_Decimal_Ctor_UInt64;
+        public static ConstructorInfo Decimal_Ctor_UInt64 =>
+                                       s_Decimal_Ctor_UInt64 ??
+                                      (s_Decimal_Ctor_UInt64 = typeof(decimal).GetConstructor(new[] { typeof(ulong) }));
+
         private static ConstructorInfo s_Decimal_Ctor_Int32_Int32_Int32_Bool_Byte;
         public  static ConstructorInfo   Decimal_Ctor_Int32_Int32_Int32_Bool_Byte =>
                                        s_Decimal_Ctor_Int32_Int32_Int32_Bool_Byte ??

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -1168,9 +1168,15 @@ namespace System.Linq.Expressions.Compiler
 
                 if (long.MinValue <= value && value <= long.MaxValue)
                 {
-                    long longValue = decimal.ToInt64(value);
-                    il.EmitLong(longValue);
+                    il.EmitLong(decimal.ToInt64(value));
                     il.EmitNew(Decimal_Ctor_Int64);
+                    return;
+                }
+
+                if (value > 0 && value <= ulong.MaxValue)
+                {
+                    il.EmitULong(decimal.ToUInt64(value));
+                    il.EmitNew(Decimal_Ctor_UInt64);
                     return;
                 }
 

--- a/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
@@ -60,7 +60,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckDecimalConstantTest(bool useInterpreter)
         {
-            foreach (decimal value in new decimal[] { decimal.Zero, decimal.One, decimal.MinusOne, decimal.MinValue, decimal.MaxValue, int.MinValue, int.MaxValue, int.MinValue - 1L, int.MaxValue + 1L, long.MinValue, long.MaxValue })
+            foreach (decimal value in new decimal[] { decimal.Zero, decimal.One, decimal.MinusOne, decimal.MinValue, decimal.MaxValue, int.MinValue, int.MaxValue, int.MinValue - 1L, int.MaxValue + 1L, long.MinValue, long.MaxValue, long.MaxValue + 1m, ulong.MaxValue, ulong.MaxValue + 1m })
             {
                 VerifyDecimalConstant(value, useInterpreter);
             }


### PR DESCRIPTION
Use ldsfld instead of newobj for decimals in decimal's static fields.

Lighter IL and no constructor cost.