### PR TITLE
Simplify and optimise S.L.Expressions type-test instructions.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -847,11 +847,6 @@ namespace System.Linq.Expressions.Interpreter
             Emit(TypeEqualsInstruction.Instance);
         }
 
-        public void EmitNullableTypeEquals()
-        {
-            Emit(NullableTypeEqualsInstruction.Instance);
-        }
-
         public void EmitArrayLength()
         {
             Emit(ArrayLengthInstruction.Instance);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -110,25 +110,6 @@ namespace System.Linq.Expressions.Interpreter
         }
     }
 
-    internal sealed class NullableTypeEqualsInstruction : Instruction
-    {
-        public static readonly NullableTypeEqualsInstruction Instance = new NullableTypeEqualsInstruction();
-
-        public override int ConsumedStack => 2;
-        public override int ProducedStack => 1;
-        public override string InstructionName => "NullableTypeEquals";
-
-        private NullableTypeEqualsInstruction() { }
-
-        public override int Run(InterpretedFrame frame)
-        {
-            object type = frame.Pop();
-            object obj = frame.Pop();
-            frame.Push((object)obj?.GetType() == type);
-            return 1;
-        }
-    }
-
     internal abstract class NullableMethodCallInstruction : Instruction
     {
         private static NullableMethodCallInstruction s_hasValue, s_value, s_equals, s_getHashCode, s_getValueOrDefault1, s_toString;


### PR DESCRIPTION
`NullableTypeEqualsInstruction` exactly duplicates `TypeEqualsInstruction`.

Remove it, and use `GetNonNullableType()` on type argument so result is the same for nullables and non-nullables.

Path using type-equal test for type-is on nullables will work with any value type, so test for being a value type rather than being a nullable.

`ConstantCheck.AnalyzeTypeIs` call in `CompileTypeIsExpression()` may have found only a nullity test is necessary, in which case emit it instead of full type test.