### PR TITLE
Official Test build fix

### DIFF
--- a/Tools-Override/CloudTest.targets
+++ b/Tools-Override/CloudTest.targets
@@ -176,6 +176,11 @@
     <ItemGroup>
        <ForUpload Include="@(UnfilteredTestArchives)" />
     </ItemGroup>
+    <!-- To work around the removal of the build task, also need to turn the list of test archives to a property 
+         like the previous build task would have output --> 
+    <PropertyGroup>
+      <ForUploadList>@(UnfilteredTestArchives)</ForUploadList>
+    </PropertyGroup>
 
     <Message Condition="'$(FilterToTestTFM)' != ''" Text="Using test archives for TFM: $(FilterToTestTFM)" />
     <Message Text="Using OS-Specific test archives from: $(TestArchivesRoot)" />


### PR DESCRIPTION
2nd attempt trying to unblock Helix build break introduced by removal of FilterTo... properties.  ForUploadList was a property previously set by the build task in charge of filtering, which was broken by the removal of these variables.