### PR TITLE
Adding new definition for UAP and UAPAOT builds and adding it to pipebuild

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows-UAP.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows-UAP.json
@@ -474,7 +474,7 @@
   "path": "\\",
   "type": "build",
   "id": 5308,
-  "name": "DotNet-CoreFx-Trusted-Windows-UWP",
+  "name": "DotNet-CoreFx-Trusted-Windows-UAP",
   "url": "https://devdiv.visualstudio.com/DefaultCollection/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/5308",
   "project": {
     "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",

--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows-UWP.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows-UWP.json
@@ -1,0 +1,487 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Delete 'corefx'",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "-path $(build.SourcesDirectory)\\corefx",
+        "inlineScript": "param($path)\n\nif (Test-Path $path){\n    # this will print out an error each time a file can't be deleted.\n    Remove-Item -Recurse -Force $path\n }\n\nif (Test-Path $path){\n    # in case corefx is still alive\n    .\\diag_tools\\handle.exe -accepteula $path\n }",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "git clone",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(PB_Git)",
+        "arguments": "clone $(PB_VsoCorefxGitUrl) corefx",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "git checkout",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(PB_Git)",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "corefx",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Install Signing Plugin",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "30666190-6959-11e5-9f96-f56098202fef",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "signType": "$(PB_SignType)",
+        "zipSources": "false",
+        "version": "",
+        "feedSource": "https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run $(Build.SourcesDirectory)\\corefx\\clean.cmd",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(Build.SourcesDirectory)\\corefx\\clean.cmd",
+        "arguments": "-all",
+        "workingFolder": "corefx",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run $(Build.SourcesDirectory)\\corefx\\sync.cmd",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(Build.SourcesDirectory)\\corefx\\sync.cmd",
+        "arguments": "$(PB_SyncArguments)",
+        "workingFolder": "corefx",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Generate Version Assets",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(Build.SourcesDirectory)\\corefx\\build-managed.cmd",
+        "arguments": "-GenerateVersion -OfficialBuildId=$(OfficialBuildId)",
+        "workingFolder": "corefx",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run $(Build.SourcesDirectory)\\corefx\\build.cmd",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(Build.SourcesDirectory)\\corefx\\build.cmd",
+        "arguments": "$(PB_BuildArguments)",
+        "workingFolder": "corefx",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Push packages to Azure",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(Build.SourcesDirectory)\\corefx\\publish-packages.cmd",
+        "arguments": "-AzureAccount=$(PB_CloudDropAccountName) -AzureToken=$(CloudDropAccessToken) -Container=$(PB_Label) -- /p:OverwriteOnPublish=true",
+        "workingFolder": "corefx",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": true,
+      "displayName": "Copy Publish Artifact: BuildLogs",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "1d341bb0-2106-458c-8422-d00bcea6512a",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "CopyRoot": "",
+        "Contents": "*.log\ncorefx\\*.log\ncorefx\\src\\*.log",
+        "ArtifactName": "BuildLogs",
+        "ArtifactType": "Container",
+        "TargetPath": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Publish symbols path: \\\\cpvsbuild\\drops\\DotNetCore\\$(PB_SymbolsBuildIdRoot)$(System.DefinitionId)\\$(Build.BuildNumber)\\symbols",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "0675668a-7bba-4ccb-901d-5ad6554ca653",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "SymbolsPath": "\\\\cpvsbuild\\drops\\DotNetCore\\$(PB_SymbolsBuildIdRoot)$(System.DefinitionId)\\$(Build.BuildNumber)\\symbols",
+        "SearchPattern": "corefx\\bin\\*$(PB_Platform).$(PB_ConfigurationGroup)\\**\\*.pdb",
+        "SymbolsFolder": "",
+        "SkipIndexing": "false",
+        "TreatNotIndexedAsWarning": "false",
+        "SymbolsMaximumWaitTime": "",
+        "SymbolsProduct": "",
+        "SymbolsVersion": "",
+        "SymbolsArtifactName": "Symbols_$(PB_ConfigurationGroup)"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Index symbols on http://symweb",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "af503aa3-9d06-44b6-a549-d063a544a5c5",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "symbolStore": "\\\\cpvsbuild\\drops\\DotNetCore\\$(PB_SymbolsBuildIdRoot)$(System.DefinitionId)\\$(Build.BuildNumber)\\symbols",
+        "contacts": "jhendrix;mawilkie",
+        "project": "DDE"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Publish to Symbols to Artifact Services",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "29827cd1-5c33-4ff0-a817-abd46970ffc4",
+        "versionSpec": "0.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "symbolServiceURI": "https://devdiv.artifacts.visualstudio.com/DefaultCollection",
+        "requestName": "$(system.teamProject)/$(Build.BuildNumber)/$(Build.BuildId)",
+        "sourcePath": "$(Build.SourcesDirectory)\\corefx\\bin",
+        "assemblyPath": "",
+        "toLowerCase": "true",
+        "detailedLog": "true",
+        "expirationInDays": "",
+        "usePat": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": true,
+      "displayName": "Execute cleanup tasks",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "521a94ea-9e68-468a-8167-6dcf361ea776",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {}
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Final clean to remove any lingering process",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(Build.SourcesDirectory)\\corefx\\clean.cmd",
+        "arguments": "",
+        "workingFolder": "corefx",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Build solution corefx\\Tools\\scripts\\vstsagent\\cleanupagent.proj",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "solution": "corefx\\Tools\\scripts\\vstsagent\\cleanupagent.proj",
+        "platform": "",
+        "configuration": "",
+        "msbuildArguments": "/p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
+        "clean": "false",
+        "maximumCpuCount": "false",
+        "restoreNugetPackages": "false",
+        "logProjectEvents": "false",
+        "createLogFile": "false",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "14.0",
+        "msbuildArchitecture": "x86",
+        "msbuildLocation": ""
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "234347",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    }
+  ],
+  "variables": {
+    "system.debug": {
+      "value": "false",
+      "allowOverride": true
+    },
+    "PB_ConfigurationGroup": {
+      "value": "Debug",
+      "allowOverride": true
+    },
+    "PB_Platform": {
+      "value": "x64",
+      "allowOverride": true
+    },
+    "PB_CloudDropAccountName": {
+      "value": "dotnetbuildoutput"
+    },
+    "CloudDropAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "OfficialBuildId": {
+      "value": "$(Build.BuildNumber)",
+      "allowOverride": true
+    },
+    "PB_Label": {
+      "value": "$(Build.BuildNumber)",
+      "allowOverride": true
+    },
+    "SourceVersion": {
+      "value": "HEAD",
+      "allowOverride": true
+    },
+    "Build.Clean": {
+      "value": "all"
+    },
+    "PB_VsoAccountName": {
+      "value": "dn-bot"
+    },
+    "VsoPassword": {
+      "value": null,
+      "isSecret": true
+    },
+    "PB_VsoRepositoryName": {
+      "value": "DotNet-CoreFX-Trusted",
+      "allowOverride": true
+    },
+    "PB_VsoCorefxGitUrl": {
+      "value": "https://github.com/dotnet/corefx"
+    },
+    "PB_SourceBranch": {
+      "value": "master",
+      "allowOverride": true
+    },
+    "PB_Git": {
+      "value": "$(ProgramFiles)\\Git\\cmd\\git.exe"
+    },
+    "TeamName": {
+      "value": "DotNetCore"
+    },
+    "PB_RuntimeOS": {
+      "value": "win10"
+    },
+    "PB_CleanAgent": {
+      "value": "true"
+    },
+    "PB_SymbolsBuildIdRoot": {
+      "value": "DotNet-CoreFx-"
+    },
+    "PB_SyncArguments": {
+      "value": "-p -- /p:ArchGroup=x64  /p:RuntimeOS=win10",
+      "allowOverride": true
+    },
+    "PB_BuildArguments": {
+      "value": "-buildArch=x64 -Release -- /p:SignType=test /p:RuntimeOS=win10",
+      "allowOverride": true
+    },
+    "PB_BuildTestsArguments": {
+      "value": "-buildArch=x64 -Release -SkipTests -- /p:RuntimeOS=win10",
+      "allowOverride": true
+    },
+    "PB_CreateHelixArguments": {
+      "value": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=true\" /p:\"BuildMoniker=none\" /p:\"TargetQueue=Windows.10.Amd64\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT",
+      "allowOverride": true
+    }
+  },
+  "demands": [
+    "Agent.OS -equals windows_nt"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 10,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)",
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 180,
+  "repository": {
+    "properties": {
+      "labelSources": "0",
+      "reportBuildStatus": "true",
+      "fetchDepth": "0",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "true",
+      "cleanOptions": "3"
+    },
+    "id": "0a2b2664-c1be-429c-9b40-8a24dee27a4a",
+    "type": "TfsGit",
+    "name": "DotNet-BuildPipeline",
+    "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-BuildPipeline",
+    "defaultBranch": "refs/heads/master",
+    "clean": "false",
+    "checkoutSubmodules": false
+  },
+  "quality": "definition",
+  "queue": {
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    },
+    "id": 36,
+    "name": "DotNet-Build"
+  },
+  "path": "\\",
+  "type": "build",
+  "id": 5308,
+  "name": "DotNet-CoreFx-Trusted-Windows-UWP",
+  "url": "https://devdiv.visualstudio.com/DefaultCollection/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/5308",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097529
+  }
+}

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -278,6 +278,136 @@
             "Platform": "x86",
             "ConfigurationGroup": "Release"
           }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Parameters": {
+            "PB_Platform": "arm",
+            "PB_BuildArguments": "-framework=uap -buildArch=arm -Release -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=arm /p:ConfigurationGroup=Release /p:\"EnableCloudTest=false\" /p:\"BuildMoniker=none\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "arm",
+            "ConfigurationGroup": "Release",
+            "SubType": "Uap Vertical"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Parameters": {
+            "PB_Platform": "arm64",
+            "PB_BuildArguments": "-framework=uap -buildArch=arm64 -Release -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=arm64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=false\" /p:\"BuildMoniker=none\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "arm64",
+            "ConfigurationGroup": "Release",
+            "SubType": "Uap Vertical"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Parameters": {
+            "PB_Platform": "x64",
+            "PB_BuildArguments": "-framework=uap -buildArch=x64 -Release -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=true\" /p:\"BuildMoniker=none\" /p:\"TargetQueue=Windows.10.Amd64\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x64",
+            "ConfigurationGroup": "Release",
+            "SubType": "Uap Vertical"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Parameters": {
+            "PB_Platform": "x86",
+            "PB_TargetQueue": "Windows.10.Amd64",
+            "PB_BuildArguments": "-framework=uap -buildArch=x86 -Release -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x86 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=true\" /p:\"BuildMoniker=none\" /p:\"TargetQueue=Windows.10.Amd64\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x86",
+            "ConfigurationGroup": "Release",
+            "SubType": "Uap Vertical"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Parameters": {
+            "PB_Platform": "arm",
+            "PB_BuildArguments": "-framework=uapaot -buildArch=arm -Release -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=arm /p:ConfigurationGroup=Release /p:\"EnableCloudTest=false\" /p:\"BuildMoniker=none\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "arm",
+            "ConfigurationGroup": "Release",
+            "SubType": "Uapaot Vertical"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Parameters": {
+            "PB_Platform": "arm64",
+            "PB_BuildArguments": "-framework=uapaot -buildArch=arm64 -Release -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=arm64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=false\" /p:\"BuildMoniker=none\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "arm64",
+            "ConfigurationGroup": "Release",
+            "SubType": "Uapaot Vertical"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Parameters": {
+            "PB_Platform": "x64",
+            "PB_BuildArguments": "-framework=uapaot -buildArch=x64 -Release -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=true\" /p:\"BuildMoniker=none\" /p:\"TargetQueue=Windows.10.Amd64\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x64",
+            "ConfigurationGroup": "Release",
+            "SubType": "Uapaot Vertical"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Parameters": {
+            "PB_Platform": "x86",
+            "PB_TargetQueue": "Windows.10.Amd64",
+            "PB_BuildArguments": "-framework=uapaot -buildArch=x86 -Release -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x86 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=true\" /p:\"BuildMoniker=none\" /p:\"TargetQueue=Windows.10.Amd64\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x86",
+            "ConfigurationGroup": "Release",
+            "SubType": "Uapaot Vertical"
+          }
         }
       ]
     },
@@ -552,6 +682,136 @@
             "Type": "build/product/",
             "Platform": "x86",
             "ConfigurationGroup": "Debug"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Parameters": {
+            "PB_Platform": "arm",
+            "PB_BuildArguments": "-framework:uap -buildArch=arm -Debug -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=arm /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=false\" /p:\"BuildMoniker=none\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "arm",
+            "ConfigurationGroup": "Debug",
+            "SubType": "Uap Vertical"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Parameters": {
+            "PB_Platform": "arm64",
+            "PB_BuildArguments": "-framework:uap -buildArch=arm64 -Debug -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=arm64 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=false\" /p:\"BuildMoniker=none\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "arm64",
+            "ConfigurationGroup": "Debug",
+            "SubType": "Uap Vertical"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Parameters": {
+            "PB_Platform": "x64",
+            "PB_BuildArguments": "-framework:uap -buildArch=x64 -Debug -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=true\" /p:\"BuildMoniker=none\" /p:\"TargetQueue=Windows.10.Amd64\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x64",
+            "ConfigurationGroup": "Debug",
+            "SubType": "Uap Vertical"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Parameters": {
+            "PB_Platform": "x86",
+            "PB_TargetQueue": "Windows.10.Amd64",
+            "PB_BuildArguments": "-framework:uap -buildArch=x86 -Debug -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x86 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=true\" /p:\"BuildMoniker=none\" /p:\"TargetQueue=Windows.10.Amd64\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x86",
+            "ConfigurationGroup": "Debug",
+            "SubType": "Uap Vertical"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Parameters": {
+            "PB_Platform": "arm",
+            "PB_BuildArguments": "-framework:uapaot -buildArch=arm -Debug -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=arm /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=false\" /p:\"BuildMoniker=none\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "arm",
+            "ConfigurationGroup": "Debug",
+            "SubType": "Uapaot Vertical"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Parameters": {
+            "PB_Platform": "arm64",
+            "PB_BuildArguments": "-framework:uapaot -buildArch=arm64 -Debug -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=arm64 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=false\" /p:\"BuildMoniker=none\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "arm64",
+            "ConfigurationGroup": "Debug",
+            "SubType": "Uapaot Vertical"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Parameters": {
+            "PB_Platform": "x64",
+            "PB_BuildArguments": "-framework:uapaot -buildArch=x64 -Debug -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=true\" /p:\"BuildMoniker=none\" /p:\"TargetQueue=Windows.10.Amd64\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x64",
+            "ConfigurationGroup": "Debug",
+            "SubType": "Uapaot Vertical"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Parameters": {
+            "PB_Platform": "x86",
+            "PB_TargetQueue": "Windows.10.Amd64",
+            "PB_BuildArguments": "-framework:uapaot -buildArch=x86 -Debug -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x86 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x86 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=true\" /p:\"BuildMoniker=none\" /p:\"TargetQueue=Windows.10.Amd64\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x86",
+            "ConfigurationGroup": "Debug",
+            "SubType": "Uapaot Vertical"
           }
         }
       ]

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -280,7 +280,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
           "Parameters": {
             "PB_Platform": "arm",
             "PB_BuildArguments": "-framework=uap -buildArch=arm -Release -- /p:SignType=real /p:RuntimeOS=win10",
@@ -296,23 +296,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
-          "Parameters": {
-            "PB_Platform": "arm64",
-            "PB_BuildArguments": "-framework=uap -buildArch=arm64 -Release -- /p:SignType=real /p:RuntimeOS=win10",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10",
-            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=arm64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=false\" /p:\"BuildMoniker=none\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "arm64",
-            "ConfigurationGroup": "Release",
-            "SubType": "Uap"
-          }
-        },
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
           "Parameters": {
             "PB_Platform": "x64",
             "PB_BuildArguments": "-framework=uap -buildArch=x64 -Release -- /p:SignType=real /p:RuntimeOS=win10",
@@ -328,7 +312,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
           "Parameters": {
             "PB_Platform": "x86",
             "PB_TargetQueue": "Windows.10.Amd64",
@@ -345,7 +329,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
           "Parameters": {
             "PB_Platform": "arm",
             "PB_BuildArguments": "-framework=uapaot -buildArch=arm -Release -- /p:SignType=real /p:RuntimeOS=win10",
@@ -357,27 +341,11 @@
             "Type": "build/product/",
             "Platform": "arm",
             "ConfigurationGroup": "Release",
-            "SubType": "Uapaot Vertical"
+            "SubType": "Uapaot"
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
-          "Parameters": {
-            "PB_Platform": "arm64",
-            "PB_BuildArguments": "-framework=uapaot -buildArch=arm64 -Release -- /p:SignType=real /p:RuntimeOS=win10",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10",
-            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=arm64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=false\" /p:\"BuildMoniker=none\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "arm64",
-            "ConfigurationGroup": "Release",
-            "SubType": "Uapaot Vertical"
-          }
-        },
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
           "Parameters": {
             "PB_Platform": "x64",
             "PB_BuildArguments": "-framework=uapaot -buildArch=x64 -Release -- /p:SignType=real /p:RuntimeOS=win10",
@@ -389,11 +357,11 @@
             "Type": "build/product/",
             "Platform": "x64",
             "ConfigurationGroup": "Release",
-            "SubType": "Uapaot Vertical"
+            "SubType": "Uapaot"
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
           "Parameters": {
             "PB_Platform": "x86",
             "PB_TargetQueue": "Windows.10.Amd64",
@@ -406,7 +374,7 @@
             "Type": "build/product/",
             "Platform": "x86",
             "ConfigurationGroup": "Release",
-            "SubType": "Uapaot Vertical"
+            "SubType": "Uapaot"
           }
         }
       ]
@@ -685,7 +653,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
           "Parameters": {
             "PB_Platform": "arm",
             "PB_BuildArguments": "-framework:uap -buildArch=arm -Debug -- /p:SignType=real /p:RuntimeOS=win10",
@@ -701,23 +669,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
-          "Parameters": {
-            "PB_Platform": "arm64",
-            "PB_BuildArguments": "-framework:uap -buildArch=arm64 -Debug -- /p:SignType=real /p:RuntimeOS=win10",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10",
-            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=arm64 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=false\" /p:\"BuildMoniker=none\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "arm64",
-            "ConfigurationGroup": "Debug",
-            "SubType": "Uap"
-          }
-        },
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
           "Parameters": {
             "PB_Platform": "x64",
             "PB_BuildArguments": "-framework:uap -buildArch=x64 -Debug -- /p:SignType=real /p:RuntimeOS=win10",
@@ -733,7 +685,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
           "Parameters": {
             "PB_Platform": "x86",
             "PB_TargetQueue": "Windows.10.Amd64",
@@ -750,7 +702,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
           "Parameters": {
             "PB_Platform": "arm",
             "PB_BuildArguments": "-framework:uapaot -buildArch=arm -Debug -- /p:SignType=real /p:RuntimeOS=win10",
@@ -762,27 +714,11 @@
             "Type": "build/product/",
             "Platform": "arm",
             "ConfigurationGroup": "Debug",
-            "SubType": "Uapaot Vertical"
+            "SubType": "Uapaot"
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
-          "Parameters": {
-            "PB_Platform": "arm64",
-            "PB_BuildArguments": "-framework:uapaot -buildArch=arm64 -Debug -- /p:SignType=real /p:RuntimeOS=win10",
-            "PB_SyncArguments": "-p -- /p:ArchGroup=arm64 /p:RuntimeOS=win10",
-            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=arm64 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=false\" /p:\"BuildMoniker=none\" /p:\"TestProduct=corefx\" /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Windows_NT\" /p:FilterToOSGroup=Windows_NT"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "arm64",
-            "ConfigurationGroup": "Debug",
-            "SubType": "Uapaot Vertical"
-          }
-        },
-        {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
           "Parameters": {
             "PB_Platform": "x64",
             "PB_BuildArguments": "-framework:uapaot -buildArch=x64 -Debug -- /p:SignType=real /p:RuntimeOS=win10",
@@ -794,11 +730,11 @@
             "Type": "build/product/",
             "Platform": "x64",
             "ConfigurationGroup": "Debug",
-            "SubType": "Uapaot Vertical"
+            "SubType": "Uapaot"
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UWP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
           "Parameters": {
             "PB_Platform": "x86",
             "PB_TargetQueue": "Windows.10.Amd64",
@@ -811,7 +747,7 @@
             "Type": "build/product/",
             "Platform": "x86",
             "ConfigurationGroup": "Debug",
-            "SubType": "Uapaot Vertical"
+            "SubType": "Uapaot"
           }
         }
       ]

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -292,7 +292,7 @@
             "Type": "build/product/",
             "Platform": "arm",
             "ConfigurationGroup": "Release",
-            "SubType": "Uap Vertical"
+            "SubType": "Uap"
           }
         },
         {
@@ -308,7 +308,7 @@
             "Type": "build/product/",
             "Platform": "arm64",
             "ConfigurationGroup": "Release",
-            "SubType": "Uap Vertical"
+            "SubType": "Uap"
           }
         },
         {
@@ -324,7 +324,7 @@
             "Type": "build/product/",
             "Platform": "x64",
             "ConfigurationGroup": "Release",
-            "SubType": "Uap Vertical"
+            "SubType": "Uap"
           }
         },
         {
@@ -341,7 +341,7 @@
             "Type": "build/product/",
             "Platform": "x86",
             "ConfigurationGroup": "Release",
-            "SubType": "Uap Vertical"
+            "SubType": "Uap"
           }
         },
         {
@@ -697,7 +697,7 @@
             "Type": "build/product/",
             "Platform": "arm",
             "ConfigurationGroup": "Debug",
-            "SubType": "Uap Vertical"
+            "SubType": "Uap"
           }
         },
         {
@@ -713,7 +713,7 @@
             "Type": "build/product/",
             "Platform": "arm64",
             "ConfigurationGroup": "Debug",
-            "SubType": "Uap Vertical"
+            "SubType": "Uap"
           }
         },
         {
@@ -729,7 +729,7 @@
             "Type": "build/product/",
             "Platform": "x64",
             "ConfigurationGroup": "Debug",
-            "SubType": "Uap Vertical"
+            "SubType": "Uap"
           }
         },
         {
@@ -746,7 +746,7 @@
             "Type": "build/product/",
             "Platform": "x86",
             "ConfigurationGroup": "Debug",
-            "SubType": "Uap Vertical"
+            "SubType": "Uap"
           }
         },
         {

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.builds
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.builds
@@ -5,7 +5,7 @@
   <Import Project="$(MSBuildProjectName).props" />
 
   <ItemGroup>
-    <!-- identity project, runtime specific projects are included by props above. Will not be includded on uapaot builds. -->
+    <!-- identity project, runtime specific projects are included by props above. Will not be built on uapaot builds. -->
     <Project Include="$(MSBuildProjectName).pkgproj" Condition="'$(TargetGroup)'=='uap'" />
   </ItemGroup>
 

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.props
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.props
@@ -4,18 +4,16 @@
   <PropertyGroup>
     <_runtimeOSVersionIndex>$(RuntimeOS.IndexOfAny(".-0123456789"))</_runtimeOSVersionIndex>
     <_runtimeOSFamily Condition="'$(_runtimeOSVersionIndex)' != '-1'">$(RuntimeOS.SubString(0, $(_runtimeOSVersionIndex)))</_runtimeOSFamily>
+    <_aotSuffix Condition="'$(TargetGroup)' == 'uapaot'">-aot</_aotSuffix>
   </PropertyGroup>
   
   <Choose>
     <When Condition="'$(PackageRID)' != ''" />
     <When Condition="'$(_runtimeOSFamily)' == 'win'">
       <PropertyGroup>
-        <PackageRID Condition="'$(ArchGroup)' == 'x86' OR '$(ArchGroup)' == 'x64'">win7-$(ArchGroup)</PackageRID>
-        <PackageRID Condition="'$(ArchGroup)' == 'arm'">win8-$(ArchGroup)</PackageRID>
-        <PackageRID Condition="'$(ArchGroup)' == 'arm64'">win10-$(ArchGroup)</PackageRID>
-        <PackageRID Condition="('$(ArchGroup)' == 'x86' OR '$(ArchGroup)' == 'x64') And '$(TargetGroup)' == 'uapaot'">win7-$(ArchGroup)-aot</PackageRID>
-        <PackageRID Condition="'$(ArchGroup)' == 'arm' And '$(TargetGroup)' == 'uapaot'">win8-$(ArchGroup)-aot</PackageRID>
-        <PackageRID Condition="'$(ArchGroup)' == 'arm64' And '$(TargetGroup)' == 'uapaot'">win10-$(ArchGroup)-aot</PackageRID>
+        <PackageRID Condition="'$(ArchGroup)' == 'x86' OR '$(ArchGroup)' == 'x64'">win7-$(ArchGroup)$(_aotSuffix)</PackageRID>
+        <PackageRID Condition="'$(ArchGroup)' == 'arm'">win8-$(ArchGroup)$(_aotSuffix)</PackageRID>
+        <PackageRID Condition="'$(ArchGroup)' == 'arm64'">win10-$(ArchGroup)$(_aotSuffix)</PackageRID>
       </PropertyGroup>
     </When>
     <Otherwise>


### PR DESCRIPTION
cc: @chcosta @weshaggard 
FYI: @joshfree 

This PR:
 - Sets up a new build definition called DotNet-CoreFx-Trusted-Windows-UWP that is very similar to the one we currently have for Windows except that it doesn't run build-tests nor it triggers jobs for Helix.
 - Change pipebuild.json in order to add these additional configurations to our official build. It adds 16 builds in total (4 build architectures<x86 x64 arm arm64> * 2 verticals<uap and uapaot> * 2 flavors<Debug and Release>)