### PR TITLE
Enable XmlSerializer to Soap Encode Array

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -221,15 +221,17 @@ namespace System.Xml.Serialization
             }
             else
             {
+                MethodInfo addMethod = targetCollectionType.GetMethod("Add");
+                if (addMethod == null)
+                {
+                    throw new InvalidOperationException("addMethod == null");
+                }
+
+                var arguments = new object[1];
                 foreach (var item in sourceCollection)
                 {
-                    MethodInfo addMethod = targetCollectionType.GetMethod("Add");
-                    if (addMethod == null)
-                    {
-                        throw new InvalidOperationException("addMethod == null");
-                    }
-
-                    addMethod.Invoke(targetCollection, new object[] { item });
+                    arguments[0] = item;
+                    addMethod.Invoke(targetCollection, arguments);
                 }
             }
         }

--- a/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -423,8 +423,15 @@ namespace System.Xml.Serialization
             object value = null;
             if (element.Mapping is ArrayMapping)
             {
-                WriteArray(ref o, (ArrayMapping)element.Mapping, readOnly, element.IsNullable, defaultNamespace, fixupIndex, fixup, member);
-                value = o;
+                if (collectionMember != null)
+                {
+                    WriteArray(ref value, (ArrayMapping)element.Mapping, readOnly, element.IsNullable, defaultNamespace, fixupIndex, fixup, member);
+                }
+                else
+                {
+                    WriteArray(ref o, (ArrayMapping)element.Mapping, readOnly, element.IsNullable, defaultNamespace, fixupIndex, fixup, member);
+                    value = o;
+                }
             }
             else if (element.Mapping is NullableMapping)
             {

--- a/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -209,26 +209,27 @@ namespace System.Xml.Serialization
             }
         }
 
-        private static void AddObjectsIntoTargetCollection(object collection, List<object> collectionMember, Type collectionType)
+        private static void AddObjectsIntoTargetCollection(object targetCollection, List<object> sourceCollection, Type targetCollectionType)
         {
-            if (typeof(IList).IsAssignableFrom(collectionType))
+            var targetList = targetCollection as IList;
+            if (targetList != null)
             {
-                foreach (var item in collectionMember)
+                foreach (var item in sourceCollection)
                 {
-                    ((IList)collection).Add(item);
+                    targetList.Add(item);
                 }
             }
             else
             {
-                foreach (var item in collectionMember)
+                foreach (var item in sourceCollection)
                 {
-                    MethodInfo addMethod = collectionType.GetMethod("Add");
+                    MethodInfo addMethod = targetCollectionType.GetMethod("Add");
                     if (addMethod == null)
                     {
-                        throw new InvalidOperationException("(addMethod == null)");
+                        throw new InvalidOperationException("addMethod == null");
                     }
 
-                    addMethod.Invoke(collection, new object[] { item });
+                    addMethod.Invoke(targetCollection, new object[] { item });
                 }
             }
         }

--- a/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -214,7 +214,7 @@ namespace System.Xml.Serialization
             var targetList = targetCollection as IList;
             if (targetList != null)
             {
-                foreach (var item in sourceCollection)
+                foreach (object item in sourceCollection)
                 {
                     targetList.Add(item);
                 }
@@ -228,7 +228,7 @@ namespace System.Xml.Serialization
                 }
 
                 var arguments = new object[1];
-                foreach (var item in sourceCollection)
+                foreach (object item in sourceCollection)
                 {
                     arguments[0] = item;
                     addMethod.Invoke(targetCollection, arguments);

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -2850,7 +2850,6 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
         }
     }
 
-    [ActiveIssue(15525)]
     [Fact]
     public static void SoapEncodedSerializationTest_List()
     {
@@ -2879,9 +2878,13 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
             using (var reader = new XmlTextReader(ms))
             {
                 reader.ReadStartElement("wrapper");
-                var deserialized = (MyGroup2)ser.Deserialize(reader);
-                Assert.Equal(value.GroupName, deserialized.GroupName);
-                Assert.Equal(value.MyItems.Count(), deserialized.MyItems.Count());
+                var actual = (MyGroup2)ser.Deserialize(reader);
+                Assert.Equal(value.GroupName, actual.GroupName);
+                Assert.Equal(value.MyItems.Count(), actual.MyItems.Count());
+                for (int i = 0; i < value.MyItems.Count(); i++)
+                {
+                    Assert.Equal(value.MyItems[i].ItemName, actual.MyItems[i].ItemName);
+                }
             }
         }
     }

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -2539,13 +2539,24 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
             writer.WriteStartElement("root");
             ser.Serialize(writer, value);
             writer.WriteEndElement();
+            writer.Flush();
             ms.Position = 0;
 
-            string expectedOutput = "<root><SoapEncodedTestType2 xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" id=\"id1\"><TestType3 href=\"#id2\" /></SoapEncodedTestType2><SoapEncodedTestType3 id=\"id2\" d2p1:type=\"SoapEncodedTestType3\" xmlns:d2p1=\"http://www.w3.org/2001/XMLSchema-instance\"><StringValue xmlns:q1=\"http://www.w3.org/2001/XMLSchema\" d2p1:type=\"q1:string\">foo</StringValue></SoapEncodedTestType3>";
+            string expectedOutput = "<root><SoapEncodedTestType2 xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" id=\"id1\"><TestType3 href=\"#id2\" /></SoapEncodedTestType2><SoapEncodedTestType3 id=\"id2\" d2p1:type=\"SoapEncodedTestType3\" xmlns:d2p1=\"http://www.w3.org/2001/XMLSchema-instance\"><StringValue xmlns:q1=\"http://www.w3.org/2001/XMLSchema\" d2p1:type=\"q1:string\">foo</StringValue></SoapEncodedTestType3></root>";
             string actualOutput = new StreamReader(ms).ReadToEnd();
             Utils.CompareResult result = Utils.Compare(expectedOutput, actualOutput);
             Assert.True(result.Equal, string.Format("{1}{0}Test failed for input: {2}{0}Expected: {3}{0}Actual: {4}",
                 Environment.NewLine, result.ErrorMessage, value, expectedOutput, actualOutput));
+
+            ms.Position = 0;
+            using (var reader = new XmlTextReader(ms))
+            {
+                reader.ReadStartElement("root");
+                var actual = (SoapEncodedTestType2)ser.Deserialize(reader);
+                Assert.NotNull(actual);
+                Assert.NotNull(actual.TestType3);
+                Assert.Equal(value.TestType3.StringValue, actual.TestType3.StringValue);
+            }
         }
     }
 
@@ -2801,7 +2812,6 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
     }
 
     [Fact]
-    [ActiveIssue(15525)]
     public static void SoapEncodedSerializationTest_Array()
     {
         XmlTypeMapping myTypeMapping = new SoapReflectionImporter().ImportTypeMapping(typeof(MyGroup));
@@ -2829,9 +2839,13 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
             using (var reader = new XmlTextReader(ms))
             {
                 reader.ReadStartElement("wrapper");
-                var deserialized = (MyGroup)ser.Deserialize(reader);
-                Assert.Equal(value.GroupName, deserialized.GroupName);
-                Assert.Equal(value.MyItems.Count(), deserialized.MyItems.Count());
+                var actual = (MyGroup)ser.Deserialize(reader);
+                Assert.Equal(value.GroupName, actual.GroupName);
+                Assert.Equal(value.MyItems.Count(), actual.MyItems.Count());
+                for(int i = 0; i < value.MyItems.Count(); i++)
+                {
+                    Assert.Equal(value.MyItems[i].ItemName, actual.MyItems[i].ItemName);
+                }
             }
         }
     }


### PR DESCRIPTION
The fix is to enable XmlSerializer to serialize/deserialize array into/from soap-encoded message.

Fix #15525