### PR TITLE
Lighten some numeric conversions in S.L.Expression interpreter

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -783,6 +783,11 @@ namespace System.Linq.Expressions.Interpreter
             Emit(new NumericConvertInstruction.Unchecked(from, to, isLiftedToNull));
         }
 
+        public void EmitConvertToUnderlying(TypeCode to, bool isLiftedToNull)
+        {
+            Emit(new NumericConvertInstruction.ToUnderlying(to, isLiftedToNull));
+        }
+
         public void EmitCast(Type toType)
         {
             Emit(CastInstruction.Create(toType));

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
@@ -32,8 +32,7 @@ namespace System.Linq.Expressions.Interpreter
                 {
                     // We cannot have null in a non-lifted numeric context. Throw the exception
                     // about not Nullable object requiring a value.
-                    converted = (int)(int?)obj;
-                    throw ContractUtils.Unreachable;
+                    return (int)(int?)obj;
                 }
             }
             else
@@ -295,6 +294,37 @@ namespace System.Linq.Expressions.Interpreter
                         case TypeCode.Single: return (float)obj;
                         case TypeCode.Double: return (double)obj;
                         case TypeCode.Decimal: return (decimal)obj;
+                        default: throw ContractUtils.Unreachable;
+                    }
+                }
+            }
+        }
+
+        internal sealed class ToUnderlying : NumericConvertInstruction
+        {
+            public override string InstructionName => "ConvertToUnderlying";
+
+            public ToUnderlying(TypeCode to, bool isLiftedToNull)
+                : base(to, to, isLiftedToNull)
+            {
+            }
+
+            protected override object Convert(object obj)
+            {
+                unchecked
+                {
+                    switch (_to)
+                    {
+                        case TypeCode.Boolean: return (bool)obj;
+                        case TypeCode.Byte: return (byte)obj;
+                        case TypeCode.SByte: return (sbyte)obj;
+                        case TypeCode.Int16: return (short)obj;
+                        case TypeCode.Char: return (char)obj;
+                        case TypeCode.Int32: return (int)obj;
+                        case TypeCode.Int64: return (long)obj;
+                        case TypeCode.UInt16: return (ushort)obj;
+                        case TypeCode.UInt32: return (uint)obj;
+                        case TypeCode.UInt64: return (ulong)obj;
                         default: throw ContractUtils.Unreachable;
                     }
                 }


### PR DESCRIPTION
When casting enum → underlying type we can do a single direct unchecked cast to the type, so do so.

Remove code that uses reflection to construct a nullable type when the target is nullable, as the boxing makes this irrelevant.