### PR TITLE
Add a HashSet<T>.CreateSetComparer overload taking an IEqualityComparer

### DIFF
--- a/src/Common/tests/System/Collections/TestingTypes.cs
+++ b/src/Common/tests/System/Collections/TestingTypes.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace System.Collections.Tests
 {
@@ -86,6 +87,30 @@ namespace System.Collections.Tests
         {
             return obj.GetHashCode();
         }
+    }
+
+    // It walks like EqualityComparer<T>.Default, it quacks like EqualityComparer<T>.Default
+    // but it quite definitely is not EqualityComparer<T>.Default.
+    public class DefaultCopyCatComparer<T> : IEqualityComparer<T>
+    {
+        public bool Equals(T x, T y) => EqualityComparer<T>.Default.Equals(x, y);
+
+        public int GetHashCode(T obj) => EqualityComparer<T>.Default.GetHashCode(obj);
+
+        public override bool Equals(object obj) => obj is DefaultCopyCatComparer<T>;
+
+        public override int GetHashCode() => ~EqualityComparer<T>.Default.GetHashCode();
+    }
+
+    public class ReferenceEqualityComparer<T> : IEqualityComparer<T> where T : class
+    {
+        public bool Equals(T x, T y) => ReferenceEquals(x, y);
+
+        public int GetHashCode(T obj) => RuntimeHelpers.GetHashCode(obj);
+
+        public override bool Equals(object obj) => obj is ReferenceEqualityComparer<T>;
+
+        public override int GetHashCode() => 0x4A54C0DE;
     }
 
     [Serializable]

--- a/src/System.Collections/ref/System.Collections.cs
+++ b/src/System.Collections/ref/System.Collections.cs
@@ -202,6 +202,7 @@ namespace System.Collections.Generic
         public void CopyTo(T[] array, int arrayIndex) { }
         public void CopyTo(T[] array, int arrayIndex, int count) { }
         public static IEqualityComparer<HashSet<T>> CreateSetComparer() { throw null; }
+        public static IEqualityComparer<HashSet<T>> CreateSetComparer(IEqualityComparer<T> comparer) { throw null; }
         public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
         public System.Collections.Generic.HashSet<T>.Enumerator GetEnumerator() { throw null; }
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -1115,6 +1115,15 @@ namespace System.Collections.Generic
         }
 
         /// <summary>
+        /// Returns an <see cref="IEqualityComparer{HashSet{T}}"/> object that can be used for equality testing of two <see cref="HashSet{T}"/> objects.
+        /// </summary>
+        /// <param name="comparer">The <see cref="IEqualityComparer{T}"/> to use in comparing the sets' elements, or <code>null</code>
+        /// to use the default comparer.</param>
+        /// <returns>An <see cref="IEqualityComparer{HashSet{T}}"/> for comparing sets</returns>
+        public static IEqualityComparer<HashSet<T>> CreateSetComparer(IEqualityComparer<T> comparer)
+            => new HashSetEqualityComparer<T>(comparer);
+
+        /// <summary>
         /// Initializes buckets and slots arrays. Uses suggested capacity by finding next prime
         /// greater than or equal to capacity.
         /// </summary>
@@ -1650,19 +1659,13 @@ namespace System.Collections.Generic
             return result;
         }
 
-
         /// <summary>
-        /// Internal method used for HashSetEqualityComparer. Compares set1 and set2 according 
-        /// to specified comparer.
-        /// 
-        /// Because items are hashed according to a specific equality comparer, we have to resort
-        /// to n^2 search if they're using different equality comparers.
+        /// Legacy method matching previous inconsistent equality method used via nullary CreateSetComparer method.
         /// </summary>
         /// <param name="set1"></param>
         /// <param name="set2"></param>
-        /// <param name="comparer"></param>
         /// <returns></returns>
-        internal static bool HashSetEquals(HashSet<T> set1, HashSet<T> set2, IEqualityComparer<T> comparer)
+        internal static bool LegacyHashSetEquals(HashSet<T> set1, HashSet<T> set2)
         {
             // handle null cases first
             if (set1 == null)
@@ -1676,6 +1679,7 @@ namespace System.Collections.Generic
             }
 
             // all comparers are the same; this is faster
+            // This is also incorrect, but kept for compat.
             if (AreEqualityComparersEqual(set1, set2))
             {
                 if (set1.Count != set2.Count)
@@ -1693,7 +1697,8 @@ namespace System.Collections.Generic
                 return true;
             }
             else
-            {  // n^2 search because items are hashed according to their respective ECs
+            {
+                EqualityComparer<T> comparer = EqualityComparer<T>.Default;
                 foreach (T set2Item in set2)
                 {
                     bool found = false;
@@ -1712,6 +1717,93 @@ namespace System.Collections.Generic
                 }
                 return true;
             }
+        }
+
+        /// <summary>
+        /// Internal method used for HashSetEqualityComparer. Compares set1 and set2 according 
+        /// to specified comparer.
+        /// Because items are hashed according to a specific equality comparer, we have to resort
+        /// to building a new set if neither use that equality comparer.
+        /// </summary>
+        /// <param name="set1">The first set to compare.</param>
+        /// <param name="set2">The second set to compare.</param>
+        /// <param name="comparer">The comparer for comparing elements.</param>
+        /// <returns><c>true</c> if the two sets are equivalent, <c>false</c> otherwise.</returns>
+        internal static bool HashSetEquals(HashSet<T> set1, HashSet<T> set2, IEqualityComparer<T> comparer)
+        {
+            if (set1 == set2)
+            {
+                return true;
+            }
+
+            if (set1 == null || set2 == null)
+            {
+                return false;
+            }
+
+            int count1 = set1.Count;
+            int count2 = set2.Count;
+            if (count1 == 0)
+            {
+                return count2 == 0;
+            }
+
+            if (count2 == 0)
+            {
+                return false;
+            }
+
+            if (comparer.Equals(set1._comparer))
+            {
+                if (comparer.Equals(set2._comparer))
+                {
+                    // Since both sets are using our comparer as their comparer, we can test for set-equality,
+                    // which is the fastest path, and the most-common use-case.
+                    return set1.Count == set2.Count && set1.ContainsAllElements(set2);
+                }
+
+                if (count1 > count2)
+                {
+                    // Filtering set2 according to comparer can result in fewer than set2.Count elements,
+                    // but never more, so short-circuit if set2.Count is less than set1.Count.
+                    return false;
+                }
+            }
+            else if (comparer.Equals(set2._comparer))
+            {
+                // We need a starting point of a set according to the comparer, and set1 doesn't meet
+                // that criteria. If set2 does, swap to use it.
+                if (count1 < count2)
+                {
+                    return false;
+                }
+
+                HashSet<T> swapTemp = set1;
+                set1 = set2;
+                set2 = swapTemp;
+                count1 = count2;
+            }
+            else
+            {
+                // Neither set use our comparer, so create a new one with the contents of set1.
+                set1 = new HashSet<T>(set1, comparer);
+                count1 = set1.Count;
+                if (count1 > count2)
+                {
+                    return false;
+                }
+            }
+
+            HashSet<T> seen = new HashSet<T>(comparer);
+            foreach (T item in set2)
+            {
+                if (seen.Add(item) && !set1.Contains(item))
+                {
+                    return false;
+                }
+            }
+
+            return seen.Count == count1;
         }
 
         /// <summary>

--- a/src/System.Collections/src/System/Collections/Generic/HashSetEqualityComparer.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSetEqualityComparer.cs
@@ -2,13 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-
 namespace System.Collections.Generic
 {
-
     /// <summary>
     /// Equality comparer for hashsets of hashsets
     /// </summary>
@@ -20,26 +15,68 @@ namespace System.Collections.Generic
 
         public HashSetEqualityComparer()
         {
-            _comparer = EqualityComparer<T>.Default;
+            // null comparer signals legacy use.
         }
 
-        // using m_comparer to keep equals properties in tact; don't want to choose one of the comparers
-        public bool Equals(HashSet<T> x, HashSet<T> y)
+        public HashSetEqualityComparer(IEqualityComparer<T> comparer)
         {
-            return HashSet<T>.HashSetEquals(x, y, _comparer);
+            _comparer = comparer ?? EqualityComparer<T>.Default;
         }
+
+        public bool Equals(HashSet<T> x, HashSet<T> y)
+            => _comparer == null ? HashSet<T>.LegacyHashSetEquals(x, y) : HashSet<T>.HashSetEquals(x, y, _comparer);
 
         public int GetHashCode(HashSet<T> obj)
         {
-            int hashCode = 0;
-            if (obj != null)
+            if (obj == null)
             {
+                return 0;
+            }
+
+            if (_comparer == null)
+            {
+                IEqualityComparer<T> comparer = EqualityComparer<T>.Default;
+                // Legacy behaviour for compat.
+                int hashCode = 0;
                 foreach (T t in obj)
                 {
-                    hashCode = hashCode ^ (_comparer.GetHashCode(t) & 0x7FFFFFFF);
+                    hashCode = hashCode ^ (comparer.GetHashCode(t) & 0x7FFFFFFF);
                 }
-            } // else returns hashcode of 0 for null hashsets
-            return hashCode;
+
+                return hashCode;
+            }
+
+            unchecked
+            {
+                int hashCode = 0x5EED5EED; // Arbitrary seed with a mix of 1s and 0s throughout the value.
+                IEqualityComparer<T> comparer = _comparer;
+
+                // Already know the set is distinct as considered by comparer, so we don't need to track duplicates.
+                if (comparer.Equals(obj.Comparer))
+                {
+                    foreach (T item in obj)
+                    {
+                        hashCode ^= comparer.GetHashCode(item);
+                    }
+
+                    hashCode += obj.Count;
+                }
+                else
+                {
+                    HashSet<T> seen = new HashSet<T>(comparer);
+                    foreach (T item in obj)
+                    {
+                        if (seen.Add(item))
+                        {
+                            hashCode ^= comparer.GetHashCode(item);
+                        }
+                    }
+
+                    hashCode += seen.Count;
+                }
+
+                return hashCode;
+            }
         }
 
         // Equals method for the comparer itself. 
@@ -50,13 +87,23 @@ namespace System.Collections.Generic
             {
                 return false;
             }
-            return (_comparer == comparer._comparer);
+
+            if (_comparer == null)
+            {
+                return comparer._comparer == null;
+            }
+
+            return comparer._comparer != null && _comparer.Equals(comparer._comparer);
         }
 
         public override int GetHashCode()
         {
+            if (_comparer == null)
+            {
+                return 1; // Non-zero to differ from the HashSetEqualityComparer itself being null with most uses.
+            }
+
             return _comparer.GetHashCode();
         }
     }
 }
-


### PR DESCRIPTION
`null` is treated as shorthand for `EqualityComparer<T>.Default`.

Consider two sets equal iff for each element in either there is an element in the other that the passed comparer considers equal.

Take some short-cuts where available, but only if it results in the precise behaviour described above.

Keep old behaviour in current overload.

Closes #14416

Offers a workaround to #12560