### PR TITLE
Span: Rename IsReferenceFree to IsReferenceOrContainsReferences

### DIFF
--- a/src/System.Memory/src/System/ReadOnlySpan.cs
+++ b/src/System.Memory/src/System/ReadOnlySpan.cs
@@ -111,7 +111,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe ReadOnlySpan(void* pointer, int length)
         {
-            if (!SpanHelpers.IsReferenceFree<T>())
+            if (SpanHelpers.IsReferenceOrContainsReferences<T>())
                 ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
             if (length < 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);

--- a/src/System.Memory/src/System/Span.cs
+++ b/src/System.Memory/src/System/Span.cs
@@ -111,7 +111,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe Span(void* pointer, int length)
         {
-            if (!SpanHelpers.IsReferenceFree<T>())
+            if (SpanHelpers.IsReferenceOrContainsReferences<T>())
                 ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
             if (length < 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
@@ -261,19 +261,19 @@ namespace System
             }
             else
             {
-                if (SpanHelpers.IsReferenceFree<T>())
-                {
-                    ref byte b = ref Unsafe.As<T, byte>(ref DangerousGetPinnableReference());
-
-                    SpanHelpers.ClearPointerSizedWithoutReferences(ref b, byteLength);
-                }
-                else
+                if (SpanHelpers.IsReferenceOrContainsReferences<T>())
                 {
                     UIntPtr pointerSizedLength = (UIntPtr)((length * Unsafe.SizeOf<T>()) / sizeof(IntPtr));
 
                     ref IntPtr ip = ref Unsafe.As<T, IntPtr>(ref DangerousGetPinnableReference());
 
                     SpanHelpers.ClearPointerSizedWithReferences(ref ip, pointerSizedLength);
+                }
+                else
+                {
+                    ref byte b = ref Unsafe.As<T, byte>(ref DangerousGetPinnableReference());
+
+                    SpanHelpers.ClearPointerSizedWithoutReferences(ref b, byteLength);
                 }
             }
         }
@@ -562,7 +562,7 @@ namespace System
         public static Span<byte> AsBytes<T>(this Span<T> source)
             where T : struct
         {
-            if (!SpanHelpers.IsReferenceFree<T>())
+            if (SpanHelpers.IsReferenceOrContainsReferences<T>())
                 ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
 
             int newLength = checked(source.Length * Unsafe.SizeOf<T>());
@@ -584,7 +584,7 @@ namespace System
         public static ReadOnlySpan<byte> AsBytes<T>(this ReadOnlySpan<T> source)
             where T : struct
         {
-            if (!SpanHelpers.IsReferenceFree<T>())
+            if (SpanHelpers.IsReferenceOrContainsReferences<T>())
                 ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
 
             int newLength = checked(source.Length * Unsafe.SizeOf<T>());
@@ -610,10 +610,10 @@ namespace System
             where TFrom : struct
             where TTo : struct
         {
-            if (!SpanHelpers.IsReferenceFree<TFrom>())
+            if (SpanHelpers.IsReferenceOrContainsReferences<TFrom>())
                 ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TFrom));
 
-            if (!SpanHelpers.IsReferenceFree<TTo>())
+            if (SpanHelpers.IsReferenceOrContainsReferences<TTo>())
                 ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TTo));
 
             int newLength = checked((int)((long)source.Length * Unsafe.SizeOf<TFrom>() / Unsafe.SizeOf<TTo>()));
@@ -639,10 +639,10 @@ namespace System
             where TFrom : struct
             where TTo : struct
         {
-            if (!SpanHelpers.IsReferenceFree<TFrom>())
+            if (SpanHelpers.IsReferenceOrContainsReferences<TFrom>())
                 ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TFrom));
 
-            if (!SpanHelpers.IsReferenceFree<TTo>())
+            if (SpanHelpers.IsReferenceOrContainsReferences<TTo>())
                 ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TTo));
 
             int newLength = checked((int)((long)source.Length * Unsafe.SizeOf<TFrom>() / Unsafe.SizeOf<TTo>()));

--- a/src/System.Memory/src/System/SpanHelpers.cs
+++ b/src/System.Memory/src/System/SpanHelpers.cs
@@ -45,48 +45,18 @@ namespace System
         }
 
         /// <summary>
-        /// Determine if a type is eligible for storage in unmanaged memory. TODO: To be replaced by a ContainsReference() api.
+        /// Determine if a type is eligible for storage in unmanaged memory.
+        /// Portable equivalent of RuntimeHelpers.IsReferenceOrContainsReferences<T>()
         /// </summary>
-        public static bool IsReferenceFree<T>() => PerTypeValues<T>.IsReferenceFree;
+        public static bool IsReferenceOrContainsReferences<T>() => PerTypeValues<T>.IsReferenceOrContainsReferences;
 
-        private static bool IsReferenceFreeCore<T>()
-        {
-            // Under the JIT, these become constant-folded.
-            if (typeof(T) == typeof(byte))
-                return true;
-            if (typeof(T) == typeof(sbyte))
-                return true;
-            if (typeof(T) == typeof(bool))
-                return true;
-            if (typeof(T) == typeof(char))
-                return true;
-            if (typeof(T) == typeof(short))
-                return true;
-            if (typeof(T) == typeof(ushort))
-                return true;
-            if (typeof(T) == typeof(int))
-                return true;
-            if (typeof(T) == typeof(uint))
-                return true;
-            if (typeof(T) == typeof(long))
-                return true;
-            if (typeof(T) == typeof(ulong))
-                return true;
-            if (typeof(T) == typeof(IntPtr))
-                return true;
-            if (typeof(T) == typeof(UIntPtr))
-                return true;
-
-            return IsReferenceFreeCoreSlow(typeof(T));
-        }
-
-        private static bool IsReferenceFreeCoreSlow(Type type)
+        private static bool IsReferenceOrContainsReferencesCore(Type type)
         {
             if (type.GetTypeInfo().IsPrimitive) // This is hopefully the common case. All types that return true for this are value types w/out embedded references.
-                return true;
+                return false;
 
             if (!type.GetTypeInfo().IsValueType)
-                return false;
+                return true;
 
             // If type is a Nullable<> of something, unwrap it first.
             Type underlyingNullable = Nullable.GetUnderlyingType(type);
@@ -94,28 +64,25 @@ namespace System
                 type = underlyingNullable;
 
             if (type.GetTypeInfo().IsEnum)
-                return true;
+                return false;
 
             foreach (FieldInfo field in type.GetTypeInfo().DeclaredFields)
             {
                 if (field.IsStatic)
                     continue;
-                if (!IsReferenceFreeCoreSlow(field.FieldType))
-                    return false;
+                if (IsReferenceOrContainsReferencesCore(field.FieldType))
+                    return true;
             }
-            return true;
+            return false;
         }
 
         public static class PerTypeValues<T>
         {
             //
             // Latch to ensure that excruciatingly expensive validation check for constructing a Span around a raw pointer is done
-            // only once per type (unless of course, the validation fails.)
+            // only once per type.
             //
-            // false == not yet computed or found to be not reference free.
-            // true == confirmed reference free
-            //
-            public static readonly bool IsReferenceFree = IsReferenceFreeCore<T>();
+            public static readonly bool IsReferenceOrContainsReferences = IsReferenceOrContainsReferencesCore(typeof(T));
 
             public static readonly T[] EmptyArray = new T[0];
 

--- a/src/System.Memory/tests/Span/Overflow.cs
+++ b/src/System.Memory/tests/Span/Overflow.cs
@@ -10,7 +10,6 @@ namespace System.SpanTests
 {
     public static partial class SpanTests
     {
-        [Fact(Skip = "Issue # 14484 - Disabling IndexOverflow test until FastSpan has a GetItem implementation. Related: issue # 13681")]
         public static void IndexOverflow()
         {
             //


### PR DESCRIPTION
- Rename IsReferenceFree to IsReferenceOrContainsReferences for consistency with #14047
- Remove IsReferenceFreeCore micro-optimization that is actually hurting. This code runs just once and
it is cheaper to do a check via reflection than to spend time in the JIT to optimize the extra code.
- Re-enabled disables test