### PR TITLE
Prohibit open generics in Expression.Property and Expression.Field

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -281,6 +281,8 @@ namespace System.Linq.Expressions
                 }
             }
 
+            ValidateMethodInfo(mi, nameof(property));
+
             return MemberExpression.Make(expression, property);
         }
 

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -277,6 +277,10 @@ namespace System.Linq.Expressions.Tests
     public class GenericClass<T>
     {
         public void Method() { }
+
+        public static T Field;
+
+        public static T Property => Field;
     }
 
     public class NonGenericClass
@@ -287,6 +291,10 @@ namespace System.Linq.Expressions.Tests
 
         public void GenericMethod<T>() { }
         public static void StaticMethod() { }
+
+        public static readonly NonGenericClass NonGenericField = new NonGenericClass();
+
+        public static NonGenericClass NonGenericProperty => NonGenericField;
     }
 
     public class InvalidTypesData : IEnumerable<object[]>

--- a/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -243,6 +243,18 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        public static void Field_ByrefTypeFieldAccessor_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Property(null, typeof(GenericClass<string>).MakeByRefType(), nameof(GenericClass<string>.Field)));
+        }
+
+        [Fact]
+        public static void Field_GenericFieldAccessor_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Property(null, typeof(GenericClass<>), nameof(GenericClass<string>.Field)));
+        }
+
+        [Fact]
         public static void Field_InstanceField_NullExpression_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentNullException>("expression", () => Expression.Field(null, "fieldName"));
@@ -488,14 +500,21 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public static void Property_GenericPropertyAccessor_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>("propertyAccessor", () => Expression.Property(null, typeof(GenericClass<>).GetMethod(nameof(GenericClass<string>.Method))));
+            Assert.Throws<ArgumentException>("propertyAccessor", () => Expression.Property(null, typeof(GenericClass<>).GetProperty(nameof(GenericClass<string>.Property)).GetGetMethod()));
             Assert.Throws<ArgumentException>("propertyAccessor", () => Expression.Property(null, typeof(NonGenericClass).GetMethod(nameof(NonGenericClass.GenericMethod))));
+            Assert.Throws<ArgumentException>("property", () => Expression.Property(null, typeof(GenericClass<>).GetProperty(nameof(GenericClass<string>.Property))));
         }
 
         [Fact]
         public static void Property_PropertyAccessorNotFromProperty_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>("propertyAccessor", () => Expression.Property(null, typeof(NonGenericClass).GetMethod(nameof(NonGenericClass.StaticMethod))));
+        }
+
+        [Fact]
+        public static void Property_ByRefStaticAccess_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Property(null, typeof(NonGenericClass).MakeByRefType(), nameof(NonGenericClass.NonGenericProperty)));
         }
 
         [Fact]
@@ -563,6 +582,28 @@ namespace System.Linq.Expressions.Tests
 
             MemberExpression e2 = Expression.Property(Expression.Parameter(typeof(DateTime), "d"), typeof(DateTime).GetProperty(nameof(DateTime.Year)));
             Assert.Equal("d.Year", e2.ToString());
+        }
+
+        [Fact]
+        public static void UpdateSameResturnsSame()
+        {
+            var exp = Expression.Constant(new PS {II = 42});
+            var pro = Expression.Property(exp, nameof(PS.II));
+            Assert.Same(pro, pro.Update(exp));
+        }
+
+        [Fact]
+        public static void UpdateStaticResturnsSame()
+        {
+            var pro = Expression.Property(null, typeof(PS), nameof(PS.SI));
+            Assert.Same(pro, pro.Update(null));
+        }
+
+        [Fact]
+        public static void UpdateDifferentResturnsDifferent()
+        {
+            var pro = Expression.Property(Expression.Constant(new PS {II = 42}), nameof(PS.II));
+            Assert.NotSame(pro, pro.Update(Expression.Constant(new PS {II = 42})));
         }
     }
 }


### PR DESCRIPTION
Contributes to #8081.

Also fill other testing gaps in MemberExpression.