### PR TITLE
Make sure Memory and Unsafe are packaged w/o RID

### DIFF
--- a/src/System.Memory/src/Configurations.props
+++ b/src/System.Memory/src/Configurations.props
@@ -2,9 +2,10 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard1.0-Windows_NT;
-      netstandard-Windows_NT;
+      netstandard1.0;
+      netstandard;
       netcoreapp-Windows_NT;
+      netcoreapp-Unix;
       uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -8,12 +8,14 @@
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap'">true</IsPartialFacadeAssembly>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Windows_NT-Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Windows_NT-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
@@ -31,14 +33,15 @@
     <Compile Include="System\Pinnable.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
-    <ProjectReference Include="..\..\System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Reflection" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
+    <Reference Condition="'$(TargetGroup)' != 'netstandard1.0'" Include="System.Runtime.CompilerServices.Unsafe" />
+    <ProjectReference Condition="'$(TargetGroup)' == 'netstandard1.0'" Include="..\..\System.Runtime.CompilerServices.Unsafe\ref\System.Runtime.CompilerServices.Unsafe.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
-    <ProjectReference Include="..\..\System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <ReferenceFromRuntime Include="System.Private.CoreLib" />
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj" />

--- a/src/System.Runtime.CompilerServices.Unsafe/System.Runtime.CompilerServices.Unsafe.sln
+++ b/src/System.Runtime.CompilerServices.Unsafe/System.Runtime.CompilerServices.Unsafe.sln
@@ -8,10 +8,17 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.CompilerServ
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.CompilerServices.Unsafe", "src\System.Runtime.CompilerServices.Unsafe.ilproj", "{04BA3E3C-6979-4792-B19E-C797AD607F42}"
+	ProjectSection(ProjectDependencies) = postProject
+		{649A377C-1E07-4105-B01F-7F1044D3356C} = {649A377C-1E07-4105-B01F-7F1044D3356C}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.CompilerServices.Unsafe", "ref\System.Runtime.CompilerServices.Unsafe.csproj", "{649A377C-1E07-4105-B01F-7F1044D3356C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1A2F9F4A-A032-433E-B914-ADD5992BB178}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E893-4E87-987E-04EF0DCEAEFD}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,10 +30,14 @@ Global
 		{8012DD70-A6D7-45C0-BC8E-DFFB48D86E08}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{8012DD70-A6D7-45C0-BC8E-DFFB48D86E08}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{8012DD70-A6D7-45C0-BC8E-DFFB48D86E08}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
-		{04BA3E3C-6979-4792-B19E-C797AD607F42}.Debug|Any CPU.ActiveCfg = netstandard1.0-Windows_NT-Debug|Any CPU
-		{04BA3E3C-6979-4792-B19E-C797AD607F42}.Debug|Any CPU.Build.0 = netstandard1.0-Windows_NT-Debug|Any CPU
-		{04BA3E3C-6979-4792-B19E-C797AD607F42}.Release|Any CPU.ActiveCfg = netstandard1.0-Windows_NT-Release|Any CPU
-		{04BA3E3C-6979-4792-B19E-C797AD607F42}.Release|Any CPU.Build.0 = netstandard1.0-Windows_NT-Release|Any CPU
+		{04BA3E3C-6979-4792-B19E-C797AD607F42}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
+		{04BA3E3C-6979-4792-B19E-C797AD607F42}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
+		{04BA3E3C-6979-4792-B19E-C797AD607F42}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
+		{04BA3E3C-6979-4792-B19E-C797AD607F42}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
+		{649A377C-1E07-4105-B01F-7F1044D3356C}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{649A377C-1E07-4105-B01F-7F1044D3356C}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{649A377C-1E07-4105-B01F-7F1044D3356C}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{649A377C-1E07-4105-B01F-7F1044D3356C}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -34,5 +45,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{8012DD70-A6D7-45C0-BC8E-DFFB48D86E08} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{04BA3E3C-6979-4792-B19E-C797AD607F42} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{649A377C-1E07-4105-B01F-7F1044D3356C} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Runtime.CompilerServices.Unsafe/pkg/System.Runtime.CompilerServices.Unsafe.pkgproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/pkg/System.Runtime.CompilerServices.Unsafe.pkgproj
@@ -3,9 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <PackageIndex Include="$(ProjectDir)\pkg\baseline\packageBaseline.1.1.json" />
-    <ProjectReference Include="..\src\System.Runtime.CompilerServices.Unsafe.ilproj">
+    <ProjectReference Include="..\ref\System.Runtime.CompilerServices.Unsafe.csproj">
       <SupportedFramework>net45;netcore45;wp8;wpa81;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
+    <ProjectReference Include="..\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/ref/Configurations.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/ref/Configurations.props
@@ -2,9 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
-      <!-- ilproj's cannot be built outside of Windows, https://github.com/dotnet/buildtools/issues/1301 -->
-      netstandard1.0-Windows_NT;
-      netstandard-Windows_NT;
+      netstandard1.0;
+      netstandard;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.cs
+++ b/src/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace System.Runtime.CompilerServices
+{
+    public static partial class Unsafe
+    {
+        public static ref T AddByteOffset<T>(ref T source, System.IntPtr byteOffset) { throw null; }
+        public static ref T Add<T>(ref T source, int elementOffset) { throw null; }
+        public static ref T Add<T>(ref T source, System.IntPtr elementOffset) { throw null; }
+        public static bool AreSame<T>(ref T left, ref T right) { throw null; }
+        public unsafe static void* AsPointer<T>(ref T value) { throw null; }
+        public unsafe static ref T AsRef<T>(void* source) { throw null; }
+        public static T As<T>(object o) where T : class { throw null; }
+        public static ref TTo As<TFrom, TTo>(ref TFrom source) { throw null; }
+        public static System.IntPtr ByteOffset<T>(ref T origin, ref T target) { throw null; }
+        public static void CopyBlock(ref byte destination, ref byte source, uint byteCount) { }
+        public unsafe static void CopyBlock(void* destination, void* source, uint byteCount) { }
+        public static void CopyBlockUnaligned(ref byte destination, ref byte source, uint byteCount) { }
+        public unsafe static void CopyBlockUnaligned(void* destination, void* source, uint byteCount) { }
+        public unsafe static void Copy<T>(void* destination, ref T source) { }
+        public unsafe static void Copy<T>(ref T destination, void* source) { }
+        public static void InitBlock(ref byte startAddress, byte value, uint byteCount) { }
+        public unsafe static void InitBlock(void* startAddress, byte value, uint byteCount) { }
+        public static void InitBlockUnaligned(ref byte startAddress, byte value, uint byteCount) { }
+        public unsafe static void InitBlockUnaligned(void* startAddress, byte value, uint byteCount) { }
+        public unsafe static T Read<T>(void* source) { throw null; }
+        public static int SizeOf<T>() { throw null; }
+        public static ref T SubtractByteOffset<T>(ref T source, System.IntPtr byteOffset) { throw null; }
+        public static ref T Subtract<T>(ref T source, int elementOffset) { throw null; }
+        public static ref T Subtract<T>(ref T source, System.IntPtr elementOffset) { throw null; }
+        public unsafe static void Write<T>(void* destination, T value) { }
+    }
+}

--- a/src/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.csproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.csproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectGuid>{649A377C-1E07-4105-B01F-7F1044D3356C}</ProjectGuid>
+    <CLSCompliant>false</CLSCompliant>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="System.Runtime.CompilerServices.Unsafe.cs" />
+    <Reference Include="System.Runtime" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.il
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.il
@@ -1,43 +1,39 @@
-// Metadata version: v4.0.30319
-.assembly extern System.Runtime
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:0:0:0
-}
+#include "coreassembly.h"
+
 .assembly System.Runtime.CompilerServices.Unsafe
 {
-  .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
-  .custom instance void [System.Runtime]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+  .custom instance void [CORE_ASSEMBLY]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [CORE_ASSEMBLY]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
                                                                                                                    63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 02 00 00 00 00 00 ) 
+  //  .custom instance void [CORE_ASSEMBLY]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [CORE_ASSEMBLY]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 02 00 00 00 00 00 ) 
 
-  .custom instance void [System.Runtime]System.Reflection.AssemblyFileVersionAttribute::.ctor(string) = ( 01 00 07 34 2E 30 2E 30 2E 30 00 00 )             // ...4.0.0.0..
-  .custom instance void [System.Runtime]System.Reflection.AssemblyInformationalVersionAttribute::.ctor(string) = ( 01 00 07 34 2E 30 2E 30 2E 30 00 00 )             // ...4.0.0.0..
-  .custom instance void [System.Runtime]System.Reflection.AssemblyTitleAttribute::.ctor(string) = ( 01 00 26 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..&System.Runtim
+  .custom instance void [CORE_ASSEMBLY]System.Reflection.AssemblyFileVersionAttribute::.ctor(string) = ( 01 00 07 34 2E 30 2E 30 2E 30 00 00 )             // ...4.0.0.0..
+  .custom instance void [CORE_ASSEMBLY]System.Reflection.AssemblyInformationalVersionAttribute::.ctor(string) = ( 01 00 07 34 2E 30 2E 30 2E 30 00 00 )             // ...4.0.0.0..
+  .custom instance void [CORE_ASSEMBLY]System.Reflection.AssemblyTitleAttribute::.ctor(string) = ( 01 00 26 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..&System.Runtim
                                                                                               65 2E 43 6F 6D 70 69 6C 65 72 53 65 72 76 69 63   // e.CompilerServic
                                                                                               65 73 2E 55 6E 73 61 66 65 00 00 )                // es.Unsafe..
-  .custom instance void [System.Runtime]System.Reflection.AssemblyDescriptionAttribute::.ctor(string) = ( 01 00 26 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..&System.Runtim
+  .custom instance void [CORE_ASSEMBLY]System.Reflection.AssemblyDescriptionAttribute::.ctor(string) = ( 01 00 26 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..&System.Runtim
                                                                                                     65 2E 43 6F 6D 70 69 6C 65 72 53 65 72 76 69 63   // e.CompilerServic
                                                                                                     65 73 2E 55 6E 73 61 66 65 00 00 )                // es.Unsafe..
-  .custom instance void [System.Runtime]System.Reflection.AssemblyMetadataAttribute::.ctor(string, string) = (
+  .custom instance void [CORE_ASSEMBLY]System.Reflection.AssemblyMetadataAttribute::.ctor(string, string) = (
     01 00 15 2e 4e 45 54 46 72 61 6d 65 77 6f 72 6b
     41 73 73 65 6d 62 6c 79 00 00 00
   ) // ".NETFrameworkAssembly", ""
-  .custom instance void [System.Runtime]System.Reflection.AssemblyMetadataAttribute::.ctor(string, string) = (
+  .custom instance void [CORE_ASSEMBLY]System.Reflection.AssemblyMetadataAttribute::.ctor(string, string) = (
     01 00 0b 53 65 72 76 69 63 65 61 62 6c 65 04 54
     72 75 65 00 00
   ) // "Serviceable", "True"
-  .custom instance void [System.Runtime]System.Reflection.AssemblyCopyrightAttribute::.ctor(string) = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+  .custom instance void [CORE_ASSEMBLY]System.Reflection.AssemblyCopyrightAttribute::.ctor(string) = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
                                                                                         43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
                                                                                         6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
                                                                                         64 2E 00 00 )                                     // d...
-  .custom instance void [System.Runtime]System.Reflection.AssemblyCompanyAttribute::.ctor(string) = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+  .custom instance void [CORE_ASSEMBLY]System.Reflection.AssemblyCompanyAttribute::.ctor(string) = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
                                                                                       70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
-  .custom instance void [System.Runtime]System.Reflection.AssemblyProductAttribute::.ctor(string) = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+  .custom instance void [CORE_ASSEMBLY]System.Reflection.AssemblyProductAttribute::.ctor(string) = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
                                                                                       4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
-  .custom instance void [System.Runtime]System.CLSCompliantAttribute::.ctor(bool) = (
+  .custom instance void [CORE_ASSEMBLY]System.CLSCompliantAttribute::.ctor(bool) = (
     01 00 00 00 00
   ) // false
   .hash algorithm 0x00008004
@@ -56,7 +52,7 @@
 // =============== CLASS MEMBERS DECLARATION ===================
 
 .class public abstract auto ansi sealed beforefieldinit System.Runtime.CompilerServices.Unsafe
-       extends [System.Runtime]System.Object
+       extends [CORE_ASSEMBLY]System.Object
 {
   .method public hidebysig static !!T Read<T>(void* source) cil managed aggressiveinlining
   {
@@ -332,9 +328,9 @@
 } // end of class System.Runtime.CompilerServices.Unsafe
 
 .class private auto ansi sealed beforefieldinit System.Runtime.Versioning.NonVersionableAttribute
-       extends [System.Runtime]System.Attribute
+       extends [CORE_ASSEMBLY]System.Attribute
 {
-  .custom instance void [System.Runtime]System.AttributeUsageAttribute::.ctor(valuetype [System.Runtime]System.AttributeTargets) = ( 01 00 6C 00 00 00 02 00 54 02 0D 41 6C 6C 6F 77   // ..l.....T..Allow
+  .custom instance void [CORE_ASSEMBLY]System.AttributeUsageAttribute::.ctor(valuetype [CORE_ASSEMBLY]System.AttributeTargets) = ( 01 00 6C 00 00 00 02 00 54 02 0D 41 6C 6C 6F 77   // ..l.....T..Allow
                                                                                                                                      4D 75 6C 74 69 70 6C 65 00 54 02 09 49 6E 68 65   // Multiple.T..Inhe
                                                                                                                                      72 69 74 65 64 00 )                               // rited.
   .method public hidebysig specialname rtspecialname 
@@ -342,7 +338,7 @@
   {
         .maxstack 1
         ldarg.0
-        call instance void [System.Runtime]System.Attribute::.ctor()
+        call instance void [CORE_ASSEMBLY]System.Attribute::.ctor()
         ret
   } // end of method NonVersionableAttribute::.ctor
 

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
@@ -4,11 +4,20 @@
   <PropertyGroup>
     <DocumentationFile>$(MSBuildThisFileDirectory)System.Runtime.CompilerServices.Unsafe.xml</DocumentationFile>
     <ProjectGuid>{04BA3E3C-6979-4792-B19E-C797AD607F42}</ProjectGuid>
+    <IlasmFlags>$(IlasmFlags) /INCLUDE=include\$(TargetGroup)</IlasmFlags>
+    <!-- cannot build on unix, but package as OS-agnostic -->
+    <PackageTargetRuntime />
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System.Runtime.CompilerServices.Unsafe.il" />
+    <Reference Include="System.Runtime" />
   </ItemGroup>
+  <Target Name="RunAfterCoreCompile" AfterTargets="CoreCompile">
+    <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition="'$(TargetsTriggeredByCompilation)' != ''" />
+  </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/src/include/netstandard/coreassembly.h
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/include/netstandard/coreassembly.h
@@ -1,0 +1,20 @@
+#define CORE_ASSEMBLY "System.Runtime"
+
+// Metadata version: v4.0.30319
+.assembly extern CORE_ASSEMBLY
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 4:0:0:0
+}
+
+/*  ILasm currently complains when seeing a [netstandard]System.Object
+    temporarily reference System.Runtime until we can get a fix in ilasm.
+#define CORE_ASSEMBLY "netstandard"
+
+// Metadata version: v4.0.30319
+.assembly extern CORE_ASSEMBLY
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+*/

--- a/src/System.Runtime.CompilerServices.Unsafe/src/include/netstandard1.0/coreassembly.h
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/include/netstandard1.0/coreassembly.h
@@ -1,0 +1,8 @@
+#define CORE_ASSEMBLY "System.Runtime"
+
+// Metadata version: v4.0.30319
+.assembly extern CORE_ASSEMBLY
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 4:0:0:0
+}


### PR DESCRIPTION
The workaround being used by our build system to only build these
packages on Windows was leaking into the packaging.

To fix that I overrode the packaging RID for Unsafe, since it was the
only thing that actually needed the filtering.

Then to fix Memory I added a reference assembly for unsafe and built
against that instead.

Eventually we'll be able to remove the filtering from unsafe but having
a reference assembly for this is general goodness.

I also tried to tackle cross-compiling Unsafe for netstandard.dll and hit
what appears to be a bug in `ilasm`.  It didn't like me claiming that 
System.Object was in netstandard, and instead tried to insist it was in 
mscorlib and added a reference to that to the output assembly.  I could 
change System.Object to some other type (eg: System.Attribute) and it 
was fine. @jkotas I think this is one of those hard-coding-the core assembly
bugs.  We should see if it's fixed by using a newer ilasm (@mellinoe is
working on that), if not we should hunt it down and fix it in coreclr.

/cc @mellinoe @ahsonkhan @weshaggard 