### PR TITLE
Use x64 nupkgs on armel build and arm nupkgs on arm build

### DIFF
--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -6,7 +6,7 @@
     <NugetRuntimeIdentifier Condition="'$(OSGroup)' == 'Windows_NT' AND '$(RunningOnUnix)' == 'true'">win7-x64</NugetRuntimeIdentifier>
     <NugetRuntimeIdentifier Condition="'$(OSGroup)' == 'Unix' AND '$(RunningOnUnix)' != 'true'">ubuntu.14.04-x64</NugetRuntimeIdentifier>
     <!-- WORKAROUND: Force external packages to be restored for x64 until arm packages are fully broughtup-->
-    <NugetRuntimeIdentifier Condition="'$(ArchGroup)' == 'arm'">$(RuntimeOS)-x64</NugetRuntimeIdentifier>
+    <NugetRuntimeIdentifier Condition="'$(ArchGroup)' == 'armel'">$(RuntimeOS)-x64</NugetRuntimeIdentifier>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)' == 'uapaot'">
     <ProjectJsonTemplate>$(MSBuildThisFileDirectory)NETNative/project.json.template</ProjectJsonTemplate>


### PR DESCRIPTION
Force external pakcages to be restored for x64 until armel packages are fully broughtup

Related issue : https://github.com/dotnet/corefx/pull/15900
