### PR TITLE
DiagnosticListener performance improvements #16128

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
@@ -11,12 +11,13 @@ namespace System.Diagnostics {
     public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     public static IObservable<DiagnosticListener> AllListeners { get { throw null; } } 
     public virtual void Dispose() { }
-    public override bool IsEnabled(string name) { throw null; }
-    public override bool IsEnabled(string name, object arg1, object arg2 = null) { throw null; }
+    public bool IsEnabled() { throw null; }
+    public sealed override bool IsEnabled(string name) { throw null; }
+    public sealed override bool IsEnabled(string name, object arg1, object arg2 = null) { throw null; }
     public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer) { throw null; }
     public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer, System.Predicate<string> isEnabled) { throw null; }
     public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer, System.Func<string, object, object, bool> isEnabled) { throw null; }
-    public override void Write(string name, object parameters) { }
+    public sealed override void Write(string name, object parameters) { }
   }
   public abstract partial class DiagnosticSource {
     protected DiagnosticSource() { }

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
@@ -12,12 +12,12 @@ namespace System.Diagnostics {
     public static IObservable<DiagnosticListener> AllListeners { get { throw null; } } 
     public virtual void Dispose() { }
     public bool IsEnabled() { throw null; }
-    public sealed override bool IsEnabled(string name) { throw null; }
-    public sealed override bool IsEnabled(string name, object arg1, object arg2 = null) { throw null; }
+    public override bool IsEnabled(string name) { throw null; }
+    public override bool IsEnabled(string name, object arg1, object arg2 = null) { throw null; }
     public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer) { throw null; }
     public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer, System.Predicate<string> isEnabled) { throw null; }
     public virtual System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.KeyValuePair<string, object>> observer, System.Func<string, object, object, bool> isEnabled) { throw null; }
-    public sealed override void Write(string name, object parameters) { }
+    public override void Write(string name, object parameters) { }
   }
   public abstract partial class DiagnosticSource {
     protected DiagnosticSource() { }

--- a/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md
+++ b/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md
@@ -173,23 +173,25 @@ Thus the event names only need to be unique within a component.
 
   * DO - use standard names for particular payload items.   (TODO: Put the list here as we define standard payload names).
   
-### Other Conventions 
-
+### Filtering
+ 
  * DO - always enclose the Write() call in a call to 'IsEnabled' for the same event name.  Otherwise
    a lot of setup logic will be called even if there is nothing listening for the event.
- 
- * DO NOT - make the DiagnosticListener public.   There is no need to as subscribers will 
-  use the AllListener property to hook up. 
+
+ * CONSIDER - enclosing IsEnabled(string, object, object) calls with pure IsEnabled(string) call to avoid
+  extra cost of creating context in case consumer is not interested in such events at all.
  
  * CONSIDER - passing public named types instances to 'IsEnabled' overloads with object parameters
   to keep IsEnabled as efficient as possible.
 
- * CONSIDER - enclosing IsEnabled(string, object, object) calls with pure IsEnabled(string) call to avoid
-  extra cost of creating context in case consumer is not interested in such events at all.
-
  * DO - when subscribing to DiagnosticSource with advanced filter for event name and extended context, 
   make sure filter returns true for null context properties if consumer is interested
   in at least some events with context
+
+### Other Conventions 
+
+  * DO NOT - make the DiagnosticListener public.   There is no need to as subscribers will 
+  use the AllListener property to hook up. 
 
  ----------------------------------------
 ## Consuming Data with DiagnosticListener. 

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -190,7 +190,7 @@ namespace System.Diagnostics
         /// <summary>
         /// Override abstract method
         /// </summary>
-        public sealed override bool IsEnabled(string name)
+        public override bool IsEnabled(string name)
         {
             for (DiagnosticSubscription curSubscription = _subscriptions; curSubscription != null; curSubscription = curSubscription.Next)
             {
@@ -204,7 +204,7 @@ namespace System.Diagnostics
         /// <summary>
         /// Override abstract method
         /// </summary>
-        public sealed override bool IsEnabled(string name, object arg1, object arg2 = null)
+        public override bool IsEnabled(string name, object arg1, object arg2 = null)
         {
             for (DiagnosticSubscription curSubscription = _subscriptions; curSubscription != null; curSubscription = curSubscription.Next)
             {
@@ -217,7 +217,7 @@ namespace System.Diagnostics
         /// <summary>
         /// Override abstract method
         /// </summary>
-        public sealed override void Write(string name, object value)
+        public override void Write(string name, object value)
         {
             for (DiagnosticSubscription curSubscription = _subscriptions; curSubscription != null; curSubscription = curSubscription.Next)
                 curSubscription.Observer.OnNext(new KeyValuePair<string, object>(name, value));

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -174,10 +174,22 @@ namespace System.Diagnostics
         #region private
 
         // NotificationSource implementation
+
+        /// <summary>
+        /// Optional: If there is an expensive setup for the notification,
+        /// you may call IsEnabled() as the first and most efficient check before doing this setup. 
+        /// Producers may use this check before IsEnabled(string) in the most performance-critical parts of the system
+        /// to ensure somebody listens to the DiagnosticListener at all.
+        /// </summary>
+        public bool IsEnabled()
+        {
+            return _subscriptions != null;
+        }
+
         /// <summary>
         /// Override abstract method
         /// </summary>
-        public override bool IsEnabled(string name)
+        public sealed override bool IsEnabled(string name)
         {
             for (DiagnosticSubscription curSubscription = _subscriptions; curSubscription != null; curSubscription = curSubscription.Next)
             {
@@ -191,7 +203,7 @@ namespace System.Diagnostics
         /// <summary>
         /// Override abstract method
         /// </summary>
-        public override bool IsEnabled(string name, object arg1, object arg2 = null)
+        public sealed override bool IsEnabled(string name, object arg1, object arg2 = null)
         {
             for (DiagnosticSubscription curSubscription = _subscriptions; curSubscription != null; curSubscription = curSubscription.Next)
             {
@@ -204,7 +216,7 @@ namespace System.Diagnostics
         /// <summary>
         /// Override abstract method
         /// </summary>
-        public override void Write(string name, object value)
+        public sealed override void Write(string name, object value)
         {
             for (DiagnosticSubscription curSubscription = _subscriptions; curSubscription != null; curSubscription = curSubscription.Next)
                 curSubscription.Observer.OnNext(new KeyValuePair<string, object>(name, value));

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -176,11 +176,12 @@ namespace System.Diagnostics
         // NotificationSource implementation
 
         /// <summary>
-        /// Optional: If there is an expensive setup for the notification,
-        /// you may call IsEnabled() as the first and most efficient check before doing this setup. 
-        /// Producers may use this check before IsEnabled(string) in the most performance-critical parts of the system
-        /// to ensure somebody listens to the DiagnosticListener at all.
+        /// Determines whether there are any registered subscribers
         /// </summary>
+        /// <remarks> If there is an expensive setup for the notification,
+        /// you may call IsEnabled() as the first and most efficient check before doing this setup. 
+        /// Producers may optionally use this check before IsEnabled(string) in the most performance-critical parts of the system
+        /// to ensure somebody listens to the DiagnosticListener at all.</remarks>
         public bool IsEnabled()
         {
             return _subscriptions != null;

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
@@ -121,6 +121,7 @@ namespace System.Diagnostics.Tests
                     return name == "StructPayload";
                 };
 
+                Assert.False(listener.IsEnabled());
                 using (listener.Subscribe(new ObserverToList<TelemData>(result), predicate))
                 {
                     Assert.False(source.IsEnabled("Uninteresting"));
@@ -129,6 +130,7 @@ namespace System.Diagnostics.Tests
                     Assert.True(source.IsEnabled("StructPayload", "arg1", "arg2"));
                     Assert.True(seenUninteresting);
                     Assert.True(seenStructPayload);
+                    Assert.True(listener.IsEnabled());
                 }
             }
         }


### PR DESCRIPTION
This change adds `DiagnosticListener.IsEnabled()` method as a quick check that somebody listens to this DiagnosticListener

See #16128 for more details.