### PR TITLE
Errata, spelling and typo

### DIFF
--- a/Documentation/building/build-tests-against-packages.md
+++ b/Documentation/building/build-tests-against-packages.md
@@ -41,7 +41,7 @@ This scenario uses a versions file (https://github.com/dotnet/versions/blob/mast
  - ```build-tests.cmd -BuildTestsAgainstPackages -- /p:"PackagesDrops=[ProjectDir]bin/packages/[Release|Debug]/"```
   - -BuildTestsAgainstPackages tells the build to use the project.json files you generated in the "Generate Test project.json files" step
   - /p:"PackagesDrops=[ProjectDir]bin/packages/[Release|Debug]/" tells the build to use the packages from your local build drop.
-   - If the package versions you are referencing have been published publically, you can omit the "PackagesDrops" property.
+   - If the package versions you are referencing have been published publicly, you can omit the "PackagesDrops" property.
 
 ## Common Questions
 

--- a/Documentation/building/cross-platform-testing.md
+++ b/Documentation/building/cross-platform-testing.md
@@ -1,6 +1,6 @@
 # Running XUnit tests cross platform
 
-Unlike Windows, where we run tests as part of the build, we have a seperate
+Unlike Windows, where we run tests as part of the build, we have a separate
 explicit testing step on Linux and OSX. Over time, this special step will go
 away in favor of a similar "run tests during the build" model.
 

--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -72,7 +72,7 @@ but the headers are no longer available since that library version is out of sup
 Some compilers get upset over new headers being in `/usr/local/include` with the old library being present at
 `/usr/lib/libcrypto.dylib` (the tools have no issue with the versioned files, e.g. `/usr/lib/libcrypto.0.9.8.dylib`),
 and so Homebrew does not allow the OpenSSL package to be installed into system default paths. A minimal installation
-is presented here to facilitiate simplifying runtime requirements and compile-time requirements (for build systems using
+is presented here to facilitate simplifying runtime requirements and compile-time requirements (for build systems using
 CMake's `find_package`, like ours):
 ```sh
 # We need to make the runtime libraries discoverable, as well as make

--- a/Documentation/building/versioning.md
+++ b/Documentation/building/versioning.md
@@ -34,7 +34,7 @@ In the case of packages, there is one small difference compared to the assembly 
 How does the Official Build workflow works
 ------------------------------------------
 
-Our Official Builds are a little different than the regular dev flow, and that is because Official Builds need the ability to not only force a specific BuildNumberMinor, but also a BuildNumberMajor. The way they do it, is by passing in the parameter `OfficialBuildId` which specifies the SeedDate that should be used and the revision of the build. For example, the following invocation: `build.cmd -OfficialBuildId=20160523.99` will use May 23 2016 as the SeedDate to generate the version, and it will set '99' as the BuildNumberMinor. With this funcionality, our OfficialBuilds are able to have an orchestrator that triggers different builds and force all of them to have the same version.
+Our Official Builds are a little different than the regular dev flow, and that is because Official Builds need the ability to not only force a specific BuildNumberMinor, but also a BuildNumberMajor. The way they do it, is by passing in the parameter `OfficialBuildId` which specifies the SeedDate that should be used and the revision of the build. For example, the following invocation: `build.cmd -OfficialBuildId=20160523.99` will use May 23 2016 as the SeedDate to generate the version, and it will set '99' as the BuildNumberMinor. With this functionality, our OfficialBuilds are able to have an orchestrator that triggers different builds and force all of them to have the same version.
 
 Getting the version of a native binary in non-Windows platforms
 ========================================================

--- a/Documentation/coding-guidelines/netstandard20-corefx-infra.md
+++ b/Documentation/coding-guidelines/netstandard20-corefx-infra.md
@@ -93,4 +93,4 @@ Folks still consume our current packages so we need to keep building those until
   - As packages are deleted we'll need to opt-in to Microsoft.Private.CoreFx.NETCore.App in some way.
     - proposal:
       - each CSProj is evaluated for layout path in the context of all of its build configurations.
-      - We'll determine applicability similar to how we do for pkgprojs to idenitify which config to binplace.
+      - We'll determine applicability similar to how we do for pkgprojs to identify which config to binplace.

--- a/Documentation/coding-guidelines/package-projects.md
+++ b/Documentation/coding-guidelines/package-projects.md
@@ -10,7 +10,7 @@ In either case the file name of the `.pkgproj` is just {assemblyName}.pkgproj an
 
 ## Package samples
 ### Simple portable library
-This is the simplest case.  The package project need only reference the single project that implements the portable libary.
+This is the simplest case.  The package project need only reference the single project that implements the portable library.
 
 Sample `System.Text.Encodings.Web.pkgproj`
 ```
@@ -147,7 +147,7 @@ Tests can be similarly filtered grouping the compilation directives under:
 (from `\tests\FunctionalTests\System.Net.Security.Tests.csproj`)
 
 ### Platform-specific library
-These packages need to provide a different platform specific implementation on each platform.  They do this by splitting the implementations into seperate packages and associating those platform specific packages with the primary reference package.  Each platform specific package sets `PackageTargetRuntime` to the specific platform RID that it applies.
+These packages need to provide a different platform specific implementation on each platform.  They do this by splitting the implementations into separate packages and associating those platform specific packages with the primary reference package.  Each platform specific package sets `PackageTargetRuntime` to the specific platform RID that it applies.
 
 Sample `System.IO.FileSystem.pkgproj`
 ```
@@ -222,7 +222,7 @@ Sample `System.IO.FileSystem.pkgproj`
 ```
 
 ## Asset selection
-The makeup of a package folder is primarily a grouping of project references to the projects that compose that package.  Settings within each referenced project determines where that asset will be placed in the package.  For example, reference assembly projects will be placed under the `ref/{targetMoniker}` folder in the package and implementations will be under either `lib/{targetMoniker}` or `runtimes/{rid}/lib/{targetMoniker}`.  Whenever NuGet evaulates a package in the context of a referencing project it will choose the best compile time asset (preferring `ref`, then falling back to `lib`) and runtime asset (preffering `runtimes/{rid}/lib` and falling back to `lib`) for every package that is referenced.  For more information see http://docs.nuget.org/.
+The makeup of a package folder is primarily a grouping of project references to the projects that compose that package.  Settings within each referenced project determines where that asset will be placed in the package.  For example, reference assembly projects will be placed under the `ref/{targetMoniker}` folder in the package and implementations will be under either `lib/{targetMoniker}` or `runtimes/{rid}/lib/{targetMoniker}`.  Whenever NuGet evaluates a package in the context of a referencing project it will choose the best compile time asset (preferring `ref`, then falling back to `lib`) and runtime asset (preferring `runtimes/{rid}/lib` and falling back to `lib`) for every package that is referenced.  For more information see http://docs.nuget.org/.
 
 Asset projects (`.csproj`, `.vbproj`, or `.depproj`) can control their `{targetMoniker}` using the `PackageTargetFramework` property in the project file.  Similarly `{rid}` is controlled using the `PackageTargetRuntime` property.  In the corefx repo we automatically select default values for these properties based on the [Build pivots](#build-pivots).  These can be overridden in the project reference using metadata of the same name, but this is rarely needed.
 
@@ -261,7 +261,7 @@ Part of package build is to ensure that a package is applicable on all platforms
     </ProjectReference>
     ```
 
-2. Through SupportedFramework items with Version metdata.
+2. Through SupportedFramework items with Version metadata.
     ```
     <!-- no version indicates latest is supported -->
     <SupportedFramework Include="net46;netcore50;netcoreapp1.0" />
@@ -293,7 +293,7 @@ If the library is also a "classic" reference assembly, not referenced by default
 Package validation will catch a case where we know a library is supported inbox but a package is using an asset from the package.  This data is driven by framework lists from previously-shipped targeting packs.  The error will appear as: *Framework net45 should support Microsoft.CSharp inbox but {explanation of problem}.  You may need to add <InboxOnTargetFramework Include="net45" /> to your project.*
 
 ###External assets
-Runtime specific packages are used to break apart implementations into seperate packages and enable "pay-for-play".  For example: don't download the Windows implementation if we're only building/deploying for linux.  In most cases we can completely seperate implementations into seperate packages such that they easily translate.  For example:
+Runtime specific packages are used to break apart implementations into separate packages and enable "pay-for-play".  For example: don't download the Windows implementation if we're only building/deploying for linux.  In most cases we can completely separate implementations into separate packages such that they easily translate.  For example:
 ```
 runtimes/win/lib/dotnet5.4/System.Banana.dll
 runtimes/unix/lib/dotnet5.4/System.Banana.dll
@@ -305,7 +305,7 @@ Consider the following:
 runtimes/win/lib/dotnet5.4/System.Banana.dll
 runtimes/win/lib/net46/System.Banana.dll
 ```
-Suppose we wanted to split the desktop (`net46`) implementation into a seperate package than the portable implementation.  Doing so would cause both the `dotnet5.4` asset and the `net46` asset to be applicable and result in a bin-clash.  This is because in a single package the `net46` asset is preferred over the `dotnet5.4` asset, but in seperate packages both are in view.  The packaging validation will catch this problem and display an error such as
+Suppose we wanted to split the desktop (`net46`) implementation into a separate package than the portable implementation.  Doing so would cause both the `dotnet5.4` asset and the `net46` asset to be applicable and result in a bin-clash.  This is because in a single package the `net46` asset is preferred over the `dotnet5.4` asset, but in separate packages both are in view.  The packaging validation will catch this problem and display an error such as
 
 *System.Banana includes both package1/runtimes/win/lib/net46/System.Banana.dll and package2/runtimes/win/lib/dotnet5.4/System.Banana.dll an on net46 which have the same name and will clash when both packages are used.*
 

--- a/Documentation/coding-guidelines/project-guidelines.md
+++ b/Documentation/coding-guidelines/project-guidelines.md
@@ -93,7 +93,7 @@ All supported targets with unique windows/unix build for netcoreapp:
 A full or individual project build is centered around BuildConfiguration and will be setup in one of the following ways:
 
 1. `$(BuildConfiguration)` can directly be passed to the build.
-2. `$(Configuration)` can be passed to the build and `$(BuildConfiguration)` will be set to `$(Configuration)-$(ArchGroup)`. This is a convinence mechanism primarily to help with VS support because VS uses the `Configuration` property for switching between various configurations in the UI. NOTE: this only works well for individual projects and not the root builds.
+2. `$(Configuration)` can be passed to the build and `$(BuildConfiguration)` will be set to `$(Configuration)-$(ArchGroup)`. This is a convenience mechanism primarily to help with VS support because VS uses the `Configuration` property for switching between various configurations in the UI. NOTE: this only works well for individual projects and not the root builds.
 3. `$(TargetGroup), $(OSGroup), $(ConfigurationGroup), $(ArchGroup)` can individually be passed in to change the default value for just part of the `BuildConfiguration`.
 4. If nothing is passed to the build then we will default `BuildConfiguration` from the environment. Example: `netcoreapp-[OSGroup Running On]-Debug-x64`.
 
@@ -173,12 +173,12 @@ There are two types of reference assembly projects:
 
 1. Libraries that are contain APIs in netstandard
  - `BuildConfigurations` should contain non-netstandard configurations for the platforms they support.
- - Should use a relative path `<ProjectReference>` to the dependencies it has. Those depedencies should only be libraries with similar build configurations and be part of netstandard.
+ - Should use a relative path `<ProjectReference>` to the dependencies it has. Those dependencies should only be libraries with similar build configurations and be part of netstandard.
 <BR/>//**CONSIDER**: just using Reference with a custom task to pull from TP or turn to ProjectReference
 2. Libraries that are built on top of netstandard
  - `BuildConfigurations` should contain only netstandard configurations.
  - Should contain `<Reference Include='netstandard'>`
- - Anything outside of netstandard should use a relative path `<ProjectReference>` to its dependencies it has. Those depdencies should only be libraries that are built against netstandard as well.
+ - Anything outside of netstandard should use a relative path `<ProjectReference>` to its dependencies it has. Those dependencies should only be libraries that are built against netstandard as well.
 
 ###ref output
 The output for the ref project build will be a flat targeting pack folder in the following directory:


### PR DESCRIPTION

build-tests-against-packages.md
- Change: ‘publically’ to ‘publicly’

cross-platform-testing.md
- Change ‘seperate’ to ‘separate’

netstandard20-corefx-infra.md
- Change ‘idenitify’ to ‘identify’

package-projects.md
- Change ‘evaulates’ to ‘evaluates’
- Change ‘libary’ to ‘library’
- Change ‘metdata’ to ‘metadata’
- Change ‘preffering’ to ‘preferring’
- Change ‘seperate’ to ‘separate’

project-guidelines.md
- Change ‘convinence’ to ‘convenience’
- Change ‘depedencies’ to ‘dependencies’

unix-instruction.md
- Change ‘facilitiate’ to ‘facilitate’

versioning.md:
- Change ‘funcionality’ to ‘functionality’