### PR TITLE
Getting the infrastructure fot NetFX test runner inplace

### DIFF
--- a/Tools-Override/XUnitNetFXConfigFileTemplate.txt
+++ b/Tools-Override/XUnitNetFXConfigFileTemplate.txt
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<configuration>
+   <runtime>  
+      <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1"> 
+
+         <dependentAssembly>  
+            <assemblyIdentity name="xunit.execution.dotnet" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+            <codeBase version="2.2.0.3300" href="{RunTimePath}xunit.execution.dotnet.dll"/>
+         </dependentAssembly>
+
+         <dependentAssembly>  
+            <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+            <bindingRedirect oldVersion="4.0.0.0" newVersion="4.0.1.0"/>
+            <codeBase version="4.0.2.0" href="{RunTimePath}System.IO.FileSystem.dll"/>
+         </dependentAssembly>
+
+         <dependentAssembly>  
+            <assemblyIdentity name="Xunit.NetCore.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+            <codeBase version="999.999.999.999" href="{RunTimePath}Xunit.NetCore.Extensions.dll"/>
+         </dependentAssembly>
+
+         <dependentAssembly>  
+            <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+            <codeBase version="2.2.0.3300" href="{RunTimePath}xunit.core.dll"/>
+         </dependentAssembly>
+
+         <dependentAssembly>  
+            <assemblyIdentity name="xunit.assert" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+            <codeBase version="2.2.0.3300" href="{RunTimePath}xunit.assert.dll"/>
+         </dependentAssembly>
+
+         <dependentAssembly>  
+            <assemblyIdentity name="xunit.execution.desktop" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+            <codeBase version="2.2.0.3300" href="{RunTimePath}xunit.execution.desktop.dll"/>
+         </dependentAssembly>
+      
+         <dependentAssembly>  
+            <assemblyIdentity name="xunit.abstractions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+            <codeBase version="2.0.0.0" href="{RunTimePath}xunit.abstractions.dll"/>
+         </dependentAssembly>
+
+         <dependentAssembly>  
+            <assemblyIdentity name="xunit.runner.utility.desktop" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+            <codeBase version="2.2.0.3444" href="{RunTimePath}xunit.runner.utility.desktop.dll"/>
+         </dependentAssembly>
+
+         <dependentAssembly>
+            <assemblyIdentity name="netstandard" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+            <codeBase version="2.0.0.0" href="{RunTimePath}netstandard.dll"/>
+         </dependentAssembly>
+
+         <dependentAssembly>
+            <assemblyIdentity name="System.IO.Ports" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+            <codeBase version="4.0.0.0" href="{RunTimePath}System.IO.Ports.dll"/>
+         </dependentAssembly>
+
+         <dependentAssembly>  
+            <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+            <bindingRedirect oldVersion="4.0.0.0" newVersion="4.0.2.0"/>
+            <codeBase version="4.0.2.0" href="{RunTimePath}System.Runtime.InteropServices.RuntimeInformation.dll"/>
+         </dependentAssembly>
+
+         <dependentAssembly>
+            <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+            <codeBase version="4.1.0.0" href="{RunTimePath}System.Text.Encoding.CodePages.dll"/>
+         </dependentAssembly>
+
+         <dependentAssembly>
+            <assemblyIdentity name="Microsoft.Win32.Registry" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+            <codeBase version="4.1.0.0" href="{RunTimePath}Microsoft.Win32.Registry.dll"/>
+         </dependentAssembly>
+      </assemblyBinding>
+   </runtime>
+</configuration>

--- a/Tools-Override/XUnitNetFXConfigFileTemplate.txt
+++ b/Tools-Override/XUnitNetFXConfigFileTemplate.txt
@@ -5,69 +5,69 @@
 
          <dependentAssembly>  
             <assemblyIdentity name="xunit.execution.dotnet" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-            <codeBase version="2.2.0.3300" href="{RunTimePath}xunit.execution.dotnet.dll"/>
+            <codeBase version="2.2.0.3300" href="{RuntimePath}xunit.execution.dotnet.dll"/>
          </dependentAssembly>
 
          <dependentAssembly>  
             <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
             <bindingRedirect oldVersion="4.0.0.0" newVersion="4.0.1.0"/>
-            <codeBase version="4.0.2.0" href="{RunTimePath}System.IO.FileSystem.dll"/>
+            <codeBase version="4.0.2.0" href="{RuntimePath}System.IO.FileSystem.dll"/>
          </dependentAssembly>
 
          <dependentAssembly>  
             <assemblyIdentity name="Xunit.NetCore.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-            <codeBase version="999.999.999.999" href="{RunTimePath}Xunit.NetCore.Extensions.dll"/>
+            <codeBase version="999.999.999.999" href="{RuntimePath}Xunit.NetCore.Extensions.dll"/>
          </dependentAssembly>
 
          <dependentAssembly>  
             <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-            <codeBase version="2.2.0.3300" href="{RunTimePath}xunit.core.dll"/>
+            <codeBase version="2.2.0.3300" href="{RuntimePath}xunit.core.dll"/>
          </dependentAssembly>
 
          <dependentAssembly>  
             <assemblyIdentity name="xunit.assert" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-            <codeBase version="2.2.0.3300" href="{RunTimePath}xunit.assert.dll"/>
+            <codeBase version="2.2.0.3300" href="{RuntimePath}xunit.assert.dll"/>
          </dependentAssembly>
 
          <dependentAssembly>  
             <assemblyIdentity name="xunit.execution.desktop" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-            <codeBase version="2.2.0.3300" href="{RunTimePath}xunit.execution.desktop.dll"/>
+            <codeBase version="2.2.0.3300" href="{RuntimePath}xunit.execution.desktop.dll"/>
          </dependentAssembly>
       
          <dependentAssembly>  
             <assemblyIdentity name="xunit.abstractions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-            <codeBase version="2.0.0.0" href="{RunTimePath}xunit.abstractions.dll"/>
+            <codeBase version="2.0.0.0" href="{RuntimePath}xunit.abstractions.dll"/>
          </dependentAssembly>
 
          <dependentAssembly>  
             <assemblyIdentity name="xunit.runner.utility.desktop" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-            <codeBase version="2.2.0.3444" href="{RunTimePath}xunit.runner.utility.desktop.dll"/>
+            <codeBase version="2.2.0.3444" href="{RuntimePath}xunit.runner.utility.desktop.dll"/>
          </dependentAssembly>
 
          <dependentAssembly>
             <assemblyIdentity name="netstandard" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-            <codeBase version="2.0.0.0" href="{RunTimePath}netstandard.dll"/>
+            <codeBase version="2.0.0.0" href="{RuntimePath}netstandard.dll"/>
          </dependentAssembly>
 
          <dependentAssembly>
             <assemblyIdentity name="System.IO.Ports" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-            <codeBase version="4.0.0.0" href="{RunTimePath}System.IO.Ports.dll"/>
+            <codeBase version="4.0.0.0" href="{RuntimePath}System.IO.Ports.dll"/>
          </dependentAssembly>
 
          <dependentAssembly>  
             <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
             <bindingRedirect oldVersion="4.0.0.0" newVersion="4.0.2.0"/>
-            <codeBase version="4.0.2.0" href="{RunTimePath}System.Runtime.InteropServices.RuntimeInformation.dll"/>
+            <codeBase version="4.0.2.0" href="{RuntimePath}System.Runtime.InteropServices.RuntimeInformation.dll"/>
          </dependentAssembly>
 
          <dependentAssembly>
             <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-            <codeBase version="4.1.0.0" href="{RunTimePath}System.Text.Encoding.CodePages.dll"/>
+            <codeBase version="4.1.0.0" href="{RuntimePath}System.Text.Encoding.CodePages.dll"/>
          </dependentAssembly>
 
          <dependentAssembly>
             <assemblyIdentity name="Microsoft.Win32.Registry" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-            <codeBase version="4.1.0.0" href="{RunTimePath}Microsoft.Win32.Registry.dll"/>
+            <codeBase version="4.1.0.0" href="{RuntimePath}Microsoft.Win32.Registry.dll"/>
          </dependentAssembly>
       </assemblyBinding>
    </runtime>

--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -47,7 +47,7 @@
   <PropertyGroup>
     <XunitResultsFileName>testResults.xml</XunitResultsFileName>
 
-    <XunitOptions Condition="'$(RunningOnNetFx)' == 'true'">$(XunitOptions) -noshadow </XunitOptions>
+    <XunitOptions Condition="'$(RunningOnNetFx)' == 'true'">$(XunitOptions) -noshadow -noappdomain </XunitOptions>
     <XunitOptions>$(XunitOptions) -xml $(XunitResultsFileName)</XunitOptions>
 
     <XunitOptions Condition="'$(Performance)'!='true'">$(XunitOptions) -notrait Benchmark=true</XunitOptions>
@@ -94,8 +94,9 @@
       <SupplementalTestData Include="$(RuntimePath)xunit.console.netcore.exe" />
     </ItemGroup>
     <ItemGroup Condition="'$(RunningOnNetFx)' == 'true'">
-      <SupplementalTestData Include="$(RuntimePath)xunit*.*" />
-      <SupplementalTestData Include="$(RuntimePath)*.xslt" />
+      <SupplementalTestData Include="$(RuntimePath)xunit.console.exe" />
+      <SupplementalTestData Include="$(RuntimePath)xunit.console.exe.config" />
+      <SupplementalTestData Include="$(RuntimePath)xunit.execution.desktop.dll" />
     </ItemGroup>
   </Target>
 

--- a/dir.props
+++ b/dir.props
@@ -276,8 +276,7 @@
     <NETCoreAppTestSharedFrameworkPath>$(NETCoreAppTestRootPath)shared/Microsoft.NETCore.App/$(NETCoreAppTestSharedFxVersion)/</NETCoreAppTestSharedFrameworkPath>
 
     <!-- Constructed shared fx path for testing -->
-    <TestSharedFxDir Condition="'$(_bc_TargetGroup)' != 'netfx'">$(NETCoreAppTestRootPath)</TestSharedFxDir>
-    <TestSharedFxDir Condition="'$(_bc_TargetGroup)' == 'netfx'">$(RuntimePath)</TestSharedFxDir>
+    <TestSharedFxDir Condition="'$(BinplaceTestSharedFramework)' == 'true'">$(NETCoreAppTestRootPath)</TestSharedFxDir>
 
     <PackagesBasePath Condition="'$(PackagesBasePath)'==''">$(BinDir)$(OSPlatformConfig)</PackagesBasePath>
     <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(PackageOutputRoot)$(ConfigurationGroup)/</PackageOutputPath>

--- a/dir.props
+++ b/dir.props
@@ -276,7 +276,8 @@
     <NETCoreAppTestSharedFrameworkPath>$(NETCoreAppTestRootPath)shared/Microsoft.NETCore.App/$(NETCoreAppTestSharedFxVersion)/</NETCoreAppTestSharedFrameworkPath>
 
     <!-- Constructed shared fx path for testing -->
-    <TestSharedFxDir>$(NETCoreAppTestRootPath)</TestSharedFxDir>
+    <TestSharedFxDir Condition="'$(_bc_TargetGroup)' != 'netfx'">$(NETCoreAppTestRootPath)</TestSharedFxDir>
+    <TestSharedFxDir Condition="'$(_bc_TargetGroup)' == 'netfx'">$(RuntimePath)</TestSharedFxDir>
 
     <PackagesBasePath Condition="'$(PackagesBasePath)'==''">$(BinDir)$(OSPlatformConfig)</PackagesBasePath>
     <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(PackageOutputRoot)$(ConfigurationGroup)/</PackageOutputPath>

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -44,7 +44,7 @@
     
     <WriteLinesToFile
       File="$(RuntimePath)\xunit.console.exe.config"
-      Lines="$([System.IO.File]::ReadAllText('$(ToolsDir)\XUnitNetFXConfigFileTemplate.txt').Replace('{RunTimePath}', $(RuntimePath)))"
+      Lines="$([System.IO.File]::ReadAllText('$(ToolsDir)\XUnitNetFXConfigFileTemplate.txt').Replace('{RuntimePath}', $(RuntimePath)))"
       Overwrite="true" />
 
     <ItemGroup>

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -32,11 +32,23 @@
             Text="Error: looks the package $(PackagesDir)$(XUnitRunnerPackageId)\$(XUnitPackageVersion) not restored or missing xunit.console.exe."
     />
     <ItemGroup>
-      <ReferenceCopyLocalPaths Include="$(PackagesDir)$(XUnitRunnerPackageId)\$(XUnitPackageVersion)\tools\*.*">
+      <ReferenceCopyLocalPaths 
+        Include="$(PackagesDir)$(XUnitRunnerPackageId)\$(XUnitPackageVersion)\tools\*.*"
+        Exclude="$(PackagesDir)$(XUnitRunnerPackageId)\$(XUnitPackageVersion)\tools\xunit.console.exe.config"
+      >
         <Private>false</Private>
         <NuGetPackageId>$(XUnitRunnerPackageId)</NuGetPackageId>
         <NuGetPackageVersion>$(XUnitPackageVersion)</NuGetPackageVersion>
       </ReferenceCopyLocalPaths>
     </ItemGroup>
-  </Target>
+    
+    <WriteLinesToFile
+      File="$(RuntimePath)\xunit.console.exe.config"
+      Lines="$([System.IO.File]::ReadAllText('$(ToolsDir)\XUnitNetFXConfigFileTemplate.txt').Replace('{RunTimePath}', $(RuntimePath)))"
+      Overwrite="true" />
+
+    <ItemGroup>
+      <FileWrites Include="$(RuntimePath)\xunit.console.exe.config" />
+    </ItemGroup>
+</Target>
 </Project>

--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
@@ -333,62 +333,6 @@ namespace System.Collections.Tests
 
         #endregion
 
-        #region TryGetValue
-
-        [Fact]
-        public void HashSet_Generic_TryGetValue_Contains()
-        {
-            T value = CreateT(1);
-            HashSet<T> set = new HashSet<T> { value };
-            T equalValue = CreateT(1);
-            T actualValue;
-            Assert.True(set.TryGetValue(equalValue, out actualValue));
-            Assert.Equal(value, actualValue);
-            if (!typeof(T).IsValueType)
-            {
-                Assert.Same(value, actualValue);
-            }
-        }
-
-        [Fact]
-        public void HashSet_Generic_TryGetValue_Contains_OverwriteOutputParam()
-        {
-            T value = CreateT(1);
-            HashSet<T> set = new HashSet<T> { value };
-            T equalValue = CreateT(1);
-            T actualValue = CreateT(2);
-            Assert.True(set.TryGetValue(equalValue, out actualValue));
-            Assert.Equal(value, actualValue);
-            if (!typeof(T).IsValueType)
-            {
-                Assert.Same(value, actualValue);
-            }
-        }
-
-        [Fact]
-        public void HashSet_Generic_TryGetValue_NotContains()
-        {
-            T value = CreateT(1);
-            HashSet<T> set = new HashSet<T> { value };
-            T equalValue = CreateT(2);
-            T actualValue;
-            Assert.False(set.TryGetValue(equalValue, out actualValue));
-            Assert.Equal(default(T), actualValue);
-        }
-
-        [Fact]
-        public void HashSet_Generic_TryGetValue_NotContains_OverwriteOutputParam()
-        {
-            T value = CreateT(1);
-            HashSet<T> set = new HashSet<T> { value };
-            T equalValue = CreateT(2);
-            T actualValue = equalValue;
-            Assert.False(set.TryGetValue(equalValue, out actualValue));
-            Assert.Equal(default(T), actualValue);
-        }
-
-        #endregion
-
         [Fact]
         public void CanBeCastedToISet()
         {

--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.netcoreapp.Tests.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.netcoreapp.Tests.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    /// <summary>
+    /// Contains tests that ensure the correctness of the HashSet class.
+    /// </summary>
+    public abstract partial class HashSet_Generic_Tests<T> : ISet_Generic_Tests<T>
+    {
+        #region TryGetValue
+
+        [Fact]
+        public void HashSet_Generic_TryGetValue_Contains()
+        {
+            T value = CreateT(1);
+            HashSet<T> set = new HashSet<T> { value };
+            T equalValue = CreateT(1);
+            T actualValue;
+            Assert.True(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(value, actualValue);
+            if (!typeof(T).IsValueType)
+            {
+                Assert.Same(value, actualValue);
+            }
+        }
+
+        [Fact]
+        public void HashSet_Generic_TryGetValue_Contains_OverwriteOutputParam()
+        {
+            T value = CreateT(1);
+            HashSet<T> set = new HashSet<T> { value };
+            T equalValue = CreateT(1);
+            T actualValue = CreateT(2);
+            Assert.True(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(value, actualValue);
+            if (!typeof(T).IsValueType)
+            {
+                Assert.Same(value, actualValue);
+            }
+        }
+
+        [Fact]
+        public void HashSet_Generic_TryGetValue_NotContains()
+        {
+            T value = CreateT(1);
+            HashSet<T> set = new HashSet<T> { value };
+            T equalValue = CreateT(2);
+            T actualValue;
+            Assert.False(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(default(T), actualValue);
+        }
+
+        [Fact]
+        public void HashSet_Generic_TryGetValue_NotContains_OverwriteOutputParam()
+        {
+            T value = CreateT(1);
+            HashSet<T> set = new HashSet<T> { value };
+            T equalValue = CreateT(2);
+            T actualValue = equalValue;
+            Assert.False(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(default(T), actualValue);
+        }
+
+        #endregion
+    }
+}

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
@@ -11,7 +11,7 @@ namespace System.Collections.Tests
     /// <summary>
     /// Contains tests that ensure the correctness of the SortedSet class.
     /// </summary>
-    public abstract class SortedSet_Generic_Tests<T> : ISet_Generic_Tests<T>
+    public abstract partial class SortedSet_Generic_Tests<T> : ISet_Generic_Tests<T>
     {
         #region ISet<T> Helper Methods
 
@@ -330,62 +330,6 @@ namespace System.Collections.Tests
             Assert.True(comparerSet1.SetEquals(set));
             Assert.True(comparerSet2.SetEquals(set));
         }
-        #endregion
-
-        #region TryGetValue
-
-        [Fact]
-        public void SortedSet_Generic_TryGetValue_Contains()
-        {
-            T value = CreateT(1);
-            SortedSet<T> set = new SortedSet<T> { value };
-            T equalValue = CreateT(1);
-            T actualValue;
-            Assert.True(set.TryGetValue(equalValue, out actualValue));
-            Assert.Equal(value, actualValue);
-            if (!typeof(T).IsValueType)
-            {
-                Assert.Same(value, actualValue);
-            }
-        }
-
-        [Fact]
-        public void SortedSet_Generic_TryGetValue_Contains_OverwriteOutputParam()
-        {
-            T value = CreateT(1);
-            SortedSet<T> set = new SortedSet<T> { value };
-            T equalValue = CreateT(1);
-            T actualValue = CreateT(2);
-            Assert.True(set.TryGetValue(equalValue, out actualValue));
-            Assert.Equal(value, actualValue);
-            if (!typeof(T).IsValueType)
-            {
-                Assert.Same(value, actualValue);
-            }
-        }
-
-        [Fact]
-        public void SortedSet_Generic_TryGetValue_NotContains()
-        {
-            T value = CreateT(1);
-            SortedSet<T> set = new SortedSet<T> { value };
-            T equalValue = CreateT(2);
-            T actualValue;
-            Assert.False(set.TryGetValue(equalValue, out actualValue));
-            Assert.Equal(default(T), actualValue);
-        }
-
-        [Fact]
-        public void SortedSet_Generic_TryGetValue_NotContains_OverwriteOutputParam()
-        {
-            T value = CreateT(1);
-            SortedSet<T> set = new SortedSet<T> { value };
-            T equalValue = CreateT(2);
-            T actualValue = equalValue;
-            Assert.False(set.TryGetValue(equalValue, out actualValue));
-            Assert.Equal(default(T), actualValue);
-        }
-
         #endregion
     }
 }

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.netcoreapp.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.netcoreapp.Tests.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    /// <summary>
+    /// Contains tests that ensure the correctness of the SortedSet class.
+    /// </summary>
+    public abstract partial class SortedSet_Generic_Tests<T> : ISet_Generic_Tests<T>
+    {
+        #region TryGetValue
+
+        [Fact]
+        public void SortedSet_Generic_TryGetValue_Contains()
+        {
+            T value = CreateT(1);
+            SortedSet<T> set = new SortedSet<T> { value };
+            T equalValue = CreateT(1);
+            T actualValue;
+            Assert.True(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(value, actualValue);
+            if (!typeof(T).IsValueType)
+            {
+                Assert.Same(value, actualValue);
+            }
+        }
+
+        [Fact]
+        public void SortedSet_Generic_TryGetValue_Contains_OverwriteOutputParam()
+        {
+            T value = CreateT(1);
+            SortedSet<T> set = new SortedSet<T> { value };
+            T equalValue = CreateT(1);
+            T actualValue = CreateT(2);
+            Assert.True(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(value, actualValue);
+            if (!typeof(T).IsValueType)
+            {
+                Assert.Same(value, actualValue);
+            }
+        }
+
+        [Fact]
+        public void SortedSet_Generic_TryGetValue_NotContains()
+        {
+            T value = CreateT(1);
+            SortedSet<T> set = new SortedSet<T> { value };
+            T equalValue = CreateT(2);
+            T actualValue;
+            Assert.False(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(default(T), actualValue);
+        }
+
+        [Fact]
+        public void SortedSet_Generic_TryGetValue_NotContains_OverwriteOutputParam()
+        {
+            T value = CreateT(1);
+            SortedSet<T> set = new SortedSet<T> { value };
+            T equalValue = CreateT(2);
+            T actualValue = equalValue;
+            Assert.False(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(default(T), actualValue);
+        }
+
+        #endregion
+    }
+}

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -9,6 +9,10 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+    <Compile Include="Generic\SortedSet\SortedSet.Generic.netcoreapp.Tests.cs" />
+    <Compile Include="Generic\HashSet\HashSet.Generic.netcoreapp.Tests.cs" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
       <Link>Common\System\AssertExtensions.cs</Link>

--- a/src/System.Linq/tests/SelectManyTests.cs
+++ b/src/System.Linq/tests/SelectManyTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace System.Linq.Tests
 {
-    public class SelectManyTests : EnumerableTests
+    public partial class SelectManyTests : EnumerableTests
     {
         [Fact]
         public void EmptySource()
@@ -474,45 +474,6 @@ namespace System.Linq.Tests
         {
             var iterator = counts.SelectMany(c => Enumerable.Range(1, c));
             Assert.Throws<OverflowException>(() => iterator.Count());
-        }
-
-        [Theory]
-        [InlineData(10)]
-        public void EvaluateSelectorOncePerItem(int count)
-        {
-            int[] timesCalledMap = new int[count];
-
-            IEnumerable<int> source = Enumerable.Range(0, 10);
-            IEnumerable<int> iterator = source.SelectMany(index =>
-            {
-                timesCalledMap[index]++;
-                return new[] { index };
-            });
-            
-            // Iteration
-            foreach (int index in iterator)
-            {
-                Assert.Equal(Enumerable.Repeat(1, index + 1), timesCalledMap.Take(index + 1));
-                Assert.Equal(Enumerable.Repeat(0, timesCalledMap.Length - index - 1), timesCalledMap.Skip(index + 1));
-            }
-
-            Array.Clear(timesCalledMap, 0, timesCalledMap.Length);
-
-            // ToArray
-            iterator.ToArray();
-            Assert.Equal(Enumerable.Repeat(1, timesCalledMap.Length), timesCalledMap);
-
-            Array.Clear(timesCalledMap, 0, timesCalledMap.Length);
-
-            // ToList
-            iterator.ToList();
-            Assert.Equal(Enumerable.Repeat(1, timesCalledMap.Length), timesCalledMap);
-
-            Array.Clear(timesCalledMap, 0, timesCalledMap.Length);
-
-            // ToHashSet
-            iterator.ToHashSet();
-            Assert.Equal(Enumerable.Repeat(1, timesCalledMap.Length), timesCalledMap);
         }
     }
 }

--- a/src/System.Linq/tests/SelectManyTests.netcoreapp.cs
+++ b/src/System.Linq/tests/SelectManyTests.netcoreapp.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Linq.Tests
+{
+    public partial class SelectManyTests : EnumerableTests
+    {
+        [Theory]
+        [InlineData(10)]
+        public void EvaluateSelectorOncePerItem(int count)
+        {
+            int[] timesCalledMap = new int[count];
+
+            IEnumerable<int> source = Enumerable.Range(0, 10);
+            IEnumerable<int> iterator = source.SelectMany(index =>
+            {
+                timesCalledMap[index]++;
+                return new[] { index };
+            });
+            
+            // Iteration
+            foreach (int index in iterator)
+            {
+                Assert.Equal(Enumerable.Repeat(1, index + 1), timesCalledMap.Take(index + 1));
+                Assert.Equal(Enumerable.Repeat(0, timesCalledMap.Length - index - 1), timesCalledMap.Skip(index + 1));
+            }
+
+            Array.Clear(timesCalledMap, 0, timesCalledMap.Length);
+
+            // ToArray
+            iterator.ToArray();
+            Assert.Equal(Enumerable.Repeat(1, timesCalledMap.Length), timesCalledMap);
+
+            Array.Clear(timesCalledMap, 0, timesCalledMap.Length);
+
+            // ToList
+            iterator.ToList();
+            Assert.Equal(Enumerable.Repeat(1, timesCalledMap.Length), timesCalledMap);
+
+            Array.Clear(timesCalledMap, 0, timesCalledMap.Length);
+
+            // ToHashSet
+            iterator.ToHashSet();
+            Assert.Equal(Enumerable.Repeat(1, timesCalledMap.Length), timesCalledMap);
+        }
+    }
+}

--- a/src/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/System.Linq/tests/System.Linq.Tests.csproj
@@ -14,6 +14,7 @@
     <Compile Include="TakeLastTests.cs" />
     <Compile Include="OrderByTests.cs" />
     <Compile Include="ToHashSetTests.cs" />
+    <Compile Include="SelectManyTests.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AggregateTests.cs" />

--- a/src/System.Text.Encoding.CodePages/src/Configurations.props
+++ b/src/System.Text.Encoding.CodePages/src/Configurations.props
@@ -5,6 +5,7 @@
       netcoreapp-Unix;
       netcoreapp-Windows_NT;
       uap-Windows_NT;
+      netstandard-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This change will enable running the tests with NetFX.
Note that we still need to go through all tests and fix any issues there like assembly binding issues or the test is written in way that not suitable for the desktop runs

The change also include some fixes in return the src and test sources compile back with NetFx