### PR TITLE
Fix run-tests.bat

### DIFF
--- a/run-test.cmd
+++ b/run-test.cmd
@@ -1,16 +1,24 @@
 @if not defined _echo @echo off
-
+setlocal 
 :: To run tests outside of MSBuild.exe
-:: %1 is the path to the tests\<OSConfig> folder
-:: %2 is the path to the packages folder
+:: %1 is the path to the bin\<OSConfig> folder
+:: %2 is the path to the tools\testdotnetcli folder
 
-pushd %1
+set LOCATION=%1
+set RUNTIME_PATH=%2
+
+if "%LOCATION%" == "" set LOCATION=%~dp0\bin\Windows_NT.AnyCPU.Debug
+if "%RUNTIME_PATH%" == "" set RUNTIME_PATH=%~dp0\Tools\testdotnetcli
+
+pushd %LOCATION%
 
 FOR /D %%F IN (*.Tests) DO (
-	IF EXIST %%F\netcoreapp1.0 (
-		pushd %%F\netcoreapp1.0
+	IF EXIST %%F\netcoreapp (
+		pushd %%F\netcoreapp
+                @echo Looking in %cd%...
 		IF EXIST RunTests.cmd (
-			CALL RunTests.cmd %2
+                        @echo ... found tests
+			CALL RunTests.cmd %RUNTIME_PATH%
 		)
 		popd
 	)


### PR DESCRIPTION
This makes run-tests.bat work. It would be nice if there was a way to run tests and get a summary of results, rather than grep all the log files afterwards.

@jkotas