### PR TITLE
Build System.Private.DataContractSerialization on uapaot

### DIFF
--- a/referenceFromRuntime.targets
+++ b/referenceFromRuntime.targets
@@ -36,7 +36,7 @@
       <_filteredReferencePathFromRuntimeByFileName Include="@(_referencePathFromRuntimeByFileName)"
           Condition="'@(_referencePathFromRuntimeByFileName)' == '@(ReferenceFromRuntime)' AND '%(Identity)' != ''" />
 
-      <_missingReferenceFromRuntime Include="@(ReferenceFromRuntime)" Exclude="'@(_referencePathFromRuntimeByFileName)" />
+      <_missingReferenceFromRuntime Include="@(ReferenceFromRuntime)" Exclude="@(_referencePathFromRuntimeByFileName)" />
 
       <!-- transform back to path -->
       <ReferencePath Include="@(_filteredReferencePathFromRuntimeByFileName->'%(ReferencePath)')" />

--- a/src/System.Private.DataContractSerialization/src/Configurations.props
+++ b/src/System.Private.DataContractSerialization/src/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netcoreapp;
       uap-Windows_NT;
+      uapaot-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -11,9 +11,9 @@
     <DebugSymbols>true</DebugSymbols>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DefineConstants>$(DefineConstants);FEATURE_SERIALIZATION</DefineConstants>
-    <DefineConstants Condition="'$(TargetGroup)'=='uap101aot'">$(DefineConstants);NET_NATIVE</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'=='uapaot'">$(DefineConstants);NET_NATIVE</DefineConstants>
     <!-- We do not want to block reflection for this assembly -->
-    <BlockReflectionAttribute Condition="'$(TargetGroup)'=='uap101aot'">false</BlockReflectionAttribute>
+    <BlockReflectionAttribute Condition="'$(TargetGroup)'=='uapaot'">false</BlockReflectionAttribute>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
@@ -161,7 +161,7 @@
     <Compile Include="System\Runtime\Serialization\XsdDataContractExporter.cs" />
     <Compile Include="System\Xml\IFragmentCapableXmlDictionaryWriter.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='uap101aot'">
+  <ItemGroup Condition="'$(TargetGroup)'=='uapaot'">
     <ReferenceFromRuntime Include="System.Private.CoreLib.Augments" />
     <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataObject.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataObject.cs
@@ -13,7 +13,7 @@ namespace System.Runtime.Serialization
     {
         private IList<ExtensionDataMember> _members;
 
-#if USE_REFEMIT
+#if USE_REFEMIT || NET_NATIVE
         public ExtensionDataObject()
 #else
         internal ExtensionDataObject()
@@ -21,7 +21,7 @@ namespace System.Runtime.Serialization
         {
         }
 
-#if USE_REFEMIT
+#if USE_REFEMIT || NET_NATIVE
         public IList<ExtensionDataMember> Members
 #else
         internal IList<ExtensionDataMember> Members
@@ -32,7 +32,7 @@ namespace System.Runtime.Serialization
         }
     }
 
-#if USE_REFEMIT
+#if USE_REFEMIT || NET_NATIVE
     public class ExtensionDataMember
 #else
     internal class ExtensionDataMember
@@ -67,7 +67,7 @@ namespace System.Runtime.Serialization
         }
     }
 
-#if USE_REFEMIT
+#if USE_REFEMIT || NET_NATIVE
     public interface IDataNode
 #else
     internal interface IDataNode

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataReader.cs
@@ -530,7 +530,7 @@ namespace System.Runtime.Serialization
         }
     }
 
-#if USE_REFEMIT
+#if USE_REFEMIT || NET_NATIVE
     public class AttributeData
 #else
     internal class AttributeData
@@ -542,7 +542,7 @@ namespace System.Runtime.Serialization
         public string value;
     }
 
-#if USE_REFEMIT
+#if USE_REFEMIT || NET_NATIVE
     public class ElementData
 #else
     internal class ElementData

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/PrimitiveDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/PrimitiveDataContract.cs
@@ -1017,12 +1017,12 @@ namespace System.Runtime.Serialization
     }
 
 #if NET_NATIVE
-    public class TimeSpanDataContract : PrimitiveDataContract
+    public class XsDurationDataContract : TimeSpanDataContract
 #else
     internal class XsDurationDataContract : TimeSpanDataContract
 #endif
     {
-        internal XsDurationDataContract() : base(DictionaryGlobals.TimeSpanLocalName, DictionaryGlobals.SchemaNamespace) { }
+        public XsDurationDataContract() : base(DictionaryGlobals.TimeSpanLocalName, DictionaryGlobals.SchemaNamespace) { }
     }
 
 #if NET_NATIVE


### PR DESCRIPTION
The fix is to get System.Private.DataContractSerialization to have a uapaot build.