### PR TITLE
Android - Fall back to mkstemp if mkstemps is not available

### DIFF
--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -68,6 +68,8 @@
 #cmakedefine01 HAVE_UNAME
 #cmakedefine01 HAVE_FUTIMES
 #cmakedefine01 HAVE_FUTIMENS
+#cmakedefine01 HAVE_MKSTEMPS
+#cmakedefine01 HAVE_MKSTEMP
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -584,7 +584,15 @@ extern "C" int32_t SystemNative_Link(const char* source, const char* linkTarget)
 extern "C" intptr_t SystemNative_MksTemps(char* pathTemplate, int32_t suffixLength)
 {
     intptr_t result;
+#if HAVE_MKSTEMPS
     while (CheckInterrupted(result = mkstemps(pathTemplate, suffixLength)));
+#elif
+    // mkstemps is not available bionic/Android, but mkstemp is
+    (void)suffixLength; // To prevent the compiler from generating errors because suffixLength is unused
+    while (CheckInterrupted(result = mkstemp(pathTemplate)));
+#else
+#error "Cannot find mkstemps nor mkstemp on this platform"
+#endif
     return  result;
 }
 

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -593,9 +593,11 @@ extern "C" intptr_t SystemNative_MksTemps(char* pathTemplate, int32_t suffixLeng
 
     int32_t pathTemplateLength = static_cast<int32_t>(strlen(pathTemplate));
 
-    if (suffixLength < 0 || suffixLength > pathTemplateLength)
+    // pathTemplate must include at least XXXXXX (6 characters) which are not part of
+    // the suffix
+    if (suffixLength < 0 || suffixLength > pathTemplateLength - 6)
     {
-        errno = ERANGE;
+        errno = EINVAL;
         return -1;
     }
 

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -586,10 +586,38 @@ extern "C" intptr_t SystemNative_MksTemps(char* pathTemplate, int32_t suffixLeng
     intptr_t result;
 #if HAVE_MKSTEMPS
     while (CheckInterrupted(result = mkstemps(pathTemplate, suffixLength)));
-#elif
+#elif HAVE_MKSTEMP
     // mkstemps is not available bionic/Android, but mkstemp is
-    (void)suffixLength; // To prevent the compiler from generating errors because suffixLength is unused
+    // mkstemp doesn't allow the suffix that msktemps does allow, so we'll need to
+    // remove that before passing pathTemplate to mkstemp
+
+    int32_t pathTemplateLength = static_cast<int32_t>(strlen(pathTemplate));
+
+    if (suffixLength < 0 || suffixLength > pathTemplateLength)
+    {
+        errno = ERANGE;
+        return -1;
+    }
+
+    // Make mkstemp ignore the suffix by setting the first char of the suffix to \0,
+    // if there is a suffix
+    int32_t firstSuffixIndex = 0;
+    char firstSuffixChar = 0;
+
+    if (suffixLength > 0)
+    {
+        firstSuffixIndex = pathTemplateLength - suffixLength;
+        firstSuffixChar = pathTemplate[firstSuffixIndex];
+        pathTemplate[firstSuffixIndex] = 0;
+    }
+
     while (CheckInterrupted(result = mkstemp(pathTemplate)));
+
+    // Reset the first char of the suffix back to its original value, if there is a suffix
+    if (suffixLength > 0)
+    {
+        pathTemplate[firstSuffixIndex] = firstSuffixChar;
+    }
 #else
 #error "Cannot find mkstemps nor mkstemp on this platform"
 #endif

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -377,8 +377,7 @@ check_cxx_source_compiles(
     int main()
     {
         char* path = strdup(\"abc\");
-        int ret = mkstemps(path, 3);
-        return 0;
+        return mkstemps(path, 3);
     }
     "
     HAVE_MKSTEMPS)
@@ -392,8 +391,7 @@ check_cxx_source_compiles(
     int main()
     {
         char* path = strdup(\"abc\");
-        int ret = mkstemp(path);
-        return 0;
+        return mkstemp(path);
     }
     "
     HAVE_MKSTEMP)

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -371,6 +371,7 @@ check_prototype_definition(
 check_cxx_source_compiles(
     "
     #include <stdlib.h>
+    #include <string.h>
 
     int main()
     {
@@ -384,6 +385,7 @@ check_cxx_source_compiles(
 check_cxx_source_compiles(
     "
     #include <stdlib.h>
+    #include <string.h>
 
     int main()
     {

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -376,6 +376,7 @@ check_cxx_source_compiles(
     {
         char* path = strdup(\"abc\");
         int ret = mkstemps(path, 3);
+        return 0;
     }
     "
     HAVE_MKSTEMPS)
@@ -388,6 +389,7 @@ check_cxx_source_compiles(
     {
         char* path = strdup(\"abc\");
         int ret = mkstemp(path);
+        return 0;
     }
     "
     HAVE_MKSTEMP)

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -370,6 +370,34 @@ check_prototype_definition(
 
 check_cxx_source_compiles(
     "
+    #include <stdlib.h>
+
+    int main()
+    {
+        char* path = strdup(\"abc\");
+        int ret = mkstemps(path, 3);
+    }
+    "
+    HAVE_MKSTEMPS)
+
+check_cxx_source_compiles(
+    "
+    #include <stdlib.h>
+
+    int main()
+    {
+        char* path = strdup(\"abc\");
+        int ret = mkstemp(path);
+    }
+    "
+    HAVE_MKSTEMP)
+
+if (NOT HAVE_MKSTEMPS AND NOT HAVE_MKSTEMP)
+    message(FATAL_ERROR "Cannot find mkstemp nor mkstemp on this platform.")
+endif()
+
+check_cxx_source_compiles(
+    "
     #include <sys/types.h>
     #include <sys/socketvar.h>
     #include <netinet/ip.h>

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -371,6 +371,7 @@ check_prototype_definition(
 check_cxx_source_compiles(
     "
     #include <stdlib.h>
+    #include <unistd.h>
     #include <string.h>
 
     int main()
@@ -385,6 +386,7 @@ check_cxx_source_compiles(
 check_cxx_source_compiles(
     "
     #include <stdlib.h>
+    #include <unistd.h>
     #include <string.h>
 
     int main()


### PR DESCRIPTION
`mkstemps` is not available on Android, but `mkstemp` is as an alternative.

This PR updates the build files to check for the existence of both `mkstemps`  and `mkstemp`, and falls back to `mkstemp` if it is not available.