### PR TITLE
Added a TryGetValue method to HashSet and SortedSet

### DIFF
--- a/src/System.Collections/ref/System.Collections.cs
+++ b/src/System.Collections/ref/System.Collections.cs
@@ -209,6 +209,7 @@ namespace System.Collections.Generic
         System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         public void TrimExcess() { }
+        public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
         public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
@@ -584,6 +585,7 @@ namespace System.Collections.Generic
         System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
         void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
         public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -450,6 +450,30 @@ namespace System.Collections.Generic
         }
 
         /// <summary>
+        /// Searches the set for a given value and returns the equal value it finds, if any.
+        /// </summary>
+        /// <param name="equalValue">The value to search for.</param>
+        /// <param name="actualValue">The value from the set that the search found, or the original value if the search yielded no match.</param>
+        /// <returns>A value indicating whether the search was successful.</returns>
+        /// <remarks>
+        /// This can be useful when you want to reuse a previously stored reference instead of 
+        /// a newly constructed one (so that more sharing of references can occur) or to look up
+        /// a value that has more complete data than the value you currently have, although their
+        /// comparer functions indicate they are equal.
+        /// </remarks>
+        public bool TryGetValue(T equalValue, out T actualValue)
+        {
+            int i = _buckets != null ? InternalIndexOf(equalValue) : -1;
+            if (i >= 0)
+            {
+                actualValue = _slots[i].value;
+                return true;
+            }
+            actualValue = default(T);
+            return false;
+        }
+
+        /// <summary>
         /// Take the union of this HashSet with other. Modifies this set.
         /// 
         /// Implementation note: GetSuggestedCapacity (to increase capacity in advance avoiding 

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -463,11 +463,14 @@ namespace System.Collections.Generic
         /// </remarks>
         public bool TryGetValue(T equalValue, out T actualValue)
         {
-            int i = _buckets != null ? InternalIndexOf(equalValue) : -1;
-            if (i >= 0)
+            if (_buckets != null)
             {
-                actualValue = _slots[i].value;
-                return true;
+                int i = InternalIndexOf(equalValue);
+                if (i >= 0)
+                {
+                    actualValue = _slots[i].value;
+                    return true;
+                }
             }
             actualValue = default(T);
             return false;

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -2025,6 +2025,30 @@ namespace System.Collections.Generic
 
         #region Miscellaneous
 
+        /// <summary>
+        /// Searches the set for a given value and returns the equal value it finds, if any.
+        /// </summary>
+        /// <param name="equalValue">The value to search for.</param>
+        /// <param name="actualValue">The value from the set that the search found, or the original value if the search yielded no match.</param>
+        /// <returns>A value indicating whether the search was successful.</returns>
+        /// <remarks>
+        /// This can be useful when you want to reuse a previously stored reference instead of 
+        /// a newly constructed one (so that more sharing of references can occur) or to look up
+        /// a value that has more complete data than the value you currently have, although their
+        /// comparer functions indicate they are equal.
+        /// </remarks>
+        public bool TryGetValue(T equalValue, out T actualValue)
+        {
+            Node node = FindNode(equalValue);
+            if (node != null)
+            {
+                actualValue = node.Item;
+                return true;
+            }
+            actualValue = default(T);
+            return false;
+        }
+
         // Used for set checking operations (using enumerables) that rely on counting
         private static int Log2(int value)
         {

--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
@@ -335,6 +335,35 @@ namespace System.Collections.Tests
 
         #endregion
 
+        #region TryGetValue
+
+        [Fact]
+        public void HashSet_Generic_TryGetValue_Contains()
+        {
+            T value = CreateT(1);
+            HashSet<T> set = new HashSet<T> { value };
+            T equalValue = CreateT(1);
+            T actualValue;
+            Assert.True(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(value, actualValue);
+            if (!typeof(T).IsValueType)
+            {
+                Assert.Same(value, actualValue);
+            }
+        }
+
+        [Fact]
+        public void HashSet_Generic_TryGetValue_NotContains()
+        {
+            T value = CreateT(1);
+            HashSet<T> set = new HashSet<T> { value };
+            T equalValue = CreateT(2);
+            T actualValue;
+            Assert.False(set.TryGetValue(equalValue, out actualValue));
+        }
+
+        #endregion
+
         [Fact]
         public void CanBeCastedToISet()
         {

--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
@@ -353,6 +353,21 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        public void HashSet_Generic_TryGetValue_Contains_OverwriteOutputParam()
+        {
+            T value = CreateT(1);
+            HashSet<T> set = new HashSet<T> { value };
+            T equalValue = CreateT(1);
+            T actualValue = CreateT(2);
+            Assert.True(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(value, actualValue);
+            if (!typeof(T).IsValueType)
+            {
+                Assert.Same(value, actualValue);
+            }
+        }
+
+        [Fact]
         public void HashSet_Generic_TryGetValue_NotContains()
         {
             T value = CreateT(1);
@@ -360,6 +375,18 @@ namespace System.Collections.Tests
             T equalValue = CreateT(2);
             T actualValue;
             Assert.False(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(default(T), actualValue);
+        }
+
+        [Fact]
+        public void HashSet_Generic_TryGetValue_NotContains_OverwriteOutputParam()
+        {
+            T value = CreateT(1);
+            HashSet<T> set = new HashSet<T> { value };
+            T equalValue = CreateT(2);
+            T actualValue = equalValue;
+            Assert.False(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(default(T), actualValue);
         }
 
         #endregion

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
@@ -333,5 +333,35 @@ namespace System.Collections.Tests
         }
 #endif
         #endregion
+
+        #region TryGetValue
+
+        [Fact]
+        public void SortedSet_Generic_TryGetValue_Contains()
+        {
+            T value = CreateT(1);
+            SortedSet<T> set = new SortedSet<T> { value };
+            T equalValue = CreateT(1);
+            T actualValue;
+            bool contains = set.TryGetValue(equalValue, out actualValue);
+            Assert.True(contains);
+            Assert.Equal(value, actualValue);
+            if (!typeof(T).IsValueType)
+            {
+                Assert.Same(value, actualValue);
+            }
+        }
+
+        [Fact]
+        public void SortedSet_Generic_TryGetValue_NotContains()
+        {
+            T value = CreateT(1);
+            SortedSet<T> set = new SortedSet<T> { value };
+            T equalValue = CreateT(2);
+            T actualValue;
+            Assert.False(set.TryGetValue(equalValue, out actualValue));
+        }
+
+        #endregion
     }
 }

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
@@ -343,8 +343,22 @@ namespace System.Collections.Tests
             SortedSet<T> set = new SortedSet<T> { value };
             T equalValue = CreateT(1);
             T actualValue;
-            bool contains = set.TryGetValue(equalValue, out actualValue);
-            Assert.True(contains);
+            Assert.True(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(value, actualValue);
+            if (!typeof(T).IsValueType)
+            {
+                Assert.Same(value, actualValue);
+            }
+        }
+
+        [Fact]
+        public void SortedSet_Generic_TryGetValue_Contains_OverwriteOutputParam()
+        {
+            T value = CreateT(1);
+            SortedSet<T> set = new SortedSet<T> { value };
+            T equalValue = CreateT(1);
+            T actualValue = CreateT(2);
+            Assert.True(set.TryGetValue(equalValue, out actualValue));
             Assert.Equal(value, actualValue);
             if (!typeof(T).IsValueType)
             {
@@ -360,6 +374,18 @@ namespace System.Collections.Tests
             T equalValue = CreateT(2);
             T actualValue;
             Assert.False(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(default(T), actualValue);
+        }
+
+        [Fact]
+        public void SortedSet_Generic_TryGetValue_NotContains_OverwriteOutputParam()
+        {
+            T value = CreateT(1);
+            SortedSet<T> set = new SortedSet<T> { value };
+            T equalValue = CreateT(2);
+            T actualValue = equalValue;
+            Assert.False(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(default(T), actualValue);
         }
 
         #endregion

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.TreeSubSet.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.TreeSubSet.Tests.cs
@@ -26,11 +26,10 @@ namespace System.Collections.Tests
     {
         protected override string Min => 0.ToString().PadLeft(10);
         protected override string Max => int.MaxValue.ToString().PadLeft(10);
-        private int _current = 1;
 
         protected override string CreateT(int seed)
         {
-            return _current++.ToString().PadLeft(10);
+            return seed.ToString().PadLeft(10);
         }
 
         public override void ICollection_Generic_Remove_DefaultValueContainedInCollection(int count)


### PR DESCRIPTION
Closes #15691

Added a `TryGetValue` method to `HashSet` and `SortedSet`.

Also fixed a bug in a `SortedSet` test as subsequent calls to `CreateT` with the same `seed` should return an equivalent value. The current implementation completely ignored the `seed`.