### PR TITLE
Adds back CodeDom Evidence as additional implementation.

### DIFF
--- a/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerParameters.Evidence.cs
+++ b/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerParameters.Evidence.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Policy;
+
+namespace System.CodeDom.Compiler
+{
+    public partial class CompilerParameters
+    {
+        [NonSerialized]
+        private Evidence _evidence;
+
+        [Obsolete("CAS policy is obsolete and will be removed in a future release of the .NET Framework."
+                + " Please see http://go2.microsoft.com/fwlink/?LinkId=131738 for more information.")]
+        public Evidence Evidence
+        {
+            get { return _evidence?.Clone(); }
+            set { _evidence = value?.Clone(); }
+         }
+    }
+}

--- a/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerParameters.cs
+++ b/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerParameters.cs
@@ -7,7 +7,7 @@ using System.Collections.Specialized;
 namespace System.CodeDom.Compiler
 {
     [Serializable]
-    public class CompilerParameters
+    public partial class CompilerParameters
     {
         private readonly StringCollection _assemblyNames = new StringCollection();
         private readonly StringCollection _embeddedResources = new StringCollection();

--- a/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerResults.Evidence.cs
+++ b/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerResults.Evidence.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Policy;
+
+namespace System.CodeDom.Compiler
+{
+    public partial class CompilerResults
+    {
+    	private Evidence _evidence;
+
+        [Obsolete("CAS policy is obsolete and will be removed in a future release of the .NET Framework. Please see http://go2.microsoft.com/fwlink/?LinkId=131738 for more information.")]
+        public Evidence Evidence
+        {
+            get { return _evidence?.Clone(); }
+            set { _evidence = value?.Clone(); }
+        }
+    }
+}

--- a/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerResults.cs
+++ b/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerResults.cs
@@ -8,7 +8,7 @@ using System.Reflection;
 namespace System.CodeDom.Compiler
 {
     [Serializable]
-    public class CompilerResults
+    public partial class CompilerResults
     {
         private readonly CompilerErrorCollection _errors = new CompilerErrorCollection();
         private readonly StringCollection _output = new StringCollection();


### PR DESCRIPTION
This fixes Mono breakage caused by https://github.com/dotnet/corefx/commit/a929f58f5d98f6800383f97804eb30ef62343eab