### PR TITLE
Test byref, pointer & generic types can't be used with Expression.Unbox

### DIFF
--- a/src/System.Linq.Expressions/tests/Unary/UnboxTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnboxTests.cs
@@ -183,5 +183,39 @@ namespace System.Linq.Expressions.Tests
             Assert.Same(unbox, unbox.Reduce());
             Assert.Throws<ArgumentException>(null, () => unbox.ReduceAndCheck());
         }
+
+        [Fact]
+        public static void PointerType()
+        {
+            Type pointerType = typeof(int).MakePointerType();
+            Assert.Throws<ArgumentException>("type", () => Expression.Unbox(Expression.Constant(new object()), pointerType));
+        }
+
+        [Fact]
+        public static void ByRefType()
+        {
+            Type byRefType = typeof(int).MakeByRefType();
+            Assert.Throws<ArgumentException>("type", () => Expression.Unbox(Expression.Constant(new object()), byRefType));
+        }
+
+        private struct GenericValueType<T>
+        {
+            public T Value { get; set; }
+        }
+
+        [Fact]
+        public static void GenericType()
+        {
+            Type genType = typeof(GenericValueType<>);
+            Assert.Throws<ArgumentException>("type", () => Expression.Unbox(Expression.Constant(new object()), genType));
+        }
+
+
+        [Fact]
+        public static void GenericTypeParameters()
+        {
+            Type genType = typeof(GenericValueType<>);
+            Assert.Throws<ArgumentException>("type", () => Expression.Unbox(Expression.Constant(new object()), genType.MakeGenericType(genType)));
+        }
     }
 }


### PR DESCRIPTION
Contributes to #8081