### PR TITLE
Add signing to windows native build

### DIFF
--- a/src/sign.builds
+++ b/src/sign.builds
@@ -10,8 +10,20 @@
 
   <UsingTask AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="ReadSigningRequired" />
 
+  <ItemGroup>
+    <WindowsNativeLocation Include="$(NativeBinDir)\clrcompression.dll" />
+    <WindowsNativeLocation Include="$(NativeBinDir)_aot\clrcompression.dll" />
+  </ItemGroup>
+  
+  <Target Name="GenerateSignForWindowsNative">
+    <WriteSigningRequired AuthenticodeSig="$(AuthenticodeSig)"
+                          StrongNameSig="$(null)"
+                          MarkerFile="%(WindowsNativeLocation.Identity).requires_signing" />
+  </Target>
+
   <!-- populates item group FilesToSign with the list of files to sign -->
-  <Target Name="GetFilesToSignItems">
+  <Target Name="GetFilesToSignItems"
+          DependsOnTargets="GenerateSignForWindowsNative">
     <!-- read all of the marker files and populate the FilesToSign item group -->
     <ItemGroup>
       <SignMarkerFile Include="$(OutDir)**\*.requires_signing" />

--- a/src/sign.builds
+++ b/src/sign.builds
@@ -17,7 +17,6 @@
   
   <Target Name="GenerateSignForWindowsNative">
     <WriteSigningRequired AuthenticodeSig="$(AuthenticodeSig)"
-                          StrongNameSig="$(null)"
                           MarkerFile="%(WindowsNativeLocation.Identity).requires_signing" />
   </Target>
 


### PR DESCRIPTION
The clrcompression.dll built in the open isn't getting correctly signed because it is missing a requires_signing file adjacent to the dll. This commit adds a special-case to build that file when building sign.builds for the managed build since the native build never touches that code.
