### PR TITLE
Fixes CompilerResults serialization

### DIFF
--- a/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerResults.cs
+++ b/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerResults.cs
@@ -14,12 +14,25 @@ namespace System.CodeDom.Compiler
         private readonly StringCollection _output = new StringCollection();
         private Assembly _compiledAssembly;
 
+        [NonSerialized]
+        private TempFileCollection _tempFiles;
+
         public CompilerResults(TempFileCollection tempFiles)
         {
-            TempFiles = tempFiles;
+            _tempFiles = tempFiles;
         }
 
-        public TempFileCollection TempFiles { get; set; }
+        public TempFileCollection TempFiles
+        {
+            get
+            {
+                return _tempFiles;
+            }
+            set
+            {
+                _tempFiles = value;
+            }
+        }
 
         public Assembly CompiledAssembly
         {


### PR DESCRIPTION
Serialization attribute was removed in https://github.com/dotnet/corefx/commits/master/src/Common/src/System/IO/TempFileCollection.cs but the reference was not updated.

Sadly had to expand auto-property because csc still does not `field:` attribute target there.