### PR TITLE
Don't cast S.L.Expression arithmetic results to type they already fit

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
@@ -201,14 +201,17 @@ namespace System.Linq.Expressions.Compiler
                         {
                             _ilg.Emit(OpCodes.Ldc_I4_0);
                             _ilg.Emit(OpCodes.Ceq);
+                            return;
                         }
-                        else
-                        {
-                            _ilg.Emit(OpCodes.Not);
-                        }
-                        break;
+
+                        goto case ExpressionType.OnesComplement;
                     case ExpressionType.OnesComplement:
                         _ilg.Emit(OpCodes.Not);
+                        if (!operandType.IsUnsigned())
+                        {
+                            // Guaranteed to fit within result type: no conversion
+                            return;
+                        }
                         break;
                     case ExpressionType.IsFalse:
                         _ilg.Emit(OpCodes.Ldc_I4_0);
@@ -221,12 +224,14 @@ namespace System.Linq.Expressions.Compiler
                         // Not an arithmetic operation -> no conversion
                         return;
                     case ExpressionType.UnaryPlus:
-                        _ilg.Emit(OpCodes.Nop);
-                        break;
+                        // Guaranteed to fit within result type: no conversion
+                        return;
                     case ExpressionType.Negate:
                     case ExpressionType.NegateChecked:
                         _ilg.Emit(OpCodes.Neg);
-                        break;
+                        // Guaranteed to fit within result type: no conversion
+                        // (integer NegateChecked was rewritten to 0 - operand and doesn't hit here).
+                        return;
                     case ExpressionType.TypeAs:
                         if (operandType.GetTypeInfo().IsValueType)
                         {


### PR DESCRIPTION
For types smaller than 32 bit the 32-bit results of arithmetic operations are converted to ensure they fit that smaller size, with checks if appropriate.

Several operations cannot produce a result that does not already fit (most obviously `x & y` can never overflow the size of `x` and `y`).

`EmitUnaryOperator` already skips the conversion in some cases. Skip more there and skip some in `EmitBinaryOperator`.