### PR TITLE
Remove dead parameter from SortedSet.InOrderTreeWalk

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
@@ -124,7 +124,7 @@ namespace System.Collections.Generic
                 return comp >= 0;
             }
 
-            internal override bool InOrderTreeWalk(TreeWalkPredicate<T> action, bool reverse)
+            internal override bool InOrderTreeWalk(TreeWalkPredicate<T> action)
             {
                 VersionCheck();
 
@@ -142,7 +142,7 @@ namespace System.Collections.Generic
                     if (IsWithinRange(current.Item))
                     {
                         stack.Push(current);
-                        current = (reverse ? current.Right : current.Left);
+                        current = current.Left;
                     }
                     else if (_lBoundActive && Comparer.Compare(_min, current.Item) > 0)
                     {
@@ -162,13 +162,13 @@ namespace System.Collections.Generic
                         return false;
                     }
 
-                    Node node = (reverse ? current.Left : current.Right);
+                    Node node = current.Right;
                     while (node != null)
                     {
                         if (IsWithinRange(node.Item))
                         {
                             stack.Push(node);
-                            node = (reverse ? node.Right : node.Left);
+                            node = node.Left;
                         }
                         else if (_lBoundActive && Comparer.Compare(_min, node.Item) > 0)
                         {

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -210,11 +210,7 @@ namespace System.Collections.Generic
         // If the action delegate returns false, stop the walk.
         // Return true if the entire tree has been walked.
         // Otherwise returns false.
-
-        internal bool InOrderTreeWalk(TreeWalkPredicate<T> action) => InOrderTreeWalk(action, reverse: false);
-
-        // Allows for the change in traversal direction. Reverse visits nodes in descending order
-        internal virtual bool InOrderTreeWalk(TreeWalkPredicate<T> action, bool reverse)
+        internal virtual bool InOrderTreeWalk(TreeWalkPredicate<T> action)
         {
             if (_root == null)
             {
@@ -230,7 +226,7 @@ namespace System.Collections.Generic
             while (current != null)
             {
                 stack.Push(current);
-                current = (reverse ? current.Right : current.Left);
+                current = current.Left;
             }
             while (stack.Count != 0)
             {
@@ -240,11 +236,11 @@ namespace System.Collections.Generic
                     return false;
                 }
 
-                Node node = (reverse ? current.Left : current.Right);
+                Node node = current.Right;
                 while (node != null)
                 {
                     stack.Push(node);
-                    node = (reverse ? node.Right : node.Left);
+                    node = node.Left;
                 }
             }
             return true;


### PR DESCRIPTION
Not sure if this was left in deliberately or not