### PR TITLE
Re-enable Vector3GetHashCodeTest test

### DIFF
--- a/src/System.Numerics.Vectors/tests/Vector3Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector3Tests.cs
@@ -41,7 +41,6 @@ namespace System.Numerics.Tests
             Assert.Equal(3.3f, b[2]);
         }
 
-        [ActiveIssue(15713)]
         [Fact]
         public void Vector3GetHashCodeTest()
         {


### PR DESCRIPTION
Closes https://github.com/dotnet/corefx/issues/15713.  Test should be fixed by https://github.com/dotnet/coreclr/pull/9496.
cc: @CarolEidt, @mellinoe 