### PR TITLE
Add post-close delay  to async SerialPort tests

### DIFF
--- a/src/System.IO.Ports/tests/Legacy/SerialStream/Close.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialStream/Close.cs
@@ -18,8 +18,7 @@ namespace Legacy.SerialStream
         // The number of the bytes that should read/write buffers
         private static readonly int numReadBytes = 32;
         private static readonly int numWriteBytes = 32;
-
-        [ActiveIssue(16055)]
+        
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void OpenClose_WriteMethods()
         {
@@ -36,7 +35,6 @@ namespace Legacy.SerialStream
                 catch (InvalidOperationException)
                 {
                 }
-            
 
                 try
                 {
@@ -63,8 +61,7 @@ namespace Legacy.SerialStream
                 }
             }
         }
-
-        [ActiveIssue(16055)]
+        
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void OpenClose_ReadMethods()
         {
@@ -123,8 +120,7 @@ namespace Legacy.SerialStream
                 }
             }
         }
-
-        [ActiveIssue(16055)]
+        
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void OpenClose_DiscardMethods()
         {
@@ -152,7 +148,7 @@ namespace Legacy.SerialStream
             }
         }
 
-        [ActiveIssue(16055)]
+        
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void OpenClose_OpenClose()
         {
@@ -183,7 +179,6 @@ namespace Legacy.SerialStream
             }
         }
 
-        [ActiveIssue(16055)]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void OpenClose_Properties()
         {
@@ -201,8 +196,7 @@ namespace Legacy.SerialStream
                 serPortProp.VerifyPropertiesAndPrint(com);
             }
         }
-
-        [ActiveIssue(16055)]
+        
         [ConditionalFact(nameof(HasNullModem))]
         public void OpenFillBuffersClose()
         {
@@ -257,9 +251,10 @@ namespace Legacy.SerialStream
                 {
                 }
             }
+            // Give the port time to finish closing since we potentially have an unclosed BeginRead/BeginWrite
+            Thread.Sleep(200);
         }
-
-        [ActiveIssue(16055)]
+        
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void OpenCloseNewInstanceOpen()
         {
@@ -297,8 +292,7 @@ namespace Legacy.SerialStream
                 }
             }
         }
-
-        [ActiveIssue(16055)]
+        
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void Open_BaseStreamClose_Open()
         {
@@ -317,8 +311,7 @@ namespace Legacy.SerialStream
                 serPortProp.VerifyPropertiesAndPrint(com);
             }
         }
-
-        [ActiveIssue(16055)]
+        
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void Open_BaseStreamClose_Close()
         {
@@ -339,7 +332,6 @@ namespace Legacy.SerialStream
             }
         }
 
-        [ActiveIssue(16055)]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void Open_MultipleBaseStreamClose()
         {

--- a/src/System.IO.Ports/tests/Legacy/SerialStream/EndRead.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialStream/EndRead.cs
@@ -17,8 +17,7 @@ namespace Legacy.SerialStream
     {
         #region Test Cases
 
-        [ActiveIssue(16055)]
-        [ConditionalFact(nameof(HasNullModem))]
+       [ConditionalFact(nameof(HasNullModem))]
         public void EndReadAfterClose()
         {
             using (var com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
@@ -42,9 +41,10 @@ namespace Legacy.SerialStream
 
                 VerifyEndReadException(serialStream, asyncResult, null);
             }
+            // Give the port time to finish closing since we potentially have an unclosed BeginRead/BeginWrite
+            Thread.Sleep(200);
         }
 
-        [ActiveIssue(16055)]
         [ConditionalFact(nameof(HasNullModem))]
         public void EndReadAfterSerialStreamClose()
         {
@@ -69,9 +69,10 @@ namespace Legacy.SerialStream
 
                 VerifyEndReadException(serialStream, asyncResult, null);
             }
+            // Give the port time to finish closing since we potentially have an unclosed BeginRead/BeginWrite
+            Thread.Sleep(200);
         }
 
-        [ActiveIssue(16055)]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void AsyncResult_Null()
         {
@@ -84,7 +85,6 @@ namespace Legacy.SerialStream
             }
         }
 
-        [ActiveIssue(16055)]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void AsyncResult_WriteResult()
         {
@@ -98,9 +98,11 @@ namespace Legacy.SerialStream
                 IAsyncResult writeAsyncResult = com.BaseStream.BeginWrite(new byte[8], 0, 8, null, null);
                 VerifyEndReadException(com.BaseStream, writeAsyncResult, typeof(ArgumentException));
             }
+            // Give the port time to finish closing since we have an unclosed BeginRead/BeginWrite
+            Thread.Sleep(200);
         }
 
-        [ActiveIssue(16055)]
+
         [ConditionalFact(nameof(HasNullModem))]
         public void AsyncResult_MultipleSameResult()
         {
@@ -121,9 +123,11 @@ namespace Legacy.SerialStream
 
                 VerifyEndReadException(com1.BaseStream, readAsyncResult, typeof(ArgumentException));
             }
+            // Give the port time to finish closing since we have an unclosed BeginRead/BeginWrite
+            Thread.Sleep(200);
         }
 
-        [ActiveIssue(16055)]
+
         [ConditionalFact(nameof(HasNullModem))]
         public void AsyncResult_MultipleInOrder()
         {
@@ -166,9 +170,11 @@ namespace Legacy.SerialStream
                         endReadReturnValue);
                 }
             }
+            // Give the port time to finish closing since we potentially have an unclosed BeginRead/BeginWrite
+            Thread.Sleep(200);
         }
 
-        [ActiveIssue(16055)]
+
         [ConditionalFact(nameof(HasNullModem))]
         public void AsyncResult_MultipleOutOfOrder()
         {
@@ -212,9 +218,9 @@ namespace Legacy.SerialStream
                     Fail("ERROR!!! Expected EndRead to return={0} actual={1} for first read", numBytesToRead1,
                         endReadReturnValue);
                 }
-
-
             }
+            // Give the port time to finish closing since we potentially have an unclosed BeginRead/BeginWrite
+            Thread.Sleep(200);
         }
         #endregion
 

--- a/src/System.IO.Ports/tests/Legacy/SerialStream/EndWrite.cs
+++ b/src/System.IO.Ports/tests/Legacy/SerialStream/EndWrite.cs
@@ -16,8 +16,7 @@ namespace Legacy.SerialStream
     public class EndWrite : PortsTest
     {
         #region Test Cases
-
-        [ActiveIssue(16055)]
+        
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void EndWriteAfterClose()
         {
@@ -33,9 +32,10 @@ namespace Legacy.SerialStream
 
                 VerifyEndWriteException(serialStream, asyncResult, null);
             }
+            // Give the port time to finish closing since we potentially have an unclosed BeginRead/BeginWrite
+            Thread.Sleep(200);
         }
 
-        [ActiveIssue(16055)]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void EndWriteAfterSerialStreamClose()
         {
@@ -50,15 +50,11 @@ namespace Legacy.SerialStream
                 serialStream.Close();
 
                 VerifyEndWriteException(serialStream, asyncResult, null);
-
-                com.Close();
-                Thread.Sleep(200);
-
-                // Give the port time to finish closing since we have an unclosed BeginWrite - see  - see Dev10 #591344
             }
+            // Give the port time to finish closing since we have an unclosed BeginWrite - see  - see Dev10 #591344
+            Thread.Sleep(200);
         }
 
-        [ActiveIssue(16055)]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void AsyncResult_Null()
         {
@@ -71,7 +67,6 @@ namespace Legacy.SerialStream
             }
         }
 
-        [ActiveIssue(16055)]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void AsyncResult_ReadResult()
         {
@@ -84,15 +79,14 @@ namespace Legacy.SerialStream
                 com.BaseStream.BeginWrite(new byte[8], 0, 8, null, null);
                 com.BaseStream.BeginWrite(new byte[8], 0, 8, null, null);
 
-                IAsyncResult writeAsyncResult = com.BaseStream.BeginRead(new byte[8], 0, 8, null, null);
-                VerifyEndWriteException(com.BaseStream, writeAsyncResult, typeof(ArgumentException));
+                IAsyncResult readAsyncResult = com.BaseStream.BeginRead(new byte[8], 0, 8, null, null);
+                VerifyEndWriteException(com.BaseStream, readAsyncResult, typeof(ArgumentException));
 
-                // Not needed if this scenario is run last.
-                // System.Threading.Thread.Sleep(200);  // Give the port time to finish closing since we have an unclosed BeginWrite
             }
+            // Give the port time to finish closing since we have an unclosed BeginRead/BeginWrite
+            Thread.Sleep(200);
         }
-
-        [ActiveIssue(16055)]
+        
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void AsyncResult_MultipleSameResult()
         {
@@ -109,9 +103,10 @@ namespace Legacy.SerialStream
 
                 VerifyEndWriteException(com.BaseStream, writeAsyncResult, typeof(ArgumentException));
             }
+            // Give the port time to finish closing since we potentially have an unclosed BeginRead/BeginWrite
+            Thread.Sleep(200);
         }
 
-        [ActiveIssue(16055)]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void AsyncResult_MultipleInOrder()
         {
@@ -131,9 +126,11 @@ namespace Legacy.SerialStream
                 com.BaseStream.EndWrite(readAsyncResult2);
                 com.BaseStream.EndWrite(readAsyncResult3);
             }
+            // Give the port time to finish closing since we potentially have an unclosed BeginRead/BeginWrite
+            Thread.Sleep(200);
         }
 
-        [ActiveIssue(16055)]
+
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void AsyncResult_MultipleOutOfOrder()
         {
@@ -154,9 +151,10 @@ namespace Legacy.SerialStream
                 com.BaseStream.EndWrite(readAsyncResult3);
                 com.BaseStream.EndWrite(readAsyncResult1);
             }
+            // Give the port time to finish closing since we potentially have an unclosed BeginRead/BeginWrite
+            Thread.Sleep(200);
         }
 
-        [ActiveIssue(16055)]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void InBreak()
         {
@@ -173,6 +171,8 @@ namespace Legacy.SerialStream
 
                 com1.DiscardOutBuffer();
             }
+            // Give the port time to finish closing since we have an unclosed BeginRead/BeginWrite
+            Thread.Sleep(200);
         }
         #endregion
 


### PR DESCRIPTION
Possible fix for #16055 - it's really a work around for long-established problems in SerialPort rather than a test fix, but it should do for now.