### PR TITLE
Add BitArray tests

### DIFF
--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -12,10 +12,6 @@ namespace System.Collections
     [Serializable]
     public sealed class BitArray : ICollection, ICloneable
     {
-        private BitArray()
-        {
-        }
-
         /*=========================================================================
         ** Allocates space to hold length bit values. All of the values in the bit
         ** array are set to false.

--- a/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
@@ -101,6 +101,12 @@ namespace System.Collections.Tests
             Assert.False(collection.IsSynchronized);
         }
 
+        [Fact]
+        public static void Ctor_NullBoolArray_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("values", () => new BitArray((bool[])null));
+        }
+
         public static IEnumerable<object[]> Ctor_BitArray_TestData()
         {
             yield return new object[] { "bool[](empty)", new BitArray(new bool[0]) };
@@ -146,6 +152,12 @@ namespace System.Collections.Tests
             Assert.False(collection.IsSynchronized);
         }
 
+        [Fact]
+        public static void Ctor_NullBitArray_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("bits", () => new BitArray((BitArray)null));
+        }
+
         public static IEnumerable<object[]> Ctor_IntArray_TestData()
         {
             yield return new object[] { new int[0], new bool[0] };
@@ -174,27 +186,21 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void Ctor_BitArray_Null_ThrowsArgumentNullException()
-        {
-            Assert.Throws<ArgumentNullException>("bits", () => new BitArray((BitArray)null));
-        }
-
-        [Fact]
-        public static void Ctor_BoolArray_Null_ThrowsArgumentNullException()
-        {
-            Assert.Throws<ArgumentNullException>("values", () => new BitArray((bool[])null));
-        }
-
-        [Fact]
-        public static void Ctor_IntArray_Null_ThrowsArgumentNullException()
+        public static void Ctor_NullIntArray_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("values", () => new BitArray((int[])null));
+        }
+
+        [Fact]
+        public static void Ctor_LargeIntArrayOverflowingBitArray_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>("values", () => new BitArray(new int[int.MaxValue / BitsPerInt32 + 1 ]));
         }
 
         public static IEnumerable<object[]> Ctor_ByteArray_TestData()
         {
             yield return new object[] { new byte[0], new bool[0] };
-            foreach (int size in new[] { 1, 2, BitsPerInt32 / BitsPerByte, 2 * BitsPerInt32 / BitsPerByte })
+            foreach (int size in new[] { 1, 2, 3, BitsPerInt32 / BitsPerByte, 2 * BitsPerInt32 / BitsPerByte })
             {
                 yield return new object[] { Enumerable.Repeat((byte)0xff, size).ToArray(), Enumerable.Repeat(true, size * BitsPerByte).ToArray() };
                 yield return new object[] { Enumerable.Repeat((byte)0x00, size).ToArray(), Enumerable.Repeat(false, size * BitsPerByte).ToArray() };
@@ -219,9 +225,15 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void Ctor_ByteArray_Null_ThrowsArgumentNullException()
+        public static void Ctor_NullByteArray_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("bytes", () => new BitArray((byte[])null));
+        }
+
+        [Fact]
+        public static void Ctor_LargeByteArrayOverflowingBitArray_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>("bytes", () => new BitArray(new byte[int.MaxValue / BitsPerByte + 1 ]));
         }
 
 #if netstandard17
@@ -244,7 +256,7 @@ namespace System.Collections.Tests
             BitArray bitArray = new BitArray(int.MaxValue - 30);
             BitArray clone = (BitArray)bitArray.Clone();
 
-            Assert.Equal(bitArray.Length, clone.Length);            
+            Assert.Equal(bitArray.Length, clone.Length);  
         }
 #endif //netstandard17
     }

--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -157,6 +157,24 @@ namespace System.Collections.Tests
             }
         }
 
+        [Fact]
+        public static void GetEnumerator_CloneEnumerator_ReturnsUniqueEnumerator()
+        {
+            BitArray bitArray = new BitArray(1);
+            IEnumerator enumerator = bitArray.GetEnumerator();
+            ICloneable cloneableEnumerator = enumerator as ICloneable;
+            Assert.NotNull(cloneableEnumerator);
+
+            IEnumerator clonedEnumerator = (IEnumerator)cloneableEnumerator.Clone();
+            Assert.NotSame(enumerator, clonedEnumerator);
+
+            Assert.True(clonedEnumerator.MoveNext());
+            Assert.False(clonedEnumerator.MoveNext());
+
+            Assert.True(enumerator.MoveNext());
+            Assert.False(enumerator.MoveNext());
+        }
+
         public static IEnumerable<object[]> Length_Set_Data()
         {
             int[] sizes = { 1, BitsPerByte, BitsPerByte + 1, BitsPerInt32, BitsPerInt32 + 1 };

--- a/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.netcoreapp.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.netcoreapp.cs
@@ -82,6 +82,13 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        public static void LeftShift_NegativeCount_ThrowsArgumentOutOfRangeException()
+        {
+            BitArray bitArray = new BitArray(1);
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => bitArray.LeftShift(-1));
+        }
+
+        [Fact]
         public static void RightShift_Iterator()
         {
             BitArray ba = new BitArray(BitsPerInt32 / 2);
@@ -122,6 +129,13 @@ namespace System.Collections.Tests
             Assert.All(bits.Cast<bool>(), bit => Assert.False(bit));
             bits.RightShift(1);
             Assert.All(bits.Cast<bool>(), bit => Assert.False(bit));
+        }
+
+        [Fact]
+        public static void RightShift_NegativeCount_ThrowsArgumentOutOfRangeException()
+        {
+            BitArray bitArray = new BitArray(1);
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => bitArray.RightShift(-1));
         }
 
         #endregion


### PR DESCRIPTION
- LeftShift/RightShift negative tests
- `ICloneable` BitArrayEnumerator
- Large `int[]` or `byte[]` passed to constructor
- `byte[]` of count 3 passed to constructor
- Also clean up the ordering/naming of some `null` constructor negative tests