### PR TITLE
Move to using new filtering system for runtime.depproj

### DIFF
--- a/Tools-Override/depProj.targets
+++ b/Tools-Override/depProj.targets
@@ -97,7 +97,7 @@ See the LICENSE file in the project root for more information.
 
   <PropertyGroup>
     <!-- don't use TargetingPackReference, we do our own filtering -->
-    <SkipFilterTargetingPackResolvedNugetPackages Condition="'$(SkipFilterTargetingPackResolvedNugetPackages)'==''">true</SkipFilterTargetingPackResolvedNugetPackages>
+    <SkipFilterTargetingPackResolvedNugetPackages>true</SkipFilterTargetingPackResolvedNugetPackages>
   </PropertyGroup>
   
   <!-- Support filtering to a subset of packages or files -->

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -11,12 +11,11 @@
   <PropertyGroup Condition="'$(TargetGroup)' == 'uapaot'">
     <ProjectJsonTemplate>$(MSBuildThisFileDirectory)NETNative/project.json.template</ProjectJsonTemplate>
     <NuGetDeploySourceItem>Reference</NuGetDeploySourceItem>
-    <SkipFilterTargetingPackResolvedNugetPackages>false</SkipFilterTargetingPackResolvedNugetPackages>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='uapaot'">
-    <TargetingPackReference Include="System.Private.CoreLib" />
-    <TargetingPackReference Include="System.Private.Interop" />
-    <TargetingPackReference Include="System.Private.Threading" />
+    <FileToExclude Include="System.Private.CoreLib.Augments" />
+    <FileToExclude Include="System.Private.CoreLib.DynamicDelegate" />
+    <FileToExclude Include="System.Private.CoreLib.WinRTInterop" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Moving runtime.depproj to use the new filtering mechanism as pointed out in [this comment](https://github.com/dotnet/corefx/pull/15929#discussion_r99965099)

cc: @weshaggard 