### PR TITLE
Fix reading of null chars in Console.ReadLine on Unix

### DIFF
--- a/src/System.Console/src/System/IO/StdInReader.cs
+++ b/src/System.Console/src/System/IO/StdInReader.cs
@@ -162,7 +162,7 @@ namespace System.IO
                             Console.Clear();
                         }
                     }
-                    else
+                    else if (keyInfo.KeyChar != '\0')
                     {
                         _readLineSB.Append(keyInfo.KeyChar);
                         if (!previouslyProcessed)


### PR DESCRIPTION
Fixes #16076 

@nguerrera, can you help verify this fixes the issue you were seeing?

cc: @ianhays