### PR TITLE
Generate aot-runtime specific packages

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.UAP/Configurations.props
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       uap-Windows_NT;
+      uapaot-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.builds
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.builds
@@ -4,9 +4,9 @@
 
   <Import Project="$(MSBuildProjectName).props" />
 
-  <ItemGroup Condition="'$(TargetGroup)'=='uap'">
-    <!-- identity project, runtime specific projects are included by props above -->
-    <Project Include="$(MSBuildProjectName).pkgproj" />
+  <ItemGroup>
+    <!-- identity project, runtime specific projects are included by props above. Will not be includded on uapaot builds. -->
+    <Project Include="$(MSBuildProjectName).pkgproj" Condition="'$(TargetGroup)'=='uap'" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.props
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.props
@@ -13,6 +13,9 @@
         <PackageRID Condition="'$(ArchGroup)' == 'x86' OR '$(ArchGroup)' == 'x64'">win7-$(ArchGroup)</PackageRID>
         <PackageRID Condition="'$(ArchGroup)' == 'arm'">win8-$(ArchGroup)</PackageRID>
         <PackageRID Condition="'$(ArchGroup)' == 'arm64'">win10-$(ArchGroup)</PackageRID>
+        <PackageRID Condition="('$(ArchGroup)' == 'x86' OR '$(ArchGroup)' == 'x64') And '$(TargetGroup)' == 'uapaot'">win7-$(ArchGroup)-aot</PackageRID>
+        <PackageRID Condition="'$(ArchGroup)' == 'arm' And '$(TargetGroup)' == 'uapaot'">win8-$(ArchGroup)-aot</PackageRID>
+        <PackageRID Condition="'$(ArchGroup)' == 'arm64' And '$(TargetGroup)' == 'uapaot'">win10-$(ArchGroup)-aot</PackageRID>
       </PropertyGroup>
     </When>
     <Otherwise>
@@ -31,6 +34,16 @@
       <Platform>arm</Platform>
     </OfficialBuildRID>
     <OfficialBuildRID Include="win10-arm64">
+      <Platform>arm64</Platform>
+    </OfficialBuildRID>
+    <OfficialBuildRID Include="win7-x86-aot">
+      <Platform>x86</Platform>
+    </OfficialBuildRID>
+    <OfficialBuildRID Include="win7-x64-aot" />
+    <OfficialBuildRID Include="win8-arm-aot">
+      <Platform>arm</Platform>
+    </OfficialBuildRID>
+    <OfficialBuildRID Include="win10-arm64-aot">
       <Platform>arm64</Platform>
     </OfficialBuildRID>
 


### PR DESCRIPTION
This commit will enable the generation of the aot-specific runtime packages for Microsoft.Private.Corefx.UAP. 

cc: @weshaggard @ericstj @jkotas 

FYI: @joshfree 