### PR TITLE
Disable network test that is failing regularly

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -71,6 +71,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
+        [ActiveIssue(9543, TestPlatforms.Windows)] // reuseClient==false fails in debug/release, reuseClient==true fails sporadically in release
         [ConditionalTheory(nameof(BackendSupportsCustomCertificateHandling))]
         [InlineData(6, false)]
         [InlineData(3, true)]


### PR DESCRIPTION
Manual_CertificateSentMatchesCertificateReceived_Success is causing windows_nt to fail, so add back the [ActiveIssue] that was removed a few days ago. See https://github.com/dotnet/corefx/issues/16148
