### PR TITLE
Disable Crypto tests for Fedora\Ubuntu

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class ChainTests
     {
         // #9293: Our Fedora and Ubuntu CI machines use NTFS for "tmphome", which causes our filesystem permissions checks to fail.
-        private static bool IsReliableInCI { get; } =
+        internal static bool IsReliableInCI { get; } =
             !PlatformDetection.IsFedora23 &&
             !PlatformDetection.IsFedora24 &&
             !PlatformDetection.IsUbuntu1604 &&

--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -11,6 +11,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 {
     public static class ChainTests
     {
+        // #9293: Our Fedora and Ubuntu CI machines use NTFS for "tmphome", which causes our filesystem permissions checks to fail.
+        private static bool IsReliableInCI { get; } =
+            !PlatformDetection.IsFedora23 &&
+            !PlatformDetection.IsFedora24 &&
+            !PlatformDetection.IsUbuntu1604 &&
+            !PlatformDetection.IsUbuntu1610;
+
         private static bool TrustsMicrosoftDotComRoot
         {
             get
@@ -120,7 +127,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [Fact]
+        [ConditionalFact(nameof(IsReliableInCI))]
         public static void VerifyChainFromHandle_Unix()
         {
             using (var microsoftDotCom = new X509Certificate2(TestData.MicrosoftDotComSslCertBytes))

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
@@ -15,8 +15,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     [Collection("X509Filesystem")]
     public static class X509FilesystemTests
     {
-        // #9293: Our Fedora23 and Ubuntu1610 CI machines use NTFS for "tmphome", which causes our filesystem permissions checks to fail.
-        private static bool IsReliableInCI { get; } = !PlatformDetection.IsFedora23 && !PlatformDetection.IsUbuntu1610;
+        // #9293: Our Fedora and Ubuntu CI machines use NTFS for "tmphome", which causes our filesystem permissions checks to fail.
+        private static bool IsReliableInCI { get; } =
+            !PlatformDetection.IsFedora23 &&
+            !PlatformDetection.IsFedora24 &&
+            !PlatformDetection.IsUbuntu1604 &&
+            !PlatformDetection.IsUbuntu1610;
 
         [ActiveIssue(12833, TestPlatforms.AnyUnix)]
         [Fact]

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509FilesystemTests.Unix.cs
@@ -15,12 +15,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     [Collection("X509Filesystem")]
     public static class X509FilesystemTests
     {
-        // #9293: Our Fedora and Ubuntu CI machines use NTFS for "tmphome", which causes our filesystem permissions checks to fail.
-        private static bool IsReliableInCI { get; } =
-            !PlatformDetection.IsFedora23 &&
-            !PlatformDetection.IsFedora24 &&
-            !PlatformDetection.IsUbuntu1604 &&
-            !PlatformDetection.IsUbuntu1610;
+        // #9293: Our Fedora23 and Ubuntu1610 CI machines use NTFS for "tmphome", which causes our filesystem permissions checks to fail.
+        private static bool IsReliableInCI { get; } = ChainTests.IsReliableInCI;
 
         [ActiveIssue(12833, TestPlatforms.AnyUnix)]
         [Fact]


### PR DESCRIPTION
Per issue #16225 and #9293 disable some Fedora and Ubuntu tests that are failing in CI due to hardware using NTFS partitions instead of Unix.