### PR TITLE
Faster Span

### DIFF
--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -38,10 +38,13 @@
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Condition="'$(TargetGroup)' != 'netstandard1.0'" Include="System.Runtime.CompilerServices.Unsafe" />
+    <Reference Condition="'$(TargetGroup)' != 'netstandard1.0'" Include="System.Numerics.Vectors" />
     <ProjectReference Condition="'$(TargetGroup)' == 'netstandard1.0'" Include="..\..\System.Runtime.CompilerServices.Unsafe\ref\System.Runtime.CompilerServices.Unsafe.csproj" />
+    <ProjectReference Condition="'$(TargetGroup)' == 'netstandard1.0'" Include="..\..\System.Numerics.Vectors\ref\System.Numerics.Vectors.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <Reference Include="System.Runtime.CompilerServices.Unsafe" />
+    <Reference Include="System.Numerics.Vectors" />
     <ReferenceFromRuntime Include="System.Private.CoreLib" />
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj" />

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -38,9 +38,11 @@
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Condition="'$(TargetGroup)' != 'netstandard1.0'" Include="System.Runtime.CompilerServices.Unsafe" />
-    <Reference Condition="'$(TargetGroup)' != 'netstandard1.0'" Include="System.Numerics.Vectors" />
+    <Reference Condition="'$(TargetGroup)' != 'netcoreapp' and '$(TargetGroup)' != 'netfx' and '$(TargetGroup)' != 'uap'" Include="System.Numerics.Vectors" />
     <ProjectReference Condition="'$(TargetGroup)' == 'netstandard1.0'" Include="..\..\System.Runtime.CompilerServices.Unsafe\ref\System.Runtime.CompilerServices.Unsafe.csproj" />
-    <ProjectReference Condition="'$(TargetGroup)' == 'netstandard1.0'" Include="..\..\System.Numerics.Vectors\ref\System.Numerics.Vectors.csproj" />
+    <ProjectReference Condition="'$(TargetGroup)' == 'netcoreapp'" Include="..\..\System.Numerics.Vectors\ref\System.Numerics.Vectors.csproj" />
+    <ProjectReference Condition="'$(TargetGroup)' == 'netfx'" Include="..\..\System.Numerics.Vectors\ref\System.Numerics.Vectors.csproj" />
+    <ProjectReference Condition="'$(TargetGroup)' == 'uap'" Include="..\..\System.Numerics.Vectors\ref\System.Numerics.Vectors.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <Reference Include="System.Runtime.CompilerServices.Unsafe" />

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -37,12 +37,9 @@
     <Reference Include="System.Reflection" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Numerics.Vectors" />
     <Reference Condition="'$(TargetGroup)' != 'netstandard1.0'" Include="System.Runtime.CompilerServices.Unsafe" />
-    <Reference Condition="'$(TargetGroup)' != 'netcoreapp' and '$(TargetGroup)' != 'netfx' and '$(TargetGroup)' != 'uap'" Include="System.Numerics.Vectors" />
     <ProjectReference Condition="'$(TargetGroup)' == 'netstandard1.0'" Include="..\..\System.Runtime.CompilerServices.Unsafe\ref\System.Runtime.CompilerServices.Unsafe.csproj" />
-    <ProjectReference Condition="'$(TargetGroup)' == 'netcoreapp'" Include="..\..\System.Numerics.Vectors\ref\System.Numerics.Vectors.csproj" />
-    <ProjectReference Condition="'$(TargetGroup)' == 'netfx'" Include="..\..\System.Numerics.Vectors\ref\System.Numerics.Vectors.csproj" />
-    <ProjectReference Condition="'$(TargetGroup)' == 'uap'" Include="..\..\System.Numerics.Vectors\ref\System.Numerics.Vectors.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <Reference Include="System.Runtime.CompilerServices.Unsafe" />

--- a/src/System.Memory/src/System/Pinnable.cs
+++ b/src/System.Memory/src/System/Pinnable.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace System

--- a/src/System.Memory/src/System/Span.cs
+++ b/src/System.Memory/src/System/Span.cs
@@ -28,8 +28,9 @@ namespace System
         public Span(T[] array)
         {
             if (array == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
-            if (default(T) == null && array.GetType() != typeof(T[]))
+                ThrowHelper.ThrowArgumentNullException_Array();
+            // Check will be Jitted out for ValueTypes
+            if (!SpanHelpers.IsValueType<T>() && array.GetType() != typeof(T[]))
                 ThrowHelper.ThrowArrayTypeMismatchException_ArrayTypeMustBeExactMatch(typeof(T));
 
             _length = array.Length;
@@ -52,16 +53,13 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span(T[] array, int start)
         {
-            if (array == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
-            if (default(T) == null && array.GetType() != typeof(T[]))
+            if (array == null || (uint)start > (uint)array.Length)
+                ThrowHelper.ThrowArgumentNullOrOutOfRangeException(array);
+            // Check will be Jitted out for ValueTypes
+            if (!SpanHelpers.IsValueType<T>() && array.GetType() != typeof(T[]))
                 ThrowHelper.ThrowArrayTypeMismatchException_ArrayTypeMustBeExactMatch(typeof(T));
 
-            int arrayLength = array.Length;
-            if ((uint)start > (uint)arrayLength)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
-
-            _length = arrayLength - start;
+            _length = array.Length - start;
             _pinnable = Unsafe.As<Pinnable<T>>(array);
             _byteOffset = SpanHelpers.PerTypeValues<T>.ArrayAdjustment.Add<T>(start);
         }
@@ -82,12 +80,11 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span(T[] array, int start, int length)
         {
-            if (array == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
-            if (default(T) == null && array.GetType() != typeof(T[]))
+            if (array == null || (uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
+                ThrowHelper.ThrowArgumentNullOrOutOfRangeException(array);
+            // Check will be Jitted out for ValueTypes
+            if (!SpanHelpers.IsValueType<T>() && array.GetType() != typeof(T[]))
                 ThrowHelper.ThrowArrayTypeMismatchException_ArrayTypeMustBeExactMatch(typeof(T));
-            if ((uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             _length = length;
             _pinnable = Unsafe.As<Pinnable<T>>(array);
@@ -111,10 +108,11 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe Span(void* pointer, int length)
         {
+            // Check will be Jitted out for valid types
             if (SpanHelpers.IsReferenceOrContainsReferences<T>())
                 ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
             if (length < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                ThrowHelper.ThrowArgumentOutOfRangeException_Length();
 
             _length = length;
             _pinnable = null;
@@ -138,10 +136,8 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Span<T> DangerousCreate(object obj, ref T objectData, int length)
         {
-            if (obj == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.obj);
-            if (length < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+            if (obj == null || length < 0)
+                ThrowHelper.ThrowArgumentNullOrOutOfRangeException(length);
 
             Pinnable<T> pinnable = Unsafe.As<Pinnable<T>>(obj);
             IntPtr byteOffset = Unsafe.ByteOffset<T>(ref pinnable.Data, ref objectData);
@@ -244,6 +240,7 @@ namespace System
 
             var byteLength = (UIntPtr)((uint)length * Unsafe.SizeOf<T>());
 
+            // Branch will be Jit eliminated
             if ((Unsafe.SizeOf<T>() & (sizeof(IntPtr) - 1)) != 0) 
             {
                 if (_pinnable == null)
@@ -261,6 +258,7 @@ namespace System
             }
             else
             {
+                // Branch will be Jit eliminated
                 if (SpanHelpers.IsReferenceOrContainsReferences<T>())
                 {
                     UIntPtr pointerSizedLength = (UIntPtr)((length * Unsafe.SizeOf<T>()) / sizeof(IntPtr));
@@ -288,6 +286,7 @@ namespace System
             if (length == 0)
                 return;
 
+            // Branch will be Jit eliminated
             if (Unsafe.SizeOf<T>() == 1)
             {
                 byte fill = Unsafe.As<T, byte>(ref value);
@@ -463,11 +462,10 @@ namespace System
         public Span<T> Slice(int start)
         {
             if ((uint)start > (uint)_length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                ThrowHelper.ThrowArgumentOutOfRangeException_Start();
 
             IntPtr newOffset = _byteOffset.Add<T>(start);
-            int length = _length - start;
-            return new Span<T>(_pinnable, newOffset, length);
+            return new Span<T>(_pinnable, newOffset, _length - start);
         }
 
         /// <summary>
@@ -482,7 +480,7 @@ namespace System
         public Span<T> Slice(int start, int length)
         {
             if ((uint)start > (uint)_length || (uint)length > (uint)(_length - start))
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                ThrowHelper.ThrowArgumentOutOfRangeException_Start();
 
             IntPtr newOffset = _byteOffset.Add<T>(start);
             return new Span<T>(_pinnable, newOffset, length);
@@ -562,6 +560,7 @@ namespace System
         public static Span<byte> AsBytes<T>(this Span<T> source)
             where T : struct
         {
+            // Check will be Jitted out for valid types
             if (SpanHelpers.IsReferenceOrContainsReferences<T>())
                 ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
 
@@ -584,6 +583,7 @@ namespace System
         public static ReadOnlySpan<byte> AsBytes<T>(this ReadOnlySpan<T> source)
             where T : struct
         {
+            // Check will be Jitted out for valid types
             if (SpanHelpers.IsReferenceOrContainsReferences<T>())
                 ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
 
@@ -610,9 +610,10 @@ namespace System
             where TFrom : struct
             where TTo : struct
         {
+            // Check will be Jitted out for valid types
             if (SpanHelpers.IsReferenceOrContainsReferences<TFrom>())
                 ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TFrom));
-
+            // Check will be Jitted out for valid types
             if (SpanHelpers.IsReferenceOrContainsReferences<TTo>())
                 ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TTo));
 
@@ -639,9 +640,10 @@ namespace System
             where TFrom : struct
             where TTo : struct
         {
+            // Check will be Jitted out for valid types
             if (SpanHelpers.IsReferenceOrContainsReferences<TFrom>())
                 ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TFrom));
-
+            // Check will be Jitted out for valid types
             if (SpanHelpers.IsReferenceOrContainsReferences<TTo>())
                 ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TTo));
 
@@ -658,7 +660,7 @@ namespace System
         public static ReadOnlySpan<char> Slice(this string text)
         {
             if (text == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.text);
+                ThrowHelper.ThrowArgumentNullException_Text();
 
             return new ReadOnlySpan<char>(Unsafe.As<Pinnable<char>>(text), StringAdjustment, text.Length);
         }
@@ -675,16 +677,13 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<char> Slice(this string text, int start)
         {
-            if (text == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.text);
-            int textLength = text.Length;
-            if ((uint)start > (uint)textLength)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+            if (text == null || (uint)start > (uint)text.Length)
+                ThrowHelper.ThrowArgumentNullOrOutOfRangeException(text);
 
             unsafe
             {
                 byte* byteOffset = ((byte*)StringAdjustment) + (uint)(start * sizeof(char));
-                return new ReadOnlySpan<char>(Unsafe.As<Pinnable<char>>(text), (IntPtr)byteOffset, textLength - start);
+                return new ReadOnlySpan<char>(Unsafe.As<Pinnable<char>>(text), (IntPtr)byteOffset, text.Length - start);
             }
         }
 
@@ -701,11 +700,8 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<char> Slice(this string text, int start, int length)
         {
-            if (text == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.text);
-            int textLength = text.Length;
-            if ((uint)start > (uint)textLength || (uint)length > (uint)(textLength - start))
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+            if (text == null || (uint)start > (uint)text.Length || (uint)length > (uint)(text.Length - start))
+                ThrowHelper.ThrowArgumentNullOrOutOfRangeException(text);
 
             unsafe
             {

--- a/src/System.Memory/src/System/SpanExtensions.cs
+++ b/src/System.Memory/src/System/SpanExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace System

--- a/src/System.Memory/src/System/SpanExtensions.cs
+++ b/src/System.Memory/src/System/SpanExtensions.cs
@@ -31,6 +31,10 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOf(this Span<byte> span, byte value)
         {
+            if (!BitConverter.IsLittleEndian)
+            {
+                return SpanHelpers.IndexOfBigEndian(ref span.DangerousGetPinnableReference(), value, span.Length);
+            }
             return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value, span.Length);
         }
 
@@ -130,6 +134,10 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOf(this ReadOnlySpan<byte> span, byte value)
         {
+            if (!BitConverter.IsLittleEndian)
+            {
+                return SpanHelpers.IndexOfBigEndian(ref span.DangerousGetPinnableReference(), value, span.Length);
+            }
             return SpanHelpers.IndexOf(ref span.DangerousGetPinnableReference(), value, span.Length);
         }
 

--- a/src/System.Memory/src/System/SpanHelpers.cs
+++ b/src/System.Memory/src/System/SpanHelpers.cs
@@ -4,7 +4,6 @@
 
 using System.Reflection;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 
 namespace System
@@ -50,6 +49,8 @@ namespace System
         /// </summary>
         public static bool IsReferenceOrContainsReferences<T>() => PerTypeValues<T>.IsReferenceOrContainsReferences;
 
+        public static bool IsValueType<T>() => PerTypeValues<T>.IsValueType;
+
         private static bool IsReferenceOrContainsReferencesCore(Type type)
         {
             if (type.GetTypeInfo().IsPrimitive) // This is hopefully the common case. All types that return true for this are value types w/out embedded references.
@@ -83,6 +84,8 @@ namespace System
             // only once per type.
             //
             public static readonly bool IsReferenceOrContainsReferences = IsReferenceOrContainsReferencesCore(typeof(T));
+
+            public static readonly bool IsValueType = typeof(T).GetTypeInfo().IsValueType;
 
             public static readonly T[] EmptyArray = new T[0];
 

--- a/src/System.Memory/src/System/ThrowHelper.cs
+++ b/src/System.Memory/src/System/ThrowHelper.cs
@@ -23,9 +23,45 @@ namespace System
 
     internal static class ThrowHelper
     {
-        internal static void ThrowArgumentNullException(ExceptionArgument argument) { throw CreateArgumentNullException(argument); }
+        internal static void ThrowArgumentNullException_Array() { throw CreateArgumentNullException(ExceptionArgument.array); }
+        internal static void ThrowArgumentNullException_Text() { throw CreateArgumentNullException(ExceptionArgument.text); }
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static Exception CreateArgumentNullException(ExceptionArgument argument) { return new ArgumentNullException(argument.ToString()); }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Exception CreateArgumentNullOrOutofRangeException(int length) {
+            if (length < 0)
+            {
+                return CreateArgumentOutOfRangeException(ExceptionArgument.length);
+            }
+
+            return CreateArgumentNullException(ExceptionArgument.obj);
+        }
+        internal static void ThrowArgumentNullOrOutOfRangeException(int length) { throw CreateArgumentNullOrOutofRangeException(length); }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Exception CreateArgumentNullOrOutofRangeException(Array array)
+        {
+            if (array == null)
+            {
+                return CreateArgumentNullException(ExceptionArgument.array);
+            }
+
+            return CreateArgumentOutOfRangeException(ExceptionArgument.start);
+        }
+        internal static void ThrowArgumentNullOrOutOfRangeException(Array array) { throw CreateArgumentNullOrOutofRangeException(array); }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Exception CreateArgumentNullOrOutofRangeException(string text)
+        {
+            if (text == null)
+            {
+                return CreateArgumentNullException(ExceptionArgument.text);
+            }
+
+            return CreateArgumentOutOfRangeException(ExceptionArgument.start);
+        }
+        internal static void ThrowArgumentNullOrOutOfRangeException(string text) { throw CreateArgumentNullOrOutofRangeException(text); }
 
         internal static void ThrowArrayTypeMismatchException_ArrayTypeMustBeExactMatch(Type type) { throw CreateArrayTypeMismatchException_ArrayTypeMustBeExactMatch(type); }
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -43,7 +79,8 @@ namespace System
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static Exception CreateIndexOutOfRangeException() { return new IndexOutOfRangeException(); }
 
-        internal static void ThrowArgumentOutOfRangeException(ExceptionArgument argument) { throw CreateArgumentOutOfRangeException(argument); }
+        internal static void ThrowArgumentOutOfRangeException_Start() { throw CreateArgumentOutOfRangeException(ExceptionArgument.start); }
+        internal static void ThrowArgumentOutOfRangeException_Length() { throw CreateArgumentOutOfRangeException(ExceptionArgument.length); }
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static Exception CreateArgumentOutOfRangeException(ExceptionArgument argument) { return new ArgumentOutOfRangeException(argument.ToString()); }
     }


### PR DESCRIPTION
Slim the span hot methods `.ctor`+`Slice` as they are very hot and always inlined

Vectorized `IndexOf` for byte and `SequenceEqual` for byte and char

/cc @jkotas 