### PR TITLE
Compile Expressions stelem & ldelem for enums as underlying type.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -193,10 +193,6 @@ namespace System.Linq.Expressions.Compiler
             {
                 il.Emit(OpCodes.Ldelem_Ref);
             }
-            else if (type.GetTypeInfo().IsEnum)
-            {
-                il.Emit(OpCodes.Ldelem, type);
-            }
             else
             {
                 switch (type.GetTypeCode())
@@ -245,11 +241,6 @@ namespace System.Linq.Expressions.Compiler
         {
             Debug.Assert(type != null);
 
-            if (type.GetTypeInfo().IsEnum)
-            {
-                il.Emit(OpCodes.Stelem, type);
-                return;
-            }
             switch (type.GetTypeCode())
             {
                 case TypeCode.Boolean:


### PR DESCRIPTION
Currently the larger fully-typed version is used, but they can be loaded and stored as their underlying types, with shorter codes which is also close to the C# compiler's behaviour.