### PR TITLE
Build all configurations - official build

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Windows-NoTest.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Windows-NoTest.json
@@ -474,7 +474,7 @@
   "path": "\\",
   "type": "build",
   "id": 5308,
-  "name": "DotNet-CoreFx-Trusted-Windows-UAP",
+  "name": "DotNet-CoreFx-Trusted-Windows-NoTest",
   "url": "https://devdiv.visualstudio.com/DefaultCollection/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/5308",
   "project": {
     "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -376,6 +376,22 @@
             "ConfigurationGroup": "Release",
             "SubType": "Uapaot"
           }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
+          "Parameters": {
+            "PB_Platform": "x64",
+            "PB_BuildArguments": "-allConfigurations -buildArch=x64 -Release -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "**NOT_USED**"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x64",
+            "ConfigurationGroup": "Release",
+            "SubType": "AllConfigurations"
+          }
         }
       ]
     },
@@ -748,6 +764,22 @@
             "Platform": "x86",
             "ConfigurationGroup": "Debug",
             "SubType": "Uapaot"
+          }
+        },
+        {
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
+          "Parameters": {
+            "PB_Platform": "x64",
+            "PB_BuildArguments": "-allConfigurations -buildArch=x64 -Debug -- /p:SignType=real /p:RuntimeOS=win10",
+            "PB_SyncArguments": "-p -- /p:ArchGroup=x64 /p:RuntimeOS=win10",
+            "PB_CreateHelixArguments": "**NOT_USED**"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x64",
+            "ConfigurationGroup": "Debug",
+            "SubType": "AllConfigurations"
           }
         }
       ]

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -280,7 +280,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
           "Parameters": {
             "PB_Platform": "arm",
             "PB_BuildArguments": "-framework=uap -buildArch=arm -Release -- /p:SignType=real /p:RuntimeOS=win10",
@@ -296,7 +296,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
           "Parameters": {
             "PB_Platform": "x64",
             "PB_BuildArguments": "-framework=uap -buildArch=x64 -Release -- /p:SignType=real /p:RuntimeOS=win10",
@@ -312,7 +312,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
           "Parameters": {
             "PB_Platform": "x86",
             "PB_TargetQueue": "Windows.10.Amd64",
@@ -329,7 +329,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
           "Parameters": {
             "PB_Platform": "arm",
             "PB_BuildArguments": "-framework=uapaot -buildArch=arm -Release -- /p:SignType=real /p:RuntimeOS=win10",
@@ -345,7 +345,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
           "Parameters": {
             "PB_Platform": "x64",
             "PB_BuildArguments": "-framework=uapaot -buildArch=x64 -Release -- /p:SignType=real /p:RuntimeOS=win10",
@@ -361,7 +361,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
           "Parameters": {
             "PB_Platform": "x86",
             "PB_TargetQueue": "Windows.10.Amd64",
@@ -653,7 +653,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
           "Parameters": {
             "PB_Platform": "arm",
             "PB_BuildArguments": "-framework:uap -buildArch=arm -Debug -- /p:SignType=real /p:RuntimeOS=win10",
@@ -669,7 +669,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
           "Parameters": {
             "PB_Platform": "x64",
             "PB_BuildArguments": "-framework:uap -buildArch=x64 -Debug -- /p:SignType=real /p:RuntimeOS=win10",
@@ -685,7 +685,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
           "Parameters": {
             "PB_Platform": "x86",
             "PB_TargetQueue": "Windows.10.Amd64",
@@ -702,7 +702,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
           "Parameters": {
             "PB_Platform": "arm",
             "PB_BuildArguments": "-framework:uapaot -buildArch=arm -Debug -- /p:SignType=real /p:RuntimeOS=win10",
@@ -718,7 +718,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
           "Parameters": {
             "PB_Platform": "x64",
             "PB_BuildArguments": "-framework:uapaot -buildArch=x64 -Debug -- /p:SignType=real /p:RuntimeOS=win10",
@@ -734,7 +734,7 @@
           }
         },
         {
-          "Name": "DotNet-CoreFx-Trusted-Windows-UAP",
+          "Name": "DotNet-CoreFx-Trusted-Windows-NoTest",
           "Parameters": {
             "PB_Platform": "x86",
             "PB_TargetQueue": "Windows.10.Amd64",


### PR DESCRIPTION
This adds two legs that build all configurations (with no testing) to the official build.

This will be used for producing packages.