### PR TITLE
Add unchecked missed due to race between PRs

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -405,7 +405,7 @@ namespace System.Linq.Expressions.Compiler
         {
             if (int.MinValue <= value & value <= uint.MaxValue)
             {
-                il.EmitPrimitive((int)value);
+                il.EmitPrimitive(unchecked((int)value));
                 // While often not of consequence depending on what follows, there are cases where this
                 // casting matters. Values [0, int.MaxValue] can use either safely, but negative values
                 // must use conv.i8 and those (int.MaxValue, uint.MaxValue] must use conv.u8, or else


### PR DESCRIPTION
#15885 marked code depending on unchecked arithmetic or conversions in src/System/Linq/Expressions/Compiler/ILGen.cs as explicitly `unchecked`, but meanwhile #15797 was pending which added another such case.

Mark it as `unchecked`.