### PR TITLE
Remove 'using Res = System.SR;' alias

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.cs
@@ -13,7 +13,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
-using Res = System.SR;
 
 namespace System
 {
@@ -193,7 +192,7 @@ namespace System.Data.Common
 
         internal static PlatformNotSupportedException DbTypeNotSupported(string dbType)
         {
-            PlatformNotSupportedException e = new PlatformNotSupportedException(Res.GetString(Res.SQL_DbTypeNotSupportedOnThisPlatform, dbType));
+            PlatformNotSupportedException e = new PlatformNotSupportedException(SR.GetString(SR.SQL_DbTypeNotSupportedOnThisPlatform, dbType));
             return e;
         }
         internal static InvalidCastException InvalidCast()
@@ -227,26 +226,26 @@ namespace System.Data.Common
 
         internal static InvalidOperationException MethodCalledTwice(string method)
         {
-            InvalidOperationException e = new InvalidOperationException(Res.GetString(Res.ADP_CalledTwice, method));
+            InvalidOperationException e = new InvalidOperationException(SR.GetString(SR.ADP_CalledTwice, method));
             return e;
         }
 
 
         internal static ArgumentException InvalidMultipartName(string property, string value)
         {
-            ArgumentException e = new ArgumentException(Res.GetString(Res.ADP_InvalidMultipartName, Res.GetString(property), value));
+            ArgumentException e = new ArgumentException(SR.GetString(SR.ADP_InvalidMultipartName, SR.GetString(property), value));
             return e;
         }
 
         internal static ArgumentException InvalidMultipartNameIncorrectUsageOfQuotes(string property, string value)
         {
-            ArgumentException e = new ArgumentException(Res.GetString(Res.ADP_InvalidMultipartNameQuoteUsage, Res.GetString(property), value));
+            ArgumentException e = new ArgumentException(SR.GetString(SR.ADP_InvalidMultipartNameQuoteUsage, SR.GetString(property), value));
             return e;
         }
 
         internal static ArgumentException InvalidMultipartNameToManyParts(string property, string value, int limit)
         {
-            ArgumentException e = new ArgumentException(Res.GetString(Res.ADP_InvalidMultipartNameToManyParts, Res.GetString(property), value, limit));
+            ArgumentException e = new ArgumentException(SR.GetString(SR.ADP_InvalidMultipartNameToManyParts, SR.GetString(property), value, limit));
             return e;
         }
 
@@ -285,7 +284,7 @@ namespace System.Data.Common
 
         internal static ArgumentOutOfRangeException InvalidEnumerationValue(Type type, int value)
         {
-            return ADP.ArgumentOutOfRange(Res.GetString(Res.ADP_InvalidEnumerationValue, type.Name, value.ToString(System.Globalization.CultureInfo.InvariantCulture)), type.Name);
+            return ADP.ArgumentOutOfRange(SR.GetString(SR.ADP_InvalidEnumerationValue, type.Name, value.ToString(System.Globalization.CultureInfo.InvariantCulture)), type.Name);
         }
 
 
@@ -368,19 +367,19 @@ namespace System.Data.Common
         //
         internal static ArgumentException ConnectionStringSyntax(int index)
         {
-            return Argument(Res.GetString(Res.ADP_ConnectionStringSyntax, index));
+            return Argument(SR.GetString(SR.ADP_ConnectionStringSyntax, index));
         }
         internal static ArgumentException KeywordNotSupported(string keyword)
         {
-            return Argument(Res.GetString(Res.ADP_KeywordNotSupported, keyword));
+            return Argument(SR.GetString(SR.ADP_KeywordNotSupported, keyword));
         }
         internal static ArgumentException InvalidMinMaxPoolSizeValues()
         {
-            return ADP.Argument(Res.GetString(Res.ADP_InvalidMinMaxPoolSizeValues));
+            return ADP.Argument(SR.GetString(SR.ADP_InvalidMinMaxPoolSizeValues));
         }
         internal static ArgumentException ConvertFailed(Type fromType, Type toType, Exception innerException)
         {
-            return ADP.Argument(Res.GetString(Res.SqlConvert_ConvertFailed, fromType.FullName, toType.FullName), innerException);
+            return ADP.Argument(SR.GetString(SR.SqlConvert_ConvertFailed, fromType.FullName, toType.FullName), innerException);
         }
 
 
@@ -389,7 +388,7 @@ namespace System.Data.Common
         //
         internal static InvalidOperationException NoConnectionString()
         {
-            return InvalidOperation(Res.GetString(Res.ADP_NoConnectionString));
+            return InvalidOperation(SR.GetString(SR.ADP_NoConnectionString));
         }
 
         internal static Exception MethodNotImplemented([CallerMemberName] string methodName = "")
@@ -403,17 +402,17 @@ namespace System.Data.Common
             {
                 case (ConnectionState.Closed):
                 case (ConnectionState.Connecting | ConnectionState.Broken):
-                    return Res.GetString(Res.ADP_ConnectionStateMsg_Closed);
+                    return SR.GetString(SR.ADP_ConnectionStateMsg_Closed);
                 case (ConnectionState.Connecting):
-                    return Res.GetString(Res.ADP_ConnectionStateMsg_Connecting);
+                    return SR.GetString(SR.ADP_ConnectionStateMsg_Connecting);
                 case (ConnectionState.Open):
-                    return Res.GetString(Res.ADP_ConnectionStateMsg_Open);
+                    return SR.GetString(SR.ADP_ConnectionStateMsg_Open);
                 case (ConnectionState.Open | ConnectionState.Executing):
-                    return Res.GetString(Res.ADP_ConnectionStateMsg_OpenExecuting);
+                    return SR.GetString(SR.ADP_ConnectionStateMsg_OpenExecuting);
                 case (ConnectionState.Open | ConnectionState.Fetching):
-                    return Res.GetString(Res.ADP_ConnectionStateMsg_OpenFetching);
+                    return SR.GetString(SR.ADP_ConnectionStateMsg_OpenFetching);
                 default:
-                    return Res.GetString(Res.ADP_ConnectionStateMsg, state.ToString());
+                    return SR.GetString(SR.ADP_ConnectionStateMsg, state.ToString());
             }
         }
 
@@ -427,21 +426,21 @@ namespace System.Data.Common
         }
         internal static Exception InvalidConnectionOptionValueLength(string key, int limit)
         {
-            return Argument(Res.GetString(Res.ADP_InvalidConnectionOptionValueLength, key, limit));
+            return Argument(SR.GetString(SR.ADP_InvalidConnectionOptionValueLength, key, limit));
         }
         internal static Exception InvalidConnectionOptionValue(string key, Exception inner)
         {
-            return Argument(Res.GetString(Res.ADP_InvalidConnectionOptionValue, key), inner);
+            return Argument(SR.GetString(SR.ADP_InvalidConnectionOptionValue, key), inner);
         }
         internal static Exception MissingConnectionOptionValue(string key, string requiredAdditionalKey)
         {
-            return Argument(Res.GetString(Res.ADP_MissingConnectionOptionValue, key, requiredAdditionalKey));
+            return Argument(SR.GetString(SR.ADP_MissingConnectionOptionValue, key, requiredAdditionalKey));
         }
 
 
         internal static Exception WrongType(Type got, Type expected)
         {
-            return Argument(Res.GetString(Res.SQL_WrongType, got.ToString(), expected.ToString()));
+            return Argument(SR.GetString(SR.SQL_WrongType, got.ToString(), expected.ToString()));
         }
 
 
@@ -450,12 +449,12 @@ namespace System.Data.Common
         //
         internal static Exception PooledOpenTimeout()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.ADP_PooledOpenTimeout));
+            return ADP.InvalidOperation(SR.GetString(SR.ADP_PooledOpenTimeout));
         }
 
         internal static Exception NonPooledOpenTimeout()
         {
-            return ADP.TimeoutException(Res.GetString(Res.ADP_NonPooledOpenTimeout));
+            return ADP.TimeoutException(SR.GetString(SR.ADP_NonPooledOpenTimeout));
         }
 
         //
@@ -463,31 +462,31 @@ namespace System.Data.Common
         //
         internal static ArgumentException CollectionRemoveInvalidObject(Type itemType, ICollection collection)
         {
-            return Argument(Res.GetString(Res.ADP_CollectionRemoveInvalidObject, itemType.Name, collection.GetType().Name));
+            return Argument(SR.GetString(SR.ADP_CollectionRemoveInvalidObject, itemType.Name, collection.GetType().Name));
         }
         internal static ArgumentNullException CollectionNullValue(string parameter, Type collection, Type itemType)
         {
-            return ArgumentNull(parameter, Res.GetString(Res.ADP_CollectionNullValue, collection.Name, itemType.Name));
+            return ArgumentNull(parameter, SR.GetString(SR.ADP_CollectionNullValue, collection.Name, itemType.Name));
         }
         internal static IndexOutOfRangeException CollectionIndexInt32(int index, Type collection, int count)
         {
-            return IndexOutOfRange(Res.GetString(Res.ADP_CollectionIndexInt32, index.ToString(CultureInfo.InvariantCulture), collection.Name, count.ToString(CultureInfo.InvariantCulture)));
+            return IndexOutOfRange(SR.GetString(SR.ADP_CollectionIndexInt32, index.ToString(CultureInfo.InvariantCulture), collection.Name, count.ToString(CultureInfo.InvariantCulture)));
         }
         internal static IndexOutOfRangeException CollectionIndexString(Type itemType, string propertyName, string propertyValue, Type collection)
         {
-            return IndexOutOfRange(Res.GetString(Res.ADP_CollectionIndexString, itemType.Name, propertyName, propertyValue, collection.Name));
+            return IndexOutOfRange(SR.GetString(SR.ADP_CollectionIndexString, itemType.Name, propertyName, propertyValue, collection.Name));
         }
         internal static InvalidCastException CollectionInvalidType(Type collection, Type itemType, object invalidValue)
         {
-            return InvalidCast(Res.GetString(Res.ADP_CollectionInvalidType, collection.Name, itemType.Name, invalidValue.GetType().Name));
+            return InvalidCast(SR.GetString(SR.ADP_CollectionInvalidType, collection.Name, itemType.Name, invalidValue.GetType().Name));
         }
         internal static ArgumentException ParametersIsNotParent(Type parameterType, ICollection collection)
         {
-            return Argument(Res.GetString(Res.ADP_CollectionIsNotParent, parameterType.Name, collection.GetType().Name));
+            return Argument(SR.GetString(SR.ADP_CollectionIsNotParent, parameterType.Name, collection.GetType().Name));
         }
         internal static ArgumentException ParametersIsParent(Type parameterType, ICollection collection)
         {
-            return Argument(Res.GetString(Res.ADP_CollectionIsNotParent, parameterType.Name, collection.GetType().Name));
+            return Argument(SR.GetString(SR.ADP_CollectionIsNotParent, parameterType.Name, collection.GetType().Name));
         }
 
         //
@@ -495,26 +494,26 @@ namespace System.Data.Common
         //
         internal static InvalidOperationException TransactionConnectionMismatch()
         {
-            return Provider(Res.GetString(Res.ADP_TransactionConnectionMismatch));
+            return Provider(SR.GetString(SR.ADP_TransactionConnectionMismatch));
         }
         internal static InvalidOperationException TransactionRequired(string method)
         {
-            return Provider(Res.GetString(Res.ADP_TransactionRequired, method));
+            return Provider(SR.GetString(SR.ADP_TransactionRequired, method));
         }
 
 
         internal static Exception CommandTextRequired(string method)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_CommandTextRequired, method));
+            return InvalidOperation(SR.GetString(SR.ADP_CommandTextRequired, method));
         }
 
         internal static InvalidOperationException ConnectionRequired(string method)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_ConnectionRequired, method));
+            return InvalidOperation(SR.GetString(SR.ADP_ConnectionRequired, method));
         }
         internal static InvalidOperationException OpenConnectionRequired(string method, ConnectionState state)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_OpenConnectionRequired, method, ADP.ConnectionStateMsg(state)));
+            return InvalidOperation(SR.GetString(SR.ADP_OpenConnectionRequired, method, ADP.ConnectionStateMsg(state)));
         }
 
         internal static Exception OpenReaderExists()
@@ -524,7 +523,7 @@ namespace System.Data.Common
 
         internal static Exception OpenReaderExists(Exception e)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_OpenReaderExists), e);
+            return InvalidOperation(SR.GetString(SR.ADP_OpenReaderExists), e);
         }
 
 
@@ -533,18 +532,18 @@ namespace System.Data.Common
         //
         internal static Exception NonSeqByteAccess(long badIndex, long currIndex, string method)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_NonSeqByteAccess, badIndex.ToString(CultureInfo.InvariantCulture), currIndex.ToString(CultureInfo.InvariantCulture), method));
+            return InvalidOperation(SR.GetString(SR.ADP_NonSeqByteAccess, badIndex.ToString(CultureInfo.InvariantCulture), currIndex.ToString(CultureInfo.InvariantCulture), method));
         }
 
         internal static Exception NegativeParameter(string parameterName)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_NegativeParameter, parameterName));
+            return InvalidOperation(SR.GetString(SR.ADP_NegativeParameter, parameterName));
         }
 
 
         internal static Exception InvalidSeekOrigin(string parameterName)
         {
-            return ArgumentOutOfRange(Res.GetString(Res.ADP_InvalidSeekOrigin), parameterName);
+            return ArgumentOutOfRange(SR.GetString(SR.ADP_InvalidSeekOrigin), parameterName);
         }
 
         //
@@ -552,12 +551,12 @@ namespace System.Data.Common
         //
         internal static Exception InvalidMetaDataValue()
         {
-            return ADP.Argument(Res.GetString(Res.ADP_InvalidMetaDataValue));
+            return ADP.Argument(SR.GetString(SR.ADP_InvalidMetaDataValue));
         }
 
         internal static InvalidOperationException NonSequentialColumnAccess(int badCol, int currCol)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_NonSequentialColumnAccess, badCol.ToString(CultureInfo.InvariantCulture), currCol.ToString(CultureInfo.InvariantCulture)));
+            return InvalidOperation(SR.GetString(SR.ADP_NonSequentialColumnAccess, badCol.ToString(CultureInfo.InvariantCulture), currCol.ToString(CultureInfo.InvariantCulture)));
         }
 
 
@@ -566,27 +565,27 @@ namespace System.Data.Common
         //
         internal static Exception InvalidCommandTimeout(int value, [CallerMemberName] string property = "")
         {
-            return Argument(Res.GetString(Res.ADP_InvalidCommandTimeout, value.ToString(CultureInfo.InvariantCulture)), property);
+            return Argument(SR.GetString(SR.ADP_InvalidCommandTimeout, value.ToString(CultureInfo.InvariantCulture)), property);
         }
         internal static Exception UninitializedParameterSize(int index, Type dataType)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_UninitializedParameterSize, index.ToString(CultureInfo.InvariantCulture), dataType.Name));
+            return InvalidOperation(SR.GetString(SR.ADP_UninitializedParameterSize, index.ToString(CultureInfo.InvariantCulture), dataType.Name));
         }
         internal static Exception PrepareParameterType(DbCommand cmd)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_PrepareParameterType, cmd.GetType().Name));
+            return InvalidOperation(SR.GetString(SR.ADP_PrepareParameterType, cmd.GetType().Name));
         }
         internal static Exception PrepareParameterSize(DbCommand cmd)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_PrepareParameterSize, cmd.GetType().Name));
+            return InvalidOperation(SR.GetString(SR.ADP_PrepareParameterSize, cmd.GetType().Name));
         }
         internal static Exception PrepareParameterScale(DbCommand cmd, string type)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_PrepareParameterScale, cmd.GetType().Name, type));
+            return InvalidOperation(SR.GetString(SR.ADP_PrepareParameterScale, cmd.GetType().Name, type));
         }
         internal static Exception MismatchedAsyncResult(string expectedMethod, string gotMethod)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_MismatchedAsyncResult, expectedMethod, gotMethod));
+            return InvalidOperation(SR.GetString(SR.ADP_MismatchedAsyncResult, expectedMethod, gotMethod));
         }
 
         //
@@ -594,23 +593,23 @@ namespace System.Data.Common
         //
         internal static Exception ConnectionIsDisabled(Exception InnerException)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_ConnectionIsDisabled), InnerException);
+            return InvalidOperation(SR.GetString(SR.ADP_ConnectionIsDisabled), InnerException);
         }
         internal static Exception ClosedConnectionError()
         {
-            return InvalidOperation(Res.GetString(Res.ADP_ClosedConnectionError));
+            return InvalidOperation(SR.GetString(SR.ADP_ClosedConnectionError));
         }
         internal static Exception ConnectionAlreadyOpen(ConnectionState state)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_ConnectionAlreadyOpen, ADP.ConnectionStateMsg(state)));
+            return InvalidOperation(SR.GetString(SR.ADP_ConnectionAlreadyOpen, ADP.ConnectionStateMsg(state)));
         }
         internal static Exception OpenConnectionPropertySet(string property, ConnectionState state)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_OpenConnectionPropertySet, property, ADP.ConnectionStateMsg(state)));
+            return InvalidOperation(SR.GetString(SR.ADP_OpenConnectionPropertySet, property, ADP.ConnectionStateMsg(state)));
         }
         internal static Exception EmptyDatabaseName()
         {
-            return Argument(Res.GetString(Res.ADP_EmptyDatabaseName));
+            return Argument(SR.GetString(SR.ADP_EmptyDatabaseName));
         }
 
         internal enum ConnectionError
@@ -622,7 +621,7 @@ namespace System.Data.Common
         }
         internal static Exception InternalConnectionError(ConnectionError internalError)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_InternalConnectionError, (int)internalError));
+            return InvalidOperation(SR.GetString(SR.ADP_InternalConnectionError, (int)internalError));
         }
 
         internal enum InternalErrorCode
@@ -666,17 +665,17 @@ namespace System.Data.Common
         }
         internal static Exception InternalError(InternalErrorCode internalError)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_InternalProviderError, (int)internalError));
+            return InvalidOperation(SR.GetString(SR.ADP_InternalProviderError, (int)internalError));
         }
 
         internal static Exception InvalidConnectRetryCountValue()
         {
-            return Argument(Res.GetString(Res.SQLCR_InvalidConnectRetryCountValue));
+            return Argument(SR.GetString(SR.SQLCR_InvalidConnectRetryCountValue));
         }
 
         internal static Exception InvalidConnectRetryIntervalValue()
         {
-            return Argument(Res.GetString(Res.SQLCR_InvalidConnectRetryIntervalValue));
+            return Argument(SR.GetString(SR.SQLCR_InvalidConnectRetryIntervalValue));
         }
 
         //
@@ -684,27 +683,27 @@ namespace System.Data.Common
         //
         internal static Exception DataReaderClosed([CallerMemberName] string method = "")
         {
-            return InvalidOperation(Res.GetString(Res.ADP_DataReaderClosed, method));
+            return InvalidOperation(SR.GetString(SR.ADP_DataReaderClosed, method));
         }
         internal static ArgumentOutOfRangeException InvalidSourceBufferIndex(int maxLen, long srcOffset, string parameterName)
         {
-            return ArgumentOutOfRange(Res.GetString(Res.ADP_InvalidSourceBufferIndex, maxLen.ToString(CultureInfo.InvariantCulture), srcOffset.ToString(CultureInfo.InvariantCulture)), parameterName);
+            return ArgumentOutOfRange(SR.GetString(SR.ADP_InvalidSourceBufferIndex, maxLen.ToString(CultureInfo.InvariantCulture), srcOffset.ToString(CultureInfo.InvariantCulture)), parameterName);
         }
         internal static ArgumentOutOfRangeException InvalidDestinationBufferIndex(int maxLen, int dstOffset, string parameterName)
         {
-            return ArgumentOutOfRange(Res.GetString(Res.ADP_InvalidDestinationBufferIndex, maxLen.ToString(CultureInfo.InvariantCulture), dstOffset.ToString(CultureInfo.InvariantCulture)), parameterName);
+            return ArgumentOutOfRange(SR.GetString(SR.ADP_InvalidDestinationBufferIndex, maxLen.ToString(CultureInfo.InvariantCulture), dstOffset.ToString(CultureInfo.InvariantCulture)), parameterName);
         }
         internal static IndexOutOfRangeException InvalidBufferSizeOrIndex(int numBytes, int bufferIndex)
         {
-            return IndexOutOfRange(Res.GetString(Res.SQL_InvalidBufferSizeOrIndex, numBytes.ToString(CultureInfo.InvariantCulture), bufferIndex.ToString(CultureInfo.InvariantCulture)));
+            return IndexOutOfRange(SR.GetString(SR.SQL_InvalidBufferSizeOrIndex, numBytes.ToString(CultureInfo.InvariantCulture), bufferIndex.ToString(CultureInfo.InvariantCulture)));
         }
         internal static Exception InvalidDataLength(long length)
         {
-            return IndexOutOfRange(Res.GetString(Res.SQL_InvalidDataLength, length.ToString(CultureInfo.InvariantCulture)));
+            return IndexOutOfRange(SR.GetString(SR.SQL_InvalidDataLength, length.ToString(CultureInfo.InvariantCulture)));
         }
         internal static InvalidOperationException AsyncOperationPending()
         {
-            return InvalidOperation(Res.GetString(Res.ADP_PendingAsyncOperation));
+            return InvalidOperation(SR.GetString(SR.ADP_PendingAsyncOperation));
         }
 
         //
@@ -712,45 +711,45 @@ namespace System.Data.Common
         //
         internal static Exception StreamClosed([CallerMemberName] string method = "")
         {
-            return InvalidOperation(Res.GetString(Res.ADP_StreamClosed, method));
+            return InvalidOperation(SR.GetString(SR.ADP_StreamClosed, method));
         }
         internal static IOException ErrorReadingFromStream(Exception internalException)
         {
-            return IO(Res.GetString(Res.SqlMisc_StreamErrorMessage), internalException);
+            return IO(SR.GetString(SR.SqlMisc_StreamErrorMessage), internalException);
         }
 
         internal static ArgumentException InvalidDataType(string typeName)
         {
-            return Argument(Res.GetString(Res.ADP_InvalidDataType, typeName));
+            return Argument(SR.GetString(SR.ADP_InvalidDataType, typeName));
         }
         internal static ArgumentException UnknownDataType(Type dataType)
         {
-            return Argument(Res.GetString(Res.ADP_UnknownDataType, dataType.FullName));
+            return Argument(SR.GetString(SR.ADP_UnknownDataType, dataType.FullName));
         }
         internal static ArgumentException DbTypeNotSupported(System.Data.DbType type, Type enumtype)
         {
-            return Argument(Res.GetString(Res.ADP_DbTypeNotSupported, type.ToString(), enumtype.Name));
+            return Argument(SR.GetString(SR.ADP_DbTypeNotSupported, type.ToString(), enumtype.Name));
         }
         internal static ArgumentException InvalidOffsetValue(int value)
         {
-            return Argument(Res.GetString(Res.ADP_InvalidOffsetValue, value.ToString(CultureInfo.InvariantCulture)));
+            return Argument(SR.GetString(SR.ADP_InvalidOffsetValue, value.ToString(CultureInfo.InvariantCulture)));
         }
         internal static ArgumentException InvalidSizeValue(int value)
         {
-            return Argument(Res.GetString(Res.ADP_InvalidSizeValue, value.ToString(CultureInfo.InvariantCulture)));
+            return Argument(SR.GetString(SR.ADP_InvalidSizeValue, value.ToString(CultureInfo.InvariantCulture)));
         }
         internal static ArgumentException ParameterValueOutOfRange(Decimal value)
         {
-            return ADP.Argument(Res.GetString(Res.ADP_ParameterValueOutOfRange, value.ToString((IFormatProvider)null)));
+            return ADP.Argument(SR.GetString(SR.ADP_ParameterValueOutOfRange, value.ToString((IFormatProvider)null)));
         }
         internal static ArgumentException ParameterValueOutOfRange(SqlDecimal value)
         {
-            return ADP.Argument(Res.GetString(Res.ADP_ParameterValueOutOfRange, value.ToString()));
+            return ADP.Argument(SR.GetString(SR.ADP_ParameterValueOutOfRange, value.ToString()));
         }
 
         internal static ArgumentException VersionDoesNotSupportDataType(string typeName)
         {
-            return Argument(Res.GetString(Res.ADP_VersionDoesNotSupportDataType, typeName));
+            return Argument(SR.GetString(SR.ADP_VersionDoesNotSupportDataType, typeName));
         }
         internal static Exception ParameterConversionFailed(object value, Type destType, Exception inner)
         {
@@ -758,7 +757,7 @@ namespace System.Data.Common
             Debug.Assert(null != inner, "null inner on conversion failure");
 
             Exception e;
-            string message = Res.GetString(Res.ADP_ParameterConversionFailed, value.GetType().Name, destType.Name);
+            string message = SR.GetString(SR.ADP_ParameterConversionFailed, value.GetType().Name, destType.Name);
             if (inner is ArgumentException)
             {
                 e = new ArgumentException(message, inner);
@@ -807,11 +806,11 @@ namespace System.Data.Common
         //
         internal static Exception ParallelTransactionsNotSupported(DbConnection obj)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_ParallelTransactionsNotSupported, obj.GetType().Name));
+            return InvalidOperation(SR.GetString(SR.ADP_ParallelTransactionsNotSupported, obj.GetType().Name));
         }
         internal static Exception TransactionZombied(DbTransaction obj)
         {
-            return InvalidOperation(Res.GetString(Res.ADP_TransactionZombied, obj.GetType().Name));
+            return InvalidOperation(SR.GetString(SR.ADP_TransactionZombied, obj.GetType().Name));
         }
 
 
@@ -1077,10 +1076,10 @@ namespace System.Data.Common
         }
 
 
-        internal static readonly string[] AzureSqlServerEndpoints = {Res.GetString(Res.AZURESQL_GenericEndpoint),
-                                                                     Res.GetString(Res.AZURESQL_GermanEndpoint),
-                                                                     Res.GetString(Res.AZURESQL_UsGovEndpoint),
-                                                                     Res.GetString(Res.AZURESQL_ChinaEndpoint)};
+        internal static readonly string[] AzureSqlServerEndpoints = {SR.GetString(SR.AZURESQL_GenericEndpoint),
+                                                                     SR.GetString(SR.AZURESQL_GermanEndpoint),
+                                                                     SR.GetString(SR.AZURESQL_UsGovEndpoint),
+                                                                     SR.GetString(SR.AZURESQL_ChinaEndpoint)};
 
         // This method assumes dataSource parameter is in TCP connection string format.
         internal static bool IsAzureSqlServerEndpoint(string dataSource)

--- a/src/System.Data.SqlClient/src/System/Data/DataException.cs
+++ b/src/System.Data.SqlClient/src/System/Data/DataException.cs
@@ -6,8 +6,6 @@
 
 //------------------------------------------------------------------------------
 
-using Res = System.SR;
-
 
 namespace System.Data
 {
@@ -44,7 +42,7 @@ namespace System.Data
         }
         public static Exception InvalidOffsetLength()
         {
-            return _Argument(Res.GetString(Res.Data_InvalidOffsetLength));
+            return _Argument(SR.GetString(SR.Data_InvalidOffsetLength));
         }
     }// ExceptionBuilder
 }

--- a/src/System.Data.SqlClient/src/System/Data/OperationAbortedException.cs
+++ b/src/System.Data.SqlClient/src/System/Data/OperationAbortedException.cs
@@ -7,7 +7,6 @@
 //------------------------------------------------------------------------------
 
 using System.Runtime.Serialization;
-using Res = System.SR;
 
 namespace System.Data
 {
@@ -28,11 +27,11 @@ namespace System.Data
             OperationAbortedException e;
             if (inner == null)
             {
-                e = new OperationAbortedException(Res.GetString(Res.ADP_OperationAborted), null);
+                e = new OperationAbortedException(SR.GetString(SR.ADP_OperationAborted), null);
             }
             else
             {
-                e = new OperationAbortedException(Res.GetString(Res.ADP_OperationAbortedExceptionMessage), inner);
+                e = new OperationAbortedException(SR.GetString(SR.ADP_OperationAbortedExceptionMessage), inner);
             }
             return e;
         }

--- a/src/System.Data.SqlClient/src/System/Data/Sql/SqlMetaData.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Sql/SqlMetaData.cs
@@ -15,8 +15,6 @@ using System.Data.SqlClient;
 
 namespace Microsoft.SqlServer.Server
 {
-    using Res = System.SR;
-
     // class SqlMetaData
     //   Simple immutable implementation of the a metadata-holding class.  Only
     //    complexities are:
@@ -463,49 +461,49 @@ namespace Microsoft.SqlServer.Server
             if (SqlDbType.Char == dbType)
             {
                 if (maxLength > x_lServerMaxANSI || maxLength < 0)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
+                    throw ADP.Argument(SR.GetString(SR.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
                 lLocale = Locale.GetCurrentCultureLcid();
             }
             else if (SqlDbType.VarChar == dbType)
             {
                 if ((maxLength > x_lServerMaxANSI || maxLength < 0) && maxLength != Max)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
+                    throw ADP.Argument(SR.GetString(SR.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
                 lLocale = Locale.GetCurrentCultureLcid();
             }
             else if (SqlDbType.NChar == dbType)
             {
                 if (maxLength > x_lServerMaxUnicode || maxLength < 0)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
+                    throw ADP.Argument(SR.GetString(SR.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
                 lLocale = Locale.GetCurrentCultureLcid();
             }
             else if (SqlDbType.NVarChar == dbType)
             {
                 if ((maxLength > x_lServerMaxUnicode || maxLength < 0) && maxLength != Max)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
+                    throw ADP.Argument(SR.GetString(SR.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
                 lLocale = Locale.GetCurrentCultureLcid();
             }
             else if (SqlDbType.NText == dbType || SqlDbType.Text == dbType)
             {
                 // old-style lobs only allowed with Max length
                 if (SqlMetaData.Max != maxLength)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
+                    throw ADP.Argument(SR.GetString(SR.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
                 lLocale = Locale.GetCurrentCultureLcid();
             }
             else if (SqlDbType.Binary == dbType)
             {
                 if (maxLength > x_lServerMaxBinary || maxLength < 0)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
+                    throw ADP.Argument(SR.GetString(SR.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
             }
             else if (SqlDbType.VarBinary == dbType)
             {
                 if ((maxLength > x_lServerMaxBinary || maxLength < 0) && maxLength != Max)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
+                    throw ADP.Argument(SR.GetString(SR.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
             }
             else if (SqlDbType.Image == dbType)
             {
                 // old-style lobs only allowed with Max length
                 if (SqlMetaData.Max != maxLength)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
+                    throw ADP.Argument(SR.GetString(SR.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
             }
             else
                 throw SQL.InvalidSqlDbTypeForConstructor(dbType);
@@ -540,28 +538,28 @@ namespace Microsoft.SqlServer.Server
             if (SqlDbType.Char == dbType)
             {
                 if (maxLength > x_lServerMaxANSI || maxLength < 0)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
+                    throw ADP.Argument(SR.GetString(SR.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
             }
             else if (SqlDbType.VarChar == dbType)
             {
                 if ((maxLength > x_lServerMaxANSI || maxLength < 0) && maxLength != Max)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
+                    throw ADP.Argument(SR.GetString(SR.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
             }
             else if (SqlDbType.NChar == dbType)
             {
                 if (maxLength > x_lServerMaxUnicode || maxLength < 0)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
+                    throw ADP.Argument(SR.GetString(SR.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
             }
             else if (SqlDbType.NVarChar == dbType)
             {
                 if ((maxLength > x_lServerMaxUnicode || maxLength < 0) && maxLength != Max)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
+                    throw ADP.Argument(SR.GetString(SR.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
             }
             else if (SqlDbType.NText == dbType || SqlDbType.Text == dbType)
             {
                 // old-style lobs only allowed with Max length
                 if (SqlMetaData.Max != maxLength)
-                    throw ADP.Argument(Res.GetString(Res.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
+                    throw ADP.Argument(SR.GetString(SR.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
             }
             else
                 throw SQL.InvalidSqlDbTypeForConstructor(dbType);

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.cs
@@ -11,7 +11,6 @@ using System.Globalization;
 using System.Data.SqlClient;
 using System.Text;
 using System.Diagnostics;
-using Res = System.SR;
 
 
 namespace System.Data
@@ -73,7 +72,7 @@ namespace System.Data
                             {
                                 SNINativeMethodWrapper.SNI_Error sniError;
                                 SNINativeMethodWrapper.SNIGetLastError(out sniError);
-                                throw CreateLocalDBException(errorMessage: Res.GetString("LocalDB_FailedGetDLLHandle"), sniError: (int)sniError.sniError);
+                                throw CreateLocalDBException(errorMessage: SR.GetString("LocalDB_FailedGetDLLHandle"), sniError: (int)sniError.sniError);
                             }
                         }
                     }
@@ -110,7 +109,7 @@ namespace System.Data
                             if (functionAddr == IntPtr.Zero)
                             {
                                 int hResult = Marshal.GetLastWin32Error();
-                                throw CreateLocalDBException(errorMessage: Res.GetString("LocalDB_MethodNotFound"));
+                                throw CreateLocalDBException(errorMessage: SR.GetString("LocalDB_MethodNotFound"));
                             }
                             s_localDBFormatMessage = Marshal.GetDelegateForFunctionPointer<LocalDBFormatMessageDelegate>(functionAddr);
                         }
@@ -153,12 +152,12 @@ namespace System.Data
                     if (hResult >= 0)
                         return buffer.ToString();
                     else
-                        return string.Format(CultureInfo.CurrentCulture, "{0} (0x{1:X}).", Res.GetString("LocalDB_UnobtainableMessage"), hResult);
+                        return string.Format(CultureInfo.CurrentCulture, "{0} (0x{1:X}).", SR.GetString("LocalDB_UnobtainableMessage"), hResult);
                 }
             }
             catch (SqlException exc)
             {
-                return string.Format(CultureInfo.CurrentCulture, "{0} ({1}).", Res.GetString("LocalDB_UnobtainableMessage"), exc.Message);
+                return string.Format(CultureInfo.CurrentCulture, "{0} ({1}).", SR.GetString("LocalDB_UnobtainableMessage"), exc.Message);
             }
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
@@ -17,8 +17,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 
-using Res = System.SR;
-
 
 namespace System.Data.SqlClient
 {
@@ -414,7 +412,7 @@ namespace System.Data.SqlClient
             string[] parts;
             try
             {
-                parts = MultipartIdentifier.ParseMultipartIdentifier(this.DestinationTableName, "[\"", "]\"", Res.SQL_BulkCopyDestinationTableName, true);
+                parts = MultipartIdentifier.ParseMultipartIdentifier(this.DestinationTableName, "[\"", "]\"", SR.SQL_BulkCopyDestinationTableName, true);
             }
             catch (Exception e)
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -20,8 +20,6 @@ using Microsoft.SqlServer.Server;
 
 namespace System.Data.SqlClient
 {
-    using Res = System.SR;
-
     internal abstract class DataFeed
     {
     }
@@ -1625,7 +1623,7 @@ namespace System.Data.SqlClient
             {
                 string errorMsg;
                 {
-                    errorMsg = Res.SQL_TypeName;
+                    errorMsg = SR.SQL_TypeName;
                 }
                 return MultipartIdentifier.ParseMultipartIdentifier(typeName, "[\"", "]\"", '.', 3, true, errorMsg, true);
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
@@ -17,8 +17,6 @@ using System.Threading.Tasks;
 
 namespace System.Data.SqlClient
 {
-    using Res = System.SR;
-
     internal static class AsyncHelper
     {
         internal static Task CreateContinuationTask(Task task, Action onSuccess, SqlInternalConnectionTds connectionToDoom = null, Action<Exception> onFailure = null)
@@ -170,56 +168,56 @@ namespace System.Data.SqlClient
         }
         internal static Exception InvalidPacketSize()
         {
-            return ADP.ArgumentOutOfRange(Res.GetString(Res.SQL_InvalidTDSPacketSize));
+            return ADP.ArgumentOutOfRange(SR.GetString(SR.SQL_InvalidTDSPacketSize));
         }
         internal static Exception InvalidPacketSizeValue()
         {
-            return ADP.Argument(Res.GetString(Res.SQL_InvalidPacketSizeValue));
+            return ADP.Argument(SR.GetString(SR.SQL_InvalidPacketSizeValue));
         }
         internal static Exception InvalidSSPIPacketSize()
         {
-            return ADP.Argument(Res.GetString(Res.SQL_InvalidSSPIPacketSize));
+            return ADP.Argument(SR.GetString(SR.SQL_InvalidSSPIPacketSize));
         }
         internal static Exception NullEmptyTransactionName()
         {
-            return ADP.Argument(Res.GetString(Res.SQL_NullEmptyTransactionName));
+            return ADP.Argument(SR.GetString(SR.SQL_NullEmptyTransactionName));
         }
         internal static Exception UserInstanceFailoverNotCompatible()
         {
-            return ADP.Argument(Res.GetString(Res.SQL_UserInstanceFailoverNotCompatible));
+            return ADP.Argument(SR.GetString(SR.SQL_UserInstanceFailoverNotCompatible));
         }
         internal static Exception InvalidSQLServerVersionUnknown()
         {
-            return ADP.DataAdapter(Res.GetString(Res.SQL_InvalidSQLServerVersionUnknown));
+            return ADP.DataAdapter(SR.GetString(SR.SQL_InvalidSQLServerVersionUnknown));
         }
         internal static Exception SynchronousCallMayNotPend()
         {
-            return new Exception(Res.GetString(Res.Sql_InternalError));
+            return new Exception(SR.GetString(SR.Sql_InternalError));
         }
         internal static Exception ConnectionLockedForBcpEvent()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_ConnectionLockedForBcpEvent));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_ConnectionLockedForBcpEvent));
         }
         internal static Exception InstanceFailure()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_InstanceFailure));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_InstanceFailure));
         }
         internal static Exception InvalidPartnerConfiguration(string server, string database)
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_InvalidPartnerConfiguration, server, database));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_InvalidPartnerConfiguration, server, database));
         }
         internal static Exception MARSUnspportedOnConnection()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_MarsUnsupportedOnConnection));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_MarsUnsupportedOnConnection));
         }
 
         internal static Exception CannotModifyPropertyAsyncOperationInProgress([CallerMemberName] string property = "")
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_CannotModifyPropertyAsyncOperationInProgress, property));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_CannotModifyPropertyAsyncOperationInProgress, property));
         }
         internal static Exception NonLocalSSEInstance()
         {
-            return ADP.NotSupported(Res.GetString(Res.SQL_NonLocalSSEInstance));
+            return ADP.NotSupported(SR.GetString(SR.SQL_NonLocalSSEInstance));
         }
         //
         // SQL.DataCommand
@@ -227,7 +225,7 @@ namespace System.Data.SqlClient
 
         internal static ArgumentOutOfRangeException NotSupportedEnumerationValue(Type type, int value)
         {
-            return ADP.ArgumentOutOfRange(Res.GetString(Res.SQL_NotSupportedEnumerationValue, type.Name, value.ToString(System.Globalization.CultureInfo.InvariantCulture)), type.Name);
+            return ADP.ArgumentOutOfRange(SR.GetString(SR.SQL_NotSupportedEnumerationValue, type.Name, value.ToString(System.Globalization.CultureInfo.InvariantCulture)), type.Name);
         }
 
         internal static ArgumentOutOfRangeException NotSupportedCommandType(CommandType value)
@@ -273,19 +271,19 @@ namespace System.Data.SqlClient
 
         internal static Exception OperationCancelled()
         {
-            Exception exception = ADP.InvalidOperation(Res.GetString(Res.SQL_OperationCancelled));
+            Exception exception = ADP.InvalidOperation(SR.GetString(SR.SQL_OperationCancelled));
             return exception;
         }
 
         internal static Exception PendingBeginXXXExists()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_PendingBeginXXXExists));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_PendingBeginXXXExists));
         }
 
 
         internal static Exception NonXmlResult()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_NonXmlResult));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_NonXmlResult));
         }
 
         //
@@ -293,23 +291,23 @@ namespace System.Data.SqlClient
         //
         internal static Exception InvalidParameterTypeNameFormat()
         {
-            return ADP.Argument(Res.GetString(Res.SQL_InvalidParameterTypeNameFormat));
+            return ADP.Argument(SR.GetString(SR.SQL_InvalidParameterTypeNameFormat));
         }
         internal static Exception InvalidParameterNameLength(string value)
         {
-            return ADP.Argument(Res.GetString(Res.SQL_InvalidParameterNameLength, value));
+            return ADP.Argument(SR.GetString(SR.SQL_InvalidParameterNameLength, value));
         }
         internal static Exception PrecisionValueOutOfRange(byte precision)
         {
-            return ADP.Argument(Res.GetString(Res.SQL_PrecisionValueOutOfRange, precision.ToString(CultureInfo.InvariantCulture)));
+            return ADP.Argument(SR.GetString(SR.SQL_PrecisionValueOutOfRange, precision.ToString(CultureInfo.InvariantCulture)));
         }
         internal static Exception ScaleValueOutOfRange(byte scale)
         {
-            return ADP.Argument(Res.GetString(Res.SQL_ScaleValueOutOfRange, scale.ToString(CultureInfo.InvariantCulture)));
+            return ADP.Argument(SR.GetString(SR.SQL_ScaleValueOutOfRange, scale.ToString(CultureInfo.InvariantCulture)));
         }
         internal static Exception TimeScaleValueOutOfRange(byte scale)
         {
-            return ADP.Argument(Res.GetString(Res.SQL_TimeScaleValueOutOfRange, scale.ToString(CultureInfo.InvariantCulture)));
+            return ADP.Argument(SR.GetString(SR.SQL_TimeScaleValueOutOfRange, scale.ToString(CultureInfo.InvariantCulture)));
         }
         internal static Exception InvalidSqlDbType(SqlDbType value)
         {
@@ -317,33 +315,33 @@ namespace System.Data.SqlClient
         }
         internal static Exception UnsupportedTVPOutputParameter(ParameterDirection direction, string paramName)
         {
-            return ADP.NotSupported(Res.GetString(Res.SqlParameter_UnsupportedTVPOutputParameter,
+            return ADP.NotSupported(SR.GetString(SR.SqlParameter_UnsupportedTVPOutputParameter,
                         direction.ToString(), paramName));
         }
         internal static Exception DBNullNotSupportedForTVPValues(string paramName)
         {
-            return ADP.NotSupported(Res.GetString(Res.SqlParameter_DBNullNotSupportedForTVP, paramName));
+            return ADP.NotSupported(SR.GetString(SR.SqlParameter_DBNullNotSupportedForTVP, paramName));
         }
         internal static Exception UnexpectedTypeNameForNonStructParams(string paramName)
         {
-            return ADP.NotSupported(Res.GetString(Res.SqlParameter_UnexpectedTypeNameForNonStruct, paramName));
+            return ADP.NotSupported(SR.GetString(SR.SqlParameter_UnexpectedTypeNameForNonStruct, paramName));
         }
         internal static Exception ParameterInvalidVariant(string paramName)
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_ParameterInvalidVariant, paramName));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_ParameterInvalidVariant, paramName));
         }
 
         internal static Exception MustSetTypeNameForParam(string paramType, string paramName)
         {
-            return ADP.Argument(Res.GetString(Res.SQL_ParameterTypeNameRequired, paramType, paramName));
+            return ADP.Argument(SR.GetString(SR.SQL_ParameterTypeNameRequired, paramType, paramName));
         }
         internal static Exception EnumeratedRecordMetaDataChanged(string fieldName, int recordNumber)
         {
-            return ADP.Argument(Res.GetString(Res.SQL_EnumeratedRecordMetaDataChanged, fieldName, recordNumber));
+            return ADP.Argument(SR.GetString(SR.SQL_EnumeratedRecordMetaDataChanged, fieldName, recordNumber));
         }
         internal static Exception EnumeratedRecordFieldCountChanged(int recordNumber)
         {
-            return ADP.Argument(Res.GetString(Res.SQL_EnumeratedRecordFieldCountChanged, recordNumber));
+            return ADP.Argument(SR.GetString(SR.SQL_EnumeratedRecordFieldCountChanged, recordNumber));
         }
 
         //
@@ -355,27 +353,27 @@ namespace System.Data.SqlClient
         //
         internal static Exception InvalidTDSVersion()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_InvalidTDSVersion));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_InvalidTDSVersion));
         }
         internal static Exception ParsingError()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_ParsingError));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_ParsingError));
         }
         internal static Exception MoneyOverflow(string moneyValue)
         {
-            return ADP.Overflow(Res.GetString(Res.SQL_MoneyOverflow, moneyValue));
+            return ADP.Overflow(SR.GetString(SR.SQL_MoneyOverflow, moneyValue));
         }
         internal static Exception SmallDateTimeOverflow(string datetime)
         {
-            return ADP.Overflow(Res.GetString(Res.SQL_SmallDateTimeOverflow, datetime));
+            return ADP.Overflow(SR.GetString(SR.SQL_SmallDateTimeOverflow, datetime));
         }
         internal static Exception SNIPacketAllocationFailure()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_SNIPacketAllocationFailure));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_SNIPacketAllocationFailure));
         }
         internal static Exception TimeOverflow(string time)
         {
-            return ADP.Overflow(Res.GetString(Res.SQL_TimeOverflow, time));
+            return ADP.Overflow(SR.GetString(SR.SQL_TimeOverflow, time));
         }
 
         //
@@ -383,43 +381,43 @@ namespace System.Data.SqlClient
         //
         internal static Exception InvalidRead()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_InvalidRead));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_InvalidRead));
         }
 
         internal static Exception NonBlobColumn(string columnName)
         {
-            return ADP.InvalidCast(Res.GetString(Res.SQL_NonBlobColumn, columnName));
+            return ADP.InvalidCast(SR.GetString(SR.SQL_NonBlobColumn, columnName));
         }
 
         internal static Exception NonCharColumn(string columnName)
         {
-            return ADP.InvalidCast(Res.GetString(Res.SQL_NonCharColumn, columnName));
+            return ADP.InvalidCast(SR.GetString(SR.SQL_NonCharColumn, columnName));
         }
 
         internal static Exception StreamNotSupportOnColumnType(string columnName)
         {
-            return ADP.InvalidCast(Res.GetString(Res.SQL_StreamNotSupportOnColumnType, columnName));
+            return ADP.InvalidCast(SR.GetString(SR.SQL_StreamNotSupportOnColumnType, columnName));
         }
 
         internal static Exception TextReaderNotSupportOnColumnType(string columnName)
         {
-            return ADP.InvalidCast(Res.GetString(Res.SQL_TextReaderNotSupportOnColumnType, columnName));
+            return ADP.InvalidCast(SR.GetString(SR.SQL_TextReaderNotSupportOnColumnType, columnName));
         }
 
         internal static Exception XmlReaderNotSupportOnColumnType(string columnName)
         {
-            return ADP.InvalidCast(Res.GetString(Res.SQL_XmlReaderNotSupportOnColumnType, columnName));
+            return ADP.InvalidCast(SR.GetString(SR.SQL_XmlReaderNotSupportOnColumnType, columnName));
         }
 
 
         internal static Exception InvalidSqlDbTypeForConstructor(SqlDbType type)
         {
-            return ADP.Argument(Res.GetString(Res.SqlMetaData_InvalidSqlDbTypeForConstructorFormat, type.ToString()));
+            return ADP.Argument(SR.GetString(SR.SqlMetaData_InvalidSqlDbTypeForConstructorFormat, type.ToString()));
         }
 
         internal static Exception NameTooLong(string parameterName)
         {
-            return ADP.Argument(Res.GetString(Res.SqlMetaData_NameTooLong), parameterName);
+            return ADP.Argument(SR.GetString(SR.SqlMetaData_NameTooLong), parameterName);
         }
 
         internal static Exception InvalidSortOrder(SortOrder order)
@@ -429,32 +427,32 @@ namespace System.Data.SqlClient
 
         internal static Exception MustSpecifyBothSortOrderAndOrdinal(SortOrder order, int ordinal)
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SqlMetaData_SpecifyBothSortOrderAndOrdinal, order.ToString(), ordinal));
+            return ADP.InvalidOperation(SR.GetString(SR.SqlMetaData_SpecifyBothSortOrderAndOrdinal, order.ToString(), ordinal));
         }
 
         internal static Exception UnsupportedColumnTypeForSqlProvider(string columnName, string typeName)
         {
-            return ADP.Argument(Res.GetString(Res.SqlProvider_InvalidDataColumnType, columnName, typeName));
+            return ADP.Argument(SR.GetString(SR.SqlProvider_InvalidDataColumnType, columnName, typeName));
         }
         internal static Exception NotEnoughColumnsInStructuredType()
         {
-            return ADP.Argument(Res.GetString(Res.SqlProvider_NotEnoughColumnsInStructuredType));
+            return ADP.Argument(SR.GetString(SR.SqlProvider_NotEnoughColumnsInStructuredType));
         }
         internal static Exception DuplicateSortOrdinal(int sortOrdinal)
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SqlProvider_DuplicateSortOrdinal, sortOrdinal));
+            return ADP.InvalidOperation(SR.GetString(SR.SqlProvider_DuplicateSortOrdinal, sortOrdinal));
         }
         internal static Exception MissingSortOrdinal(int sortOrdinal)
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SqlProvider_MissingSortOrdinal, sortOrdinal));
+            return ADP.InvalidOperation(SR.GetString(SR.SqlProvider_MissingSortOrdinal, sortOrdinal));
         }
         internal static Exception SortOrdinalGreaterThanFieldCount(int columnOrdinal, int sortOrdinal)
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SqlProvider_SortOrdinalGreaterThanFieldCount, sortOrdinal, columnOrdinal));
+            return ADP.InvalidOperation(SR.GetString(SR.SqlProvider_SortOrdinalGreaterThanFieldCount, sortOrdinal, columnOrdinal));
         }
         internal static Exception IEnumerableOfSqlDataRecordHasNoRows()
         {
-            return ADP.Argument(Res.GetString(Res.IEnumerableOfSqlDataRecordHasNoRows));
+            return ADP.Argument(SR.GetString(SR.IEnumerableOfSqlDataRecordHasNoRows));
         }
 
 
@@ -465,19 +463,19 @@ namespace System.Data.SqlClient
         //
         internal static Exception BulkLoadMappingInaccessible()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_BulkLoadMappingInaccessible));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_BulkLoadMappingInaccessible));
         }
         internal static Exception BulkLoadMappingsNamesOrOrdinalsOnly()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_BulkLoadMappingsNamesOrOrdinalsOnly));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_BulkLoadMappingsNamesOrOrdinalsOnly));
         }
         internal static Exception BulkLoadCannotConvertValue(Type sourcetype, MetaType metatype, Exception e)
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_BulkLoadCannotConvertValue, sourcetype.Name, metatype.TypeName), e);
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_BulkLoadCannotConvertValue, sourcetype.Name, metatype.TypeName), e);
         }
         internal static Exception BulkLoadNonMatchingColumnMapping()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_BulkLoadNonMatchingColumnMapping));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_BulkLoadNonMatchingColumnMapping));
         }
         internal static Exception BulkLoadNonMatchingColumnName(string columnName)
         {
@@ -485,55 +483,55 @@ namespace System.Data.SqlClient
         }
         internal static Exception BulkLoadNonMatchingColumnName(string columnName, Exception e)
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_BulkLoadNonMatchingColumnName, columnName), e);
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_BulkLoadNonMatchingColumnName, columnName), e);
         }
         internal static Exception BulkLoadStringTooLong()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_BulkLoadStringTooLong));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_BulkLoadStringTooLong));
         }
         internal static Exception BulkLoadInvalidVariantValue()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_BulkLoadInvalidVariantValue));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_BulkLoadInvalidVariantValue));
         }
         internal static Exception BulkLoadInvalidTimeout(int timeout)
         {
-            return ADP.Argument(Res.GetString(Res.SQL_BulkLoadInvalidTimeout, timeout.ToString(CultureInfo.InvariantCulture)));
+            return ADP.Argument(SR.GetString(SR.SQL_BulkLoadInvalidTimeout, timeout.ToString(CultureInfo.InvariantCulture)));
         }
         internal static Exception BulkLoadExistingTransaction()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_BulkLoadExistingTransaction));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_BulkLoadExistingTransaction));
         }
         internal static Exception BulkLoadNoCollation()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_BulkLoadNoCollation));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_BulkLoadNoCollation));
         }
         internal static Exception BulkLoadConflictingTransactionOption()
         {
-            return ADP.Argument(Res.GetString(Res.SQL_BulkLoadConflictingTransactionOption));
+            return ADP.Argument(SR.GetString(SR.SQL_BulkLoadConflictingTransactionOption));
         }
         internal static Exception BulkLoadLcidMismatch(int sourceLcid, string sourceColumnName, int destinationLcid, string destinationColumnName)
         {
-            return ADP.InvalidOperation(Res.GetString(Res.Sql_BulkLoadLcidMismatch, sourceLcid, sourceColumnName, destinationLcid, destinationColumnName));
+            return ADP.InvalidOperation(SR.GetString(SR.Sql_BulkLoadLcidMismatch, sourceLcid, sourceColumnName, destinationLcid, destinationColumnName));
         }
         internal static Exception InvalidOperationInsideEvent()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_BulkLoadInvalidOperationInsideEvent));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_BulkLoadInvalidOperationInsideEvent));
         }
         internal static Exception BulkLoadMissingDestinationTable()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_BulkLoadMissingDestinationTable));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_BulkLoadMissingDestinationTable));
         }
         internal static Exception BulkLoadInvalidDestinationTable(string tableName, Exception inner)
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_BulkLoadInvalidDestinationTable, tableName), inner);
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_BulkLoadInvalidDestinationTable, tableName), inner);
         }
         internal static Exception BulkLoadBulkLoadNotAllowDBNull(string columnName)
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_BulkLoadNotAllowDBNull, columnName));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_BulkLoadNotAllowDBNull, columnName));
         }
         internal static Exception BulkLoadPendingOperation()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_BulkLoadPendingOperation));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_BulkLoadPendingOperation));
         }
 
         //
@@ -541,12 +539,12 @@ namespace System.Data.SqlClient
         //
         internal static Exception ConnectionDoomed()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_ConnectionDoomed));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_ConnectionDoomed));
         }
 
         internal static Exception OpenResultCountExceeded()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SQL_OpenResultCountExceeded));
+            return ADP.InvalidOperation(SR.GetString(SR.SQL_OpenResultCountExceeded));
         }
 
         internal static readonly byte[] AttentionHeader = new byte[] {
@@ -571,7 +569,7 @@ namespace System.Data.SqlClient
         /// </summary>
         internal static Exception MultiSubnetFailoverWithFailoverPartner(bool serverProvidedFailoverPartner, SqlInternalConnectionTds internalConnection)
         {
-            string msg = Res.GetString(Res.SQLMSF_FailoverPartnerNotSupported);
+            string msg = SR.GetString(SR.SQLMSF_FailoverPartnerNotSupported);
             if (serverProvidedFailoverPartner)
             {
                 // Replacing InvalidOperation with SQL exception
@@ -611,13 +609,13 @@ namespace System.Data.SqlClient
 
         internal static Exception ROR_FailoverNotSupportedConnString()
         {
-            return ADP.Argument(Res.GetString(Res.SQLROR_FailoverNotSupported));
+            return ADP.Argument(SR.GetString(SR.SQLROR_FailoverNotSupported));
         }
 
         internal static Exception ROR_FailoverNotSupportedServer(SqlInternalConnectionTds internalConnection)
         {
             SqlErrorCollection errors = new SqlErrorCollection();
-            errors.Add(new SqlError(0, (byte)0x00, TdsEnums.FATAL_ERROR_CLASS, null, (Res.GetString(Res.SQLROR_FailoverNotSupported)), "", 0));
+            errors.Add(new SqlError(0, (byte)0x00, TdsEnums.FATAL_ERROR_CLASS, null, (SR.GetString(SR.SQLROR_FailoverNotSupported)), "", 0));
             SqlException exc = SqlException.CreateException(errors, null, internalConnection);
             exc._doNotReconnect = true;
             return exc;
@@ -626,7 +624,7 @@ namespace System.Data.SqlClient
         internal static Exception ROR_RecursiveRoutingNotSupported(SqlInternalConnectionTds internalConnection)
         {
             SqlErrorCollection errors = new SqlErrorCollection();
-            errors.Add(new SqlError(0, (byte)0x00, TdsEnums.FATAL_ERROR_CLASS, null, (Res.GetString(Res.SQLROR_RecursiveRoutingNotSupported)), "", 0));
+            errors.Add(new SqlError(0, (byte)0x00, TdsEnums.FATAL_ERROR_CLASS, null, (SR.GetString(SR.SQLROR_RecursiveRoutingNotSupported)), "", 0));
             SqlException exc = SqlException.CreateException(errors, null, internalConnection);
             exc._doNotReconnect = true;
             return exc;
@@ -635,7 +633,7 @@ namespace System.Data.SqlClient
         internal static Exception ROR_UnexpectedRoutingInfo(SqlInternalConnectionTds internalConnection)
         {
             SqlErrorCollection errors = new SqlErrorCollection();
-            errors.Add(new SqlError(0, (byte)0x00, TdsEnums.FATAL_ERROR_CLASS, null, (Res.GetString(Res.SQLROR_UnexpectedRoutingInfo)), "", 0));
+            errors.Add(new SqlError(0, (byte)0x00, TdsEnums.FATAL_ERROR_CLASS, null, (SR.GetString(SR.SQLROR_UnexpectedRoutingInfo)), "", 0));
             SqlException exc = SqlException.CreateException(errors, null, internalConnection);
             exc._doNotReconnect = true;
             return exc;
@@ -644,7 +642,7 @@ namespace System.Data.SqlClient
         internal static Exception ROR_InvalidRoutingInfo(SqlInternalConnectionTds internalConnection)
         {
             SqlErrorCollection errors = new SqlErrorCollection();
-            errors.Add(new SqlError(0, (byte)0x00, TdsEnums.FATAL_ERROR_CLASS, null, (Res.GetString(Res.SQLROR_InvalidRoutingInfo)), "", 0));
+            errors.Add(new SqlError(0, (byte)0x00, TdsEnums.FATAL_ERROR_CLASS, null, (SR.GetString(SR.SQLROR_InvalidRoutingInfo)), "", 0));
             SqlException exc = SqlException.CreateException(errors, null, internalConnection);
             exc._doNotReconnect = true;
             return exc;
@@ -653,7 +651,7 @@ namespace System.Data.SqlClient
         internal static Exception ROR_TimeoutAfterRoutingInfo(SqlInternalConnectionTds internalConnection)
         {
             SqlErrorCollection errors = new SqlErrorCollection();
-            errors.Add(new SqlError(0, (byte)0x00, TdsEnums.FATAL_ERROR_CLASS, null, (Res.GetString(Res.SQLROR_TimeoutAfterRoutingInfo)), "", 0));
+            errors.Add(new SqlError(0, (byte)0x00, TdsEnums.FATAL_ERROR_CLASS, null, (SR.GetString(SR.SQLROR_TimeoutAfterRoutingInfo)), "", 0));
             SqlException exc = SqlException.CreateException(errors, null, internalConnection);
             exc._doNotReconnect = true;
             return exc;
@@ -681,7 +679,7 @@ namespace System.Data.SqlClient
         internal static Exception CR_NextAttemptWillExceedQueryTimeout(SqlException innerException, Guid connectionId)
         {
             SqlErrorCollection errors = new SqlErrorCollection();
-            errors.Add(new SqlError(0, 0, TdsEnums.MIN_ERROR_CLASS, null, Res.GetString(Res.SQLCR_NextAttemptWillExceedQueryTimeout), "", 0));
+            errors.Add(new SqlError(0, 0, TdsEnums.MIN_ERROR_CLASS, null, SR.GetString(SR.SQLCR_NextAttemptWillExceedQueryTimeout), "", 0));
             SqlException exc = SqlException.CreateException(errors, "", connectionId, innerException);
             return exc;
         }
@@ -689,7 +687,7 @@ namespace System.Data.SqlClient
         internal static Exception CR_EncryptionChanged(SqlInternalConnectionTds internalConnection)
         {
             SqlErrorCollection errors = new SqlErrorCollection();
-            errors.Add(new SqlError(0, 0, TdsEnums.FATAL_ERROR_CLASS, null, Res.GetString(Res.SQLCR_EncryptionChanged), "", 0));
+            errors.Add(new SqlError(0, 0, TdsEnums.FATAL_ERROR_CLASS, null, SR.GetString(SR.SQLCR_EncryptionChanged), "", 0));
             SqlException exc = SqlException.CreateException(errors, "", internalConnection);
             return exc;
         }
@@ -697,7 +695,7 @@ namespace System.Data.SqlClient
         internal static SqlException CR_AllAttemptsFailed(SqlException innerException, Guid connectionId)
         {
             SqlErrorCollection errors = new SqlErrorCollection();
-            errors.Add(new SqlError(0, 0, TdsEnums.MIN_ERROR_CLASS, null, Res.GetString(Res.SQLCR_AllAttemptsFailed), "", 0));
+            errors.Add(new SqlError(0, 0, TdsEnums.MIN_ERROR_CLASS, null, SR.GetString(SR.SQLCR_AllAttemptsFailed), "", 0));
             SqlException exc = SqlException.CreateException(errors, "", connectionId, innerException);
             return exc;
         }
@@ -705,7 +703,7 @@ namespace System.Data.SqlClient
         internal static SqlException CR_NoCRAckAtReconnection(SqlInternalConnectionTds internalConnection)
         {
             SqlErrorCollection errors = new SqlErrorCollection();
-            errors.Add(new SqlError(0, 0, TdsEnums.FATAL_ERROR_CLASS, null, Res.GetString(Res.SQLCR_NoCRAckAtReconnection), "", 0));
+            errors.Add(new SqlError(0, 0, TdsEnums.FATAL_ERROR_CLASS, null, SR.GetString(SR.SQLCR_NoCRAckAtReconnection), "", 0));
             SqlException exc = SqlException.CreateException(errors, "", internalConnection);
             return exc;
         }
@@ -713,7 +711,7 @@ namespace System.Data.SqlClient
         internal static SqlException CR_TDSVersionNotPreserved(SqlInternalConnectionTds internalConnection)
         {
             SqlErrorCollection errors = new SqlErrorCollection();
-            errors.Add(new SqlError(0, 0, TdsEnums.FATAL_ERROR_CLASS, null, Res.GetString(Res.SQLCR_TDSVestionNotPreserved), "", 0));
+            errors.Add(new SqlError(0, 0, TdsEnums.FATAL_ERROR_CLASS, null, SR.GetString(SR.SQLCR_TDSVestionNotPreserved), "", 0));
             SqlException exc = SqlException.CreateException(errors, "", internalConnection);
             return exc;
         }
@@ -721,7 +719,7 @@ namespace System.Data.SqlClient
         internal static SqlException CR_UnrecoverableServer(Guid connectionId)
         {
             SqlErrorCollection errors = new SqlErrorCollection();
-            errors.Add(new SqlError(0, 0, TdsEnums.FATAL_ERROR_CLASS, null, Res.GetString(Res.SQLCR_UnrecoverableServer), "", 0));
+            errors.Add(new SqlError(0, 0, TdsEnums.FATAL_ERROR_CLASS, null, SR.GetString(SR.SQLCR_UnrecoverableServer), "", 0));
             SqlException exc = SqlException.CreateException(errors, "", connectionId);
             return exc;
         }
@@ -729,22 +727,22 @@ namespace System.Data.SqlClient
         internal static SqlException CR_UnrecoverableClient(Guid connectionId)
         {
             SqlErrorCollection errors = new SqlErrorCollection();
-            errors.Add(new SqlError(0, 0, TdsEnums.FATAL_ERROR_CLASS, null, Res.GetString(Res.SQLCR_UnrecoverableClient), "", 0));
+            errors.Add(new SqlError(0, 0, TdsEnums.FATAL_ERROR_CLASS, null, SR.GetString(SR.SQLCR_UnrecoverableClient), "", 0));
             SqlException exc = SqlException.CreateException(errors, "", connectionId);
             return exc;
         }
 
         internal static Exception StreamWriteNotSupported()
         {
-            return ADP.NotSupported(Res.GetString(Res.SQL_StreamWriteNotSupported));
+            return ADP.NotSupported(SR.GetString(SR.SQL_StreamWriteNotSupported));
         }
         internal static Exception StreamReadNotSupported()
         {
-            return ADP.NotSupported(Res.GetString(Res.SQL_StreamReadNotSupported));
+            return ADP.NotSupported(SR.GetString(SR.SQL_StreamReadNotSupported));
         }
         internal static Exception StreamSeekNotSupported()
         {
-            return ADP.NotSupported(Res.GetString(Res.SQL_StreamSeekNotSupported));
+            return ADP.NotSupported(SR.GetString(SR.SQL_StreamSeekNotSupported));
         }
         internal static System.Data.SqlTypes.SqlNullValueException SqlNullValue()
         {
@@ -753,24 +751,24 @@ namespace System.Data.SqlClient
         }
         internal static Exception SubclassMustOverride()
         {
-            return ADP.InvalidOperation(Res.GetString(Res.SqlMisc_SubclassMustOverride));
+            return ADP.InvalidOperation(SR.GetString(SR.SqlMisc_SubclassMustOverride));
         }
 
         // ProjectK\CoreCLR specific errors
         internal static Exception UnsupportedKeyword(string keyword)
         {
-            return ADP.NotSupported(Res.GetString(Res.SQL_UnsupportedKeyword, keyword));
+            return ADP.NotSupported(SR.GetString(SR.SQL_UnsupportedKeyword, keyword));
         }
         internal static Exception NetworkLibraryKeywordNotSupported()
         {
-            return ADP.NotSupported(Res.GetString(Res.SQL_NetworkLibraryNotSupported));
+            return ADP.NotSupported(SR.GetString(SR.SQL_NetworkLibraryNotSupported));
         }
         internal static Exception UnsupportedFeatureAndToken(SqlInternalConnectionTds internalConnection, string token)
         {
-            var innerException = ADP.NotSupported(Res.GetString(Res.SQL_UnsupportedToken, token));
+            var innerException = ADP.NotSupported(SR.GetString(SR.SQL_UnsupportedToken, token));
 
             SqlErrorCollection errors = new SqlErrorCollection();
-            errors.Add(new SqlError(0, 0, TdsEnums.FATAL_ERROR_CLASS, null, Res.GetString(Res.SQL_UnsupportedFeature), "", 0));
+            errors.Add(new SqlError(0, 0, TdsEnums.FATAL_ERROR_CLASS, null, SR.GetString(SR.SQL_UnsupportedFeature), "", 0));
             SqlException exc = SqlException.CreateException(errors, "", internalConnection, innerException);
             return exc;
         }
@@ -802,119 +800,119 @@ namespace System.Data.SqlClient
 
         internal static string CultureIdError()
         {
-            return Res.GetString(Res.SQL_CultureIdError);
+            return SR.GetString(SR.SQL_CultureIdError);
         }
         internal static string EncryptionNotSupportedByClient()
         {
-            return Res.GetString(Res.SQL_EncryptionNotSupportedByClient);
+            return SR.GetString(SR.SQL_EncryptionNotSupportedByClient);
         }
         internal static string EncryptionNotSupportedByServer()
         {
-            return Res.GetString(Res.SQL_EncryptionNotSupportedByServer);
+            return SR.GetString(SR.SQL_EncryptionNotSupportedByServer);
         }
         internal static string OperationCancelled()
         {
-            return Res.GetString(Res.SQL_OperationCancelled);
+            return SR.GetString(SR.SQL_OperationCancelled);
         }
         internal static string SevereError()
         {
-            return Res.GetString(Res.SQL_SevereError);
+            return SR.GetString(SR.SQL_SevereError);
         }
         internal static string SSPIInitializeError()
         {
-            return Res.GetString(Res.SQL_SSPIInitializeError);
+            return SR.GetString(SR.SQL_SSPIInitializeError);
         }
         internal static string SSPIGenerateError()
         {
-            return Res.GetString(Res.SQL_SSPIGenerateError);
+            return SR.GetString(SR.SQL_SSPIGenerateError);
         }
         internal static string KerberosTicketMissingError()
         {
-            return Res.GetString(Res.SQL_KerberosTicketMissingError);
+            return SR.GetString(SR.SQL_KerberosTicketMissingError);
         }
         internal static string Timeout()
         {
-            return Res.GetString(Res.SQL_Timeout);
+            return SR.GetString(SR.SQL_Timeout);
         }
         internal static string Timeout_PreLogin_Begin()
         {
-            return Res.GetString(Res.SQL_Timeout_PreLogin_Begin);
+            return SR.GetString(SR.SQL_Timeout_PreLogin_Begin);
         }
         internal static string Timeout_PreLogin_InitializeConnection()
         {
-            return Res.GetString(Res.SQL_Timeout_PreLogin_InitializeConnection);
+            return SR.GetString(SR.SQL_Timeout_PreLogin_InitializeConnection);
         }
         internal static string Timeout_PreLogin_SendHandshake()
         {
-            return Res.GetString(Res.SQL_Timeout_PreLogin_SendHandshake);
+            return SR.GetString(SR.SQL_Timeout_PreLogin_SendHandshake);
         }
         internal static string Timeout_PreLogin_ConsumeHandshake()
         {
-            return Res.GetString(Res.SQL_Timeout_PreLogin_ConsumeHandshake);
+            return SR.GetString(SR.SQL_Timeout_PreLogin_ConsumeHandshake);
         }
         internal static string Timeout_Login_Begin()
         {
-            return Res.GetString(Res.SQL_Timeout_Login_Begin);
+            return SR.GetString(SR.SQL_Timeout_Login_Begin);
         }
         internal static string Timeout_Login_ProcessConnectionAuth()
         {
-            return Res.GetString(Res.SQL_Timeout_Login_ProcessConnectionAuth);
+            return SR.GetString(SR.SQL_Timeout_Login_ProcessConnectionAuth);
         }
         internal static string Timeout_PostLogin()
         {
-            return Res.GetString(Res.SQL_Timeout_PostLogin);
+            return SR.GetString(SR.SQL_Timeout_PostLogin);
         }
         internal static string Timeout_FailoverInfo()
         {
-            return Res.GetString(Res.SQL_Timeout_FailoverInfo);
+            return SR.GetString(SR.SQL_Timeout_FailoverInfo);
         }
         internal static string Timeout_RoutingDestination()
         {
-            return Res.GetString(Res.SQL_Timeout_RoutingDestinationInfo);
+            return SR.GetString(SR.SQL_Timeout_RoutingDestinationInfo);
         }
         internal static string Duration_PreLogin_Begin(long PreLoginBeginDuration)
         {
-            return Res.GetString(Res.SQL_Duration_PreLogin_Begin, PreLoginBeginDuration);
+            return SR.GetString(SR.SQL_Duration_PreLogin_Begin, PreLoginBeginDuration);
         }
         internal static string Duration_PreLoginHandshake(long PreLoginBeginDuration, long PreLoginHandshakeDuration)
         {
-            return Res.GetString(Res.SQL_Duration_PreLoginHandshake, PreLoginBeginDuration, PreLoginHandshakeDuration);
+            return SR.GetString(SR.SQL_Duration_PreLoginHandshake, PreLoginBeginDuration, PreLoginHandshakeDuration);
         }
         internal static string Duration_Login_Begin(long PreLoginBeginDuration, long PreLoginHandshakeDuration, long LoginBeginDuration)
         {
-            return Res.GetString(Res.SQL_Duration_Login_Begin, PreLoginBeginDuration, PreLoginHandshakeDuration, LoginBeginDuration);
+            return SR.GetString(SR.SQL_Duration_Login_Begin, PreLoginBeginDuration, PreLoginHandshakeDuration, LoginBeginDuration);
         }
         internal static string Duration_Login_ProcessConnectionAuth(long PreLoginBeginDuration, long PreLoginHandshakeDuration, long LoginBeginDuration, long LoginAuthDuration)
         {
-            return Res.GetString(Res.SQL_Duration_Login_ProcessConnectionAuth, PreLoginBeginDuration, PreLoginHandshakeDuration, LoginBeginDuration, LoginAuthDuration);
+            return SR.GetString(SR.SQL_Duration_Login_ProcessConnectionAuth, PreLoginBeginDuration, PreLoginHandshakeDuration, LoginBeginDuration, LoginAuthDuration);
         }
         internal static string Duration_PostLogin(long PreLoginBeginDuration, long PreLoginHandshakeDuration, long LoginBeginDuration, long LoginAuthDuration, long PostLoginDuration)
         {
-            return Res.GetString(Res.SQL_Duration_PostLogin, PreLoginBeginDuration, PreLoginHandshakeDuration, LoginBeginDuration, LoginAuthDuration, PostLoginDuration);
+            return SR.GetString(SR.SQL_Duration_PostLogin, PreLoginBeginDuration, PreLoginHandshakeDuration, LoginBeginDuration, LoginAuthDuration, PostLoginDuration);
         }
         internal static string UserInstanceFailure()
         {
-            return Res.GetString(Res.SQL_UserInstanceFailure);
+            return SR.GetString(SR.SQL_UserInstanceFailure);
         }
         internal static string PreloginError()
         {
-            return Res.GetString(Res.Snix_PreLogin);
+            return SR.GetString(SR.Snix_PreLogin);
         }
         internal static string ExClientConnectionId()
         {
-            return Res.GetString(Res.SQL_ExClientConnectionId);
+            return SR.GetString(SR.SQL_ExClientConnectionId);
         }
         internal static string ExErrorNumberStateClass()
         {
-            return Res.GetString(Res.SQL_ExErrorNumberStateClass);
+            return SR.GetString(SR.SQL_ExErrorNumberStateClass);
         }
         internal static string ExOriginalClientConnectionId()
         {
-            return Res.GetString(Res.SQL_ExOriginalClientConnectionId);
+            return SR.GetString(SR.SQL_ExOriginalClientConnectionId);
         }
         internal static string ExRoutingDestination()
         {
-            return Res.GetString(Res.SQL_ExRoutingDestination);
+            return SR.GetString(SR.SQL_ExRoutingDestination);
         }
     }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -16,7 +16,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
-using Res = System.SR;
 #if MANAGED_SNI
 using System.Data.SqlClient.SNI;
 #endif
@@ -4121,7 +4120,7 @@ namespace System.Data.SqlClient
                     buffer[map[i]] = data.SqlValue;
                     if (stateObj._longlen != 0)
                     {
-                        throw new SqlTruncateException(Res.GetString(Res.SqlMisc_TruncationMaxDataMessage));
+                        throw new SqlTruncateException(SR.GetString(SR.SqlMisc_TruncationMaxDataMessage));
                     }
                 }
                 data.Clear();

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
@@ -13,8 +13,6 @@ using System.Data.SqlTypes;
 using System.Diagnostics;
 using System.Text;
 
-using Res = System.SR;
-
 
 namespace System.Data.SqlClient
 {
@@ -600,7 +598,7 @@ namespace System.Data.SqlClient
         {
             if (null != _multipartName)
             {
-                string[] parts = MultipartIdentifier.ParseMultipartIdentifier(_multipartName, "[\"", "]\"", Res.SQL_TDSParserTableName, false);
+                string[] parts = MultipartIdentifier.ParseMultipartIdentifier(_multipartName, "[\"", "]\"", SR.SQL_TDSParserTableName, false);
                 _serverName = parts[0];
                 _catalogName = parts[1];
                 _schemaName = parts[2];

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
@@ -24,8 +24,6 @@ using System.Net;
 
 namespace System.Data.SqlClient
 {
-    using Res = System.SR;
-
     sealed internal class LastIOTimer
     {
         internal long _value;
@@ -1264,7 +1262,7 @@ namespace System.Data.SqlClient
                         int remainingData = _inBytesRead - _inBytesUsed;
                         if ((temp.Length < _inBytesUsed + remainingData) || (_inBuff.Length < remainingData))
                         {
-                            string errormessage = Res.GetString(Res.SQL_InvalidInternalPacketSize) + ' ' + temp.Length + ", " + _inBytesUsed + ", " + remainingData + ", " + _inBuff.Length;
+                            string errormessage = SR.GetString(SR.SQL_InvalidInternalPacketSize) + ' ' + temp.Length + ", " + _inBytesUsed + ", " + remainingData + ", " + _inBuff.Length;
                             throw SQL.InvalidInternalPacketSize(errormessage);
                         }
                         Buffer.BlockCopy(temp, _inBytesUsed, _inBuff, 0, remainingData);
@@ -2813,7 +2811,7 @@ namespace System.Data.SqlClient
                     if (_inBuff.Length < dataSize)
                     {
                         Debug.Assert(true, "Unexpected dataSize on Read");
-                        throw SQL.InvalidInternalPacketSize(Res.GetString(Res.SqlMisc_InvalidArraySizeMessage));
+                        throw SQL.InvalidInternalPacketSize(SR.GetString(SR.SqlMisc_InvalidArraySizeMessage));
                     }
 
                     _lastSuccessfulIOTimer._value = DateTime.UtcNow.Ticks;

--- a/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLResource.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLResource.cs
@@ -12,68 +12,66 @@
 
 namespace System.Data.SqlTypes
 {
-    using Res = System.SR;
-
     internal static class SQLResource
     {
-        internal static string NullString => Res.SqlMisc_NullString;
+        internal static string NullString => SR.SqlMisc_NullString;
 
-        internal static string MessageString => Res.SqlMisc_MessageString;
+        internal static string MessageString => SR.SqlMisc_MessageString;
 
-        internal static string ArithOverflowMessage => Res.SqlMisc_ArithOverflowMessage;
+        internal static string ArithOverflowMessage => SR.SqlMisc_ArithOverflowMessage;
 
-        internal static string DivideByZeroMessage => Res.SqlMisc_DivideByZeroMessage;
+        internal static string DivideByZeroMessage => SR.SqlMisc_DivideByZeroMessage;
 
-        internal static string NullValueMessage => Res.SqlMisc_NullValueMessage;
+        internal static string NullValueMessage => SR.SqlMisc_NullValueMessage;
 
-        internal static string TruncationMessage => Res.SqlMisc_TruncationMessage;
+        internal static string TruncationMessage => SR.SqlMisc_TruncationMessage;
 
-        internal static string DateTimeOverflowMessage => Res.SqlMisc_DateTimeOverflowMessage;
+        internal static string DateTimeOverflowMessage => SR.SqlMisc_DateTimeOverflowMessage;
 
-        internal static string ConcatDiffCollationMessage => Res.SqlMisc_ConcatDiffCollationMessage;
+        internal static string ConcatDiffCollationMessage => SR.SqlMisc_ConcatDiffCollationMessage;
 
-        internal static string CompareDiffCollationMessage => Res.SqlMisc_CompareDiffCollationMessage;
+        internal static string CompareDiffCollationMessage => SR.SqlMisc_CompareDiffCollationMessage;
 
-        internal static string InvalidFlagMessage => Res.SqlMisc_InvalidFlagMessage;
+        internal static string InvalidFlagMessage => SR.SqlMisc_InvalidFlagMessage;
 
-        internal static string NumeToDecOverflowMessage => Res.SqlMisc_NumeToDecOverflowMessage;
+        internal static string NumeToDecOverflowMessage => SR.SqlMisc_NumeToDecOverflowMessage;
 
-        internal static string ConversionOverflowMessage => Res.SqlMisc_ConversionOverflowMessage;
+        internal static string ConversionOverflowMessage => SR.SqlMisc_ConversionOverflowMessage;
 
-        internal static string InvalidDateTimeMessage => Res.SqlMisc_InvalidDateTimeMessage;
+        internal static string InvalidDateTimeMessage => SR.SqlMisc_InvalidDateTimeMessage;
 
-        internal static string TimeZoneSpecifiedMessage => Res.SqlMisc_TimeZoneSpecifiedMessage;
+        internal static string TimeZoneSpecifiedMessage => SR.SqlMisc_TimeZoneSpecifiedMessage;
 
-        internal static string InvalidArraySizeMessage => Res.SqlMisc_InvalidArraySizeMessage;
+        internal static string InvalidArraySizeMessage => SR.SqlMisc_InvalidArraySizeMessage;
 
-        internal static string InvalidPrecScaleMessage => Res.SqlMisc_InvalidPrecScaleMessage;
+        internal static string InvalidPrecScaleMessage => SR.SqlMisc_InvalidPrecScaleMessage;
 
-        internal static string FormatMessage => Res.SqlMisc_FormatMessage;
+        internal static string FormatMessage => SR.SqlMisc_FormatMessage;
 
-        internal static string NotFilledMessage => Res.SqlMisc_NotFilledMessage;
+        internal static string NotFilledMessage => SR.SqlMisc_NotFilledMessage;
 
-        internal static string AlreadyFilledMessage => Res.SqlMisc_AlreadyFilledMessage;
+        internal static string AlreadyFilledMessage => SR.SqlMisc_AlreadyFilledMessage;
 
-        internal static string ClosedXmlReaderMessage => Res.SqlMisc_ClosedXmlReaderMessage;
+        internal static string ClosedXmlReaderMessage => SR.SqlMisc_ClosedXmlReaderMessage;
 
         internal static string InvalidOpStreamClosed(string method)
         {
-            return Res.GetString(Res.SqlMisc_InvalidOpStreamClosed, method);
+            return SR.GetString(SR.SqlMisc_InvalidOpStreamClosed, method);
         }
 
         internal static string InvalidOpStreamNonWritable(string method)
         {
-            return Res.GetString(Res.SqlMisc_InvalidOpStreamNonWritable, method);
+            return SR.GetString(SR.SqlMisc_InvalidOpStreamNonWritable, method);
         }
 
         internal static string InvalidOpStreamNonReadable(string method)
         {
-            return Res.GetString(Res.SqlMisc_InvalidOpStreamNonReadable, method);
+            return SR.GetString(SR.SqlMisc_InvalidOpStreamNonReadable, method);
         }
 
         internal static string InvalidOpStreamNonSeekable(string method)
         {
-            return Res.GetString(Res.SqlMisc_InvalidOpStreamNonSeekable, method);
+            return SR.GetString(SR.SqlMisc_InvalidOpStreamNonSeekable, method);
         }
     } // SqlResource
 } // namespace System


### PR DESCRIPTION
[11 files](https://github.com/dotnet/corefx/search?utf8=%E2%9C%93&q=%22using+Res+%3D+System.SR%3B%22&type=Code) use SR via an alias defined like this:
`using Res = System.SR;`
in all other places SR is used directly (consistency).
Also, this alias requires SR to be under System namespace (Mono has to keep it under a global one - no namespace).
/cc @marek-safar 