### PR TITLE
Enabling overflow checks for debug

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -174,6 +174,7 @@
         <Optimize Condition="'$(Optimize)' == ''">false</Optimize>
         <DebugType Condition="'$(DebugType)' == ''">full</DebugType>
         <DefineConstants>$(DefineConstants),DEBUG,TRACE</DefineConstants>
+        <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
       </PropertyGroup>
     </When>
     <When Condition="'$(ConfigurationGroup)' == 'Release'">

--- a/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -569,7 +569,7 @@ namespace System.Net.WebSockets
             {
                 sendBuffer[1] = 126;
                 sendBuffer[2] = (byte)(payload.Count / 256);
-                sendBuffer[3] = (byte)payload.Count;
+                sendBuffer[3] = unchecked((byte)payload.Count);
                 maskOffset = 2 + sizeof(ushort); // additional 2 bytes for 16-bit length
             }
             else
@@ -578,7 +578,7 @@ namespace System.Net.WebSockets
                 int length = payload.Count;
                 for (int i = 9; i >= 2; i--)
                 {
-                    sendBuffer[i] = (byte)length;
+                    sendBuffer[i] = unchecked((byte)length);
                     length = length / 256;
                 }
                 maskOffset = 2 + sizeof(ulong); // additional 8 bytes for 64-bit length

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -1133,7 +1133,7 @@ nameof(boundedCapacity), boundedCapacity,
             // The function must be called in case the time out is not infinite
             Debug.Assert(originalWaitMillisecondsTimeout != Timeout.Infinite);
 
-            uint elapsedMilliseconds = (uint)Environment.TickCount - startTime;
+            uint elapsedMilliseconds = unchecked((uint)Environment.TickCount - startTime);
 
             // Check the elapsed milliseconds is greater than max int because this property is uint
             if (elapsedMilliseconds > int.MaxValue)
@@ -1389,7 +1389,7 @@ nameof(boundedCapacity), boundedCapacity,
             uint startTime = 0;
             if (millisecondsTimeout != Timeout.Infinite)
             {
-                startTime = (uint)Environment.TickCount;
+                startTime = unchecked((uint)Environment.TickCount);
             }
 
 

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -987,7 +987,7 @@ nameof(boundedCapacity), boundedCapacity,
             uint startTime = 0;
             if (millisecondsTimeout != Timeout.Infinite)
             {
-                startTime = (uint)Environment.TickCount;
+                startTime = unchecked((uint)Environment.TickCount);
             }
 
             // Fast path for adding if there is at least one unbounded collection

--- a/src/System.Drawing.Primitives/tests/ColorTests.cs
+++ b/src/System.Drawing.Primitives/tests/ColorTests.cs
@@ -188,7 +188,7 @@ namespace System.Drawing.Primitives.Tests
         [InlineData(1, 2, 3, 4)]
         public void FromArgb_Roundtrips(int a, int r, int g, int b)
         {
-            Color c1 = Color.FromArgb((int)unchecked((uint)a << 24 | (uint)r << 16 | (uint)g << 8 | (uint)b));
+            Color c1 = Color.FromArgb(unchecked((int)((uint)a << 24 | (uint)r << 16 | (uint)g << 8 | (uint)b)));
             Assert.Equal(a, c1.A);
             Assert.Equal(r, c1.R);
             Assert.Equal(g, c1.G);

--- a/src/System.IO.FileSystem/tests/FileStream/LockUnlock.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/LockUnlock.cs
@@ -164,7 +164,7 @@ namespace System.IO.Tests
                         Assert.Throws<IOException>(() => fs2.Lock(long.Parse(secondPos), long.Parse(secondLen)));
                     }
                     return SuccessExitCode;
-                }, path, secondPosition.ToString(), secondLength.ToString()).Dispose();
+                }, $"\"{path}\"", secondPosition.ToString(), secondLength.ToString()).Dispose();
 
                 fs1.Unlock(firstPosition, firstLength);
                 RemoteInvoke((secondPath, secondPos, secondLen) =>
@@ -175,7 +175,7 @@ namespace System.IO.Tests
                         fs2.Unlock(long.Parse(secondPos), long.Parse(secondLen));
                     }
                     return SuccessExitCode;
-                }, path, secondPosition.ToString(), secondLength.ToString()).Dispose();
+                }, $"\"{path}\"", secondPosition.ToString(), secondLength.ToString()).Dispose();
             }
         }
     }

--- a/src/System.Linq.Parallel/tests/Helpers/Functions.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/Functions.cs
@@ -12,12 +12,12 @@ namespace System.Linq.Parallel.Tests
         // Sum a range of integers
         public static int SumRange(int start, int count)
         {
-            return (count / 2) * (2 * start + count - 1) + (count % 2 != 0 ? start + count / 2 : 0);
+            return unchecked((count / 2) * (2 * start + count - 1) + (count % 2 != 0 ? start + count / 2 : 0));
         }
 
         public static long SumRange(long start, long count)
         {
-            return (count / 2) * (2 * start + count - 1) + (count % 2 != 0 ? start + count / 2 : 0);
+            return unchecked((count / 2) * (2 * start + count - 1) + (count % 2 != 0 ? start + count / 2 : 0));
         }
 
         public static long ProductRange(long start, long count)

--- a/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
@@ -20,7 +20,7 @@ namespace System.Linq.Parallel.Tests
         {
             // The operation will overflow for long-running sizes, but that's okay:
             // The helper is overflowing too!
-            Assert.Equal(Functions.SumRange(0, count), UnorderedSources.Default(count).Aggregate((x, y) => x + y));
+            Assert.Equal(Functions.SumRange(0, count), UnorderedSources.Default(count).Aggregate((x, y) => unchecked(x + y)));
         }
 
         [Fact]
@@ -37,7 +37,7 @@ namespace System.Linq.Parallel.Tests
         [InlineData(16)]
         public static void Aggregate_Sum_Seed(int count)
         {
-            Assert.Equal(Functions.SumRange(0, count), UnorderedSources.Default(count).Aggregate(0, (x, y) => x + y));
+            Assert.Equal(Functions.SumRange(0, count), UnorderedSources.Default(count).Aggregate(0, (x, y) => unchecked(x + y)));
         }
 
         [Fact]
@@ -91,7 +91,8 @@ namespace System.Linq.Parallel.Tests
         [InlineData(16)]
         public static void Aggregate_Sum_Result(int count)
         {
-            Assert.Equal(Functions.SumRange(0, count) + ResultFuncModifier, UnorderedSources.Default(count).Aggregate(0, (x, y) => x + y, result => result + ResultFuncModifier));
+            Assert.Equal(Functions.SumRange(0, count) + ResultFuncModifier,
+                         UnorderedSources.Default(count).Aggregate(0, (x, y) => unchecked(x + y), result => result + ResultFuncModifier));
         }
 
         [Fact]

--- a/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
@@ -147,7 +147,7 @@ namespace System.Linq.Parallel.Tests
             int actual = query.Aggregate(
                 0,
                 (accumulator, x) => accumulator + x,
-                (left, right) => left + right,
+                (left, right) => unchecked(left + right),
                 result => result + ResultFuncModifier);
             Assert.Equal(Functions.SumRange(0, count) + ResultFuncModifier, actual);
         }
@@ -216,7 +216,7 @@ namespace System.Linq.Parallel.Tests
             int actual = query.Aggregate(
                 () => 0,
                 (accumulator, x) => accumulator + x,
-                (left, right) => left + right,
+                (left, right) => unchecked(left + right),
                 result => result + ResultFuncModifier);
             Assert.Equal(Functions.SumRange(0, count) + ResultFuncModifier, actual);
         }

--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
@@ -262,7 +262,7 @@ namespace System.Net.NetworkInformation
                 sum = partialSum + carries;
             }
 
-            return (ushort)~sum;
+            return unchecked((ushort)~sum);
         }
     }
 }

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -3756,7 +3756,7 @@ namespace System
             if (nChars == 2)
             {
                 // This is the only known scheme of length 2
-                if ((((int)*lptr) | _INT_LOWERCASE_Mask) == _WS_Mask)
+                if ((unchecked((int)*lptr) | _INT_LOWERCASE_Mask) == _WS_Mask)
                 {
                     syntax = UriParser.WsUri;
                     return true;

--- a/src/System.Runtime.Extensions/src/System/BitConverter.cs
+++ b/src/System.Runtime.Extensions/src/System/BitConverter.cs
@@ -150,7 +150,7 @@ namespace System
                 ThrowValueArgumentTooSmall();
             Contract.EndContractBlock();
 
-            return (char)ToInt16(value, startIndex);
+            return unchecked((char)ToInt16(value, startIndex));
         }
 
         // Converts an array of bytes into a short.  

--- a/src/System.Runtime/tests/System/Reflection/PointerTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/PointerTests.cs
@@ -14,12 +14,12 @@ namespace System.Reflection.Tests
         public char* Property { get; set; }
         public void Method(byte* ptr, int expected)
         {
-            Assert.Equal(expected, (int)ptr);
+            Assert.Equal(expected, unchecked((int)ptr));
         }
 
         public bool* Return(int expected)
         {
-            return (bool*)expected;
+            return unchecked((bool*)expected);
         }
     }
 
@@ -66,7 +66,7 @@ namespace System.Reflection.Tests
         [MemberData(nameof(Pointers))]
         public void PointerValueRoundtrips(int value)
         {
-            void* ptr = (void*)value;
+            void* ptr = unchecked((void*)value);
             void* result = Pointer.Unbox(Pointer.Box(ptr, typeof(int*)));
             Assert.Equal((IntPtr)ptr, (IntPtr)result);
         }
@@ -87,8 +87,8 @@ namespace System.Reflection.Tests
         {
             var obj = new PointerHolder();
             FieldInfo field = typeof(PointerHolder).GetField("field");
-            field.SetValue(obj, Pointer.Box((void*)value, typeof(int*)));
-            Assert.Equal(value, (int)obj.field);
+            field.SetValue(obj, Pointer.Box(unchecked((void*)value), typeof(int*)));
+            Assert.Equal(value, unchecked((int)obj.field));
         }
 
         [Theory]
@@ -98,7 +98,7 @@ namespace System.Reflection.Tests
             var obj = new PointerHolder();
             FieldInfo field = typeof(PointerHolder).GetField("field");
             field.SetValue(obj, (IntPtr)value);
-            Assert.Equal(value, (int)obj.field);
+            Assert.Equal(value, unchecked((int)obj.field));
         }
 
         [Theory]
@@ -109,7 +109,7 @@ namespace System.Reflection.Tests
             FieldInfo field = typeof(PointerHolder).GetField("field");
             Assert.Throws<ArgumentException>(() =>
             {
-                field.SetValue(obj, Pointer.Box((void*)value, typeof(long*)));
+                field.SetValue(obj, Pointer.Box(unchecked((void*)value), typeof(long*)));
             });
         }
 
@@ -118,12 +118,12 @@ namespace System.Reflection.Tests
         public void PointerFieldGetValue(int value)
         {
             var obj = new PointerHolder();
-            obj.field = (int*)value;
+            obj.field = unchecked((int*)value);
             FieldInfo field = typeof(PointerHolder).GetField("field");
             object actualValue = field.GetValue(obj);
             Assert.IsType<Pointer>(actualValue);
             void* actualPointer = Pointer.Unbox(actualValue);
-            Assert.Equal(value, (int)actualPointer);
+            Assert.Equal(value, unchecked((int)actualPointer));
         }
 
         [Theory]
@@ -132,8 +132,8 @@ namespace System.Reflection.Tests
         {
             var obj = new PointerHolder();
             PropertyInfo property = typeof(PointerHolder).GetProperty("Property");
-            property.SetValue(obj, Pointer.Box((void*)value, typeof(char*)));
-            Assert.Equal(value, (int)obj.Property);
+            property.SetValue(obj, Pointer.Box(unchecked((void*)value), typeof(char*)));
+            Assert.Equal(value, unchecked((int)obj.Property));
         }
 
         [Theory]
@@ -143,7 +143,7 @@ namespace System.Reflection.Tests
             var obj = new PointerHolder();
             PropertyInfo property = typeof(PointerHolder).GetProperty("Property");
             property.SetValue(obj, (IntPtr)value);
-            Assert.Equal(value, (int)obj.Property);
+            Assert.Equal(value, unchecked((int)obj.Property));
         }
 
         [Theory]
@@ -154,7 +154,7 @@ namespace System.Reflection.Tests
             PropertyInfo property = typeof(PointerHolder).GetProperty("Property");
             Assert.Throws<ArgumentException>(() =>
             {
-                property.SetValue(obj, Pointer.Box((void*)value, typeof(long*)));
+                property.SetValue(obj, Pointer.Box(unchecked((void*)value), typeof(long*)));
             });
         }
 
@@ -163,12 +163,12 @@ namespace System.Reflection.Tests
         public void PointerPropertyGetValue(int value)
         {
             var obj = new PointerHolder();
-            obj.Property = (char*)value;
+            obj.Property = unchecked((char*)value);
             PropertyInfo property = typeof(PointerHolder).GetProperty("Property");
             object actualValue = property.GetValue(obj);
             Assert.IsType<Pointer>(actualValue);
             void* actualPointer = Pointer.Unbox(actualValue);
-            Assert.Equal(value, (int)actualPointer);
+            Assert.Equal(value, unchecked((int)actualPointer));
         }
 
         [Theory]
@@ -177,7 +177,7 @@ namespace System.Reflection.Tests
         {
             var obj = new PointerHolder();
             MethodInfo method = typeof(PointerHolder).GetMethod("Method");
-            method.Invoke(obj, new[] { Pointer.Box((void*)value, typeof(byte*)), value });
+            method.Invoke(obj, new[] { Pointer.Box(unchecked((void*)value), typeof(byte*)), value });
         }
 
         [Theory]
@@ -197,7 +197,7 @@ namespace System.Reflection.Tests
             MethodInfo method = typeof(PointerHolder).GetMethod("Method");
             Assert.Throws<ArgumentException>(() =>
             {
-                method.Invoke(obj, new[] { Pointer.Box((void*)value, typeof(long*)), value });
+                method.Invoke(obj, new[] { Pointer.Box(unchecked((void*)value), typeof(long*)), value });
             });
         }
 
@@ -210,16 +210,16 @@ namespace System.Reflection.Tests
             object actualValue = method.Invoke(obj, new object[] { value });
             Assert.IsType<Pointer>(actualValue);
             void* actualPointer = Pointer.Unbox(actualValue);
-            Assert.Equal(value, (int)actualPointer);
+            Assert.Equal(value, unchecked((int)actualPointer));
         }
 
         [Theory]
         [MemberData(nameof(Pointers))]
         public void PointerSerializes(int value)
         {
-            object pointer = Pointer.Box((void*)value, typeof(int*));
+            object pointer = Pointer.Box(unchecked((void*)value), typeof(int*));
             Pointer cloned = BinaryFormatterHelpers.Clone((Pointer)pointer);
-            Assert.Equal((long)Pointer.Unbox(pointer), (long)Pointer.Unbox(cloned));
+            Assert.Equal((ulong)Pointer.Unbox(pointer), (ulong)Pointer.Unbox(cloned));
         }
     }
 }

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
@@ -820,9 +820,9 @@ namespace Internal.NativeCrypto
                 // that error does not relate to the padding.  Otherwise just throw a cryptographic exception based on
                 // the error code.
                 if ((uint)((uint)dwFlags & (uint)CryptDecryptFlags.CRYPT_OAEP) == (uint)CryptDecryptFlags.CRYPT_OAEP &&
-                                                                    (uint)ErrCode != (uint)CryptKeyError.NTE_BAD_KEY)
+                                                      unchecked((uint)ErrCode) != (uint)CryptKeyError.NTE_BAD_KEY)
                 {
-                    if ((uint)ErrCode == (uint)CryptKeyError.NTE_BAD_FLAGS)
+                    if (unchecked((uint)ErrCode) == (uint)CryptKeyError.NTE_BAD_FLAGS)
                     {
                         throw new CryptographicException("Cryptography_OAEP_XPPlus_Only");
                     }


### PR DESCRIPTION
Turns on overflow/underflow checks for all managed
projects via the main dir.props file. Also contains additional
unchecked statements.

Fix #3140