### PR TITLE
Retain Scale Information in decimal ConstantExpression compilation

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
@@ -20,15 +20,41 @@ namespace System.Linq.Expressions
                                        s_Decimal_Ctor_Int32 ??
                                       (s_Decimal_Ctor_Int32 = typeof(decimal).GetConstructor(new[] { typeof(int) }));
 
+        private static ConstructorInfo s_Decimal_Ctor_UInt32;
+        public  static ConstructorInfo   Decimal_Ctor_UInt32 =>
+                                       s_Decimal_Ctor_UInt32 ??
+                                      (s_Decimal_Ctor_UInt32 = typeof(decimal).GetConstructor(new[] { typeof(uint) }));
+
         private static ConstructorInfo s_Decimal_Ctor_Int64;
         public  static ConstructorInfo   Decimal_Ctor_Int64 =>
                                        s_Decimal_Ctor_Int64 ??
                                       (s_Decimal_Ctor_Int64 = typeof(decimal).GetConstructor(new[] { typeof(long) }));
 
+        private static ConstructorInfo s_Decimal_Ctor_UInt64;
+        public  static ConstructorInfo   Decimal_Ctor_UInt64 =>
+                                       s_Decimal_Ctor_UInt64 ??
+                                      (s_Decimal_Ctor_UInt64 = typeof(decimal).GetConstructor(new[] { typeof(ulong) }));
+
         private static ConstructorInfo s_Decimal_Ctor_Int32_Int32_Int32_Bool_Byte;
         public  static ConstructorInfo   Decimal_Ctor_Int32_Int32_Int32_Bool_Byte =>
                                        s_Decimal_Ctor_Int32_Int32_Int32_Bool_Byte ??
                                       (s_Decimal_Ctor_Int32_Int32_Int32_Bool_Byte = typeof(decimal).GetConstructor(new[] { typeof(int), typeof(int), typeof(int), typeof(bool), typeof(byte) }));
+
+        private static FieldInfo s_Decimal_One;
+        public static FieldInfo Decimal_One
+            => s_Decimal_One ?? (s_Decimal_One = typeof(decimal).GetField(nameof(decimal.One)));
+
+        private static FieldInfo s_Decimal_MinusOne;
+        public static FieldInfo Decimal_MinusOne
+            => s_Decimal_MinusOne ?? (s_Decimal_MinusOne = typeof(decimal).GetField(nameof(decimal.MinusOne)));
+
+        private static FieldInfo s_Decimal_MinValue;
+        public static FieldInfo Decimal_MinValue
+            => s_Decimal_MinValue ?? (s_Decimal_MinValue = typeof(decimal).GetField(nameof(decimal.MinValue)));
+
+        private static FieldInfo s_Decimal_MaxValue;
+        public static FieldInfo Decimal_MaxValue
+            => s_Decimal_MaxValue ?? (s_Decimal_MaxValue = typeof(decimal).GetField(nameof(decimal.MaxValue)));
 
         private static ConstructorInfo s_Closure_ObjectArray_ObjectArray;
         public  static ConstructorInfo   Closure_ObjectArray_ObjectArray =>

--- a/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
@@ -953,6 +953,16 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(f.ToString(), e5.ToString());
         }
 
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void DecimalConstantRetainsScaleAnd(bool useInterpreter)
+        {
+            var lambda = Expression.Lambda<Func<decimal>>(Expression.Constant(-0.000m));
+            var func = lambda.Compile(useInterpreter);
+            var bits = decimal.GetBits(func());
+            Assert.Equal(unchecked((int)0x80030000), bits[3]);
+        }
+
+
         class Bar
         {
             public int Foo = 41;

--- a/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
@@ -60,7 +60,7 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckDecimalConstantTest(bool useInterpreter)
         {
-            foreach (decimal value in new decimal[] { decimal.Zero, decimal.One, decimal.MinusOne, decimal.MinValue, decimal.MaxValue, int.MinValue, int.MaxValue, int.MinValue - 1L, int.MaxValue + 1L, long.MinValue, long.MaxValue })
+            foreach (decimal value in new decimal[] { decimal.Zero, decimal.One, decimal.MinusOne, decimal.MinValue, decimal.MaxValue, int.MinValue, int.MaxValue, int.MinValue - 1L, int.MaxValue + 1L, long.MinValue, long.MaxValue, long.MaxValue + 1m, ulong.MaxValue, ulong.MaxValue + 1m })
             {
                 VerifyDecimalConstant(value, useInterpreter);
             }


### PR DESCRIPTION
Don't optimise IL generated when the scale of a decimal constant is other than zero, so that scale information isn't lost.

Fixes #15806

Improve the optimisations for those cases they can cover:

**Lighter IL for known decimal values**

Use `ldsfld` instead of `newobj` for decimals in decimal's static fields.

Lighter IL and no constructor cost.

**Lighter IL integral decimal constants (`int.MaxValue`, `uint.MaxValue`]**

Load 32-bit value instead of 64.

**Lighter IL integral decimal constants (`long.MaxValue`, `ulong.MaxValue`]**

Use constructor that takes `ulong` instead of components.