### PR TITLE
Fix run-test.sh

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -19,25 +19,17 @@ usage()
     echo "usage: run-test [options]"
     echo
     echo "Input sources:"
-    echo "    --coreclr-bins <location>         Location of root of the binaries directory"
-    echo "                                      containing the FreeBSD, Linux, NetBSD or OSX coreclr build"
-    echo "                                      default: <repo_root>/bin/Product/<OS>.x64.<ConfigurationGroup>"
-    echo "    --corefx-tests <location>         Location of the root binaries location containing"
-    echo "                                      the tests to run"
-    echo "                                      default: <repo_root>/bin/tests"
-    echo "    --corefx-native-bins <location>   Location of the FreeBSD, Linux, NetBSD or OSX native corefx binaries"
-    echo "                                      default: <repo_root>/bin/<OS>.x64.<ConfigurationGroup>"
-    echo "    --corefx-packages <location>      Location of the packages restored from NuGet."
-    echo "                                      default: <repo_root>/packages"
-    echo "    --testRelPath <path>              Relative path to test script"
-    echo "                                      Path is relative from the directory specified by project name"
-    echo "                                      default: default.netcoreapp1.1"
+    echo "    --runtime <location>              Location of root of the binaries directory"
+    echo "                                      containing the FreeBSD, Linux, NetBSD or OSX runtime"
+    echo "                                      default: <repo_root>/bin/testhost/netcoreapp-<OS>-<ConfigurationGroup>-<Arch>"
     echo
-    echo "Flavor/OS options:"
+    echo "Flavor/OS/Architecture options:"
     echo "    --configurationGroup <config>     ConfigurationGroup to run (Debug/Release)"
     echo "                                      default: Debug"
     echo "    --os <os>                         OS to run (FreeBSD, Linux, NetBSD or OSX)"
     echo "                                      default: detect current OS"
+    echo "    --arch <Architecture>             Architecture to run (x64, arm, x86, arm64)"
+    echo "                                      default: detect current architecture"
     echo
     echo "Execution options:"
     echo "    --sequential                      Run tests sequentially (default is to run in parallel)."
@@ -99,48 +91,49 @@ case $OSName in
         OS=Linux
         ;;
 esac
+
+# Use uname to determine what the CPU is.
+CPUName=$(uname -p)
+# Some Linux platforms report unknown for platform, but the arch for machine.
+if [ "$CPUName" == "unknown" ]; then
+    CPUName=$(uname -m)
+fi
+
+case $CPUName in
+    i686)
+        echo "Unsupported CPU $CPUName detected, test might not succeed!"
+        __Arch=x86
+        ;;
+
+    x86_64)
+        __Arch=x64
+        ;;
+
+    armv7l)
+        __Arch=arm
+        ;;
+
+    aarch64)
+        __Arch=arm64
+        ;;
+
+    *)
+        echo "Unknown CPU $CPUName detected, configuring as if for x64"
+        __Arch=x64
+        ;;
+esac
+
 # Misc defaults
 TestSelection=".*"
 TestsFailed=0
 
-# TestRelPath default
-TestRelPath="default.netcoreapp1.1"
-
 ensure_binaries_are_present()
 {
-  local LowerConfigurationGroup="$(echo $ConfigurationGroup | awk '{print tolower($0)}')"
-
-  # Copy the CoreCLR native binaries
-  if [ ! -d $CoreClrBins ]
+  if [ ! -d $Runtime ]
   then
-	echo "error: Coreclr $OS binaries not found at $CoreClrBins"
+	echo "error: Coreclr $OS binaries not found at $Runtime"
 	exit 1
   fi
-
-  # Then the native CoreFX binaries
-  if [ ! -d $CoreFxNativeBins ]
-  then
-	echo "error: Corefx native binaries should be built (use build.sh native in root)"
-	exit 1
-  fi
-}
-
-copy_test_overlay()
-{
-  testDir=$1
-
-  link_files_in_directory "$CoreClrBins" "$testDir"
-  link_files_in_directory "$CoreFxNativeBins" "$testDir"
-}
-
-# $1 is the source directory
-# $2 is the destination directory
-link_files_in_directory()
-{
-    for path in `find $1 -maxdepth 1 -type f`; do
-      fileName=`basename $path`
-      ln -f $path "$2/$fileName"
-    done
 }
 
 # $1 is the path of list file
@@ -166,7 +159,7 @@ run_selected_tests()
     selectedTests[${#selectedTests[@]}]="$TestDir"
   fi
 
-  run_all_tests ${selectedTests[@]/#/$CoreFxTests/}
+  run_all_tests ${selectedTests[@]}
 }
 
 # $1 is the name of the platform folder (e.g Unix.AnyCPU.Debug)
@@ -201,25 +194,25 @@ run_test()
     exit 0
   fi
 
-  dirName="$1/$TestRelPath"
+  dirName="$1/netcoreapp"
 
   if [ ! -d "$dirName" ]; then
-    echo "Nothing to test in $testProject"
-    exit 0
+    dirName="$1/netstandard"
+    if [ ! -d "$dirName" ]; then
+        echo "Nothing to test in $testProject"
+        exit 0
+    fi
   fi
-
-  copy_test_overlay $dirName
 
   pushd $dirName > /dev/null
 
   chmod +x ./RunTests.sh
-  chmod +x ./corerun
 
   echo
   echo "Running tests in $dirName"
-  echo "./RunTests.sh $CoreFxPackages"
+  echo "./RunTests.sh $Runtime"
   echo
-  ./RunTests.sh "$CoreFxPackages"
+  ./RunTests.sh "$Runtime"
   exitCode=$?
 
   if [ $exitCode -ne 0 ]
@@ -294,17 +287,8 @@ do
         -h|--help)
         usage
         ;;
-        --coreclr-bins)
-        CoreClrBins=$2
-        ;;
-        --corefx-tests)
-        CoreFxTests=$2
-        ;;
-        --corefx-native-bins)
-        CoreFxNativeBins=$2
-        ;;
-        --corefx-packages)
-        CoreFxPackages=$2
+        --runtime)
+        Runtime=$2
         ;;
         --restrict-proj)
         TestSelection=$2
@@ -336,9 +320,6 @@ do
         --test-dir-file)
         TestDirFile=$2
         ;;
-        --testRelPath)
-        TestRelPath=$2
-        ;;
         --outerloop)
         OuterLoop=""
         ;;
@@ -353,24 +334,9 @@ done
 
 # Compute paths to the binaries if they haven't already been computed
 
-if [ "$CoreClrBins" == "" ]
+if [ "$Runtime" == "" ]
 then
-    CoreClrBins="$ProjectRoot/bin/Product/$OS.x64.$ConfigurationGroup"
-fi
-
-if [ "$CoreFxTests" == "" ]
-then
-    CoreFxTests="$ProjectRoot/bin/tests"
-fi
-
-if [ "$CoreFxNativeBins" == "" ]
-then
-    CoreFxNativeBins="$ProjectRoot/bin/$OS.x64.$ConfigurationGroup/native"
-fi
-
-if [ "$CoreFxPackages" == "" ]
-then
-    CoreFxPackages="$ProjectRoot/packages"
+    Runtime="$ProjectRoot/bin/testhost/netcoreapp-$OS-$ConfigurationGroup-$__Arch"
 fi
 
 # Check parameters up front for valid values:
@@ -385,25 +351,6 @@ if [ ! "$OS" == "FreeBSD" ] && [ ! "$OS" == "Linux" ] && [ ! "$OS" == "NetBSD" ]
 then
     echo "error: OS should be FreeBSD, Linux, NetBSD or OSX"
     exit 1
-fi
-
-if [ "$CoreClrObjs" == "" ]
-then
-    CoreClrObjs="$ProjectRoot/bin/obj/$OS.x64.$ConfigurationGroup"
-fi
-
-# The CI system shares PR build job definitions between RC2 and master.  In RC2, we expected
-# that CoreFxTests was the path to the root folder containing the tests for a specific platform
-# (since all tests were rooted under a path like tests/Linux.AnyCPU.$ConfigurationGroup). In
-# master, we instead want CoreFxTests to point at the root of the tests folder, since tests
-# are now split across tests/AnyOS.AnyCPU.$ConfigruationGroup,
-# tests/Unix.AnyCPU.$ConfigruationGroup and tests/$OS.AnyCPU.$ConfigurationGroup.
-#
-# Until we can split the CI definitions up, we need them to pass a platform specific folder (so
-# the jobs work on RC2), so here we detect that case and use the parent folder instead.
-if [[ `basename $CoreFxTests` =~ ^(Linux|OSX|FreeBSD|NetBSD) ]]
-then
-    CoreFxTests=`dirname $CoreFxTests`
 fi
 
 export CORECLR_SERVER_GC="$serverGC"
@@ -436,9 +383,9 @@ if [ -n "$TestDirFile" ] || [ -n "$TestDir" ]
 then
     run_selected_tests
 else
-    run_all_tests "$CoreFxTests/AnyOS.AnyCPU.$ConfigurationGroup/"*
-    run_all_tests "$CoreFxTests/Unix.AnyCPU.$ConfigurationGroup/"*
-    run_all_tests "$CoreFxTests/$OS.AnyCPU.$ConfigurationGroup/"*
+    run_all_tests "$ProjectRoot/bin/AnyOS.AnyCPU.$ConfigurationGroup/"*.Tests
+    run_all_tests "$ProjectRoot/bin/Unix.AnyCPU.$ConfigurationGroup/"*.Tests
+    run_all_tests "$ProjectRoot/bin/$OS.AnyCPU.$ConfigurationGroup/"*.Tests
 fi
 
 if [ "$CoreClrCoverage" == "ON" ]

--- a/run-test.sh
+++ b/run-test.sh
@@ -200,13 +200,16 @@ run_test()
     dirName="$1/netstandard"
     if [ ! -d "$dirName" ]; then
         echo "Nothing to test in $testProject"
-        exit 0
+        return
     fi
   fi
 
-  pushd $dirName > /dev/null
+  if [ ! -e "$dirName/RunTests.sh" ]; then
+      echo "Cannot find $dirName/RunTests.sh"
+      return
+  fi
 
-  chmod +x ./RunTests.sh
+  pushd $dirName > /dev/null
 
   echo
   echo "Running tests in $dirName"


### PR DESCRIPTION
This makes run-test.sh work in x64/linux.
Remove useless argument and add --runtime argument to pass runtime directory

Not works for cross compile yet (ex. build in x64 & run in arm)