### PR TITLE
SerialPort: Disable hardware use where no loopback/nullmodem available

### DIFF
--- a/src/System.IO.Ports/tests/Legacy/Support/TCSupport.cs
+++ b/src/System.IO.Ports/tests/Legacy/Support/TCSupport.cs
@@ -104,6 +104,13 @@ namespace Legacy.Support
                 portName2 = openablePortNames.FirstOrDefault(name => name != portName1);
             }
 
+            if (loopbackPortName == null && !nullModemPresent)
+            {
+                // We don't have any supporting hardware - disable all the tests which would use just an open port
+                Console.WriteLine("No support hardware - not using serial ports");
+                portName1 = portName2 = null;
+            }
+
             s_localMachineSerialInfo = new LocalMachineSerialInfo(portName1, portName2, loopbackPortName, nullModemPresent);
 
         }

--- a/src/System.IO.Ports/tests/Legacy/Support/TCSupport.cs
+++ b/src/System.IO.Ports/tests/Legacy/Support/TCSupport.cs
@@ -104,6 +104,7 @@ namespace Legacy.Support
                 portName2 = openablePortNames.FirstOrDefault(name => name != portName1);
             }
 
+            // See Github issue #15961 and #16033 - hardware tests are currently insufficiently stable on master CI
             if (loopbackPortName == null && !nullModemPresent)
             {
                 // We don't have any supporting hardware - disable all the tests which would use just an open port


### PR DESCRIPTION
This PR stops the SerialPort tests using hardware if there isn't either a loop-back plug or a null-modem cable fitted.  

This will reduce the number of tests that run on the CI until we can work out if it's going to be feasible to stabilise them properly.

Addresses new issues #16100, #16099 and the long-running #15961 

@JeremyKuhne, @Jiayili1 