### PR TITLE
Marking code as unchecked (pt 3)

### DIFF
--- a/src/System.Linq.Expressions/tests/Array/NewArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NewArrayBoundsTests.cs
@@ -145,7 +145,7 @@ namespace System.Linq.Expressions.Tests
             }
             else
             {
-                VerifyArrayGenerator(f, arrayType, size == null ? (long?)null : (long)Convert.ToUInt64(size), defaultValue);
+                VerifyArrayGenerator(f, arrayType, size == null ? (long?)null : unchecked((long)Convert.ToUInt64(size)), defaultValue);
             }
         }
 
@@ -164,7 +164,7 @@ namespace System.Linq.Expressions.Tests
             {
                 Assert.Throws<InvalidOperationException>(() => func());
             }
-            else if ((ulong)size > int.MaxValue)
+            else if (unchecked((ulong)size) > int.MaxValue)
             {
                 Assert.Throws<OverflowException>(() => func());
             }

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
@@ -201,7 +201,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<ushort> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)(a + b), f());
+            Assert.Equal(unchecked((ushort)(a + b)), f());
         }
 
         private static void VerifyUShortAddOvf(ushort a, ushort b, bool useInterpreter)
@@ -234,7 +234,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<short> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)(a + b), f());
+            Assert.Equal(unchecked((short)(a + b)), f());
         }
 
         private static void VerifyShortAddOvf(short a, short b, bool useInterpreter)
@@ -266,7 +266,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<uint> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a + b, f());
+            Assert.Equal(unchecked(a + b), f());
         }
 
         private static void VerifyUIntAddOvf(uint a, uint b, bool useInterpreter)
@@ -298,7 +298,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<int> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a + b, f());
+            Assert.Equal(unchecked(a + b), f());
         }
 
         private static void VerifyIntAddOvf(int a, int b, bool useInterpreter)
@@ -330,7 +330,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<ulong> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a + b, f());
+            Assert.Equal(unchecked(a + b), f());
         }
 
         private static void VerifyULongAddOvf(ulong a, ulong b, bool useInterpreter)
@@ -369,7 +369,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<long> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a + b, f());
+            Assert.Equal(unchecked(a + b), f());
         }
 
         private static void VerifyLongAddOvf(long a, long b, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
@@ -219,7 +219,7 @@ namespace System.Linq.Expressions.Tests
             if (b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else
-                Assert.Equal((short)(a / b), f());
+                Assert.Equal(unchecked((short)(a / b)), f());
         }
 
         private static void VerifyUIntDivide(uint a, uint b, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
@@ -214,7 +214,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)(a * b), f());
+            Assert.Equal(unchecked((ushort)(a * b)), f());
         }
 
         private static void VerifyUShortMultiplyOvf(ushort a, ushort b, bool useInterpreter)
@@ -251,7 +251,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)(a * b), f());
+            Assert.Equal(unchecked((short)(a * b)), f());
         }
 
         private static void VerifyShortMultiplyOvf(short a, short b, bool useInterpreter)
@@ -289,7 +289,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a * b, f());
+            Assert.Equal(unchecked(a * b), f());
         }
 
         private static void VerifyUIntMultiplyOvf(uint a, uint b, bool useInterpreter)
@@ -327,7 +327,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a * b, f());
+            Assert.Equal(unchecked(a * b), f());
         }
 
         private static void VerifyIntMultiplyOvf(int a, int b, bool useInterpreter)
@@ -365,7 +365,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a * b, f());
+            Assert.Equal(unchecked(a * b), f());
         }
 
         private static void VerifyULongMultiplyOvf(ulong a, ulong b, bool useInterpreter)
@@ -403,7 +403,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<long> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a * b, f());
+            Assert.Equal(unchecked(a * b), f());
         }
 
         private static void VerifyLongMultiplyOvf(long a, long b, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableAddTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableAddTests.cs
@@ -205,7 +205,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)(a + b), f());
+            Assert.Equal(unchecked((ushort?)(a + b)), f());
         }
 
         private static void VerifyNullableUShortAddOvf(ushort? a, ushort? b, bool useInterpreter)
@@ -235,7 +235,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)(a + b), f());
+            Assert.Equal(unchecked((short?)(a + b)), f());
         }
 
         private static void VerifyNullableShortAddOvf(short? a, short? b, bool useInterpreter)
@@ -265,7 +265,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a + b, f());
+            Assert.Equal(unchecked(a + b), f());
         }
 
         private static void VerifyNullableUIntAddOvf(uint? a, uint? b, bool useInterpreter)
@@ -295,7 +295,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a + b, f());
+            Assert.Equal(unchecked(a + b), f());
         }
 
         private static void VerifyNullableIntAddOvf(int? a, int? b, bool useInterpreter)
@@ -325,7 +325,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a + b, f());
+            Assert.Equal(unchecked(a + b), f());
         }
 
         private static void VerifyNullableULongAddOvf(ulong? a, ulong? b, bool useInterpreter)
@@ -362,7 +362,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<long?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a + b, f());
+            Assert.Equal(unchecked(a + b), f());
         }
 
         private static void VerifyNullableLongAddOvf(long? a, long? b, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableDivideTests.cs
@@ -219,7 +219,7 @@ namespace System.Linq.Expressions.Tests
             if (a.HasValue && b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else
-                Assert.Equal((short?)(a / b), f());
+                Assert.Equal(unchecked((short?)(a / b)), f());
         }
 
         private static void VerifyNullableUIntDivide(uint? a, uint? b, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableMultiplyTests.cs
@@ -205,7 +205,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)(a * b), f());
+            Assert.Equal(unchecked((ushort?)(a * b)), f());
         }
 
         private static void VerifyNullableUShortMultiplyOvf(ushort? a, ushort? b, bool useInterpreter)
@@ -241,7 +241,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)(a * b), f());
+            Assert.Equal(unchecked((short?)(a * b)), f());
         }
 
         private static void VerifyNullableShortMultiplyOvf(short? a, short? b, bool useInterpreter)
@@ -278,7 +278,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a * b, f());
+            Assert.Equal(unchecked(a * b), f());
         }
 
         private static void VerifyNullableUIntMultiplyOvf(uint? a, uint? b, bool useInterpreter)
@@ -315,7 +315,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a * b, f());
+            Assert.Equal(unchecked(a * b), f());
         }
 
         private static void VerifyNullableIntMultiplyOvf(int? a, int? b, bool useInterpreter)
@@ -352,7 +352,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a * b, f());
+            Assert.Equal(unchecked(a * b), f());
         }
 
         private static void VerifyNullableULongMultiplyOvf(ulong? a, ulong? b, bool useInterpreter)
@@ -389,7 +389,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<long?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a * b, f());
+            Assert.Equal(unchecked(a * b), f());
         }
 
         private static void VerifyNullableLongMultiplyOvf(long? a, long? b, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullablePowerTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullablePowerTests.cs
@@ -394,42 +394,42 @@ namespace System.Linq.Expressions.Tests
 
         public static byte PowerByte(byte a, byte b)
         {
-            return (byte)Math.Pow(a, b);
+            return unchecked((byte)Math.Pow(a, b));
         }
 
         public static sbyte PowerSByte(sbyte a, sbyte b)
         {
-            return (sbyte)Math.Pow(a, b);
+            return unchecked((sbyte)Math.Pow(a, b));
         }
 
         public static ushort PowerUShort(ushort a, ushort b)
         {
-            return (ushort)Math.Pow(a, b);
+            return unchecked((ushort)Math.Pow(a, b));
         }
 
         public static short PowerShort(short a, short b)
         {
-            return (short)Math.Pow(a, b);
+            return unchecked((short)Math.Pow(a, b));
         }
 
         public static uint PowerUInt(uint a, uint b)
         {
-            return (uint)Math.Pow(a, b);
+            return unchecked((uint)Math.Pow(a, b));
         }
 
         public static int PowerInt(int a, int b)
         {
-            return (int)Math.Pow(a, b);
+            return unchecked((int)Math.Pow(a, b));
         }
 
         public static ulong PowerULong(ulong a, ulong b)
         {
-            return (ulong)Math.Pow(a, b);
+            return unchecked((ulong)Math.Pow(a, b));
         }
 
         public static long PowerLong(long a, long b)
         {
-            return (long)Math.Pow(a, b);
+            return unchecked((long)Math.Pow(a, b));
         }
 
         public static float PowerFloat(float a, float b)
@@ -449,7 +449,7 @@ namespace System.Linq.Expressions.Tests
 
         public static char PowerChar(char a, char b)
         {
-            return (char)Math.Pow(a, b);
+            return unchecked((char)Math.Pow(a, b));
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableSubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableSubtractTests.cs
@@ -205,7 +205,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)(a - b), f());
+            Assert.Equal(unchecked((ushort?)(a - b)), f());
         }
 
         private static void VerifyNullableUShortSubtractOvf(ushort? a, ushort? b, bool useInterpreter)
@@ -242,7 +242,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)(a - b), f());
+            Assert.Equal(unchecked((short?)(a - b)), f());
         }
 
         private static void VerifyNullableShortSubtractOvf(short? a, short? b, bool useInterpreter)
@@ -279,7 +279,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a - b, f());
+            Assert.Equal(unchecked(a - b), f());
         }
 
         private static void VerifyNullableUIntSubtractOvf(uint? a, uint? b, bool useInterpreter)
@@ -316,7 +316,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a - b, f());
+            Assert.Equal(unchecked(a - b), f());
         }
 
         private static void VerifyNullableIntSubtractOvf(int? a, int? b, bool useInterpreter)
@@ -353,7 +353,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a - b, f());
+            Assert.Equal(unchecked(a - b), f());
         }
 
         private static void VerifyNullableULongSubtractOvf(ulong? a, ulong? b, bool useInterpreter)
@@ -390,7 +390,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<long?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a - b, f());
+            Assert.Equal(unchecked(a - b), f());
         }
 
         private static void VerifyNullableLongSubtractOvf(long? a, long? b, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryPowerTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryPowerTests.cs
@@ -363,42 +363,42 @@ namespace System.Linq.Expressions.Tests
 
         public static byte PowerByte(byte a, byte b)
         {
-            return (byte)Math.Pow(a, b);
+            return unchecked((byte)Math.Pow(a, b));
         }
 
         public static sbyte PowerSByte(sbyte a, sbyte b)
         {
-            return (sbyte)Math.Pow(a, b);
+            return unchecked((sbyte)Math.Pow(a, b));
         }
 
         public static ushort PowerUShort(ushort a, ushort b)
         {
-            return (ushort)Math.Pow(a, b);
+            return unchecked((ushort)Math.Pow(a, b));
         }
 
         public static short PowerShort(short a, short b)
         {
-            return (short)Math.Pow(a, b);
+            return unchecked((short)Math.Pow(a, b));
         }
 
         public static uint PowerUInt(uint a, uint b)
         {
-            return (uint)Math.Pow(a, b);
+            return unchecked((uint)Math.Pow(a, b));
         }
 
         public static int PowerInt(int a, int b)
         {
-            return (int)Math.Pow(a, b);
+            return unchecked((int)Math.Pow(a, b));
         }
 
         public static ulong PowerULong(ulong a, ulong b)
         {
-            return (ulong)Math.Pow(a, b);
+            return unchecked((ulong)Math.Pow(a, b));
         }
 
         public static long PowerLong(long a, long b)
         {
-            return (long)Math.Pow(a, b);
+            return unchecked((long)Math.Pow(a, b));
         }
 
         public static float PowerFloat(float a, float b)
@@ -418,7 +418,7 @@ namespace System.Linq.Expressions.Tests
 
         public static char PowerChar(char a, char b)
         {
-            return (char)Math.Pow(a, b);
+            return unchecked((char)Math.Pow(a, b));
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
@@ -205,7 +205,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<byte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)(left ? a << b : a >> b), f());
+            Assert.Equal(unchecked((byte)(left ? a << b : a >> b)), f());
 
             Expression<Func<byte?>> en =
                 Expression.Lambda<Func<byte?>>(
@@ -222,7 +222,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<byte?> fn = en.Compile(useInterpreter);
 
-            Assert.Equal((byte)(left ? a << b : a >> b), fn());
+            Assert.Equal(unchecked((byte)(left ? a << b : a >> b)), fn());
         }
 
         private static void VerifyNullableByteShift(byte? a, bool useInterpreter)
@@ -254,7 +254,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte?)(left ? a << b : a >> b), f());
+            Assert.Equal(unchecked((byte?)(left ? a << b : a >> b)), f());
 
             e =
                 Expression.Lambda<Func<byte?>>(
@@ -271,7 +271,7 @@ namespace System.Linq.Expressions.Tests
 
             f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte?)(left ? a << b : a >> b), f());
+            Assert.Equal(unchecked((byte?)(left ? a << b : a >> b)), f());
         }
 
         private static void VerifySByteShift(sbyte a, bool useInterpreter)
@@ -303,7 +303,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<sbyte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)(left ? a << b : a >> b), f());
+            Assert.Equal(unchecked((sbyte)(left ? a << b : a >> b)), f());
 
             Expression<Func<sbyte?>> en =
                 Expression.Lambda<Func<sbyte?>>(
@@ -320,7 +320,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<sbyte?> fn = en.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)(left ? a << b : a >> b), fn());
+            Assert.Equal(unchecked((sbyte)(left ? a << b : a >> b)), fn());
         }
 
         private static void VerifyNullableSByteShift(sbyte? a, bool useInterpreter)
@@ -352,7 +352,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte?)(left ? a << b : a >> b), f());
+            Assert.Equal(unchecked((sbyte?)(left ? a << b : a >> b)), f());
 
             e =
                 Expression.Lambda<Func<sbyte?>>(
@@ -369,7 +369,7 @@ namespace System.Linq.Expressions.Tests
 
             f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte?)(left ? a << b : a >> b), f());
+            Assert.Equal(unchecked((sbyte?)(left ? a << b : a >> b)), f());
         }
 
         private static void VerifyUShortShift(ushort a, bool useInterpreter)
@@ -401,7 +401,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<ushort> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)(left ? a << b : a >> b), f());
+            Assert.Equal(unchecked((ushort)(left ? a << b : a >> b)), f());
 
             Expression<Func<ushort?>> en =
                 Expression.Lambda<Func<ushort?>>(
@@ -418,7 +418,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<ushort?> fn = en.Compile(useInterpreter);
 
-            Assert.Equal((ushort)(left ? a << b : a >> b), fn());
+            Assert.Equal(unchecked((ushort)(left ? a << b : a >> b)), fn());
         }
 
         private static void VerifyNullableUShortShift(ushort? a, bool useInterpreter)
@@ -450,7 +450,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)(left ? a << b : a >> b), f());
+            Assert.Equal(unchecked((ushort?)(left ? a << b : a >> b)), f());
 
             e =
                 Expression.Lambda<Func<ushort?>>(
@@ -467,7 +467,7 @@ namespace System.Linq.Expressions.Tests
 
             f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)(left ? a << b : a >> b), f());
+            Assert.Equal(unchecked((ushort?)(left ? a << b : a >> b)), f());
         }
 
         private static void VerifyShortShift(short a, bool useInterpreter)
@@ -499,7 +499,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<short> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)(left ? a << b : a >> b), f());
+            Assert.Equal(unchecked((short)(left ? a << b : a >> b)), f());
 
             Expression<Func<short?>> en =
                 Expression.Lambda<Func<short?>>(
@@ -516,7 +516,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<short?> fn = en.Compile(useInterpreter);
 
-            Assert.Equal((short)(left ? a << b : a >> b), fn());
+            Assert.Equal(unchecked((short)(left ? a << b : a >> b)), fn());
         }
 
         private static void VerifyNullableShortShift(short? a, bool useInterpreter)
@@ -548,7 +548,7 @@ namespace System.Linq.Expressions.Tests
 
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)(left ? a << b : a >> b), f());
+            Assert.Equal(unchecked((short?)(left ? a << b : a >> b)), f());
 
             e =
                 Expression.Lambda<Func<short?>>(
@@ -565,7 +565,7 @@ namespace System.Linq.Expressions.Tests
 
             f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)(left ? a << b : a >> b), f());
+            Assert.Equal(unchecked((short?)(left ? a << b : a >> b)), f());
         }
 
         private static void VerifyUIntShift(uint a, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
@@ -200,7 +200,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)(a - b), f());
+            Assert.Equal(unchecked((ushort)(a - b)), f());
         }
 
         private static void VerifyUShortSubtractOvf(ushort a, ushort b, bool useInterpreter)
@@ -237,7 +237,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)(a - b), f());
+            Assert.Equal(unchecked((short)(a - b)), f());
         }
 
         private static void VerifyShortSubtractOvf(short a, short b, bool useInterpreter)
@@ -274,7 +274,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a - b, f());
+            Assert.Equal(unchecked(a - b), f());
         }
 
         private static void VerifyUIntSubtractOvf(uint a, uint b, bool useInterpreter)
@@ -312,7 +312,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a - b, f());
+            Assert.Equal(unchecked(a - b), f());
         }
 
         private static void VerifyIntSubtractOvf(int a, int b, bool useInterpreter)
@@ -349,7 +349,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a - b, f());
+            Assert.Equal(unchecked(a - b), f());
         }
 
         private static void VerifyULongSubtractOvf(ulong a, ulong b, bool useInterpreter)
@@ -387,7 +387,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<long> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a - b, f());
+            Assert.Equal(unchecked(a - b), f());
         }
 
         private static void VerifyLongSubtractOvf(long a, long b, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/Cast/CastTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastTests.cs
@@ -2230,7 +2230,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Convert(Expression.Constant(value, typeof(El)), typeof(E)));
             Func<E> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E)value, f());
+            Assert.Equal(unchecked((E)value), f());
         }
 
         private static void VerifyEnumCastLongEnum(E value, bool useInterpreter)
@@ -2248,7 +2248,7 @@ namespace System.Linq.Expressions.Tests
                 Expression.Convert(Expression.Constant(value, typeof(Eu)), typeof(E)));
             Func<E> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E)value, f());
+            Assert.Equal(unchecked((E)value), f());
         }
 
         private static void VerifyUnsignedEnumInObjectCastEnum(Eu value, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/CompilerTests.cs
+++ b/src/System.Linq.Expressions/tests/CompilerTests.cs
@@ -334,7 +334,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void VerifyIL_Closure3()
         {
-            Expression<Func<int, Func<int, int>>> f = x => y => x + y;
+            // Using an unchecked addition to ensure that an add instruction is emitted (and not add.ovf)
+            Expression<Func<int, Func<int, int>>> f = x => y => unchecked(x + y);
 
             f.VerifyIL(
                 @".method class [System.Private.CoreLib]System.Func`2<int32,int32> ::lambda_method(class [System.Linq.Expressions]System.Runtime.CompilerServices.Closure,int32)

--- a/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
@@ -7134,7 +7134,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyByteToNullableSByte(byte value, bool useInterpreter)
@@ -7145,7 +7145,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyByteToShort(byte value, bool useInterpreter)
@@ -7470,7 +7470,7 @@ namespace System.Linq.Expressions.Tests
             Func<sbyte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((sbyte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((sbyte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -7483,7 +7483,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte?)value, f());
+            Assert.Equal(unchecked((sbyte?)value), f());
         }
 
         private static void VerifyNullableByteToShort(byte? value, bool useInterpreter)
@@ -7594,7 +7594,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyCharToNullableByte(char value, bool useInterpreter)
@@ -7605,7 +7605,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyCharToChar(char value, bool useInterpreter)
@@ -7792,7 +7792,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyCharToNullableSByte(char value, bool useInterpreter)
@@ -7803,7 +7803,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyCharToShort(char value, bool useInterpreter)
@@ -7814,7 +7814,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyCharToNullableShort(char value, bool useInterpreter)
@@ -7825,7 +7825,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyCharToUInt(char value, bool useInterpreter)
@@ -7903,7 +7903,7 @@ namespace System.Linq.Expressions.Tests
             Func<byte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((byte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((byte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -7916,7 +7916,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte?)value, f());
+            Assert.Equal(unchecked((byte?)value), f());
         }
 
         private static void VerifyNullableCharToChar(char? value, bool useInterpreter)
@@ -8128,7 +8128,7 @@ namespace System.Linq.Expressions.Tests
             Func<sbyte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((sbyte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((sbyte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -8141,7 +8141,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte?)value, f());
+            Assert.Equal(unchecked((sbyte?)value), f());
         }
 
         private static void VerifyNullableCharToShort(char? value, bool useInterpreter)
@@ -8153,7 +8153,7 @@ namespace System.Linq.Expressions.Tests
             Func<short> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((short)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((short)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -8166,7 +8166,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)value, f());
+            Assert.Equal(unchecked((short?)value), f());
         }
 
         private static void VerifyNullableCharToUInt(char? value, bool useInterpreter)
@@ -9230,7 +9230,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyDoubleToNullableByte(double value, bool useInterpreter)
@@ -9241,7 +9241,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyDoubleToChar(double value, bool useInterpreter)
@@ -9252,7 +9252,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char)value, f());
+            Assert.Equal(unchecked((char)value), f());
         }
 
         private static void VerifyDoubleToNullableChar(double value, bool useInterpreter)
@@ -9263,7 +9263,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyDoubleToDecimal(double value, bool useInterpreter)
@@ -9340,7 +9340,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E)value, f());
+            Assert.Equal(unchecked((E)value), f());
         }
 
         private static void VerifyDoubleToNullableEnum(double value, bool useInterpreter)
@@ -9351,7 +9351,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E)value, f());
+            Assert.Equal(unchecked((E)value), f());
         }
 
         private static void VerifyDoubleToEnumLong(double value, bool useInterpreter)
@@ -9362,7 +9362,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<El> f = e.Compile(useInterpreter);
 
-            Assert.Equal((El)value, f());
+            Assert.Equal(unchecked((El)value), f());
         }
 
         private static void VerifyDoubleToNullableEnumLong(double value, bool useInterpreter)
@@ -9373,7 +9373,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<El?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((El)value, f());
+            Assert.Equal(unchecked((El)value), f());
         }
 
         private static void VerifyDoubleToFloat(double value, bool useInterpreter)
@@ -9406,7 +9406,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int)value, f());
+            Assert.Equal(unchecked((int)value), f());
         }
 
         private static void VerifyDoubleToNullableInt(double value, bool useInterpreter)
@@ -9417,7 +9417,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int)value, f());
+            Assert.Equal(unchecked((int)value), f());
         }
 
         private static void VerifyDoubleToLong(double value, bool useInterpreter)
@@ -9428,7 +9428,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<long> f = e.Compile(useInterpreter);
 
-            Assert.Equal((long)value, f());
+            Assert.Equal(unchecked((long)value), f());
         }
 
         private static void VerifyDoubleToNullableLong(double value, bool useInterpreter)
@@ -9439,7 +9439,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<long?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((long)value, f());
+            Assert.Equal(unchecked((long)value), f());
         }
 
         private static void VerifyDoubleToSByte(double value, bool useInterpreter)
@@ -9450,7 +9450,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyDoubleToNullableSByte(double value, bool useInterpreter)
@@ -9461,7 +9461,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyDoubleToShort(double value, bool useInterpreter)
@@ -9472,7 +9472,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyDoubleToNullableShort(double value, bool useInterpreter)
@@ -9483,7 +9483,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyDoubleToUInt(double value, bool useInterpreter)
@@ -9494,7 +9494,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint)value, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifyDoubleToNullableUInt(double value, bool useInterpreter)
@@ -9505,7 +9505,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint)value, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifyDoubleToULong(double value, bool useInterpreter)
@@ -9516,7 +9516,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong)value, f());
+            Assert.Equal(unchecked((ulong)value), f());
         }
 
         private static void VerifyDoubleToNullableULong(double value, bool useInterpreter)
@@ -9527,7 +9527,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong)value, f());
+            Assert.Equal(unchecked((ulong)value), f());
         }
 
         private static void VerifyDoubleToUShort(double value, bool useInterpreter)
@@ -9538,7 +9538,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyDoubleToNullableUShort(double value, bool useInterpreter)
@@ -9549,7 +9549,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyNullableDoubleToByte(double? value, bool useInterpreter)
@@ -9561,7 +9561,7 @@ namespace System.Linq.Expressions.Tests
             Func<byte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((byte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((byte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -9574,7 +9574,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte?)value, f());
+            Assert.Equal(unchecked((byte?)value), f());
         }
 
         private static void VerifyNullableDoubleToChar(double? value, bool useInterpreter)
@@ -9586,7 +9586,7 @@ namespace System.Linq.Expressions.Tests
             Func<char> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((char)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((char)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -9599,7 +9599,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyNullableDoubleToDecimal(double? value, bool useInterpreter)
@@ -9685,7 +9685,7 @@ namespace System.Linq.Expressions.Tests
             Func<E> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((E)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((E)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -9698,7 +9698,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E?)value, f());
+            Assert.Equal(unchecked((E?)value), f());
         }
 
         private static void VerifyNullableDoubleToEnumLong(double? value, bool useInterpreter)
@@ -9710,7 +9710,7 @@ namespace System.Linq.Expressions.Tests
             Func<El> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((El)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((El)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -9723,7 +9723,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<El?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((El?)value, f());
+            Assert.Equal(unchecked((El?)value), f());
         }
 
         private static void VerifyNullableDoubleToFloat(double? value, bool useInterpreter)
@@ -9760,7 +9760,7 @@ namespace System.Linq.Expressions.Tests
             Func<int> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((int)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((int)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -9773,7 +9773,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int?)value, f());
+            Assert.Equal(unchecked((int?)value), f());
         }
 
         private static void VerifyNullableDoubleToLong(double? value, bool useInterpreter)
@@ -9785,7 +9785,7 @@ namespace System.Linq.Expressions.Tests
             Func<long> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((long)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((long)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -9798,7 +9798,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<long?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((long?)value, f());
+            Assert.Equal(unchecked((long?)value), f());
         }
 
         private static void VerifyNullableDoubleToSByte(double? value, bool useInterpreter)
@@ -9810,7 +9810,7 @@ namespace System.Linq.Expressions.Tests
             Func<sbyte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((sbyte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((sbyte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -9823,7 +9823,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte?)value, f());
+            Assert.Equal(unchecked((sbyte?)value), f());
         }
 
         private static void VerifyNullableDoubleToShort(double? value, bool useInterpreter)
@@ -9835,7 +9835,7 @@ namespace System.Linq.Expressions.Tests
             Func<short> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((short)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((short)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -9848,7 +9848,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)value, f());
+            Assert.Equal(unchecked((short?)value), f());
         }
 
         private static void VerifyNullableDoubleToUInt(double? value, bool useInterpreter)
@@ -9860,7 +9860,7 @@ namespace System.Linq.Expressions.Tests
             Func<uint> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((uint)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((uint)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -9873,7 +9873,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint?)value, f());
+            Assert.Equal(unchecked((uint?)value), f());
         }
 
         private static void VerifyNullableDoubleToULong(double? value, bool useInterpreter)
@@ -9885,7 +9885,7 @@ namespace System.Linq.Expressions.Tests
             Func<ulong> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ulong)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ulong)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -9898,7 +9898,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong?)value, f());
+            Assert.Equal(unchecked((ulong?)value), f());
         }
 
         private static void VerifyNullableDoubleToUShort(double? value, bool useInterpreter)
@@ -9910,7 +9910,7 @@ namespace System.Linq.Expressions.Tests
             Func<ushort> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ushort)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ushort)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -9923,7 +9923,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)value, f());
+            Assert.Equal(unchecked((ushort?)value), f());
         }
 
         private static void VerifyEnumToByte(E value, bool useInterpreter)
@@ -9934,7 +9934,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyEnumToNullableByte(E value, bool useInterpreter)
@@ -9945,7 +9945,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyEnumToChar(E value, bool useInterpreter)
@@ -9956,7 +9956,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char)value, f());
+            Assert.Equal(unchecked((char)value), f());
         }
 
         private static void VerifyEnumToNullableChar(E value, bool useInterpreter)
@@ -9967,7 +9967,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyEnumToDouble(E value, bool useInterpreter)
@@ -10110,7 +10110,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyEnumToNullableSByte(E value, bool useInterpreter)
@@ -10121,7 +10121,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyEnumToShort(E value, bool useInterpreter)
@@ -10132,7 +10132,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyEnumToNullableShort(E value, bool useInterpreter)
@@ -10143,7 +10143,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyEnumToUInt(E value, bool useInterpreter)
@@ -10154,7 +10154,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint)value, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifyEnumToNullableUInt(E value, bool useInterpreter)
@@ -10165,7 +10165,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint?)value, f());
+            Assert.Equal(unchecked((uint?)value), f());
         }
 
         private static void VerifyEnumToULong(E value, bool useInterpreter)
@@ -10176,7 +10176,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong)value, f());
+            Assert.Equal(unchecked((ulong)value), f());
         }
 
         private static void VerifyEnumToNullableULong(E value, bool useInterpreter)
@@ -10187,7 +10187,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong)value, f());
+            Assert.Equal(unchecked((ulong)value), f());
         }
 
         private static void VerifyEnumToUShort(E value, bool useInterpreter)
@@ -10198,7 +10198,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyEnumToNullableUShort(E value, bool useInterpreter)
@@ -10209,7 +10209,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyNullableEnumToByte(E? value, bool useInterpreter)
@@ -10221,7 +10221,7 @@ namespace System.Linq.Expressions.Tests
             Func<byte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((byte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((byte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -10234,7 +10234,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte?)value, f());
+            Assert.Equal(unchecked((byte?)value), f());
         }
 
         private static void VerifyNullableEnumToChar(E? value, bool useInterpreter)
@@ -10246,7 +10246,7 @@ namespace System.Linq.Expressions.Tests
             Func<char> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((char)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((char)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -10259,7 +10259,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyNullableEnumToDouble(E? value, bool useInterpreter)
@@ -10421,7 +10421,7 @@ namespace System.Linq.Expressions.Tests
             Func<sbyte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((sbyte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((sbyte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -10434,7 +10434,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte?)value, f());
+            Assert.Equal(unchecked((sbyte?)value), f());
         }
 
         private static void VerifyNullableEnumToShort(E? value, bool useInterpreter)
@@ -10446,7 +10446,7 @@ namespace System.Linq.Expressions.Tests
             Func<short> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((short)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((short)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -10459,7 +10459,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)value, f());
+            Assert.Equal(unchecked((short?)value), f());
         }
 
         private static void VerifyNullableEnumToUInt(E? value, bool useInterpreter)
@@ -10471,7 +10471,7 @@ namespace System.Linq.Expressions.Tests
             Func<uint> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((uint)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((uint)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -10484,7 +10484,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint?)value, f());
+            Assert.Equal(unchecked((uint?)value), f());
         }
 
         private static void VerifyNullableEnumToULong(E? value, bool useInterpreter)
@@ -10496,7 +10496,7 @@ namespace System.Linq.Expressions.Tests
             Func<ulong> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ulong)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ulong)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -10509,7 +10509,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong?)value, f());
+            Assert.Equal(unchecked((ulong?)value), f());
         }
 
         private static void VerifyNullableEnumToUShort(E? value, bool useInterpreter)
@@ -10521,7 +10521,7 @@ namespace System.Linq.Expressions.Tests
             Func<ushort> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ushort)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ushort)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -10534,7 +10534,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)value, f());
+            Assert.Equal(unchecked((ushort?)value), f());
         }
 
         private static void VerifyEnumLongToByte(El value, bool useInterpreter)
@@ -10545,7 +10545,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyEnumLongToNullableByte(El value, bool useInterpreter)
@@ -10556,7 +10556,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyEnumLongToChar(El value, bool useInterpreter)
@@ -10567,7 +10567,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char)value, f());
+            Assert.Equal(unchecked((char)value), f());
         }
 
         private static void VerifyEnumLongToNullableChar(El value, bool useInterpreter)
@@ -10578,7 +10578,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyEnumLongToDouble(El value, bool useInterpreter)
@@ -10611,7 +10611,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E)value, f());
+            Assert.Equal(unchecked((E)value), f());
         }
 
         private static void VerifyEnumLongToNullableEnum(El value, bool useInterpreter)
@@ -10622,7 +10622,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E)value, f());
+            Assert.Equal(unchecked((E)value), f());
         }
 
         private static void VerifyEnumLongToEnumLong(El value, bool useInterpreter)
@@ -10677,7 +10677,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int)value, f());
+            Assert.Equal(unchecked((int)value), f());
         }
 
         private static void VerifyEnumLongToNullableInt(El value, bool useInterpreter)
@@ -10688,7 +10688,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int)value, f());
+            Assert.Equal(unchecked((int)value), f());
         }
 
         private static void VerifyEnumLongToLong(El value, bool useInterpreter)
@@ -10721,7 +10721,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyEnumLongToNullableSByte(El value, bool useInterpreter)
@@ -10732,7 +10732,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyEnumLongToShort(El value, bool useInterpreter)
@@ -10743,7 +10743,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyEnumLongToNullableShort(El value, bool useInterpreter)
@@ -10754,7 +10754,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyEnumLongToUInt(El value, bool useInterpreter)
@@ -10765,7 +10765,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint)value, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifyEnumLongToNullableUInt(El value, bool useInterpreter)
@@ -10776,7 +10776,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint)value, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifyEnumLongToULong(El value, bool useInterpreter)
@@ -10787,7 +10787,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong)value, f());
+            Assert.Equal(unchecked((ulong)value), f());
         }
 
         private static void VerifyEnumLongToNullableULong(El value, bool useInterpreter)
@@ -10798,7 +10798,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong)value, f());
+            Assert.Equal(unchecked((ulong)value), f());
         }
 
         private static void VerifyEnumLongToUShort(El value, bool useInterpreter)
@@ -10809,7 +10809,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyEnumLongToNullableUShort(El value, bool useInterpreter)
@@ -10820,7 +10820,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyNullableEnumLongToByte(El? value, bool useInterpreter)
@@ -10832,7 +10832,7 @@ namespace System.Linq.Expressions.Tests
             Func<byte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((byte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((byte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -10845,7 +10845,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte?)value, f());
+            Assert.Equal(unchecked((byte?)value), f());
         }
 
         private static void VerifyNullableEnumLongToChar(El? value, bool useInterpreter)
@@ -10857,7 +10857,7 @@ namespace System.Linq.Expressions.Tests
             Func<char> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((char)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((char)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -10870,7 +10870,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyNullableEnumLongToDouble(El? value, bool useInterpreter)
@@ -10907,7 +10907,7 @@ namespace System.Linq.Expressions.Tests
             Func<E> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((E)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((E)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -10920,7 +10920,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E?)value, f());
+            Assert.Equal(unchecked((E?)value), f());
         }
 
         private static void VerifyNullableEnumLongToEnumLong(El? value, bool useInterpreter)
@@ -10982,7 +10982,7 @@ namespace System.Linq.Expressions.Tests
             Func<int> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((int)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((int)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -10995,7 +10995,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int?)value, f());
+            Assert.Equal(unchecked((int?)value), f());
         }
 
         private static void VerifyNullableEnumLongToLong(El? value, bool useInterpreter)
@@ -11032,7 +11032,7 @@ namespace System.Linq.Expressions.Tests
             Func<sbyte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((sbyte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((sbyte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -11045,7 +11045,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte?)value, f());
+            Assert.Equal(unchecked((sbyte?)value), f());
         }
 
         private static void VerifyNullableEnumLongToShort(El? value, bool useInterpreter)
@@ -11057,7 +11057,7 @@ namespace System.Linq.Expressions.Tests
             Func<short> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((short)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((short)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -11070,7 +11070,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)value, f());
+            Assert.Equal(unchecked((short?)value), f());
         }
 
         private static void VerifyNullableEnumLongToUInt(El? value, bool useInterpreter)
@@ -11082,7 +11082,7 @@ namespace System.Linq.Expressions.Tests
             Func<uint> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((uint)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((uint)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -11095,7 +11095,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint?)value, f());
+            Assert.Equal(unchecked((uint?)value), f());
         }
 
         private static void VerifyNullableEnumLongToULong(El? value, bool useInterpreter)
@@ -11107,7 +11107,7 @@ namespace System.Linq.Expressions.Tests
             Func<ulong> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ulong)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ulong)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -11120,7 +11120,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong?)value, f());
+            Assert.Equal(unchecked((ulong?)value), f());
         }
 
         private static void VerifyNullableEnumLongToUShort(El? value, bool useInterpreter)
@@ -11132,7 +11132,7 @@ namespace System.Linq.Expressions.Tests
             Func<ushort> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ushort)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ushort)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -11145,7 +11145,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)value, f());
+            Assert.Equal(unchecked((ushort?)value), f());
         }
 
         private static void VerifyFloatToByte(float value, bool useInterpreter)
@@ -11156,7 +11156,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyFloatToNullableByte(float value, bool useInterpreter)
@@ -11167,7 +11167,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyFloatToChar(float value, bool useInterpreter)
@@ -11178,7 +11178,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char)value, f());
+            Assert.Equal(unchecked((char)value), f());
         }
 
         private static void VerifyFloatToNullableChar(float value, bool useInterpreter)
@@ -11189,7 +11189,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyFloatToDecimal(float value, bool useInterpreter)
@@ -11266,7 +11266,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E)value, f());
+            Assert.Equal(unchecked((E)value), f());
         }
 
         private static void VerifyFloatToNullableEnum(float value, bool useInterpreter)
@@ -11277,7 +11277,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E)value, f());
+            Assert.Equal(unchecked((E)value), f());
         }
 
         private static void VerifyFloatToEnumLong(float value, bool useInterpreter)
@@ -11288,7 +11288,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<El> f = e.Compile(useInterpreter);
 
-            Assert.Equal((El)value, f());
+            Assert.Equal(unchecked((El)value), f());
         }
 
         private static void VerifyFloatToNullableEnumLong(float value, bool useInterpreter)
@@ -11299,7 +11299,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<El?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((El)value, f());
+            Assert.Equal(unchecked((El)value), f());
         }
 
         private static void VerifyFloatToFloat(float value, bool useInterpreter)
@@ -11332,7 +11332,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int)value, f());
+            Assert.Equal(unchecked((int)value), f());
         }
 
         private static void VerifyFloatToNullableInt(float value, bool useInterpreter)
@@ -11343,7 +11343,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int)value, f());
+            Assert.Equal(unchecked((int)value), f());
         }
 
         private static void VerifyFloatToLong(float value, bool useInterpreter)
@@ -11354,7 +11354,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<long> f = e.Compile(useInterpreter);
 
-            Assert.Equal((long)value, f());
+            Assert.Equal(unchecked((long)value), f());
         }
 
         private static void VerifyFloatToNullableLong(float value, bool useInterpreter)
@@ -11365,7 +11365,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<long?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((long)value, f());
+            Assert.Equal(unchecked((long)value), f());
         }
 
         private static void VerifyFloatToSByte(float value, bool useInterpreter)
@@ -11376,7 +11376,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyFloatToNullableSByte(float value, bool useInterpreter)
@@ -11387,7 +11387,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyFloatToShort(float value, bool useInterpreter)
@@ -11398,7 +11398,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyFloatToNullableShort(float value, bool useInterpreter)
@@ -11409,7 +11409,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyFloatToUInt(float value, bool useInterpreter)
@@ -11420,7 +11420,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint)value, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifyFloatToNullableUInt(float value, bool useInterpreter)
@@ -11431,7 +11431,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint)value, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifyFloatToULong(float value, bool useInterpreter)
@@ -11442,7 +11442,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong)value, f());
+            Assert.Equal(unchecked((ulong)value), f());
         }
 
         private static void VerifyFloatToNullableULong(float value, bool useInterpreter)
@@ -11453,7 +11453,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong)value, f());
+            Assert.Equal(unchecked((ulong)value), f());
         }
 
         private static void VerifyFloatToUShort(float value, bool useInterpreter)
@@ -11464,7 +11464,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyFloatToNullableUShort(float value, bool useInterpreter)
@@ -11475,7 +11475,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyNullableFloatToByte(float? value, bool useInterpreter)
@@ -11487,7 +11487,7 @@ namespace System.Linq.Expressions.Tests
             Func<byte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((byte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((byte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -11500,7 +11500,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte?)value, f());
+            Assert.Equal(unchecked((byte?)value), f());
         }
 
         private static void VerifyNullableFloatToChar(float? value, bool useInterpreter)
@@ -11512,7 +11512,7 @@ namespace System.Linq.Expressions.Tests
             Func<char> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((char)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((char)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -11525,7 +11525,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyNullableFloatToDecimal(float? value, bool useInterpreter)
@@ -11611,7 +11611,7 @@ namespace System.Linq.Expressions.Tests
             Func<E> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((E)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((E)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -11624,7 +11624,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E?)value, f());
+            Assert.Equal(unchecked((E?)value), f());
         }
 
         private static void VerifyNullableFloatToEnumLong(float? value, bool useInterpreter)
@@ -11636,7 +11636,7 @@ namespace System.Linq.Expressions.Tests
             Func<El> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((El)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((El)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -11649,7 +11649,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<El?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((El?)value, f());
+            Assert.Equal(unchecked((El?)value), f());
         }
 
         private static void VerifyNullableFloatToFloat(float? value, bool useInterpreter)
@@ -11686,7 +11686,7 @@ namespace System.Linq.Expressions.Tests
             Func<int> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((int)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((int)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -11699,7 +11699,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int?)value, f());
+            Assert.Equal(unchecked((int?)value), f());
         }
 
         private static void VerifyNullableFloatToLong(float? value, bool useInterpreter)
@@ -11711,7 +11711,7 @@ namespace System.Linq.Expressions.Tests
             Func<long> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((long)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((long)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -11724,7 +11724,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<long?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((long?)value, f());
+            Assert.Equal(unchecked((long?)value), f());
         }
 
         private static void VerifyNullableFloatToSByte(float? value, bool useInterpreter)
@@ -11736,7 +11736,7 @@ namespace System.Linq.Expressions.Tests
             Func<sbyte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((sbyte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((sbyte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -11749,7 +11749,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte?)value, f());
+            Assert.Equal(unchecked((sbyte?)value), f());
         }
 
         private static void VerifyNullableFloatToShort(float? value, bool useInterpreter)
@@ -11761,7 +11761,7 @@ namespace System.Linq.Expressions.Tests
             Func<short> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((short)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((short)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -11774,7 +11774,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)value, f());
+            Assert.Equal(unchecked((short?)value), f());
         }
 
         private static void VerifyNullableFloatToUInt(float? value, bool useInterpreter)
@@ -11786,7 +11786,7 @@ namespace System.Linq.Expressions.Tests
             Func<uint> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((uint)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((uint)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -11799,7 +11799,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint?)value, f());
+            Assert.Equal(unchecked((uint?)value), f());
         }
 
         private static void VerifyNullableFloatToULong(float? value, bool useInterpreter)
@@ -11811,7 +11811,7 @@ namespace System.Linq.Expressions.Tests
             Func<ulong> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ulong)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ulong)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -11824,7 +11824,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong?)value, f());
+            Assert.Equal(unchecked((ulong?)value), f());
         }
 
         private static void VerifyNullableFloatToUShort(float? value, bool useInterpreter)
@@ -11836,7 +11836,7 @@ namespace System.Linq.Expressions.Tests
             Func<ushort> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ushort)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ushort)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -11849,7 +11849,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)value, f());
+            Assert.Equal(unchecked((ushort?)value), f());
         }
 
         private static void VerifyIntToByte(int value, bool useInterpreter)
@@ -11860,7 +11860,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyIntToNullableByte(int value, bool useInterpreter)
@@ -11871,7 +11871,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyIntToChar(int value, bool useInterpreter)
@@ -11882,7 +11882,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char)value, f());
+            Assert.Equal(unchecked((char)value), f());
         }
 
         private static void VerifyIntToNullableChar(int value, bool useInterpreter)
@@ -11893,7 +11893,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyIntToDecimal(int value, bool useInterpreter)
@@ -12058,7 +12058,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyIntToNullableSByte(int value, bool useInterpreter)
@@ -12069,7 +12069,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyIntToShort(int value, bool useInterpreter)
@@ -12080,7 +12080,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyIntToNullableShort(int value, bool useInterpreter)
@@ -12091,7 +12091,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyIntToUInt(int value, bool useInterpreter)
@@ -12102,7 +12102,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint)value, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifyIntToNullableUInt(int value, bool useInterpreter)
@@ -12113,7 +12113,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint)value, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifyIntToULong(int value, bool useInterpreter)
@@ -12124,7 +12124,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong)value, f());
+            Assert.Equal(unchecked((ulong)value), f());
         }
 
         private static void VerifyIntToNullableULong(int value, bool useInterpreter)
@@ -12135,7 +12135,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong)value, f());
+            Assert.Equal(unchecked((ulong)value), f());
         }
 
         private static void VerifyIntToUShort(int value, bool useInterpreter)
@@ -12146,7 +12146,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyIntToNullableUShort(int value, bool useInterpreter)
@@ -12157,7 +12157,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyNullableIntToByte(int? value, bool useInterpreter)
@@ -12169,7 +12169,7 @@ namespace System.Linq.Expressions.Tests
             Func<byte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((byte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((byte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -12182,7 +12182,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte?)value, f());
+            Assert.Equal(unchecked((byte?)value), f());
         }
 
         private static void VerifyNullableIntToChar(int? value, bool useInterpreter)
@@ -12194,7 +12194,7 @@ namespace System.Linq.Expressions.Tests
             Func<char> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((char)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((char)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -12207,7 +12207,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyNullableIntToDecimal(int? value, bool useInterpreter)
@@ -12394,7 +12394,7 @@ namespace System.Linq.Expressions.Tests
             Func<sbyte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((sbyte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((sbyte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -12407,7 +12407,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte?)value, f());
+            Assert.Equal(unchecked((sbyte?)value), f());
         }
 
         private static void VerifyNullableIntToShort(int? value, bool useInterpreter)
@@ -12419,7 +12419,7 @@ namespace System.Linq.Expressions.Tests
             Func<short> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((short)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((short)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -12432,7 +12432,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)value, f());
+            Assert.Equal(unchecked((short?)value), f());
         }
 
         private static void VerifyNullableIntToUInt(int? value, bool useInterpreter)
@@ -12444,7 +12444,7 @@ namespace System.Linq.Expressions.Tests
             Func<uint> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((uint)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((uint)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -12457,7 +12457,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint?)value, f());
+            Assert.Equal(unchecked((uint?)value), f());
         }
 
         private static void VerifyNullableIntToULong(int? value, bool useInterpreter)
@@ -12469,7 +12469,7 @@ namespace System.Linq.Expressions.Tests
             Func<ulong> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ulong)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ulong)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -12482,7 +12482,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong?)value, f());
+            Assert.Equal(unchecked((ulong?)value), f());
         }
 
         private static void VerifyNullableIntToUShort(int? value, bool useInterpreter)
@@ -12494,7 +12494,7 @@ namespace System.Linq.Expressions.Tests
             Func<ushort> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ushort)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ushort)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -12507,7 +12507,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)value, f());
+            Assert.Equal(unchecked((ushort?)value), f());
         }
 
         private static void VerifyLongToByte(long value, bool useInterpreter)
@@ -12518,7 +12518,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyLongToNullableByte(long value, bool useInterpreter)
@@ -12529,7 +12529,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyLongToChar(long value, bool useInterpreter)
@@ -12540,7 +12540,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char)value, f());
+            Assert.Equal(unchecked((char)value), f());
         }
 
         private static void VerifyLongToNullableChar(long value, bool useInterpreter)
@@ -12551,7 +12551,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyLongToDecimal(long value, bool useInterpreter)
@@ -12606,7 +12606,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E)value, f());
+            Assert.Equal(unchecked((E)value), f());
         }
 
         private static void VerifyLongToNullableEnum(long value, bool useInterpreter)
@@ -12617,7 +12617,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E)value, f());
+            Assert.Equal(unchecked((E)value), f());
         }
 
         private static void VerifyLongToEnumLong(long value, bool useInterpreter)
@@ -12672,7 +12672,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int)value, f());
+            Assert.Equal(unchecked((int)value), f());
         }
 
         private static void VerifyLongToNullableInt(long value, bool useInterpreter)
@@ -12683,7 +12683,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int)value, f());
+            Assert.Equal(unchecked((int)value), f());
         }
 
         private static void VerifyLongToLong(long value, bool useInterpreter)
@@ -12716,7 +12716,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyLongToNullableSByte(long value, bool useInterpreter)
@@ -12727,7 +12727,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyLongToShort(long value, bool useInterpreter)
@@ -12738,7 +12738,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyLongToNullableShort(long value, bool useInterpreter)
@@ -12749,7 +12749,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyLongToUInt(long value, bool useInterpreter)
@@ -12760,7 +12760,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint)value, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifyLongToNullableUInt(long value, bool useInterpreter)
@@ -12771,7 +12771,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint)value, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifyLongToULong(long value, bool useInterpreter)
@@ -12782,7 +12782,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong)value, f());
+            Assert.Equal(unchecked((ulong)value), f());
         }
 
         private static void VerifyLongToNullableULong(long value, bool useInterpreter)
@@ -12793,7 +12793,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong)value, f());
+            Assert.Equal(unchecked((ulong)value), f());
         }
 
         private static void VerifyLongToUShort(long value, bool useInterpreter)
@@ -12804,7 +12804,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyLongToNullableUShort(long value, bool useInterpreter)
@@ -12815,7 +12815,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyNullableLongToByte(long? value, bool useInterpreter)
@@ -12827,7 +12827,7 @@ namespace System.Linq.Expressions.Tests
             Func<byte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((byte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((byte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -12840,7 +12840,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte?)value, f());
+            Assert.Equal(unchecked((byte?)value), f());
         }
 
         private static void VerifyNullableLongToChar(long? value, bool useInterpreter)
@@ -12852,7 +12852,7 @@ namespace System.Linq.Expressions.Tests
             Func<char> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((char)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((char)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -12865,7 +12865,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyNullableLongToDecimal(long? value, bool useInterpreter)
@@ -12927,7 +12927,7 @@ namespace System.Linq.Expressions.Tests
             Func<E> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((E)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((E)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -12940,7 +12940,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E?)value, f());
+            Assert.Equal(unchecked((E?)value), f());
         }
 
         private static void VerifyNullableLongToEnumLong(long? value, bool useInterpreter)
@@ -13002,7 +13002,7 @@ namespace System.Linq.Expressions.Tests
             Func<int> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((int)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((int)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -13015,7 +13015,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int?)value, f());
+            Assert.Equal(unchecked((int?)value), f());
         }
 
         private static void VerifyNullableLongToLong(long? value, bool useInterpreter)
@@ -13052,7 +13052,7 @@ namespace System.Linq.Expressions.Tests
             Func<sbyte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((sbyte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((sbyte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -13065,7 +13065,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte?)value, f());
+            Assert.Equal(unchecked((sbyte?)value), f());
         }
 
         private static void VerifyNullableLongToShort(long? value, bool useInterpreter)
@@ -13077,7 +13077,7 @@ namespace System.Linq.Expressions.Tests
             Func<short> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((short)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((short)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -13090,7 +13090,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)value, f());
+            Assert.Equal(unchecked((short?)value), f());
         }
 
         private static void VerifyNullableLongToUInt(long? value, bool useInterpreter)
@@ -13102,7 +13102,7 @@ namespace System.Linq.Expressions.Tests
             Func<uint> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((uint)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((uint)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -13115,7 +13115,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint?)value, f());
+            Assert.Equal(unchecked((uint?)value), f());
         }
 
         private static void VerifyNullableLongToULong(long? value, bool useInterpreter)
@@ -13127,7 +13127,7 @@ namespace System.Linq.Expressions.Tests
             Func<ulong> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ulong)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ulong)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -13140,7 +13140,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong?)value, f());
+            Assert.Equal(unchecked((ulong?)value), f());
         }
 
         private static void VerifyNullableLongToUShort(long? value, bool useInterpreter)
@@ -13152,7 +13152,7 @@ namespace System.Linq.Expressions.Tests
             Func<ushort> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ushort)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ushort)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -13165,7 +13165,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)value, f());
+            Assert.Equal(unchecked((ushort?)value), f());
         }
 
         private static void VerifySByteToByte(sbyte value, bool useInterpreter)
@@ -13176,7 +13176,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifySByteToNullableByte(sbyte value, bool useInterpreter)
@@ -13187,7 +13187,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifySByteToChar(sbyte value, bool useInterpreter)
@@ -13198,7 +13198,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char)value, f());
+            Assert.Equal(unchecked((char)value), f());
         }
 
         private static void VerifySByteToNullableChar(sbyte value, bool useInterpreter)
@@ -13209,7 +13209,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char)value, f());
+            Assert.Equal(unchecked((char)value), f());
         }
 
         private static void VerifySByteToDecimal(sbyte value, bool useInterpreter)
@@ -13418,7 +13418,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint)value, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifySByteToNullableUInt(sbyte value, bool useInterpreter)
@@ -13429,7 +13429,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint)value, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifySByteToULong(sbyte value, bool useInterpreter)
@@ -13440,7 +13440,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong)value, f());
+            Assert.Equal(unchecked((ulong)value), f());
         }
 
         private static void VerifySByteToNullableULong(sbyte value, bool useInterpreter)
@@ -13451,7 +13451,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong)value, f());
+            Assert.Equal(unchecked((ulong)value), f());
         }
 
         private static void VerifySByteToUShort(sbyte value, bool useInterpreter)
@@ -13462,7 +13462,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifySByteToNullableUShort(sbyte value, bool useInterpreter)
@@ -13473,7 +13473,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyNullableSByteToByte(sbyte? value, bool useInterpreter)
@@ -13485,7 +13485,7 @@ namespace System.Linq.Expressions.Tests
             Func<byte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((byte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((byte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -13498,7 +13498,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte?)value, f());
+            Assert.Equal(unchecked((byte?)value), f());
         }
 
         private static void VerifyNullableSByteToChar(sbyte? value, bool useInterpreter)
@@ -13510,7 +13510,7 @@ namespace System.Linq.Expressions.Tests
             Func<char> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((char)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((char)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -13523,7 +13523,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyNullableSByteToDecimal(sbyte? value, bool useInterpreter)
@@ -13760,7 +13760,7 @@ namespace System.Linq.Expressions.Tests
             Func<uint> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((uint)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((uint)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -13773,7 +13773,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint?)value, f());
+            Assert.Equal(unchecked((uint?)value), f());
         }
 
         private static void VerifyNullableSByteToULong(sbyte? value, bool useInterpreter)
@@ -13785,7 +13785,7 @@ namespace System.Linq.Expressions.Tests
             Func<ulong> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ulong)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ulong)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -13798,7 +13798,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong?)value, f());
+            Assert.Equal(unchecked((ulong?)value), f());
         }
 
         private static void VerifyNullableSByteToUShort(sbyte? value, bool useInterpreter)
@@ -13810,7 +13810,7 @@ namespace System.Linq.Expressions.Tests
             Func<ushort> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ushort)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ushort)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -13823,7 +13823,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)value, f());
+            Assert.Equal(unchecked((ushort?)value), f());
         }
 
         private static void VerifyShortToByte(short value, bool useInterpreter)
@@ -13834,7 +13834,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyShortToNullableByte(short value, bool useInterpreter)
@@ -13845,7 +13845,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyShortToChar(short value, bool useInterpreter)
@@ -13856,7 +13856,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char)value, f());
+            Assert.Equal(unchecked((char)value), f());
         }
 
         private static void VerifyShortToNullableChar(short value, bool useInterpreter)
@@ -13867,7 +13867,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyShortToDecimal(short value, bool useInterpreter)
@@ -14032,7 +14032,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyShortToNullableSByte(short value, bool useInterpreter)
@@ -14043,7 +14043,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyShortToShort(short value, bool useInterpreter)
@@ -14076,7 +14076,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint)value, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifyShortToNullableUInt(short value, bool useInterpreter)
@@ -14087,7 +14087,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint)value, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifyShortToULong(short value, bool useInterpreter)
@@ -14098,7 +14098,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong)value, f());
+            Assert.Equal(unchecked((ulong)value), f());
         }
 
         private static void VerifyShortToNullableULong(short value, bool useInterpreter)
@@ -14109,7 +14109,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong)value, f());
+            Assert.Equal(unchecked((ulong)value), f());
         }
 
         private static void VerifyShortToUShort(short value, bool useInterpreter)
@@ -14120,7 +14120,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyShortToNullableUShort(short value, bool useInterpreter)
@@ -14131,7 +14131,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyNullableShortToByte(short? value, bool useInterpreter)
@@ -14143,7 +14143,7 @@ namespace System.Linq.Expressions.Tests
             Func<byte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((byte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((byte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -14156,7 +14156,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte?)value, f());
+            Assert.Equal(unchecked((byte?)value), f());
         }
 
         private static void VerifyNullableShortToChar(short? value, bool useInterpreter)
@@ -14168,7 +14168,7 @@ namespace System.Linq.Expressions.Tests
             Func<char> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((char)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((char)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -14181,7 +14181,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyNullableShortToDecimal(short? value, bool useInterpreter)
@@ -14368,7 +14368,7 @@ namespace System.Linq.Expressions.Tests
             Func<sbyte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((sbyte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((sbyte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -14381,7 +14381,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte?)value, f());
+            Assert.Equal(unchecked((sbyte?)value), f());
         }
 
         private static void VerifyNullableShortToShort(short? value, bool useInterpreter)
@@ -14418,7 +14418,7 @@ namespace System.Linq.Expressions.Tests
             Func<uint> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((uint)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((uint)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -14431,7 +14431,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint?)value, f());
+            Assert.Equal(unchecked((uint?)value), f());
         }
 
         private static void VerifyNullableShortToULong(short? value, bool useInterpreter)
@@ -14443,7 +14443,7 @@ namespace System.Linq.Expressions.Tests
             Func<ulong> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ulong)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ulong)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -14456,7 +14456,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ulong?)value, f());
+            Assert.Equal(unchecked((ulong?)value), f());
         }
 
         private static void VerifyNullableShortToUShort(short? value, bool useInterpreter)
@@ -14468,7 +14468,7 @@ namespace System.Linq.Expressions.Tests
             Func<ushort> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ushort)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ushort)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -14481,7 +14481,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)value, f());
+            Assert.Equal(unchecked((ushort?)value), f());
         }
 
         private static void VerifyUIntToByte(uint value, bool useInterpreter)
@@ -14492,7 +14492,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyUIntToNullableByte(uint value, bool useInterpreter)
@@ -14503,7 +14503,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyUIntToChar(uint value, bool useInterpreter)
@@ -14514,7 +14514,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char)value, f());
+            Assert.Equal(unchecked((char)value), f());
         }
 
         private static void VerifyUIntToNullableChar(uint value, bool useInterpreter)
@@ -14525,7 +14525,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyUIntToDecimal(uint value, bool useInterpreter)
@@ -14580,7 +14580,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E)value, f());
+            Assert.Equal(unchecked((E)value), f());
         }
 
         private static void VerifyUIntToNullableEnum(uint value, bool useInterpreter)
@@ -14591,7 +14591,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E)value, f());
+            Assert.Equal(unchecked((E)value), f());
         }
 
         private static void VerifyUIntToEnumLong(uint value, bool useInterpreter)
@@ -14646,7 +14646,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int)value, f());
+            Assert.Equal(unchecked((int)value), f());
         }
 
         private static void VerifyUIntToNullableInt(uint value, bool useInterpreter)
@@ -14657,7 +14657,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int)value, f());
+            Assert.Equal(unchecked((int)value), f());
         }
 
         private static void VerifyUIntToLong(uint value, bool useInterpreter)
@@ -14690,7 +14690,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyUIntToNullableSByte(uint value, bool useInterpreter)
@@ -14701,7 +14701,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyUIntToShort(uint value, bool useInterpreter)
@@ -14712,7 +14712,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyUIntToNullableShort(uint value, bool useInterpreter)
@@ -14723,7 +14723,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyUIntToUInt(uint value, bool useInterpreter)
@@ -14778,7 +14778,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyUIntToNullableUShort(uint value, bool useInterpreter)
@@ -14789,7 +14789,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyNullableUIntToByte(uint? value, bool useInterpreter)
@@ -14801,7 +14801,7 @@ namespace System.Linq.Expressions.Tests
             Func<byte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((byte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((byte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -14814,7 +14814,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte?)value, f());
+            Assert.Equal(unchecked((byte?)value), f());
         }
 
         private static void VerifyNullableUIntToChar(uint? value, bool useInterpreter)
@@ -14826,7 +14826,7 @@ namespace System.Linq.Expressions.Tests
             Func<char> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((char)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((char)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -14839,7 +14839,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyNullableUIntToDecimal(uint? value, bool useInterpreter)
@@ -14901,7 +14901,7 @@ namespace System.Linq.Expressions.Tests
             Func<E> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((E)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((E)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -14914,7 +14914,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E?)value, f());
+            Assert.Equal(unchecked((E?)value), f());
         }
 
         private static void VerifyNullableUIntToEnumLong(uint? value, bool useInterpreter)
@@ -14976,7 +14976,7 @@ namespace System.Linq.Expressions.Tests
             Func<int> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((int)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((int)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -14989,7 +14989,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int?)value, f());
+            Assert.Equal(unchecked((int?)value), f());
         }
 
         private static void VerifyNullableUIntToLong(uint? value, bool useInterpreter)
@@ -15026,7 +15026,7 @@ namespace System.Linq.Expressions.Tests
             Func<sbyte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((sbyte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((sbyte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -15039,7 +15039,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte?)value, f());
+            Assert.Equal(unchecked((sbyte?)value), f());
         }
 
         private static void VerifyNullableUIntToShort(uint? value, bool useInterpreter)
@@ -15051,7 +15051,7 @@ namespace System.Linq.Expressions.Tests
             Func<short> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((short)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((short)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -15064,7 +15064,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)value, f());
+            Assert.Equal(unchecked((short?)value), f());
         }
 
         private static void VerifyNullableUIntToUInt(uint? value, bool useInterpreter)
@@ -15126,7 +15126,7 @@ namespace System.Linq.Expressions.Tests
             Func<ushort> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ushort)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ushort)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -15139,7 +15139,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)value, f());
+            Assert.Equal(unchecked((ushort?)value), f());
         }
 
         private static void VerifyULongToByte(ulong value, bool useInterpreter)
@@ -15150,7 +15150,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyULongToNullableByte(ulong value, bool useInterpreter)
@@ -15161,7 +15161,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyULongToChar(ulong value, bool useInterpreter)
@@ -15172,7 +15172,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char)value, f());
+            Assert.Equal(unchecked((char)value), f());
         }
 
         private static void VerifyULongToNullableChar(ulong value, bool useInterpreter)
@@ -15183,7 +15183,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyULongToDecimal(ulong value, bool useInterpreter)
@@ -15238,7 +15238,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E)value, f());
+            Assert.Equal(unchecked((E)value), f());
         }
 
         private static void VerifyULongToNullableEnum(ulong value, bool useInterpreter)
@@ -15249,7 +15249,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E)value, f());
+            Assert.Equal(unchecked((E)value), f());
         }
 
         private static void VerifyULongToEnumLong(ulong value, bool useInterpreter)
@@ -15260,7 +15260,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<El> f = e.Compile(useInterpreter);
 
-            Assert.Equal((El)value, f());
+            Assert.Equal(unchecked((El)value), f());
         }
 
         private static void VerifyULongToNullableEnumLong(ulong value, bool useInterpreter)
@@ -15271,7 +15271,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<El?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((El)value, f());
+            Assert.Equal(unchecked((El)value), f());
         }
 
         private static void VerifyULongToFloat(ulong value, bool useInterpreter)
@@ -15304,7 +15304,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int)value, f());
+            Assert.Equal(unchecked((int)value), f());
         }
 
         private static void VerifyULongToNullableInt(ulong value, bool useInterpreter)
@@ -15315,7 +15315,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int)value, f());
+            Assert.Equal(unchecked((int)value), f());
         }
 
         private static void VerifyULongToLong(ulong value, bool useInterpreter)
@@ -15326,7 +15326,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<long> f = e.Compile(useInterpreter);
 
-            Assert.Equal((long)value, f());
+            Assert.Equal(unchecked((long)value), f());
         }
 
         private static void VerifyULongToNullableLong(ulong value, bool useInterpreter)
@@ -15337,7 +15337,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<long?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((long)value, f());
+            Assert.Equal(unchecked((long)value), f());
         }
 
         private static void VerifyULongToSByte(ulong value, bool useInterpreter)
@@ -15348,7 +15348,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyULongToNullableSByte(ulong value, bool useInterpreter)
@@ -15359,7 +15359,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyULongToShort(ulong value, bool useInterpreter)
@@ -15370,7 +15370,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyULongToNullableShort(ulong value, bool useInterpreter)
@@ -15381,7 +15381,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyULongToUInt(ulong value, bool useInterpreter)
@@ -15392,7 +15392,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint)value, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifyULongToNullableUInt(ulong value, bool useInterpreter)
@@ -15403,7 +15403,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint)value, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifyULongToULong(ulong value, bool useInterpreter)
@@ -15436,7 +15436,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyULongToNullableUShort(ulong value, bool useInterpreter)
@@ -15447,7 +15447,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort)value, f());
+            Assert.Equal(unchecked((ushort)value), f());
         }
 
         private static void VerifyNullableULongToByte(ulong? value, bool useInterpreter)
@@ -15459,7 +15459,7 @@ namespace System.Linq.Expressions.Tests
             Func<byte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((byte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((byte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -15472,7 +15472,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte?)value, f());
+            Assert.Equal(unchecked((byte?)value), f());
         }
 
         private static void VerifyNullableULongToChar(ulong? value, bool useInterpreter)
@@ -15484,7 +15484,7 @@ namespace System.Linq.Expressions.Tests
             Func<char> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((char)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((char)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -15497,7 +15497,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)value, f());
+            Assert.Equal(unchecked((char?)value), f());
         }
 
         private static void VerifyNullableULongToDecimal(ulong? value, bool useInterpreter)
@@ -15559,7 +15559,7 @@ namespace System.Linq.Expressions.Tests
             Func<E> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((E)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((E)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -15572,7 +15572,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<E?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((E?)value, f());
+            Assert.Equal(unchecked((E?)value), f());
         }
 
         private static void VerifyNullableULongToEnumLong(ulong? value, bool useInterpreter)
@@ -15584,7 +15584,7 @@ namespace System.Linq.Expressions.Tests
             Func<El> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((El)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((El)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -15597,7 +15597,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<El?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((El?)value, f());
+            Assert.Equal(unchecked((El?)value), f());
         }
 
         private static void VerifyNullableULongToFloat(ulong? value, bool useInterpreter)
@@ -15634,7 +15634,7 @@ namespace System.Linq.Expressions.Tests
             Func<int> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((int)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((int)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -15647,7 +15647,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((int?)value, f());
+            Assert.Equal(unchecked((int?)value), f());
         }
 
         private static void VerifyNullableULongToLong(ulong? value, bool useInterpreter)
@@ -15659,7 +15659,7 @@ namespace System.Linq.Expressions.Tests
             Func<long> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((long)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((long)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -15672,7 +15672,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<long?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((long?)value, f());
+            Assert.Equal(unchecked((long?)value), f());
         }
 
         private static void VerifyNullableULongToSByte(ulong? value, bool useInterpreter)
@@ -15684,7 +15684,7 @@ namespace System.Linq.Expressions.Tests
             Func<sbyte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((sbyte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((sbyte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -15697,7 +15697,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte?)value, f());
+            Assert.Equal(unchecked((sbyte?)value), f());
         }
 
         private static void VerifyNullableULongToShort(ulong? value, bool useInterpreter)
@@ -15709,7 +15709,7 @@ namespace System.Linq.Expressions.Tests
             Func<short> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((short)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((short)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -15722,7 +15722,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)value, f());
+            Assert.Equal(unchecked((short?)value), f());
         }
 
         private static void VerifyNullableULongToUInt(ulong? value, bool useInterpreter)
@@ -15734,7 +15734,7 @@ namespace System.Linq.Expressions.Tests
             Func<uint> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((uint)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((uint)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -15747,7 +15747,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((uint?)value, f());
+            Assert.Equal(unchecked((uint?)value), f());
         }
 
         private static void VerifyNullableULongToULong(ulong? value, bool useInterpreter)
@@ -15784,7 +15784,7 @@ namespace System.Linq.Expressions.Tests
             Func<ushort> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((ushort)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((ushort)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -15797,7 +15797,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)value, f());
+            Assert.Equal(unchecked((ushort?)value), f());
         }
 
         private static void VerifyUShortToByte(ushort value, bool useInterpreter)
@@ -15808,7 +15808,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyUShortToNullableByte(ushort value, bool useInterpreter)
@@ -15819,7 +15819,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte)value, f());
+            Assert.Equal(unchecked((byte)value), f());
         }
 
         private static void VerifyUShortToChar(ushort value, bool useInterpreter)
@@ -16006,7 +16006,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyUShortToNullableSByte(ushort value, bool useInterpreter)
@@ -16017,7 +16017,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte)value, f());
+            Assert.Equal(unchecked((sbyte)value), f());
         }
 
         private static void VerifyUShortToShort(ushort value, bool useInterpreter)
@@ -16028,7 +16028,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyUShortToNullableShort(ushort value, bool useInterpreter)
@@ -16039,7 +16039,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short)value, f());
+            Assert.Equal(unchecked((short)value), f());
         }
 
         private static void VerifyUShortToUInt(ushort value, bool useInterpreter)
@@ -16117,7 +16117,7 @@ namespace System.Linq.Expressions.Tests
             Func<byte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((byte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((byte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -16130,7 +16130,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte?)value, f());
+            Assert.Equal(unchecked((byte?)value), f());
         }
 
         private static void VerifyNullableUShortToChar(ushort? value, bool useInterpreter)
@@ -16342,7 +16342,7 @@ namespace System.Linq.Expressions.Tests
             Func<sbyte> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((sbyte)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((sbyte)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -16355,7 +16355,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte?)value, f());
+            Assert.Equal(unchecked((sbyte?)value), f());
         }
 
         private static void VerifyNullableUShortToShort(ushort? value, bool useInterpreter)
@@ -16367,7 +16367,7 @@ namespace System.Linq.Expressions.Tests
             Func<short> f = e.Compile(useInterpreter);
 
             if (value.HasValue)
-                Assert.Equal((short)value.GetValueOrDefault(), f());
+                Assert.Equal(unchecked((short)value.GetValueOrDefault()), f());
             else
                 Assert.Throws<InvalidOperationException>(() => f());
         }
@@ -16380,7 +16380,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)value, f());
+            Assert.Equal(unchecked((short?)value), f());
         }
 
         private static void VerifyNullableUShortToUInt(ushort? value, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/Dynamic/BinaryOperationTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/BinaryOperationTests.cs
@@ -134,7 +134,7 @@ namespace System.Dynamic.Tests
         {
             dynamic dX = x;
             dynamic dY = y;
-            Assert.Equal(x + y, dX + dY);
+            Assert.Equal(unchecked(x + y), unchecked(dX + dY));
         }
 
         [Theory, MemberData(nameof(CrossJoinInt32))]
@@ -251,7 +251,7 @@ namespace System.Dynamic.Tests
         {
             dynamic dX = x;
             dynamic dY = y;
-            Assert.Equal(x * y, dX * dY);
+            Assert.Equal(unchecked(x * y), unchecked(dX * dY));
         }
 
         [Theory, MemberData(nameof(CrossJoinInt32))]
@@ -302,7 +302,7 @@ namespace System.Dynamic.Tests
         {
             dynamic dX = x;
             dynamic dY = y;
-            Assert.Equal(x - y, dX - dY);
+            Assert.Equal(unchecked(x - y), unchecked(dX - dY));
         }
 
         [Theory, MemberData(nameof(CrossJoinInt32))]
@@ -329,8 +329,12 @@ namespace System.Dynamic.Tests
         {
             dynamic dX = x;
             dynamic dY = y;
-            dX += dY;
-            Assert.Equal(x + y, dX);
+
+            unchecked
+            {
+                dX += dY;
+                Assert.Equal(x + y, dX);
+            }
         }
 
         [Theory, MemberData(nameof(CrossJoinInt32))]
@@ -420,8 +424,12 @@ namespace System.Dynamic.Tests
         {
             dynamic dX = x;
             dynamic dY = y;
-            dX *= dY;
-            Assert.Equal(x * y, dX);
+
+            unchecked
+            {
+                dX *= dY;
+                Assert.Equal(x * y, dX);
+            }
         }
 
         [Theory, MemberData(nameof(CrossJoinInt32))]
@@ -468,8 +476,12 @@ namespace System.Dynamic.Tests
         {
             dynamic dX = x;
             dynamic dY = y;
-            dX -= dY;
-            Assert.Equal(x - y, dX);
+
+            unchecked
+            {
+                dX -= dY;
+                Assert.Equal(x - y, dX);
+            }
         }
 
         [Theory, MemberData(nameof(CrossJoinInt32))]

--- a/src/System.Linq.Expressions/tests/Dynamic/ConvertBinderTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/ConvertBinderTests.cs
@@ -51,8 +51,8 @@ namespace System.Dynamic.Tests
         public void ConvertExplicit(long x)
         {
             dynamic d = x;
-            int xi = (int)d;
-            Assert.Equal((int)x, xi);
+            int xi = unchecked((int)d);
+            Assert.Equal(unchecked((int)x), xi);
         }
 
         [Theory, MemberData(nameof(Int64Arges))]

--- a/src/System.Linq.Expressions/tests/Dynamic/UnaryOperationTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/UnaryOperationTests.cs
@@ -132,16 +132,24 @@ namespace System.Dynamic.Tests
         public void DecrementPrefixInt32(int x)
         {
             dynamic d = x;
-            Assert.Equal(x - 1, --d);
-            Assert.Equal(x - 1, d);
+
+            unchecked
+            {
+                Assert.Equal(x - 1, --d);
+                Assert.Equal(x - 1, d);
+            }
         }
 
         [Theory, MemberData(nameof(Int32Args))]
         public void DecrementPostfixInt32(int x)
         {
             dynamic d = x;
-            Assert.Equal(x, d--);
-            Assert.Equal(x - 1, d);
+
+            unchecked
+            {
+                Assert.Equal(x, d--);
+                Assert.Equal(x - 1, d);
+            }
         }
 
         [Theory, MemberData(nameof(Int32Args))]
@@ -184,16 +192,24 @@ namespace System.Dynamic.Tests
         public void IncrementPrefixInt32(int x)
         {
             dynamic d = x;
-            Assert.Equal(x + 1, ++d);
-            Assert.Equal(x + 1, d);
+
+            unchecked
+            {
+                Assert.Equal(x + 1, ++d);
+                Assert.Equal(x + 1, d);
+            }
         }
 
         [Theory, MemberData(nameof(Int32Args))]
         public void IncrementPostfixInt32(int x)
         {
             dynamic d = x;
-            Assert.Equal(x, d++);
-            Assert.Equal(x + 1, d);
+
+            unchecked
+            {
+                Assert.Equal(x, d++);
+                Assert.Equal(x + 1, d);
+            }
         }
 
         [Theory, MemberData(nameof(Int32Args))]
@@ -236,7 +252,7 @@ namespace System.Dynamic.Tests
         public void NegateInt32(int x)
         {
             dynamic d = x;
-            Assert.Equal(-x, -d);
+            Assert.Equal(unchecked(-x), unchecked(-d));
         }
 
         [Theory, MemberData(nameof(Int32Args))]

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -419,9 +419,9 @@ namespace System.Linq.Expressions.Tests
         public static readonly Number MinValue = new Number(int.MinValue);
         public static readonly Number MaxValue = new Number(int.MaxValue);
 
-        public static Number operator +(Number l, Number r) => new Number(l._value + r._value);
+        public static Number operator +(Number l, Number r) => new Number(unchecked(l._value + r._value));
         public static Number operator -(Number l, Number r) => new Number(l._value - r._value);
-        public static Number operator *(Number l, Number r) => new Number(l._value * r._value);
+        public static Number operator *(Number l, Number r) => new Number(unchecked(l._value * r._value));
         public static Number operator /(Number l, Number r) => new Number(l._value / r._value);
         public static Number operator %(Number l, Number r) => new Number(l._value % r._value);
 

--- a/src/System.Linq.Expressions/tests/ILReader/ILReader.cs
+++ b/src/System.Linq.Expressions/tests/ILReader/ILReader.cs
@@ -27,7 +27,7 @@ namespace System.Linq.Expressions.Tests
             foreach (FieldInfo fi in typeof(OpCodes).GetFields(BindingFlags.Public | BindingFlags.Static))
             {
                 OpCode opCode = (OpCode)fi.GetValue(null);
-                ushort value = (ushort)opCode.Value;
+                ushort value = unchecked((ushort)opCode.Value);
                 if (value < 0x100)
                 {
                     s_OneByteOpCodes[value] = opCode;

--- a/src/System.Linq.Expressions/tests/InterpreterTests.cs
+++ b/src/System.Linq.Expressions/tests/InterpreterTests.cs
@@ -17,7 +17,8 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void VerifyInstructions_Simple()
         {
-            Expression<Func<string, bool>> f = s => s != null && s.Substring(1).Length * 2 > 0;
+            // Using an unchecked multiplication to ensure that a mul instruction is emitted (and not mul.ovf)
+            Expression<Func<string, bool>> f = s => s != null && unchecked(s.Substring(1).Length * 2) > 0;
 
             f.VerifyInstructions(
                 @"object lambda_method(object[])

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaAddNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaAddNullableTests.cs
@@ -466,7 +466,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyAddNullableInt(int? a, int? b, bool useInterpreter)
         {
-            int? expected = a + b;
+            int? expected = unchecked(a + b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(int?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(int?), "p1");
@@ -559,7 +559,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyAddNullableLong(long? a, long? b, bool useInterpreter)
         {
-            long? expected = a + b;
+            long? expected = unchecked(a + b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(long?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(long?), "p1");
@@ -652,7 +652,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyAddNullableShort(short? a, short? b, bool useInterpreter)
         {
-            short? expected = (short?)(a + b);
+            short? expected = unchecked((short?)(a + b));
 
             ParameterExpression p0 = Expression.Parameter(typeof(short?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(short?), "p1");
@@ -745,7 +745,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyAddNullableUInt(uint? a, uint? b, bool useInterpreter)
         {
-            uint? expected = a + b;
+            uint? expected = unchecked(a + b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(uint?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(uint?), "p1");
@@ -838,7 +838,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyAddNullableULong(ulong? a, ulong? b, bool useInterpreter)
         {
-            ulong? expected = a + b;
+            ulong? expected = unchecked(a + b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(ulong?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(ulong?), "p1");
@@ -931,7 +931,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyAddNullableUShort(ushort? a, ushort? b, bool useInterpreter)
         {
-            ushort? expected = (ushort?)(a + b);
+            ushort? expected = unchecked((ushort?)(a + b));
 
             ParameterExpression p0 = Expression.Parameter(typeof(ushort?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(ushort?), "p1");

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaAddTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaAddTests.cs
@@ -148,7 +148,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyAddByte(byte a, byte b, bool useInterpreter)
         {
-            byte expected = (byte)(a + b);
+            byte expected = unchecked((byte)(a + b));
 
             ParameterExpression p0 = Expression.Parameter(typeof(int), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(int), "p1");
@@ -168,7 +168,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f1 = e1.Compile(useInterpreter);
 
-            Assert.Equal(expected, (byte)f1());
+            Assert.Equal(expected, unchecked((byte)f1()));
 
             // verify with values passed to make parameters
             Expression<Func<int, int, Func<int>>> e2 =
@@ -179,7 +179,7 @@ namespace System.Linq.Expressions.Tests
                     new ParameterExpression[] { p0, p1 });
             Func<int, int, Func<int>> f2 = e2.Compile(useInterpreter);
 
-            Assert.Equal(expected, (byte)f2(a, b)());
+            Assert.Equal(expected, unchecked((byte)f2(a, b)()));
 
             // verify with values directly passed
             Expression<Func<Func<int, int, int>>> e3 =
@@ -194,7 +194,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int, int, int> f3 = e3.Compile(useInterpreter)();
 
-            Assert.Equal(expected, (byte)f3(a, b));
+            Assert.Equal(expected, unchecked((byte)f3(a, b)));
 
             // verify as a function generator
             Expression<Func<Func<int, int, int>>> e4 =
@@ -205,7 +205,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<Func<int, int, int>> f4 = e4.Compile(useInterpreter);
 
-            Assert.Equal(expected, (byte)f4()(a, b));
+            Assert.Equal(expected, unchecked((byte)f4()(a, b)));
 
             // verify with currying
             Expression<Func<int, Func<int, int>>> e5 =
@@ -216,7 +216,7 @@ namespace System.Linq.Expressions.Tests
                     new ParameterExpression[] { p0 });
             Func<int, Func<int, int>> f5 = e5.Compile(useInterpreter);
 
-            Assert.Equal(expected, (byte)f5(a)(b));
+            Assert.Equal(expected, unchecked((byte)f5(a)(b)));
 
             // verify with one parameter
             Expression<Func<Func<int, int>>> e6 =
@@ -231,7 +231,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<int, int> f6 = e6.Compile(useInterpreter)();
 
-            Assert.Equal(expected, (byte)f6(b));
+            Assert.Equal(expected, unchecked((byte)f6(b)));
         }
 
         #endregion
@@ -573,7 +573,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyAddInt(int a, int b, bool useInterpreter)
         {
-            int expected = a + b;
+            int expected = unchecked(a + b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(int), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(int), "p1");
@@ -666,7 +666,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyAddLong(long a, long b, bool useInterpreter)
         {
-            long expected = a + b;
+            long expected = unchecked(a + b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(long), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(long), "p1");
@@ -759,7 +759,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyAddShort(short a, short b, bool useInterpreter)
         {
-            short expected = (short)(a + b);
+            short expected = unchecked((short)(a + b));
 
             ParameterExpression p0 = Expression.Parameter(typeof(short), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(short), "p1");
@@ -852,7 +852,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyAddUInt(uint a, uint b, bool useInterpreter)
         {
-            uint expected = a + b;
+            uint expected = unchecked(a + b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(uint), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(uint), "p1");
@@ -954,7 +954,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyAddULong(ulong a, ulong b, bool useInterpreter)
         {
-            ulong expected = a + b;
+            ulong expected = unchecked(a + b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(ulong), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(ulong), "p1");
@@ -1047,7 +1047,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyAddUShort(ushort a, ushort b, bool useInterpreter)
         {
-            ushort expected = (ushort)(a + b);
+            ushort expected = unchecked((ushort)(a + b));
 
             ParameterExpression p0 = Expression.Parameter(typeof(ushort), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(ushort), "p1");

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaDivideNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaDivideNullableTests.cs
@@ -836,7 +836,7 @@ namespace System.Linq.Expressions.Tests
             else
             {
                 divideByZero = false;
-                expected = (short?)(a / b);
+                expected = unchecked((short?)(a / b));
             }
 
             ParameterExpression p0 = Expression.Parameter(typeof(short?), "p0");

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaDivideTests.cs
@@ -837,7 +837,7 @@ namespace System.Linq.Expressions.Tests
             else
             {
                 divideByZero = false;
-                expected = (short)(a / b);
+                expected = unchecked((short)(a / b));
             }
 
             ParameterExpression p0 = Expression.Parameter(typeof(short), "p0");

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyNullableTests.cs
@@ -467,7 +467,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyMultiplyNullableInt(int? a, int? b, bool useInterpreter)
         {
-            int? expected = a * b;
+            int? expected = unchecked(a * b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(int?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(int?), "p1");
@@ -560,7 +560,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyMultiplyNullableLong(long? a, long? b, bool useInterpreter)
         {
-            long? expected = a * b;
+            long? expected = unchecked(a * b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(long?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(long?), "p1");
@@ -653,7 +653,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyMultiplyNullableShort(short? a, short? b, bool useInterpreter)
         {
-            short? expected = (short?)(a * b);
+            short? expected = unchecked((short?)(a * b));
             ParameterExpression p0 = Expression.Parameter(typeof(short?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(short?), "p1");
 
@@ -745,7 +745,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyMultiplyNullableUInt(uint? a, uint? b, bool useInterpreter)
         {
-            uint? expected = a * b;
+            uint? expected = unchecked(a * b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(uint?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(uint?), "p1");
@@ -838,7 +838,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyMultiplyNullableULong(ulong? a, ulong? b, bool useInterpreter)
         {
-            ulong? expected = a * b;
+            ulong? expected = unchecked(a * b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(ulong?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(ulong?), "p1");
@@ -931,7 +931,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyMultiplyNullableUShort(ushort? a, ushort? b, bool useInterpreter)
         {
-            ushort? expected = (ushort?)(a * b);
+            ushort? expected = unchecked((ushort?)(a * b));
 
             ParameterExpression p0 = Expression.Parameter(typeof(ushort?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(ushort?), "p1");

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyTests.cs
@@ -467,7 +467,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyMultiplyInt(int a, int b, bool useInterpreter)
         {
-            int expected = a * b;
+            int expected = unchecked(a * b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(int), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(int), "p1");
@@ -560,7 +560,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyMultiplyLong(long a, long b, bool useInterpreter)
         {
-            long expected = a * b;
+            long expected = unchecked(a * b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(long), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(long), "p1");
@@ -653,7 +653,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyMultiplyShort(short a, short b, bool useInterpreter)
         {
-            short expected = (short)(a * b);
+            short expected = unchecked((short)(a * b));
 
             ParameterExpression p0 = Expression.Parameter(typeof(short), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(short), "p1");
@@ -747,7 +747,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyMultiplyUInt(uint a, uint b, bool useInterpreter)
         {
-            uint expected = a * b;
+            uint expected = unchecked(a * b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(uint), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(uint), "p1");
@@ -840,7 +840,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyMultiplyULong(ulong a, ulong b, bool useInterpreter)
         {
-            ulong expected = a * b;
+            ulong expected = unchecked(a * b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(ulong), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(ulong), "p1");
@@ -933,7 +933,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifyMultiplyUShort(ushort a, ushort b, bool useInterpreter)
         {
-            ushort expected = (ushort)(a * b);
+            ushort expected = unchecked((ushort)(a * b));
 
             ParameterExpression p0 = Expression.Parameter(typeof(ushort), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(ushort), "p1");

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractNullableTests.cs
@@ -465,7 +465,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifySubtractNullableInt(int? a, int? b, bool useInterpreter)
         {
-            int? expected = a - b;
+            int? expected = unchecked(a - b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(int?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(int?), "p1");
@@ -558,7 +558,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifySubtractNullableLong(long? a, long? b, bool useInterpreter)
         {
-            long? expected = a - b;
+            long? expected = unchecked(a - b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(long?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(long?), "p1");
@@ -651,7 +651,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifySubtractNullableShort(short? a, short? b, bool useInterpreter)
         {
-            short? expected = (short?)(a - b);
+            short? expected = unchecked((short?)(a - b));
 
             ParameterExpression p0 = Expression.Parameter(typeof(short?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(short?), "p1");
@@ -744,7 +744,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifySubtractNullableUInt(uint? a, uint? b, bool useInterpreter)
         {
-            uint? expected = a - b;
+            uint? expected = unchecked(a - b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(uint?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(uint?), "p1");
@@ -837,7 +837,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifySubtractNullableULong(ulong? a, ulong? b, bool useInterpreter)
         {
-            ulong? expected = a - b;
+            ulong? expected = unchecked(a - b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(ulong?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(ulong?), "p1");
@@ -930,7 +930,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifySubtractNullableUShort(ushort? a, ushort? b, bool useInterpreter)
         {
-            ushort? expected = (ushort?)(a - b);
+            ushort? expected = unchecked((ushort?)(a - b));
 
             ParameterExpression p0 = Expression.Parameter(typeof(ushort?), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(ushort?), "p1");

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractTests.cs
@@ -465,7 +465,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifySubtractInt(int a, int b, bool useInterpreter)
         {
-            int expected = a - b;
+            int expected = unchecked(a - b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(int), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(int), "p1");
@@ -558,7 +558,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifySubtractLong(long a, long b, bool useInterpreter)
         {
-            long expected = a - b;
+            long expected = unchecked(a - b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(long), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(long), "p1");
@@ -651,7 +651,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifySubtractShort(short a, short b, bool useInterpreter)
         {
-            short expected = (short)(a - b);
+            short expected = unchecked((short)(a - b));
 
             ParameterExpression p0 = Expression.Parameter(typeof(short), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(short), "p1");
@@ -744,7 +744,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifySubtractUInt(uint a, uint b, bool useInterpreter)
         {
-            uint expected = a - b;
+            uint expected = unchecked(a - b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(uint), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(uint), "p1");
@@ -837,7 +837,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifySubtractULong(ulong a, ulong b, bool useInterpreter)
         {
-            ulong expected = a - b;
+            ulong expected = unchecked(a - b);
 
             ParameterExpression p0 = Expression.Parameter(typeof(ulong), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(ulong), "p1");
@@ -930,7 +930,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void VerifySubtractUShort(ushort a, ushort b, bool useInterpreter)
         {
-            ushort expected = (ushort)(a - b);
+            ushort expected = unchecked((ushort)(a - b));
 
             ParameterExpression p0 = Expression.Parameter(typeof(ushort), "p0");
             ParameterExpression p1 = Expression.Parameter(typeof(ushort), "p1");

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotNullableTests.cs
@@ -132,7 +132,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<Func<byte?, byte?>> f4 = e4.Compile(useInterpreter);
 
-            byte? expected = (byte?)~value;
+            byte? expected = unchecked((byte?)~value);
 
             Assert.Equal(expected, f1());
             Assert.Equal(expected, f2(value)());
@@ -510,7 +510,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<Func<ushort?, ushort?>> f4 = e4.Compile(useInterpreter);
 
-            ushort? expected = (ushort?)~value;
+            ushort? expected = unchecked((ushort?)~value);
 
             Assert.Equal(expected, f1());
             Assert.Equal(expected, f2(value)());

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotTests.cs
@@ -132,7 +132,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<Func<byte, byte>> f4 = e4.Compile(useInterpreter);
 
-            byte expected = (byte)~value;
+            byte expected = unchecked((byte)~value);
 
             Assert.Equal(expected, f1());
             Assert.Equal(expected, f2(value)());
@@ -510,7 +510,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<Func<ushort, ushort>> f4 = e4.Compile(useInterpreter);
 
-            ushort expected = (ushort)~value;
+            ushort expected = unchecked((ushort)~value);
 
             Assert.Equal(expected, f1());
             Assert.Equal(expected, f2(value)());

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedAddNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedAddNullableTests.cs
@@ -186,12 +186,12 @@ namespace System.Linq.Expressions.Tests
 
         public static byte AddNullableByte(byte a, byte b)
         {
-            return (byte)(a + b);
+            return unchecked((byte)(a + b));
         }
 
         public static char AddNullableChar(char a, char b)
         {
-            return (char)(a + b);
+            return unchecked((char)(a + b));
         }
 
         public static decimal AddNullableDecimal(decimal a, decimal b)
@@ -211,37 +211,37 @@ namespace System.Linq.Expressions.Tests
 
         public static int AddNullableInt(int a, int b)
         {
-            return (int)(a + b);
+            return unchecked((int)(a + b));
         }
 
         public static long AddNullableLong(long a, long b)
         {
-            return (long)(a + b);
+            return unchecked((long)(a + b));
         }
 
         public static sbyte AddNullableSByte(sbyte a, sbyte b)
         {
-            return (sbyte)(a + b);
+            return unchecked((sbyte)(a + b));
         }
 
         public static short AddNullableShort(short a, short b)
         {
-            return (short)(a + b);
+            return unchecked((short)(a + b));
         }
 
         public static uint AddNullableUInt(uint a, uint b)
         {
-            return (uint)(a + b);
+            return unchecked((uint)(a + b));
         }
 
         public static ulong AddNullableULong(ulong a, ulong b)
         {
-            return (ulong)(a + b);
+            return unchecked((ulong)(a + b));
         }
 
         public static ushort AddNullableUShort(ushort a, ushort b)
         {
-            return (ushort)(a + b);
+            return unchecked((ushort)(a + b));
         }
 
         #endregion
@@ -258,7 +258,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableByte")));
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte?)(a + b), f());
+            Assert.Equal(unchecked((byte?)(a + b)), f());
         }
 
         private static void VerifyAddNullableChar(char? a, char? b, bool useInterpreter)
@@ -271,7 +271,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableChar")));
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)(a + b), f());
+            Assert.Equal(unchecked((char?)(a + b)), f());
         }
 
         private static void VerifyAddNullableDecimal(decimal? a, decimal? b, bool useInterpreter)
@@ -334,7 +334,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableInt")));
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a + b, f());
+            Assert.Equal(unchecked(a + b), f());
         }
 
         private static void VerifyAddNullableLong(long? a, long? b, bool useInterpreter)
@@ -347,7 +347,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableLong")));
             Func<long?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a + b, f());
+            Assert.Equal(unchecked(a + b), f());
         }
 
         private static void VerifyAddNullableSByte(sbyte? a, sbyte? b, bool useInterpreter)
@@ -360,7 +360,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableSByte")));
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte?)(a + b), f());
+            Assert.Equal(unchecked((sbyte?)(a + b)), f());
         }
 
         private static void VerifyAddNullableShort(short? a, short? b, bool useInterpreter)
@@ -373,7 +373,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableShort")));
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)(a + b), f());
+            Assert.Equal(unchecked((short?)(a + b)), f());
         }
 
         private static void VerifyAddNullableUInt(uint? a, uint? b, bool useInterpreter)
@@ -386,7 +386,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableUInt")));
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a + b, f());
+            Assert.Equal(unchecked(a + b), f());
         }
 
         private static void VerifyAddNullableULong(ulong? a, ulong? b, bool useInterpreter)
@@ -399,7 +399,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableULong")));
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a + b, f());
+            Assert.Equal(unchecked(a + b), f());
         }
 
         private static void VerifyAddNullableUShort(ushort? a, ushort? b, bool useInterpreter)
@@ -412,7 +412,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedAddNullableTests).GetTypeInfo().GetDeclaredMethod("AddNullableUShort")));
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)(a + b), f());
+            Assert.Equal(unchecked((ushort?)(a + b)), f());
         }
 
         private static void VerifyAddNullableNumber(Number? a, Number? b, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedDivideNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedDivideNullableTests.cs
@@ -231,12 +231,12 @@ namespace System.Linq.Expressions.Tests
 
         public static sbyte DivideNullableSByte(sbyte a, sbyte b)
         {
-            return (sbyte)(a / b);
+            return unchecked((sbyte)(a / b));
         }
 
         public static short DivideNullableShort(short a, short b)
         {
-            return (short)(a / b);
+            return unchecked((short)(a / b));
         }
 
         public static uint DivideNullableUInt(uint a, uint b)
@@ -381,7 +381,7 @@ namespace System.Linq.Expressions.Tests
             if (a.HasValue && b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else
-                Assert.Equal((sbyte?)(a / b), f());
+                Assert.Equal(unchecked((sbyte?)(a / b)), f());
         }
 
         private static void VerifyDivideNullableShort(short? a, short? b, bool useInterpreter)
@@ -397,7 +397,7 @@ namespace System.Linq.Expressions.Tests
             if (a.HasValue && b == 0)
                 Assert.Throws<DivideByZeroException>(() => f());
             else
-                Assert.Equal((short?)(a / b), f());
+                Assert.Equal(unchecked((short?)(a / b)), f());
         }
 
         private static void VerifyDivideNullableUInt(uint? a, uint? b, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyNullableTests.cs
@@ -186,12 +186,12 @@ namespace System.Linq.Expressions.Tests
 
         public static byte MultiplyNullableByte(byte a, byte b)
         {
-            return (byte)(a * b);
+            return unchecked((byte)(a * b));
         }
 
         public static char MultiplyNullableChar(char a, char b)
         {
-            return (char)(a * b);
+            return unchecked((char)(a * b));
         }
 
         public static decimal MultiplyNullableDecimal(decimal a, decimal b)
@@ -211,37 +211,37 @@ namespace System.Linq.Expressions.Tests
 
         public static int MultiplyNullableInt(int a, int b)
         {
-            return (int)(a * b);
+            return unchecked((int)(a * b));
         }
 
         public static long MultiplyNullableLong(long a, long b)
         {
-            return (long)(a * b);
+            return unchecked((long)(a * b));
         }
 
         public static sbyte MultiplyNullableSByte(sbyte a, sbyte b)
         {
-            return (sbyte)(a * b);
+            return unchecked((sbyte)(a * b));
         }
 
         public static short MultiplyNullableShort(short a, short b)
         {
-            return (short)(a * b);
+            return unchecked((short)(a * b));
         }
 
         public static uint MultiplyNullableUInt(uint a, uint b)
         {
-            return (uint)(a * b);
+            return unchecked((uint)(a * b));
         }
 
         public static ulong MultiplyNullableULong(ulong a, ulong b)
         {
-            return (ulong)(a * b);
+            return unchecked((ulong)(a * b));
         }
 
         public static ushort MultiplyNullableUShort(ushort a, ushort b)
         {
-            return (ushort)(a * b);
+            return unchecked((ushort)(a * b));
         }
 
         #endregion
@@ -258,7 +258,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableByte")));
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte?)(a * b), f());
+            Assert.Equal(unchecked((byte?)(a * b)), f());
         }
 
         private static void VerifyMultiplyNullableChar(char? a, char? b, bool useInterpreter)
@@ -271,7 +271,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableChar")));
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)(a * b), f());
+            Assert.Equal(unchecked((char?)(a * b)), f());
         }
 
         private static void VerifyMultiplyNullableDecimal(decimal? a, decimal? b, bool useInterpreter)
@@ -334,7 +334,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableInt")));
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a * b, f());
+            Assert.Equal(unchecked(a * b), f());
         }
 
         private static void VerifyMultiplyNullableLong(long? a, long? b, bool useInterpreter)
@@ -347,7 +347,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableLong")));
             Func<long?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a * b, f());
+            Assert.Equal(unchecked(a * b), f());
         }
 
         private static void VerifyMultiplyNullableSByte(sbyte? a, sbyte? b, bool useInterpreter)
@@ -360,7 +360,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableSByte")));
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte?)(a * b), f());
+            Assert.Equal(unchecked((sbyte?)(a * b)), f());
         }
 
         private static void VerifyMultiplyNullableShort(short? a, short? b, bool useInterpreter)
@@ -373,7 +373,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableShort")));
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)(a * b), f());
+            Assert.Equal(unchecked((short?)(a * b)), f());
         }
 
         private static void VerifyMultiplyNullableUInt(uint? a, uint? b, bool useInterpreter)
@@ -386,7 +386,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableUInt")));
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a * b, f());
+            Assert.Equal(unchecked(a * b), f());
         }
 
         private static void VerifyMultiplyNullableULong(ulong? a, ulong? b, bool useInterpreter)
@@ -399,7 +399,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableULong")));
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a * b, f());
+            Assert.Equal(unchecked(a * b), f());
         }
 
         private static void VerifyMultiplyNullableUShort(ushort? a, ushort? b, bool useInterpreter)
@@ -412,7 +412,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedMultiplyNullableTests).GetTypeInfo().GetDeclaredMethod("MultiplyNullableUShort")));
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)(a * b), f());
+            Assert.Equal(unchecked((ushort?)(a * b)), f());
         }
 
         private static void VerifyMultiplyNullableNumber(Number? a, Number? b, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractNullableTests.cs
@@ -186,12 +186,12 @@ namespace System.Linq.Expressions.Tests
 
         public static byte SubtractNullableByte(byte a, byte b)
         {
-            return (byte)(a - b);
+            return unchecked((byte)(a - b));
         }
 
         public static char SubtractNullableChar(char a, char b)
         {
-            return (char)(a - b);
+            return unchecked((char)(a - b));
         }
 
         public static decimal SubtractNullableDecimal(decimal a, decimal b)
@@ -211,37 +211,37 @@ namespace System.Linq.Expressions.Tests
 
         public static int SubtractNullableInt(int a, int b)
         {
-            return (int)(a - b);
+            return unchecked((int)(a - b));
         }
 
         public static long SubtractNullableLong(long a, long b)
         {
-            return (long)(a - b);
+            return unchecked((long)(a - b));
         }
 
         public static sbyte SubtractNullableSByte(sbyte a, sbyte b)
         {
-            return (sbyte)(a - b);
+            return unchecked((sbyte)(a - b));
         }
 
         public static short SubtractNullableShort(short a, short b)
         {
-            return (short)(a - b);
+            return unchecked((short)(a - b));
         }
 
         public static uint SubtractNullableUInt(uint a, uint b)
         {
-            return (uint)(a - b);
+            return unchecked((uint)(a - b));
         }
 
         public static ulong SubtractNullableULong(ulong a, ulong b)
         {
-            return (ulong)(a - b);
+            return unchecked((ulong)(a - b));
         }
 
         public static ushort SubtractNullableUShort(ushort a, ushort b)
         {
-            return (ushort)(a - b);
+            return unchecked((ushort)(a - b));
         }
 
         #endregion
@@ -258,7 +258,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableByte")));
             Func<byte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((byte?)(a - b), f());
+            Assert.Equal(unchecked((byte?)(a - b)), f());
         }
 
         private static void VerifySubtractNullableChar(char? a, char? b, bool useInterpreter)
@@ -271,7 +271,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableChar")));
             Func<char?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((char?)(a - b), f());
+            Assert.Equal(unchecked((char?)(a - b)), f());
         }
 
         private static void VerifySubtractNullableDecimal(decimal? a, decimal? b, bool useInterpreter)
@@ -334,7 +334,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableInt")));
             Func<int?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a - b, f());
+            Assert.Equal(unchecked(a - b), f());
         }
 
         private static void VerifySubtractNullableLong(long? a, long? b, bool useInterpreter)
@@ -347,7 +347,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableLong")));
             Func<long?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a - b, f());
+            Assert.Equal(unchecked(a - b), f());
         }
 
         private static void VerifySubtractNullableSByte(sbyte? a, sbyte? b, bool useInterpreter)
@@ -360,7 +360,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableSByte")));
             Func<sbyte?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((sbyte?)(a - b), f());
+            Assert.Equal(unchecked((sbyte?)(a - b)), f());
         }
 
         private static void VerifySubtractNullableShort(short? a, short? b, bool useInterpreter)
@@ -373,7 +373,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableShort")));
             Func<short?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((short?)(a - b), f());
+            Assert.Equal(unchecked((short?)(a - b)), f());
         }
 
         private static void VerifySubtractNullableUInt(uint? a, uint? b, bool useInterpreter)
@@ -386,7 +386,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableUInt")));
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a - b, f());
+            Assert.Equal(unchecked(a - b), f());
         }
 
         private static void VerifySubtractNullableULong(ulong? a, ulong? b, bool useInterpreter)
@@ -399,7 +399,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableULong")));
             Func<ulong?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(a - b, f());
+            Assert.Equal(unchecked(a - b), f());
         }
 
         private static void VerifySubtractNullableUShort(ushort? a, ushort? b, bool useInterpreter)
@@ -412,7 +412,7 @@ namespace System.Linq.Expressions.Tests
                         typeof(LiftedSubtractNullableTests).GetTypeInfo().GetDeclaredMethod("SubtractNullableUShort")));
             Func<ushort?> f = e.Compile(useInterpreter);
 
-            Assert.Equal((ushort?)(a - b), f());
+            Assert.Equal(unchecked((ushort?)(a - b)), f());
         }
 
         private static void VerifySubtractNullableNumber(Number? a, Number? b, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -110,7 +110,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void CheckedExpressions()
         {
-            Expression<Func<int, int, int>> exp = (a, b) => a + b;
+            Expression<Func<int, int, int>> exp = (a, b) => unchecked(a + b);
             BinaryExpression bex = exp.Body as BinaryExpression;
             Assert.NotNull(bex);
             Assert.Equal(bex.NodeType, ExpressionType.Add);
@@ -120,7 +120,7 @@ namespace System.Linq.Expressions.Tests
             Assert.NotNull(bex);
             Assert.Equal(bex.NodeType, ExpressionType.AddChecked);
 
-            exp = (a, b) => a * b;
+            exp = (a, b) => unchecked(a * b);
             bex = exp.Body as BinaryExpression;
             Assert.NotNull(bex);
             Assert.Equal(bex.NodeType, ExpressionType.Multiply);
@@ -130,7 +130,7 @@ namespace System.Linq.Expressions.Tests
             Assert.NotNull(bex);
             Assert.Equal(bex.NodeType, ExpressionType.MultiplyChecked);
 
-            Expression<Func<double, int>> exp2 = (a) => (int)a;
+            Expression<Func<double, int>> exp2 = (a) => unchecked((int)a);
             UnaryExpression uex = exp2.Body as UnaryExpression;
             Assert.NotNull(uex);
             Assert.Equal(uex.NodeType, ExpressionType.Convert);
@@ -2780,7 +2780,8 @@ namespace System.Linq.Expressions.Tests
         [ClassData(typeof(CompilationTypes))]
         public static void TestConvertToNullable(bool useInterpreter)
         {
-            Expression<Func<int, int?>> f = x => (int?)x;
+            // Using an unchecked cast to ensure that a Convert expression is used (and not ConvertChecked)
+            Expression<Func<int, int?>> f = x => unchecked((int?)x);
             Assert.Equal(f.Body.NodeType, ExpressionType.Convert);
             Func<int, int?> d = f.Compile(useInterpreter);
             Assert.Equal(2, d(2));

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/IncDecAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/IncDecAssignTests.cs
@@ -31,12 +31,12 @@ namespace System.Linq.Expressions.Tests
 
         public static IEnumerable<object[]> Int16sAndDecrements()
         {
-            return Int16s.Select(i => new object[] { typeof(short), i, (short)(i - 1) });
+            return Int16s.Select(i => new object[] { typeof(short), i, unchecked((short)(i - 1)) });
         }
 
         public static IEnumerable<object[]> Int16sAndIncrements()
         {
-            return Int16s.Select(i => new object[] { typeof(short), i, (short)(i + 1) });
+            return Int16s.Select(i => new object[] { typeof(short), i, unchecked((short)(i + 1)) });
         }
 
         public static IEnumerable<short?> NullableInt16s
@@ -46,12 +46,12 @@ namespace System.Linq.Expressions.Tests
 
         public static IEnumerable<object[]> NullableInt16sAndDecrements()
         {
-            return NullableInt16s.Select(i => new object[] { typeof(short?), i, (short?)(i - 1) });
+            return NullableInt16s.Select(i => new object[] { typeof(short?), i, unchecked((short?)(i - 1)) });
         }
 
         public static IEnumerable<object[]> NullableInt16sAndIncrements()
         {
-            return NullableInt16s.Select(i => new object[] { typeof(short?), i, (short?)(i + 1) });
+            return NullableInt16s.Select(i => new object[] { typeof(short?), i, unchecked((short?)(i + 1)) });
         }
 
         public static IEnumerable<ushort> UInt16s
@@ -64,12 +64,12 @@ namespace System.Linq.Expressions.Tests
 
         public static IEnumerable<object[]> UInt16sAndDecrements()
         {
-            return UInt16s.Select(i => new object[] { typeof(ushort), i, (ushort)(i - 1) });
+            return UInt16s.Select(i => new object[] { typeof(ushort), i, unchecked((ushort)(i - 1)) });
         }
 
         public static IEnumerable<object[]> UInt16sAndIncrements()
         {
-            return UInt16s.Select(i => new object[] { typeof(ushort), i, (ushort)(i + 1) });
+            return UInt16s.Select(i => new object[] { typeof(ushort), i, unchecked((ushort)(i + 1)) });
         }
 
         public static IEnumerable<ushort?> NullableUInt16s
@@ -79,12 +79,12 @@ namespace System.Linq.Expressions.Tests
 
         public static IEnumerable<object[]> NullableUInt16sAndDecrements()
         {
-            return NullableUInt16s.Select(i => new object[] { typeof(ushort?), i, (ushort?)(i - 1) });
+            return NullableUInt16s.Select(i => new object[] { typeof(ushort?), i, unchecked((ushort?)(i - 1)) });
         }
 
         public static IEnumerable<object[]> NullableUInt16sAndIncrements()
         {
-            return NullableUInt16s.Select(i => new object[] { typeof(ushort?), i, (ushort?)(i + 1) });
+            return NullableUInt16s.Select(i => new object[] { typeof(ushort?), i, unchecked((ushort?)(i + 1)) });
         }
 
         public static IEnumerable<int> Int32s
@@ -97,12 +97,12 @@ namespace System.Linq.Expressions.Tests
 
         public static IEnumerable<object[]> Int32sAndDecrements()
         {
-            return Int32s.Select(i => new object[] { typeof(int), i, i - 1 });
+            return Int32s.Select(i => new object[] { typeof(int), i, unchecked(i - 1) });
         }
 
         public static IEnumerable<object[]> Int32sAndIncrements()
         {
-            return Int32s.Select(i => new object[] { typeof(int), i, i + 1 });
+            return Int32s.Select(i => new object[] { typeof(int), i, unchecked(i + 1) });
         }
 
         public static IEnumerable<int?> NullableInt32s
@@ -112,12 +112,12 @@ namespace System.Linq.Expressions.Tests
 
         public static IEnumerable<object[]> NullableInt32sAndDecrements()
         {
-            return NullableInt32s.Select(i => new object[] { typeof(int?), i, i - 1 });
+            return NullableInt32s.Select(i => new object[] { typeof(int?), i, unchecked(i - 1) });
         }
 
         public static IEnumerable<object[]> NullableInt32sAndIncrements()
         {
-            return NullableInt32s.Select(i => new object[] { typeof(int?), i, i + 1 });
+            return NullableInt32s.Select(i => new object[] { typeof(int?), i, unchecked(i + 1) });
         }
 
         public static IEnumerable<uint> UInt32s
@@ -130,12 +130,12 @@ namespace System.Linq.Expressions.Tests
 
         public static IEnumerable<object[]> UInt32sAndDecrements()
         {
-            return UInt32s.Select(i => new object[] { typeof(uint), i, i - 1 });
+            return UInt32s.Select(i => new object[] { typeof(uint), i, unchecked(i - 1) });
         }
 
         public static IEnumerable<object[]> UInt32sAndIncrements()
         {
-            return UInt32s.Select(i => new object[] { typeof(uint), i, i + 1 });
+            return UInt32s.Select(i => new object[] { typeof(uint), i, unchecked(i + 1) });
         }
 
         public static IEnumerable<uint?> NullableUInt32s
@@ -145,12 +145,12 @@ namespace System.Linq.Expressions.Tests
 
         public static IEnumerable<object[]> NullableUInt32sAndDecrements()
         {
-            return NullableUInt32s.Select(i => new object[] { typeof(uint?), i, i - 1 });
+            return NullableUInt32s.Select(i => new object[] { typeof(uint?), i, unchecked(i - 1) });
         }
 
         public static IEnumerable<object[]> NullableUInt32sAndIncrements()
         {
-            return NullableUInt32s.Select(i => new object[] { typeof(uint?), i, i + 1 });
+            return NullableUInt32s.Select(i => new object[] { typeof(uint?), i, unchecked(i + 1) });
         }
 
         public static IEnumerable<long> Int64s
@@ -163,12 +163,12 @@ namespace System.Linq.Expressions.Tests
 
         public static IEnumerable<object[]> Int64sAndDecrements()
         {
-            return Int64s.Select(i => new object[] { typeof(long), i, i - 1 });
+            return Int64s.Select(i => new object[] { typeof(long), i, unchecked(i - 1) });
         }
 
         public static IEnumerable<object[]> Int64sAndIncrements()
         {
-            return Int64s.Select(i => new object[] { typeof(long), i, i + 1 });
+            return Int64s.Select(i => new object[] { typeof(long), i, unchecked(i + 1) });
         }
 
         public static IEnumerable<long?> NullableInt64s
@@ -178,12 +178,12 @@ namespace System.Linq.Expressions.Tests
 
         public static IEnumerable<object[]> NullableInt64sAndDecrements()
         {
-            return NullableInt64s.Select(i => new object[] { typeof(long?), i, i - 1 });
+            return NullableInt64s.Select(i => new object[] { typeof(long?), i, unchecked(i - 1) });
         }
 
         public static IEnumerable<object[]> NullableInt64sAndIncrements()
         {
-            return NullableInt64s.Select(i => new object[] { typeof(long?), i, i + 1 });
+            return NullableInt64s.Select(i => new object[] { typeof(long?), i, unchecked(i + 1) });
         }
 
         public static IEnumerable<ulong> UInt64s
@@ -196,12 +196,12 @@ namespace System.Linq.Expressions.Tests
 
         public static IEnumerable<object[]> UInt64sAndDecrements()
         {
-            return UInt64s.Select(i => new object[] { typeof(ulong), i, i - 1 });
+            return UInt64s.Select(i => new object[] { typeof(ulong), i, unchecked(i - 1) });
         }
 
         public static IEnumerable<object[]> UInt64sAndIncrements()
         {
-            return UInt64s.Select(i => new object[] { typeof(ulong), i, i + 1 });
+            return UInt64s.Select(i => new object[] { typeof(ulong), i, unchecked(i + 1) });
         }
 
         public static IEnumerable<ulong?> NullableUInt64s
@@ -211,12 +211,12 @@ namespace System.Linq.Expressions.Tests
 
         public static IEnumerable<object[]> NullableUInt64sAndDecrements()
         {
-            return NullableUInt64s.Select(i => new object[] { typeof(ulong?), i, i - 1 });
+            return NullableUInt64s.Select(i => new object[] { typeof(ulong?), i, unchecked(i - 1) });
         }
 
         public static IEnumerable<object[]> NullableUInt64sAndIncrements()
         {
-            return NullableUInt64s.Select(i => new object[] { typeof(ulong?), i, i + 1 });
+            return NullableUInt64s.Select(i => new object[] { typeof(ulong?), i, unchecked(i + 1) });
         }
 
         public static IEnumerable<decimal> Decimals

--- a/src/System.Linq.Expressions/tests/Unary/IncrementDecrementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncrementDecrementTests.cs
@@ -17,7 +17,7 @@ namespace System.Linq.Expressions.Tests
 
             public int Value { get; }
 
-            public static Decrementable operator --(Decrementable operand) => new Decrementable(operand.Value - 1);
+            public static Decrementable operator --(Decrementable operand) => new Decrementable(unchecked(operand.Value - 1));
         }
 
         public struct Incrementable
@@ -29,16 +29,16 @@ namespace System.Linq.Expressions.Tests
 
             public int Value { get; }
 
-            public static Incrementable operator ++(Incrementable operand) => new Incrementable(operand.Value + 1);
+            public static Incrementable operator ++(Incrementable operand) => new Incrementable(unchecked(operand.Value + 1));
         }
 
-        public static Incrementable DoublyIncrement(Incrementable operand) => new Incrementable(operand.Value + 2);
+        public static Incrementable DoublyIncrement(Incrementable operand) => new Incrementable(unchecked(operand.Value + 2));
 
-        public static int DoublyIncrementInt32(int operand) => operand + 2;
+        public static int DoublyIncrementInt32(int operand) => unchecked(operand + 2);
 
-        public static Decrementable DoublyDecrement(Decrementable operand) => new Decrementable(operand.Value - 2);
+        public static Decrementable DoublyDecrement(Decrementable operand) => new Decrementable(unchecked(operand.Value - 2));
 
-        public static int DoublyDecrementInt32(int operand) => operand - 2;
+        public static int DoublyDecrementInt32(int operand) => unchecked(operand - 2);
 
         protected static IEnumerable<object[]> NonArithmeticObjects(bool includeReferenceTypes)
         {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableTests.cs
@@ -151,7 +151,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Negate(Expression.Constant(value, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
-            Assert.Equal((int?)(-value), f());
+            Assert.Equal(unchecked((int?)(-value)), f());
         }
 
         private static void VerifyArithmeticNegateNullableLong(long? value, bool useInterpreter)
@@ -161,7 +161,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Negate(Expression.Constant(value, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<long?> f = e.Compile(useInterpreter);
-            Assert.Equal((long?)(-value), f());
+            Assert.Equal(unchecked((long?)(-value)), f());
         }
 
         private static void VerifyArithmeticNegateNullableSByte(sbyte? value, bool useInterpreter)
@@ -176,7 +176,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Negate(Expression.Constant(value, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
-            Assert.Equal((short?)(-value), f());
+            Assert.Equal(unchecked((short?)(-value)), f());
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
@@ -158,7 +158,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Negate(Expression.Constant(value, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile(useInterpreter);
-            Assert.Equal((int)(-value), f());
+            Assert.Equal(unchecked((int)(-value)), f());
         }
 
         private static void VerifyArithmeticNegateLong(long value, bool useInterpreter)
@@ -168,7 +168,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Negate(Expression.Constant(value, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
             Func<long> f = e.Compile(useInterpreter);
-            Assert.Equal((long)(-value), f());
+            Assert.Equal(unchecked((long)(-value)), f());
         }
 
         private static void VerifyArithmeticNegateSByte(sbyte value)
@@ -183,7 +183,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Negate(Expression.Constant(value, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
             Func<short> f = e.Compile(useInterpreter);
-            Assert.Equal((short)(-value), f());
+            Assert.Equal(unchecked((short)(-value)), f());
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotNullableTests.cs
@@ -121,7 +121,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Not(Expression.Constant(value, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
-            Assert.Equal((byte?)(~value), f());
+            Assert.Equal(unchecked((byte?)(~value)), f());
         }
 
         private static void VerifyBitwiseNotNullableInt(int? value, bool useInterpreter)
@@ -191,7 +191,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Not(Expression.Constant(value, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
-            Assert.Equal((ushort?)(~value), f());
+            Assert.Equal(unchecked((ushort?)(~value)), f());
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotTests.cs
@@ -128,7 +128,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Not(Expression.Constant(value, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
             Func<byte> f = e.Compile(useInterpreter);
-            Assert.Equal((byte)(~value), f());
+            Assert.Equal(unchecked((byte)(~value)), f());
         }
 
         private static void VerifyBitwiseNotInt(int value, bool useInterpreter)
@@ -198,7 +198,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Not(Expression.Constant(value, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort> f = e.Compile(useInterpreter);
-            Assert.Equal((ushort)(~value), f());
+            Assert.Equal(unchecked((ushort)(~value)), f());
         }
 
         #endregion

--- a/src/System.Linq.Expressions/tests/Unary/UnaryDecrementNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryDecrementNullableTests.cs
@@ -23,7 +23,7 @@ namespace System.Linq.Expressions.Tests
             {
                 if (operand.HasValue)
                 {
-                    int dec = operand.GetValueOrDefault().Value - 1;
+                    int dec = unchecked(operand.GetValueOrDefault().Value - 1);
                     if (dec == 0)
                     {
                         return null;
@@ -180,7 +180,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Decrement(Expression.Constant(value, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
-            Assert.Equal((short?)(--value), f());
+            Assert.Equal(unchecked((short?)(--value)), f());
         }
 
         private static void VerifyDecrementNullableUShort(ushort? value, bool useInterpreter)
@@ -190,7 +190,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Decrement(Expression.Constant(value, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
-            Assert.Equal((ushort?)(--value), f());
+            Assert.Equal(unchecked((ushort?)(--value)), f());
         }
 
         private static void VerifyDecrementNullableInt(int? value, bool useInterpreter)
@@ -200,7 +200,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Decrement(Expression.Constant(value, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
-            Assert.Equal((int?)(--value), f());
+            Assert.Equal(unchecked((int?)(--value)), f());
         }
 
         private static void VerifyDecrementNullableUInt(uint? value, bool useInterpreter)
@@ -210,7 +210,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Decrement(Expression.Constant(value, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
-            Assert.Equal((uint?)(--value), f());
+            Assert.Equal(unchecked((uint?)(--value)), f());
         }
 
         private static void VerifyDecrementNullableLong(long? value, bool useInterpreter)
@@ -220,7 +220,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Decrement(Expression.Constant(value, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<long?> f = e.Compile(useInterpreter);
-            Assert.Equal((long?)(--value), f());
+            Assert.Equal(unchecked((long?)(--value)), f());
         }
 
         private static void VerifyDecrementNullableULong(ulong? value, bool useInterpreter)
@@ -230,7 +230,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Decrement(Expression.Constant(value, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
-            Assert.Equal((ulong?)(--value), f());
+            Assert.Equal(unchecked((ulong?)(--value)), f());
         }
 
         private static void VerifyDecrementNullableFloat(float? value, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/Unary/UnaryDecrementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryDecrementTests.cs
@@ -157,7 +157,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Decrement(Expression.Constant(value, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
             Func<short> f = e.Compile(useInterpreter);
-            Assert.Equal((short)(--value), f());
+            Assert.Equal(unchecked((short)(--value)), f());
         }
 
         private static void VerifyDecrementUShort(ushort value, bool useInterpreter)
@@ -167,7 +167,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Decrement(Expression.Constant(value, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort> f = e.Compile(useInterpreter);
-            Assert.Equal((ushort)(--value), f());
+            Assert.Equal(unchecked((ushort)(--value)), f());
         }
 
         private static void VerifyDecrementInt(int value, bool useInterpreter)
@@ -177,7 +177,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Decrement(Expression.Constant(value, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile(useInterpreter);
-            Assert.Equal((int)(--value), f());
+            Assert.Equal(unchecked((int)(--value)), f());
         }
 
         private static void VerifyDecrementIntMakeUnary(int value, bool useInterpreter)
@@ -187,7 +187,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.MakeUnary(ExpressionType.Decrement, Expression.Constant(value), null),
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile(useInterpreter);
-            Assert.Equal(--value, f());
+            Assert.Equal(unchecked(--value), f());
         }
 
         private static void VerifyDecrementUInt(uint value, bool useInterpreter)
@@ -197,7 +197,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Decrement(Expression.Constant(value, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
             Func<uint> f = e.Compile(useInterpreter);
-            Assert.Equal((uint)(--value), f());
+            Assert.Equal(unchecked((uint)(--value)), f());
         }
 
         private static void VerifyDecrementLong(long value, bool useInterpreter)
@@ -207,7 +207,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Decrement(Expression.Constant(value, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
             Func<long> f = e.Compile(useInterpreter);
-            Assert.Equal((long)(--value), f());
+            Assert.Equal(unchecked((long)(--value)), f());
         }
 
         private static void VerifyDecrementULong(ulong value, bool useInterpreter)
@@ -217,7 +217,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Decrement(Expression.Constant(value, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong> f = e.Compile(useInterpreter);
-            Assert.Equal((ulong)(--value), f());
+            Assert.Equal(unchecked((ulong)(--value)), f());
         }
 
         private static void VerifyDecrementFloat(float value, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIncrementNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIncrementNullableTests.cs
@@ -23,7 +23,7 @@ namespace System.Linq.Expressions.Tests
             {
                 if (operand.HasValue)
                 {
-                    int dec = operand.GetValueOrDefault().Value + 1;
+                    int dec = unchecked(operand.GetValueOrDefault().Value + 1);
                     if (dec == 0)
                     {
                         return null;
@@ -180,7 +180,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Increment(Expression.Constant(value, typeof(short?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<short?> f = e.Compile(useInterpreter);
-            Assert.Equal((short?)(++value), f());
+            Assert.Equal(unchecked((short?)(++value)), f());
         }
 
         private static void VerifyIncrementNullableUShort(ushort? value, bool useInterpreter)
@@ -190,7 +190,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Increment(Expression.Constant(value, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
-            Assert.Equal((ushort?)(++value), f());
+            Assert.Equal(unchecked((ushort?)(++value)), f());
         }
 
         private static void VerifyIncrementNullableInt(int? value, bool useInterpreter)
@@ -200,7 +200,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Increment(Expression.Constant(value, typeof(int?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<int?> f = e.Compile(useInterpreter);
-            Assert.Equal((int?)(++value), f());
+            Assert.Equal(unchecked((int?)(++value)), f());
         }
 
         private static void VerifyIncrementNullableUInt(uint? value, bool useInterpreter)
@@ -210,7 +210,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Increment(Expression.Constant(value, typeof(uint?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
-            Assert.Equal((uint?)(++value), f());
+            Assert.Equal(unchecked((uint?)(++value)), f());
         }
 
         private static void VerifyIncrementNullableLong(long? value, bool useInterpreter)
@@ -220,7 +220,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Increment(Expression.Constant(value, typeof(long?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<long?> f = e.Compile(useInterpreter);
-            Assert.Equal((long?)(++value), f());
+            Assert.Equal(unchecked((long?)(++value)), f());
         }
 
         private static void VerifyIncrementNullableULong(ulong? value, bool useInterpreter)
@@ -230,7 +230,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Increment(Expression.Constant(value, typeof(ulong?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong?> f = e.Compile(useInterpreter);
-            Assert.Equal((ulong?)(++value), f());
+            Assert.Equal(unchecked((ulong?)(++value)), f());
         }
 
         private static void VerifyIncrementNullableFloat(float? value, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIncrementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIncrementTests.cs
@@ -157,7 +157,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Increment(Expression.Constant(value, typeof(short))),
                     Enumerable.Empty<ParameterExpression>());
             Func<short> f = e.Compile(useInterpreter);
-            Assert.Equal((short)(++value), f());
+            Assert.Equal(unchecked((short)(++value)), f());
         }
 
         private static void VerifyIncrementUShort(ushort value, bool useInterpreter)
@@ -167,7 +167,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Increment(Expression.Constant(value, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort> f = e.Compile(useInterpreter);
-            Assert.Equal((ushort)(++value), f());
+            Assert.Equal(unchecked((ushort)(++value)), f());
         }
 
         private static void VerifyIncrementInt(int value, bool useInterpreter)
@@ -177,7 +177,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Increment(Expression.Constant(value, typeof(int))),
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile(useInterpreter);
-            Assert.Equal((int)(++value), f());
+            Assert.Equal(unchecked((int)(++value)), f());
         }
 
         private static void VerifyIncrementIntMakeUnary(int value, bool useInterpreter)
@@ -187,7 +187,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.MakeUnary(ExpressionType.Increment, Expression.Constant(value), null),
                     Enumerable.Empty<ParameterExpression>());
             Func<int> f = e.Compile(useInterpreter);
-            Assert.Equal(++value, f());
+            Assert.Equal(unchecked(++value), f());
         }
         private static void VerifyIncrementUInt(uint value, bool useInterpreter)
         {
@@ -196,7 +196,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Increment(Expression.Constant(value, typeof(uint))),
                     Enumerable.Empty<ParameterExpression>());
             Func<uint> f = e.Compile(useInterpreter);
-            Assert.Equal((uint)(++value), f());
+            Assert.Equal(unchecked((uint)(++value)), f());
         }
 
         private static void VerifyIncrementLong(long value, bool useInterpreter)
@@ -206,7 +206,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Increment(Expression.Constant(value, typeof(long))),
                     Enumerable.Empty<ParameterExpression>());
             Func<long> f = e.Compile(useInterpreter);
-            Assert.Equal((long)(++value), f());
+            Assert.Equal(unchecked((long)(++value)), f());
         }
 
         private static void VerifyIncrementULong(ulong value, bool useInterpreter)
@@ -216,7 +216,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.Increment(Expression.Constant(value, typeof(ulong))),
                     Enumerable.Empty<ParameterExpression>());
             Func<ulong> f = e.Compile(useInterpreter);
-            Assert.Equal((ulong)(++value), f());
+            Assert.Equal(unchecked((ulong)(++value)), f());
         }
 
         private static void VerifyIncrementFloat(float value, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementNullableTests.cs
@@ -111,7 +111,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.OnesComplement(Expression.Constant(value, typeof(ushort?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort?> f = e.Compile(useInterpreter);
-            Assert.Equal((ushort?)(~value), f());
+            Assert.Equal(unchecked((ushort?)(~value)), f());
         }
 
         private static void VerifyArithmeticOnesComplementNullableInt(int? value, bool useInterpreter)
@@ -161,7 +161,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.OnesComplement(Expression.Constant(value, typeof(byte?))),
                     Enumerable.Empty<ParameterExpression>());
             Func<byte?> f = e.Compile(useInterpreter);
-            Assert.Equal((byte?)(~value), f());
+            Assert.Equal(unchecked((byte?)(~value)), f());
         }
 
         private static void VerifyArithmeticOnesComplementNullableSByte(sbyte? value, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementTests.cs
@@ -120,7 +120,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.OnesComplement(Expression.Constant(value, typeof(ushort))),
                     Enumerable.Empty<ParameterExpression>());
             Func<ushort> f = e.Compile(useInterpreter);
-            Assert.Equal((ushort)(~value), f());
+            Assert.Equal(unchecked((ushort)(~value)), f());
         }
 
         private static void VerifyArithmeticOnesComplementInt(int value, bool useInterpreter)
@@ -170,7 +170,7 @@ namespace System.Linq.Expressions.Tests
                     Expression.OnesComplement(Expression.Constant(value, typeof(byte))),
                     Enumerable.Empty<ParameterExpression>());
             Func<byte> f = e.Compile(useInterpreter);
-            Assert.Equal((byte)(~value), f());
+            Assert.Equal(unchecked((byte)(~value)), f());
         }
 
         private static void VerifyArithmeticOnesComplementSByte(sbyte value, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/Unary/UnaryQuoteTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryQuoteTests.cs
@@ -104,7 +104,8 @@ namespace System.Linq.Expressions.Tests
         [Theory, ClassData(typeof(CompilationTypes))]
         public void Quote_Lambda_Closure2(bool useInterpreter)
         {
-            Expression<Func<int, Func<int, LambdaExpression>>> f = x => y => GetQuote<Func<int>>(() => x + y);
+            // Using an unchecked addition to ensure that an Add expression is used (and not AddChecked)
+            Expression<Func<int, Func<int, LambdaExpression>>> f = x => y => GetQuote<Func<int>>(() => unchecked(x + y));
 
             var quote = f.Compile(useInterpreter)(1)(2);
 


### PR DESCRIPTION
Marking code that may intentionally lead to over or underflows with
unchecked in preparation of turning on CheckForOverflowUnderflow for
all projects (issue #3140)
NOTE: Commit contains only tests for System.Linq.Expressions