### PR TITLE
Android: Fall back to futimens if futimes is not available

### DIFF
--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -67,6 +67,7 @@
 #cmakedefine01 HAVE_GETDOMAINNAME
 #cmakedefine01 HAVE_UNAME
 #cmakedefine01 HAVE_FUTIMES
+#cmakedefine01 HAVE_FUTIMENS
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -66,6 +66,7 @@
 #cmakedefine01 HAVE_CRT_EXTERNS_H
 #cmakedefine01 HAVE_GETDOMAINNAME
 #cmakedefine01 HAVE_UNAME
+#cmakedefine01 HAVE_FUTIMES
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -1093,18 +1093,18 @@ extern "C" int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destination
     {
 #if HAVE_FUTIMES
         struct timeval origTimes[2];
-        origTimes[0].tv_usec = 0;
-        origTimes[1].tv_usec = 0;
         origTimes[0].tv_sec = sourceStat.st_atime;
+        origTimes[0].tv_usec = 0;
         origTimes[1].tv_sec = sourceStat.st_mtime;
+        origTimes[1].tv_usec = 0;
         while (CheckInterrupted(ret = futimes(outFd, origTimes)));
 #elif HAVE_FUTIMENS
         // futimes is not a POSIX function, and not available on Android,
         // but futimens is
         struct timespec origTimes[2];
-        origTimes[0].tv_usec = 0;
-        origTimes[1].tv_usec = 0;
+        origTimes[0].tv_sec = sourceStat.st_atime;
         origTimes[0].tv_nsec = 0;
+        origTimes[1].tv_sec = sourceStat.st_mtime;
         origTimes[1].tv_nsec = 0;
         while (CheckInterrupted(ret = futimens(outFd, origTimes)));
 #endif

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -321,6 +321,18 @@ check_function_exists(
     mach_timebase_info
     HAVE_MACH_TIMEBASE_INFO)
 
+check_function_exists(
+    futimes
+    HAVE_FUTIMES)
+
+check_function_exists(
+    futimens
+    HAVE_FUTIMENS)
+
+if(NOT HAVE_FUTIMES AND NOT HAVE_FUTIMENS)
+    message(FATAL_ERROR "Cannot find futimes nor futimens on this platform.")
+endif()
+
 check_cxx_source_runs(
     "
     #include <sys/mman.h>

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -329,10 +329,6 @@ check_function_exists(
     futimens
     HAVE_FUTIMENS)
 
-if(NOT HAVE_FUTIMES AND NOT HAVE_FUTIMENS)
-    message(FATAL_ERROR "Cannot find futimes nor futimens on this platform.")
-endif()
-
 check_cxx_source_runs(
     "
     #include <sys/mman.h>


### PR DESCRIPTION
On Android, `futimes`, which is not a Posix function, is not available but `futimens` is.

This PR updates the `System.Native`  build process to fall back to `futimens` if `futimes` is not available.