### PR TITLE
Workaround recent test break for Helix runs

### DIFF
--- a/Tools-Override/CloudTest.targets
+++ b/Tools-Override/CloudTest.targets
@@ -279,10 +279,23 @@
   <Target Name="CreateFuncTestListJson"
           DependsOnTargets="CreateAzureStorage"
           Condition="'$(Performance)' != 'true' or '$(FuncTestsDisabled)' != 'true'">
-    <!-- create item group of functional tests -->
-    <CreateItem Include="$(ForUploadList)">
-      <Output TaskParameter="Include" ItemName="FunctionalTest"/>
-    </CreateItem>
+    <!-- create item group of functional tests 
+         Due to recent refactoring, calculating the right paths for Uris is challenging, so just reuse the previous
+         include approach to get a full list. 
+         This allows us to use RecursiveDir as the path to the zip instead of guessing and generating it again.
+    -->
+    <ItemGroup>
+      <FunctionalTest Include="$(TestArchivesRoot)**/*.zip" >
+        <RelativeBlobPath>$(Platform)$(ConfigurationGroup)/Tests/$([System.String]::Copy('%(RecursiveDir)').Replace('\', '/'))%(Filename)%(Extension)</RelativeBlobPath>
+      </FunctionalTest>
+      <FunctionalTest Include="$(AnyOSTestArchivesRoot)**/*.zip" >
+        <RelativeBlobPath>$(Platform)$(ConfigurationGroup)/Tests/$([System.String]::Copy('%(RecursiveDir)').Replace('\', '/'))%(Filename)%(Extension)</RelativeBlobPath>
+      </FunctionalTest>
+      <!-- Only include Unix folders if supported by the current target OS -->
+      <FunctionalTest Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)**/*.zip" >
+        <RelativeBlobPath>$(Platform)$(ConfigurationGroup)/Tests/$([System.String]::Copy('%(RecursiveDir)').Replace('\', '/'))%(Filename)%(Extension)</RelativeBlobPath>
+      </FunctionalTest>
+    </ItemGroup>
 
     <PropertyGroup>
       <OtherRunnerScriptArgs Condition="'$(FilterToTargetGroup)' == 'net46'">$(OtherRunnerScriptArgs) --xunit-test-type=desktop </OtherRunnerScriptArgs>

--- a/Tools-Override/CloudTest.targets
+++ b/Tools-Override/CloudTest.targets
@@ -285,16 +285,10 @@
          This allows us to use RecursiveDir as the path to the zip instead of guessing and generating it again.
     -->
     <ItemGroup>
-      <FunctionalTest Include="$(TestArchivesRoot)**/*.zip" >
-        <RelativeBlobPath>$(Platform)$(ConfigurationGroup)/Tests/$([System.String]::Copy('%(RecursiveDir)').Replace('\', '/'))%(Filename)%(Extension)</RelativeBlobPath>
-      </FunctionalTest>
-      <FunctionalTest Include="$(AnyOSTestArchivesRoot)**/*.zip" >
-        <RelativeBlobPath>$(Platform)$(ConfigurationGroup)/Tests/$([System.String]::Copy('%(RecursiveDir)').Replace('\', '/'))%(Filename)%(Extension)</RelativeBlobPath>
-      </FunctionalTest>
+      <FunctionalTest Include="$(TestArchivesRoot)**/*.zip" />
+      <FunctionalTest Include="$(AnyOSTestArchivesRoot)**/*.zip" />
       <!-- Only include Unix folders if supported by the current target OS -->
-      <FunctionalTest Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)**/*.zip" >
-        <RelativeBlobPath>$(Platform)$(ConfigurationGroup)/Tests/$([System.String]::Copy('%(RecursiveDir)').Replace('\', '/'))%(Filename)%(Extension)</RelativeBlobPath>
-      </FunctionalTest>
+      <FunctionalTest Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)**/*.zip" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -313,6 +307,7 @@
       </FunctionalTest>
     </ItemGroup>
     <WriteItemsToJson JsonFileName="$(FuncTestListFile)" Items="@(FunctionalTest)" />
+          
     <!-- add test lists to the list of items for upload -->
     <ItemGroup>
       <ForUpload Include="$(FuncTestListFile)">


### PR DESCRIPTION
… by calculating Functional test list again in the target.  Previously this was done by the FilterForUpload task, which is now deprecated.

@joperezr @danmosemsft 