### PR TITLE
Move slow SerialPort tests to outerloop

### DIFF
--- a/src/System.IO.Ports/tests/Legacy/SerialPort/ReadByte_Generic.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/ReadByte_Generic.cs
@@ -66,6 +66,7 @@ public class ReadByte_Generic : PortsTest
         }
     }
 
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasOneSerialPort))]
     public void Timeout()
     {
@@ -82,6 +83,7 @@ public class ReadByte_Generic : PortsTest
         }
     }
 
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasOneSerialPort))]
     public void SuccessiveReadTimeoutNoData()
     {

--- a/src/System.IO.Ports/tests/Legacy/SerialPort/ReadChar_Generic.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/ReadChar_Generic.cs
@@ -67,7 +67,7 @@ public class ReadChar_Generic : PortsTest
         }
     }
 
-
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasOneSerialPort))]
     public void Timeout()
     {
@@ -83,7 +83,7 @@ public class ReadChar_Generic : PortsTest
         }
     }
 
-
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasOneSerialPort))]
     public void SuccessiveReadTimeoutNoData()
     {

--- a/src/System.IO.Ports/tests/Legacy/SerialPort/ReadLine_Generic.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/ReadLine_Generic.cs
@@ -81,6 +81,7 @@ public class ReadLine_Generic : PortsTest
         }
     }
 
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasOneSerialPort))]
     public void Timeout()
     {
@@ -96,6 +97,7 @@ public class ReadLine_Generic : PortsTest
         }
     }
 
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasOneSerialPort))]
     public void SuccessiveReadTimeoutNoData()
     {

--- a/src/System.IO.Ports/tests/Legacy/SerialPort/ReadTo_Generic.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/ReadTo_Generic.cs
@@ -82,6 +82,7 @@ public class ReadTo_Generic : PortsTest
         }
     }
 
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasOneSerialPort))]
     public void Timeout()
     {
@@ -97,7 +98,8 @@ public class ReadTo_Generic : PortsTest
             VerifyTimeout(com);
         }
     }
-    
+
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasOneSerialPort))]
     public void SuccessiveReadTimeoutNoData()
     {

--- a/src/System.IO.Ports/tests/Legacy/SerialPort/Read_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/Read_byte_int_int_Generic.cs
@@ -79,7 +79,7 @@ public class Read_byte_int_int_Generic : PortsTest
         }
     }
 
-
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasOneSerialPort))]
     public void Timeout()
     {
@@ -95,7 +95,7 @@ public class Read_byte_int_int_Generic : PortsTest
         }
     }
 
-
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasOneSerialPort))]
     public void SuccessiveReadTimeoutNoData()
     {

--- a/src/System.IO.Ports/tests/Legacy/SerialPort/Read_char_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/Read_char_int_int_Generic.cs
@@ -80,7 +80,7 @@ public class Read_char_int_int_Generic : PortsTest
         }
     }
 
-
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasOneSerialPort))]
     public void Timeout()
     {
@@ -96,7 +96,7 @@ public class Read_char_int_int_Generic : PortsTest
         }
     }
 
-
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasOneSerialPort))]
     public void SuccessiveReadTimeoutNoData()
     {

--- a/src/System.IO.Ports/tests/Legacy/SerialPort/WriteLine_Generic.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/WriteLine_Generic.cs
@@ -103,6 +103,7 @@ public class WriteLine_Generic : PortsTest
     }
 
     [ActiveIssue(15752)]
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasOneSerialPort))]
     public void SuccessiveReadTimeout()
     {

--- a/src/System.IO.Ports/tests/Legacy/SerialPort/Write_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/Write_byte_int_int_Generic.cs
@@ -76,6 +76,7 @@ public class Write_byte_int_int_generic : PortsTest
         }
     }
 
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasNullModem))]
     public void Timeout()
     {
@@ -104,6 +105,7 @@ public class Write_byte_int_int_generic : PortsTest
     }
 
     [ActiveIssue(15752)]
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasOneSerialPort))]
     public void SuccessiveReadTimeout()
     {

--- a/src/System.IO.Ports/tests/Legacy/SerialPort/Write_char_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/Write_char_int_int_Generic.cs
@@ -77,6 +77,7 @@ public class Write_char_int_int_generic : PortsTest
         }
     }
 
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasNullModem))]
     public void Timeout()
     {
@@ -106,6 +107,7 @@ public class Write_char_int_int_generic : PortsTest
     }
 
     [ActiveIssue(15752)]
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasOneSerialPort))]
     public void SuccessiveReadTimeout()
     {

--- a/src/System.IO.Ports/tests/Legacy/SerialPort/Write_str_Generic.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/Write_str_Generic.cs
@@ -105,6 +105,7 @@ public class Write_str_Generic : PortsTest
     }
 
     [ActiveIssue(15752)]
+    [OuterLoop("Slow test")]
     [ConditionalFact(nameof(HasOneSerialPort))]
     public void SuccessiveReadTimeout()
     {


### PR DESCRIPTION
The tests in this PR all take several seconds to run on a machine with just a serial port (like the CI machines).   This PR takes the inner-loop run-time here for this set of tests down from about 120s to about 10s.

#15961