### PR TITLE
Remove coveralls.io reference

### DIFF
--- a/external/test-runtime/project.json
+++ b/external/test-runtime/project.json
@@ -8,7 +8,6 @@
     "Microsoft.DotNet.xunit.performance.runner.cli": "1.0.0-alpha-build0040",
     "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0040",
     "Newtonsoft.Json": "9.0.1",
-    "coveralls.io": "1.4",
     "OpenCover": "4.6.519",
     "ReportGenerator": "2.5.0",
     "System.IO.Compression.TestData": "1.0.4-prerelease",


### PR DESCRIPTION
The referenced package version is gone

/cc @stephentoub 

Don't merge immediately, there may be other reference points. 