### PR TITLE
Cleanup netstandard ifdefs and conditions

### DIFF
--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
@@ -215,7 +215,6 @@ namespace System.Security.Cryptography.Rsa.Tests
             Assert.Equal(TestData.HelloBytes, output);
         }
 
-#if netstandard17
         [Fact]
         public static void NotSupportedValueMethods()
         {
@@ -225,6 +224,5 @@ namespace System.Security.Cryptography.Rsa.Tests
                 Assert.Throws<NotSupportedException>(() => rsa.EncryptValue(null));
             }
         }
-#endif
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESCipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESCipherTests.cs
@@ -90,7 +90,6 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             }
         }
 
-#if netstandard17
         [Fact]
         public static void TripleDESRoundTrip192BitsISO10126ECB()
         {
@@ -161,8 +160,6 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
                 Assert.NotEqual<byte>(plainText, decrypted);
             }
         }
-
-#endif
 
         [Fact]
         public static void TripleDESRoundTrip192BitsZerosCBC()

--- a/src/Microsoft.Win32.Primitives/tests/Microsoft.Win32.Primitives.Tests.csproj
+++ b/src/Microsoft.Win32.Primitives/tests/Microsoft.Win32.Primitives.Tests.csproj
@@ -8,8 +8,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="Win32Exception.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
     <Compile Include="Win32Exception.netstandard.cs" />
     <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>

--- a/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
+++ b/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}</ProjectGuid>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard'">$(DefineConstants);netstandard17</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />

--- a/src/System.Collections.NonGeneric/tests/HashtableTests.cs
+++ b/src/System.Collections.NonGeneric/tests/HashtableTests.cs
@@ -20,7 +20,7 @@ namespace System.Collections.Tests
             var hash = new ComparableHashtable();
             VerifyHashtable(hash, null, null);
         }
-#if netstandard17
+
         [Fact]
         public static void Ctor_HashCodeProvider_Comparer()
         {
@@ -42,7 +42,6 @@ namespace System.Collections.Tests
                 nullComparer ? null : StringComparer.OrdinalIgnoreCase);
             VerifyHashtable(hash, null, hash.EqualityComparer);
         }
-#endif //netstandard17
 
         [Fact]
         public static void Ctor_IDictionary()
@@ -66,7 +65,6 @@ namespace System.Collections.Tests
             Assert.Throws<ArgumentNullException>("d", () => new Hashtable((IDictionary)null)); // Dictionary is null
         }
 
-#if netstandard17
         [Fact]
         public static void Ctor_IDictionary_HashCodeProvider_Comparer()
         {
@@ -88,7 +86,6 @@ namespace System.Collections.Tests
         {
             Assert.Throws<ArgumentNullException>("d", () => new Hashtable(null, CaseInsensitiveHashCodeProvider.Default, StringComparer.OrdinalIgnoreCase)); // Dictionary is null
         }
-#endif //netstandard17
 
         [Fact]
         public static void Ctor_IEqualityComparer()
@@ -116,7 +113,6 @@ namespace System.Collections.Tests
             VerifyHashtable(hash, null, null);
         }
 
-#if netstandard17
         [Theory]
         [InlineData(0)]
         [InlineData(10)]
@@ -126,7 +122,6 @@ namespace System.Collections.Tests
             var hash = new ComparableHashtable(capacity, CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
             VerifyHashtable(hash, null, hash.EqualityComparer);
         }
-#endif //netstandard17
 
         [Fact]
         public static void Ctor_Int_Invalid()
@@ -135,7 +130,6 @@ namespace System.Collections.Tests
             Assert.Throws<ArgumentException>(() => new Hashtable(int.MaxValue)); // Capacity / load factor > int.MaxValue
         }
 
-#if netstandard17
         [Fact]
         public static void Ctor_IDictionary_Int()
         {
@@ -152,7 +146,6 @@ namespace System.Collections.Tests
 
             VerifyHashtable(hash1, hash2, hash1.EqualityComparer);
         }
-#endif //netstandard17
 
         [Fact]
         public static void Ctor_IDictionary_Int_Invalid()
@@ -225,7 +218,6 @@ namespace System.Collections.Tests
             VerifyHashtable(hash, null, null);
         }
 
-#if netstandard17
         [Theory]
         [InlineData(0, 0.1)]
         [InlineData(10, 0.2)]
@@ -236,7 +228,6 @@ namespace System.Collections.Tests
             var hash = new ComparableHashtable(capacity, loadFactor, CaseInsensitiveHashCodeProvider.DefaultInvariant, StringComparer.OrdinalIgnoreCase);
             VerifyHashtable(hash, null, hash.EqualityComparer);
         }
-#endif //netstandard17
 
         [Fact]
         public static void Ctor_Int_Int_GenerateNewPrime()
@@ -803,7 +794,6 @@ namespace System.Collections.Tests
             }
         }
 
-#if netstandard17
         [Fact]
         public static void HashCodeProvider_Set_ImpactsSearch()
         {
@@ -885,7 +875,6 @@ namespace System.Collections.Tests
             public int FixedHashCode;
             public int GetHashCode(object obj) => FixedHashCode;
         }
-#endif //netstandard17
 
         private static void VerifyHashtable(ComparableHashtable hash1, Hashtable hash2, IEqualityComparer ikc)
         {
@@ -936,15 +925,11 @@ namespace System.Collections.Tests
 
             public ComparableHashtable(int capacity, float loadFactor) : base(capacity, loadFactor) { }
 
-#if netstandard17
             public ComparableHashtable(int capacity, IHashCodeProvider hcp, IComparer comparer) : base(capacity, hcp, comparer) { }
-#endif //netstandard17
 
             public ComparableHashtable(int capacity, IEqualityComparer ikc) : base(capacity, ikc) { }
 
-#if netstandard17
             public ComparableHashtable(IHashCodeProvider hcp, IComparer comparer) : base(hcp, comparer) { }
-#endif //netstandard17
 
             public ComparableHashtable(IEqualityComparer ikc) : base(ikc) { }
 
@@ -952,29 +937,23 @@ namespace System.Collections.Tests
 
             public ComparableHashtable(IDictionary d, float loadFactor) : base(d, loadFactor) { }
 
-#if netstandard17
             public ComparableHashtable(IDictionary d, IHashCodeProvider hcp, IComparer comparer) : base(d, hcp, comparer) { }
-#endif //netstandard17
 
             public ComparableHashtable(IDictionary d, IEqualityComparer ikc) : base(d, ikc) { }
 
-#if netstandard17
             public ComparableHashtable(IDictionary d, float loadFactor, IHashCodeProvider hcp, IComparer comparer) : base(d, loadFactor, hcp, comparer) { }
-#endif //netstandard17
 
             public ComparableHashtable(IDictionary d, float loadFactor, IEqualityComparer ikc) : base(d, loadFactor, ikc) { }
 
-#if netstandard17
             public ComparableHashtable(int capacity, float loadFactor, IHashCodeProvider hcp, IComparer comparer) : base(capacity, loadFactor, hcp, comparer) { }
-#endif //netstandard17
 
             public ComparableHashtable(int capacity, float loadFactor, IEqualityComparer ikc) : base(capacity, loadFactor, ikc) { }
 
             public new IEqualityComparer EqualityComparer => base.EqualityComparer;
-#if netstandard17
+
             public IHashCodeProvider HashCodeProvider { get { return hcp; } set { hcp = value; } }
+
             public IComparer Comparer { get { return comparer; } set { comparer = value; } }
-#endif //netstandard17
         }
 
         private class BadHashCode

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{EE95AE39-845A-42D3-86D0-8065DBE56612}</ProjectGuid>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard'">$(DefineConstants);netstandard17</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -50,13 +50,6 @@
     <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'!='netstandard'">
-    <Compile Include="$(CommonPath)\System\SerializableAttribute.cs">
-      <Link>Common\System\SerializableAttribute.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
     <Compile Include="CaseInsensitiveHashCodeProviderTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs</Link>

--- a/src/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.CtorTests.cs
+++ b/src/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.CtorTests.cs
@@ -20,7 +20,7 @@ namespace System.Collections.Specialized.Tests
 
             Assert.False(((ICollection)nameValueCollection).IsSynchronized);
         }
-#if netstandard17
+
         [Fact]
         public void Ctor_Provider_Comparer()
         {
@@ -46,7 +46,6 @@ namespace System.Collections.Specialized.Tests
 
             Assert.False(((ICollection)nameValueCollection).IsSynchronized);
         }
-#endif //netstandard17
 
         [Theory]
         [InlineData(0)]

--- a/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
+++ b/src/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
@@ -83,13 +83,6 @@
     <Compile Include="StringDictionary\StringDictionary.SyncRootTests.cs" />
     <Compile Include="StringDictionary\StringDictionary.ValuesTests.cs" />
     <Compile Include="StringDictionary\StringDictionaryClearTests.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'!='netstandard'">
-    <Compile Include="$(CommonPath)\System\SerializableAttribute.cs">
-      <Link>Common\System\SerializableAttribute.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
     <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs</Link>
     </Compile>

--- a/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
@@ -236,7 +236,6 @@ namespace System.Collections.Tests
             Assert.Throws<ArgumentException>("bytes", () => new BitArray(new byte[int.MaxValue / BitsPerByte + 1 ]));
         }
 
-#if netstandard17
         [Fact]
         public static void Ctor_Simple_Method_Tests()
         {
@@ -258,6 +257,5 @@ namespace System.Collections.Tests
 
             Assert.Equal(bitArray.Length, clone.Length);  
         }
-#endif //netstandard17
     }
 }

--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
@@ -269,7 +269,6 @@ namespace System.Collections.Tests
 
         #region CreateSetComparer
 
-#if netstandard17
         [Fact]
         public void SetComparer_SetEqualsTests()
         {
@@ -331,7 +330,6 @@ namespace System.Collections.Tests
             Assert.True(noComparerSet.SequenceEqual(set, HashSet<T>.CreateSetComparer()));
             Assert.False(comparerSet.SequenceEqual(set));
         }
-#endif
 
         #endregion
 

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
@@ -297,7 +297,6 @@ namespace System.Collections.Tests
 
         #region CreateSetComparer
 
-#if netstandard17
         [Fact]
         public void SetComparer_SetEqualsTests()
         {
@@ -331,7 +330,6 @@ namespace System.Collections.Tests
             Assert.True(comparerSet1.SetEquals(set));
             Assert.True(comparerSet2.SetEquals(set));
         }
-#endif
         #endregion
     }
 }

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{F5EB9630-AD29-4880-963F-F2D39C684D8A}</ProjectGuid>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard'">$(DefineConstants);netstandard17</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -114,7 +114,7 @@
     <Compile Include="Generic\List\List.Generic.Tests.AddRange.cs" />
     <Compile Include="Generic\List\List.Generic.Tests.BinarySearch.cs" />
     <Compile Include="Generic\List\List.Generic.Tests.Constructor.cs" />
-    <Compile Include="Generic\List\List.Generic.Tests.ConvertAll.cs" Condition="'$(TargetGroup)'=='netstandard'" />
+    <Compile Include="Generic\List\List.Generic.Tests.ConvertAll.cs" />
     <Compile Include="Generic\List\List.Generic.Tests.Find.cs" />
     <Compile Include="Generic\List\List.Generic.Tests.Remove.cs" />
     <Compile Include="Generic\List\List.Generic.Tests.Sort.cs" />
@@ -142,13 +142,6 @@
     <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'!='netstandard' and '$(TargetGroup)'!='netcoreapp'">
-    <Compile Include="$(CommonPath)\System\SerializableAttribute.cs">
-      <Link>Common\System\SerializableAttribute.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
     <Compile Include="Generic\Comparers\EqualityComparer.Generic.Serialization.Tests.cs" />
     <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs</Link>

--- a/src/System.ComponentModel.Primitives/tests/System.ComponentModel.Primitives.Tests.csproj
+++ b/src/System.ComponentModel.Primitives/tests/System.ComponentModel.Primitives.Tests.csproj
@@ -24,8 +24,6 @@
     <Compile Include="ParenthesizePropertyNameAttributeTests.cs" />
     <Compile Include="ReadOnlyAttributeTests.cs" />
     <Compile Include="RefreshPropertiesAttributeTests.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
     <Compile Include="EventHandlerListTests.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Data.Common/tests/System.Data.Common.Tests.csproj
+++ b/src/System.Data.Common/tests/System.Data.Common.Tests.csproj
@@ -12,8 +12,6 @@
     <Compile Include="System\Data\Common\DbCommandTests.cs" />
     <Compile Include="System\Data\Common\DbConnectionTests.cs" />
     <Compile Include="System\Data\Common\DbExceptionTests.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
     <Compile Include="DataProvider.cs" />
     <Compile Include="System\Data\Common\DataAdapterTest.cs" />
     <Compile Include="System\Data\Common\DataColumnMappingCollectionTest.cs" />

--- a/src/System.Data.Common/tests/System.Data.Common.Tests.csproj
+++ b/src/System.Data.Common/tests/System.Data.Common.Tests.csproj
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{B473F77D-4168-4123-932A-E88020B768FA}</ProjectGuid>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard'">$(DefineConstants);netstandard17</DefineConstants>
     <NoWarn>0168,0169,0414,0219,0649</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />

--- a/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
@@ -32,8 +32,6 @@
     <Compile Include="ProcessThreadTests.cs" />
     <Compile Include="ProcessWaitingTests.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
     <Compile Include="ProcessTests.netstandard.cs" />
     <Compile Include="ProcessStartInfoTests.netstandard.cs" />
   </ItemGroup>

--- a/src/System.Diagnostics.Tools/tests/System.Diagnostics.Tools.Tests.csproj
+++ b/src/System.Diagnostics.Tools/tests/System.Diagnostics.Tools.Tests.csproj
@@ -12,8 +12,6 @@
   <ItemGroup>
     <Compile Include="System\CodeDom\Compiler\GeneratedCodeAttributeTests.cs" />
     <Compile Include="System\Diagnostics\CodeAnalysis\SuppressMessageAttributeTests.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
     <Compile Include="System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttributeTests.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Drawing.Primitives/tests/System.Drawing.Primitives.Tests.csproj
+++ b/src/System.Drawing.Primitives/tests/System.Drawing.Primitives.Tests.csproj
@@ -16,8 +16,6 @@
     <Compile Include="RectangleTests.cs" />
     <Compile Include="SizeFTests.cs" />
     <Compile Include="SizeTests.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
     <Compile Include="ColorTests.cs" />
     <Compile Include="SerializationTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">

--- a/src/System.Globalization.Calendars/tests/System.Globalization.Calendars.Tests.csproj
+++ b/src/System.Globalization.Calendars/tests/System.Globalization.Calendars.Tests.csproj
@@ -113,7 +113,7 @@
       <Link>Common\System\PlatformDetection.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
+  <ItemGroup>
     <Compile Include="Misc\Calendars.netstandard.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -138,7 +138,7 @@
       <Name>RemoteExecutorConsoleApp</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
+  <ItemGroup>
     <Compile Include="CharUnicodeInfo\CharUnicodeInfoTests.netstandard.cs" />
     <Compile Include="CompareInfo\CompareInfoTests.netstandard.cs" />
     <Compile Include="CultureInfo\CultureInfoTests.netstandard.cs" />

--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -10,7 +10,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="DeflateStreamTests.cs" />
-    <Compile Include="DeflateStreamTests.netstandard.cs" Condition="'$(TargetGroup)'=='netstandard'" />
+    <Compile Include="DeflateStreamTests.netstandard.cs" />
     <Compile Include="GZipStreamTests.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
     <Compile Include="ZipArchive\zip_CreateTests.cs" />

--- a/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
+++ b/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
@@ -10,7 +10,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-OSX-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
+  <ItemGroup>
     <Compile Include="FileSystemWatcher.netstandard.cs" />
     <Compile Include="InternalBufferOverflowException.cs" />
     <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -13,7 +13,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
+  <ItemGroup>
     <Compile Include="FileInfo\Serialization.cs" />
     <Compile Include="FileInfo\Replace.cs" />
     <Compile Include="FileStream\Handle.cs" />

--- a/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -11,7 +11,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
+  <ItemGroup>
     <Compile Include="NamedPipeTests\NamedPipeTest.RunAsClient.cs" />
     <Compile Include="NamedPipeTests\NamedPipeTest.Read.netstandard.cs" />
     <Compile Include="NamedPipeTests\NamedPipeTest.netstandard.cs" />

--- a/src/System.IO.UnmanagedMemoryStream/tests/System.IO.UnmanagedMemoryStream.Tests.csproj
+++ b/src/System.IO.UnmanagedMemoryStream/tests/System.IO.UnmanagedMemoryStream.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
+  <ItemGroup>
     <Compile Include="Uma.TestStructs.cs" />
     <Compile Include="Uma.ReadWriteStruct.cs" />
     <Compile Include="Uma.ReadWriteStructArray.cs" />

--- a/src/System.IO/tests/BinaryWriter/BinaryWriterTests.cs
+++ b/src/System.IO/tests/BinaryWriter/BinaryWriterTests.cs
@@ -316,7 +316,6 @@ namespace System.IO.Tests
             }
         }
 
-#if netstandard17
         [Fact]
         public void BinaryWriter_CloseTests()
         {
@@ -329,7 +328,6 @@ namespace System.IO.Tests
                 binaryWriter.Close();
             }
         }
-#endif //netstandard17
 
         [Fact]
         public void BinaryWriter_DisposeTests_Negative()
@@ -342,7 +340,6 @@ namespace System.IO.Tests
             }
         }
 
-#if netstandard17
         [Fact]
         public void BinaryWriter_CloseTests_Negative()
         {
@@ -353,7 +350,6 @@ namespace System.IO.Tests
                 ValidateDisposedExceptions(binaryWriter);
             }
         }
-#endif //netstandard17
 
         private void ValidateDisposedExceptions(BinaryWriter binaryWriter)
         {

--- a/src/System.IO/tests/StreamWriter/StreamWriter.CloseTests.cs
+++ b/src/System.IO/tests/StreamWriter/StreamWriter.CloseTests.cs
@@ -27,7 +27,6 @@ namespace System.IO.Tests
             ValidateDisposedExceptions(sw2);
         }
 
-#if netstandard17
         [Fact]
         public void AfterCloseThrows()
         {
@@ -39,7 +38,6 @@ namespace System.IO.Tests
             sw2.Close();
             ValidateDisposedExceptions(sw2);
         }
-#endif //netstandard17
 
         private void ValidateDisposedExceptions(StreamWriter sw)
         {
@@ -80,7 +78,6 @@ namespace System.IO.Tests
             Assert.Throws<ObjectDisposedException>(() => sw2.Flush());
         }
 
-#if netstandard17
         [Fact]
         public void CantFlushAfterClose()
         {
@@ -93,6 +90,5 @@ namespace System.IO.Tests
             sw2.Close();
             Assert.Throws<ObjectDisposedException>(() => sw2.Flush());
         }
-#endif //netstandard17
     }
 }

--- a/src/System.IO/tests/StringReader/StringReader.CtorTests.cs
+++ b/src/System.IO/tests/StringReader/StringReader.CtorTests.cs
@@ -156,7 +156,6 @@ namespace System.IO.Tests
             Assert.Equal(str1, sr.ReadToEnd());
         }
 
-#if netstandard17
         [Fact]
         public static void Closed_DisposedExceptions()
         {
@@ -164,7 +163,6 @@ namespace System.IO.Tests
             sr.Close();
             ValidateDisposedExceptions(sr);
         }
-#endif //netstandard17
 
         [Fact]
         public static void Disposed_DisposedExceptions()

--- a/src/System.IO/tests/StringWriter/StringWriterTests.cs
+++ b/src/System.IO/tests/StringWriter/StringWriterTests.cs
@@ -235,7 +235,6 @@ namespace System.IO.Tests
             Assert.Equal(sb.ToString(), sw.GetStringBuilder().ToString());
         }
 
-#if netstandard17
         [Fact]
         public static void Closed_DisposedExceptions()
         {
@@ -243,7 +242,6 @@ namespace System.IO.Tests
             sw.Close();
             ValidateDisposedExceptions(sw);
         }
-#endif //netstandard17
 
         [Fact]
         public static void Disposed_DisposedExceptions()

--- a/src/System.IO/tests/System.IO.Tests.csproj
+++ b/src/System.IO/tests/System.IO.Tests.csproj
@@ -11,7 +11,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
+  <ItemGroup>
     <Compile Include="IndentedTextWriter.cs" />
     <Compile Include="BinaryReader\BinaryReaderTests.cs" />
     <Compile Include="MemoryStream\MemoryStream.GetBufferTests.cs" />
@@ -22,8 +22,6 @@
     <Compile Include="StreamWriter\StreamWriter.StringCtorTests.cs" />
     <Compile Include="Stream\Stream.APMMethodsTests.cs" />
     <Compile Include="BufferedStream\BufferedStreamTests.netstandard.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="BinaryWriter\BinaryWriter.WriteByteCharTests.cs" />
     <Compile Include="BinaryWriter\BinaryWriter.WriteTests.cs" />
     <Compile Include="BinaryWriter\BinaryWriterTests.cs" />

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
@@ -73,7 +73,7 @@
       <Link>Common\tests\System\PlatformDetection.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
+  <ItemGroup>
     <Compile Include="LoggingTest.cs" />
     <Compile Include="NetworkAvailabilityChangedTests.cs" />
     <Compile Include="NetworkInterfaceIPv4Statistics.cs" />

--- a/src/System.Net.Ping/tests/FunctionalTests/System.Net.Ping.Functional.Tests.csproj
+++ b/src/System.Net.Ping/tests/FunctionalTests/System.Net.Ping.Functional.Tests.csproj
@@ -10,11 +10,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
+  <ItemGroup>
     <Compile Include="PingTest.cs" />
     <Compile Include="LoggingTest.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="PingExceptionTest.cs" />
     <Compile Include="PingOptionsTest.cs" />
     <Compile Include="TestSettings.cs" />

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
@@ -280,7 +280,6 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.False(ip4.GetHashCode().Equals(ip6.GetHashCode()));
         }
 
-#if NetStandard17
 #pragma warning disable 618
          [Fact]
          public static void Address_Property_Failure()
@@ -299,6 +298,5 @@ namespace System.Net.Primitives.Functional.Tests
              Assert.Equal("10.0.168.192" , ip1.ToString());
          }
 #pragma warning restore 618
-#endif //NetStandard17
     }
 }

--- a/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
+++ b/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
@@ -27,8 +27,6 @@
     <Compile Include="IPEndPointTest.cs" />
     <Compile Include="NetworkCredentialTest.cs" />
     <Compile Include="SocketAddressTest.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
     <Compile Include="LoggingTest.cs" />
     <Compile Include="SerializationTest.cs" />
     <Compile Include="RequestCachePolicyTest.cs" />

--- a/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
+++ b/src/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
@@ -4,9 +4,6 @@
   <PropertyGroup>
     <ProjectGuid>{E671BC9F-A64C-4504-8B00-7A3215B99AF9}</ProjectGuid>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard'">
-    <DefineConstants>NetStandard17</DefineConstants>
-  </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />

--- a/src/System.Net.Requests/tests/HttpWebResponseTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebResponseTest.cs
@@ -15,9 +15,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData("text/html")]
         [InlineData("text/html; charset=utf-8")]
-#if netstandard17 // Depends on a bug fix made for 1.1 release.  Can be un-ifdef'd once an updated package is available on NuGet
         [InlineData("TypeAndNoSubType")]
-#endif
         public async Task ContentType_ServerResponseHasContentTypeHeader_ContentTypeReceivedCorrectly(string expectedContentType)
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>

--- a/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <ProjectGuid>{E520B5FD-C6FF-46CF-8079-6C8098013EA3}</ProjectGuid>
     <StringResourcesPath>../src/Resources/Strings.resx</StringResourcesPath>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard'">$(DefineConstants);netstandard17</DefineConstants>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />

--- a/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -37,7 +37,7 @@
       <Name>RemoteExecutorConsoleApp</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
+  <ItemGroup>
     <Compile Include="AuthorizationTest.cs" />
     <Compile Include="AuthenticationManagerTest.cs" />
     <Compile Include="GlobalProxySelectionTest.cs" />

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -89,7 +89,7 @@
     <Compile Include="SslStreamAlertsTest.cs" />
     <Compile Include="SslStreamSystemDefaultsTest.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
+  <ItemGroup>
     <Compile Include="LoggingTest.cs" />
     <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>

--- a/src/System.Net.WebHeaderCollection/tests/System.Net.WebHeaderCollection.Tests.csproj
+++ b/src/System.Net.WebHeaderCollection/tests/System.Net.WebHeaderCollection.Tests.csproj
@@ -9,8 +9,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="WebHeaderCollectionTest.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
     <Compile Include="LoggingTest.cs" />
     <Compile Include="WebHeaderCollectionTest.netstandard.cs" />
     <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">

--- a/src/System.Net.WebSockets/tests/System.Net.WebSockets.Tests.csproj
+++ b/src/System.Net.WebSockets/tests/System.Net.WebSockets.Tests.csproj
@@ -10,10 +10,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
-    <Compile Include="WebSocketTests.cs" />
-  </ItemGroup>
   <ItemGroup>
+    <Compile Include="WebSocketTests.cs" />
     <Compile Include="WebSocketExceptionTests.cs" />
     <Compile Include="WebSocketReceiveResultTests.cs" />
   </ItemGroup>

--- a/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
+++ b/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
@@ -45,7 +45,7 @@
   <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
     <Compile Include="KeyedCollection\TestMethods.netcoreapp.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
+  <ItemGroup>
     <Compile Include="KeyedCollection\Serialization.netstandard.cs" />
     <Compile Include="ObservableCollection\ObservableCollection_ConstructorAndPropertyTests.netstandard.cs" />
     <Compile Include="ObservableCollection\ObservableCollection_Serialization.netstandard.cs" />

--- a/src/System.Private.Uri/tests/FunctionalTests/System.Private.Uri.Functional.Tests.csproj
+++ b/src/System.Private.Uri/tests/FunctionalTests/System.Private.Uri.Functional.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="UriIsWellFormedUriStringTest.cs" />
     <Compile Include="UriMailToTest.cs" />
     <Compile Include="UriParameterValidationTest.cs" />
+    <Compile Include="UriParserTest.cs" />
     <Compile Include="UriRelativeResolutionTest.cs" />
     <Compile Include="UriTests.cs" />
     <Compile Include="WebSocketsUriParserTest.cs" />
@@ -29,9 +30,6 @@
     <Compile Include="$(CommonTestPath)\System\ThreadCultureChange.cs">
       <Link>Common\System\ThreadCultureChange.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
-    <Compile Include="UriParserTest.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.Xml.Linq/tests/TreeManipulation/System.Xml.Linq.TreeManipulation.Tests.csproj
+++ b/src/System.Private.Xml.Linq/tests/TreeManipulation/System.Xml.Linq.TreeManipulation.Tests.csproj
@@ -48,8 +48,6 @@
     <Compile Include="XNodeReplaceOnElement.cs" />
     <Compile Include="XNodeSequenceRemove.cs" />
     <Compile Include="XElementChangedNotificationTests.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
     <Compile Include="SaveWithFileName.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Reflection.Emit/tests/System.Reflection.Emit.Tests.csproj
+++ b/src/System.Reflection.Emit/tests/System.Reflection.Emit.Tests.csproj
@@ -109,8 +109,6 @@
     <Compile Include="TypeBuilder\TypeBuilderSize.cs" />
     <Compile Include="TypeBuilder\TypeBuilderToString.cs" />
     <Compile Include="Utilities.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
     <Compile Include="TypeBuilder\TypeBuilderCreateType.netstandard.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Reflection/tests/System.Reflection.Tests.csproj
+++ b/src/System.Reflection/tests/System.Reflection.Tests.csproj
@@ -24,8 +24,6 @@
     <Compile Include="ReflectionContextTests.cs" />
     <Compile Include="TypeInfoTests.cs" />
     <Compile Include="ExceptionTests.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
     <Compile Include="FieldInfoTests.netstandard.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Resources.ResourceManager/tests/System.Resources.ResourceManager.Tests.csproj
+++ b/src/System.Resources.ResourceManager/tests/System.Resources.ResourceManager.Tests.csproj
@@ -18,8 +18,6 @@
       <DependentUpon>TestResx.resx</DependentUpon>
     </Compile>
     <Compile Include="SatelliteContractVersionAttributeTests.cs" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetGroup)' == 'netstandard' ">
     <Compile Include="$(CommonTestPath)/System/Runtime/Serialization/Formatters/BinaryFormatterHelpers.cs">
       <Link>System/Runtime/Serialization/Formatters/BinaryFormatterHelpers.cs</Link>
     </Compile>

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <ProjectGuid>{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard2.0'">$(DefineConstants);netstandard17</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />

--- a/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.Exit.cs
@@ -39,7 +39,6 @@ namespace System.Tests
             }
         }
 
-#if netstandard17
         [Theory]
         [MemberData(nameof(ExitCodeValues))]
         public static void ExitCode_Roundtrips(int exitCode)
@@ -49,7 +48,6 @@ namespace System.Tests
 
             Environment.ExitCode = 0; // in case the test host has a void returning Main
         }
-#endif //netstandard17
 
         [ActiveIssue("https://github.com/dotnet/coreclr/issues/6206")]
         [Theory]

--- a/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
@@ -18,7 +18,6 @@ namespace System.Tests
             Assert.Throws<ArgumentException>("variable", () => Environment.SetEnvironmentVariable("", "test"));
             Assert.Throws<ArgumentException>("value", () => Environment.SetEnvironmentVariable("test", new string('s', 65 * 1024)));
 
-#if netstandard17
             Assert.Throws<ArgumentException>("variable", () => Environment.SetEnvironmentVariable("", "test", EnvironmentVariableTarget.Machine));
             Assert.Throws<ArgumentNullException>("variable", () => Environment.SetEnvironmentVariable(null, "test", EnvironmentVariableTarget.User));
             Assert.Throws<ArgumentNullException>("variable", () => Environment.GetEnvironmentVariable(null, EnvironmentVariableTarget.Process));
@@ -29,7 +28,6 @@ namespace System.Tests
             {
                 Assert.Throws<ArgumentException>("variable", () => Environment.SetEnvironmentVariable(new string('s', 256), "value", EnvironmentVariableTarget.User));
             }
-#endif
         }
 
         [Fact]
@@ -149,7 +147,6 @@ namespace System.Tests
             }
         }
 
-#if netstandard17
         public void EnvironmentVariablesAreHashtable()
         {
             // On NetFX, the type returned was always Hashtable
@@ -213,7 +210,6 @@ namespace System.Tests
                 }
             }
         }
-#endif
 
         private static void SetEnvironmentVariableWithPInvoke(string name, string value)
         {

--- a/src/System.Runtime.Handles/tests/System.Runtime.Handles.Tests.csproj
+++ b/src/System.Runtime.Handles/tests/System.Runtime.Handles.Tests.csproj
@@ -12,8 +12,6 @@
     <Compile Include="SafeHandle.cs" />
     <Compile Include="SafeWaitHandle.cs" />
     <Compile Include="SafeWaitHandleExtensions.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
     <Compile Include="CriticalHandle.netstandard.cs" />
     <Compile Include="SafeHandle.netstandard.cs" />
   </ItemGroup>

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -137,7 +137,7 @@
   <ItemGroup Condition="'$(TargetGroup)' != 'netcoreapp'">
     <Compile Include="System\StringSplitExtensions.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
+  <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.Generic.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.Generic.Serialization.Tests.cs</Link>
     </Compile>

--- a/src/System.Runtime/tests/System/Threading/WaitHandleTests.netstandard.cs
+++ b/src/System.Runtime/tests/System/Threading/WaitHandleTests.netstandard.cs
@@ -111,6 +111,7 @@ namespace System.Threading.Tests
         [Theory]
         [MemberData(nameof(SignalAndWait_MemberData))]
         [PlatformSpecific(TestPlatforms.Windows)] // other platforms don't support SignalAndWait
+        [ActiveIssue(16074)]
         private static void SignalAndWait(
             WaitHandle toSignal,
             AutoResetEvent toWaitOn,

--- a/src/System.Security.Cryptography.Algorithms/tests/HashAlgorithmTest.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HashAlgorithmTest.cs
@@ -32,7 +32,6 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
             Assert.Equal(expected, actual);
         }
 
-#if netstandard17
         private void VerifyICryptoTransformStream(Stream input, string output)
         {
             byte[] expected = ByteUtils.HexToByteArray(output);
@@ -53,11 +52,9 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
 
             Assert.Equal(expected, actual);
         }
-#endif
 
         protected void VerifyMultiBlock(string block1, string block2, string expectedHash, string emptyHash)
         {
-#if netstandard17
             byte[] block1_bytes = ByteUtils.AsciiBytes(block1);
             byte[] block2_bytes = ByteUtils.AsciiBytes(block2);
             byte[] expected_bytes = ByteUtils.HexToByteArray(expectedHash);
@@ -66,10 +63,8 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
             VerifyTransformBlockOutput(block1_bytes, block2_bytes);
             VerifyTransformBlockHash(block1_bytes, block2_bytes, expected_bytes, emptyHash_bytes);
             VerifyTransformBlockComputeHashInteraction(block1_bytes, block2_bytes, expected_bytes, emptyHash_bytes);
-#endif
         }
 
-#if netstandard17
         private void VerifyTransformBlockOutput(byte[] block1, byte[] block2)
         {
             using (HashAlgorithm hash = Create())
@@ -195,7 +190,6 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
                 Assert.Throws<ArgumentException>(null, () => hash.TransformFinalBlock(Array.Empty<byte>(), 0, 1));
             }
         }
-#endif
 
         protected void Verify(byte[] input, string output)
         {
@@ -209,10 +203,8 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
 
                 Assert.Equal(expected, actual);
 
-#if netstandard17
                 actual = hash.Hash;
                 Assert.Equal(expected, actual);
-#endif
             }
         }
 
@@ -223,12 +215,10 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
                 VerifyComputeHashStream(stream, output);
             }
 
-#if netstandard17
             using (Stream stream = new DataRepeatingStream(input, repeatCount))
             {
                 VerifyICryptoTransformStream(stream, output);
             }
-#endif
         }
 
         [Fact]

--- a/src/System.Security.Cryptography.Algorithms/tests/HmacSha1Tests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HmacSha1Tests.cs
@@ -47,7 +47,6 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
             using (HMACSHA1 h1 = new HMACSHA1(key))
             {
                 VerifyHmac_KeyAlreadySet(h1, 1, digest);
-#if netstandard17
                 using (HMACSHA1 h2 = new HMACSHA1(key, true))
                 {
                     VerifyHmac_KeyAlreadySet(h2, 1, digest);
@@ -58,7 +57,6 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
                     VerifyHmac_KeyAlreadySet(h1, 1, digest);
                     Assert.Equal(h1.Key, h2.Key);
                 }
-#endif
             }
         }
 

--- a/src/System.Security.Cryptography.Algorithms/tests/HmacSha384Tests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HmacSha384Tests.cs
@@ -20,7 +20,6 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
 
         protected override int BlockSize { get { return 128; } }
 
-#if netstandard17
         [Fact]
         public void ProduceLegacyHmacValues()
         {
@@ -31,7 +30,6 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
                 Assert.Throws<PlatformNotSupportedException>(() => h.ProduceLegacyHmacValues = true);
             }
         }
-#endif
 
         [Fact]
         public void HmacSha384_Rfc4231_1()

--- a/src/System.Security.Cryptography.Algorithms/tests/HmacSha512Tests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HmacSha512Tests.cs
@@ -20,7 +20,6 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
 
         protected override int BlockSize { get { return 128; } }
 
-#if netstandard17
         [Fact]
         public void ProduceLegacyHmacValues()
         {
@@ -31,7 +30,6 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
                 Assert.Throws<PlatformNotSupportedException>(() => h.ProduceLegacyHmacValues = true);
             }
         }
-#endif        
 
         [Fact]
         public void HmacSha512_Rfc4231_1()

--- a/src/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.cs
@@ -134,7 +134,6 @@ namespace System.Security.Cryptography.RNG.Tests
             }
         }
 
-#if netstandard17
         [Fact]
         public static void GetNonZeroBytes()
         {
@@ -191,7 +190,6 @@ namespace System.Security.Cryptography.RNG.Tests
                 rng.GetBytes(rand, 0, 0);
             }
         }
-#endif
 
         private static void DifferentSequential(int arraySize)
         {
@@ -238,7 +236,6 @@ namespace System.Security.Cryptography.RNG.Tests
             Assert.NotEqual(first, second);
         }
 
-#if netstandard17
         [Fact]
         public static void GetBytes_InvalidArgs()
         {
@@ -275,6 +272,5 @@ namespace System.Security.Cryptography.RNG.Tests
                 // Empty; don't throw NotImplementedException
             }
         }
-#endif
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/tests/Rfc2898Tests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/Rfc2898Tests.cs
@@ -271,7 +271,6 @@ namespace System.Security.Cryptography.DeriveBytesTests
                 });
         }
 
-#if netstandard17
         public static void CryptDeriveKey_NotSupported()
         {
             using (var deriveBytes = new Rfc2898DeriveBytes(TestPassword, s_testSalt))
@@ -279,7 +278,6 @@ namespace System.Security.Cryptography.DeriveBytesTests
                 Assert.Throws<PlatformNotSupportedException>(() => deriveBytes.CryptDeriveKey("RC2", "SHA1", 128, new byte[8]));
             }
         }
-#endif
 
         private static void TestKnownValue(string password, byte[] salt, int iterationCount, byte[] expected)
         {

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{508A7D81-6462-459C-9F8F-B58FCCCFC8E7}</ProjectGuid>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard'">$(DefineConstants);netstandard17</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />

--- a/src/System.Security.Cryptography.Encoding/tests/Oid.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Oid.cs
@@ -16,11 +16,9 @@ namespace System.Security.Cryptography.Encoding.Tests
             Assert.Equal("", oid.Value);
             Assert.Null(oid.FriendlyName);
 
-#if netstandard17
             oid = new Oid();
             Assert.Null(oid.Value);
             Assert.Null(oid.FriendlyName);
-#endif            
         }
 
         [Theory]

--- a/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
+++ b/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <ProjectGuid>{0581E9FA-D639-4B88-96D8-D092760F90B0}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants Condition="'$(TargetGroup)'==''">$(DefineConstants);netstandard17</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Unix-Release|AnyCPU'" />

--- a/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
+++ b/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Compile Include="AsnEncodedData.cs" />
     <Compile Include="AsnEncodedDataCollectionTests.cs" />
+    <Compile Include="Base64TransformsTests.cs" />
     <Compile Include="DerEncoderTests.cs" />
     <Compile Include="DerSequenceReaderTests.cs" />
     <Compile Include="Oid.cs" />
@@ -26,9 +27,6 @@
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
-    <Compile Include="Base64TransformsTests.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -65,8 +65,6 @@
     </Compile>
     <Compile Include="EcDsaOpenSslProvider.cs" />
     <Compile Include="RsaOpenSslTests.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
     <Compile Include="DsaOpenSslProvider.cs" />
     <Compile Include="DsaOpenSslTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AsymmetricSignatureFormatter.cs">

--- a/src/System.Security.Cryptography.Primitives/tests/CryptoStream.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/CryptoStream.cs
@@ -159,7 +159,6 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
             }
         }
 
-#if netstandard17
         [Fact]
         public static void Clear()
         {
@@ -203,7 +202,6 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
                 Assert.True(encryptStream.FlushCalled);
             }
         }
-#endif
 
         [Fact]
         public static void MultipleDispose()

--- a/src/System.Security.Cryptography.Primitives/tests/Length32Hash.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/Length32Hash.cs
@@ -8,17 +8,10 @@ namespace System.Security.Cryptography.Hashing.Tests
     {
         private uint _length;
 
-#if netstandard17
         public Length32Hash()
         {
             HashSizeValue = sizeof(uint);
         }
-#else
-        public override int HashSize
-        {
-            get { return sizeof(uint); }
-        }
-#endif
 
         protected override void HashCore(byte[] array, int ibStart, int cbSize)
         {

--- a/src/System.Security.Cryptography.Primitives/tests/SimpleHashAlgorithmTest.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/SimpleHashAlgorithmTest.cs
@@ -146,7 +146,6 @@ namespace System.Security.Cryptography.Hashing.Tests
             }
         }
 
-#if netstandard17 
         [Fact]
         public void ClearIsDispose()
         {
@@ -160,7 +159,6 @@ namespace System.Security.Cryptography.Hashing.Tests
                 Assert.Throws<ObjectDisposedException>(() => hash.ComputeHash(stream));
             }
         }
-#endif
 
         private void ArrayHash(byte[] array)
         {

--- a/src/System.Security.Cryptography.Primitives/tests/Sum32Hash.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/Sum32Hash.cs
@@ -8,17 +8,10 @@ namespace System.Security.Cryptography.Hashing.Tests
     {
         private uint _sum;
 
-#if netstandard17
         public Sum32Hash()
         {
             HashSizeValue = sizeof(uint);
         }
-#else
-        public override int HashSize
-        {
-            get { return sizeof(uint); }
-        }
-#endif
 
         protected override void HashCore(byte[] array, int ibStart, int cbSize)
         {

--- a/src/System.Security.Cryptography.Primitives/tests/SymmetricAlgorithm/Trivial.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/SymmetricAlgorithm/Trivial.cs
@@ -10,8 +10,6 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
 {
     public static class TrivialTests
     {
-        
-#if netstandard17 
         [Theory]
         [InlineData(-1)]
         [InlineData(0)]
@@ -60,7 +58,6 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
                 Assert.True(t.IsDisposed);
             }
         }
-#endif
 
         [Fact]
         public static void TestAutomaticKey()
@@ -378,14 +375,10 @@ namespace System.Security.Cryptography.Encryption.Tests.Symmetric
                 PaddingValue = (PaddingMode)anyValue;
             }
 
-#if netstandard17
-
             public void SetFeedbackSize(int value)
             {
                 FeedbackSizeValue = value;
             }
-
-#endif
 
             public static readonly byte[] GeneratedKey = GenerateRandom(13);
             public static readonly byte[] GeneratedIV = GenerateRandom(5);

--- a/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
+++ b/src/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
@@ -4,8 +4,7 @@
   <Import Project="$(CommonTestPath)\Tests.props" />
   <PropertyGroup>
     <ProjectGuid>{101EB757-55A4-4F48-841C-C088640B8F57}</ProjectGuid>
-    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);netcoreapp11;netstandard17</DefineConstants>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard'">$(DefineConstants);netstandard17</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);netcoreapp11</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -75,10 +75,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                 Assert.Equal(notAfter, cert2.NotAfter);
                 Assert.Equal(notBefore, cert2.NotBefore);
-#if netstandard17
+
                 Assert.Equal(notAfter.ToString(), cert2.GetExpirationDateString());
                 Assert.Equal(notBefore.ToString(), cert2.GetEffectiveDateString());
-#endif
 
                 Assert.Equal("00D01E4090000046520000000100000004", cert2.SerialNumber);
                 Assert.Equal("1.2.840.113549.1.1.5", cert2.SignatureAlgorithm.Value);
@@ -87,7 +86,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-#if netstandard17
         [Fact]
         [OuterLoop("May require using the network, to download CRLs and intermediates")]
         public void TestVerify()
@@ -148,7 +146,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 _log.WriteLine($"X509Certificate2.Verify exception: {testName}, {e}");
             }
         }
-#endif
 
         [Fact]
         public static void X509CertEmptyToString()
@@ -277,9 +274,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.ThrowsAny<CryptographicException>(() => c.IssuerName);
                 Assert.ThrowsAny<CryptographicException>(() => c.PublicKey);
                 Assert.ThrowsAny<CryptographicException>(() => c.Extensions);
-#if netstandard17
                 Assert.ThrowsAny<CryptographicException>(() => c.PrivateKey);
-#endif
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainHolder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainHolder.cs
@@ -17,12 +17,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             _chain = new X509Chain();
         }
 
-#if netstandard17
         public ChainHolder(IntPtr chainContext)
         {
             _chain = new X509Chain(chainContext);
         }
-#endif
 
         public X509Chain Chain => _chain;
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -63,7 +63,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-#if netstandard17
         [PlatformSpecific(TestPlatforms.Windows)]
         [Fact]
         public static void VerifyChainFromHandle()
@@ -194,7 +193,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.True(valid, "Chain built validly after reset");
             }
         }
-#endif
 
         /// <summary>
         /// Tests that when a certificate chain has a root certification which is not trusted by the trust provider,

--- a/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
@@ -41,7 +41,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.ThrowsAny<CryptographicException>(() => c.FriendlyName = "Hi");
             Assert.ThrowsAny<CryptographicException>(() => ignored = c.SubjectName);
             Assert.ThrowsAny<CryptographicException>(() => ignored = c.IssuerName);
-#if netstandard17
             Assert.ThrowsAny<CryptographicException>(() => c.GetCertHashString());
             Assert.ThrowsAny<CryptographicException>(() => c.GetEffectiveDateString());
             Assert.ThrowsAny<CryptographicException>(() => c.GetExpirationDateString());
@@ -53,7 +52,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.ThrowsAny<CryptographicException>(() => c.GetIssuerName());
             Assert.ThrowsAny<CryptographicException>(() => c.GetName());
 #pragma warning restore 0618
-#endif
         }
 
         [Fact]
@@ -77,12 +75,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (X509Certificate2 c = new X509Certificate2(TestData.MsCertificate))
             {
                 assert(c);
-#if netstandard17
                 using (X509Certificate2 c2 = new X509Certificate2(c))
                 {
                     assert(c2);
                 }
-#endif
             }
         }
 
@@ -107,16 +103,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (X509Certificate2 c = new X509Certificate2(TestData.MsCertificatePemBytes))
             {
                 assert(c);
-#if netstandard17
                 using (X509Certificate2 c2 = new X509Certificate2(c))
                 {
                     assert(c2);
                 }
-#endif
             }
         }
 
-#if netstandard17
         [Fact]
         public static void TestSerializeDeserialize_DER()
         {
@@ -290,7 +283,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.ThrowsAny<CryptographicException>(() => c.GetRSAPrivateKey());
             }
         }
-#endif
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // StoreSavedAsSerializedCerData not supported on Unix
@@ -308,12 +300,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (X509Certificate2 c = new X509Certificate2(TestData.StoreSavedAsSerializedCerData))
             {
                 assert(c);
-#if netstandard17
                 using (X509Certificate2 c2 = new X509Certificate2(c))
                 {
                     assert(c2);
                 }
-#endif
             }
         }
 
@@ -338,7 +328,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             using (new X509Certificate2(TestData.MsCertificate, (string)null)) { }
             using (new X509Certificate2(TestData.MsCertificate, (string)null, X509KeyStorageFlags.DefaultKeySet)) { }
 
-#if netstandard17
             Assert.Throws<ArgumentNullException>(() => X509Certificate.CreateFromCertFile(null));
             Assert.Throws<ArgumentNullException>(() => X509Certificate.CreateFromSignedFile(null));
             Assert.Throws<ArgumentNullException>("cert", () => new X509Certificate2((X509Certificate2)null));
@@ -347,7 +336,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             // A null SecureString password does not throw
             using (new X509Certificate2(TestData.MsCertificate, (SecureString)null)) { }
             using (new X509Certificate2(TestData.MsCertificate, (SecureString)null, X509KeyStorageFlags.DefaultKeySet)) { }
-#endif
 
             // For compat reasons, the (byte[]) constructor (and only that constructor) treats a null or 0-length array as the same
             // as calling the default constructor.

--- a/src/System.Security.Cryptography.X509Certificates/tests/InteropTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/InteropTests.cs
@@ -85,10 +85,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Equal(pCertContext, h);
                 pCertContext = IntPtr.Zero;
 
-#if netstandard17
                 Assert.Equal(rawData, c.GetRawCertData());
                 Assert.Equal(rawData, c.GetRawCertDataString().HexToByteArray());
-#endif
 
                 string issuer = c.Issuer;
                 Assert.Equal(

--- a/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
@@ -46,10 +46,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             {
                 byte[] serial = c.GetSerialNumber();
                 Assert.Equal(expectedSerial, serial);
-#if netstandard17
                 string serialHex = c.GetSerialNumberString();
                 Assert.Equal(expectedSerialHex, serialHex);
-#endif
             }
         }
 
@@ -63,10 +61,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             {
                 byte[] thumbPrint = c.GetCertHash();
                 Assert.Equal(expectedThumbPrint, thumbPrint);
-#if netstandard17
                 string thumbPrintHex = c.GetCertHashString();
                 Assert.Equal(expectedThumbPrintHex, thumbPrintHex);
-#endif
             }
         }
 
@@ -123,10 +119,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             {
                 byte[] publicKey = c.GetPublicKey();
                 Assert.Equal(expectedPublicKey, publicKey);
-#if netstandard17
                 string publicKeyHex = c.GetPublicKeyString();
                 Assert.Equal(expectedPublicKeyHex, publicKeyHex, true);
-#endif
             }
         }
 
@@ -147,30 +141,24 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Equal(
                     "CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
                     issuer);
-#if netstandard17
 #pragma warning disable 0618
                 Assert.Equal(c.Issuer, c.GetIssuerName());
 #pragma warning restore 0618
-#endif
 
                 string subject = c.Subject;
                 Assert.Equal(
                     "CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
                     subject);
-#if netstandard17
 #pragma warning disable 0618
                 Assert.Equal(subject, c.GetName());
 #pragma warning restore 0618
-#endif
 
                 string expectedThumbprintHash = "67B1757863E3EFF760EA9EBB02849AF07D3A8080";
                 byte[] expectedThumbprint = expectedThumbprintHash.HexToByteArray();
                 byte[] actualThumbprint = c.GetCertHash();
                 Assert.Equal(expectedThumbprint, actualThumbprint);
-#if netstandard17
                 string actualThumbprintHash = c.GetCertHashString();
                 Assert.Equal(expectedThumbprintHash, actualThumbprintHash);
-#endif
             }
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
@@ -241,7 +241,6 @@ Wry5FNNo
             }
         }
 
-#if netstandard17
         [Fact]
         public static void TestPrivateKey()
         {
@@ -250,7 +249,6 @@ Wry5FNNo
                 Assert.Null(c.PrivateKey);
             }
         }
-#endif
 
         [Fact]
         public static void TestVersion()

--- a/src/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
@@ -64,7 +64,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.Equal("1.2.840.10040.4.1", pk.Oid.Value);
         }
 
-#if netstandard17
         [Fact]
         public static void TestPublicKey_Key_RSA()
         {
@@ -118,7 +117,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.Equal(expected_q, dsaParameters.Q);
             Assert.Equal(expected_y, dsaParameters.Y);
         }
-#endif
 
         [Fact]
         public static void TestEncodedKeyValue_RSA()
@@ -310,7 +308,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-#if netstandard17
         [Fact]
         public static void TestPublicKey_Key_ECDsa()
         {
@@ -320,7 +317,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Throws<NotSupportedException>(() => cert.PublicKey.Key);
             }
         }
-#endif
 
         [Fact]
         public static void TestECDsaPublicKey_ValidatesSignature()

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -4,8 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{A28B0064-EFB2-4B77-B97C-DECF5DAB074E}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants Condition="'$(TargetGroup)'=='netstandard'">$(DefineConstants);netstandard17</DefineConstants>
-    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netstandard17;netcoreapp11</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp11</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -18,7 +18,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-#if netstandard17
         [Fact]
         public static void Constructor_DefaultStoreName()
         {
@@ -94,7 +93,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
             Assert.Throws<CryptographicException>(() => store.StoreHandle);
         }
-#endif
 
         [Fact]
         public static void ReadMyCertificates()
@@ -216,10 +214,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void TestAddAndRemove() {}
 
-#if netstandard17
         [Fact]
         public static void TestAddRangeAndRemoveRange() {}
-#endif
         */
 
         [Fact]

--- a/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
+++ b/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
@@ -8,10 +8,6 @@
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
-    <Compile Include="PrincipalPermissionTests.cs" />
-    <Compile Include="SecurityElementTests.cs" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="ApplicationTrustTests.cs" />
     <Compile Include="CodeConnectAccessTests.cs" />
@@ -24,6 +20,8 @@
     <Compile Include="TrustManagerContextTests.cs" />
     <Compile Include="PermissionSetTests.cs" />
     <Compile Include="PermissionTests.cs" />
+    <Compile Include="PrincipalPermissionTests.cs" />
+    <Compile Include="SecurityElementTests.cs" />
     <Compile Include="HostSecurityManagerTests.cs" />
     <Compile Include="HostProtectionTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">

--- a/src/System.Text.Encoding.CodePages/tests/System.Text.Encoding.CodePages.Tests.csproj
+++ b/src/System.Text.Encoding.CodePages/tests/System.Text.Encoding.CodePages.Tests.csproj
@@ -9,8 +9,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="EncodingCodePages.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
     <Compile Include="EncodingCodePages.netstandard.cs" />
     <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>

--- a/src/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
+++ b/src/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
@@ -70,8 +70,6 @@
     <Compile Include="UTF8Encoding\UTF8EncodingGetMaxCharCount.cs" />
     <Compile Include="UTF8Encoding\UTF8EncodingTests.cs" />
     <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
     <Compile Include="Encoding\Encoding.netstandard.cs" />
     <Compile Include="UnicodeEncoding\UnicodeEncoding.netstandard.cs" />
     <Compile Include="Decoder\Decoder.netstandard.cs" />

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -39,7 +39,7 @@
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetGroup)' == 'netstandard'">
+  <ItemGroup>
     <Compile Include="Regex.Serialization.cs" />
     <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>

--- a/src/System.Threading.Overlapped/tests/System.Threading.Overlapped.Tests.csproj
+++ b/src/System.Threading.Overlapped/tests/System.Threading.Overlapped.Tests.csproj
@@ -22,8 +22,6 @@
     <Compile Include="ThreadPoolBoundHandle_AllocateNativeOverlappedTests.cs" />
     <Compile Include="ThreadPoolBoundHandle_DisposeTests.cs" />
     <Compile Include="ThreadPoolBoundHandle_BindHandleTests.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
     <Compile Include="OverlappedTests.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
+++ b/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
@@ -49,7 +49,7 @@
       <Link>CommonTest\System\Threading\ThreadPoolHelpers.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
+  <ItemGroup>
     <Compile Include="Task\TaskDisposeTests.netstandard.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Threading.Timer/tests/System.Threading.Timer.Tests.csproj
+++ b/src/System.Threading.Timer/tests/System.Threading.Timer.Tests.csproj
@@ -11,8 +11,6 @@
     <Compile Include="TimerConstructorTests.cs" />
     <Compile Include="TimerChangeTests.cs" />
     <Compile Include="TimerFiringTests.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
     <Compile Include="TimerConstructorTests.netstandard.cs" />
     <Compile Include="TimerChangeTests.netstandard.cs" />
     <Compile Include="TimerFiringTests.netstandard.cs" />

--- a/src/System.Threading/tests/System.Threading.Tests.csproj
+++ b/src/System.Threading/tests/System.Threading.Tests.csproj
@@ -17,6 +17,8 @@
     <Compile Include="EtwTests.cs" />
     <Compile Include="EventWaitHandleTests.cs" />
     <Compile Include="InterlockedTests.cs" />
+    <Compile Include="HostExecutionContextTests.cs" />
+    <Compile Include="HostExecutionContextManagerTests.cs" />
     <Compile Include="ManualResetEventTests.cs" />
     <Compile Include="ManualResetEventSlimCancellationTests.cs" />
     <Compile Include="ManualResetEventSlimTests.cs" />
@@ -26,10 +28,14 @@
     <Compile Include="SemaphoreSlimTests.cs" />
     <Compile Include="SemaphoreTests.cs" />
     <Compile Include="SpinLockTests.cs" />
+    <Compile Include="ReaderWriterLockTests.cs" />
     <Compile Include="ReaderWriterLockSlimTests.cs" />
     <Compile Include="SpinWaitTests.cs" />
     <Compile Include="ThreadLocalTests.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
+    <Compile Include="ExecutionContextTests.netstandard.cs" />
+    <Compile Include="MonitorTests.netstandard.cs" />
+    <Compile Include="SynchronizationContextTests.netstandard.cs" />
     <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>CommonTest\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
@@ -39,14 +45,6 @@
     <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
       <Link>CommonTest\System\IO\FileCleanupTestBase.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
-    <Compile Include="ExecutionContextTests.netstandard.cs" />
-    <Compile Include="HostExecutionContextTests.cs" />
-    <Compile Include="HostExecutionContextManagerTests.cs" />
-    <Compile Include="MonitorTests.netstandard.cs" />
-    <Compile Include="ReaderWriterLockTests.cs" />
-    <Compile Include="SynchronizationContextTests.netstandard.cs" />
     <Compile Include="$(CommonTestPath)\System\Threading\ThreadTestHelpers.cs">
       <Link>CommonTest\System\Threading\ThreadTestHelpers.cs</Link>
     </Compile>


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/15849

There is still quite a bit of cruft left - e.g. the `*.netstandard.cs` files should be folded into the main test .cs files as appropriate. They do not need separate files and the .netstandard suffix on them is just confusing.