### PR TITLE
Fix hang in SerialPort tests EventHandlers_CalledSerially

### DIFF
--- a/src/System.IO.Ports/tests/Legacy/SerialPort/Event_Generic.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/Event_Generic.cs
@@ -3,155 +3,28 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO.Ports;
 using System.IO.PortsTests;
 using System.Threading;
 using Legacy.Support;
 using Xunit;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 public class Event_Generic : PortsTest
 {
-    //Maximum time to wait for all of the expected events to be firered
-    public static readonly int MAX_TIME_WAIT = 5000;
+    // Maximum time to wait for all of the expected events to be firered
+    private static readonly int MAX_TIME_WAIT = 5000;
 
-    //Time to wait inbetween trigering events
-    public static readonly int TRIGERING_EVENTS_WAIT_TIME = 500;
+    // Time to wait inbetween triggering events
+    private static readonly int TRIGERING_EVENTS_WAIT_TIME = 500;
 
     #region Test Cases
 
-    [ConditionalFact(nameof(HasNullModem), Skip="Unhandled exceptions in background threads cause test harness to crash")]
-    public void EventHandler_ThrowsException()
-    {
-        using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
-        using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
-        {
-            PinChangedEventHandler pinChangedEventHandler = new PinChangedEventHandler(com1, true);
-            ReceivedEventHandler receivedEventHandler = new ReceivedEventHandler(com1, true);
-            ErrorEventHandler errorEventHandler = new ErrorEventHandler(com1, true);
-
-            /***************************************************************
-            Scenario Description: All of the event handler are going to throw and we are 
-            going to verify that the event handler will still get called.
-    
-            We want to verify that throwing does not cause the thread calling the event 
-            handlers to die.		
-            ***************************************************************/
-
-            Debug.WriteLine("Verifying where the event handlers throws");
-
-            com1.Open();
-            com2.Open();
-
-            Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-            com1.PinChanged += pinChangedEventHandler.HandleEvent;
-            com1.DataReceived += receivedEventHandler.HandleEvent;
-            com1.ErrorReceived += errorEventHandler.HandleEvent;
-
-            //This should cause ErrorEvent to be fired with a parity error since the 
-            //8th bit on com1 is the parity bit, com1 one expest this bit to be 1(Mark), 
-            //and com2 is writing 0 for this bit
-            com1.DataBits = 7;
-            com1.Parity = Parity.Mark;
-            com2.BaseStream.Write(new byte[1], 0, 1);
-            Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-            //This should cause PinChangedEvent to be fired with SerialPinChanges.DsrChanged
-            //since we are setting DtrEnable to true
-            com2.DtrEnable = true;
-            Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-            //This should cause ReceivedEvent to be fired with ReceivedChars
-            //since we are writing some bytes
-            com1.DataBits = 8;
-            com1.Parity = Parity.None;
-            com2.BaseStream.Write(new byte[] {40}, 0, 1);
-            Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-            //This should cause a fame error since the 8th bit is not set,
-            //and com1 is set to 7 data bits so the 8th bit will +12v where
-            //com1 expects the stop bit at the 8th bit to be -12v
-            com1.DataBits = 7;
-            com1.Parity = Parity.None;
-            com2.BaseStream.Write(new byte[] {0x01}, 0, 1);
-            Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-            //This should cause PinChangedEvent to be fired with SerialPinChanges.CtsChanged
-            //since we are setting RtsEnable to true
-            com2.RtsEnable = true;
-            Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-            //This should cause ReceivedEvent to be fired with EofReceived 
-            //since we are writing the EOF char		
-            com1.DataBits = 8;
-            com1.Parity = Parity.None;
-            com2.BaseStream.Write(new byte[] {26}, 0, 1);
-            Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-            //This should cause PinChangedEvent to be fired with SerialPinChanges.Break
-            //since we are setting BreakState to true
-            com2.BreakState = true;
-            Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
-            if (!pinChangedEventHandler.WaitForEvent(MAX_TIME_WAIT, 3))
-            {
-                Fail("Err_28282haied Expected 3 PinChangedEvents to be fired and only {0} occured",
-                    pinChangedEventHandler.NumEventsHandled);
-            }
-
-            if (!receivedEventHandler.WaitForEvent(MAX_TIME_WAIT, 2))
-            {
-                Fail("Err_2912hsie Expected 2 ReceivedEvents  to be fired and only {0} occured",
-                    receivedEventHandler.NumEventsHandled);
-            }
-
-            if (!errorEventHandler.WaitForEvent(MAX_TIME_WAIT, 2))
-            {
-                Fail("Err_191291jaied Expected 3 ErrorEvents to be fired and only {0} occured",
-                    errorEventHandler.NumEventsHandled);
-            }
-
-            //[] Verify all PinChangedEvents should have occured
-            if (!pinChangedEventHandler.Validate(SerialPinChange.DsrChanged, 0))
-            {
-                Fail("Err_24597aqqoo!!! PinChangedEvent DsrChanged event not fired");
-            }
-
-            if (!pinChangedEventHandler.Validate(SerialPinChange.CtsChanged, 0))
-            {
-                Fail("Err_144754ajied!!! PinChangedEvent CtsChanged event not fired");
-                
-            }
-
-            if (!pinChangedEventHandler.Validate(SerialPinChange.Break, 0))
-            {
-                Fail("Err_15488ahied!!! PinChangedEvent Break event not fired");
-            }
-
-            //[] Verify all ReceivedEvent should have occured
-            if (!receivedEventHandler.Validate(SerialData.Chars, 0))
-            {
-                Fail("Err_54552aheied!!! ReceivedEvent ReceivedChars event not fired");
-            }
-
-            if (!receivedEventHandler.Validate(SerialData.Eof, 0))
-            {
-                Fail("Err_4588ajeod!!! ReceivedEvent EofReceived event not fired");
-            }
-
-            //[] Verify all ErrorEvents should have occured
-            if (!errorEventHandler.Validate(SerialError.RXParity, 0))
-            {
-                Fail("Err_1051ajheid!!! ErrorEvent RxParity event not fired");
-            }
-
-            if (!errorEventHandler.Validate(SerialError.Frame, 0))
-            {
-                Fail("Err_61805aheud!!! ErrorEvent Frame event not fired");
-            }
-        }
-    }
-
+    [OuterLoop("Slow Test")]
     [ConditionalFact(nameof(HasNullModem))]
     public void EventHandlers_CalledSerially()
     {
@@ -163,16 +36,18 @@ public class Event_Generic : PortsTest
             ErrorEventHandler errorEventHandler = new ErrorEventHandler(com1, false, true);
             int numPinChangedEvents = 0, numErrorEvents = 0, numReceivedEvents = 0;
             int iterationWaitTime = 100;
-            bool threadFound;
 
             /***************************************************************
             Scenario Description: All of the event handlers should be called sequentially never
-            at the same time on multiple thread. Basically we will block a thread and verify 
+            at the same time on multiple thread. Basically we will block each event handler caller thread and verify 
             that no other thread is in another event handler
 
             ***************************************************************/
 
-            Debug.WriteLine("Verifying where the event handlers are called serially");
+            Debug.WriteLine("Verifying that event handlers are called serially");
+
+            com1.WriteTimeout = 5000;
+            com2.WriteTimeout = 5000;
 
             com1.Open();
             com2.Open();
@@ -188,10 +63,8 @@ public class Event_Generic : PortsTest
             com1.DataBits = 7;
             com1.Parity = Parity.Mark;
             com2.BaseStream.Write(new byte[1], 0, 1);
-
             Debug.Print("ERROREvent Triggered");
             Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
-
 
             //This should cause PinChangedEvent to be fired with SerialPinChanges.DsrChanged
             //since we are setting DtrEnable to true
@@ -235,7 +108,7 @@ public class Event_Generic : PortsTest
             com2.BreakState = true;
             Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
 
-            threadFound = true;
+            bool threadFound = true;
             Stopwatch sw = Stopwatch.StartNew();
             while (threadFound && sw.ElapsedMilliseconds < MAX_TIME_WAIT)
             {
@@ -249,7 +122,7 @@ public class Event_Generic : PortsTest
 
                     if (pinChangedEventHandler.WaitForEvent(iterationWaitTime, numPinChangedEvents + 1))
                     {
-//A thread is in PinChangedEvent verify that it is not in any other
+                        // A thread is in PinChangedEvent: verify that it is not in any other handler at the same time
                         if (receivedEventHandler.NumEventsHandled != numReceivedEvents)
                         {
                             Fail("Err_191818ahied A thread is in PinChangedEvent and ReceivedEvent");
@@ -270,7 +143,7 @@ public class Event_Generic : PortsTest
 
                     if (receivedEventHandler.WaitForEvent(iterationWaitTime, numReceivedEvents + 1))
                     {
-//A thread is in ReceivedEvent verify that it is not in any other
+                        // A thread is in ReceivedEvent: verify that it is not in any other handler at the same time
                         if (pinChangedEventHandler.NumEventsHandled != numPinChangedEvents)
                         {
                             Fail("Err_2288ajed A thread is in ReceivedEvent and PinChangedEvent");
@@ -291,17 +164,15 @@ public class Event_Generic : PortsTest
 
                     if (errorEventHandler.WaitForEvent(iterationWaitTime, numErrorEvents + 1))
                     {
-//A thread is in ErrorEvent verify that it is not in any other
+                        // A thread is in ErrorEvent: verify that it is not in any other handler at the same time
                         if (pinChangedEventHandler.NumEventsHandled != numPinChangedEvents)
                         {
                             Fail("Err_01208akiehd A thread is in ErrorEvent and PinChangedEvent");
-                            
                         }
 
                         if (receivedEventHandler.NumEventsHandled != numReceivedEvents)
                         {
                             Fail("Err_1254847ajied A thread is in ErrorEvent and ReceivedEvent");
-                            
                         }
 
                         ++numErrorEvents;
@@ -311,19 +182,19 @@ public class Event_Generic : PortsTest
                     }
                 }
             }
-
+            
             if (!pinChangedEventHandler.WaitForEvent(MAX_TIME_WAIT, 3))
             {
                 Fail("Err_2288ajied Expected 3 PinChangedEvents to be fired and only {0} occured",
                     pinChangedEventHandler.NumEventsHandled);
             }
-
+            
             if (!receivedEventHandler.WaitForEvent(MAX_TIME_WAIT, 2))
             {
                 Fail("Err_122808aoeid Expected 2 ReceivedEvents  to be fired and only {0} occured",
                     receivedEventHandler.NumEventsHandled);
             }
-
+            
             if (!errorEventHandler.WaitForEvent(MAX_TIME_WAIT, 2))
             {
                 Fail("Err_215887ajeid Expected 3 ErrorEvents to be fired and only {0} occured",
@@ -331,46 +202,27 @@ public class Event_Generic : PortsTest
             }
 
             //[] Verify all PinChangedEvents should have occured
-            if (!pinChangedEventHandler.Validate(SerialPinChange.DsrChanged, 0))
-            {
-                Fail("Err_258087aieid!!! PinChangedEvent DsrChanged event not fired");
-                
-            }
-
-            if (!pinChangedEventHandler.Validate(SerialPinChange.CtsChanged, 0))
-            {
-                Fail("Err_5548ajhied!!! PinChangedEvent CtsChanged event not fired");
-            }
-
-            if (!pinChangedEventHandler.Validate(SerialPinChange.Break, 0))
-            {
-                Fail("Err_25848ajiied!!! PinChangedEvent Break event not fired");
-            }
+            pinChangedEventHandler.Validate(SerialPinChange.DsrChanged, 0);
+            pinChangedEventHandler.Validate(SerialPinChange.CtsChanged, 0);
+            pinChangedEventHandler.Validate(SerialPinChange.Break, 0);
 
             //[] Verify all ReceivedEvent should have occured
-            if (!receivedEventHandler.Validate(SerialData.Chars, 0))
-            {
-                Fail("Err_0211558ajoied!!! ReceivedEvent ReceivedChars event not fired");
-            }
-
-            if (!receivedEventHandler.Validate(SerialData.Eof, 0))
-            {
-                Fail("Err_215588zahid!!! ReceivedEvent EofReceived event not fired");
-            }
-
+            receivedEventHandler.Validate(SerialData.Chars, 0);
+            receivedEventHandler.Validate(SerialData.Eof, 0);
+            
             //[] Verify all ErrorEvents should have occured
-            if (!errorEventHandler.Validate(SerialError.RXParity, 0))
-            {
-                Fail("Err_515188ahjid!!! ErrorEvent RxParity event not fired");
-            }
-
-            if (!errorEventHandler.Validate(SerialError.Frame, 0))
-            {
-                Fail("Err_55874884ajie!!! ErrorEvent Frame event not fired");
-            }
+            errorEventHandler.Validate(SerialError.RXParity, 0);
+            errorEventHandler.Validate(SerialError.Frame, 0);
+            
+            // It's important that we close com1 BEFORE com2 (the using() block would do this the other way around normally)
+            // This is because we have our special blocking event handlers hooked onto com1, and closing com2 is likely to 
+            // cause a pin-change event which then hangs and prevents com1 from closing.
+            // An alternative approach would be to unhook all the event-handlers before leaving the using() block.
+            com1.Close();
         }
     }
 
+    [OuterLoop("Slow Test")]
     [ConditionalFact(nameof(HasNullModem))]
     public void Thread_In_PinChangedEvent()
     {
@@ -378,7 +230,6 @@ public class Event_Generic : PortsTest
         using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
         {
             PinChangedEventHandler pinChangedEventHandler = new PinChangedEventHandler(com1, false, true);
-            Thread closeThread = new Thread(delegate() { com1.Close(); });
 
             Debug.WriteLine(
                 "Verifying that if a thread is blocked in a PinChangedEvent handler the port can still be closed");
@@ -399,14 +250,16 @@ public class Event_Generic : PortsTest
                     pinChangedEventHandler.NumEventsHandled);
             }
 
-            closeThread.Start();
+            Task task = Task.Run(() => com1.Close());
             Thread.Sleep(5000);
 
             pinChangedEventHandler.ResumeHandleEvent();
-            closeThread.Join();
+
+            Assert.True(task.Wait(2000), "Waiting for Close task completion");
         }
     }
 
+    [OuterLoop("Slow Test")]
     [ConditionalFact(nameof(HasNullModem))]
     public void Thread_In_ReceivedEvent()
     {
@@ -414,7 +267,6 @@ public class Event_Generic : PortsTest
         using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
         {
             ReceivedEventHandler receivedEventHandler = new ReceivedEventHandler(com1, false, true);
-            Thread closeThread = new Thread(delegate() { com1.Close(); });
 
             Debug.WriteLine(
                 "Verifying that if a thread is blocked in a RecevedEvent handler the port can still be closed");
@@ -436,18 +288,18 @@ public class Event_Generic : PortsTest
             {
                 Fail("Err_122808aoeid Expected 1 ReceivedEvents  to be fired and only {0} occured",
                     receivedEventHandler.NumEventsHandled);
-                
             }
 
-            closeThread.Start();
+            Task task = Task.Run(() => com1.Close());
             Thread.Sleep(5000);
 
             receivedEventHandler.ResumeHandleEvent();
-            closeThread.Join();
 
+            Assert.True(task.Wait(2000), "Waiting for Close task completion");
         }
     }
 
+    [OuterLoop("Slow Test")]
     [ConditionalFact(nameof(HasNullModem))]
     public void Thread_In_ErrorEvent()
     {
@@ -455,7 +307,6 @@ public class Event_Generic : PortsTest
         using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
         {
             ErrorEventHandler errorEventHandler = new ErrorEventHandler(com1, false, true);
-            Thread closeThread = new Thread(delegate() { com1.Close(); });
 
             Debug.WriteLine("Verifying that if a thread is blocked in a ErrorEvent handler the port can still be closed");
 
@@ -475,83 +326,69 @@ public class Event_Generic : PortsTest
 
             if (!errorEventHandler.WaitForEvent(MAX_TIME_WAIT, 1))
             {
-                Fail("Err_215887ajeid Expected 1 ErrorEvents to be fired and only {0} occured",
-                    errorEventHandler.NumEventsHandled);
-                
+                Fail("Err_215887ajeid Expected 1 ErrorEvents to be fired and only {0} occured",errorEventHandler.NumEventsHandled);
             }
 
-            closeThread.Start();
+            Task task = Task.Run(() => com1.Close());
             Thread.Sleep(5000);
 
             errorEventHandler.ResumeHandleEvent();
-            closeThread.Join();
-
+            Assert.True(task.Wait(2000), "Waiting for Close task completion");
         }
     }
     #endregion
 
     #region Verification for Test Cases
 
-    public class IgnoreException : Exception
+    private class IgnoreException : Exception
     {
-        public IgnoreException()
-            : base()
-        {
-        }
-
         public IgnoreException(string message)
             : base(message)
         {
         }
     }
 
-
-    public class PinChangedEventHandler
+    /// <summary>
+    /// Base class for all test event handlers
+    /// </summary>
+    /// <typeparam name="T">The type of the EventType object which is passed to the event handler</typeparam>
+    private class TestEventHandler<T>
     {
-        public System.Collections.ArrayList EventType;
-        public System.Collections.ArrayList BytesToRead;
-        public System.Collections.ArrayList Source;
-        public int NumEventsHandled;
-        private SerialPort _com;
-        private bool _shouldThrow;
-        private bool _shouldWait;
-        private AutoResetEvent _eventHandlerWait;
+        private readonly List<T> _eventTypes = new List<T>();
+        private readonly List<int> _bytesToRead = new List<int>();
+        private readonly List<SerialPort> _sources = new List<SerialPort>();
+        private readonly SerialPort _com;
+        private readonly bool _shouldThrow;
+        private readonly bool _shouldWait;
+        private readonly AutoResetEvent _eventHandlerWait = new AutoResetEvent(false);
+        private readonly object _lock = new object();
 
-        public PinChangedEventHandler(SerialPort com) : this(com, false, false) { }
+        public int NumEventsHandled { get; private set; }
 
-        public PinChangedEventHandler(SerialPort com, bool shouldThrow) : this(com, shouldThrow, false) { }
-
-        public PinChangedEventHandler(SerialPort com, bool shouldThrow, bool shouldWait)
+        protected TestEventHandler(SerialPort com, bool shouldThrow, bool shouldWait)
         {
             if (shouldThrow && shouldWait)
+            {
                 throw new ArgumentException("shouldThrow and shouldWait can not both be true");
+            }
 
             _com = com;
-            NumEventsHandled = 0;
-
-            EventType = new System.Collections.ArrayList();
-            Source = new System.Collections.ArrayList();
-            BytesToRead = new System.Collections.ArrayList();
-
             _shouldThrow = shouldThrow;
             _shouldWait = shouldWait;
-
-            _eventHandlerWait = new AutoResetEvent(false);
         }
 
-
-        public void HandleEvent(object source, SerialPinChangedEventArgs e)
+        protected void HandleEvent(object source, T eventType)
         {
             int bytesToRead = _com.BytesToRead;
 
-            lock (this)
+            lock (_lock)
             {
-                BytesToRead.Add(bytesToRead);
-                EventType.Add(e.EventType);
-                Source.Add(source);
+                _bytesToRead.Add(bytesToRead);
+                _eventTypes.Add(eventType);
+                _sources.Add((SerialPort)source);
 
                 NumEventsHandled++;
-                Monitor.Pulse(this);
+                Monitor.Pulse(_lock);
             }
 
             if (_shouldThrow)
@@ -561,7 +398,7 @@ public class Event_Generic : PortsTest
 
             if (_shouldWait)
             {
-                _eventHandlerWait.WaitOne();
+                Assert.True(_eventHandlerWait.WaitOne(10000));
             }
         }
 
@@ -570,109 +407,83 @@ public class Event_Generic : PortsTest
             _eventHandlerWait.Set();
         }
 
-
-        public void RemoveAt(int index)
+        private void RemoveAt(int index)
         {
-            lock (this)
+            lock (_lock)
             {
-                EventType.RemoveAt(index);
-                BytesToRead.RemoveAt(index);
-                Source.RemoveAt(index);
-
+                _eventTypes.RemoveAt(index);
+                _bytesToRead.RemoveAt(index);
+                _sources.RemoveAt(index);
                 NumEventsHandled--;
             }
         }
 
-
         public void Clear()
         {
-            lock (this)
+            lock (_lock)
             {
-                EventType.Clear();
-                BytesToRead.Clear();
-                Source.Clear();
+                _eventTypes.Clear();
+                _bytesToRead.Clear();
+                _sources.Clear();
 
                 NumEventsHandled = 0;
             }
         }
 
-
         public bool WaitForEvent(int maxMilliseconds, int totalNumberOfEvents)
         {
             Stopwatch sw = new Stopwatch();
 
-            lock (this)
+            lock (_lock)
             {
                 sw.Start();
-
-                while (maxMilliseconds > sw.ElapsedMilliseconds && NumEventsHandled < totalNumberOfEvents)
+                long remaining;
+                while ((remaining = (maxMilliseconds - sw.ElapsedMilliseconds)) > 0 && NumEventsHandled < totalNumberOfEvents)
                 {
-                    Monitor.Wait(this, (int)(maxMilliseconds - sw.ElapsedMilliseconds));
+                    Monitor.Wait(_lock, (int)remaining);
                 }
-
                 return totalNumberOfEvents <= NumEventsHandled;
             }
         }
 
-
-        //Since we can not garantee the order or the exact time that the event handler is called 
-        //We will look for an event that was fired that matches the type and that bytesToRead 
-        //is greater then the parameter    
-        public bool Validate(SerialPinChange eventType, int bytesToRead)
+        // Since we can not garantee the order or the exact time that the event handler is called 
+        // We will look for an event that was fired that matches the type and that bytesToRead 
+        // is greater then the parameter    
+        public void Validate(T eventType, int bytesToRead)
         {
-            bool retValue = false;
-
-            lock (this)
+            lock (_lock)
             {
-                for (int i = 0; i < EventType.Count; i++)
+                for (int i = 0; i < _eventTypes.Count; i++)
                 {
-                    if (eventType == (SerialPinChange)EventType[i] && bytesToRead <= (int)BytesToRead[i] && (SerialPort)Source[i] == _com)
+                    if (Equals(eventType, _eventTypes[i]) && bytesToRead <= _bytesToRead[i] && _sources[i] == _com)
                     {
-                        EventType.RemoveAt(i);
-                        BytesToRead.RemoveAt(i);
-                        Source.RemoveAt(i);
-
-                        NumEventsHandled--;
-                        retValue = true;
-
-                        break;
+                        RemoveAt(i);
+                        return;
                     }
                 }
             }
-
-            return retValue;
+            Assert.True(false, $"Failed to validate event type {eventType}");
         }
 
-
-        public int NumberOfOccurencesOfType(SerialData eventType)
+        public int NumberOfOccurencesOfType(T eventType)
         {
-            int numOccurences = 0;
-
-            lock (this)
+            lock (_lock)
             {
-                for (int i = 0; i < EventType.Count; i++)
-                {
-                    if (eventType == (SerialData)EventType[i])
-                    {
-                        numOccurences++;
-                    }
-                }
+                return _eventTypes.Count(et => Equals(et, eventType));
             }
-
-            return numOccurences;
         }
 
         public override string ToString()
         {
-            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            StringBuilder sb = new StringBuilder();
 
-            for (int i = 0; i < EventType.Count; i++)
+            for (int i = 0; i < _eventTypes.Count; i++)
             {
                 sb.Append(i);
                 sb.Append(": Type: ");
-                sb.Append((SerialData)EventType[i]);
+                sb.Append(_eventTypes[i]);
                 sb.Append(" BytesToRead: ");
-                sb.Append(BytesToRead[i]);
+                sb.Append(_eventTypes[i]);
                 sb.Append("\n");
             }
 
@@ -680,280 +491,39 @@ public class Event_Generic : PortsTest
         }
     }
 
-    public class ErrorEventHandler
+    private class PinChangedEventHandler : TestEventHandler<SerialPinChange>
     {
-        public System.Collections.ArrayList EventType;
-        public System.Collections.ArrayList Source;
-        public System.Collections.ArrayList BytesToRead;
-        public int NumEventsHandled;
-        private SerialPort _com;
-        private bool _shouldThrow;
-        private bool _shouldWait;
-        private AutoResetEvent _eventHandlerWait;
-
-
-        public ErrorEventHandler(SerialPort com) : this(com, false, false) { }
-
-        public ErrorEventHandler(SerialPort com, bool shouldThrow) : this(com, shouldThrow, false) { }
-
-        public ErrorEventHandler(SerialPort com, bool shouldThrow, bool shouldWait)
+        public PinChangedEventHandler(SerialPort com, bool shouldThrow, bool shouldWait) : base(com, shouldThrow, shouldWait)
         {
-            if (shouldThrow && shouldWait)
-                throw new ArgumentException("shouldThrow and shouldWait can not both be true");
-
-            _com = com;
-            NumEventsHandled = 0;
-
-            EventType = new System.Collections.ArrayList();
-            Source = new System.Collections.ArrayList();
-            BytesToRead = new System.Collections.ArrayList();
-
-            _shouldThrow = shouldThrow;
-            _shouldWait = shouldWait;
-
-            _eventHandlerWait = new AutoResetEvent(false);
         }
 
-
-        public void HandleEvent(object source, SerialErrorReceivedEventArgs e)
+        public void HandleEvent(object source, SerialPinChangedEventArgs e)
         {
-            int bytesToRead = _com.BytesToRead;
-
-            lock (this)
-            {
-                BytesToRead.Add(bytesToRead);
-                EventType.Add(e.EventType);
-                Source.Add(source);
-                NumEventsHandled++;
-                Monitor.Pulse(this);
-            }
-
-            if (_shouldThrow)
-            {
-                throw new IgnoreException("I was told to throw");
-            }
-
-            if (_shouldWait)
-            {
-                _eventHandlerWait.WaitOne();
-            }
-        }
-
-        public void ResumeHandleEvent()
-        {
-            _eventHandlerWait.Set();
-        }
-
-
-        public bool WaitForEvent(int maxMilliseconds, int totalNumberOfEvents)
-        {
-            Stopwatch sw = new Stopwatch();
-
-            lock (this)
-            {
-                sw.Start();
-                while (maxMilliseconds > sw.ElapsedMilliseconds && NumEventsHandled < totalNumberOfEvents)
-                {
-                    Monitor.Wait(this, (int)(maxMilliseconds - sw.ElapsedMilliseconds));
-                }
-
-                return totalNumberOfEvents <= NumEventsHandled;
-            }
-        }
-
-
-        //Since we can not garantee the order or the exact time that the event handler is called 
-        //We wil look for an event that was firered that matches the type and that bytesToRead 
-        //is greater then the parameter    
-        public bool Validate(SerialError eventType, int bytesToRead)
-        {
-            bool retValue = false;
-
-            lock (this)
-            {
-                for (int i = 0; i < EventType.Count; i++)
-                {
-                    if (eventType == (SerialError)EventType[i] && bytesToRead <= (int)BytesToRead[i] && (SerialPort)Source[i] == _com)
-                    {
-                        EventType.RemoveAt(i);
-                        BytesToRead.RemoveAt(i);
-                        Source.RemoveAt(i);
-                        NumEventsHandled--;
-                        retValue = true;
-                        break;
-                    }
-                }
-            }
-
-            return retValue;
+            HandleEvent(source, e.EventType);
         }
     }
 
-    public class ReceivedEventHandler
-    {
-        public System.Collections.ArrayList EventType;
-        public System.Collections.ArrayList BytesToRead;
-        public System.Collections.ArrayList Source;
-        public int NumEventsHandled;
-        private SerialPort _com;
-        private bool _shouldThrow;
-        private bool _shouldWait;
-        private AutoResetEvent _eventHandlerWait;
-
-        public ReceivedEventHandler(SerialPort com) : this(com, false, false) { }
-
-        public ReceivedEventHandler(SerialPort com, bool shouldThrow) : this(com, shouldThrow, false) { }
-
-        public ReceivedEventHandler(SerialPort com, bool shouldThrow, bool shouldWait)
+    private class ErrorEventHandler : TestEventHandler<SerialError>
+    { 
+        public ErrorEventHandler(SerialPort com, bool shouldThrow, bool shouldWait) : base(com, shouldThrow, shouldWait)
         {
-            if (shouldThrow && shouldWait)
-                throw new ArgumentException("shouldThrow and shouldWait can not both be true");
+        }
 
-            _com = com;
-            NumEventsHandled = 0;
+        public void HandleEvent(object source, SerialErrorReceivedEventArgs e)
+        {
+            HandleEvent(source, e.EventType);
+        }
+    }
 
-            EventType = new System.Collections.ArrayList();
-            Source = new System.Collections.ArrayList();
-            BytesToRead = new System.Collections.ArrayList();
-
-            _shouldThrow = shouldThrow;
-            _shouldWait = shouldWait;
-
-            _eventHandlerWait = new AutoResetEvent(false);
+    private class ReceivedEventHandler : TestEventHandler<SerialData>
+    {
+        public ReceivedEventHandler(SerialPort com, bool shouldThrow, bool shouldWait) : base(com, shouldThrow, shouldWait)
+        {
         }
 
         public void HandleEvent(object source, SerialDataReceivedEventArgs e)
         {
-            int bytesToRead = _com.BytesToRead;
-
-            lock (this)
-            {
-                BytesToRead.Add(bytesToRead);
-                EventType.Add(e.EventType);
-                Source.Add(source);
-
-                NumEventsHandled++;
-
-                Monitor.Pulse(this);
-            }
-
-            if (_shouldThrow)
-            {
-                throw new IgnoreException("I was told to throw");
-            }
-
-            if (_shouldWait)
-            {
-                _eventHandlerWait.WaitOne();
-            }
-        }
-
-        public void ResumeHandleEvent()
-        {
-            _eventHandlerWait.Set();
-        }
-
-
-        public void Clear()
-        {
-            lock (this)
-            {
-                EventType.Clear();
-                BytesToRead.Clear();
-
-                NumEventsHandled = 0;
-            }
-        }
-
-
-        public bool WaitForEvent(int maxMilliseconds, int totalNumberOfEvents)
-        {
-            Stopwatch sw = new Stopwatch();
-
-            lock (this)
-            {
-                sw.Start();
-
-                while (maxMilliseconds > sw.ElapsedMilliseconds && NumEventsHandled < totalNumberOfEvents)
-                {
-                    Monitor.Wait(this, (int)(maxMilliseconds - sw.ElapsedMilliseconds));
-                }
-
-                return totalNumberOfEvents <= NumEventsHandled;
-            }
-        }
-
-        public bool WaitForEvent(int maxMilliseconds, SerialData eventType)
-        {
-            Stopwatch sw = new Stopwatch();
-
-            lock (this)
-            {
-                sw.Start();
-
-                while (maxMilliseconds > sw.ElapsedMilliseconds)
-                {
-                    Monitor.Wait(this, (int)(maxMilliseconds - sw.ElapsedMilliseconds));
-
-                    for (int i = 0; i < EventType.Count; i++)
-                    {
-                        if (eventType == (SerialData)EventType[i])
-                        {
-                            return true;
-                        }
-                    }
-                }
-
-                return false;
-            }
-        }
-
-
-        //Since we can not garantee the order or the exact time that the event handler is called 
-        //We wil look for an event that was firered that matches the type and that bytesToRead 
-        //is greater then the parameter
-        public bool Validate(SerialData eventType, int bytesToRead)
-        {
-            bool retValue = false;
-
-            lock (this)
-            {
-                for (int i = 0; i < EventType.Count; i++)
-                {
-                    if (eventType == (SerialData)EventType[i] && bytesToRead <= (int)BytesToRead[i] && (SerialPort)Source[i] == _com)
-                    {
-                        EventType.RemoveAt(i);
-                        BytesToRead.RemoveAt(i);
-                        Source.RemoveAt(i);
-
-                        NumEventsHandled--;
-                        retValue = true;
-
-                        break;
-                    }
-                }
-            }
-
-            return retValue;
-        }
-
-
-        public int NumberOfOccurencesOfType(SerialData eventType)
-        {
-            int numOccurences = 0;
-
-            lock (this)
-            {
-                for (int i = 0; i < EventType.Count; i++)
-                {
-                    if (eventType == (SerialData)EventType[i])
-                    {
-                        numOccurences++;
-                    }
-                }
-            }
-
-            return numOccurences;
+            HandleEvent(source, e.EventType);
         }
     }
     #endregion


### PR DESCRIPTION
This PR fixes a hang that was caused by the introduction of the `using()` blocks on the SerialPort objects rather than the explicit `Close` calls which were made in legacy.

I've also done a considerable tidy-up and refactored three near-identical test helper classes into a generic base with three derivations.

EventHandler_ThrowsException has been removed - this was not called by the netfx code - it relies on the very old framework behaviour of swallowing unhandled interrupts on background threads, so clearly hasn't worked since that changed (4.0? 2.0? can't remember).   It's dead and gone, anyway.

Fixes #16013 