### PR TITLE
Filtering down the NETNative TargetingPack to avoid type conflicts

### DIFF
--- a/Tools-Override/depProj.targets
+++ b/Tools-Override/depProj.targets
@@ -97,7 +97,7 @@ See the LICENSE file in the project root for more information.
 
   <PropertyGroup>
     <!-- don't use TargetingPackReference, we do our own filtering -->
-    <SkipFilterTargetingPackResolvedNugetPackages>true</SkipFilterTargetingPackResolvedNugetPackages>
+    <SkipFilterTargetingPackResolvedNugetPackages Condition="'$(SkipFilterTargetingPackResolvedNugetPackages)'==''">true</SkipFilterTargetingPackResolvedNugetPackages>
   </PropertyGroup>
   
   <!-- Support filtering to a subset of packages or files -->

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -11,6 +11,13 @@
   <PropertyGroup Condition="'$(TargetGroup)' == 'uapaot'">
     <ProjectJsonTemplate>$(MSBuildThisFileDirectory)NETNative/project.json.template</ProjectJsonTemplate>
     <NuGetDeploySourceItem>Reference</NuGetDeploySourceItem>
+    <SkipFilterTargetingPackResolvedNugetPackages>false</SkipFilterTargetingPackResolvedNugetPackages>
   </PropertyGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='uapaot'">
+    <TargetingPackReference Include="System.Private.CoreLib" />
+    <TargetingPackReference Include="System.Private.Interop" />
+    <TargetingPackReference Include="System.Private.Threading" />
+    <TargetingPackReference Include="System.Private.CoreLib.WinRTInterop" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -17,7 +17,6 @@
     <TargetingPackReference Include="System.Private.CoreLib" />
     <TargetingPackReference Include="System.Private.Interop" />
     <TargetingPackReference Include="System.Private.Threading" />
-    <TargetingPackReference Include="System.Private.CoreLib.WinRTInterop" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -162,10 +162,23 @@
     <Compile Include="System\Xml\IFragmentCapableXmlDictionaryWriter.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='uapaot'">
-    <ReferenceFromRuntime Include="System.Private.CoreLib.Augments" />
+    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="..\..\System.Private.Xml\src\System.Private.Xml.csproj" />
+    <ProjectReference Include="..\..\System.Private.Xml.Linq\src\System.Private.Xml.Linq.csproj" />
+    <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
+    <ProjectReference Include="..\..\System.Runtime.Extensions\src\System.Runtime.Extensions.csproj" />
+    <ProjectReference Include="..\..\System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj" />
+    <ProjectReference Include="..\..\System.Collections\src\System.Collections.csproj" />
+    <ProjectReference Include="..\..\System.Collections.Specialized\src\System.Collections.Specialized.csproj" />
+    <ProjectReference Include="..\..\System.Linq\src\System.Linq.csproj" />
+    <ProjectReference Include="..\..\System.Text.RegularExpressions\src\System.Text.RegularExpressions.csproj" />
+    <ProjectReference Include="..\..\System.Collections.NonGeneric\src\System.Collections.NonGeneric.csproj" />
+    <ProjectReference Include="..\..\System.Runtime.Serialization.Primitives\src\System.Runtime.Serialization.Primitives.csproj" />
+    <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.csproj" />
+    <ProjectReference Include="..\..\System.Resources.ResourceManager\src\System.Resources.ResourceManager.csproj" />
     <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'!='uapaot'">
     <Reference Include="System.CodeDom" />
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.Concurrent" />

--- a/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -161,24 +161,7 @@
     <Compile Include="System\Runtime\Serialization\XsdDataContractExporter.cs" />
     <Compile Include="System\Xml\IFragmentCapableXmlDictionaryWriter.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='uapaot'">
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
-    <ProjectReference Include="..\..\System.Private.Xml\src\System.Private.Xml.csproj" />
-    <ProjectReference Include="..\..\System.Private.Xml.Linq\src\System.Private.Xml.Linq.csproj" />
-    <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
-    <ProjectReference Include="..\..\System.Runtime.Extensions\src\System.Runtime.Extensions.csproj" />
-    <ProjectReference Include="..\..\System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj" />
-    <ProjectReference Include="..\..\System.Collections\src\System.Collections.csproj" />
-    <ProjectReference Include="..\..\System.Collections.Specialized\src\System.Collections.Specialized.csproj" />
-    <ProjectReference Include="..\..\System.Linq\src\System.Linq.csproj" />
-    <ProjectReference Include="..\..\System.Text.RegularExpressions\src\System.Text.RegularExpressions.csproj" />
-    <ProjectReference Include="..\..\System.Collections.NonGeneric\src\System.Collections.NonGeneric.csproj" />
-    <ProjectReference Include="..\..\System.Runtime.Serialization.Primitives\src\System.Runtime.Serialization.Primitives.csproj" />
-    <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.csproj" />
-    <ProjectReference Include="..\..\System.Resources.ResourceManager\src\System.Resources.ResourceManager.csproj" />
-    <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'!='uapaot'">
+  <ItemGroup>
     <Reference Include="System.CodeDom" />
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.Concurrent" />

--- a/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -161,6 +161,9 @@
     <Compile Include="System\Runtime\Serialization\XsdDataContractExporter.cs" />
     <Compile Include="System\Xml\IFragmentCapableXmlDictionaryWriter.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='uapaot'">
+    <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="System.CodeDom" />
     <Reference Include="System.Collections" />

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
@@ -11,9 +11,6 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Security;
-#if NET_NATIVE
-using Internal.Runtime.Augments;
-#endif
 
 namespace System.Runtime.Serialization
 {
@@ -929,11 +926,7 @@ namespace System.Runtime.Serialization
 
         internal static object UnsafeGetUninitializedObject(Type type)
         {
-#if !NET_NATIVE
             return FormatterServices.GetUninitializedObject(type);
-#else
-            return RuntimeAugments.NewObject(type.TypeHandle);
-#endif
         }
 
         /// <SecurityNote>

--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
@@ -53,7 +53,6 @@
     <ReferenceFromRuntime Include="System.Private.Threading" />
     <Reference Include="Windows" />
     <Reference Include="mscorlib" />
-    <ReferenceFromRuntime Include="System.Private.CoreLib.WinRTInterop" />
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj">
       <TargetGroup>uapaot</TargetGroup>
     </ProjectReference>


### PR DESCRIPTION
cc: @weshaggard @MattGal 

NETNative TargetingPack contains some implementation assemblies and some reference assemblies which may cause type conflicts at runtime. With this PR we are removing those potential conflicts away.