### PR TITLE
Prevent compiling against runtime implementation libraries

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
@@ -27,6 +27,7 @@
 
   <PropertyGroup>
     <IsLineupPackage Condition="'$(PackageTargetRuntime)' == ''">true</IsLineupPackage>
+    <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>     
     <TargetFrameworkName>netcoreapp</TargetFrameworkName>
     <TargetFrameworkVersion>2.0</TargetFrameworkVersion>
     <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>


### PR DESCRIPTION
When building a project with a package reference to Microsoft.Private.CoreFx.NetCoreApp, the project was trying to compile against runtime implementation libraries.  this is related to https://github.com/NuGet/Home/issues/4207.  Prevent this behavior by placing a placeholder under ref.

Also see https://github.com/dotnet/core-setup/pull/1029/files

/cc @weshaggard @eerhardt @ericstj @ellismg 
