### PR TITLE
Fix Http test that randomly fails under Windows

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
@@ -106,12 +106,31 @@ namespace System.Net.Http.Functional.Tests
                 Task task = stream.ReadAsync(buffer, 0, buffer.Length, cts.Token);
                 cts.Cancel();
 
-                // Verify that the task completes successfully or is canceled.
+                // Verify that the task completed.
                 Assert.True(((IAsyncResult)task).AsyncWaitHandle.WaitOne(new TimeSpan(0, 5, 0)));
                 Assert.True(task.IsCompleted, "Task was not yet completed");
-                if (task.IsFaulted)
+
+                // Verify that the task completed successfully or is canceled.
+                if (PlatformDetection.IsWindows)
                 {
-                    task.GetAwaiter().GetResult();
+                    // On Windows, we may fault because canceling the task destroys the request handle
+                    // which may randomly cause an ObjectDisposedException (or other exception).
+                    Assert.True(
+                        task.Status == TaskStatus.RanToCompletion ||
+                        task.Status == TaskStatus.Canceled ||
+                        task.Status == TaskStatus.Faulted);
+                }
+                else
+                {
+                    if (task.IsFaulted)
+                    {
+                        // Propagate exception for debugging
+                        task.GetAwaiter().GetResult();
+                    }
+
+                    Assert.True(
+                        task.Status == TaskStatus.RanToCompletion ||
+                        task.Status == TaskStatus.Canceled);
                 }
             }
         }


### PR DESCRIPTION
Addresses #13938 where the test is failing randomly under Windows due to random exception when an http request is being canceled. The fix is to allow the exception (or faulted task) in Windows because in Windows, when the task is canceled, the request handle is destroyed, which may cause an ObjectDisposedException (or other http exception) in other tasks.

 Also applies to #14519 (make system.net tests reliable)