### PR TITLE
Cleanup some code in SortedSet

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -587,7 +587,7 @@ namespace System.Collections.Generic
 
             InOrderTreeWalk(node =>
             {
-                if (index == count)
+                if (index >= count)
                 {
                     return false;
                 }
@@ -673,19 +673,19 @@ namespace System.Collections.Generic
             Debug.Assert(parent != null);
             Debug.Assert(grandParent != null);
 
-            bool parentIsRightChild = (grandParent.Right == parent);
-            bool currentIsRightChild = (parent.Right == current);
+            bool parentIsOnRight = (grandParent.Right == parent);
+            bool currentIsOnRight = (parent.Right == current);
 
             Node newChildOfGreatGrandParent;
-            if (parentIsRightChild == currentIsRightChild)
+            if (parentIsOnRight == currentIsOnRight)
             {
                 // Same orientation, single rotation
-                newChildOfGreatGrandParent = currentIsRightChild ? grandParent.RotateLeft() : grandParent.RotateRight();
+                newChildOfGreatGrandParent = currentIsOnRight ? grandParent.RotateLeft() : grandParent.RotateRight();
             }
             else
             {
                 // Different orientation, double rotation
-                newChildOfGreatGrandParent = currentIsRightChild ? grandParent.RotateLeftRight() : grandParent.RotateRightLeft();
+                newChildOfGreatGrandParent = currentIsOnRight ? grandParent.RotateLeftRight() : grandParent.RotateRightLeft();
                 // Current node now becomes the child of `greatGrandParent`
                 parent = greatGrandParent;
             }
@@ -1737,7 +1737,9 @@ namespace System.Collections.Generic
 
             public Node DeepClone(int count)
             {
+#if DEBUG
                 Debug.Assert(count == GetCount());
+#endif
                 
                 // Breadth-first traversal to recreate nodes, preorder traversal to replicate nodes.
 
@@ -1779,14 +1781,9 @@ namespace System.Collections.Generic
                 return newRoot;
             }
 
-            public int GetCount()
-            {
-#if !DEBUG
-                throw new InvalidOperationException($"Do not call {nameof(GetCount)} in Release builds.");
-#else
-                return 1 + (Left?.GetCount() ?? 0) + (Right?.GetCount() ?? 0);
+#if DEBUG
+            public int GetCount() => 1 + (Left?.GetCount() ?? 0) + (Right?.GetCount() ?? 0);
 #endif
-            }
 
             public Node ShallowClone() => new Node(Item, IsRed);
 
@@ -1850,7 +1847,7 @@ namespace System.Collections.Generic
         [Serializable]
         public struct Enumerator : IEnumerator<T>, IEnumerator, ISerializable, IDeserializationCallback
         {
-            private static Node s_dummyNode = new Node(default(T), isRed: true);
+            private static readonly Node s_dummyNode = new Node(default(T), isRed: true);
 
             private SortedSet<T> _tree;
             private int _version;

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -290,6 +290,7 @@ namespace System.Collections.Generic
                 {
                     Threading.Interlocked.CompareExchange(ref _syncRoot, new object(), null);
                 }
+
                 return _syncRoot;
             }
         }
@@ -298,10 +299,10 @@ namespace System.Collections.Generic
 
         #region Subclass helpers
 
-        // virtual function for subclass that needs to update count
+        // Virtual function for TreeSubSet, which may need to update its count.
         internal virtual void VersionCheck() { }
 
-        // virtual function for subclass that needs to do range checks
+        // Virtual function for TreeSubSet, which may need to do range checks.
         internal virtual bool IsWithinRange(T item) => true;
 
         #endregion
@@ -316,7 +317,7 @@ namespace System.Collections.Generic
         {
             if (_root == null)
             {
-                // empty tree
+                // The tree is empty and this is the first item.
                 _root = new Node(item, isRed: false);
                 _count = 1;
                 _version++;

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -92,7 +92,7 @@ namespace System.Collections.Generic
                 throw new ArgumentNullException(nameof(collection));
             }
 
-            // These are explicit type checks in the mould of HashSet. It would have worked better with
+            // These are explicit type checks in the mold of HashSet. It would have worked better with
             // something like an ISorted<T> interface. (We could make this work for SortedList.Keys, etc.)
             SortedSet<T> sortedSet = collection as SortedSet<T>;
             if (sortedSet != null && !(sortedSet is TreeSubSet) && HasEqualComparer(sortedSet))
@@ -110,6 +110,9 @@ namespace System.Collections.Generic
             T[] elements = EnumerableHelpers.ToArray(collection, out count);
             if (count > 0)
             {
+                // If `comparer` is null, sets it to Comparer<T>.Default. We checked for this condition in the IComparer<T> constructor.
+                // Array.Sort handles null comparers, but we need this later when we use `comparer.Compare` directly.
+                comparer = _comparer;
                 Array.Sort(elements, 0, count, comparer);
 
                 // Overwrite duplicates while shifting the distinct elements towards
@@ -204,7 +207,7 @@ namespace System.Collections.Generic
                 current = current.Left;
             }
 
-            while (stack.Count > 0)
+            while (stack.Count != 0)
             {
                 current = stack.Pop();
                 if (!action(current))
@@ -1804,7 +1807,7 @@ namespace System.Collections.Generic
                     newCurrent = newCurrent.Left;
                 }
 
-                while (originalNodes.Count > 0)
+                while (originalNodes.Count != 0)
                 {
                     originalCurrent = originalNodes.Pop();
                     newCurrent = newNodes.Pop();
@@ -1826,7 +1829,14 @@ namespace System.Collections.Generic
                 return newRoot;
             }
 
-            public int GetCount() => 1 + (Left?.GetCount() ?? 0) + (Right?.GetCount() ?? 0);
+            public int GetCount()
+            {
+#if !DEBUG
+                throw new InvalidOperationException($"Do not call {nameof(GetCount)} in Release builds.");
+#else
+                return 1 + (Left?.GetCount() ?? 0) + (Right?.GetCount() ?? 0);
+#endif
+            }
 
             public Node ShallowClone() => new Node(Item, IsRed);
         }

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
@@ -36,18 +36,7 @@ namespace System.Collections.Tests
         {
             IComparer<T> comparer = GetIComparer();
             SortedSet<T> set = new SortedSet<T>(comparer);
-            if (comparer == null)
-                Assert.Equal(Comparer<T>.Default, set.Comparer);
-            else
-                Assert.Equal(comparer, set.Comparer);
-        }
-
-        [Fact]
-        public void SortedSet_Generic_Constructor_IComparer_Null()
-        {
-            IComparer<T> comparer = GetIComparer();
-            SortedSet<T> set = new SortedSet<T>((IComparer<T>)null);
-            Assert.Equal(Comparer<T>.Default, set.Comparer);
+            Assert.Equal(comparer ?? Comparer<T>.Default, set.Comparer);
         }
 
         [Theory]
@@ -72,6 +61,15 @@ namespace System.Collections.Tests
         {
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, 0);
             SortedSet<T> set = new SortedSet<T>(enumerable, GetIComparer());
+            Assert.True(set.SetEquals(enumerable));
+        }
+
+        [Theory]
+        [MemberData(nameof(EnumerableTestData))]
+        public void SortedSet_Generic_Constructor_IEnumerable_IComparer_NullComparer(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
+        {
+            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, 0);
+            SortedSet<T> set = new SortedSet<T>(enumerable, comparer: null);
             Assert.True(set.SetEquals(enumerable));
         }
 
@@ -123,9 +121,7 @@ namespace System.Collections.Tests
         {
             if (setLength >= 3)
             {
-                IComparer<T> comparer = GetIComparer();
-                if (comparer == null)
-                    comparer = Comparer<T>.Default;
+                IComparer<T> comparer = GetIComparer() ?? Comparer<T>.Default;
                 SortedSet<T> set = (SortedSet<T>)GenericISetFactory(setLength);
                 T firstElement = set.ElementAt(1);
                 T lastElement = set.ElementAt(setLength - 2);
@@ -147,9 +143,7 @@ namespace System.Collections.Tests
         {
             if (setLength >= 2)
             {
-                IComparer<T> comparer = GetIComparer();
-                if (comparer == null)
-                    comparer = Comparer<T>.Default;
+                IComparer<T> comparer = GetIComparer() ?? Comparer<T>.Default;
                 SortedSet<T> set = (SortedSet<T>)GenericISetFactory(setLength);
                 T firstElement = set.ElementAt(0);
                 T lastElement = set.ElementAt(setLength - 1);
@@ -165,9 +159,7 @@ namespace System.Collections.Tests
             if (setLength >= 3)
             {
                 SortedSet<T> set = (SortedSet<T>)GenericISetFactory(setLength);
-                IComparer<T> comparer = GetIComparer();
-                if (comparer == null)
-                    comparer = Comparer<T>.Default;
+                IComparer<T> comparer = GetIComparer() ?? Comparer<T>.Default;
                 T firstElement = set.ElementAt(0);
                 T middleElement = set.ElementAt(setLength / 2);
                 T lastElement = set.ElementAt(setLength - 1);

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.cs
@@ -30,6 +30,11 @@ namespace System.Collections.Tests
         protected override bool DefaultValueAllowed => true;
     }
 
+    public class SortedSet_Generic_Tests_int_With_NullComparer : SortedSet_Generic_Tests_int
+    {
+        protected override IComparer<int> GetIComparer() => null;
+    }
+
     [OuterLoop]
     public class SortedSet_Generic_Tests_EquatableBackwardsOrder : SortedSet_Generic_Tests<EquatableBackwardsOrder>
     {


### PR DESCRIPTION
- Rename and make `AreComparersEqual` an instance method
  - Check for reference equality before calling into `Equals()`
- Refactor large constructor body into smaller methods
- Add XML docs
- Add braces
- Remove `SortedSet<T>.` name qualification when it isn't necessary

/cc @ianhays @safern 