### PR TITLE
Remove all TargetingPackReference's and project.json's from project files

### DIFF
--- a/src/System.Globalization/tests/Performance/System.Globalization.Performance.Tests.csproj
+++ b/src/System.Globalization/tests/Performance/System.Globalization.Performance.Tests.csproj
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <IncludePerformanceTests>true</IncludePerformanceTests>
-    <DefineConstants Condition="'$(TargetGroup)' == 'net46'">$(DefineConstants);net46</DefineConstants>
     <ProjectGuid>{0BA6851E-0E75-453D-9D2A-CEB94E4DE975}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
@@ -16,12 +15,6 @@
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
-    <TargetingPackReference Include="System" />
-    <TargetingPackReference Include="System.Threading.Tasks" />
-    <TargetingPackReference Include="System.Core" />
-    <TargetingPackReference Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(CommonTestPath)\Data\UnicodeData.8.0.txt">

--- a/src/System.Resources.ResourceManager/src/System.Resources.ResourceManager.csproj
+++ b/src/System.Resources.ResourceManager/src/System.Resources.ResourceManager.csproj
@@ -29,7 +29,6 @@
     <Compile Include="$(CommonPath)\System\SR.Core.cs">
       <Link>Common\System\SR.Core.cs</Link>
     </Compile>
-    <TargetingPackReference Include="System.Private.CoreLib.WinRTInterop" />
     <Reference Include="mscorlib" />
     <Reference Include="Windows" />
     <Reference Include="System.Resources.Reader" />

--- a/src/System.Runtime.Extensions/tests/TestApp/TestApp.csproj
+++ b/src/System.Runtime.Extensions/tests/TestApp/TestApp.csproj
@@ -18,8 +18,5 @@
       <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="project.json" />
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime/tests/TestAssembly/TestAssembly.csproj
+++ b/src/System.Runtime/tests/TestAssembly/TestAssembly.csproj
@@ -17,8 +17,5 @@
       <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAssemblyAttribute.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="project.json" />
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime/tests/TestLoadAssembly/TestLoadAssembly.csproj
+++ b/src/System.Runtime/tests/TestLoadAssembly/TestLoadAssembly.csproj
@@ -12,8 +12,5 @@
   <ItemGroup>
     <Compile Include="TestLoadAssembly.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="project.json" />
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
The only remaining uses are in the CoreFX.Tools project, which still needs them and will be removed eventually, anyways.

Fixes #14669 

@weshaggard 