### PR TITLE
Propagate exception for failing net.http test for better diagnosis.

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
@@ -108,7 +108,11 @@ namespace System.Net.Http.Functional.Tests
 
                 // Verify that the task completes successfully or is canceled.
                 Assert.True(((IAsyncResult)task).AsyncWaitHandle.WaitOne(new TimeSpan(0, 5, 0)));
-                Assert.True(task.Status == TaskStatus.RanToCompletion || task.Status == TaskStatus.Canceled);
+                Assert.True(task.IsCompleted, "Task was not yet completed");
+                if (task.IsFaulted)
+                {
+                    task.GetAwaiter().GetResult();
+                }
             }
         }
 


### PR DESCRIPTION
related to https://github.com/dotnet/corefx/issues/13938

thanks @stephentoub for the idea