### PR TITLE
[DO NOT MERGE][TEST-ONLY] Enable dumpling and cause some tests to fail on purpose

### DIFF
--- a/src/System.AppContext/tests/AppContext.Switch.cs
+++ b/src/System.AppContext/tests/AppContext.Switch.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Tests
@@ -16,6 +17,8 @@ namespace System.Tests
             bool isEnabled;
             Assert.False(AppContext.TryGetSwitch(switchName, out isEnabled));
             Assert.False(isEnabled);
+            IntPtr ptr = new IntPtr(42);
+            Marshal.StructureToPtr(42, ptr, true);
         }
 
 

--- a/src/System.AppContext/tests/System.AppContext.Tests.csproj
+++ b/src/System.AppContext/tests/System.AppContext.Tests.csproj
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{6F04B167-A03F-4206-8481-60213C3EF9B9}</ProjectGuid>
+    <EnableDumpling Condition="'$(ConfigurationGroup)' == 'Debug'">true</EnableDumpling>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />

--- a/src/System.Buffers/tests/ArrayPool/UnitTests.cs
+++ b/src/System.Buffers/tests/ArrayPool/UnitTests.cs
@@ -27,6 +27,7 @@ namespace System.Buffers.ArrayPool.Tests
         public static void SharedInstanceCreatesAnInstanceOnFirstCall()
         {
             Assert.NotNull(ArrayPool<byte>.Shared);
+            throw new Exception("This should not trigger dumpling.");
         }
 
         [Fact]

--- a/src/System.Buffers/tests/System.Buffers.Tests.csproj
+++ b/src/System.Buffers/tests/System.Buffers.Tests.csproj
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}</ProjectGuid>
+    <EnableDumpling Condition="'$(ConfigurationGroup)' == 'Debug'">true</EnableDumpling>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />


### PR DESCRIPTION
I'm submitting this again to see how it works with the buildtools changes I have made. From the last attempt, I think that a couple of runs will still fail because the machine images are missing one of the python libraries we use.