### PR TITLE
Fix OuterLoop test System.Xml.Tests.CReaderTestModule.TCMaxSettings

### DIFF
--- a/src/System.Private.Xml/tests/Readers/ReaderSettings/MaxSettings.cs
+++ b/src/System.Private.Xml/tests/Readers/ReaderSettings/MaxSettings.cs
@@ -12,7 +12,7 @@ namespace System.Xml.Tests
     [TestCase(Name = "MaxCharacters Settings", Desc = "MaxCharacters Settings")]
     public partial class TCMaxSettings : TCXMLReaderBaseGeneral
     {
-        private long _defaultCharsEnt = 0;
+        private long _defaultCharsEnt = (long)1e7;  // By default, entity resolving is limited to 10 million characters (On full .NET the default used to be zero (=unlimited) as LegacyXmlSettings was enabled)
         private long _defaultCharsDoc = 0;
         private long _maxVal = Int64.MaxValue;
         private long _bigVal = 100000;
@@ -330,8 +330,8 @@ namespace System.Xml.Tests
             using (XmlReader reader = ReaderHelper.Create(new StringReader(xml), rs))
             {
                 while (reader.Read()) ;
-                CError.Compare((int)reader.Settings.MaxCharactersFromEntities, 0, "Error");
-                CError.Compare((int)reader.Settings.MaxCharactersInDocument, 0, "Error");
+                CError.Compare((long)reader.Settings.MaxCharactersFromEntities, _defaultCharsEnt, "Error");
+                CError.Compare((long)reader.Settings.MaxCharactersInDocument, _defaultCharsDoc, "Error");
             }
             return TEST_PASS;
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/16024

This outerloop test needs to be updated as a result of the change made in https://github.com/dotnet/corefx/pull/15973

Prior to that change, `XmlReaderSettings` used to read full framework registry keys to decide the default value of entity resolving limit. Default used to be 0 (=unlimited), but is 10 million characters now. 
[The user can still override it with any value.]

cc: @jkotas @danmosemsft 