### PR TITLE
Allow casts between bool-based enums and bool, checked and unchecked

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -236,12 +236,12 @@ namespace System.Dynamic.Utils
             // Primitive runtime conversions
             // All conversions amongst enum, bool, char, integer and float types
             // (and their corresponding nullable types) are legal except for
-            // nonbool==>bool and nonbool==>bool?
-            // Since we have already covered bool==>bool, bool==>bool?, etc, above,
-            // we can just disallow having a bool or bool? destination type here.
-            if (IsConvertible(source) && IsConvertible(dest) && GetNonNullableType(dest) != typeof(bool))
+            // nonbool==>bool and nonbool==>bool? which are only legal from
+            // bool-backed enums.
+            if (IsConvertible(source) && IsConvertible(dest))
             {
-                return true;
+                return GetNonNullableType(dest) != typeof(bool)
+                       || source.IsEnum && source.GetEnumUnderlyingType() == typeof(bool);
             }
             return false;
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -789,6 +789,14 @@ namespace System.Linq.Expressions.Compiler
             else
             {
                 TypeCode tc = typeTo.GetTypeCode();
+                if (tc == typeFrom.GetTypeCode())
+                {
+                    // Between enums of same underlying type, or between such an enum and the underlying type itself.
+                    // Includes bool-backed enums, which is the only valid conversion to or from bool.
+                    // Just leave the value on the stack, and treat it as the wanted type.
+                    return;
+                }
+
                 if (isChecked)
                 {
                     // Overflow checking needs to know if the source value on the IL stack is unsigned or not.
@@ -894,10 +902,6 @@ namespace System.Linq.Expressions.Compiler
                             {
                                 il.Emit(OpCodes.Conv_I8);
                             }
-                            break;
-                        case TypeCode.Boolean:
-                            il.Emit(OpCodes.Ldc_I4_0);
-                            il.Emit(OpCodes.Cgt_Un);
                             break;
                         default:
                             throw Error.UnhandledConvert(typeTo);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
@@ -225,6 +225,7 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.Single: return (float)obj;
                         case TypeCode.Double: return (double)obj;
                         case TypeCode.Decimal: return (decimal)obj;
+                        case TypeCode.Boolean: return obj != 0;
                         default: throw ContractUtils.Unreachable;
                     }
                 }

--- a/src/System.Linq.Expressions/tests/Cast/CastTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastTests.cs
@@ -2403,12 +2403,35 @@ namespace System.Linq.Expressions.Tests
             Assert.True(func());
         }
 
+        [Theory, PerCompilationType(nameof(EnumerableTypeArgs))]
+        public static void CanCastReferenceToUnderlyingTypeToEnumTypeChecked(Type type, bool useInterpreter)
+        {
+            object value = Activator.CreateInstance(type);
+            Expression<Func<bool>> exp = Expression.Lambda<Func<bool>>(
+                Expression.Equal(
+                    Expression.Default(type),
+                    Expression.ConvertChecked(Expression.Constant(value, typeof(object)), type)));
+            Func<bool> func = exp.Compile(useInterpreter);
+            Assert.True(func());
+        }
+
         [Theory, PerCompilationType(nameof(EnumerableTypesAndIncompatibleObjects))]
         public static void CannotCastReferenceToWrongUnderlyingTypeEnum(Type type, object value, bool useInterpreter)
         {
             Expression<Action> exp = Expression.Lambda<Action>(
                 Expression.Block(
                     Expression.Convert(Expression.Constant(value, typeof(object)), type),
+                    Expression.Empty()));
+            Action act = exp.Compile(useInterpreter);
+            Assert.Throws<InvalidCastException>(act);
+        }
+
+        [Theory, PerCompilationType(nameof(EnumerableTypesAndIncompatibleObjects))]
+        public static void CannotCastReferenceToWrongUnderlyingTypeEnumChecked(Type type, object value, bool useInterpreter)
+        {
+            Expression<Action> exp = Expression.Lambda<Action>(
+                Expression.Block(
+                    Expression.ConvertChecked(Expression.Constant(value, typeof(object)), type),
                     Expression.Empty()));
             Action act = exp.Compile(useInterpreter);
             Assert.Throws<InvalidCastException>(act);
@@ -2427,12 +2450,62 @@ namespace System.Linq.Expressions.Tests
             Assert.True(func());
         }
 
+        [Theory, PerCompilationType(nameof(EnumerableTypeArgs))]
+        public static void CanCastUnderlyingTypeToEnumTypeChecked(Type type, bool useInterpreter)
+        {
+            Type underlying = Enum.GetUnderlyingType(type);
+            object value = Activator.CreateInstance(underlying);
+            Expression<Func<bool>> exp = Expression.Lambda<Func<bool>>(
+                Expression.Equal(
+                    Expression.Default(type),
+                    Expression.ConvertChecked(Expression.Constant(value, underlying), type)));
+            Func<bool> func = exp.Compile(useInterpreter);
+            Assert.True(func());
+        }
+
+        [Theory, PerCompilationType(nameof(EnumerableTypeArgs))]
+        public static void CanCastEnumTypeToUnderlyingType(Type type, bool useInterpreter)
+        {
+            Type underlying = Enum.GetUnderlyingType(type);
+            object value = Activator.CreateInstance(type);
+            Expression<Func<bool>> exp = Expression.Lambda<Func<bool>>(
+                Expression.Equal(
+                    Expression.Default(underlying),
+                    Expression.Convert(Expression.Constant(value, type), underlying)));
+            Func<bool> func = exp.Compile(useInterpreter);
+            Assert.True(func());
+        }
+
+        [Theory, PerCompilationType(nameof(EnumerableTypeArgs))]
+        public static void CanCastEnumTypeToUnderlyingTypeChecked(Type type, bool useInterpreter)
+        {
+            Type underlying = Enum.GetUnderlyingType(type);
+            object value = Activator.CreateInstance(type);
+            Expression<Func<bool>> exp = Expression.Lambda<Func<bool>>(
+                Expression.Equal(
+                    Expression.Default(underlying),
+                    Expression.ConvertChecked(Expression.Constant(value, type), underlying)));
+            Func<bool> func = exp.Compile(useInterpreter);
+            Assert.True(func());
+        }
+
         [Theory, PerCompilationType(nameof(EnumerableTypesAndIncompatibleUnderlyingObjects))]
         public static void CannotCastWrongUnderlyingTypeEnum(Type type, object value, bool useInterpreter)
         {
             Expression<Action> exp = Expression.Lambda<Action>(
                 Expression.Block(
                     Expression.Convert(Expression.Constant(value, typeof(object)), type),
+                    Expression.Empty()));
+            Action act = exp.Compile(useInterpreter);
+            Assert.Throws<InvalidCastException>(act);
+        }
+
+        [Theory, PerCompilationType(nameof(EnumerableTypesAndIncompatibleUnderlyingObjects))]
+        public static void CannotCastWrongUnderlyingTypeEnumChecked(Type type, object value, bool useInterpreter)
+        {
+            Expression<Action> exp = Expression.Lambda<Action>(
+                Expression.Block(
+                    Expression.ConvertChecked(Expression.Constant(value, typeof(object)), type),
                     Expression.Empty()));
             Action act = exp.Compile(useInterpreter);
             Assert.Throws<InvalidCastException>(act);


### PR DESCRIPTION
Fixes #15991

Remove prohibition on creating bool-enum -> bool conversions.

Implement in compiler: Since this is the only acceptable conversion to or from boolean types, catch casts between same underlying types and do nothing, as the values on the stack is unchanged anyway.

As well as fixing this case it slightly optimises other enum casts with the same underlying type and is closer to what the C# compiler does.

Remove the case introduced in #13518 as it should no longer be hit, and anything doing so is a bug.

Implement in interpreter: Duplicate the conversion for `Convert` to that for `ConvertChecked`. Also introduce a check on conversions between same underlying type to optimise such paths similarly to what is done in the compiler, though not applicable when underlying type is the final result.