### PR TITLE
Microsoft.CSharp fix for assembly names comparison

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -1318,17 +1318,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     goto SetMemo;
                 }
 
-#if UNSUPPORTEDAPI
                 result = assemblyThatDefinesAttribute.GetCustomAttributes()
                     .OfType<InternalsVisibleToAttribute>()
                     .Select(ivta => new AssemblyName(ivta.AssemblyName))
                     .Any(an => AssemblyName.ReferenceMatchesDefinition(an, assyName));
-#else
-                result = Enumerable.Any(assemblyThatDefinesAttribute.GetCustomAttributes()
-                                        .OfType<InternalsVisibleToAttribute>()
-                                        .Select(ivta => new AssemblyName(ivta.AssemblyName)),
-                                        an => an.Equals(assyName));
-#endif
+
             SetMemo:
                 _internalsVisibleToCalculated[key] = result;
             }


### PR DESCRIPTION
 to work with not strongly named assemblies as well