### PR TITLE
Pointing to V2 myget feed since there is an ongoing problem with their V3 feed

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -84,8 +84,8 @@
     <DnuSourceList Condition="'$(BuildTestsAgainstPackages)' == 'true'" Include="$(PackagesDrops)" />
     <!-- Need to escape double forward slash (%2F) or MSBuild will normalize to one slash on Unix. -->
     <!-- Including buildtools to pull in TestSuite packages and repackaged xunit dependencies-->
-    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
-    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-buildtools/" />
+    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-core/" />
     <DnuSourceList Include="https:%2F%2Fapi.nuget.org/v3/index.json" />
   </ItemGroup>
 


### PR DESCRIPTION
cc: @ericstj @mmitche 
FYI: @MattGal @stephentoub 

Looks like Myget is having some issues with their V3 feeds so we can't restore a few set of packages which is breaking our CI and official builds. This change will point them temporarily back to the V2 feed which we have verified that works.