### PR TITLE
[WIP] Support IsEnabled with addtional arguments #15984

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
@@ -12,13 +12,16 @@ namespace System.Diagnostics {
     public static IObservable<DiagnosticListener> AllListeners { get { throw null; } } 
     public virtual void Dispose() { }
     public override bool IsEnabled(string name) { throw null; }
+    public override bool IsEnabled(string name, object arg1, object arg2) { throw null; }
     public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer) { throw null; }
     public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer, System.Predicate<string> isEnabled) { throw null; }
+    public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer, System.Func<string, object, object, bool> isEnabled) { throw null; }
     public override void Write(string name, object parameters) { }
   }
   public abstract partial class DiagnosticSource {
     protected DiagnosticSource() { }
     public abstract bool IsEnabled(string name);
+    public virtual bool IsEnabled(string name, object arg1, object arg2) { throw null; }
     public abstract void Write(string name, object value);
   }
 }

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
@@ -12,7 +12,7 @@ namespace System.Diagnostics {
     public static IObservable<DiagnosticListener> AllListeners { get { throw null; } } 
     public virtual void Dispose() { }
     public override bool IsEnabled(string name) { throw null; }
-    public override bool IsEnabled(string name, object arg1, object arg2) { throw null; }
+    public override bool IsEnabled(string name, object arg1, object arg2 = null) { throw null; }
     public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer) { throw null; }
     public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer, System.Predicate<string> isEnabled) { throw null; }
     public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer, System.Func<string, object, object, bool> isEnabled) { throw null; }
@@ -21,7 +21,7 @@ namespace System.Diagnostics {
   public abstract partial class DiagnosticSource {
     protected DiagnosticSource() { }
     public abstract bool IsEnabled(string name);
-    public virtual bool IsEnabled(string name, object arg1, object arg2) { throw null; }
+    public virtual bool IsEnabled(string name, object arg1, object arg2 = null) { throw null; }
     public abstract void Write(string name, object value);
   }
 }

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.csproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <Compile Include="System.Diagnostics.DiagnosticSource.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.1'">
-    <Compile Include="System.Diagnostics.DiagnosticSourceActivity.cs" />
+  <ItemGroup Condition="'$(TargetGroup)' != 'netstandard1.1'">
+    <Compile Include="System.Diagnostics.DiagnosticSourceActivity.cs" />        
     <Reference Include="System.Runtime" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md
+++ b/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md
@@ -384,22 +384,22 @@ Producers may call DiagnosticSource.IsEnabled() overloads and supply additional 
 And consumers may use such properties to filter events more precisely.
 
 ```C#
-	// Create a predicate (asks only for Requests for certains URIs)
-	Func<string, object, bool> predicate = (string eventName, object context, object activity) => 
-	{
-		if (eventName == "RequestStart")
-		{
+    // Create a predicate (asks only for Requests for certains URIs)
+    Func<string, object, object, bool> predicate = (string eventName, object context, object activity) => 
+    {
+        if (eventName == "RequestStart")
+        {
 		    HttpRequestMessage request = context as HttpRequestMessage;
 		    if (request != null)
-			{
-				return IsUriEnabled(request.RequestUri);
-			}
-		}
-		return false;
-	}
+            {
+                return IsUriEnabled(request.RequestUri);
+            }
+        }
+        return false;
+    }
 
-	// Subscribe with a filter predicate
-	IDisposable subscription = listener.Subscribe(observer, predicate);
+    // Subscribe with a filter predicate
+    IDisposable subscription = listener.Subscribe(observer, predicate);
 ```
 
 Note that producer is not aware of filter consumer has provided. DiagnosticListener 

--- a/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md
+++ b/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md
@@ -177,11 +177,21 @@ Thus the event names only need to be unique within a component.
 
  * DO - always enclose the Write() call in a call to 'IsEnabled' for the same event name.  Otherwise
    a lot of setup logic will be called even if there is nothing listening for the event.
-
+ 
  * DO NOT - make the DiagnosticListener public.   There is no need to as subscribers will 
   use the AllListener property to hook up. 
+ 
+ * CONSIDER - passing public named types instances to 'IsEnabled' overloads with object parameters
+  to keep IsEnabled as efficient as possible.
 
-----------------------------------------
+ * CONSIDER - enclosing IsEnabled(string, object, object) calls with pure IsEnabled(string) call to avoid
+  extra cost of creating context in case consumer is not interested in such events at all.
+
+ * DO - when subscribing to DiagnosticSource with advanced filter for event name and extended context, 
+  make sure filter returns true for null context properties if consumer is interested
+  in at least some events with context
+
+ ----------------------------------------
 ## Consuming Data with DiagnosticListener. 
 
 Up until now, this guide has focused on how to instrument code to generate logging
@@ -337,8 +347,8 @@ ReflectEmit, but that is beyond the scope of this document.
 #### Filtering 
  
 In the example above the code uses the IObservable.Subscribe to hook up the callback, which
-causes all events to be given to the callback.   However DiagnosticListener has a overload of 
-Subscribe that allows the controller to control which events get through.
+causes all events to be given to the callback.   However DiagnosticListener has a overloads of 
+Subscribe that allow the controller to control which events get through.
 
 Thus we could replace the listener.Subscribe call in the previous example with the following 
 code
@@ -361,6 +371,43 @@ code
 ```
 Which very efficiently only subscribes to the 'RequestStart' events.   All other events will cause the DiagnosticSource.IsEnabled()
 method to return false, and thus be efficiently filtered out.  
+
+##### Context-based Filtering
+Some scenarios require advanced filtering based on extended context. 
+Producers may call DiagnosticSource.IsEnabled() overloads and supply additional event properties.
+
+```C#
+	if (httpLogger.IsEnabled("RequestStart", aRequest, anActivity))
+		httpLogger.Write("RequestStart", new { Url="http://clr", Request=aRequest });
+```
+
+And consumers may use such properties to filter events more precisely.
+
+```C#
+	// Create a predicate (asks only for Requests for certains URIs)
+	Func<string, object, bool> predicate = (string eventName, object context, object activity) => 
+	{
+		if (eventName == "RequestStart")
+		{
+		    HttpRequestMessage request = context as HttpRequestMessage;
+		    if (request != null)
+			{
+				return IsUriEnabled(request.RequestUri);
+			}
+		}
+		return false;
+	}
+
+	// Subscribe with a filter predicate
+	IDisposable subscription = listener.Subscribe(observer, predicate);
+```
+
+Note that producer is not aware of filter consumer has provided. DiagnosticListener 
+will invoke provided filter ommiting additional arguments if necessary, thus the filter
+should expect to receive null context.
+Producers should enclose IsEnabled call with event name and context with pure IsEnabled
+call for event name, so consumers must ensure that filter allows events without context
+to pass through.
 
 ----------------------------------------
 ## Consuming DiagnosticSource Data with with EventListeners and ETW

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
@@ -48,10 +48,15 @@ namespace System.Diagnostics
         /// before doing this setup with context 
         /// </summary>
         /// <param name="name">The name of the event being written.</param>
-        /// <param name="arg1">An object that represents the additional context for IsEnabled</param>
-        /// <param name="arg2">An object that represents the additional context for IsEnabled</param>
+        /// <param name="arg1">An object that represents the additional context for IsEnabled.
+        /// Consumers should expect to receive null which may indicate that producer called pure 
+        /// IsEnabled(string)  to check if consumer wants to get notifications for such events at all. 
+        /// Based on it, producer may call IsEnabled(string, object, object) again with non-null context </param>
+        /// <param name="arg2">Optional. An object that represents the additional context for IsEnabled. 
+        /// Null by default. Consumers shoud expect to receive null which may indicate that producer 
+        /// called pure IsEnabled(string) or producer passed all necessary context in arg1</param>
         /// <seealso cref="IsEnabled(string)"/>
-        public virtual bool IsEnabled(string name, object arg1, object arg2)
+        public virtual bool IsEnabled(string name, object arg1, object arg2 = null)
         {
             return IsEnabled(name);
         }

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
@@ -42,5 +42,19 @@ namespace System.Diagnostics
         /// </summary>
         /// <param name="name">The name of the event being written.</param>
         public abstract bool IsEnabled(string name);
+
+        /// <summary>
+        /// Optional: if there is expensive setup for the notification, you can call IsEnabled
+        /// before doing this setup with context 
+        /// </summary>
+        /// <param name="name">The name of the event being written.</param>
+        /// <param name="arg1">An object that represents the additional context for IsEnabled</param>
+        /// <param name="arg2">An object that represents the additional context for IsEnabled</param>
+        /// <seealso cref="IsEnabled(string)"/>
+        public virtual bool IsEnabled(string name, object arg1, object arg2)
+        {
+            return IsEnabled(name);
+        }
+
     }
 }

--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -143,9 +143,8 @@ namespace System.Diagnostics.Tests
             var child1 = new Activity("child1");
             var child2 = new Activity("child2");
             //start 2 children in different execution contexts
-            var t1 = Task.Run(() => child1.Start());
-            var t2 = Task.Run(() => child2.Start());
-            Task.WhenAll(t1, t2).Wait();
+            Task.Run(() => child1.Start()).Wait();
+            Task.Run(() => child2.Start()).Wait();
 #if DEBUG
             Assert.Equal($"{parent.Id}.{child1.OperationName}_1", child1.Id);
             Assert.Equal($"{parent.Id}.{child2.OperationName}_2", child2.Id);

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
@@ -124,10 +124,43 @@ namespace System.Diagnostics.Tests
                 using (listener.Subscribe(new ObserverToList<TelemData>(result), predicate))
                 {
                     Assert.False(source.IsEnabled("Uninteresting"));
+                    Assert.False(source.IsEnabled("Uninteresting", "arg1", "arg2"));
                     Assert.True(source.IsEnabled("StructPayload"));
-
+                    Assert.True(source.IsEnabled("StructPayload", "arg1", "arg2"));
                     Assert.True(seenUninteresting);
                     Assert.True(seenStructPayload);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Simple tests for the IsEnabled method.
+        /// </summary>
+        [Fact]
+        public void IsEnabledMultipleArgs()
+        {
+            using (DiagnosticListener listener = new DiagnosticListener("Testing"))
+            {
+                DiagnosticSource source = listener;
+                var result = new List<KeyValuePair<string, object>>();
+                Func<string, object, object, bool> isEnabled = (name, arg1, arg2) =>
+                {
+                    if (arg1 != null)
+                        return (bool) arg1;
+                    if (arg2 != null)
+                        return (bool) arg2;
+                    return true;
+                };
+
+                using (listener.Subscribe(new ObserverToList<TelemData>(result), isEnabled))
+                {
+                    Assert.True(source.IsEnabled("event"));
+                    Assert.True(source.IsEnabled("event", null, null));
+                    Assert.True(source.IsEnabled("event", null, true));
+
+                    Assert.False(source.IsEnabled("event", false, false));
+                    Assert.False(source.IsEnabled("event", false, null));
+                    Assert.False(source.IsEnabled("event", null, false));
                 }
             }
         }

--- a/src/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
@@ -16,5 +16,8 @@
     <Compile Include="DiagnosticSourceEventSourceBridgeTests.cs" />
     <Compile Include="DiagnosticSourceTests.cs" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetGroup)' != 'netstandard1.1'">
+    <Compile Include="ActivityTests.cs" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
This change introduces IsEnabled(string, object, object) obverload in DiagnosticSource for advanced events filtering based on additional event context.
It also adds DiagnosticListener.Subscribe overload capable of filtering events based on such context.

See #15984 for more details