### PR TITLE
Remove Fedora 24 test execution

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -47,7 +47,7 @@
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
             "PB_DockerTag": "fedora24_prereqs_v4",
-            "PB_TargetQueue": "Fedora.23.Amd64"
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Release /p:\"EnableCloudTest=false\" /p:\"TestProduct=corefx /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:FilterToOSGroup=Linux /p:\"BuildMoniker=none\""
           },
           "ReportingParameters": {
             "OperatingSystem": "Fedora 24",
@@ -436,7 +436,7 @@
           "Name": "DotNet-CoreFx-Trusted-Linux",
           "Parameters": {
             "PB_DockerTag": "fedora24_prereqs_v4",
-            "PB_TargetQueue": "Fedora.23.Amd64"
+            "PB_CreateHelixArguments": "/t:CloudBuild /p:ArchGroup=x64 /p:ConfigurationGroup=Debug /p:\"EnableCloudTest=false\" /p:\"TestProduct=corefx /p:\"TimeoutInSeconds=1200\" /p:\"TargetOS=Linux\" /p:FilterToOSGroup=Linux /p:\"BuildMoniker=none\""
           },
           "ReportingParameters": {
             "OperatingSystem": "Fedora 24",


### PR DESCRIPTION
We don't have Fedora 24 VMs currently and the mismatch makes un-runnable tests.  

Checked with @joperezr , TargetOS and FilterToOSGroup are likely still necessary (due to other properties deriving from them) so I've chosen to leave things alone for now.

With 24 EOL'ing soon, we'll probably want to move all 2.0 stuff to Fedora 25 in the near future.  @chulhul is working on an updated image.

@weshaggard @chcosta 