### PR TITLE
Improvements to Complex trig and hyperbolic trig functions

### DIFF
--- a/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
@@ -223,17 +223,24 @@ namespace System.Numerics
 
         public static Complex Sin(Complex value)
         {
-            double a = value._real;
-            double b = value._imaginary;
-            return new Complex(Math.Sin(a) * Math.Cosh(b), Math.Cos(a) * Math.Sinh(b));
+            // We need both sinh and cosh of imaginary part. To avoid multiple calls to Math.Exp with the same value,
+            // we compute them both here from a single call to Math.Exp.
+            double p = Math.Exp(value._imaginary);
+            double q = 1.0 / p;
+            double sinh = (p - q) * 0.5;
+            double cosh = (p + q) * 0.5;
+            return new Complex(Math.Sin(value._real) * cosh, Math.Cos(value._real) * sinh);
+            // There is a small region where sinh and/or cosh (correctly) overflow, while sin and/or cos are small enough
+            // that the product is representable, but since small * infinity = infinity, we still (incorrectly) return
+            // infinity. We have not attempted to fix this problem.
         }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Sinh", Justification = "Sinh is the name of a mathematical function.")]
         public static Complex Sinh(Complex value)
         {
-            double a = value._real;
-            double b = value._imaginary;
-            return new Complex(Math.Sinh(a) * Math.Cos(b), Math.Cosh(a) * Math.Sin(b));
+            // Use sinh(z) = -i sin(iz) to compute via sin(z).
+            Complex sin = Sin(new Complex(-value._imaginary, value._real));
+            return new Complex(sin._imaginary, -sin._real);
         }
 
         public static Complex Asin(Complex value)
@@ -245,19 +252,19 @@ namespace System.Numerics
             return (-ImaginaryOne) * Log(ImaginaryOne * value + Sqrt(One - value * value));
         }
 
-        public static Complex Cos(Complex value)
-        {
-            double a = value._real;
-            double b = value._imaginary;
-            return new Complex(Math.Cos(a) * Math.Cosh(b), -(Math.Sin(a) * Math.Sinh(b)));
+        public static Complex Cos(Complex value) {
+            double p = Math.Exp(value._imaginary);
+            double q = 1.0 / p;
+            double sinh = (p - q) * 0.5;
+            double cosh = (p + q) * 0.5;
+            return new Complex(Math.Cos(value._real) * cosh, -Math.Sin(value._real) * sinh);
         }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Cosh", Justification = "Cosh is the name of a mathematical function.")]
         public static Complex Cosh(Complex value)
         {
-            double a = value._real;
-            double b = value._imaginary;
-            return new Complex(Math.Cosh(a) * Math.Cos(b), Math.Sinh(a) * Math.Sin(b));
+            // Use cosh(z) = cos(iz) to compute via cos(z).
+            return Cos(new Complex(-value._imaginary, value._real));
         }
 
         public static Complex Acos(Complex value)
@@ -271,13 +278,40 @@ namespace System.Numerics
 
         public static Complex Tan(Complex value)
         {
-            return (Sin(value) / Cos(value));
+            // tan z = sin z / cos z, but to avoid unnecessary repeated trig computations, use
+            //   tan z = \frac{\sin(2x) + i \sinh(2y)}{\cos(2x) + \cosh(2y)}
+            // (see from Abromowitz & Stegun 4.3.57 or derive by hand), and compute trig functions here.
+
+            // Even this can only be used for |y| not-too-big, beacuse sinh and cosh (correctly) overflow
+            // for quite moderate y, even though their ratio does not. In that case, divide
+            // through by cosh to get:
+            //   tan z = \frac{\frac{\sin(2x)}{\cosh(2y)} + i \tanh(2y)}{1 + \frac{\cos(2x)}{\cosh(2y)}}
+            // which correctly computes the (tiny) real part and the (normal-sized) imaginary part.
+            
+            double x2 = 2.0 * value._real;
+            double y2 = 2.0 * value._imaginary;
+            double p = Math.Exp(y2);
+            double q = 1.0 / p;
+            double cosh = (p + q) * 0.5;
+            if (Math.Abs(value._imaginary) <= 4.0)
+            {
+                double sinh = (p - q) * 0.5;
+                double D = Math.Cos(x2) + cosh;
+                return new Complex(Math.Sin(x2) / D, sinh / D);
+            }
+            else
+            {
+                double D = 1.0 + Math.Cos(x2) / cosh;
+                return new Complex(Math.Sin(x2) / cosh / D, Math.Tanh(y2) / D);
+            }
         }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Tanh", Justification = "Tanh is the name of a mathematical function.")]
         public static Complex Tanh(Complex value)
         {
-            return (Sinh(value) / Cosh(value));
+            // Use tanh(z) = -i tan(iz) to compute via tan(z).
+            Complex tan = Tan(new Complex(-value._imaginary, value._real));
+            return new Complex(tan._imaginary, -tan._real);
         }
 
         public static Complex Atan(Complex value)

--- a/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
@@ -279,13 +279,13 @@ namespace System.Numerics
         public static Complex Tan(Complex value)
         {
             // tan z = sin z / cos z, but to avoid unnecessary repeated trig computations, use
-            //   tan z = \frac{\sin(2x) + i \sinh(2y)}{\cos(2x) + \cosh(2y)}
-            // (see from Abromowitz & Stegun 4.3.57 or derive by hand), and compute trig functions here.
+            //   tan z = (sin(2x) + i sinh(2y)) / (cos(2x) + cosh(2y))
+            // (see Abramowitz & Stegun 4.3.57 or derive by hand), and compute trig functions here.
 
             // Even this can only be used for |y| not-too-big, beacuse sinh and cosh (correctly) overflow
             // for quite moderate y, even though their ratio does not. In that case, divide
             // through by cosh to get:
-            //   tan z = \frac{\frac{\sin(2x)}{\cosh(2y)} + i \tanh(2y)}{1 + \frac{\cos(2x)}{\cosh(2y)}}
+            //   tan z = (sin(2x) / cosh(2y) + i \tanh(2y)) / (1 + cos(2x) / cosh(2y))
             // which correctly computes the (tiny) real part and the (normal-sized) imaginary part.
             
             double x2 = 2.0 * value._real;

--- a/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
@@ -230,9 +230,10 @@ namespace System.Numerics
             double sinh = (p - q) * 0.5;
             double cosh = (p + q) * 0.5;
             return new Complex(Math.Sin(value._real) * cosh, Math.Cos(value._real) * sinh);
-            // There is a small region where sinh and/or cosh (correctly) overflow, while sin and/or cos are small enough
-            // that the product is representable, but since small * infinity = infinity, we still (incorrectly) return
-            // infinity. We have not attempted to fix this problem.
+            // There is a known limitation with this algorithm: inputs that cause sinh and cosh to overflow, but for
+            // which sin or cos are small enough that sin * cosh or cos * sinh are still representable, nonetheless
+            // produce overflow. For example, Sin((0.01, 711.0)) should produce (~3.0E306, PositiveInfinity), but
+            // instead produces (PositiveInfinity, PositiveInfinity). 
         }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Sinh", Justification = "Sinh is the name of a mathematical function.")]
@@ -282,9 +283,8 @@ namespace System.Numerics
             //   tan z = (sin(2x) + i sinh(2y)) / (cos(2x) + cosh(2y))
             // (see Abramowitz & Stegun 4.3.57 or derive by hand), and compute trig functions here.
 
-            // Even this can only be used for |y| not-too-big, beacuse sinh and cosh (correctly) overflow
-            // for quite moderate y, even though their ratio does not. In that case, divide
-            // through by cosh to get:
+            // This approach does not work for |y| > ~355, because sinh(2y) and cosh(2y) overflow,
+            // even though their ratio does not. In that case, divide through by cosh to get:
             //   tan z = (sin(2x) / cosh(2y) + i \tanh(2y)) / (1 + cos(2x) / cosh(2y))
             // which correctly computes the (tiny) real part and the (normal-sized) imaginary part.
             

--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -1358,7 +1358,8 @@ namespace System.Numerics.Tests
             Tan_Advanced(real, imaginary, expectedReal, expectedImaginary);
         }
 
-        public static IEnumerable<object[]> Tan_Advanced_TestData() {
+        public static IEnumerable<object[]> Tan_Advanced_TestData()
+        {
 
             // .NET does not compute simple trig functions of large values correctly, so we can't make any
             // assertions about complex trig functions with large real parts.
@@ -1374,12 +1375,45 @@ namespace System.Numerics.Tests
             yield return new object[] { double.NaN, double.PositiveInfinity, double.NaN, double.NaN };
             yield return new object[] { double.NaN, double.NaN, double.NaN, double.NaN };
 
+            // Simple regression test; previous code returned wrong result for this argument
+            yield return new object[] { 0.0, 750.0, 0.0, 1.0 };
+
+        }
+
+        public static IEnumerable<object[]> Tan_Legacy_TestData()
+        {
+            // These tests assert previous behavior which is not mathematically correct.
+            // They are superceded by Tan_Advanced_TestData.
+
+            yield return new object[] { double.MaxValue, 0, Math.Sin(double.MaxValue) / Math.Cos(double.MaxValue), 0 };
+            yield return new object[] { double.MinValue, 0, Math.Sin(double.MinValue) / Math.Cos(double.MinValue), 0 };
+
+            yield return new object[] { 0, double.MaxValue, double.NaN, double.NaN };
+            yield return new object[] { 0, double.MinValue, double.NaN, double.NaN };
+
+            foreach (double invalidReal in s_invalidDoubleValues)
+            {
+                yield return new object[] { invalidReal, 1, double.NaN, double.NaN }; // Invalid real
+                foreach (double invalidImaginary in s_invalidDoubleValues)
+                {
+                    yield return new object[] { 1, invalidImaginary, double.NaN, double.NaN }; // Invalid imaginary
+                    yield return new object[] { invalidReal, invalidImaginary, double.NaN, double.NaN }; // Invalid real, invalid imaginary
+                }
+            }
         }
 
         [Theory, MemberData("Tan_Advanced_TestData")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void Tan_Advanced(double real, double imaginary, double expectedReal, double expectedImaginary)
         {
+            var complex = new Complex(real, imaginary);
+            Complex result = Complex.Tan(complex);
+            VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
+        }
+
+        [Theory, MemberData("Tan_Legacy_TestData")]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void Tan_Legacy (double real, double imaginary, double expectedReal, double expectedImaginary) {
             var complex = new Complex(real, imaginary);
             Complex result = Complex.Tan(complex);
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
@@ -1414,12 +1448,46 @@ namespace System.Numerics.Tests
             yield return new object[] { double.PositiveInfinity, double.NaN, double.NaN, double.NaN };
             yield return new object[] { 0.0, double.NaN, double.NaN, double.NaN };
             yield return new object[] { double.NaN, double.NaN, double.NaN, double.NaN };
+
+            // Simple regression test; previous code returned wrong result for this argument
+            yield return new object[] { -750.0, 0.0, -1.0, 0.0 };
+        }
+
+        public static IEnumerable<object[]> Tanh_Legacy_TestData()
+        {
+            // These tests assert previous behavior which is not mathematically correct.
+            // They are superceded by Tanh_Advanced_TestData.
+
+            // Boundary values
+            yield return new object[] { double.MinValue, 0, double.NaN, double.NaN };
+            yield return new object[] { 0, double.MaxValue, 0, Math.Sin(double.MaxValue) / Math.Cos(double.MaxValue) };
+            yield return new object[] { 0, double.MinValue, 0, Math.Sin(double.MinValue) / Math.Cos(double.MinValue) };
+
+
+            // Invalid values
+            foreach (double invalidReal in s_invalidDoubleValues)
+            {
+                yield return new object[] { invalidReal, 1, double.NaN, double.NaN }; // Invalid real
+                foreach (double invalidImaginary in s_invalidDoubleValues)
+                {
+                    yield return new object[] { 1, invalidImaginary, double.NaN, double.NaN }; // Invalid imaginary
+                    yield return new object[] { invalidReal, invalidImaginary, double.NaN, double.NaN }; // Invalid real, invalid imaginary
+                }
+            }
         }
 
         [Theory, MemberData("Tanh_Advanced_TestData")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void Tanh_Advanced(double real, double imaginary, double expectedReal, double expectedImaginary)
         {
+            var complex = new Complex(real, imaginary);
+            Complex result = Complex.Tanh(complex);
+            VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
+        }
+
+        [Theory, MemberData("Tanh_Legacy_TestData")]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void Tanh_Legacy (double real, double imaginary, double expectedReal, double expectedImaginary) {
             var complex = new Complex(real, imaginary);
             Complex result = Complex.Tanh(complex);
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);

--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -1375,15 +1375,13 @@ namespace System.Numerics.Tests
             yield return new object[] { double.NaN, double.PositiveInfinity, double.NaN, double.NaN };
             yield return new object[] { double.NaN, double.NaN, double.NaN, double.NaN };
 
-            // Simple regression test; previous code returned wrong result for this argument
             yield return new object[] { 0.0, 750.0, 0.0, 1.0 };
 
         }
 
         public static IEnumerable<object[]> Tan_Legacy_TestData()
         {
-            // These tests assert previous behavior which is not mathematically correct.
-            // They are superceded by Tan_Advanced_TestData.
+            // These tests validate legacy .NET behavior.
 
             yield return new object[] { double.MaxValue, 0, Math.Sin(double.MaxValue) / Math.Cos(double.MaxValue), 0 };
             yield return new object[] { double.MinValue, 0, Math.Sin(double.MinValue) / Math.Cos(double.MinValue), 0 };
@@ -1449,14 +1447,12 @@ namespace System.Numerics.Tests
             yield return new object[] { 0.0, double.NaN, double.NaN, double.NaN };
             yield return new object[] { double.NaN, double.NaN, double.NaN, double.NaN };
 
-            // Simple regression test; previous code returned wrong result for this argument
             yield return new object[] { -750.0, 0.0, -1.0, 0.0 };
         }
 
         public static IEnumerable<object[]> Tanh_Legacy_TestData()
         {
-            // These tests assert previous behavior which is not mathematically correct.
-            // They are superceded by Tanh_Advanced_TestData.
+            // These tests validate legacy .NET behavior.
 
             // Boundary values
             yield return new object[] { double.MinValue, 0, double.NaN, double.NaN };

--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -1358,7 +1358,7 @@ namespace System.Numerics.Tests
             Tan_Advanced(real, imaginary, expectedReal, expectedImaginary);
         }
 
-        public static IEnumerable<object[]> Tan_Advanced_TestData () {
+        public static IEnumerable<object[]> Tan_Advanced_TestData() {
 
             // .NET does not compute simple trig functions of large values correctly, so we can't make any
             // assertions about complex trig functions with large real parts.

--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -1358,29 +1358,26 @@ namespace System.Numerics.Tests
             Tan_Advanced(real, imaginary, expectedReal, expectedImaginary);
         }
 
-        public static IEnumerable<object[]> Tan_Advanced_TestData()
-        {
-            yield return new object[] { double.MaxValue, 0, Math.Sin(double.MaxValue) / Math.Cos(double.MaxValue), 0 };
-            yield return new object[] { double.MinValue, 0, Math.Sin(double.MinValue) / Math.Cos(double.MinValue), 0 };
+        public static IEnumerable<object[]> Tan_Advanced_TestData () {
 
-            yield return new object[] { 0, double.MaxValue, double.NaN, double.NaN };
-            yield return new object[] { 0, double.MinValue, double.NaN, double.NaN };
+            // .NET does not compute simple trig functions of large values correctly, so we can't make any
+            // assertions about complex trig functions with large real parts.
 
-            yield return new object[] { double.MaxValue, double.MaxValue, double.NaN, double.NaN };
-            yield return new object[] { double.MinValue, double.MinValue, double.NaN, double.NaN };
+            yield return new object[] { 0.0, double.MaxValue, 0.0, 1.0 };
+            yield return new object[] { 0.0, -double.MaxValue, 0.0, -1.0 };
 
-            foreach (double invalidReal in s_invalidDoubleValues)
-            {
-                yield return new object[] { invalidReal, 1, double.NaN, double.NaN }; // Invalid real
-                foreach (double invalidImaginary in s_invalidDoubleValues)
-                {
-                    yield return new object[] { 1, invalidImaginary, double.NaN, double.NaN }; // Invalid imaginary
-                    yield return new object[] { invalidReal, invalidImaginary, double.NaN, double.NaN }; // Invalid real, invalid imaginary
-                }
-            }
+            yield return new object[] { 0.0, double.PositiveInfinity, 0.0, 1.0 };
+            yield return new object[] { 0.0, double.NegativeInfinity, 0.0, -1.0 };
+
+            yield return new object[] { 0.0, double.NaN, double.NaN, double.NaN };
+            yield return new object[] { double.NaN, 0.0, double.NaN, double.NaN };
+            yield return new object[] { double.NaN, double.PositiveInfinity, double.NaN, double.NaN };
+            yield return new object[] { double.NaN, double.NaN, double.NaN, double.NaN };
+
         }
 
         [Theory, MemberData("Tan_Advanced_TestData")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void Tan_Advanced(double real, double imaginary, double expectedReal, double expectedImaginary)
         {
             var complex = new Complex(real, imaginary);
@@ -1388,16 +1385,7 @@ namespace System.Numerics.Tests
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
         }
 
-        public static IEnumerable<object[]> Tanh_Basic_TestData()
-        {
-            // Boundary values
-            yield return new object[] { double.MaxValue, 0 };
-            yield return new object[] { double.MaxValue, double.MaxValue };
-            yield return new object[] { double.MinValue, double.MinValue };
-        }
-
         [Theory]
-        [MemberData(nameof(Tanh_Basic_TestData))]
         [MemberData(nameof(Primitives_2_TestData))]
         [MemberData(nameof(SmallRandom_2_TestData))]
         public static void Tanh_Basic(double real, double imaginary)
@@ -1413,24 +1401,23 @@ namespace System.Numerics.Tests
 
         public static IEnumerable<object[]> Tanh_Advanced_TestData()
         {
-            // Boundary values
-            yield return new object[] { double.MinValue, 0, double.NaN, double.NaN };
-            yield return new object[] { 0, double.MaxValue, 0, Math.Sin(double.MaxValue) / Math.Cos(double.MaxValue) };
-            yield return new object[] { 0, double.MinValue, 0, Math.Sin(double.MinValue) / Math.Cos(double.MinValue) };
+            // .NET does not compute simple trig functions of large values correctly, so we can't make any
+            // assertions about complex hyperbolic trig functions with large imaginary parts.
 
-            // Invalid values
-            foreach (double invalidReal in s_invalidDoubleValues)
-            {
-                yield return new object[] { invalidReal, 1, double.NaN, double.NaN }; // Invalid real
-                foreach (double invalidImaginary in s_invalidDoubleValues)
-                {
-                    yield return new object[] { 1, invalidImaginary, double.NaN, double.NaN }; // Invalid imaginary
-                    yield return new object[] { invalidReal, invalidImaginary, double.NaN, double.NaN }; // Invalid real, invalid imaginary
-                }
-            }
+            yield return new object[] { double.MaxValue, 0.0, 1.0, 0.0 };
+            yield return new object[] { -double.MaxValue, 0.0, -1.0, 0.0 };
+
+            yield return new object[] { double.PositiveInfinity, 0.0, 1.0, 0.0 };
+            yield return new object[] { double.NegativeInfinity, 0.0, -1.0, 0.0 };
+
+            yield return new object[] { double.NaN, 0.0, double.NaN, double.NaN };
+            yield return new object[] { double.PositiveInfinity, double.NaN, double.NaN, double.NaN };
+            yield return new object[] { 0.0, double.NaN, double.NaN, double.NaN };
+            yield return new object[] { double.NaN, double.NaN, double.NaN, double.NaN };
         }
 
         [Theory, MemberData("Tanh_Advanced_TestData")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void Tanh_Advanced(double real, double imaginary, double expectedReal, double expectedImaginary)
         {
             var complex = new Complex(real, imaginary);


### PR DESCRIPTION
This is a series of relatively minor improvements to the complex trig functions and complex hyperbolic trig functions.

Sin and Cos perf is improved by only making one call to Math.Exp to compute the required real hyperbolic trig functions. (Hopefully the JIT compiler is smart enough to make a single FPU call for the required real sin and cos, but that's not something I can force. It would be nice if there were a Math.SinAndCos method that explicitly forced this.)

Tan perf is similiarly improved, and, more importantly, modified to correctly handle the large region (all |z.Im| larger than about 710) for which Sin and Cos overflow but Tan doesn't.

Sinh, Cosh, and Tanh are modified to call Sin, Cos, and Tan, so that all current and future improvements to the complex trig functions automatically feed into the complex hyperbolic trig functions.

Several test cases for Tan and Tanh involving large arguments needed to be changed. Some of the previous test assertions were simply assertions of the previous bad behavior, e.g. demanding NaN for Tanh(big real) instead of 1. These have been changed to assert the new, mathematically correct behavior. Some of the previous test assertions are inappropriate given the bad behavior of the .NET real trig functions, e.g. demanding Tan(x + 0.0 i) = Math.Sin(x) / Math.Cos(x) for big x, even though Math.Sin(x) and Math.Cos(x) return incorrect values for big x. I have simply removed these tests. I have added attributes to skip all the changed tests for NetFx; there are still many shared test assertions for not-big arguments that are satisfied by both new and old code.

(The fix for Asin and Acos come next. I wanted to get these simple fixes for the basic trig functions in before submitting a complicated one for the inverse trig functions.)