### PR TITLE
Robustify Mono configuration tests

### DIFF
--- a/src/Common/tests/System/IO/TempDirectory.cs
+++ b/src/Common/tests/System/IO/TempDirectory.cs
@@ -35,6 +35,8 @@ namespace System.IO
             DeleteDirectory();
         }
 
+        public string GenerateRandomFilePath() => IO.Path.Combine(Path, IO.Path.GetRandomFileName());
+
         private void DeleteDirectory()
         {
             try { Directory.Delete(Path, recursive: true); }

--- a/src/System.Configuration.ConfigurationManager/tests/Mono/TestUtil.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/Mono/TestUtil.cs
@@ -35,20 +35,11 @@ namespace MonoTests.System.Configuration.Util
 
     public static class TestUtil
     {
-
         public static void RunWithTempFile(Action<string> action)
         {
-            var filename = Path.GetTempFileName();
-
-            try
+            using (var temp = new TempDirectory())
             {
-                File.Delete(filename);
-                action(filename);
-            }
-            finally
-            {
-                if (File.Exists(filename))
-                    File.Delete(filename);
+                action(temp.GenerateRandomFilePath());
             }
         }
 
@@ -57,21 +48,9 @@ namespace MonoTests.System.Configuration.Util
 
         public static void RunWithTempFiles(MyAction<string, string> action)
         {
-            var file1 = Path.GetTempFileName();
-            var file2 = Path.GetTempFileName();
-
-            try
+            using (var temp = new TempDirectory())
             {
-                File.Delete(file1);
-                File.Delete(file2);
-                action(file1, file2);
-            }
-            finally
-            {
-                if (File.Exists(file1))
-                    File.Delete(file1);
-                if (File.Exists(file2))
-                    File.Delete(file2);
+                action(temp.GenerateRandomFilePath(), temp.GenerateRandomFilePath());
             }
         }
 


### PR DESCRIPTION
Creating a temp file and deleting then rewriting over it is risky. File
deletions aren't synchronous- they are just flagged for deletion.

This change uses one of our existing temp directory classes and creates
random filenames within.

See #16270

@ianhays, @danmosemsft 