### PR TITLE
Optimize ImmutableQueue.CreateRange

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 
@@ -79,6 +80,13 @@ namespace System.Collections.Immutable
         /// <typeparam name="T">The type of items to store in the queue.</typeparam>
         /// <param name="list">The list to copy items from.</param>
         /// <returns>The new immutable queue.</returns>
+        /// <remarks>
+        /// This version is a faster method of creating an immutable queue because it pushes
+        /// the items onto the queue's forwards stack in reverse order. This eliminates the need
+        /// to have a backwards stack and then expensively reverse that stack when two items are
+        /// dequeued. Additionally, we make one fewer virtual method call per item than the
+        /// enumerable version.
+        /// </remarks>
         private static ImmutableQueue<T> CreateRange<T>(IList<T> ilist)
         {
             Debug.Assert(ilist != null);

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue.cs
@@ -33,10 +33,7 @@ namespace System.Collections.Immutable
         /// <param name="item">The item to prepopulate.</param>
         /// <returns>The new immutable collection.</returns>
         [Pure]
-        public static ImmutableQueue<T> Create<T>(T item)
-        {
-            return new ImmutableQueue<T>(ImmutableStack.Create(item), ImmutableStack<T>.Empty);
-        }
+        public static ImmutableQueue<T> Create<T>(T item) => ImmutableQueue<T>.Empty.Enqueue(item);
 
         /// <summary>
         /// Creates a new immutable queue from the specified items.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue.cs
@@ -78,7 +78,7 @@ namespace System.Collections.Immutable
         /// Creates a new immutable queue from the specified list.
         /// </summary>
         /// <typeparam name="T">The type of items to store in the queue.</typeparam>
-        /// <param name="list">The list to copy items from.</param>
+        /// <param name="ilist">The list to copy items from.</param>
         /// <returns>The new immutable queue.</returns>
         /// <remarks>
         /// This version is a faster method of creating an immutable queue because it pushes

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue.cs
@@ -94,12 +94,6 @@ namespace System.Collections.Immutable
             Debug.Assert(ilist != null);
             Debug.Assert(!(ilist is ImmutableList<T>), $"{nameof(ImmutableList<T>)} has poor random access complexity.");
 
-            var array = ilist as T[];
-            if (array != null)
-            {
-                return CreateRange(array: array);
-            }
-
             int count = ilist.Count;
             if (count <= 0)
             {
@@ -115,31 +109,6 @@ namespace System.Collections.Immutable
 
             return new ImmutableQueue<T>(forwards: forwards, backwards: ImmutableStack<T>.Empty);
         }
-        
-        /// <summary>
-        /// Creates a new immutable queue from the specified array.
-        /// </summary>
-        /// <typeparam name="T">The type of items to store in the queue.</typeparam>
-        /// <param name="array">The array to copy items from.</param>
-        /// <returns>The new immutable queue.</returns>
-        private static ImmutableQueue<T> CreateRange<T>(T[] array)
-        {
-            Debug.Assert(array != null);
-
-            if (array.Length == 0)
-            {
-                return ImmutableQueue<T>.Empty;
-            }
-
-            var forwards = ImmutableStack<T>.Empty;
-
-            for (int i = array.Length - 1; i >= 0; i--)
-            {
-                forwards = forwards.Push(array[i]);
-            }
-
-            return new ImmutableQueue<T>(forwards: forwards, backwards: ImmutableStack<T>.Empty);
-        }
 
         /// <summary>
         /// Creates a new immutable queue from the specified items.
@@ -151,7 +120,7 @@ namespace System.Collections.Immutable
         public static ImmutableQueue<T> Create<T>(params T[] items)
         {
             Requires.NotNull(items, nameof(items));
-            return CreateRange(array: items);
+            return CreateRange(ilist: items);
         }
 
         /// <summary>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.cs
@@ -50,8 +50,8 @@ namespace System.Collections.Immutable
         /// <param name="backwards">The backwards stack.</param>
         internal ImmutableQueue(ImmutableStack<T> forwards, ImmutableStack<T> backwards)
         {
-            Requires.NotNull(forwards, nameof(forwards));
-            Requires.NotNull(backwards, nameof(backwards));
+            Debug.Assert(forwards != null);
+            Debug.Assert(backwards != null);
 
             _forwards = forwards;
             _backwards = backwards;

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.cs
@@ -46,8 +46,8 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableQueue{T}"/> class.
         /// </summary>
-        /// <param name="forwards">The forward stack.</param>
-        /// <param name="backwards">The backward stack.</param>
+        /// <param name="forwards">The forwards stack.</param>
+        /// <param name="backwards">The backwards stack.</param>
         internal ImmutableQueue(ImmutableStack<T> forwards, ImmutableStack<T> backwards)
         {
             Requires.NotNull(forwards, nameof(forwards));
@@ -154,7 +154,7 @@ namespace System.Collections.Immutable
 
             if (this.IsEmpty)
             {
-                return new ImmutableQueue<T>(ImmutableStack.Create(item), ImmutableStack<T>.Empty);
+                return new ImmutableQueue<T>(ImmutableStack.Create(value), ImmutableStack<T>.Empty);
             }
             else
             {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.cs
@@ -46,16 +46,15 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableQueue{T}"/> class.
         /// </summary>
-        /// <param name="forward">The forward stack.</param>
-        /// <param name="backward">The backward stack.</param>
-        private ImmutableQueue(ImmutableStack<T> forward, ImmutableStack<T> backward)
+        /// <param name="forwards">The forward stack.</param>
+        /// <param name="backwards">The backward stack.</param>
+        internal ImmutableQueue(ImmutableStack<T> forwards, ImmutableStack<T> backwards)
         {
-            Requires.NotNull(forward, nameof(forward));
-            Requires.NotNull(backward, nameof(backward));
+            Requires.NotNull(forwards, nameof(forwards));
+            Requires.NotNull(backwards, nameof(backwards));
 
-            _forwards = forward;
-            _backwards = backward;
-            _backwardsReversed = null;
+            _forwards = forwards;
+            _backwards = backwards;
         }
 
         /// <summary>
@@ -76,7 +75,11 @@ namespace System.Collections.Immutable
         /// </value>
         public bool IsEmpty
         {
-            get { return _forwards.IsEmpty && _backwards.IsEmpty; }
+            get
+            {
+                Debug.Assert(!_forwards.IsEmpty || _backwards.IsEmpty);
+                return _forwards.IsEmpty;
+            }
         }
 
         /// <summary>
@@ -151,7 +154,7 @@ namespace System.Collections.Immutable
 
             if (this.IsEmpty)
             {
-                return new ImmutableQueue<T>(ImmutableStack<T>.Empty.Push(value), ImmutableStack<T>.Empty);
+                return new ImmutableQueue<T>(ImmutableStack.Create(item), ImmutableStack<T>.Empty);
             }
             else
             {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack_1.cs
@@ -52,7 +52,8 @@ namespace System.Collections.Immutable
         /// <param name="tail">The rest of the elements on the stack.</param>
         private ImmutableStack(T head, ImmutableStack<T> tail)
         {
-            Requires.NotNull(tail, nameof(tail));
+            Debug.Assert(tail != null);
+            
             _head = head;
             _tail = tail;
         }

--- a/src/System.Collections.Immutable/tests/ImmutableQueueTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableQueueTest.cs
@@ -220,6 +220,10 @@ namespace System.Collections.Immutable.Tests
             Assert.False(queue.IsEmpty);
             Assert.Equal(new[] { 1, 2 }, queue);
 
+            queue = ImmutableQueue.CreateRange(new List<int> { 1, 2 });
+            Assert.False(queue.IsEmpty);
+            Assert.Equal(new[] { 1, 2 }, queue);
+
             Assert.Throws<ArgumentNullException>("items", () => ImmutableQueue.CreateRange((IEnumerable<int>)null));
             Assert.Throws<ArgumentNullException>("items", () => ImmutableQueue.Create((int[])null));
         }


### PR DESCRIPTION
If the enumerable supports random access then we can push the items on to the forwards stack in reverse order. This avoids having to make an expensive allocation where (previously) when two items were dequeued, we would have to reverse the entire backwards stack.

If the enumerable does not support random access, we can still do better than the current implementation because we can deal with ImmutableStacks directly and not allocate an ImmutableQueue wrapper over them for every item.

/cc @ianhays, @AArnott, @safern 