### PR TITLE
Retain VSTS Drop of packages indefinitely

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -218,7 +218,7 @@
         "toLowerCase": "true",
         "detailedLog": "false",
         "usePat": "false",
-        "retentionDays": "30",
+        "retentionDays": "",
         "dropMetadataContainerName": "DropMetadata"
       }
     }


### PR DESCRIPTION
Until we have an automated way to specifically retain stabilizing builds, we should retain all builds' packages forever. We can manually delete dev builds if we need to. I'll do this to all the non-checked-in builds.

I used a testing VSTS def to see that just blanking the value makes it indefinite.

@chcosta 
/cc @markwilkie 