### PR TITLE
Re-enable Http test with fix for race condition

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Net.Test.Common;
@@ -71,7 +72,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [ActiveIssue(9543)] // fails sporadically with 'WinHttpException : The server returned an invalid or unrecognized response' or 'TaskCanceledException : A task was canceled'
         [ConditionalTheory(nameof(BackendSupportsCustomCertificateHandling))]
         [InlineData(6, false)]
         [InlineData(3, true)]
@@ -90,15 +90,26 @@ namespace System.Net.Http.Functional.Tests
 
             Func<HttpClient, Socket, Uri, X509Certificate2, Task> makeAndValidateRequest = async (client, server, url, cert) =>
             {
-                await TestHelper.WhenAllCompletedOrAnyFailed(
-                    client.GetStringAsync(url),
-                    LoopbackServer.AcceptSocketAsync(server, async (socket, stream, reader, writer) =>
-                    {
-                        SslStream sslStream = Assert.IsType<SslStream>(stream);
-                        Assert.Equal(cert, sslStream.RemoteCertificate);
-                        await LoopbackServer.ReadWriteAcceptedAsync(socket, reader, writer);
-                        return null;
-                    }, options));
+                Task<string> clientTask = client.GetStringAsync(url);
+                Task<List<string>> serverTask = LoopbackServer.AcceptSocketAsync(server, async (socket, stream, reader, writer) =>
+                {
+                    SslStream sslStream = Assert.IsType<SslStream>(stream);
+                    Assert.Equal(cert, sslStream.RemoteCertificate);
+                    socket.NoDelay = true;
+                    var result = await LoopbackServer.ReadWriteAcceptedAsync(socket, reader, writer);
+
+                    // Wait for a bit so client can process response before server goes down.
+                    await Task.Delay(100);
+
+                    return result;
+                }, options);
+
+                await TestHelper.WhenAllCompletedOrAnyFailed(clientTask, serverTask);
+
+                Assert.Equal(string.Empty, clientTask.Result);
+                Assert.NotNull(serverTask.Result);
+                Assert.True(serverTask.Result.Count > 0);
+                Assert.False(string.IsNullOrEmpty(serverTask.Result[0]));
             };
 
             await LoopbackServer.CreateServerAsync(async (server, url) =>


### PR DESCRIPTION
Fix for https://github.com/dotnet/corefx/issues/9543

The test was failing with "a task has been canceled" or "The server returned an invalid or unrecognized response". It appears there is a race condition where the server writes to the stream and then immediately disposes (when AcceptSocketAsync ends) but the client is still pending the read. 

The fix is to add 'socket.NoDelay = true' before the call to ReadWriteAcceptedAsync and then an 'await Task.Delay(100) afterwards.

With some slight modifications to the original test to encourage the exceptions, I could repro an exception every 5-10 runs. When applying the NoDelay=true and Task.Delay(100) I have 750+ runs without exception so far (still running).

cc @CIPop @davidsh 