### PR TITLE
Remove castclass when emitting some S.L.Expressions expressions.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/BoundConstants.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/BoundConstants.cs
@@ -197,10 +197,6 @@ namespace System.Linq.Expressions.Compiler
             {
                 lc.IL.Emit(OpCodes.Unbox_Any, type);
             }
-            else if (type != typeof(object))
-            {
-                lc.IL.Emit(OpCodes.Castclass, type);
-            }
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.Storage.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.Storage.cs
@@ -142,7 +142,6 @@ namespace System.Linq.Expressions.Compiler
                 _array.EmitLoad();
                 Compiler.IL.EmitInt(_index);
                 Compiler.IL.Emit(OpCodes.Ldelem_Ref);
-                Compiler.IL.Emit(OpCodes.Castclass, _boxType);
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -132,7 +132,6 @@ namespace System.Linq.Expressions.Compiler
                 {
                     EmitExpression(node);
                     Debug.Assert(TypeUtils.AreReferenceAssignable(type, node.Type));
-                    _ilg.Emit(OpCodes.Castclass, type);
                 }
                 else
                 {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
@@ -206,28 +206,16 @@ namespace System.Linq.Expressions.Compiler
         private void EmitReferenceCoalesceWithoutConversion(BinaryExpression b)
         {
             Label labEnd = _ilg.DefineLabel();
-            Label labCast = _ilg.DefineLabel();
             EmitExpression(b.Left);
             _ilg.Emit(OpCodes.Dup);
             _ilg.Emit(OpCodes.Ldnull);
             _ilg.Emit(OpCodes.Ceq);
-            _ilg.Emit(OpCodes.Brfalse, labCast);
+            _ilg.Emit(OpCodes.Brfalse, labEnd);
             _ilg.Emit(OpCodes.Pop);
             EmitExpression(b.Right);
-            if (!TypeUtils.AreEquivalent(b.Right.Type, b.Type))
+            if (b.Right.Type.GetTypeInfo().IsValueType)
             {
-                if (b.Right.Type.GetTypeInfo().IsValueType)
-                {
-                    _ilg.Emit(OpCodes.Box, b.Right.Type);
-                }
-                _ilg.Emit(OpCodes.Castclass, b.Type);
-            }
-            _ilg.Emit(OpCodes.Br_S, labEnd);
-            _ilg.MarkLabel(labCast);
-            if (!TypeUtils.AreEquivalent(b.Left.Type, b.Type))
-            {
-                Debug.Assert(!b.Left.Type.GetTypeInfo().IsValueType);
-                _ilg.Emit(OpCodes.Castclass, b.Type);
+                _ilg.Emit(OpCodes.Box, b.Right.Type);
             }
             _ilg.MarkLabel(labEnd);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
@@ -31,11 +31,6 @@ namespace System.Linq.Expressions.Compiler
                 EmitConstant(_scope.NearestHoistedLocals, typeof(object));
                 _scope.EmitGet(_scope.NearestHoistedLocals.SelfVariable);
                 _ilg.Emit(OpCodes.Call, RuntimeOps_Quote);
-
-                if (quote.Type != typeof(Expression))
-                {
-                    _ilg.Emit(OpCodes.Castclass, quote.Type);
-                }
             }
         }
 

--- a/src/System.Linq.Expressions/tests/CompilerTests.cs
+++ b/src/System.Linq.Expressions/tests/CompilerTests.cs
@@ -254,13 +254,12 @@ namespace System.Linq.Expressions.Tests
                     IL_0001: ldfld      class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::Constants
                     IL_0006: ldc.i4.0
                     IL_0007: ldelem.ref
-                    IL_0008: castclass  class [System.Private.CoreLib]System.Reflection.MethodInfo
-                    IL_000d: ldtoken    class [System.Private.CoreLib]System.Func`1<int32>
-                    IL_0012: call       class [System.Private.CoreLib]System.Type class [System.Private.CoreLib]System.Type::GetTypeFromHandle(valuetype [System.Private.CoreLib]System.RuntimeTypeHandle)
-                    IL_0017: ldnull
-                    IL_0018: callvirt   instance class [System.Private.CoreLib]System.Delegate class [System.Private.CoreLib]System.Reflection.MethodInfo::CreateDelegate(class [System.Private.CoreLib]System.Type,object)
-                    IL_001d: castclass  class [System.Private.CoreLib]System.Func`1<int32>
-                    IL_0022: ret
+                    IL_0008: ldtoken    class [System.Private.CoreLib]System.Func`1<int32>
+                    IL_000d: call       class [System.Private.CoreLib]System.Type class [System.Private.CoreLib]System.Type::GetTypeFromHandle(valuetype [System.Private.CoreLib]System.RuntimeTypeHandle)
+                    IL_0012: ldnull
+                    IL_0013: callvirt   instance class [System.Private.CoreLib]System.Delegate class [System.Private.CoreLib]System.Reflection.MethodInfo::CreateDelegate(class [System.Private.CoreLib]System.Type,object)
+                    IL_0018: castclass  class [System.Private.CoreLib]System.Func`1<int32>
+                    IL_001d: ret
                   }
 
                   // closure.Constants[0]
@@ -299,15 +298,14 @@ namespace System.Linq.Expressions.Tests
                     IL_0011: ldfld      class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::Constants
                     IL_0016: ldc.i4.0
                     IL_0017: ldelem.ref
-                    IL_0018: castclass  class [System.Private.CoreLib]System.Reflection.MethodInfo
-                    IL_001d: ldtoken    class [System.Private.CoreLib]System.Func`1<int32>
-                    IL_0022: call       class [System.Private.CoreLib]System.Type class [System.Private.CoreLib]System.Type::GetTypeFromHandle(valuetype [System.Private.CoreLib]System.RuntimeTypeHandle)
-                    IL_0027: ldnull
-                    IL_0028: ldloc.0
-                    IL_0029: newobj     instance void class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::.ctor(object[],object[])
-                    IL_002e: callvirt   instance class [System.Private.CoreLib]System.Delegate class [System.Private.CoreLib]System.Reflection.MethodInfo::CreateDelegate(class [System.Private.CoreLib]System.Type,object)
-                    IL_0033: castclass  class [System.Private.CoreLib]System.Func`1<int32>
-                    IL_0038: ret
+                    IL_0018: ldtoken    class [System.Private.CoreLib]System.Func`1<int32>
+                    IL_001d: call       class [System.Private.CoreLib]System.Type class [System.Private.CoreLib]System.Type::GetTypeFromHandle(valuetype [System.Private.CoreLib]System.RuntimeTypeHandle)
+                    IL_0022: ldnull
+                    IL_0023: ldloc.0
+                    IL_0024: newobj     instance void class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::.ctor(object[],object[])
+                    IL_0029: callvirt   instance class [System.Private.CoreLib]System.Delegate class [System.Private.CoreLib]System.Reflection.MethodInfo::CreateDelegate(class [System.Private.CoreLib]System.Type,object)
+                    IL_002e: castclass  class [System.Private.CoreLib]System.Func`1<int32>
+                    IL_0033: ret
                   }
 
                   // closure.Constants[0]
@@ -324,9 +322,8 @@ namespace System.Linq.Expressions.Tests
                     IL_0007: ldloc.0
                     IL_0008: ldc.i4.0
                     IL_0009: ldelem.ref
-                    IL_000a: castclass  class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>
-                    IL_000f: ldfld      class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>::Value
-                    IL_0014: ret
+                    IL_000a: ldfld      class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>::Value
+                    IL_000f: ret
                   }",
                 appendInnerLambdas: true);
         }
@@ -356,15 +353,14 @@ namespace System.Linq.Expressions.Tests
                     IL_0011: ldfld      class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::Constants
                     IL_0016: ldc.i4.0
                     IL_0017: ldelem.ref
-                    IL_0018: castclass  class [System.Private.CoreLib]System.Reflection.MethodInfo
-                    IL_001d: ldtoken    class [System.Private.CoreLib]System.Func`2<int32,int32>
-                    IL_0022: call       class [System.Private.CoreLib]System.Type class [System.Private.CoreLib]System.Type::GetTypeFromHandle(valuetype [System.Private.CoreLib]System.RuntimeTypeHandle)
-                    IL_0027: ldnull
-                    IL_0028: ldloc.0
-                    IL_0029: newobj     instance void class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::.ctor(object[],object[])
-                    IL_002e: callvirt   instance class [System.Private.CoreLib]System.Delegate class [System.Private.CoreLib]System.Reflection.MethodInfo::CreateDelegate(class [System.Private.CoreLib]System.Type,object)
-                    IL_0033: castclass  class [System.Private.CoreLib]System.Func`2<int32,int32>
-                    IL_0038: ret
+                    IL_0018: ldtoken    class [System.Private.CoreLib]System.Func`2<int32,int32>
+                    IL_001d: call       class [System.Private.CoreLib]System.Type class [System.Private.CoreLib]System.Type::GetTypeFromHandle(valuetype [System.Private.CoreLib]System.RuntimeTypeHandle)
+                    IL_0022: ldnull
+                    IL_0023: ldloc.0
+                    IL_0024: newobj     instance void class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::.ctor(object[],object[])
+                    IL_0029: callvirt   instance class [System.Private.CoreLib]System.Delegate class [System.Private.CoreLib]System.Reflection.MethodInfo::CreateDelegate(class [System.Private.CoreLib]System.Type,object)
+                    IL_002e: castclass  class [System.Private.CoreLib]System.Func`2<int32,int32>
+                    IL_0033: ret
                   }
 
                   // closure.Constants[0]
@@ -381,11 +377,10 @@ namespace System.Linq.Expressions.Tests
                     IL_0007: ldloc.0
                     IL_0008: ldc.i4.0
                     IL_0009: ldelem.ref
-                    IL_000a: castclass  class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>
-                    IL_000f: ldfld      class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>::Value
-                    IL_0014: ldarg.1
-                    IL_0015: add
-                    IL_0016: ret
+                    IL_000a: ldfld      class [System.Runtime]System.Runtime.CompilerServices.StrongBox`1<int32>::Value
+                    IL_000f: ldarg.1
+                    IL_0010: add
+                    IL_0011: ret
                   }",
                 appendInnerLambdas: true);
         }

--- a/src/System.Linq.Expressions/tests/StackSpillerTests.cs
+++ b/src/System.Linq.Expressions/tests/StackSpillerTests.cs
@@ -1016,14 +1016,13 @@ namespace System.Linq.Expressions.Tests
                       IL_000f: ldfld      class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::Constants
                       IL_0014: ldc.i4.0   
                       IL_0015: ldelem.ref 
-                      IL_0016: castclass  class [System.Linq.Expressions.Tests]System.Linq.Expressions.Tests.StackSpillerTests+Assign
-                      IL_001b: ldloc.0    
-                      IL_001c: ldloc.1    
-                      IL_001d: callvirt   instance void class [System.Linq.Expressions.Tests]System.Linq.Expressions.Tests.StackSpillerTests+Assign::Invoke(int32&,int32)
+                      IL_0016: ldloc.0    
+                      IL_0017: ldloc.1    
+                      IL_0018: callvirt   instance void class [System.Linq.Expressions.Tests]System.Linq.Expressions.Tests.StackSpillerTests+Assign::Invoke(int32&,int32)
 
                       // return x
-                      IL_0022: ldloc.2    
-                      IL_0023: ret        
+                      IL_001d: ldloc.2    
+                      IL_001e: ret        
                     }",
                 instructions: @"
                     object lambda_method(object[])
@@ -2014,16 +2013,15 @@ namespace System.Linq.Expressions.Tests
                   IL_001f: ldfld      class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure::Constants
                   IL_0024: ldc.i4.0
                   IL_0025: ldelem.ref
-                  IL_0026: castclass  int64[]
-                  IL_002b: call       class [System.Linq.Expressions]System.Runtime.CompilerServices.IRuntimeVariables class [System.Linq.Expressions]System.Runtime.CompilerServices.RuntimeOps::CreateRuntimeVariables(object[],int64[])
+                  IL_0026: call       class [System.Linq.Expressions]System.Runtime.CompilerServices.IRuntimeVariables class [System.Linq.Expressions]System.Runtime.CompilerServices.RuntimeOps::CreateRuntimeVariables(object[],int64[])
 
                   // Load arg1 from V_2
-                  IL_0030: ldloc.2
+                  IL_002b: ldloc.2
 
                   // Evaluate `target(arg0, arg1)` delegate invocation
-                  IL_0031: callvirt   instance void class [System.Private.CoreLib]System.Action`2<class [System.Linq.Expressions]System.Runtime.CompilerServices.IRuntimeVariables,int32>::Invoke(class [System.Linq.Expressions]System.Runtime.CompilerServices.IRuntimeVariables,int32)
+                  IL_002c: callvirt   instance void class [System.Private.CoreLib]System.Action`2<class [System.Linq.Expressions]System.Runtime.CompilerServices.IRuntimeVariables,int32>::Invoke(class [System.Linq.Expressions]System.Runtime.CompilerServices.IRuntimeVariables,int32)
 
-                  IL_0036: ret
+                  IL_0031: ret
                 }"
             );
         }


### PR DESCRIPTION
Cases where the `O` value on stack is guaranteed to be derived from or implement the required type.

`castclass` therefore doesn't serve as a check, throwing `InvalidCastException` when needed, as it never is, and might still be jitted.