### PR TITLE
Allow long SerialPort tests to be shortened globally

### DIFF
--- a/src/System.IO.Ports/tests/Legacy/SerialPort/Event_Close_Stress.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/Event_Close_Stress.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Diagnostics;
 using System.IO.Ports;
 using System.IO.PortsTests;
@@ -11,7 +12,7 @@ using Xunit;
 public class Event_Close_Stress : PortsTest
 {
     //Maximum time to wait for all of the expected events to be firered
-    public static readonly int MAX_TEST_TIME = 3 * 60 * 1000;
+    private static readonly TimeSpan TestDuration = TCSupport.RunShortStressTests ? TimeSpan.FromSeconds(10) : TimeSpan.FromMinutes(3);
 
     #region Test Cases
 
@@ -28,7 +29,7 @@ public class Event_Close_Stress : PortsTest
             com2.Open();
 
             stopwatch.Start();
-            while (count % 100 != 0 || stopwatch.ElapsedMilliseconds < MAX_TEST_TIME)
+            while (count % 100 != 0 || stopwatch.ElapsedMilliseconds < TestDuration.TotalMilliseconds)
             {
                 com1.Open();
 
@@ -66,7 +67,7 @@ public class Event_Close_Stress : PortsTest
             com2.Open();
 
             stopwatch.Start();
-            while (count % 100 != 0 || stopwatch.ElapsedMilliseconds < MAX_TEST_TIME)
+            while (count % 100 != 0 || stopwatch.ElapsedMilliseconds < TestDuration.TotalMilliseconds)
             {
                 com1.Open();
 
@@ -114,7 +115,7 @@ public class Event_Close_Stress : PortsTest
             frameErrorBytes[0] = 0x01;
 
             stopwatch.Start();
-            while (count % 100 != 0 || stopwatch.ElapsedMilliseconds < MAX_TEST_TIME)
+            while (count % 100 != 0 || stopwatch.ElapsedMilliseconds < TestDuration.TotalMilliseconds)
             {
                 com1.Open();
 

--- a/src/System.IO.Ports/tests/Legacy/SerialPort/Open_Stress.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/Open_Stress.cs
@@ -25,8 +25,8 @@ public class Open_stress : PortsTest
 
             try
             {
-                // TODO - Verify number of iterations (original is 1000 which makes test very slow)
-                for (int i = 0; i < 10; ++i)
+                int iterationCount = TCSupport.RunShortStressTests ? 10 : 1000;
+                for (int i = 0; i < iterationCount; ++i)
                 {
                     com.RtsEnable = true;
                     com.Open();
@@ -76,12 +76,11 @@ public class Open_stress : PortsTest
 
             for (int i = 0; i < xmitBytes.Length; ++i)
                 xmitBytes[i] = (byte)i;
-
-
+            
             try
             {
-                // TODO - Verify number of iterations (original is 1000 which makes test very slow)
-                for (int i = 0; i < 10; ++i)
+                int iterationCount = TCSupport.RunShortStressTests ? 10 : 1000;
+                for (int i = 0; i < iterationCount; ++i)
                 {
                     com.Open();
                     com.Handshake = Handshake.RequestToSend;

--- a/src/System.IO.Ports/tests/Legacy/SerialPort/ReadBufferSize.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/ReadBufferSize.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO.Ports;
 using System.IO;
 using System.IO.PortsTests;
+using System.Linq;
 using Legacy.Support;
 using Xunit;
 
@@ -276,7 +277,7 @@ public class ReadBufferSize_Property : PortsTest
 
                 com1.Read(rcvBytes, 0, newBytesToRead);
 
-                Assert.Equal(xmitBytes, rcvBytes);
+                Assert.Equal(xmitBytes.Take(newReadBufferSize), rcvBytes.Take(newReadBufferSize));
 
                 Debug.WriteLine("Verifying properties after bytes have been read");
                 serPortProp.SetProperty("BytesToRead", 0);

--- a/src/System.IO.Ports/tests/Legacy/SerialPort/ReadExisting_Generic.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/ReadExisting_Generic.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO.Ports;
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Linq;
 using Legacy.Support;
 using Xunit;
 
@@ -180,7 +181,7 @@ public class ReadExisting_Generic : PortsTest
             char[] actualChars = (com1.ReadExisting()).ToCharArray();
 
             //Compare the chars that were written with the ones we expected to read
-            Assert.Equal(expectedChars, actualChars);
+            Assert.Equal(expectedChars, actualChars.Take(expectedChars.Length).ToArray());
 
             if (1 < com1.BytesToRead)
             {

--- a/src/System.IO.Ports/tests/Legacy/SerialPort/Read_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/Read_byte_int_int_Generic.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO.Ports;
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Linq;
 using Legacy.Support;
 using Xunit;
 
@@ -249,7 +250,7 @@ public class Read_byte_int_int_Generic : PortsTest
             com1.Read(actualBytes, 0, actualBytes.Length);
 
             //Compare the chars that were written with the ones we expected to read
-            Assert.Equal(expectedBytes, actualBytes);
+            Assert.Equal(expectedBytes, actualBytes.Take(expectedBytes.Length).ToArray());
 
             if (1 < com1.BytesToRead)
             {

--- a/src/System.IO.Ports/tests/Legacy/SerialPort/ReceivedBytesThreshold.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/ReceivedBytesThreshold.cs
@@ -267,42 +267,6 @@ public class ReceivedBytesThreshold_Property : PortsTest
         }
     }
 
-    [ConditionalFact(nameof(HasNullModem), Skip="Was not run in legacy tests")]
-    public void ReceivedBytesThreshold_Twice()
-    {
-        using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
-        using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
-        {
-            ReceivedEventHandler rcvEventHandler = new ReceivedEventHandler(com1);
-            SerialPortProperties serPortProp = new SerialPortProperties();
-
-            Random rndGen = new Random(-55);
-            int receivedBytesThreshold = rndGen.Next(MIN_RND_THRESHOLD, MAX_RND_THRESHOLD);
-
-            com1.ReceivedBytesThreshold = receivedBytesThreshold;
-            com1.Open();
-            com2.Open();
-            com1.DataReceived += rcvEventHandler.HandleEvent;
-
-            serPortProp.SetAllPropertiesToOpenDefaults();
-            serPortProp.SetProperty("ReceivedBytesThreshold", receivedBytesThreshold);
-            serPortProp.SetProperty("PortName", TCSupport.LocalMachineSerialInfo.FirstAvailablePortName);
-
-            Debug.WriteLine(
-                "Verifying writing twice the number of bytes of ReceivedBytesThreshold and ReceivedEvent firered twice");
-
-            com2.Write(new byte[com1.ReceivedBytesThreshold * 2], 0, com1.ReceivedBytesThreshold * 2);
-
-            rcvEventHandler.WaitForEvent(SerialData.Chars, 2, MAX_TIME_WAIT);
-            
-            com1.DiscardInBuffer();
-
-            serPortProp.VerifyPropertiesAndPrint(com1);
-            rcvEventHandler.Validate(SerialData.Chars, com1.ReceivedBytesThreshold, 0);
-            rcvEventHandler.Validate(SerialData.Chars, 2 * com1.ReceivedBytesThreshold, 1);
-        }
-    }
-
     [ConditionalFact(nameof(HasNullModem))]
     public void ReceivedBytesThreshold_Int32MinValue()
     {

--- a/src/System.IO.Ports/tests/Legacy/SerialPort/Stress01.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialPort/Stress01.cs
@@ -16,7 +16,7 @@ public class Write_char_int_int_stress01 : PortsTest
     private const int TRANSMIT_BUFFER_SIZE = 4096;
     private const int MAX_BUFFER_SIZE = 4096;
 
-    private const int MAX_RUN_TIME = 1000 * 60 * 20;
+    private static readonly TimeSpan TestDuration = TCSupport.RunShortStressTests ? TimeSpan.FromSeconds(10) : TimeSpan.FromMinutes(20);
 
     [ConditionalFact(nameof(HasNullModem))]
     public void WriteChars()
@@ -42,7 +42,7 @@ public class Write_char_int_int_stress01 : PortsTest
                 com2.Open();
 
             sw.Start();
-            while (sw.ElapsedMilliseconds < MAX_RUN_TIME)
+            while (sw.ElapsedMilliseconds < TestDuration.TotalMilliseconds)
             {
                 switch (random.Next(0, 2))
                 {

--- a/src/System.IO.Ports/tests/Legacy/Support/TCSupport.cs
+++ b/src/System.IO.Ports/tests/Legacy/Support/TCSupport.cs
@@ -230,6 +230,11 @@ namespace Legacy.Support
             }
         }
 
+        /// <summary>
+        /// Set this true to shorten the very long-running stress tests
+        /// </summary>
+        public static bool RunShortStressTests { get; set; } = true;
+
         public delegate bool Predicate();
 
         public delegate T ValueGenerator<T>();


### PR DESCRIPTION
The SerialPort tests include some very long (3 minutes, 20 minutes) 'stress' tests, which make working on the test suite miserable.  This PR adds a global setting which allows us to shorten them to a few seconds.

These tests don't run as part of CI at present because they require hardware support, so this isn't a CI issue.

Ultimately we will need to have a mechanism for doing 'manual' tests which could control this global setting, for now it's just a cleaner alternative to having local adjustments to timings all over the place.

All part of issue #15752