### PR TITLE
Warn for attempt to build on 32 bit unix

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -68,6 +68,9 @@ get_current_linux_name() {
 }
 
 if [ -z "$__DOTNET_PKG" ]; then
+    if [ "$(uname -m | grep "i[3456]86")" = "i686" ]; then
+        echo "Warning: build not supported on 32 bit Unix"
+    fi
 OSName=$(uname -s)
     case $OSName in
         Darwin)


### PR DESCRIPTION
My old laptop has a 32 bit CPU (!) and it wasn't immeidately obvious why I couldn't build. The reason is we don't have CLI packages for 32 bit unix today.