### PR TITLE
Fix the project.json templating under external to not always restore

### DIFF
--- a/external/dir.targets
+++ b/external/dir.targets
@@ -26,10 +26,9 @@
       Lines="$([System.IO.File]::ReadAllText('$(ProjectJsonTemplate)').Replace('{RID}', $(NuGetRuntimeIdentifier)).Replace('{TFM}', $(NuGetTargetMoniker)).Replace('{PackageId}', $(TargetingPackNugetPackageId)))"
       Overwrite="true"
                       />
-    <ItemGroup>
-      <FileWrites Include="$(ProjectJson);$(ProjectLockJson)" />
-    </ItemGroup>
 
+    <!-- if lock file exists be sure to update timestamp otherwise we could get in a state of aways calling restore but the lock file not being updated -->
+    <Touch Condition="Exists('$(ProjectLockJson)')" Files="$(ProjectLockJson)" />
   </Target>
 
   <!-- Override build and GetTargetPath to return all items deployed -->
@@ -39,8 +38,8 @@
           Returns="@(BinplaceItem)" />
 
   <!-- Depprojs need to run Compile in order to populate items that will be copied to output -->
-  <Target Name="GetTargetPath" 
-          DependsOnTargets="Compile;GetBinplaceItems" 
+  <Target Name="GetTargetPath"
+          DependsOnTargets="Compile;GetBinplaceItems"
           Returns="@(BinplaceItem)" />
 
 </Project>


### PR DESCRIPTION
Currently we generate a project.json and project.lock.json file
for the depproj's under external and we add the files to the clean-up
list. This causes us to always delete them if we do a rebuild and thus
causes a restore to happen each time. When this was just on the depproj's
it wasn't a big deal but now we take ProjectReferences to these from other
projects and we don't want to have to do a restore everytime we do a rebuild
of an individual library.

To ensure we don't get into this state we will not clean-up these generate
project.json files unless the project.json.template is updated or we clean
the entire bin folder. While this isn't great I think it is better then
having to be online all the time to do a rebuild of an individual library.

cc @ericstj 

Contributes to https://github.com/dotnet/corefx/issues/16097. 