### PR TITLE
Prepare uap package

### DIFF
--- a/binplace.targets
+++ b/binplace.targets
@@ -9,7 +9,6 @@
     <IsNETCoreAppRef Condition="'$(IsNETCoreAppRef)' == ''">$(IsNETCoreApp)</IsNETCoreAppRef>
     <IsUAPRef Condition="'$(IsUAPRef)' == ''">$(IsUAP)</IsUAPRef>
 
-
     <BuildingDesktopFacade Condition="'$(IsDesktopFacade)' == 'true' And ('$(TargetGroup)' == 'netfx' Or $(TargetGroup.StartsWith('net4')))" >true</BuildingDesktopFacade>
 
     <!-- if building desktop facade, we don't bin place the refs -->
@@ -36,7 +35,7 @@
       <RefPath Condition="'$(IsUAPRef)'=='true'">$(UAPPackageRefPath)</RefPath>
       <RuntimePath>$(UAPPackageRuntimePath)</RuntimePath>
     </BinplaceConfiguration>
-	<!-- binplace targeting packs which may be different from BuildConfiguration -->
+    <!-- binplace targeting packs which may be different from BuildConfiguration -->
     <BinplaceConfiguration Include="netstandard-$(OSGroup)">
       <RefPath>$(RefRootPath)netstandard</RefPath>
     </BinplaceConfiguration>

--- a/binplace.targets
+++ b/binplace.targets
@@ -7,6 +7,8 @@
          https://github.com/dotnet/corefx/issues/14291 is tracking cleaning this up -->
     <IsRuntimeAndReferenceAssembly Condition="'$(IsRuntimeAndReferenceAssembly)' == '' and '$(IsRuntimeAssembly)' == 'true' and Exists('$(SourceDir)/$(AssemblyName)') and !Exists('$(SourceDir)/$(AssemblyName)/ref') and !$(AssemblyName.StartsWith('System.Private'))">true</IsRuntimeAndReferenceAssembly>
     <IsNETCoreAppRef Condition="'$(IsNETCoreAppRef)' == ''">$(IsNETCoreApp)</IsNETCoreAppRef>
+    <IsUAPRef Condition="'$(IsUAPRef)' == ''">$(IsUAP)</IsUAPRef>
+
 
     <BuildingDesktopFacade Condition="'$(IsDesktopFacade)' == 'true' And ('$(TargetGroup)' == 'netfx' Or $(TargetGroup.StartsWith('net4')))" >true</BuildingDesktopFacade>
 
@@ -31,7 +33,7 @@
       <RuntimePath>$(NETCoreAppPackageRuntimePath)</RuntimePath>
     </BinplaceConfiguration>
     <BinplaceConfiguration Condition="'$(IsUAP)' == 'true'" Include="uap-$(OSGroup)">
-      <RefPath>$(UAPPackageRefPath)</RefPath>
+      <RefPath Condition="'$(IsUAPRef)'=='true'">$(UAPPackageRefPath)</RefPath>
       <RuntimePath>$(UAPPackageRuntimePath)</RuntimePath>
     </BinplaceConfiguration>
 	<!-- binplace targeting packs which may be different from BuildConfiguration -->

--- a/binplace.targets
+++ b/binplace.targets
@@ -30,7 +30,11 @@
       <RefPath Condition="'$(IsNETCoreAppRef)' == 'true'">$(NETCoreAppPackageRefPath)</RefPath>
       <RuntimePath>$(NETCoreAppPackageRuntimePath)</RuntimePath>
     </BinplaceConfiguration>
-    <!-- binplace targeting packs which may be different from BuildConfiguration -->
+    <BinplaceConfiguration Condition="'$(IsUAP)' == 'true'" Include="uap-$(OSGroup)">
+      <RefPath>$(UAPPackageRefPath)</RefPath>
+      <RuntimePath>$(UAPPackageRuntimePath)</RuntimePath>
+    </BinplaceConfiguration>
+	<!-- binplace targeting packs which may be different from BuildConfiguration -->
     <BinplaceConfiguration Include="netstandard-$(OSGroup)">
       <RefPath>$(RefRootPath)netstandard</RefPath>
     </BinplaceConfiguration>

--- a/dir.props
+++ b/dir.props
@@ -255,10 +255,10 @@
     <RuntimeProjectFile Condition="'$(RuntimeProjectFile)' == ''">$(ProjectDir)\external\runtime\runtime.depproj</RuntimeProjectFile>
     
     <!-- Paths to binplace package content -->
-    <NETCoreAppPackageRefPath>$(BinDir)netcoreapp\pkg\ref</NETCoreAppPackageRefPath>
-    <NETCoreAppPackageRuntimePath>$(BinDir)netcoreapp\pkg\lib</NETCoreAppPackageRuntimePath>
-    <UAPPackageRefPath>$(BinDir)uap\pkg\ref</UAPPackageRefPath>
-    <UAPPackageRuntimePath>$(BinDir)uap\pkg\lib</UAPPackageRuntimePath>
+    <NETCoreAppPackageRefPath>$(BinDir)pkg\netcoreapp\ref</NETCoreAppPackageRefPath>
+    <NETCoreAppPackageRuntimePath>$(BinDir)pkg\netcoreapp\lib</NETCoreAppPackageRuntimePath>
+    <UAPPackageRefPath>$(BinDir)pkg\uap\ref</UAPPackageRefPath>
+    <UAPPackageRuntimePath>$(BinDir)pkg\uap\lib</UAPPackageRuntimePath>
 
     <!-- Constructed shared fx path for testing -->
     <TestSharedFxDir>$(ToolsDir)testdotnetcli</TestSharedFxDir>

--- a/dir.props
+++ b/dir.props
@@ -257,6 +257,8 @@
     <!-- Paths to binplace package content -->
     <NETCoreAppPackageRefPath>$(BinDir)netcoreapp\pkg\ref</NETCoreAppPackageRefPath>
     <NETCoreAppPackageRuntimePath>$(BinDir)netcoreapp\pkg\lib</NETCoreAppPackageRuntimePath>
+    <UAPPackageRefPath>$(BinDir)uap\pkg\ref</UAPPackageRefPath>
+    <UAPPackageRuntimePath>$(BinDir)uap\pkg\lib</UAPPackageRuntimePath>
 
     <!-- Constructed shared fx path for testing -->
     <TestSharedFxDir>$(ToolsDir)testdotnetcli</TestSharedFxDir>

--- a/external/netfx/netfx.depproj
+++ b/external/netfx/netfx.depproj
@@ -25,5 +25,11 @@
     <FileToExclude Include="System.EnterpriseServices.Thunk" />
     <FileToExclude Include="System.EnterpriseServices.Wrapper" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='uap' or '$(TargetGroup)'=='uapaot'">
+    <TargetingPackReference Include="System.ComponentModel.DataAnnotations" />
+    <TargetingPackReference Include="System.Net" />
+    <TargetingPackReference Include="System.Windows" />
+    <TargetingPackReference Include="System.Xml.Serialization" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/external/netfx/netfx.depproj
+++ b/external/netfx/netfx.depproj
@@ -25,11 +25,5 @@
     <FileToExclude Include="System.EnterpriseServices.Thunk" />
     <FileToExclude Include="System.EnterpriseServices.Wrapper" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='uap' or '$(TargetGroup)'=='uapaot'">
-    <TargetingPackReference Include="System.ComponentModel.DataAnnotations" />
-    <TargetingPackReference Include="System.Net" />
-    <TargetingPackReference Include="System.Windows" />
-    <TargetingPackReference Include="System.Xml.Serialization" />
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/Microsoft.CSharp/dir.props
+++ b/src/Microsoft.CSharp/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.VisualBasic/dir.props
+++ b/src/Microsoft.VisualBasic/dir.props
@@ -5,5 +5,6 @@
     <PackageVersion>10.2.0</PackageVersion>
     <AssemblyVersion>10.0.3.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Win32.Primitives/dir.props
+++ b/src/Microsoft.Win32.Primitives/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Win32.Registry/dir.props
+++ b/src/Microsoft.Win32.Registry/dir.props
@@ -5,6 +5,8 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
+    <IsUAP>true</IsUAP>
+    <IsUAPRef>false</IsUAPRef>
     <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Win32.Registry/src/Configurations.props
+++ b/src/Microsoft.Win32.Registry/src/Configurations.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
+      uap-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
       netfx;

--- a/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
+++ b/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
@@ -16,7 +16,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' or '$(TargetGroup)' == 'uap'">
     <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.RegistryOptions.cs">
       <Link>Common\Interop\Windows\Interop.RegistryOptions.cs</Link>
     </Compile>
@@ -31,7 +31,7 @@
     <Compile Include="Microsoft\Win32\SafeHandles\SafeRegistryHandle.cs" />
     <Compile Include="System\Security\AccessControl\RegistryRights.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' AND '$(TargetsWindows)' == 'true'">
+  <ItemGroup Condition="('$(TargetGroup)' == 'netcoreapp' or '$(TargetGroup)' == 'uap') AND '$(TargetsWindows)' == 'true'">
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>

--- a/src/System.AppContext/dir.props
+++ b/src/System.AppContext/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Buffers/dir.props
+++ b/src/System.Buffers/dir.props
@@ -4,5 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
+    <IsUAPRef>false</IsUAPRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Collections.Concurrent/dir.props
+++ b/src/System.Collections.Concurrent/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.14.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Collections.Immutable/dir.props
+++ b/src/System.Collections.Immutable/dir.props
@@ -5,5 +5,6 @@
     <PackageVersion>1.4.0</PackageVersion>
     <AssemblyVersion>1.2.2</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Collections.NonGeneric/dir.props
+++ b/src/System.Collections.NonGeneric/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Collections.Specialized/dir.props
+++ b/src/System.Collections.Specialized/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Collections/dir.props
+++ b/src/System.Collections/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.ComponentModel.Annotations/dir.props
+++ b/src/System.ComponentModel.Annotations/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsDesktopFacade>true</IsDesktopFacade>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.ComponentModel.EventBasedAsync/dir.props
+++ b/src/System.ComponentModel.EventBasedAsync/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.ComponentModel.Primitives/dir.props
+++ b/src/System.ComponentModel.Primitives/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.ComponentModel.TypeConverter/dir.props
+++ b/src/System.ComponentModel.TypeConverter/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.ComponentModel/dir.props
+++ b/src/System.ComponentModel/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Console/dir.props
+++ b/src/System.Console/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Data.Common/dir.props
+++ b/src/System.Data.Common/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsDesktopFacade>true</IsDesktopFacade>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Data.SqlClient/dir.props
+++ b/src/System.Data.SqlClient/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>    
   </PropertyGroup>
 </Project>

--- a/src/System.Diagnostics.Contracts/dir.props
+++ b/src/System.Diagnostics.Contracts/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Diagnostics.Debug/dir.props
+++ b/src/System.Diagnostics.Debug/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Diagnostics.DiagnosticSource/dir.props
+++ b/src/System.Diagnostics.DiagnosticSource/dir.props
@@ -4,5 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
+    <IsUAPRef>false</IsUAPRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Diagnostics.FileVersionInfo/dir.props
+++ b/src/System.Diagnostics.FileVersionInfo/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Diagnostics.Process/dir.props
+++ b/src/System.Diagnostics.Process/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Diagnostics.Process/src/Configurations.props
+++ b/src/System.Diagnostics.Process/src/Configurations.props
@@ -5,6 +5,7 @@
       netcoreapp-Linux;
       netcoreapp-OSX;
       netcoreapp-Windows_NT;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Diagnostics.StackTrace/dir.props
+++ b/src/System.Diagnostics.StackTrace/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsDesktopFacade>true</IsDesktopFacade>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Diagnostics.TextWriterTraceListener/dir.props
+++ b/src/System.Diagnostics.TextWriterTraceListener/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Diagnostics.Tools/dir.props
+++ b/src/System.Diagnostics.Tools/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Diagnostics.TraceSource/dir.props
+++ b/src/System.Diagnostics.TraceSource/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Diagnostics.Tracing/dir.props
+++ b/src/System.Diagnostics.Tracing/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Drawing.Primitives/dir.props
+++ b/src/System.Drawing.Primitives/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Dynamic.Runtime/dir.props
+++ b/src/System.Dynamic.Runtime/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Globalization.Calendars/dir.props
+++ b/src/System.Globalization.Calendars/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Globalization.Extensions/dir.props
+++ b/src/System.Globalization.Extensions/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Globalization/dir.props
+++ b/src/System.Globalization/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Compression.ZipFile/dir.props
+++ b/src/System.IO.Compression.ZipFile/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Compression/dir.props
+++ b/src/System.IO.Compression/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsDesktopFacade>true</IsDesktopFacade>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.FileSystem.DriveInfo/dir.props
+++ b/src/System.IO.FileSystem.DriveInfo/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.FileSystem.DriveInfo/src/Configurations.props
+++ b/src/System.IO.FileSystem.DriveInfo/src/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netcoreapp-Unix;
       netcoreapp-Windows_NT;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.FileSystem.Primitives/dir.props
+++ b/src/System.IO.FileSystem.Primitives/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.FileSystem.Watcher/dir.props
+++ b/src/System.IO.FileSystem.Watcher/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.FileSystem.Watcher/src/Configurations.props
+++ b/src/System.IO.FileSystem.Watcher/src/Configurations.props
@@ -5,6 +5,7 @@
       netcoreapp-Linux;
       netcoreapp-OSX;
       netcoreapp-Windows_NT;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.FileSystem/dir.props
+++ b/src/System.IO.FileSystem/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.IsolatedStorage/dir.props
+++ b/src/System.IO.IsolatedStorage/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.MemoryMappedFiles/dir.props
+++ b/src/System.IO.MemoryMappedFiles/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Pipes/dir.props
+++ b/src/System.IO.Pipes/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Pipes/src/Configurations.props
+++ b/src/System.IO.Pipes/src/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netcoreapp-Unix;
       netcoreapp-Windows_NT;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.UnmanagedMemoryStream/dir.props
+++ b/src/System.IO.UnmanagedMemoryStream/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.IO/dir.props
+++ b/src/System.IO/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Linq.Expressions/dir.props
+++ b/src/System.Linq.Expressions/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Linq.Parallel/dir.props
+++ b/src/System.Linq.Parallel/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Linq.Queryable/dir.props
+++ b/src/System.Linq.Queryable/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Linq/dir.props
+++ b/src/System.Linq/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Http.Rtc/dir.props
+++ b/src/System.Net.Http.Rtc/dir.props
@@ -3,5 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Http/dir.props
+++ b/src/System.Net.Http/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.NameResolution/dir.props
+++ b/src/System.Net.NameResolution/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.NetworkInformation/dir.props
+++ b/src/System.Net.NetworkInformation/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Ping/dir.props
+++ b/src/System.Net.Ping/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Ping/src/Configurations.props
+++ b/src/System.Net.Ping/src/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netcoreapp-Unix;
       netcoreapp-Windows_NT;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Primitives/dir.props
+++ b/src/System.Net.Primitives/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Requests/dir.props
+++ b/src/System.Net.Requests/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Security/dir.props
+++ b/src/System.Net.Security/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Security/src/Configurations.props
+++ b/src/System.Net.Security/src/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netcoreapp-Unix;
       netcoreapp-Windows_NT;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.ServicePoint/dir.props
+++ b/src/System.Net.ServicePoint/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Sockets/dir.props
+++ b/src/System.Net.Sockets/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -6,7 +6,6 @@
     <ProjectGuid>{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableWinRT Condition="'$(TargetGroup)' == 'uap'">true</EnableWinRT>
-    <AssemblyVersion Condition="'$(TargetGroup)' == 'uap'">4.1.1.0</AssemblyVersion>
     <DefineConstants Condition="'$(TargetGroup)' == 'uap'">$(DefineConstants);uap</DefineConstants>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->

--- a/src/System.Net.WebClient/dir.props
+++ b/src/System.Net.WebClient/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.WebHeaderCollection/dir.props
+++ b/src/System.Net.WebHeaderCollection/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.WebProxy/dir.props
+++ b/src/System.Net.WebProxy/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.WebSockets.Client/dir.props
+++ b/src/System.Net.WebSockets.Client/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.WebSockets/dir.props
+++ b/src/System.Net.WebSockets/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Numerics.Vectors.WindowsRuntime/dir.props
+++ b/src/System.Numerics.Vectors.WindowsRuntime/dir.props
@@ -3,5 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Numerics.Vectors/dir.props
+++ b/src/System.Numerics.Vectors/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.1.3.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsDesktopFacade>true</IsDesktopFacade>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.ObjectModel/dir.props
+++ b/src/System.ObjectModel/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Private.DataContractSerialization/dir.props
+++ b/src/System.Private.DataContractSerialization/dir.props
@@ -5,5 +5,7 @@
     <AssemblyVersion>4.1.3.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
+    <IsUAP>true</IsUAP>
+    <IsUAPRef>false</IsUAPRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Private.Uri/dir.props
+++ b/src/System.Private.Uri/dir.props
@@ -4,5 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
+    <IsUAPRef>false</IsUAPRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Private.Xml.Linq/dir.props
+++ b/src/System.Private.Xml.Linq/dir.props
@@ -5,5 +5,7 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
+    <IsUAP>true</IsUAP>
+    <IsUAPRef>false</IsUAPRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Private.Xml/dir.props
+++ b/src/System.Private.Xml/dir.props
@@ -5,5 +5,7 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
+    <IsUAP>true</IsUAP>
+    <IsUAPRef>false</IsUAPRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.Context/dir.props
+++ b/src/System.Reflection.Context/dir.props
@@ -3,5 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.DispatchProxy/dir.props
+++ b/src/System.Reflection.DispatchProxy/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.Emit.ILGeneration/dir.props
+++ b/src/System.Reflection.Emit.ILGeneration/dir.props
@@ -4,5 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
+    <IsUAPRef>false</IsUAPRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.Emit.Lightweight/dir.props
+++ b/src/System.Reflection.Emit.Lightweight/dir.props
@@ -4,5 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
+    <IsUAPRef>false</IsUAPRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.Emit/dir.props
+++ b/src/System.Reflection.Emit/dir.props
@@ -4,5 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
+    <IsUAPRef>false</IsUAPRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.Extensions/dir.props
+++ b/src/System.Reflection.Extensions/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.Metadata/dir.props
+++ b/src/System.Reflection.Metadata/dir.props
@@ -5,5 +5,6 @@
     <PackageVersion>1.5.0</PackageVersion>
     <AssemblyVersion>1.4.2.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.Primitives/dir.props
+++ b/src/System.Reflection.Primitives/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.TypeExtensions/dir.props
+++ b/src/System.Reflection.TypeExtensions/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.1.2.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsDesktopFacade>true</IsDesktopFacade>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection/dir.props
+++ b/src/System.Reflection/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Resources.ResourceManager/dir.props
+++ b/src/System.Resources.ResourceManager/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Resources.Writer/dir.props
+++ b/src/System.Resources.Writer/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.CompilerServices.VisualC/dir.props
+++ b/src/System.Runtime.CompilerServices.VisualC/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.CompilerServices.VisualC/src/Configurations.props
+++ b/src/System.Runtime.CompilerServices.VisualC/src/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp;
+      uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Extensions/dir.props
+++ b/src/System.Runtime.Extensions/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Handles/dir.props
+++ b/src/System.Runtime.Handles/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.InteropServices.RuntimeInformation/dir.props
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/dir.props
@@ -4,5 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
+    <IsUAPRef>false</IsUAPRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.InteropServices.WindowsRuntime/dir.props
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.InteropServices/dir.props
+++ b/src/System.Runtime.InteropServices/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Numerics/dir.props
+++ b/src/System.Runtime.Numerics/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Serialization.Formatters/dir.props
+++ b/src/System.Runtime.Serialization.Formatters/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Serialization.Json/dir.props
+++ b/src/System.Runtime.Serialization.Json/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Serialization.Primitives/dir.props
+++ b/src/System.Runtime.Serialization.Primitives/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsDesktopFacade>true</IsDesktopFacade>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.Serialization.Xml/dir.props
+++ b/src/System.Runtime.Serialization.Xml/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.1.3.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsDesktopFacade>true</IsDesktopFacade>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/dir.props
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/dir.props
@@ -3,5 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.WindowsRuntime/dir.props
+++ b/src/System.Runtime.WindowsRuntime/dir.props
@@ -3,5 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.13.0</AssemblyVersion>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime/dir.props
+++ b/src/System.Runtime/dir.props
@@ -1,8 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>
-

--- a/src/System.Security.Claims/dir.props
+++ b/src/System.Security.Claims/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Algorithms/dir.props
+++ b/src/System.Security.Cryptography.Algorithms/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.3.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Cng/dir.props
+++ b/src/System.Security.Cryptography.Cng/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.3.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsDesktopFacade>true</IsDesktopFacade>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Csp/dir.props
+++ b/src/System.Security.Cryptography.Csp/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Csp/src/Configurations.props
+++ b/src/System.Security.Cryptography.Csp/src/Configurations.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
+      uap-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
     </BuildConfigurations>

--- a/src/System.Security.Cryptography.Encoding/dir.props
+++ b/src/System.Security.Cryptography.Encoding/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Primitives/dir.props
+++ b/src/System.Security.Cryptography.Primitives/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.X509Certificates/dir.props
+++ b/src/System.Security.Cryptography.X509Certificates/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Principal.Windows/dir.props
+++ b/src/System.Security.Principal.Windows/dir.props
@@ -5,6 +5,8 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
+    <IsUAP>true</IsUAP>
+    <IsUAPRef>false</IsUAPRef>
     <IsDesktopFacade>true</IsDesktopFacade>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Principal/dir.props
+++ b/src/System.Security.Principal/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Text.Encoding.CodePages/dir.props
+++ b/src/System.Text.Encoding.CodePages/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Text.Encoding.Extensions/dir.props
+++ b/src/System.Text.Encoding.Extensions/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Text.Encoding/dir.props
+++ b/src/System.Text.Encoding/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Text.RegularExpressions/dir.props
+++ b/src/System.Text.RegularExpressions/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Threading.Overlapped/dir.props
+++ b/src/System.Threading.Overlapped/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsDesktopFacade>true</IsDesktopFacade>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Threading.Tasks.Dataflow/dir.props
+++ b/src/System.Threading.Tasks.Dataflow/dir.props
@@ -5,5 +5,6 @@
     <PackageVersion>4.8.0</PackageVersion>
     <AssemblyVersion>4.6.2.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Threading.Tasks.Extensions/dir.props
+++ b/src/System.Threading.Tasks.Extensions/dir.props
@@ -4,5 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
+    <IsUAPRef>false</IsUAPRef>
   </PropertyGroup>
 </Project>

--- a/src/System.Threading.Tasks.Parallel/dir.props
+++ b/src/System.Threading.Tasks.Parallel/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Threading.Tasks/dir.props
+++ b/src/System.Threading.Tasks/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Threading.Thread/dir.props
+++ b/src/System.Threading.Thread/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Threading.ThreadPool/dir.props
+++ b/src/System.Threading.ThreadPool/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Threading.ThreadPool/src/Configurations.props
+++ b/src/System.Threading.ThreadPool/src/Configurations.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
+      uap-Windows_NT;
       netcoreapp-Windows_NT;
       netcoreapp-Unix;
     </BuildConfigurations>

--- a/src/System.Threading.Timer/dir.props
+++ b/src/System.Threading.Timer/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Threading/dir.props
+++ b/src/System.Threading/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Transactions/dir.props
+++ b/src/System.Transactions/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Web.HttpUtility/dir.props
+++ b/src/System.Web.HttpUtility/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Xml.ReaderWriter/dir.props
+++ b/src/System.Xml.ReaderWriter/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.2.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Xml.XDocument/dir.props
+++ b/src/System.Xml.XDocument/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Xml.XPath.XDocument/dir.props
+++ b/src/System.Xml.XPath.XDocument/dir.props
@@ -5,5 +5,6 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsDesktopFacade>true</IsDesktopFacade>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Xml.XPath/dir.props
+++ b/src/System.Xml.XPath/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Xml.XmlSerializer/dir.props
+++ b/src/System.Xml.XmlSerializer/dir.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/shims/shims.proj
+++ b/src/shims/shims.proj
@@ -74,8 +74,8 @@
     <!-- Copy the facades to the package ref and lib folders to be included in the packages -->
     <!-- TODO: replace with BinPlacing targets -->
     <ItemGroup>
-      <PackageOutputPaths Include="$(BinDir)$(TargetGroup)/pkg/ref" />
-      <PackageOutputPaths Include="$(BinDir)$(TargetGroup)/pkg/lib" />
+      <PackageOutputPaths Include="$(BinDir)pkg/$(TargetGroup)/ref" />
+      <PackageOutputPaths Include="$(BinDir)pkg/$(TargetGroup)/lib" />
       <PackageOutputPaths Include="$(RefPath)" />
       <PackageOutputPaths Include="$(RuntimePath)" />
       <ProducedFacades Include="$(GenFacadesOutputPath)*.dll" />


### PR DESCRIPTION
cc: @weshaggard @ericstj 

These changes will move packaging assets to `bin\$(TargetGroup)\pkg` into `bin\pkg\$(TargetGroup)`.
It will also mark all of the applicable libraries as UAP and will deploy them to be ready for packaging. Both folders have closure complete except for `System.IO.IsolatedStorage`