### PR TITLE
Test and optimise TypeEqual and TypeIs behaviour for pointer types.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/ConstantCheck.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/ConstantCheck.cs
@@ -61,7 +61,7 @@ namespace System.Linq.Expressions
                 return testType == typeof(void) ? AnalyzeTypeIsResult.KnownTrue : AnalyzeTypeIsResult.KnownFalse;
             }
 
-            if (testType == typeof(void))
+            if (testType == typeof(void) || testType.IsPointer)
             {
                 return AnalyzeTypeIsResult.KnownFalse;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
@@ -52,7 +52,7 @@ namespace System.Linq.Expressions
         {
             Type cType = Expression.Type;
 
-            if (cType.GetTypeInfo().IsValueType)
+            if (cType.GetTypeInfo().IsValueType || TypeOperand.IsPointer)
             {
                 if (cType.IsNullableType())
                 {

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
@@ -29,6 +29,17 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentException>("type", () => Expression.TypeEqual(exp, byRef));
         }
 
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void TypePointer(bool useInterpreter)
+        {
+            Expression exp = Expression.Constant(0);
+            Type pointer = typeof(int*);
+            var test = Expression.TypeEqual(exp, pointer);
+            var lambda = Expression.Lambda<Func<bool>>(test);
+            var func = lambda.Compile(useInterpreter);
+            Assert.False(func());
+        }
+
         [Fact]
         public void UnreadableExpression()
         {

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeIs.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeIs.cs
@@ -29,6 +29,17 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentException>("type", () => Expression.TypeIs(exp, byRef));
         }
 
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void TypePointer(bool useInterpreter)
+        {
+            Expression exp = Expression.Constant(0);
+            Type pointer = typeof(int*);
+            var test = Expression.TypeIs(exp, pointer);
+            var lambda = Expression.Lambda<Func<bool>>(test);
+            var func = lambda.Compile(useInterpreter);
+            Assert.False(func());
+        }
+
         [Fact]
         public void UnreadableExpression()
         {


### PR DESCRIPTION
Contributes to #8081, but since the current behaviour is to safely always return false, continue to allow pointer type operands.

There is already code that examines these expressions for always-false or always-true behaviour, so have pointer types also result in the always-false path being taken.