### PR TITLE
Android - Support unsigned wd in inotify_rm_watchx

### DIFF
--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -72,6 +72,7 @@
 #cmakedefine01 HAVE_MKSTEMP
 #cmakedefine01 IPV6MR_INTERFACE_UNSIGNED
 #cmakedefine01 BIND_ADDRLEN_UNSIGNED
+#cmakedefine01 INOTIFY_RM_WATCH_WD_UNSIGNED
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/Native/Unix/System.Native/pal_io.cpp
+++ b/src/Native/Unix/System.Native/pal_io.cpp
@@ -1193,7 +1193,13 @@ extern "C" int32_t SystemNative_INotifyRemoveWatch(intptr_t fd, int32_t wd)
     assert(wd >= 0);
 
 #if HAVE_INOTIFY
-    return inotify_rm_watch(ToFileDescriptor(fd), wd);
+    return inotify_rm_watch(
+        ToFileDescriptor(fd),
+#if INOTIFY_RM_WATCH_WD_UNSIGNED
+        static_cast<uint32_t>(wd));
+#else
+        wd);
+#endif
 #else
     (void)fd, (void)wd;
     errno = ENOTSUP;

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -365,6 +365,19 @@ check_cxx_source_compiles(
     IPV6MR_INTERFACE_UNSIGNED
 )
 
+check_cxx_source_compiles(
+    "
+    #include <sys/inotify.h>
+
+    int main()
+    {
+        intptr_t fd;
+        uint32_t wd;
+        return inotify_rm_watch(fd, wd);
+    }
+    "
+    INOTIFY_RM_WATCH_WD_UNSIGNED)
+
 set (CMAKE_REQUIRED_FLAGS ${PREVIOUS_CMAKE_REQUIRED_FLAGS})
 
 check_cxx_source_runs(


### PR DESCRIPTION
The `wd` param in `inotify_rm_watch` in Android is an unsigned int, not a signed one.

This PR adds a CMake configure check for the signedness of the `wd` parameter, and updates  `SystemNative_INotifyRemoveWatch` to include a `static_cast` if required.