### PR TITLE
Android - Support cross-compiling System.Native for Android

### DIFF
--- a/src/Native/Unix/System.Native/CMakeLists.txt
+++ b/src/Native/Unix/System.Native/CMakeLists.txt
@@ -42,7 +42,7 @@ add_library(System.Native-Static
 SET_TARGET_PROPERTIES(System.Native-Static PROPERTIES PREFIX "")
 SET_TARGET_PROPERTIES(System.Native-Static PROPERTIES OUTPUT_NAME System.Native CLEAN_DIRECT_OUTPUT 1)
 
-if (CMAKE_SYSTEM_NAME STREQUAL Linux)
+if (CMAKE_SYSTEM_NAME STREQUAL Linux AND NOT CLR_CMAKE_PLATFORM_ANDROID)
     target_link_libraries(System.Native rt)
 endif ()
 

--- a/src/Native/Unix/System.Native/pal_mount.cpp
+++ b/src/Native/Unix/System.Native/pal_mount.cpp
@@ -16,11 +16,11 @@
 #include <sys/statfs.h>
 #include <mntent.h>
 #define STRING_BUFFER_SIZE 8192
-#endif
 
 // Android does not define MNTOPT_RO
 #ifndef MNTOPT_RO
 #define MNTOPT_RO "r"
+#endif
 #endif
 
 static int32_t GetMountInfo(MountPointFound onFound)

--- a/src/Native/Unix/System.Native/pal_mount.cpp
+++ b/src/Native/Unix/System.Native/pal_mount.cpp
@@ -18,6 +18,11 @@
 #define STRING_BUFFER_SIZE 8192
 #endif
 
+// Android does not define MNTOPT_RO
+#ifndef MNTOPT_RO
+#define MNTOPT_RO "r"
+#endif
+
 static int32_t GetMountInfo(MountPointFound onFound)
 {
 #if HAVE_MNTINFO

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -294,6 +294,10 @@ set(HAVE_THREAD_SAFE_GETHOSTBYNAME_AND_GETHOSTBYADDR 0)
 if (CMAKE_SYSTEM_NAME STREQUAL Linux)
     set(CMAKE_REQUIRED_LIBRARIES rt)
     set(HAVE_SUPPORT_FOR_DUAL_MODE_IPV4_PACKET_INFO 1)
+
+    if (CLR_CMAKE_PLATFORM_ANDROID)
+       set(HAVE_THREAD_SAFE_GETHOSTBYNAME_AND_GETHOSTBYADDR 1)
+    endif()
 elseif (CMAKE_SYSTEM_NAME STREQUAL Darwin)
     set(HAVE_THREAD_SAFE_GETHOSTBYNAME_AND_GETHOSTBYADDR 1)
 endif ()
@@ -450,8 +454,11 @@ check_cxx_source_compiles(
     HAVE_TCP_VAR_H
 )
 
+# If sys/cdefs is not included on Android, this check will fail because
+# __BEGIN_DECLS is not defined
 check_cxx_source_compiles(
     "
+    #include <sys/cdefs.h>
     #include <netinet/tcp.h>
     int main() { int x = TCP_ESTABLISHED; return x; }
     "


### PR DESCRIPTION
This is the last set of changes that is required to, together with all the Android-related PRs, get System.Native to cross-compile for Android.

* Support for real time features (librt on most Linux systems) is part of the bionic system library, and doesn't exist as a separate library
* Annoyingly, `MNTOPT_RO` is not defined, so it needs to be re-defined
* gethostbyname and gethostaddr should be thread safe in Android > 3.0