### PR TITLE
Minimum set of changes to (hopefully) unblock Helix build.

### DIFF
--- a/Tools-Override/CloudTest.targets
+++ b/Tools-Override/CloudTest.targets
@@ -154,7 +154,14 @@
 
     <Message Text="Full, Unfiltered Test Archive Collection :: @(UnfilteredTestArchives)" Importance="Low" />
 
-    <!-- If we wish to filter tests that we upload, then altering the FilterToTestTFM and FilterToOSGroup is where to do it at. -->
+    <!-- If we wish to filter tests that we upload, then altering the FilterToTestTFM and FilterToOSGroup is where to do it at. 
+    
+    Disabled for now; We most likely no longer need this, but with the removal of the FilterToTestTFM and FilterTOOSGroup variables, 
+    this is breaking build.  For now, the old method of including the zips for upload should work.
+    
+    In the near future, this specific knowledge (for instance that the files for upload come from three folders, Regular, AnyOS, and Unix
+    Needs to be in CoreFX specific code, and CloudTest should just take a list of files generated in an external task.
+   
     <FilterForUpload UnfilteredUploadItems="@(UnfilteredTestArchives)"
              FilterToTestTFM="$(FilterToTestTFM)"
              FilterToOSGroup="$(FilterToOSGroup)" 
@@ -165,12 +172,17 @@
     <CreateItem Include="$(ForUploadList)">
       <Output TaskParameter="Include" ItemName="ForUpload"/>
     </CreateItem>
+    -->
+    <ItemGroup>
+       <ForUpload Include="@(UnfilteredTestArchives)" />
+    </ItemGroup>
 
     <Message Condition="'$(FilterToTestTFM)' != ''" Text="Using test archives for TFM: $(FilterToTestTFM)" />
     <Message Text="Using OS-Specific test archives from: $(TestArchivesRoot)" />
     <Message Text="Using AnyOS test archives from: $(AnyOSTestArchivesRoot)" />
     <Message Condition="'$(TargetsUnix)' == 'true'"  Text="Using Unix test archives from: $(UnixTestArchivesRoot)" />
 
+    <!-- Deprecated property, should clean up / remove when refactoring CloudTest-->
     <PropertyGroup>
       <RelativeBlobPathFolderContainingTests Condition="'$(FilterToTestTFM)' != ''" >Tests/$(FilterToTestTFM)</RelativeBlobPathFolderContainingTests>
       <RelativeBlobPathFolderContainingTests Condition="'$(FilterToTestTFM)' == ''" >Tests</RelativeBlobPathFolderContainingTests>


### PR DESCRIPTION
Comment out usage of FilterForUpload, and just include all the archives we produced while building.  This has been conveniently already stored in the ItemGroup "UnfilteredTestArchives"