### PR TITLE
Enabling diagnostics in the middle of a connection causes NullReferenceException

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -1005,8 +1005,10 @@ namespace System.Data.SqlClient
                 GC.ReRegisterForFinalize(this);
             }
 
+            // The _statistics can change with StatisticsEnabled. Copying to a local variable before checking for a null value.
+            SqlStatistics statistics = _statistics;
             if (StatisticsEnabled ||
-                s_diagnosticListener.IsEnabled(SqlClientDiagnosticListenerExtensions.SqlAfterExecuteCommand))
+                ( s_diagnosticListener.IsEnabled(SqlClientDiagnosticListenerExtensions.SqlAfterExecuteCommand) && statistics != null))
             {
                 ADP.TimerCurrent(out _statistics._openTimestamp);
                 tdsInnerConnection.Parser.Statistics = _statistics;

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
@@ -11,7 +11,6 @@ namespace System.Data.SqlClient.Tests
     {
 
         [Fact]
-        [ActiveIssue(14017)]
         public void ConnectionTest()
         {
             Exception e = null;


### PR DESCRIPTION
There were test failures due in SqlConnection.Open due to a NullReferenceException. 

This happens in the following case, 

1. Do not enable statistics on SqlConnection and do not enable any Diagnostic listeners listening to the Command Diagnostics, and open a connection.
2. The diagnostics are enabled just during the `TryOpen` call in SqlConnection. (This is a matter of timing, but is easily reproducible in many CI runs. )

While trying to add statistics, the SqlConnection throws a NullReferenceException while de-referencing `_statistics` which was never initialized. 

The fix is to check for `Statistics` property before adding statistics data. This is a pattern I found the SqlConnection code and used it to fix this regression.

There are two test changes
1. Enable the SqlConnectionBasicTests by removing the [ActiveIssue] tag.
2. I had to move the Diagnostic test to the ManualTest project. This is because the Diagnostic Tests should not be executed in parallel with other SqlConnection Open and manual tests are executed serially. The diagnostics tests will still be executed automatically in the CI. The diagnostics test can get a null diagnostic if another SqlConnection test is running in parallel and its intended to check the diagnostics coming out of the behavior of the tests that its executing and not other tests. 


cc @corivera @stephentoub 

Fixes #14017 