### PR TITLE
Add some SortedSet tests

### DIFF
--- a/src/Common/tests/System/Collections/ICollection.Generic.Tests.cs
+++ b/src/Common/tests/System/Collections/ICollection.Generic.Tests.cs
@@ -141,7 +141,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
-        public void ICollection_Generic_Add_DefaultValue(int count)
+        public virtual void ICollection_Generic_Add_DefaultValue(int count)
         {
             if (DefaultValueAllowed && !IsReadOnly && !AddRemoveClear_ThrowsNotSupported)
             {
@@ -374,7 +374,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
-        public void ICollection_Generic_Contains_DefaultValueOnCollectionContainingDefaultValue(int count)
+        public virtual void ICollection_Generic_Contains_DefaultValueOnCollectionContainingDefaultValue(int count)
         {
             if (DefaultValueAllowed && !IsReadOnly && !AddRemoveClear_ThrowsNotSupported)
             {
@@ -549,7 +549,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
-        public void ICollection_Generic_Remove_DefaultValueContainedInCollection(int count)
+        public virtual void ICollection_Generic_Remove_DefaultValueContainedInCollection(int count)
         {
             if (!IsReadOnly && !AddRemoveClear_ThrowsNotSupported && DefaultValueAllowed && !Enumerable.Contains(InvalidValues, default(T)))
             {

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
@@ -83,13 +83,18 @@ namespace System.Collections.Tests
         [MemberData(nameof(ValidCollectionSizes))]
         public void SortedSet_Generic_MaxAndMin(int setLength)
         {
+            SortedSet<T> set = (SortedSet<T>)GenericISetFactory(setLength);
             if (setLength > 0)
             {
-                SortedSet<T> set = (SortedSet<T>)GenericISetFactory(setLength);
                 List<T> expected = set.ToList();
                 expected.Sort(GetIComparer());
                 Assert.Equal(expected[0], set.Min);
                 Assert.Equal(expected[setLength - 1], set.Max);
+            }
+            else
+            {
+                Assert.Equal(default(T), set.Min);
+                Assert.Equal(default(T), set.Max);
             }
         }
 
@@ -195,6 +200,13 @@ namespace System.Collections.Tests
             int removedCount = set.RemoveWhere((value) => { return false; });
             Assert.Equal(0, removedCount);
             Assert.Equal(setLength, set.Count);
+        }
+
+        [Fact]
+        public void SortedSet_Generic_RemoveWhere_NullPredicate_ThrowsArgumentNullException()
+        {
+            SortedSet<T> set = (SortedSet<T>)GenericISetFactory();
+            Assert.Throws<ArgumentNullException>("match", () => set.RemoveWhere(null));
         }
 
         #endregion

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.TreeSubSet.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.TreeSubSet.Tests.cs
@@ -12,25 +12,25 @@ namespace System.Collections.Tests
     {
         protected override int Min => int.MinValue;
         protected override int Max => int.MaxValue;
-        private int Current { get; set; } = 1;
 
         protected override bool DefaultValueAllowed => true;
 
         protected override int CreateT(int seed)
         {
-            return Current++;
+            Random rand = new Random(seed);
+            return rand.Next();
         }
     }
 
     public class SortedSet_TreeSubset_String_Tests : SortedSet_TreeSubset_Tests<string>
     {
-        protected override string Min => 0.ToString().PadLeft(12);
-        protected override string Max => int.MaxValue.ToString().PadLeft(12);
-        private int Current { get; set; } = 1;
+        protected override string Min => 0.ToString().PadLeft(10);
+        protected override string Max => int.MaxValue.ToString().PadLeft(10);
+        private int _current = 1;
 
         protected override string CreateT(int seed)
         {
-            return Current++.ToString().PadLeft(12);
+            return _current++.ToString().PadLeft(10);
         }
 
         public override void ICollection_Generic_Remove_DefaultValueContainedInCollection(int count)

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.TreeSubSet.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.TreeSubSet.Tests.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    public class SortedSet_TreeSubset_Int_Tests : SortedSet_TreeSubset_Tests<int>
+    {
+        protected override int Min => int.MinValue;
+        protected override int Max => int.MaxValue;
+        private int Current { get; set; } = 1;
+
+        protected override bool DefaultValueAllowed => true;
+
+        protected override int CreateT(int seed)
+        {
+            return Current++;
+        }
+    }
+
+    public class SortedSet_TreeSubset_String_Tests : SortedSet_TreeSubset_Tests<string>
+    {
+        protected override string Min => 0.ToString().PadLeft(12);
+        protected override string Max => int.MaxValue.ToString().PadLeft(12);
+        private int Current { get; set; } = 1;
+
+        protected override string CreateT(int seed)
+        {
+            return Current++.ToString().PadLeft(12);
+        }
+
+        public override void ICollection_Generic_Remove_DefaultValueContainedInCollection(int count)
+        {
+            if (!IsReadOnly && !AddRemoveClear_ThrowsNotSupported && DefaultValueAllowed && !Enumerable.Contains(InvalidValues, default(string)))
+            {
+                int seed = count * 21;
+                ICollection<string> collection = GenericICollectionFactory(count);
+                Assert.Throws<ArgumentOutOfRangeException>("item", () => collection.Remove(default(string)));
+            }
+        }
+
+        public override void ICollection_Generic_Contains_DefaultValueOnCollectionContainingDefaultValue(int count)
+        {
+            if (DefaultValueAllowed && !IsReadOnly && !AddRemoveClear_ThrowsNotSupported)
+            {
+                ICollection<string> collection = GenericICollectionFactory(count);
+                Assert.Throws<ArgumentOutOfRangeException>("item", () => collection.Add(default(string)));
+            }
+        }
+    }
+
+    public abstract class SortedSet_TreeSubset_Tests<T> : SortedSet_Generic_Tests<T>
+    {
+        protected abstract T Min { get; }
+        protected abstract T Max { get; }
+        private SortedSet<T> OriginalSet { get; set; }
+
+        protected override ISet<T> GenericISetFactory()
+        {
+            OriginalSet = new SortedSet<T>();
+            return OriginalSet.GetViewBetween(Min, Max);
+        }
+
+        public override void ICollection_Generic_Add_DefaultValue(int count)
+        {
+            // Adding an item to a TreeSubset does nothing - it updates the parent.
+            if (DefaultValueAllowed && !IsReadOnly && !AddRemoveClear_ThrowsNotSupported)
+            {
+                ICollection<T> collection = GenericICollectionFactory(count);
+                collection.Add(default(T));
+                Assert.Equal(count, collection.Count);
+                Assert.Equal(count + 1, OriginalSet.Count);
+            }
+        }
+    }
+}

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -69,6 +69,7 @@
       <Link>Common\System\ObjectCloner.cs</Link>
     </Compile>
     <!-- Generic tests -->
+    <Compile Include="Generic\SortedSet\SortedSet.TreeSubSet.Tests.cs" />
     <Compile Include="StructuralComparisonsTests.cs" />
     <Compile Include="BitArray\BitArray_CtorTests.cs" />
     <Compile Include="BitArray\BitArray_GetSetTests.cs" />


### PR DESCRIPTION
- ISet template for the heavily customized TreeSubSet.
- Min/Max for an empty set
- `RemoveWhere(null)`

I'm going to add some specific tests for TreeSubSet when I get the time, and this PR is probably big enough as it is