### PR TITLE
Fixed cross-process tests

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
@@ -268,7 +268,7 @@ namespace System.IO.Tests
                 Assert.NotEmpty(Directory.EnumerateFiles(Directory.GetCurrentDirectory(), "*", SearchOption.TopDirectoryOnly));
 
                 return SuccessExitCode;
-            }, testDir).Dispose();
+            }, $"\"{testDir}\"").Dispose();
         }
     }
 }

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CrossProcess.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CrossProcess.cs
@@ -27,7 +27,7 @@ namespace System.IO.MemoryMappedFiles.Tests
                 acc.Flush();
 
                 // Spawn and then wait for the other process, which will verify the data and write its own known pattern
-                RemoteInvoke(DataShared_OtherProcess, file.Path).Dispose();
+                RemoteInvoke(DataShared_OtherProcess, $"\"{file.Path}\"").Dispose();
 
                 // Now verify we're seeing the data from the other process
                 for (int i = 0; i < capacity; i++)

--- a/src/System.Runtime.Extensions/tests/System/UnloadingAndProcessExitTests.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/UnloadingAndProcessExitTests.netcoreapp.cs
@@ -27,7 +27,7 @@ namespace System.Tests
                 return SuccessExitCode;
             };
 
-            using (var remote = RemoteInvoke(otherProcess, fileName))
+            using (var remote = RemoteInvoke(otherProcess, $"\"{fileName}\""))
             {
             }
 

--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -737,7 +737,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
                     b.Serialize(output, b.Deserialize(input));
                     return SuccessExitCode;
                 }
-            }, outputPath, inputPath).Dispose();
+            }, $"\"{outputPath}\"", $"\"{inputPath}\"").Dispose();
 
             // Deserialize what the other process serialized and compare it to the original
             using (FileStream fs = File.OpenRead(inputPath))

--- a/src/System.Threading/tests/MutexTests.cs
+++ b/src/System.Threading/tests/MutexTests.cs
@@ -190,7 +190,7 @@ namespace System.Threading.Tests
             };
 
             using (var mutex = new Mutex(false, mutexName))
-            using (var remote = RemoteInvoke(otherProcess, mutexName, fileName))
+            using (var remote = RemoteInvoke(otherProcess, mutexName, $"\"{fileName}\""))
             {
                 SpinWait.SpinUntil(() => File.Exists(fileName));
 


### PR DESCRIPTION
Several tests that use a secondary process fail when the path
contains spaces.

Fix #15891