### PR TITLE
Bringing back uapaot build for System.Diagnostics.Tracing

### DIFF
--- a/src/Common/src/Interop/Windows/advapi32/Interop.EventRegister.cs
+++ b/src/Common/src/Interop/Windows/advapi32/Interop.EventRegister.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
             byte level,
             ulong matchAnyKeywords,
             ulong matchAllKeywords,
-            Interop.Kernel32.EVENT_FILTER_DESCRIPTOR* filterData,
+            Interop.Advapi32.EVENT_FILTER_DESCRIPTOR* filterData,
             IntPtr callbackContext
             );
 

--- a/src/System.Diagnostics.Tracing/src/ApiCompatBaseline.uapaot.txt
+++ b/src/System.Diagnostics.Tracing/src/ApiCompatBaseline.uapaot.txt
@@ -1,27 +1,6 @@
 Compat issues with assembly System.Diagnostics.Tracing:
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventActivityOptions' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventAttribute' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventChannel' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventCommand' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventCommandEventArgs' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventCounter' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventDataAttribute' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventFieldAttribute' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventFieldFormat' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventFieldTags' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventIgnoreAttribute' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventKeywords' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventLevel' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventListener' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventManifestOptions' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventOpcode' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventSource' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventSourceAttribute' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventSourceException' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventSourceOptions' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventSourceSettings' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventTags' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventTask' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.EventWrittenEventArgs' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.Diagnostics.Tracing.NonEventAttribute' does not exist in the implementation but it does exist in the contract.
-Total Issues: 25
+MembersMustExist : Member 'System.Diagnostics.Tracing.EventAttribute.Channel.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Diagnostics.Tracing.EventAttribute.Channel.set(System.Diagnostics.Tracing.EventChannel)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Diagnostics.Tracing.EventSourceException..ctor(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Diagnostics.Tracing.EventWrittenEventArgs.Channel.get()' does not exist in the implementation but it does exist in the contract.
+Total Issues: 4

--- a/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
+++ b/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
@@ -5,9 +5,14 @@
     <AssemblyName>System.Diagnostics.Tracing</AssemblyName>
     <ProjectGuid>{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <NoWarn>CA2002</NoWarn>
-    <GenFacadesIgnoreMissingTypes Condition="'$(TargetGroup)'=='uapaot'">true</GenFacadesIgnoreMissingTypes>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='uap' or '$(TargetGroup)'=='netcoreapp'">true</IsPartialFacadeAssembly>
+    <NoWarn>CA2002,CA1018</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)'=='uapaot'">
+    <DefineConstants>$(DefineConstants);PROJECTN</DefineConstants>
+    <!-- Need to remove reference to System.Reflection.TypeExtensions
+    which is included transitively via System.Reflection -->
+    <OmitTransitiveCompileReferences>true</OmitTransitiveCompileReferences>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
@@ -22,9 +27,97 @@
     <Compile Include="FxCopBaseline.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="System\Diagnostics\Tracing\EventCounter.cs" Condition="'$(TargetGroup)'!='uapaot'" />
+    <Compile Include="System\Diagnostics\Tracing\EventCounter.cs" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='uapaot'">
+    <Compile Include="System\Diagnostics\Tracing\ActivityTracker.cs" />
+    <Compile Include="System\Diagnostics\Tracing\EventActivityOptions.cs" />
+    <Compile Include="System\Diagnostics\Tracing\EventDescriptor.cs" />
+    <Compile Include="System\Diagnostics\Tracing\EventProvider.cs" />
+    <Compile Include="System\Diagnostics\Tracing\EventSource.cs" />
+    <Compile Include="System\Diagnostics\Tracing\EventSource_ProjectN.cs" />
+    <Compile Include="System\Diagnostics\Tracing\EventSourceException.cs" />
+    <Compile Include="System\Diagnostics\Tracing\StubEnvironment.cs" />
+    <Compile Include="System\Diagnostics\Tracing\UnsafeNativeMethods.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\PropertyValue.cs" />
+    <Compile Include="System\Diagnostics\Tracing\Winmeta.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\ArrayTypeInfo.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\ConcurrentSet.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\ConcurrentSetItem.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\DataCollector.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\EmptyStruct.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\EnumerableTypeInfo.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\EnumHelper.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\EventDataAttribute.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\EventFieldAttribute.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\EventFieldFormat.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\EventIgnoreAttribute.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\EventPayload.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\EventSourceActivity.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\EventSourceOptions.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\FieldMetadata.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\InvokeTypeInfo.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\NameInfo.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\PropertyAnalysis.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\SimpleEventTypes.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\SimpleTypeInfos.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\Statics.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\TraceLoggingDataCollector.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\TraceLoggingDataType.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\TraceLoggingEventSource.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\TraceLoggingEventTraits.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\TraceLoggingEventTypes.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\TraceLoggingMetadataCollector.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\TraceLoggingTypeInfo.cs" />
+    <Compile Include="System\Diagnostics\Tracing\TraceLogging\TypeAnalysis.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+      <Link>Common\Interop\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+      <Link>Common\Interop\mincore\Interop.Errors.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetCurrentProcessId.cs">
+      <Link>Common\Interop\Interop.GetCurrentProcessId.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetCurrentThreadId.cs">
+      <Link>Common\Interop\Interop.GetCurrentThreadId.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.EventRegister.cs">
+      <Link>Common\Interop\Interop.EventRegister.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.EventUnregister.cs">
+      <Link>Common\Interop\Interop.EventUnregister.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.EventWrite.cs">
+      <Link>Common\Interop\Interop.EventWrite.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.FormatMessage.cs">
+      <Link>Common\Interop\Interop.FormatMessage.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.EventSetInformation.cs">
+      <Link>Common\Interop\Interop.EventSetInformation.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\advapi32\Interop.EventWriteTransfer.cs">
+      <Link>Common\Interop\Interop.EventWriteTransfer.cs</Link>
+    </Compile>
+    <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />
+    <Reference Include="System.Collections" />
+    <Reference Include="System.Diagnostics.Contracts" />
+    <Reference Include="System.Diagnostics.Debug" />
+    <Reference Include="System.Diagnostics.Tools" />
+    <Reference Include="System.Globalization" />
+    <Reference Include="System.Reflection" />
+    <Reference Include="System.Reflection.Extensions" />
+    <Reference Include="System.Resources.ResourceManager" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.Extensions" />
+    <Reference Include="System.Runtime.InteropServices" />
+    <Reference Include="System.Text.Encouding" />
+    <Reference Include="System.Threading" />
+    <Reference Include="System.Threading.Thread" />
+    <Reference Include="System.Threading.Timer" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='uap' or '$(TargetGroup)'=='netcoreapp'">
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Diagnostics.Contracts\src\System.Diagnostics.Contracts.csproj" />
     <ProjectReference Include="..\..\System.Diagnostics.Tools\src\System.Diagnostics.Tools.csproj" />

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventCounter.cs
@@ -437,7 +437,7 @@ namespace System.Diagnostics.Tracing
     // point this class is no longer needed and can be removed.
     internal class EventListenerHelper : EventListener {
         public new static int EventSourceIndex(EventSource eventSource) { return EventListener.EventSourceIndex(eventSource); }
-        protected override void OnEventWritten(EventWrittenEventArgs eventData) { } // override abstact methods to keep compiler happy
+        protected internal override void OnEventWritten(EventWrittenEventArgs eventData) { } // override abstact methods to keep compiler happy
     }
 
     #endregion // internal supporting classes

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSource.cs
@@ -192,6 +192,7 @@ using System.Security.Permissions;
 using System.Text;
 using System.Threading;
 using Microsoft.Win32;
+using BindingFlags = Microsoft.Reflection.BindingFlags;
 
 #if ES_BUILD_STANDALONE
 using EventDescriptor = Microsoft.Diagnostics.Tracing.EventDescriptor;

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/StubEnvironment.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/StubEnvironment.cs
@@ -344,8 +344,6 @@ namespace Microsoft.Reflection
 #if ES_BUILD_PCL || PROJECTN
 namespace System.Security
 {
-    class SuppressUnmanagedCodeSecurityAttribute : Attribute { }
-
     enum SecurityAction { Demand }
 }
 namespace System.Security.Permissions
@@ -356,18 +354,5 @@ namespace System.Security.Permissions
         public PermissionSetAttribute(System.Security.SecurityAction action) { }
         public bool Unrestricted { get; set; }
     }
-}
-#endif
-
-#if PROJECTN
-namespace System
-{
-    public static class AppDomain
-    {
-        public static int GetCurrentThreadId()
-        {
-            return (int)Interop.Kernel32.GetCurrentThreadId();
-        }
-    }    
 }
 #endif

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/UnsafeNativeMethods.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/UnsafeNativeMethods.cs
@@ -67,12 +67,12 @@ namespace Microsoft.Win32
                         [In][Out]ref long registrationHandle
                         )
             {
-                Interop.Kernel32.EtwEnableCallback indirection = delegate(ref Guid sourceId,
+                Interop.Advapi32.EtwEnableCallback indirection = delegate(ref Guid sourceId,
                                                                          int isEnabled,
                                                                          byte level,
                                                                          ulong matchAnyKeywords,
                                                                          ulong matchAllKeywords,
-                                                                         Interop.Kernel32.EVENT_FILTER_DESCRIPTOR* filterData,
+                                                                         Interop.Advapi32.EVENT_FILTER_DESCRIPTOR* filterData,
                                                                          IntPtr cbContext)
                 {
                     enableCallback(ref sourceId,
@@ -84,7 +84,7 @@ namespace Microsoft.Win32
                                    (void*)cbContext);
                 };
                 ulong temp;
-                uint status = Interop.Kernel32.EventRegister(ref providerId, indirection, (IntPtr)callbackContext, out temp);
+                uint status = Interop.Advapi32.EventRegister(ref providerId, indirection, (IntPtr)callbackContext, out temp);
                 registrationHandle = (long)temp;
                 
                 return status;
@@ -95,7 +95,7 @@ namespace Microsoft.Win32
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
             internal static uint EventUnregister([In] long registrationHandle)
             {
-                return Interop.Kernel32.EventUnregister((ulong)registrationHandle);
+                return Interop.Advapi32.EventUnregister((ulong)registrationHandle);
             }
 
 
@@ -142,7 +142,7 @@ namespace Microsoft.Win32
             {
                 IntPtr descripPtr = Marshal.AllocHGlobal(Marshal.SizeOf(eventDescriptor));
                 Marshal.StructureToPtr(eventDescriptor, descripPtr, false);
-                int status = Interop.Kernel32.EventWriteTransfer((ulong)registrationHandle, 
+                int status = Interop.Advapi32.EventWriteTransfer((ulong)registrationHandle, 
                                                         (void*)descripPtr, 
                                                         activityId, 
                                                         relatedActivityId, 
@@ -176,7 +176,7 @@ namespace Microsoft.Win32
                 [In] void* eventInformation,
                 [In] int informationLength)
             {
-                return Interop.Kernel32.EventSetInformation((ulong)registrationHandle, (int)informationClass, (IntPtr)eventInformation, informationLength);
+                return Interop.Advapi32.EventSetInformation((ulong)registrationHandle, (int)informationClass, (IntPtr)eventInformation, informationLength);
             }
 
             // We want to not use this API for the Nuget package, as it is not an allowed API in the Store.  


### PR DESCRIPTION
cc: @weshaggard @ericstj 
FYI: @DnlHarvey 

netcore50aot build of System.Diagnostics.Tracing was commented out around a year ago. After that, we have been harvesting the netcore50aot assets for packaging and the assembly became a full facade to CoreLib in netcoreapp. NETNative's Corelib doesn't have these types, so when trying to ILC the uapaot runtime we were hitting a lot of errors because EventSource was not in the assembly anymore. This PR will bring back the uapaot build and have EventSource be present again.