### PR TITLE
Fix outerloop GC region tests

### DIFF
--- a/src/System.Runtime/tests/System/GCTests.netstandard.cs
+++ b/src/System.Runtime/tests/System/GCTests.netstandard.cs
@@ -112,7 +112,7 @@ namespace System.Tests
                 Assert.True(GC.TryStartNoGCRegion(1024));
                 Assert.Throws<InvalidOperationException>(() => GC.TryStartNoGCRegion(1024));
 
-                GC.EndNoGCRegion();
+                Assert.Throws<InvalidOperationException>(() => GC.EndNoGCRegion());
 
                 return SuccessExitCode;
             }, options).Dispose();
@@ -129,7 +129,7 @@ namespace System.Tests
                 Assert.True(GC.TryStartNoGCRegion(1024, true));
                 Assert.Throws<InvalidOperationException>(() => GC.TryStartNoGCRegion(1024, true));
 
-                GC.EndNoGCRegion();
+                Assert.Throws<InvalidOperationException>(() => GC.EndNoGCRegion());
 
                 return SuccessExitCode;
             }, options).Dispose();
@@ -146,7 +146,7 @@ namespace System.Tests
                 Assert.True(GC.TryStartNoGCRegion(1024, 1024));
                 Assert.Throws<InvalidOperationException>(() => GC.TryStartNoGCRegion(1024, 1024));
 
-                GC.EndNoGCRegion();
+                Assert.Throws<InvalidOperationException>(() => GC.EndNoGCRegion());
 
                 return SuccessExitCode;
             }, options).Dispose();
@@ -163,7 +163,7 @@ namespace System.Tests
                 Assert.True(GC.TryStartNoGCRegion(1024, 1024, true));
                 Assert.Throws<InvalidOperationException>(() => GC.TryStartNoGCRegion(1024, 1024, true));
 
-                GC.EndNoGCRegion();
+                Assert.Throws<InvalidOperationException>(() => GC.EndNoGCRegion());
 
                 return SuccessExitCode;
             }, options).Dispose();


### PR DESCRIPTION
These tests are now failing in outerloop after #16072 re-enabled a bunch of tests that weren't running.

@swgillespie, is this the correct fix, or is this actually a product bug to be fixed and the tests are correct?  It seems strange to me that a failed call to TryStartNoGCRegion would change the mode such that a subsequent call to EndNoGCRegion that matches with the successful TryStartNoGCRegion would fail, but I tested on desktop and that's the behavior there as well.  Is that by design?

cc: @jkotas 