### PR TITLE
Add back DbProviderFactory::CreatePermission (as additional implementation). 

### DIFF
--- a/src/System.Data.Common/src/System/Data/Common/DbProviderFactory.CreatePermission.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbProviderFactory.CreatePermission.cs
@@ -4,6 +4,9 @@
 using System.Security;
 using System.Security.Permissions;
 
+// Additional implementation to keep public API in Mono (it has a reference to this file)
+// https://github.com/dotnet/corefx/issues/16184
+
 namespace System.Data.Common
 {
     partial class DbProviderFactory

--- a/src/System.Data.Common/src/System/Data/Common/DbProviderFactory.CreatePermission.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbProviderFactory.CreatePermission.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System.Security;
+using System.Security.Permissions;
+
+namespace System.Data.Common
+{
+    partial class DbProviderFactory
+    {
+        public virtual CodeAccessPermission CreatePermission(PermissionState state) => null;
+    }
+}

--- a/src/System.Data.Common/src/System/Data/Common/DbProviderFactory.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbProviderFactory.cs
@@ -4,7 +4,7 @@
 
 namespace System.Data.Common
 {
-    public abstract class DbProviderFactory
+    public abstract partial class DbProviderFactory
     {
         protected DbProviderFactory() { }
 


### PR DESCRIPTION
This fixes Mono breakage since it looks like this method won't be here anymore (see https://github.com/dotnet/corefx/issues/16184)
/cc @marek-safar 