### PR TITLE
Change host to idnhost on curlhandler.

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -249,49 +249,13 @@ namespace System.Net.Http
                 }
 
                 EventSourceTrace("Url: {0}", requestUri);
-                if (requestUri.Host != requestUri.IdnHost)
-                {
-                    SetCurlOption(CURLoption.CURLOPT_URL, ReplaceHostWithIdnHost(requestUri.AbsoluteUri, requestUri.Host, requestUri.IdnHost));
-                }
-                else
-                {
-                    SetCurlOption(CURLoption.CURLOPT_URL, requestUri.AbsoluteUri);
-                }
+                string idnHost = requestUri.IdnHost;
+                string url = requestUri.Host == idnHost ? 
+                                requestUri.AbsoluteUri : 
+                                new UriBuilder(requestUri) { Host = idnHost }.Uri.AbsoluteUri;
 
+                SetCurlOption(CURLoption.CURLOPT_URL, url);
                 SetCurlOption(CURLoption.CURLOPT_PROTOCOLS, (long)(CurlProtocols.CURLPROTO_HTTP | CurlProtocols.CURLPROTO_HTTPS));
-            }
-
-            private unsafe string ReplaceHostWithIdnHost(string absoluteUri, string host, string idnHost)
-            {
-                int start = absoluteUri.IndexOf(host);
-                char[] result = new char[absoluteUri.Length - host.Length + idnHost.Length];
-
-                fixed (char* uPtr = result)
-                {
-                    int i = 0;
-                    int end = start;
-                    while (i < end)
-                    {
-                        uPtr[i] = absoluteUri[i];
-                        i++;
-                    }
-
-                    end += idnHost.Length;
-                    while (i < end)
-                    {
-                        uPtr[i] = idnHost[i - start];
-                        i++;
-                    }
-
-                    end += absoluteUri.Length - host.Length - start;
-                    while (i < end)
-                    {
-                        uPtr[i] = absoluteUri[i - idnHost.Length + host.Length];
-                        i++;
-                    }
-                }
-
-                return new string(result);
             }
 
             private static bool IsLinkLocal(Uri url, out long scopeId)


### PR DESCRIPTION
cc @stephentoub @davidsh @CIPop @geoffkizer @karelz 

Verified with the URL provided in the issue, and the request is successfully parsed by curl. May require setting up a unicode Url on azure for automated testing similar to the echo servers.

The other unicode chars in the IRI are percent-encoded while constructing the Uri in the Uri class, hence only handling the host part here.

fixes #11213 