### PR TITLE
Add Activity.RootId property 

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
@@ -13,6 +13,7 @@ namespace System.Diagnostics {
     public DateTime StartTimeUtc {get { throw null; } private set {} }
     public Activity Parent {get { throw null; } private set {} }
     public string ParentId {get { throw null; } private set {} }
+    public string RootId {get { throw null; } private set {} }    
     public TimeSpan Duration {get { throw null; } private set {} }    
     public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> Tags { get { throw null; } }    
     public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> Baggage { get { throw null; } }

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.Id.MachineName.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.Id.MachineName.cs
@@ -6,7 +6,7 @@
         private string generateUniquePrefix()
         {
             int uniqNum = unchecked((int)Stopwatch.GetTimestamp());
-            return $"{s_rootIdPrefix}{Environment.MachineName}_{uniqNum:x}";
+            return $"{s_rootIdPrefix}{Environment.MachineName}-{uniqNum:x}";
         }
         #endregion
     }

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -33,7 +33,7 @@ namespace System.Diagnostics
         /// This is an ID that is specific to a particular request.   Filtering
         /// to a particular ID insures that you get only one request that matches.  
         /// Id has a hierarchical structure: /root-id.id1.id2.id3.  Id is generated when 
-        /// <see cref="Start"/> is called by appending suffix (preceeded with '.') to Paren.Id
+        /// <see cref="Start"/> is called by appending suffix (preceeded with '.') to Parent.Id
         /// or ParentId; Activity has no Id until it started
         /// See <see href="https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#activity-id"/> for nore details
         /// </summary>
@@ -63,8 +63,7 @@ namespace System.Diagnostics
 
 
         /// <summary>
-        /// Root Id is substring from Activity,Id or ParentId between '/' (or beginning) and first '.'.
-        /// It is common for all Activities involved in operation processing. 
+        /// Root Id is substring from Activity.Id (or ParentId) between '/' (or beginning) and first '.'.
         /// Filtering by root Id allows to find all Activities involved in operation processing.
         /// RootId may be null if Activity has neither ParentId nor Id.
         /// See <see href="https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#activity-id"/> for more details
@@ -329,8 +328,8 @@ namespace System.Diagnostics
         private string getRootId(string id)
         {
             //id MAY start with '/' and contain '.'. We return substring between them
-            //ParentId MAY NOT have hierarchical structure and at least initial rootId not probably was started with '/',
-            //so we must NOT include first '/' to allow mixed hierarchical and non-hierarchical request id
+            //ParentId MAY NOT have hierarchical structure and we don't know if initially rootId was started with '/',
+            //so we must NOT include first '/' to allow mixed hierarchical and non-hierarchical request id scenarios
             int rootEnd = id.IndexOf('.');
             if (rootEnd < 0)
                 rootEnd = id.Length;

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -314,7 +314,7 @@ namespace System.Diagnostics
                 //sanitize external RequestId as it may not be hierarchical. 
                 //we cannot update ParentId, we must let it be logged exactly as it was passed.
                 string parentId = ParentId[0] == s_rootIdPrefix ? ParentId : s_rootIdPrefix + ParentId;
-                ret = appendSuffix(parentId, "I_" + Interlocked.Increment(ref s_currentRootId));
+                ret = appendSuffix(parentId, "I-" + Interlocked.Increment(ref s_currentRootId));
             }
             else
             {
@@ -330,7 +330,7 @@ namespace System.Diagnostics
             //id MAY start with '/' and contain '.'. We return substring between them
             //ParentId MAY NOT have hierarchical structure and we don't know if initially rootId was started with '/',
             //so we must NOT include first '/' to allow mixed hierarchical and non-hierarchical request id scenarios
-            int rootEnd = id.IndexOf('.');
+            int rootEnd = id.IndexOf(s_idDelimiter);
             if (rootEnd < 0)
                 rootEnd = id.Length;
             int rootStart = id[0] == s_rootIdPrefix ? 1 : 0;
@@ -340,7 +340,7 @@ namespace System.Diagnostics
         private string appendSuffix(string parentId, string suffix)
         {
 #if DEBUG
-            suffix = OperationName + "_" + suffix;
+            suffix = OperationName + "-" + suffix;
 #endif
             if (parentId.Length + suffix.Length <= 127)
                 return parentId + s_idDelimiter + suffix;

--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -150,8 +150,8 @@ namespace System.Diagnostics.Tests
             Task.Run(() => child1.Start()).Wait();
             Task.Run(() => child2.Start()).Wait();
 #if DEBUG
-            Assert.Equal($"{parent.Id}.{child1.OperationName}_1", child1.Id);
-            Assert.Equal($"{parent.Id}.{child2.OperationName}_2", child2.Id);
+            Assert.Equal($"{parent.Id}.{child1.OperationName}-1", child1.Id);
+            Assert.Equal($"{parent.Id}.{child2.OperationName}-2", child2.Id);
 #else
             Assert.Equal(parent.Id + ".1", child1.Id);
             Assert.Equal(parent.Id + ".2", child2.Id);
@@ -163,7 +163,7 @@ namespace System.Diagnostics.Tests
             var child3 = new Activity("child3");
             child3.Start();
 #if DEBUG
-            Assert.Equal($"{parent.Id}.{child3.OperationName}_3", child3.Id);
+            Assert.Equal($"{parent.Id}.{child3.OperationName}-3", child3.Id);
 #else
             Assert.Equal(parent.Id + ".3", child3.Id);
 #endif

--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -19,6 +19,7 @@ namespace System.Diagnostics.Tests
             var activity = new Activity(activityName);
             Assert.Equal(activityName, activity.OperationName);
             Assert.Null(activity.Id);
+            Assert.Null(activity.RootId);
             Assert.Equal(TimeSpan.Zero, activity.Duration);            
             Assert.Null(activity.Parent);
             Assert.Null(activity.ParentId);
@@ -71,6 +72,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal("1", parent.ParentId);
             Assert.Throws<InvalidOperationException>(() => parent.SetParentId("2"));
 
+            Assert.Equal(parent.ParentId, parent.RootId);
             parent.Start();
             var child = new Activity("child");
             child.Start();
@@ -127,6 +129,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(activity, Activity.Current);
             Assert.Null(activity.Parent);
             Assert.NotNull(activity.Id);
+            Assert.NotNull(activity.RootId);
             Assert.NotEqual(default(DateTime), activity.StartTimeUtc);
 
             activity.Stop();
@@ -153,6 +156,8 @@ namespace System.Diagnostics.Tests
             Assert.Equal(parent.Id + ".1", child1.Id);
             Assert.Equal(parent.Id + ".2", child2.Id);
 #endif
+            Assert.Equal(parent.RootId, child1.RootId);
+            Assert.Equal(parent.RootId, child2.RootId);
             child1.Stop();
             child2.Stop();
             var child3 = new Activity("child3");
@@ -173,11 +178,36 @@ namespace System.Diagnostics.Tests
             var child1 = new Activity("child1");
             child1.SetParentId("123");
             child1.Start();
+            Assert.Equal("123", child1.RootId);
+            Assert.True(child1.Id[0] == '/');
             child1.Stop();
+
             var child2 = new Activity("child2");
             child2.SetParentId("123");
             child2.Start();
             Assert.NotEqual(child2.Id, child1.Id);
+            Assert.Equal("123", child2.RootId);
+        }
+
+        /// <summary>
+        /// Tests Id generation
+        /// </summary>
+        [Fact]
+        public void RootId()
+        {
+
+            var parentIds = new []{
+                "123",   //Parent does not start with '/' and does not contain '.'
+                "123.1", //Parent does not start with '/' but contains '.'
+                "/123",  //Parent starts with '/' and does not contain '.'
+                "/123.1.1" //Parent starts with '/' and contains '.'
+            };
+            foreach (var parentId in parentIds)
+            {
+                var activity = new Activity("activity");
+                activity.SetParentId(parentId);
+                Assert.Equal("123", activity.RootId);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This change adds  `string RootId {get; private set}` property to Activity.
It allows to get root part of Activity.Id that is common for all Activities involved in operation processing and may be used by logging systems to optimize queries.

/cc @vancem @glennc @SergeyKanzhelev  @brahmnes

See #16155 for more details