### PR TITLE
Android - Don't support ShmUnlink if ShmOpen is not supported

### DIFF
--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -291,9 +291,16 @@ extern "C" intptr_t SystemNative_ShmOpen(const char* name, int32_t flags, int32_
 
 extern "C" int32_t SystemNative_ShmUnlink(const char* name)
 {
+#if HAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMAP
     int32_t result;
     while (CheckInterrupted(result = shm_unlink(name)));
     return result;
+#else
+    // Not supported on e.g. Android. Also, prevent a compiler error because name is unused
+    (void)name;
+    errno = ENOTSUP;
+    return -1;
+#endif
 }
 
 static void ConvertDirent(const dirent& entry, DirectoryEntry* outputEntry)


### PR DESCRIPTION
Android does't support shared memory files. The CMake files detect that and set the `HAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMAP` value to 0.

However, `System.Native` still attempts to use `shm_unlink` in `pal_io.cpp`.

This PR changes the code so that `SystemNative_ShmUnlink` returns `ENOTSUP` if `HAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMAP` is set to `0`.