### PR TITLE
Use Array.Fill in Enumerable.Repeat.ToArray

### DIFF
--- a/src/System.Linq/src/System/Linq/Repeat.cs
+++ b/src/System.Linq/src/System/Linq/Repeat.cs
@@ -79,10 +79,7 @@ namespace System.Linq
                 TResult[] array = new TResult[_count];
                 if (_current != null)
                 {
-                    for (int i = 0; i != array.Length; ++i)
-                    {
-                        array[i] = _current;
-                    }
+                    Array.Fill(array, _current, 0, array.Length);
                 }
 
                 return array;

--- a/src/System.Linq/src/System/Linq/Repeat.cs
+++ b/src/System.Linq/src/System/Linq/Repeat.cs
@@ -79,7 +79,7 @@ namespace System.Linq
                 TResult[] array = new TResult[_count];
                 if (_current != null)
                 {
-                    Array.Fill(array, _current, 0, array.Length);
+                    Array.Fill(array, _current);
                 }
 
                 return array;


### PR DESCRIPTION
As the title says. Currently the implementation is the same (using a for-loop) and there's no difference, but in the future it could possibly be optimized by e.g. implementing it natively for reference types to avoid the checks to account for covariant arrays on every store.

/cc @JonHanna @stephentoub @VSadov 