### PR TITLE
Optimise S.L.Expressions compilation of primitive constants.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/BoundConstants.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/BoundConstants.cs
@@ -191,7 +191,7 @@ namespace System.Linq.Expressions.Compiler
                 _values.Add(value);
             }
 
-            lc.IL.EmitInt(index);
+            lc.IL.EmitPrimitive(index);
             lc.IL.Emit(OpCodes.Ldelem_Ref);
             if (type.GetTypeInfo().IsValueType)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.Storage.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.Storage.cs
@@ -140,7 +140,7 @@ namespace System.Linq.Expressions.Compiler
             internal void EmitLoadBox()
             {
                 _array.EmitLoad();
-                Compiler.IL.EmitInt(_index);
+                Compiler.IL.EmitPrimitive(_index);
                 Compiler.IL.Emit(OpCodes.Ldelem_Ref);
                 Compiler.IL.Emit(OpCodes.Castclass, _boxType);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.cs
@@ -312,7 +312,7 @@ namespace System.Linq.Expressions.Compiler
             }
 
             // create the array
-            lc.IL.EmitInt(_hoistedLocals.Variables.Count);
+            lc.IL.EmitPrimitive(_hoistedLocals.Variables.Count);
             lc.IL.Emit(OpCodes.Newarr, typeof(object));
 
             // initialize all elements
@@ -321,7 +321,7 @@ namespace System.Linq.Expressions.Compiler
             {
                 // array[i] = new StrongBox<T>(...);
                 lc.IL.Emit(OpCodes.Dup);
-                lc.IL.EmitInt(i++);
+                lc.IL.EmitPrimitive(i++);
                 Type boxType = typeof(StrongBox<>).MakeGenericType(v.Type);
 
                 int index;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -338,49 +338,12 @@ namespace System.Linq.Expressions.Compiler
             il.Emit(OpCodes.Ldstr, value);
         }
 
-        internal static void EmitBoolean(this ILGenerator il, bool value)
+        internal static void EmitPrimitive(this ILGenerator il, bool value)
         {
-            if (value)
-            {
-                il.Emit(OpCodes.Ldc_I4_1);
-            }
-            else
-            {
-                il.Emit(OpCodes.Ldc_I4_0);
-            }
+            il.Emit(value ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
         }
 
-        internal static void EmitChar(this ILGenerator il, char value)
-        {
-            il.EmitInt(value);
-            il.Emit(OpCodes.Conv_U2);
-        }
-
-        internal static void EmitByte(this ILGenerator il, byte value)
-        {
-            il.EmitInt(value);
-            il.Emit(OpCodes.Conv_U1);
-        }
-
-        internal static void EmitSByte(this ILGenerator il, sbyte value)
-        {
-            il.EmitInt(value);
-            il.Emit(OpCodes.Conv_I1);
-        }
-
-        internal static void EmitShort(this ILGenerator il, short value)
-        {
-            il.EmitInt(value);
-            il.Emit(OpCodes.Conv_I2);
-        }
-
-        internal static void EmitUShort(this ILGenerator il, ushort value)
-        {
-            il.EmitInt(value);
-            il.Emit(OpCodes.Conv_U2);
-        }
-
-        internal static void EmitInt(this ILGenerator il, int value)
+        internal static void EmitPrimitive(this ILGenerator il, int value)
         {
             OpCode c;
             switch (value)
@@ -416,7 +379,7 @@ namespace System.Linq.Expressions.Compiler
                     c = OpCodes.Ldc_I4_8;
                     break;
                 default:
-                    if (value >= -128 && value <= 127)
+                    if (value >= sbyte.MinValue && value <= sbyte.MaxValue)
                     {
                         il.Emit(OpCodes.Ldc_I4_S, (sbyte)value);
                     }
@@ -429,37 +392,39 @@ namespace System.Linq.Expressions.Compiler
             il.Emit(c);
         }
 
-        internal static void EmitUInt(this ILGenerator il, uint value)
+        private static void EmitPrimitive(this ILGenerator il, uint value)
         {
-            il.EmitInt(unchecked((int)value));
-            il.Emit(OpCodes.Conv_U4);
+            il.EmitPrimitive(unchecked((int)value));
         }
 
-        internal static void EmitLong(this ILGenerator il, long value)
+        private static void EmitPrimitive(this ILGenerator il, long value)
         {
-            il.Emit(OpCodes.Ldc_I8, value);
-
-            //
-            // Now, emit convert to give the constant type information.
-            //
-            // Otherwise, it is treated as unsigned and overflow is not
-            // detected if it's used in checked ops.
-            //
-            il.Emit(OpCodes.Conv_I8);
+            if (int.MinValue <= value & value <= uint.MaxValue)
+            {
+                il.EmitPrimitive((int)value);
+                // While often not of consequence depending on what follows, there are cases where this
+                // casting matters. Values [0, int.MaxValue] can use either safely, but negative values
+                // must use conv.i8 and those (int.MaxValue, uint.MaxValue] must use conv.u8, or else
+                // the higher bits will be wrong.
+                il.Emit(value > 0 ? OpCodes.Conv_U8 : OpCodes.Conv_I8);
+            }
+            else
+            {
+                il.Emit(OpCodes.Ldc_I8, value);
+            }
         }
 
-        internal static void EmitULong(this ILGenerator il, ulong value)
+        private static void EmitPrimitive(this ILGenerator il, ulong value)
         {
-            il.Emit(OpCodes.Ldc_I8, unchecked((long)value));
-            il.Emit(OpCodes.Conv_U8);
+            il.EmitPrimitive(unchecked((long)value));
         }
 
-        internal static void EmitDouble(this ILGenerator il, double value)
+        private static void EmitPrimitive(this ILGenerator il, double value)
         {
             il.Emit(OpCodes.Ldc_R8, value);
         }
 
-        internal static void EmitSingle(this ILGenerator il, float value)
+        private static void EmitPrimitive(this ILGenerator il, float value)
         {
             il.Emit(OpCodes.Ldc_R4, value);
         }
@@ -612,40 +577,40 @@ namespace System.Linq.Expressions.Compiler
             switch (type.GetTypeCode())
             {
                 case TypeCode.Boolean:
-                    il.EmitBoolean((bool)value);
+                    il.EmitPrimitive((bool)value);
                     return true;
                 case TypeCode.SByte:
-                    il.EmitSByte((sbyte)value);
+                    il.EmitPrimitive((sbyte)value);
                     return true;
                 case TypeCode.Int16:
-                    il.EmitShort((short)value);
+                    il.EmitPrimitive((short)value);
                     return true;
                 case TypeCode.Int32:
-                    il.EmitInt((int)value);
+                    il.EmitPrimitive((int)value);
                     return true;
                 case TypeCode.Int64:
-                    il.EmitLong((long)value);
+                    il.EmitPrimitive((long)value);
                     return true;
                 case TypeCode.Single:
-                    il.EmitSingle((float)value);
+                    il.EmitPrimitive((float)value);
                     return true;
                 case TypeCode.Double:
-                    il.EmitDouble((double)value);
+                    il.EmitPrimitive((double)value);
                     return true;
                 case TypeCode.Char:
-                    il.EmitChar((char)value);
+                    il.EmitPrimitive((char)value);
                     return true;
                 case TypeCode.Byte:
-                    il.EmitByte((byte)value);
+                    il.EmitPrimitive((byte)value);
                     return true;
                 case TypeCode.UInt16:
-                    il.EmitUShort((ushort)value);
+                    il.EmitPrimitive((ushort)value);
                     return true;
                 case TypeCode.UInt32:
-                    il.EmitUInt((uint)value);
+                    il.EmitPrimitive((uint)value);
                     return true;
                 case TypeCode.UInt64:
-                    il.EmitULong((ulong)value);
+                    il.EmitPrimitive((ulong)value);
                     return true;
                 case TypeCode.Decimal:
                     il.EmitDecimal((decimal)value);
@@ -1058,7 +1023,7 @@ namespace System.Linq.Expressions.Compiler
             Debug.Assert(elementType != null);
             Debug.Assert(count >= 0);
 
-            il.EmitInt(count);
+            il.EmitPrimitive(count);
             il.Emit(OpCodes.Newarr, elementType);
         }
 
@@ -1100,13 +1065,13 @@ namespace System.Linq.Expressions.Compiler
                 if (int.MinValue <= value && value <= int.MaxValue)
                 {
                     int intValue = decimal.ToInt32(value);
-                    il.EmitInt(intValue);
+                    il.EmitPrimitive(intValue);
                     il.EmitNew(Decimal_Ctor_Int32);
                 }
                 else if (long.MinValue <= value && value <= long.MaxValue)
                 {
                     long longValue = decimal.ToInt64(value);
-                    il.EmitLong(longValue);
+                    il.EmitPrimitive(longValue);
                     il.EmitNew(Decimal_Ctor_Int64);
                 }
                 else
@@ -1123,11 +1088,11 @@ namespace System.Linq.Expressions.Compiler
         private static void EmitDecimalBits(this ILGenerator il, decimal value)
         {
             int[] bits = decimal.GetBits(value);
-            il.EmitInt(bits[0]);
-            il.EmitInt(bits[1]);
-            il.EmitInt(bits[2]);
-            il.EmitBoolean((bits[3] & 0x80000000) != 0);
-            il.EmitByte(unchecked((byte)(bits[3] >> 16)));
+            il.EmitPrimitive(bits[0]);
+            il.EmitPrimitive(bits[1]);
+            il.EmitPrimitive(bits[2]);
+            il.EmitPrimitive((bits[3] & 0x80000000) != 0);
+            il.EmitPrimitive(unchecked((byte)(bits[3] >> 16)));
             il.EmitNew(Decimal_Ctor_Int32_Int32_Int32_Bool_Byte);
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -307,7 +307,7 @@ namespace System.Linq.Expressions.Compiler
         private void EmitShiftMask(Type leftType)
         {
             int mask = leftType.IsInteger64() ? 0x3F : 0x1F;
-            _ilg.EmitInt(mask);
+            _ilg.EmitPrimitive(mask);
             _ilg.Emit(OpCodes.And);
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -655,7 +655,7 @@ namespace System.Linq.Expressions.Compiler
                 // Result is known statically, so just emit the expression for
                 // its side effects and return the result
                 EmitExpressionAsVoid(node.Expression);
-                _ilg.EmitBoolean(result == AnalyzeTypeIsResult.KnownTrue);
+                _ilg.EmitPrimitive(result == AnalyzeTypeIsResult.KnownTrue);
                 return;
             }
 
@@ -903,7 +903,7 @@ namespace System.Linq.Expressions.Compiler
                 for (int i = 0; i < n; i++)
                 {
                     _ilg.Emit(OpCodes.Dup);
-                    _ilg.EmitInt(i);
+                    _ilg.EmitPrimitive(i);
                     EmitExpression(expressions[i]);
                     _ilg.EmitStoreElement(elementType);
                 }
@@ -1308,11 +1308,11 @@ namespace System.Linq.Expressions.Compiler
                         _ilg.Emit(OpCodes.Br_S, exit);
 
                         _ilg.MarkLabel(exitAllNull);
-                        _ilg.EmitBoolean(nodeType == ExpressionType.Equal);
+                        _ilg.EmitPrimitive(nodeType == ExpressionType.Equal);
                         _ilg.Emit(OpCodes.Br_S, exit);
 
                         _ilg.MarkLabel(exitAnyNull);
-                        _ilg.EmitBoolean(nodeType == ExpressionType.NotEqual);
+                        _ilg.EmitPrimitive(nodeType == ExpressionType.NotEqual);
 
                         _ilg.MarkLabel(exit);
                         return;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
@@ -77,7 +77,7 @@ namespace System.Linq.Expressions.Compiler
                 EmitExpression(node.Operand);
                 LocalBuilder loc = GetLocal(node.Operand.Type);
                 _ilg.Emit(OpCodes.Stloc, loc);
-                _ilg.EmitInt(0);
+                _ilg.EmitPrimitive(0);
                 _ilg.EmitConvertToType(typeof(int), node.Operand.Type, isChecked: false);
                 _ilg.Emit(OpCodes.Ldloc, loc);
                 FreeLocal(loc);


### PR DESCRIPTION
Most types use `conv` instructions but when the value is known to be in the types range (as these are ipso facto being typed as such) this has no effect. Just use `EmitInt` for all values < 32bit size.

Since `EmitInt` is now a bit of a misnomer, rename all such methods to `EmitPrimitive`.

Use shorter `ldc*` instructions for 64-bit constants when the value will fit within 32 bits, as either a signed or unsigned value.