### PR TITLE
Replace some S.L.Expressions conditional calls with conditional arguments

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -305,42 +305,21 @@ namespace System.Linq.Expressions.Compiler
         {
             Debug.Assert(fi != null);
 
-            if (fi.IsStatic)
-            {
-                il.Emit(OpCodes.Ldsflda, fi);
-            }
-            else
-            {
-                il.Emit(OpCodes.Ldflda, fi);
-            }
+            il.Emit(fi.IsStatic ? OpCodes.Ldsflda : OpCodes.Ldflda, fi);
         }
 
         internal static void EmitFieldGet(this ILGenerator il, FieldInfo fi)
         {
             Debug.Assert(fi != null);
 
-            if (fi.IsStatic)
-            {
-                il.Emit(OpCodes.Ldsfld, fi);
-            }
-            else
-            {
-                il.Emit(OpCodes.Ldfld, fi);
-            }
+            il.Emit(fi.IsStatic ? OpCodes.Ldsfld : OpCodes.Ldfld, fi);
         }
 
         internal static void EmitFieldSet(this ILGenerator il, FieldInfo fi)
         {
             Debug.Assert(fi != null);
 
-            if (fi.IsStatic)
-            {
-                il.Emit(OpCodes.Stsfld, fi);
-            }
-            else
-            {
-                il.Emit(OpCodes.Stfld, fi);
-            }
+            il.Emit(fi.IsStatic ? OpCodes.Stsfld : OpCodes.Stfld, fi);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix")]
@@ -924,14 +903,7 @@ namespace System.Linq.Expressions.Compiler
                             il.Emit(OpCodes.Conv_U4);
                             break;
                         case TypeCode.Int64:
-                            if (isFromUnsigned)
-                            {
-                                il.Emit(OpCodes.Conv_U8);
-                            }
-                            else
-                            {
-                                il.Emit(OpCodes.Conv_I8);
-                            }
+                            il.Emit(isFromUnsigned ? OpCodes.Conv_U8 : OpCodes.Conv_I8);
                             break;
                         case TypeCode.UInt64:
                             if (isFromUnsigned || isFromFloatingPoint)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -234,24 +234,10 @@ namespace System.Linq.Expressions.Compiler
                     }
                     break;
                 case ExpressionType.Divide:
-                    if (leftType.IsUnsigned())
-                    {
-                        _ilg.Emit(OpCodes.Div_Un);
-                    }
-                    else
-                    {
-                        _ilg.Emit(OpCodes.Div);
-                    }
+                    _ilg.Emit(leftType.IsUnsigned() ? OpCodes.Div_Un : OpCodes.Div);
                     break;
                 case ExpressionType.Modulo:
-                    if (leftType.IsUnsigned())
-                    {
-                        _ilg.Emit(OpCodes.Rem_Un);
-                    }
-                    else
-                    {
-                        _ilg.Emit(OpCodes.Rem);
-                    }
+                    _ilg.Emit(leftType.IsUnsigned() ? OpCodes.Rem_Un : OpCodes.Rem);
                     break;
                 case ExpressionType.And:
                 case ExpressionType.AndAlso:
@@ -262,27 +248,13 @@ namespace System.Linq.Expressions.Compiler
                     _ilg.Emit(OpCodes.Or);
                     break;
                 case ExpressionType.LessThan:
-                    if (leftType.IsUnsigned())
-                    {
-                        _ilg.Emit(OpCodes.Clt_Un);
-                    }
-                    else
-                    {
-                        _ilg.Emit(OpCodes.Clt);
-                    }
+                    _ilg.Emit(leftType.IsUnsigned() ? OpCodes.Clt_Un : OpCodes.Clt);
                     break;
                 case ExpressionType.LessThanOrEqual:
                     {
                         Label labFalse = _ilg.DefineLabel();
                         Label labEnd = _ilg.DefineLabel();
-                        if (leftType.IsUnsigned())
-                        {
-                            _ilg.Emit(OpCodes.Ble_Un_S, labFalse);
-                        }
-                        else
-                        {
-                            _ilg.Emit(OpCodes.Ble_S, labFalse);
-                        }
+                        _ilg.Emit(leftType.IsUnsigned() ? OpCodes.Ble_Un_S : OpCodes.Ble_S, labFalse);
                         _ilg.Emit(OpCodes.Ldc_I4_0);
                         _ilg.Emit(OpCodes.Br_S, labEnd);
                         _ilg.MarkLabel(labFalse);
@@ -291,27 +263,13 @@ namespace System.Linq.Expressions.Compiler
                     }
                     break;
                 case ExpressionType.GreaterThan:
-                    if (leftType.IsUnsigned())
-                    {
-                        _ilg.Emit(OpCodes.Cgt_Un);
-                    }
-                    else
-                    {
-                        _ilg.Emit(OpCodes.Cgt);
-                    }
+                    _ilg.Emit(leftType.IsUnsigned() ? OpCodes.Cgt_Un : OpCodes.Cgt);
                     break;
                 case ExpressionType.GreaterThanOrEqual:
                     {
                         Label labFalse = _ilg.DefineLabel();
                         Label labEnd = _ilg.DefineLabel();
-                        if (leftType.IsUnsigned())
-                        {
-                            _ilg.Emit(OpCodes.Bge_Un_S, labFalse);
-                        }
-                        else
-                        {
-                            _ilg.Emit(OpCodes.Bge_S, labFalse);
-                        }
+                        _ilg.Emit(leftType.IsUnsigned() ? OpCodes.Bge_Un_S : OpCodes.Bge_S, labFalse);
                         _ilg.Emit(OpCodes.Ldc_I4_0);
                         _ilg.Emit(OpCodes.Br_S, labEnd);
                         _ilg.MarkLabel(labFalse);
@@ -336,14 +294,7 @@ namespace System.Linq.Expressions.Compiler
                         throw ContractUtils.Unreachable;
                     }
                     EmitShiftMask(leftType);
-                    if (leftType.IsUnsigned())
-                    {
-                        _ilg.Emit(OpCodes.Shr_Un);
-                    }
-                    else
-                    {
-                        _ilg.Emit(OpCodes.Shr);
-                    }
+                    _ilg.Emit(leftType.IsUnsigned() ? OpCodes.Shr_Un : OpCodes.Shr);
                     break;
                 default:
                     throw Error.UnhandledBinary(op, nameof(op));

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
@@ -738,14 +738,7 @@ namespace System.Linq.Expressions
             Out('[');
             // For 3.5 subclasses, print the NodeType.
             // For Extension nodes, print the class name.
-            if (node.NodeType == ExpressionType.Extension)
-            {
-                Out(node.GetType().FullName);
-            }
-            else
-            {
-                Out(node.NodeType.ToString());
-            }
+            Out(node.NodeType == ExpressionType.Extension ? node.GetType().FullName : node.NodeType.ToString());
             Out(']');
             return node;
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -475,16 +475,9 @@ namespace System.Linq.Expressions.Interpreter
                 {
                     foreach (ByRefUpdater arg in _byrefArgs)
                     {
-                        if (arg.ArgumentIndex == -1)
-                        {
-                            // instance param, just copy back the exact instance invoked with, which
-                            // gets passed by reference from reflection for value types.
-                            arg.Update(frame, instance);
-                        }
-                        else
-                        {
-                            arg.Update(frame, args[arg.ArgumentIndex]);
-                        }
+                        // -1: instance param, just copy back the exact instance invoked with, which
+                        // gets passed by reference from reflection for value types.
+                        arg.Update(frame, arg.ArgumentIndex == -1 ? instance : args[arg.ArgumentIndex]);
                     }
                 }
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -687,38 +687,17 @@ namespace System.Linq.Expressions.Interpreter
 
         public void EmitAdd(Type type, bool @checked)
         {
-            if (@checked)
-            {
-                Emit(AddOvfInstruction.Create(type));
-            }
-            else
-            {
-                Emit(AddInstruction.Create(type));
-            }
+            Emit(@checked ? AddOvfInstruction.Create(type) : AddInstruction.Create(type));
         }
 
         public void EmitSub(Type type, bool @checked)
         {
-            if (@checked)
-            {
-                Emit(SubOvfInstruction.Create(type));
-            }
-            else
-            {
-                Emit(SubInstruction.Create(type));
-            }
+            Emit(@checked ? SubOvfInstruction.Create(type) : SubInstruction.Create(type));
         }
 
         public void EmitMul(Type type, bool @checked)
         {
-            if (@checked)
-            {
-                Emit(MulOvfInstruction.Create(type));
-            }
-            else
-            {
-                Emit(MulInstruction.Create(type));
-            }
+            Emit(@checked ? MulOvfInstruction.Create(type) : MulInstruction.Create(type));
         }
 
         public void EmitDiv(Type type)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -830,16 +830,11 @@ namespace System.Linq.Expressions.Interpreter
                             _instructions.EmitEqual(typeof(object));
                             _instructions.EmitBranchFalse(callMethod);
 
-                            if (node.NodeType == ExpressionType.Equal)
-                            {
-                                // right null, left not, false
-                                _instructions.EmitLoad(AstUtils.BoxedFalse, typeof(bool));
-                            }
-                            else
-                            {
-                                // right null, left not, true
-                                _instructions.EmitLoad(AstUtils.BoxedTrue, typeof(bool));
-                            }
+                            // right null, left not, false
+                            // right null, left not, true
+                            _instructions.EmitLoad(
+                                node.NodeType == ExpressionType.Equal ? AstUtils.BoxedFalse : AstUtils.BoxedTrue,
+                                typeof(bool));
                             _instructions.EmitBranch(end, hasResult: false, hasValue: true);
 
                             // both are not null

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -84,14 +84,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int Run(InterpretedFrame frame)
         {
             object value = frame.Pop();
-            if (_type.IsInstanceOfType(value))
-            {
-                frame.Push(value);
-            }
-            else
-            {
-                frame.Push(null);
-            }
+            frame.Push(_type.IsInstanceOfType(value) ? value : null);
             return 1;
         }
 
@@ -231,14 +224,7 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object obj = frame.Pop();
-                if (obj == null)
-                {
-                    frame.Push("");
-                }
-                else
-                {
-                    frame.Push(obj.ToString());
-                }
+                frame.Push(obj == null ? "" : obj.ToString());
                 return 1;
             }
         }
@@ -248,14 +234,7 @@ namespace System.Linq.Expressions.Interpreter
             public override int Run(InterpretedFrame frame)
             {
                 object obj = frame.Pop();
-                if (obj == null)
-                {
-                    frame.Push(0);
-                }
-                else
-                {
-                    frame.Push(obj.GetHashCode());
-                }
+                frame.Push(obj?.GetHashCode() ?? 0);
                 return 1;
             }
         }


### PR DESCRIPTION
Instead of calling the same method for either branch, branch on what the argument is. Reduces output IL produced (e.g. `EmitFieldAddress` is 28 bytes instead of 45) which might impact inlining favourably in some cases.

`EmitBoolean` left as another PR does the same thing there.