### PR TITLE
Android - Fall back to uname if getdomainname is not available

### DIFF
--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -64,6 +64,8 @@
 #cmakedefine01 HAVE_HEIMDAL_HEADERS
 #cmakedefine01 HAVE_NSGETENVIRON
 #cmakedefine01 HAVE_CRT_EXTERNS_H
+#cmakedefine01 HAVE_GETDOMAINNAME
+#cmakedefine01 HAVE_UNAME
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -934,21 +934,25 @@ extern "C" int32_t SystemNative_GetDomainName(uint8_t* name, int32_t nameLength)
     utsname  uts;
 
     // If uname returns an error, bail out.
-    if(uname(&uts) == -1) {
+    if (uname(&uts) == -1)
+    {
         return -1;
     }
 
     // If we don't have enough space to copy the name, bail out.
-    if(strlen(uts.domainname) >= namelen) {
+    if (strlen(uts.domainname) >= namelen)
+    {
         errno = EINVAL;
         return -1;
     }
 
     // Copy the domain name
-    strncpy(reinterpret_cast<char*>(name), uts.domainname, static_cast<size_t>(namelen));
+    SafeStringCopy(reinterpret_cast<char*>(name), nameLength, uts.domainname);
     return 0;
 #else
-#error "This system doesn't have getdomainname nor uname"
+    // GetDomainName is not supported on this platform.
+    errno = ENOTSUP;
+    return -1;
 #endif
 }
 

--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -31,6 +31,10 @@
 #if defined(__APPLE__) && __APPLE__
 #include <sys/socketvar.h>
 #endif
+#if !HAVE_GETDOMAINNAME && HAVE_UNAME
+#include <sys/utsname.h>
+#include <stdio.h>
+#endif
 #include <unistd.h>
 #include <vector>
 #include <pwd.h>
@@ -915,6 +919,7 @@ extern "C" int32_t SystemNative_GetDomainName(uint8_t* name, int32_t nameLength)
     assert(name != nullptr);
     assert(nameLength > 0);
 
+#if HAVE_GETDOMAINNAME
 #if HAVE_GETDOMAINNAME_SIZET
     size_t namelen = UnsignedCast(nameLength);
 #else
@@ -922,6 +927,29 @@ extern "C" int32_t SystemNative_GetDomainName(uint8_t* name, int32_t nameLength)
 #endif
 
     return getdomainname(reinterpret_cast<char*>(name), namelen);
+#elif HAVE_UNAME
+    // On Android, there's no getdomainname but we can use uname to fetch the domain name
+    // of the current device
+    size_t namelen = UnsignedCast(nameLength);
+    utsname  uts;
+
+    // If uname returns an error, bail out.
+    if(uname(&uts) == -1) {
+        return -1;
+    }
+
+    // If we don't have enough space to copy the name, bail out.
+    if(strlen(uts.domainname) >= namelen) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    // Copy the domain name
+    strncpy(reinterpret_cast<char*>(name), uts.domainname, static_cast<size_t>(namelen));
+    return 0;
+#else
+#error "This system doesn't have getdomainname nor uname"
+#endif
 }
 
 extern "C" int32_t SystemNative_GetHostName(uint8_t* name, int32_t nameLength)

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -407,6 +407,18 @@ check_function_exists(
     getpeereid
     HAVE_GETPEEREID)
 
+check_function_exists(
+    getdomainname
+    HAVE_GETDOMAINNAME)
+
+check_function_exists(
+    uname
+    HAVE_UNAME)
+
+if(NOT HAVE_GETDOMAINNAME AND NOT HAVE_UNAME)
+    message(FATAL_ERROR "Cannot find getdomainname nor uname on this platform.")
+endif()
+
 # getdomainname on OSX takes an 'int' instead of a 'size_t'
 # check if compiling with 'size_t' would cause a warning
 set (PREVIOUS_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -415,10 +415,6 @@ check_function_exists(
     uname
     HAVE_UNAME)
 
-if(NOT HAVE_GETDOMAINNAME AND NOT HAVE_UNAME)
-    message(FATAL_ERROR "Cannot find getdomainname nor uname on this platform.")
-endif()
-
 # getdomainname on OSX takes an 'int' instead of a 'size_t'
 # check if compiling with 'size_t' would cause a warning
 set (PREVIOUS_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})


### PR DESCRIPTION
On Android, `getdomainname` is not available, but `uname` can be used to get the domain name of the current device.

This PR updates the build system so that it polls for the existence of both functions and and falls back to `uname` if `getdomainname` is not available.