### PR TITLE
Fix MemberInitExpression.Reduce and ListInitExpression.Reduce

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
@@ -68,33 +68,37 @@ namespace System.Linq.Expressions
             return ReduceMemberInit(NewExpression, Bindings, keepOnStack: true);
         }
 
-        internal static Expression ReduceMemberInit(Expression objExpression, ReadOnlyCollection<MemberBinding> bindings, bool keepOnStack)
+        private static Expression ReduceMemberInit(
+            Expression objExpression, ReadOnlyCollection<MemberBinding> bindings, bool keepOnStack)
         {
-            ParameterExpression objVar = Expression.Variable(objExpression.Type, name: null);
+            ParameterExpression objVar = Variable(objExpression.Type);
             int count = bindings.Count;
-            var block = new Expression[count + 2];
-            block[0] = Expression.Assign(objVar, objExpression);
+            Expression[] block = new Expression[count + 2];
+            block[0] = Assign(objVar, objExpression);
             for (int i = 0; i < count; i++)
             {
                 block[i + 1] = ReduceMemberBinding(objVar, bindings[i]);
             }
+
             block[count + 1] = keepOnStack ? (Expression)objVar : Utils.Empty;
-            return Expression.Block(new TrueReadOnlyCollection<Expression>(block));
+            return Block(new[] {objVar}, block);
         }
 
-        internal static Expression ReduceListInit(Expression listExpression, ReadOnlyCollection<ElementInit> initializers, bool keepOnStack)
+        internal static Expression ReduceListInit(
+            Expression listExpression, ReadOnlyCollection<ElementInit> initializers, bool keepOnStack)
         {
-            ParameterExpression listVar = Expression.Variable(listExpression.Type, name: null);
+            ParameterExpression listVar = Variable(listExpression.Type);
             int count = initializers.Count;
-            var block = new Expression[count + 2];
-            block[0] = Expression.Assign(listVar, listExpression);
+            Expression[] block = new Expression[count + 2];
+            block[0] = Assign(listVar, listExpression);
             for (int i = 0; i < count; i++)
             {
                 ElementInit element = initializers[i];
-                block[i + 1] = Expression.Call(listVar, element.AddMethod, element.Arguments);
+                block[i + 1] = Call(listVar, element.AddMethod, element.Arguments);
             }
+
             block[count + 1] = keepOnStack ? (Expression)listVar : Utils.Empty;
-            return Expression.Block(new TrueReadOnlyCollection<Expression>(block));
+            return Block(new[] {listVar}, block);
         }
 
         internal static Expression ReduceMemberBinding(ParameterExpression objVar, MemberBinding binding)

--- a/src/System.Linq.Expressions/tests/MemberInit/MemberInitTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/MemberInitTests.cs
@@ -17,6 +17,15 @@ namespace System.Linq.Expressions.Tests
             VerifyMemberInit(() => new X { Y = { Z = 42, YS = { 2, 3 } }, XS = { 5, 7 } }, x => x.Y.Z == 42 && x.XS.Sum() == 5 + 7 && x.Y.YS.Sum() == 2 + 3, useInterpreter);
         }
 
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void Reduce(bool useInterpreter)
+        {
+            Expression<Func<X>> l = () => new X {Y = {Z = 42, YS = {2, 3}}, XS = {5, 7}};
+            MemberInitExpression e = l.Body as MemberInitExpression;
+            l = Expression.Lambda<Func<X>>(e.ReduceAndCheck());
+            VerifyMemberInit(l, x => x.Y.Z == 42 && x.XS.Sum() == 5 + 7 && x.Y.YS.Sum() == 2 + 3, useInterpreter);
+        }
+
         [Fact]
         public static void ToStringTest()
         {


### PR DESCRIPTION
Include the temporary variable used in the `BlockExpression` produced.

Fixes #16086

Also remove created `TrueReadOnlyCollection` as optimisation in #3686 may bypass it being useful, and otherwise one will be created in the factory called.