### PR TITLE
Remove Redundant Validation from S.L.Expressions Compilation

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -414,12 +414,6 @@
   <data name="TypeNotIEnumerable" xml:space="preserve">
     <value>Type '{0}' is not IEnumerable</value>
   </data>
-  <data name="UnexpectedCoalesceOperator" xml:space="preserve">
-    <value>Unexpected coalesce operator.</value>
-  </data>
-  <data name="InvalidCast" xml:space="preserve">
-    <value>Cannot cast from type '{0}' to type '{1}</value>
-  </data>
   <data name="UnhandledBinary" xml:space="preserve">
     <value>Unhandled binary: {0}</value>
   </data>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -669,10 +669,7 @@ namespace System.Linq.Expressions.Compiler
                 return;
             }
 
-            if (typeFrom == typeof(void) || typeTo == typeof(void))
-            {
-                throw ContractUtils.Unreachable;
-            }
+            Debug.Assert(typeFrom != typeof(void) && typeTo != typeof(void)); // Enforced in GetUserDefinedCoercionOrThrow
 
             bool isTypeFromNullable = typeFrom.IsNullableType();
             bool isTypeToNullable = typeTo.IsNullableType();
@@ -715,25 +712,18 @@ namespace System.Linq.Expressions.Compiler
 
         private static void EmitCastToType(this ILGenerator il, Type typeFrom, Type typeTo)
         {
-            if (!typeFrom.GetTypeInfo().IsValueType && typeTo.GetTypeInfo().IsValueType)
+            if (!typeFrom.GetTypeInfo().IsValueType)
             {
-                il.Emit(OpCodes.Unbox_Any, typeTo);
+                il.Emit(typeTo.GetTypeInfo().IsValueType ? OpCodes.Unbox_Any : OpCodes.Castclass, typeTo);
             }
-            else if (typeFrom.GetTypeInfo().IsValueType && !typeTo.GetTypeInfo().IsValueType)
+            else
             {
+                Debug.Assert(!typeTo.GetTypeInfo().IsValueType); // Enforced in GetUserDefinedCoercionOrThrow
                 il.Emit(OpCodes.Box, typeFrom);
                 if (typeTo != typeof(object))
                 {
                     il.Emit(OpCodes.Castclass, typeTo);
                 }
-            }
-            else if (!typeFrom.GetTypeInfo().IsValueType && !typeTo.GetTypeInfo().IsValueType)
-            {
-                il.Emit(OpCodes.Castclass, typeTo);
-            }
-            else
-            {
-                throw Error.InvalidCast(typeFrom, typeTo);
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -972,14 +972,8 @@ namespace System.Linq.Expressions.Compiler
             else
             {
                 PropertyInfo pi = binding.Member as PropertyInfo;
-                if (pi != null)
-                {
-                    EmitCall(objectType, pi.GetSetMethod(nonPublic: true));
-                }
-                else
-                {
-                    throw Error.UnhandledBinding();
-                }
+                Debug.Assert(pi != null); // Enforced in factory in ValidateSettableFieldOrPropertyMember
+                EmitCall(objectType, pi.GetSetMethod(nonPublic: true));
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
@@ -94,17 +94,17 @@ namespace System.Linq.Expressions.Compiler
             {
                 EmitNullableCoalesce(b);
             }
-            else if (b.Left.Type.GetTypeInfo().IsValueType)
-            {
-                throw Error.CoalesceUsedOnNonNullType();
-            }
-            else if (b.Conversion != null)
-            {
-                EmitLambdaReferenceCoalesce(b);
-            }
             else
             {
-                EmitReferenceCoalesceWithoutConversion(b);
+                Debug.Assert(!b.Left.Type.GetTypeInfo().IsValueType); // Enforced in Coalesce and ValidateCoalesceArgTypes
+                if (b.Conversion != null)
+                {
+                    EmitLambdaReferenceCoalesce(b);
+                }
+                else
+                {
+                    EmitReferenceCoalesceWithoutConversion(b);
+                }
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -930,20 +930,7 @@ namespace System.Linq.Expressions
         {
             return new ArgumentException(Strings.TypeNotIEnumerable(p0), paramName);
         }
-        /// <summary>
-        /// InvalidOperationException with message like "Unexpected coalesce operator."
-        /// </summary>
-        internal static Exception UnexpectedCoalesceOperator()
-        {
-            return new InvalidOperationException(Strings.UnexpectedCoalesceOperator);
-        }
-        /// <summary>
-        /// InvalidOperationException with message like "Cannot cast from type '{0}' to type '{1}"
-        /// </summary>
-        internal static Exception InvalidCast(object p0, object p1)
-        {
-            return new InvalidOperationException(Strings.InvalidCast(p0, p1));
-        }
+
         /// <summary>
         /// ArgumentException with message like "Unhandled binary: {0}"
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -575,16 +575,6 @@ namespace System.Linq.Expressions
         internal static string TypeNotIEnumerable(object p0) => SR.Format(SR.TypeNotIEnumerable, p0);
 
         /// <summary>
-        /// A string like "Unexpected coalesce operator."
-        /// </summary>
-        internal static string UnexpectedCoalesceOperator => SR.UnexpectedCoalesceOperator;
-
-        /// <summary>
-        /// A string like "Cannot cast from type '{0}' to type '{1}"
-        /// </summary>
-        internal static string InvalidCast(object p0, object p1) => SR.Format(SR.InvalidCast, p0, p1);
-
-        /// <summary>
         /// A string like "Unhandled binary: {0}"
         /// </summary>
         internal static string UnhandledBinary(object p0) => SR.Format(SR.UnhandledBinary, p0);


### PR DESCRIPTION
Removing release run-time checks for situations are already caught by validation elsewhere. Replacing with debug assertions with a comment on why the condition should be impossible.

`EmitCastToType` restructured in the course of this to avoid duplicate calls for if-else ladder.