### PR TITLE
Split some composite GC tests into separate tests

### DIFF
--- a/src/System.Runtime/tests/System/GCTests.netstandard.cs
+++ b/src/System.Runtime/tests/System/GCTests.netstandard.cs
@@ -90,35 +90,103 @@ namespace System.Tests
 
         [Fact]
         [OuterLoop]
-        public static void TryStartNoGCRegionNegTest()
+        public static void TryStartNoGCRegionNegTest1()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.TimeOut = TimeoutMilliseconds;
             RemoteInvoke(() =>
                 {
                     Assert.Throws<InvalidOperationException>(() => GC.EndNoGCRegion());
-
-                    Assert.True(GC.TryStartNoGCRegion(1024));
-                    Assert.Throws<InvalidOperationException>(() => GC.TryStartNoGCRegion(1024));
-
-                    Assert.True(GC.TryStartNoGCRegion(1024, true));
-                    Assert.Throws<InvalidOperationException>(() => GC.TryStartNoGCRegion(1024, true));
-
-                    Assert.True(GC.TryStartNoGCRegion(1024, 1024));
-                    Assert.Throws<InvalidOperationException>(() => GC.TryStartNoGCRegion(1024, 1024));
-
-                    Assert.True(GC.TryStartNoGCRegion(1024, 1024, true));
-                    Assert.Throws<InvalidOperationException>(() => GC.TryStartNoGCRegion(1024, 1024, true));
-                    Assert.True(GC.TryStartNoGCRegion(1024, true));
-                    Assert.Equal(GCSettings.LatencyMode, GCLatencyMode.NoGCRegion);
-                    Assert.Throws<InvalidOperationException>(() => GCSettings.LatencyMode = GCLatencyMode.LowLatency);
-
-                    GC.EndNoGCRegion();
-
                     return SuccessExitCode;
-
                 }, options).Dispose();
         }
+
+        [Fact]
+        [OuterLoop]
+        public static void TryStartNoGCRegionNegTest2()
+        {
+            RemoteInvokeOptions options = new RemoteInvokeOptions();
+            options.TimeOut = TimeoutMilliseconds;
+            RemoteInvoke(() =>
+            {
+                Assert.True(GC.TryStartNoGCRegion(1024));
+                Assert.Throws<InvalidOperationException>(() => GC.TryStartNoGCRegion(1024));
+
+                GC.EndNoGCRegion();
+
+                return SuccessExitCode;
+            }, options).Dispose();
+        }
+
+        [Fact]
+        [OuterLoop]
+        public static void TryStartNoGCRegionNegTest3()
+        {
+            RemoteInvokeOptions options = new RemoteInvokeOptions();
+            options.TimeOut = TimeoutMilliseconds;
+            RemoteInvoke(() =>
+            {
+                Assert.True(GC.TryStartNoGCRegion(1024, true));
+                Assert.Throws<InvalidOperationException>(() => GC.TryStartNoGCRegion(1024, true));
+
+                GC.EndNoGCRegion();
+
+                return SuccessExitCode;
+            }, options).Dispose();
+        }
+
+        [Fact]
+        [OuterLoop]
+        public static void TryStartNoGCRegionNegTest4()
+        {
+            RemoteInvokeOptions options = new RemoteInvokeOptions();
+            options.TimeOut = TimeoutMilliseconds;
+            RemoteInvoke(() =>
+            {
+                Assert.True(GC.TryStartNoGCRegion(1024, 1024));
+                Assert.Throws<InvalidOperationException>(() => GC.TryStartNoGCRegion(1024, 1024));
+
+                GC.EndNoGCRegion();
+
+                return SuccessExitCode;
+            }, options).Dispose();
+        }
+
+        [Fact]
+        [OuterLoop]
+        public static void TryStartNoGCRegionNegTest4()
+        {
+            RemoteInvokeOptions options = new RemoteInvokeOptions();
+            options.TimeOut = TimeoutMilliseconds;
+            RemoteInvoke(() =>
+            {
+                Assert.True(GC.TryStartNoGCRegion(1024, 1024, true));
+                Assert.Throws<InvalidOperationException>(() => GC.TryStartNoGCRegion(1024, 1024, true));
+
+                GC.EndNoGCRegion();
+
+                return SuccessExitCode;
+            }, options).Dispose();
+        }
+
+        [Fact]
+        [OuterLoop]
+        public static void TryStartNoGCRegionNegTest5()
+        {
+            RemoteInvokeOptions options = new RemoteInvokeOptions();
+            options.TimeOut = TimeoutMilliseconds;
+            RemoteInvoke(() =>
+            {
+                Assert.True(GC.TryStartNoGCRegion(1024, true));
+                Assert.Equal(GCSettings.LatencyMode, GCLatencyMode.NoGCRegion);
+                Assert.Throws<InvalidOperationException>(() => GCSettings.LatencyMode = GCLatencyMode.LowLatency);
+
+                GC.EndNoGCRegion();
+
+                return SuccessExitCode;
+            }, options).Dispose();
+        }
+
         [Fact]
         [OuterLoop]
         public static void TryStartNoGCRegionPosTest()
@@ -132,21 +200,60 @@ namespace System.Tests
                     Assert.Equal(GCSettings.LatencyMode, GCLatencyMode.NoGCRegion);
                     GC.EndNoGCRegion();
 
-                    Assert.True(GC.TryStartNoGCRegion(1024, true));
-                    Assert.Equal(GCSettings.LatencyMode, GCLatencyMode.NoGCRegion);
-                    GC.EndNoGCRegion();
-
-                    Assert.True(GC.TryStartNoGCRegion(1024, 1024));
-                    Assert.Equal(GCSettings.LatencyMode, GCLatencyMode.NoGCRegion);
-                    GC.EndNoGCRegion();
-
-                    Assert.True(GC.TryStartNoGCRegion(1024, 1024, true));
-                    Assert.Equal(GCSettings.LatencyMode, GCLatencyMode.NoGCRegion);
-                    GC.EndNoGCRegion();
-
                     return SuccessExitCode;
 
                 }, options).Dispose();
+        }
+
+        [Fact]
+        [OuterLoop]
+        public static void TryStartNoGCRegionPosTest2()
+        {
+            RemoteInvokeOptions options = new RemoteInvokeOptions();
+            options.TimeOut = TimeoutMilliseconds;
+            RemoteInvoke(() =>
+            {
+                Assert.True(GC.TryStartNoGCRegion(1024, true));
+                Assert.Equal(GCSettings.LatencyMode, GCLatencyMode.NoGCRegion);
+                GC.EndNoGCRegion();
+
+                return SuccessExitCode;
+
+            }, options).Dispose();
+        }
+
+        [Fact]
+        [OuterLoop]
+        public static void TryStartNoGCRegionPosTest3()
+        {
+            RemoteInvokeOptions options = new RemoteInvokeOptions();
+            options.TimeOut = TimeoutMilliseconds;
+            RemoteInvoke(() =>
+            {
+                Assert.True(GC.TryStartNoGCRegion(1024, 1024));
+                Assert.Equal(GCSettings.LatencyMode, GCLatencyMode.NoGCRegion);
+                GC.EndNoGCRegion();
+
+                return SuccessExitCode;
+
+            }, options).Dispose();
+        }
+
+        [Fact]
+        [OuterLoop]
+        public static void TryStartNoGCRegionPosTest4()
+        {
+            RemoteInvokeOptions options = new RemoteInvokeOptions();
+            options.TimeOut = TimeoutMilliseconds;
+            RemoteInvoke(() =>
+            {
+                Assert.True(GC.TryStartNoGCRegion(1024, 1024, true));
+                Assert.Equal(GCSettings.LatencyMode, GCLatencyMode.NoGCRegion);
+                GC.EndNoGCRegion();
+
+                return SuccessExitCode;
+
+            }, options).Dispose();
         }
 
         public static void TestWait(bool approach, int timeout)

--- a/src/System.Runtime/tests/System/GCTests.netstandard.cs
+++ b/src/System.Runtime/tests/System/GCTests.netstandard.cs
@@ -90,7 +90,7 @@ namespace System.Tests
 
         [Fact]
         [OuterLoop]
-        public static void TryStartNoGCRegionNegTest1()
+        public static void TryStartNoGCRegion_EndNoGCRegion_ThrowsInvalidOperationException()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.TimeOut = TimeoutMilliseconds;
@@ -103,7 +103,7 @@ namespace System.Tests
 
         [Fact]
         [OuterLoop]
-        public static void TryStartNoGCRegionNegTest2()
+        public static void TryStartNoGCRegion_StartWhileInNoGCRegion()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.TimeOut = TimeoutMilliseconds;
@@ -120,7 +120,7 @@ namespace System.Tests
 
         [Fact]
         [OuterLoop]
-        public static void TryStartNoGCRegionNegTest3()
+        public static void TryStartNoGCRegion_StartWhileInNoGCRegion_BlockingCollection()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.TimeOut = TimeoutMilliseconds;
@@ -137,7 +137,7 @@ namespace System.Tests
 
         [Fact]
         [OuterLoop]
-        public static void TryStartNoGCRegionNegTest4()
+        public static void TryStartNoGCRegion_StartWhileInNoGCRegion_LargeObjectHeapSize()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.TimeOut = TimeoutMilliseconds;
@@ -154,7 +154,7 @@ namespace System.Tests
 
         [Fact]
         [OuterLoop]
-        public static void TryStartNoGCRegionNegTest4()
+        public static void TryStartNoGCRegion_StartWhileInNoGCRegion_BlockingCollectionAndLOH()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.TimeOut = TimeoutMilliseconds;
@@ -171,7 +171,7 @@ namespace System.Tests
 
         [Fact]
         [OuterLoop]
-        public static void TryStartNoGCRegionNegTest5()
+        public static void TryStartNoGCRegion_SettingLatencyMode_ThrowsInvalidOperationException()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.TimeOut = TimeoutMilliseconds;
@@ -189,7 +189,7 @@ namespace System.Tests
 
         [Fact]
         [OuterLoop]
-        public static void TryStartNoGCRegionPosTest()
+        public static void TryStartNoGCRegion_SOHSize()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.TimeOut = TimeoutMilliseconds;
@@ -207,7 +207,7 @@ namespace System.Tests
 
         [Fact]
         [OuterLoop]
-        public static void TryStartNoGCRegionPosTest2()
+        public static void TryStartNoGCRegion_SOHSize_BlockingCollection()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.TimeOut = TimeoutMilliseconds;
@@ -224,7 +224,7 @@ namespace System.Tests
 
         [Fact]
         [OuterLoop]
-        public static void TryStartNoGCRegionPosTest3()
+        public static void TryStartNoGCRegion_SOHSize_LOHSize()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.TimeOut = TimeoutMilliseconds;
@@ -241,7 +241,7 @@ namespace System.Tests
 
         [Fact]
         [OuterLoop]
-        public static void TryStartNoGCRegionPosTest4()
+        public static void TryStartNoGCRegion_SOHSize_LOHSize_BlockingCollection()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.TimeOut = TimeoutMilliseconds;


### PR DESCRIPTION
When these tests fail (https://github.com/dotnet/corefx/issues/15158), it's difficult to tell which part of the test failed. This PR splits some of the more composite GC tests into individual facts so that it's clear what exactly went wrong when a test fails.