### PR TITLE
Revert "Disable CompileDeepTree_NoStackOverflowFast"

### DIFF
--- a/src/System.Linq.Expressions/tests/CompilerTests.cs
+++ b/src/System.Linq.Expressions/tests/CompilerTests.cs
@@ -27,7 +27,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(n, f());
         }
 
-        [Theory, ActiveIssue("https://github.com/dotnet/corefx/issues/15533"), ClassData(typeof(CompilationTypes))]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void CompileDeepTree_NoStackOverflowFast(bool useInterpreter)
         {
             Expression e = Expression.Constant(0);
@@ -38,11 +38,11 @@ namespace System.Linq.Expressions.Tests
                 e = Expression.Add(e, Expression.Constant(1));
 
             Func<int> f = null;
-            // Request a stack size of 1 to get the minimum size allowed.
+            // Request a stack size of 64K to get very small stack.
             // This reduces the size of tree needed to risk a stack overflow.
             // This though will only risk overflow once, so the outerloop test
             // above is still needed.
-            Thread t = new Thread(() => f = Expression.Lambda<Func<int>>(e).Compile(useInterpreter), 1);
+            Thread t = new Thread(() => f = Expression.Lambda<Func<int>>(e).Compile(useInterpreter), 65536);
             t.Start();
             t.Join();
 


### PR DESCRIPTION
Reverts #15534

No longer needed after dotnet/coreclr#9186