### PR TITLE
Move SspiClientContextStatus to SNI 

### DIFF
--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -154,6 +154,7 @@
     <Compile Include="System\Data\SqlClient\SNI\SNITcpHandle.cs" />
     <Compile Include="System\Data\SqlClient\SNI\SslOverTdsStream.cs" />
     <Compile Include="System\Data\SqlClient\SNI\SNICommon.cs" />
+    <Compile Include="System\Data\SqlClient\SNI\SspiClientContextStatus.cs" />
     <Compile Include="$(CommonPath)\System\Net\Security\NegotiateStreamPal.Unix.cs">
       <Link>Common\System\Net\Security\NegotiateStreamPal.Unix.cs</Link>
     </Compile>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -101,13 +101,11 @@ namespace System.Data.SqlClient.SNI
         /// <param name="serverName">Service Principal Name buffer</param>
         /// <param name="serverNameLength">Length of Service Principal Name</param>
         /// <returns>SNI error code</returns>
-        public void GenSspiClientContext(TdsParserStateObject tdsParserStateObject, byte[] receivedBuff, ref byte[] sendBuff, byte[] serverName)
+        public void GenSspiClientContext(SspiClientContextStatus sspiClientContextStatus, byte[] receivedBuff, ref byte[] sendBuff, byte[] serverName)
         {
-            SNITCPHandle tcpHandle = (SNITCPHandle)tdsParserStateObject.Handle;
-
-            SafeDeleteContext securityContext = tdsParserStateObject.sspiClientContextStatus.SecurityContext;
-            ContextFlagsPal contextFlags = tdsParserStateObject.sspiClientContextStatus.ContextFlags;
-            SafeFreeCredentials credentialsHandle = tdsParserStateObject.sspiClientContextStatus.CredentialsHandle;
+            SafeDeleteContext securityContext = sspiClientContextStatus.SecurityContext;
+            ContextFlagsPal contextFlags = sspiClientContextStatus.ContextFlags;
+            SafeFreeCredentials credentialsHandle = sspiClientContextStatus.CredentialsHandle;
 
             SecurityBuffer[] inSecurityBufferArray = null;
             if (securityContext == null) //first iteration
@@ -146,9 +144,9 @@ namespace System.Data.SqlClient.SNI
 
             sendBuff = outSecurityBuffer.token;
 
-            tdsParserStateObject.sspiClientContextStatus.SecurityContext = securityContext;
-            tdsParserStateObject.sspiClientContextStatus.ContextFlags = contextFlags;
-            tdsParserStateObject.sspiClientContextStatus.CredentialsHandle = credentialsHandle;
+            sspiClientContextStatus.SecurityContext = securityContext;
+            sspiClientContextStatus.ContextFlags = contextFlags;
+            sspiClientContextStatus.CredentialsHandle = credentialsHandle;
 
             if (IsErrorStatus(statusCode.ErrorCode))
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SspiClientContextStatus.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SspiClientContextStatus.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System.Net;
+using System.Net.Security;
+
+
+namespace System.Data.SqlClient.SNI
+{
+    internal class SspiClientContextStatus
+    {
+        public SafeFreeCredentials CredentialsHandle
+        {
+            get;
+            set;
+        }
+
+        public SafeDeleteContext SecurityContext
+        {
+            get;
+            set;
+        }
+
+        public ContextFlagsPal ContextFlags
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -6319,7 +6319,7 @@ namespace System.Data.SqlClient
         {
             try
             {
-                SNIProxy.Singleton.GenSspiClientContext(_physicalStateObj, receivedBuff, ref sendBuff, _sniSpnBuffer);
+                SNIProxy.Singleton.GenSspiClientContext(_physicalStateObj.sspiClientContextStatus, receivedBuff, ref sendBuff, _sniSpnBuffer);
             }
             catch (Exception e)
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
@@ -250,27 +250,6 @@ namespace System.Data.SqlClient
 #if MANAGED_SNI
 
         internal SspiClientContextStatus sspiClientContextStatus = new SspiClientContextStatus();
-
-        internal class SspiClientContextStatus
-        {
-            public SafeFreeCredentials CredentialsHandle
-            {
-                get;
-                set;
-            }
-
-            public SafeDeleteContext SecurityContext
-            {
-                get;
-                set;
-            }
-
-            public ContextFlagsPal ContextFlags
-            {
-                get;
-                set;
-            }
-        }
 #endif
 
         //////////////////


### PR DESCRIPTION
The following changes were added 

1. Remove SspiClientContextStatus from TdsParserStateObject to its own class.
2. Remove references to TdsParserStateObject from SNIProxy.

I am making this change so that the files in System.Data.SqlClient.SNI can be built independently of the upper TDS layers. 
This is also related to #16129 