### PR TITLE
Remove two iterators from Concat

### DIFF
--- a/src/Common/src/System/Collections/Generic/ArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/ArrayBuilder.cs
@@ -75,6 +75,24 @@ namespace System.Collections.Generic
         }
 
         /// <summary>
+        /// Gets the first item in this builder.
+        /// </summary>
+        public T First()
+        {
+            Debug.Assert(_count > 0);
+            return _array[0];
+        }
+
+        /// <summary>
+        /// Gets the last item in this builder.
+        /// </summary>
+        public T Last()
+        {
+            Debug.Assert(_count > 0);
+            return _array[_count - 1];
+        }
+
+        /// <summary>
         /// Creates an array from the contents of this builder.
         /// </summary>
         /// <remarks>

--- a/src/Common/src/System/Collections/Generic/SparseArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/SparseArrayBuilder.cs
@@ -176,6 +176,33 @@ namespace System.Collections.Generic
         }
 
         /// <summary>
+        /// Reserves a region if the items' count can be predetermined; otherwise, adds the items to this builder.
+        /// </summary>
+        /// <param name="items">The items to reserve or add.</param>
+        /// <returns><c>true</c> if the items were reserved; otherwise, <c>false</c>.</returns>
+        /// <remarks>
+        /// If the items' count is predetermined to be 0, no reservation is made and the return value is <c>false</c>.
+        /// The effect is the same as if the items were added, since adding an empty collection does nothing.
+        /// </remarks>
+        public bool ReserveOrAdd(IEnumerable<T> items)
+        {
+            int itemCount;
+            if (EnumerableHelpers.TryGetCount(items, out itemCount))
+            {
+                if (itemCount > 0)
+                {
+                    Reserve(itemCount);
+                    return true;
+                }
+            }
+            else
+            {
+                AddRange(items);
+            }
+            return false;
+        }
+
+        /// <summary>
         /// Creates an array from the contents of this builder.
         /// </summary>
         /// <remarks>

--- a/src/Common/tests/Tests/System/Collections/Generic/ArrayBuilderTests.cs
+++ b/src/Common/tests/Tests/System/Collections/Generic/ArrayBuilderTests.cs
@@ -189,10 +189,12 @@ namespace System.Collections.Generic.Tests
             {
                 count++;
                 builder.Add(item);
-                
+
                 Assert.Equal(count, builder.Count);
                 Assert.Equal(CalculateExpectedCapacity(count), builder.Capacity);
                 VerifyBuilderContents(sequence.Take(count), builder);
+                Assert.Equal(sequence.First(), builder.First());
+                Assert.Equal(item, builder.Last());
             }
 
             return builder;

--- a/src/System.Linq/src/System/Linq/Concat.cs
+++ b/src/System.Linq/src/System/Linq/Concat.cs
@@ -33,9 +33,21 @@ namespace System.Linq
         /// <typeparam name="TSource">The type of the source enumerables.</typeparam>
         private sealed class Concat2Iterator<TSource> : ConcatIterator<TSource>
         {
+            /// <summary>
+            /// The first source to concatenate.
+            /// </summary>
             private readonly IEnumerable<TSource> _first;
+
+            /// <summary>
+            /// The second source to concatenate.
+            /// </summary>
             private readonly IEnumerable<TSource> _second;
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Concat2Iterator{TSource}"/> class.
+            /// </summary>
+            /// <param name="first">The first source to concatenate.</param>
+            /// <param name="second">The second source to concatenate.</param>
             internal Concat2Iterator(IEnumerable<TSource> first, IEnumerable<TSource> second)
             {
                 Debug.Assert(first != null);
@@ -134,23 +146,55 @@ namespace System.Linq
         /// </remarks>
         private sealed class ConcatNIterator<TSource> : ConcatIterator<TSource>
         {
+            /// <summary>
+            /// The linked list of previous sources.
+            /// </summary>
             private readonly ConcatNIterator<TSource> _tail;
+            
+            /// <summary>
+            /// The source associated with this iterator.
+            /// </summary>
             private readonly IEnumerable<TSource> _head;
+
+            /// <summary>
+            /// The logical index associated with this iterator.
+            /// </summary>
             private readonly int _headIndex;
 
-            // We employ an optimization where we set a flag if all of the enumerables being concatenated
-            // are ICollections. This allows us to determine in O(1) time whether we can preallocate for
-            // ToArray and ToList, and whether we can get the count of the iterator cheaply.
+            /// <summary>
+            /// <c>true</c> if all sources this iterator concatenates implement <see cref="ICollection{TSource}"/>;
+            /// otherwise, <c>false</c>.
+            /// </summary>
+            /// <remarks>
+            /// This flag allows us to determine in O(1) time whether we can preallocate for <see cref="ToArray"/>
+            /// and <see cref="ToList"/>, and whether we can get the count of the iterator cheaply.
+            /// </remarks>
             private readonly bool _hasOnlyCollections;
 
+            /// <summary>
+            /// Gets the empty <see cref="ConcatNIterator{TSource}"/> from which all other such iterators are created.
+            /// </summary>
             internal static ConcatNIterator<TSource> Empty { get; } = new ConcatNIterator<TSource>();
             
+            /// <summary>
+            /// Creates the empty iterator.
+            /// </summary>
             private ConcatNIterator()
             {
                 _headIndex = -1;
                 _hasOnlyCollections = true;
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ConcatNIterator{TSource}"/> class.
+            /// </summary>
+            /// <param name="tail">The linked list of previous sources.</param>
+            /// <param name="head">The source associated with this iterator.</param>
+            /// <param name="headIndex">The logical index associated with this iterator.</param>
+            /// <param name="hasOnlyCollections">
+            /// <c>true</c> if all sources this iterator concatenates implement <see cref="ICollection{TSource}"/>;
+            /// otherwise, <c>false</c>.
+            /// </param>
             private ConcatNIterator(ConcatNIterator<TSource> tail, IEnumerable<TSource> head, int headIndex, bool hasOnlyCollections)
             {
                 Debug.Assert(tail != null);
@@ -164,6 +208,13 @@ namespace System.Linq
                 _hasOnlyCollections = hasOnlyCollections;
             }
 
+            /// <summary>
+            /// Gets whether this iterator contains no sources.
+            /// </summary>
+            /// <remarks>
+            /// Only one empty iterator should ever exist, so this property is equivalent to a
+            /// reference-equality comparison against <see cref="Empty"/>.
+            /// </remarks>
             private bool IsEmpty
             {
                 get

--- a/src/System.Linq/src/System/Linq/Concat.cs
+++ b/src/System.Linq/src/System/Linq/Concat.cs
@@ -291,7 +291,7 @@ namespace System.Linq
                 Debug.Assert(!_hasOnlyCollections);
 
                 var builder = new SparseArrayBuilder<TSource>(initialize: true);
-                var deferredCopies = new ArrayBuilder<IEnumerable<TSource>>();
+                var deferredCopies = new ArrayBuilder<int>();
 
                 for (int i = 0; ; i++)
                 {
@@ -308,7 +308,7 @@ namespace System.Linq
 
                     if (builder.ReserveOrAdd(source))
                     {
-                        deferredCopies.Add(source);
+                        deferredCopies.Add(i);
                     }
                 }
 
@@ -318,7 +318,7 @@ namespace System.Linq
                 for (int i = 0; i < markers.Count; i++)
                 {
                     Marker marker = markers[i];
-                    IEnumerable<TSource> source = deferredCopies[i];
+                    IEnumerable<TSource> source = GetEnumerable(deferredCopies[i]);
                     EnumerableHelpers.Copy(source, array, marker.Index, marker.Count);
                 }
 

--- a/src/System.Linq/src/System/Linq/SelectMany.cs
+++ b/src/System.Linq/src/System/Linq/SelectMany.cs
@@ -231,18 +231,10 @@ namespace System.Linq
                 {
                     IEnumerable<TResult> enumerable = _selector(element);
 
-                    int count;
-                    if (EnumerableHelpers.TryGetCount(enumerable, out count))
+                    if (builder.ReserveOrAdd(enumerable))
                     {
-                        if (count > 0)
-                        {
-                            builder.Reserve(count);
-                            deferredCopies.Add(enumerable);
-                        }
-                        continue;
+                        deferredCopies.Add(enumerable);
                     }
-
-                    builder.AddRange(enumerable);
                 }
 
                 TResult[] array = builder.ToArray();
@@ -252,7 +244,6 @@ namespace System.Linq
                 {
                     Marker marker = markers[i];
                     IEnumerable<TResult> enumerable = deferredCopies[i];
-
                     EnumerableHelpers.Copy(enumerable, array, marker.Index, marker.Count);
                 }
 


### PR DESCRIPTION
Was part of https://github.com/dotnet/corefx/pull/15389 but moved to another PR. Fixes https://github.com/dotnet/corefx/issues/15942

Changes:

- Remove 2 iterators from `Concat` that specialize for ICollections. Instead of having different iterators, set a flag on the iterator if all inputs so far have been ICollections. This allows us to determine in constant time whether we can get the count cheaply and preallocate for ToArray/ToList.

- This allows us to move the source enumerables into linked list nodes that are of uniform type, `ConcatNIterator<TSource>`. Previously, we had to typecast every time we crossed a node.

- Implement `GetCount` and `ToArray` in the derived classes rather than the base to avoid virtual calls and improve time complexity.
  - Avoid walking the linked list quadratically for `GetCount`, since we don't need to sum the counts in order.
  - Remove unnecessary virtual calls to `GetEnumerable` for 1 Concat followed by `ToArray`.
  - Make 1 Concat followed by `Count` cheap if the both of the concatees' counts can be gotten cheaply.

- Add a `ReserveOrAdd` method to `SparseArrayBuilder` which either reserves space for the enumerable if its count can be predetermined, or eagerly adds it otherwise. This saves quite a few lines of code.

**Performance tests:** <s>[memory leak reduction](https://gist.github.com/jamesqo/c8ccc43c2e9a7b8bb35c6cc6bebeb9ec) / [regressions from this change](https://gist.github.com/jamesqo/bde594c796e2c07117f77e88239a2c40)</s> Need to be updated.

/cc @JonHanna @stephentoub @VSadov 