### PR TITLE
Update AspNetCoreHosting keyword

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -164,7 +164,9 @@ namespace System.Diagnostics
                 "httpContext.Request.Path;" +
                 "httpContext.Request.QueryString" +
             "\n" +
-            "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.EndRequest@Activity1Stop:-";
+            "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.EndRequest@Activity1Stop:-" +
+                "httpContext.TraceIdentifier;" +
+                "httpContext.Response.StatusCode";
 
         // Setting EntityFrameworkCoreCommands is like having this in the FilterAndPayloadSpecs string
         // It turns on basic SQL commands.

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -586,11 +586,25 @@ namespace System.Diagnostics.Tests
                 eventSourceListener.ResetEventCountAndLastEvent();
 
                 // Stop the ASP.NET reqeust.  
-                aspNetCoreSource.Write("Microsoft.AspNetCore.Hosting.EndRequest", null);
+                aspNetCoreSource.Write("Microsoft.AspNetCore.Hosting.EndRequest", 
+                    new
+                    {
+                        httpContext = new
+                        {
+                            Response = new
+                            {
+                                StatusCode = "200"
+                            },
+                            TraceIdentifier = "MyTraceId"
+                        }
+                    });
                 Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
                 Assert.Equal("Activity1Stop", eventSourceListener.LastEvent.EventSourceEventName);
                 Assert.Equal("Microsoft.AspNetCore", eventSourceListener.LastEvent.SourceName);
                 Assert.Equal("Microsoft.AspNetCore.Hosting.EndRequest", eventSourceListener.LastEvent.EventName);
+                Assert.True(2 <= eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("MyTraceId", eventSourceListener.LastEvent.Arguments["TraceIdentifier"]);
+                Assert.Equal("200", eventSourceListener.LastEvent.Arguments["StatusCode"]);
                 eventSourceListener.ResetEventCountAndLastEvent();
             }
         }


### PR DESCRIPTION
Add httpContext.TraceIdentifier and httpContext.Response.StatusCode keywords which provide useful information for correlation.

Note: It's backporting #15179 to 1.1.0 release branch.