### PR TITLE
Pick up new S.P.DataContractSerialization 4.1.2

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/baseline.packages.props
+++ b/pkg/Microsoft.Private.PackageBaseline/baseline.packages.props
@@ -424,7 +424,7 @@
       <Version>4.0.0</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="System.Private.DataContractSerialization">
-      <Version>4.1.1</Version>
+      <Version>4.1.2</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="System.Private.Uri">
       <Version>4.0.1</Version>


### PR DESCRIPTION
This adds a necessary change on top of [PR 14526](https://github.com/dotnet/corefx/pull/14526) to have the updated System.Runtime.Serialization.Json and System.Runtime.Serialization.Xml packages reference the new 4.1.2 version of the System.Private.DataContractSerialization package.

Update the version of System.Private.DataContractSerialization listed as a BaseLinePackage from 4.1.1 to 4.1.2.

~~Mark all of the affected packages as stable.~~ This change was reverted and removed from the PR.