### PR TITLE
Remove TypeDoesNotHaveConstructorForTheSignature from S.L.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -150,9 +150,6 @@
   <data name="TypeMustNotBePointer" xml:space="preserve">
     <value>Type must not be a pointer type</value>
   </data>
-  <data name="TypeDoesNotHaveConstructorForTheSignature" xml:space="preserve">
-    <value>Type doesn't have constructor with a given signature</value>
-  </data>
   <data name="SetterMustBeVoid" xml:space="preserve">
     <value>Setter should have void type.</value>
   </data>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -352,17 +352,6 @@ namespace System.Linq.Expressions.Compiler
             il.Emit(OpCodes.Newobj, ci);
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix")]
-        internal static void EmitNew(this ILGenerator il, Type type, Type[] paramTypes)
-        {
-            Debug.Assert(type != null);
-            Debug.Assert(paramTypes != null);
-
-            ConstructorInfo ci = type.GetConstructor(paramTypes);
-            if (ci == null) throw Error.TypeDoesNotHaveConstructorForTheSignature();
-            il.EmitNew(ci);
-        }
-
         #endregion
 
         #region Constants
@@ -1126,14 +1115,14 @@ namespace System.Linq.Expressions.Compiler
             }
             else
             {
-                int rank = arrayType.GetArrayRank();
-
-                Type[] types = new Type[rank];
-                for (int i = 0; i < rank; i++)
+                Type[] types = new Type[arrayType.GetArrayRank()];
+                for (int i = 0; i < types.Length; i++)
                 {
                     types[i] = typeof(int);
                 }
-                il.EmitNew(arrayType, types);
+                ConstructorInfo ci = arrayType.GetConstructor(types);
+                Debug.Assert(ci != null);
+                il.EmitNew(ci);
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -210,13 +210,6 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// ArgumentException with message like "Type doesn't have constructor with a given signature"
-        /// </summary>
-        internal static Exception TypeDoesNotHaveConstructorForTheSignature()
-        {
-            return new ArgumentException(Strings.TypeDoesNotHaveConstructorForTheSignature);
-        }
-        /// <summary>
         /// ArgumentException with message like "Setter should have void type."
         /// </summary>
         internal static Exception SetterMustBeVoid(string paramName)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -65,11 +65,6 @@ namespace System.Linq.Expressions
         internal static string TypeMustNotBePointer => SR.TypeMustNotBePointer;
 
         /// <summary>
-        /// A string like "Type doesn't have constructor with a given signature"
-        /// </summary>
-        internal static string TypeDoesNotHaveConstructorForTheSignature => SR.TypeDoesNotHaveConstructorForTheSignature;
-
-        /// <summary>
         /// A string like "Setter should have void type."
         /// </summary>
         internal static string SetterMustBeVoid => SR.SetterMustBeVoid;


### PR DESCRIPTION
Error is only thrown in an array of rank n does not have a constructor taking n integers, which it must. Replace throw site with assertion.