### PR TITLE
Have S.L.Expressions compiler test and add constants in a single pass.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -442,18 +442,13 @@ namespace System.Linq.Expressions.Compiler
             }
 
             Type t = value as Type;
-            if (t != null && ShouldLdtoken(t))
+            if (t != null)
             {
-                return true;
+                return ShouldLdtoken(t);
             }
 
             MethodBase mb = value as MethodBase;
-            if (mb != null && ShouldLdtoken(mb))
-            {
-                return true;
-            }
-
-            return false;
+            return mb != null && ShouldLdtoken(mb);
         }
 
         // matches TryEmitILConstant
@@ -477,20 +472,14 @@ namespace System.Linq.Expressions.Compiler
                 case TypeCode.String:
                     return true;
             }
+
             return false;
         }
-
-        internal static void EmitConstant(this ILGenerator il, object value, ILocalCache locals)
-        {
-            Debug.Assert(value != null);
-            EmitConstant(il, value, value.GetType(), locals);
-        }
-
 
         //
         // Note: we support emitting more things as IL constants than
         // Linq does
-        internal static void EmitConstant(this ILGenerator il, object value, Type type, ILocalCache locals)
+        internal static bool TryEmitConstant(this ILGenerator il, object value, Type type, ILocalCache locals)
         {
             if (value == null)
             {
@@ -498,25 +487,31 @@ namespace System.Linq.Expressions.Compiler
                 // pattern for all value types (works, but requires a local and
                 // more IL)
                 il.EmitDefault(type, locals);
-                return;
+                return true;
             }
 
             // Handle the easy cases
             if (il.TryEmitILConstant(value, type))
             {
-                return;
+                return true;
             }
 
             // Check for a few more types that we support emitting as constants
             Type t = value as Type;
-            if (t != null && ShouldLdtoken(t))
+            if (t != null)
             {
-                il.EmitType(t);
-                if (type != typeof(Type))
+                if (ShouldLdtoken(t))
                 {
-                    il.Emit(OpCodes.Castclass, type);
+                    il.EmitType(t);
+                    if (type != typeof(Type))
+                    {
+                        il.Emit(OpCodes.Castclass, type);
+                    }
+
+                    return true;
                 }
-                return;
+
+                return false;
             }
 
             MethodBase mb = value as MethodBase;
@@ -533,14 +528,16 @@ namespace System.Linq.Expressions.Compiler
                 {
                     il.Emit(OpCodes.Call, MethodBase_GetMethodFromHandle_RuntimeMethodHandle);
                 }
+
                 if (type != typeof(MethodBase))
                 {
                     il.Emit(OpCodes.Castclass, type);
                 }
-                return;
+
+                return true;
             }
 
-            throw ContractUtils.Unreachable;
+            return false;
         }
 
         internal static bool ShouldLdtoken(Type t)
@@ -559,7 +556,6 @@ namespace System.Linq.Expressions.Compiler
             Type dt = mb.DeclaringType;
             return dt == null || ShouldLdtoken(dt);
         }
-
 
         private static bool TryEmitILConstant(this ILGenerator il, object value, Type type)
         {
@@ -1087,7 +1083,7 @@ namespace System.Linq.Expressions.Compiler
                                 il.Emit(OpCodes.Ldsfld, Decimal_MinusOne);
                                 return;
                             case 0:
-                                il.EmitDefault(typeof(decimal));
+                                il.EmitDefault(typeof(decimal), locals: null); // locals won't be used.
                                 return;
                             case 1:
                                 il.Emit(OpCodes.Ldsfld, Decimal_One);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -563,16 +563,19 @@ namespace System.Linq.Expressions.Compiler
             EmitConstant(node.Value, node.Type);
         }
 
+        private void EmitConstant(object value)
+        {
+            Debug.Assert(value != null);
+            EmitConstant(value, value.GetType());
+        }
+
         private void EmitConstant(object value, Type type)
         {
             // Try to emit the constant directly into IL
-            if (ILGen.CanEmitConstant(value, type))
+            if (!_ilg.TryEmitConstant(value, type, this))
             {
-                _ilg.EmitConstant(value, type, this);
-                return;
+                _boundConstants.EmitConstant(this, value, type);
             }
-
-            _boundConstants.EmitConstant(this, value, type);
         }
 
         private void EmitDynamicExpression(Expression expr)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
@@ -550,7 +550,7 @@ namespace System.Linq.Expressions.Compiler
                 // explicit guard
                 Label secondHalf = _ilg.DefineLabel();
                 _ilg.Emit(OpCodes.Ldloc, info.Value);
-                _ilg.EmitConstant(buckets[mid - 1].Last().Constant, this);
+                EmitConstant(buckets[mid - 1].Last().Constant);
                 _ilg.Emit(info.IsUnsigned ? OpCodes.Bgt_Un : OpCodes.Bgt, secondHalf);
                 EmitSwitchBuckets(info, buckets, first, mid - 1);
                 _ilg.MarkLabel(secondHalf);
@@ -565,7 +565,7 @@ namespace System.Linq.Expressions.Compiler
             if (bucket.Count == 1)
             {
                 _ilg.Emit(OpCodes.Ldloc, info.Value);
-                _ilg.EmitConstant(bucket[0].Constant, this);
+                EmitConstant(bucket[0].Constant);
                 _ilg.Emit(OpCodes.Beq, bucket[0].Label);
                 return;
             }
@@ -580,10 +580,10 @@ namespace System.Linq.Expressions.Compiler
             {
                 after = _ilg.DefineLabel();
                 _ilg.Emit(OpCodes.Ldloc, info.Value);
-                _ilg.EmitConstant(bucket.Last().Constant, this);
+                EmitConstant(bucket.Last().Constant);
                 _ilg.Emit(info.IsUnsigned ? OpCodes.Bgt_Un : OpCodes.Bgt, after.Value);
                 _ilg.Emit(OpCodes.Ldloc, info.Value);
-                _ilg.EmitConstant(bucket[0].Constant, this);
+                EmitConstant(bucket[0].Constant);
                 _ilg.Emit(info.IsUnsigned ? OpCodes.Blt_Un : OpCodes.Blt, after.Value);
             }
 
@@ -593,7 +593,7 @@ namespace System.Linq.Expressions.Compiler
             decimal key = bucket[0].Key;
             if (key != 0)
             {
-                _ilg.EmitConstant(bucket[0].Constant, this);
+                EmitConstant(bucket[0].Constant);
                 _ilg.Emit(OpCodes.Sub);
             }
 


### PR DESCRIPTION
Currently this is a two-step operation of `CanEmitConstant` followed by `EmitConstant`.

Instead have a `TryEmitConstant` that reports on success, so the same checks aren't repeated.