### PR TITLE
Add reporting parameter Crossbuild

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -162,7 +162,8 @@
           "ReportingParameters": {
             "OperatingSystem": "Ubuntu 14.04",
             "Type": "build/product/",
-            "ConfigurationGroup": "Release"
+            "ConfigurationGroup": "Release",
+            "SubType": "Crossbuild"
           }
         },
         {
@@ -175,7 +176,8 @@
           "ReportingParameters": {
             "OperatingSystem": "Ubuntu 16.04",
             "Type": "build/product/",
-            "ConfigurationGroup": "Release"
+            "ConfigurationGroup": "Release",
+            "SubType": "Crossbuild"
           }
         }
       ]
@@ -543,7 +545,8 @@
           "ReportingParameters": {
             "OperatingSystem": "Ubuntu 14.04",
             "Type": "build/product/",
-            "ConfigurationGroup": "Debug"
+            "ConfigurationGroup": "Debug",
+            "SubType": "Crossbuild"
           }
         },
         {
@@ -556,7 +559,8 @@
           "ReportingParameters": {
             "OperatingSystem": "Ubuntu 16.04",
             "Type": "build/product/",
-            "ConfigurationGroup": "Debug"
+            "ConfigurationGroup": "Debug",
+            "SubType": "Crossbuild"
           }
         }
       ]


### PR DESCRIPTION
Mission Control is having duplicated results for Ubuntu 14.04/16.04  Debug and Release because the crossbuild is not being differentiated. This change adds the `SubType` property in the `ReportingParameters` section.

cc: @MattGal @chcosta 
FYI: @wtgodbe 