### PR TITLE
Fix string.Format in System.Configuration.LocalFileSettingsProvider

### DIFF
--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/LocalFileSettingsProvider.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/LocalFileSettingsProvider.cs
@@ -474,11 +474,11 @@ namespace System.Configuration
 
             if (isUser && isApp)
             {
-                throw new ConfigurationErrorsException(SR.BothScopeAttributes);
+                throw new ConfigurationErrorsException(string.Format(SR.BothScopeAttributes, setting.Name));
             }
             else if (!(isUser || isApp))
             {
-                throw new ConfigurationErrorsException(SR.NoScopeAttributes);
+                throw new ConfigurationErrorsException(string.Format(SR.NoScopeAttributes, setting.Name));
             }
 
             return isUser;


### PR DESCRIPTION
Two exception messages ([this and a few lines below](https://github.com/dotnet/corefx/blob/e11d6ed334725a8332ef81df195a5c35d48eb967/src/System.Configuration.ConfigurationManager/src/Resources/Strings.resx#L749)) have a formatting argument `{0}`, but were not used in string.Format.  
Code style was used like [in this piece of code](https://github.com/dotnet/corefx/blob/a8dce7c1c905e994c9519e0f26b0497832942a10/src/System.Configuration.ConfigurationManager/src/System/Configuration/SettingsBase.cs#L82)

cc @JeremyKuhne @dhoehna 