### PR TITLE
Android - Support unsigned ipv6mr_interface, bind() arguments

### DIFF
--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -70,6 +70,8 @@
 #cmakedefine01 HAVE_FUTIMENS
 #cmakedefine01 HAVE_MKSTEMPS
 #cmakedefine01 HAVE_MKSTEMP
+#cmakedefine01 IPV6MR_INTERFACE_UNSIGNED
+#cmakedefine01 BIND_ADDRLEN_UNSIGNED
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -1525,8 +1525,13 @@ extern "C" Error SystemNative_SetIPv6MulticastOption(intptr_t socket, int32_t mu
 
     ipv6_mreq opt;
     memset(&opt, 0, sizeof(ipv6_mreq));
+
+#if IPV6MR_INTERFACE_UNSIGNED
     opt.ipv6mr_interface = static_cast<unsigned int>(option->InterfaceIndex);
-    
+#else
+    opt.ipv6mr_interface = option->InterfaceIndex;
+#endif
+
     ConvertByteArrayToIn6Addr(opt.ipv6mr_multiaddr, &option->Address.Address[0], NUM_BYTES_IN_IPV6_ADDRESS);
 
     int err = setsockopt(fd, IPPROTO_IP, optionName, &opt, sizeof(opt));
@@ -1784,7 +1789,12 @@ extern "C" Error SystemNative_Bind(intptr_t socket, uint8_t* socketAddress, int3
 
     int fd = ToFileDescriptor(socket);
 
+#if BIND_ADDRLEN_UNSIGNED
     int err = bind(fd, reinterpret_cast<sockaddr*>(socketAddress), static_cast<socklen_t>(socketAddressLen));
+#else
+    int err = bind(fd, reinterpret_cast<sockaddr*>(socketAddress), socketAddressLen);
+#endif
+
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 

--- a/src/Native/Unix/System.Native/pal_networking.cpp
+++ b/src/Native/Unix/System.Native/pal_networking.cpp
@@ -1526,10 +1526,11 @@ extern "C" Error SystemNative_SetIPv6MulticastOption(intptr_t socket, int32_t mu
     ipv6_mreq opt;
     memset(&opt, 0, sizeof(ipv6_mreq));
 
+    opt.ipv6mr_interface =
 #if IPV6MR_INTERFACE_UNSIGNED
-    opt.ipv6mr_interface = static_cast<unsigned int>(option->InterfaceIndex);
+        static_cast<unsigned int>(option->InterfaceIndex);
 #else
-    opt.ipv6mr_interface = option->InterfaceIndex;
+        option->InterfaceIndex;
 #endif
 
     ConvertByteArrayToIn6Addr(opt.ipv6mr_multiaddr, &option->Address.Address[0], NUM_BYTES_IN_IPV6_ADDRESS);
@@ -1789,10 +1790,13 @@ extern "C" Error SystemNative_Bind(intptr_t socket, uint8_t* socketAddress, int3
 
     int fd = ToFileDescriptor(socket);
 
+    int err = bind(
+        fd,
+        reinterpret_cast<sockaddr*>(socketAddress),
 #if BIND_ADDRLEN_UNSIGNED
-    int err = bind(fd, reinterpret_cast<sockaddr*>(socketAddress), static_cast<socklen_t>(socketAddressLen));
+        static_cast<socklen_t>(socketAddressLen));
 #else
-    int err = bind(fd, reinterpret_cast<sockaddr*>(socketAddress), socketAddressLen);
+        socketAddressLen);
 #endif
 
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -366,10 +366,6 @@ check_cxx_source_compiles(
     BIND_ADDRLEN_SIGNED
 )
 
-if(NOT BIND_ADDRLEN_UNSIGNED AND NOT BIND_ADDRLEN_SIGNED)
-    message(FATAL_ERROR "The addrlen parameter in bind() must be a signed int or an unsigned int.")
-endif()
-
 check_cxx_source_compiles(
     "
     #include <netinet/in.h>
@@ -403,10 +399,6 @@ check_cxx_source_compiles(
 )
 
 set (CMAKE_REQUIRED_FLAGS ${PREVIOUS_CMAKE_REQUIRED_FLAGS})
-
-if(NOT IPV6MR_INTERFACE_UNSIGNED AND NOT IPV6MR_INTERFACE_SIGNED)
-    message(FATAL_ERROR "ipv6mr_inteface must be either a signed int or an unsigned int.")
-endif()
 
 check_cxx_source_runs(
     "

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -329,6 +329,85 @@ check_function_exists(
     futimens
     HAVE_FUTIMENS)
 
+set (PREVIOUS_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+set (CMAKE_REQUIRED_FLAGS "-Werror -Wsign-conversion")
+
+check_cxx_source_compiles(
+    "
+    #include <sys/socket.h>
+
+    int main()
+    {
+        int fd;
+        sockaddr* addr;
+        socklen_t addrLen;
+
+        int err = bind(fd, addr, addrLen);
+        return 0;
+    }
+    "
+    BIND_ADDRLEN_UNSIGNED
+)
+
+check_cxx_source_compiles(
+    "
+    #include <sys/socket.h>
+
+    int main()
+    {
+        int fd;
+        sockaddr* addr;
+        int32_t addrLen;
+
+        int err = bind(fd, addr, addrLen);
+        return 0;
+    }
+    "
+    BIND_ADDRLEN_SIGNED
+)
+
+if(NOT BIND_ADDRLEN_UNSIGNED AND NOT BIND_ADDRLEN_SIGNED)
+    message(FATAL_ERROR "The addrlen parameter in bind() must be a signed int or an unsigned int.")
+endif()
+
+check_cxx_source_compiles(
+    "
+    #include <netinet/in.h>
+    #include <netinet/tcp.h>
+
+    int main()
+    {
+        ipv6_mreq opt;
+        unsigned int index = 0;
+        opt.ipv6mr_interface = index;
+        return 0;
+    }
+    "
+    IPV6MR_INTERFACE_UNSIGNED
+)
+
+check_cxx_source_compiles(
+    "
+    #include <netinet/in.h>
+    #include <netinet/tcp.h>
+
+    int main()
+    {
+        ipv6_mreq opt;
+        int index = 0;
+        opt.ipv6mr_interface = index;
+        return 0;
+    }
+    "
+    IPV6MR_INTERFACE_SIGNED
+)
+
+set (CMAKE_REQUIRED_FLAGS ${PREVIOUS_CMAKE_REQUIRED_FLAGS})
+
+if(NOT IPV6MR_INTERFACE_UNSIGNED AND NOT IPV6MR_INTERFACE_SIGNED)
+    message(FATAL_ERROR "ipv6mr_inteface must be either a signed int or an unsigned int.")
+endif()
+
 check_cxx_source_runs(
     "
     #include <sys/mman.h>

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -351,23 +351,6 @@ check_cxx_source_compiles(
 
 check_cxx_source_compiles(
     "
-    #include <sys/socket.h>
-
-    int main()
-    {
-        int fd;
-        sockaddr* addr;
-        int32_t addrLen;
-
-        int err = bind(fd, addr, addrLen);
-        return 0;
-    }
-    "
-    BIND_ADDRLEN_SIGNED
-)
-
-check_cxx_source_compiles(
-    "
     #include <netinet/in.h>
     #include <netinet/tcp.h>
 
@@ -380,22 +363,6 @@ check_cxx_source_compiles(
     }
     "
     IPV6MR_INTERFACE_UNSIGNED
-)
-
-check_cxx_source_compiles(
-    "
-    #include <netinet/in.h>
-    #include <netinet/tcp.h>
-
-    int main()
-    {
-        ipv6_mreq opt;
-        int index = 0;
-        opt.ipv6mr_interface = index;
-        return 0;
-    }
-    "
-    IPV6MR_INTERFACE_SIGNED
 )
 
 set (CMAKE_REQUIRED_FLAGS ${PREVIOUS_CMAKE_REQUIRED_FLAGS})


### PR DESCRIPTION
On Android, `ipv6mr_interface` is a signed int, as well as the `address_len` argument to `bind`. That causes the compilation of `System.Native` to fail because implicit conversions from unsigned int to signed int are not allowed.

This PR updates the configure scripts so that they detect whether these values should be signed or unsigned, and chooses the right values at compile time.

