### PR TITLE
Make RemoteExecutorConsoleApp runs against the full framework

### DIFF
--- a/Tools-Override/tests.targets
+++ b/Tools-Override/tests.targets
@@ -11,7 +11,6 @@
     <TestDisabled>false</TestDisabled>
     <TestDisabled Condition="'$(IsTestProject)'!='true' Or '$(SkipTests)'=='true' Or '$(RunTestsForProject)'=='false'">true</TestDisabled>
     <TestsSuccessfulSemaphore>tests.passed</TestsSuccessfulSemaphore>
-    <RunningOnNetFx Condition="'$(_bc_TargetGroup)' == 'netfx'">true</RunningOnNetFx>
   </PropertyGroup>
 
   <!-- In case that TestPath is not yet set, default it here -->
@@ -27,7 +26,7 @@
     <UnsupportedPlatformsItems Include="$(UnsupportedPlatforms)"/>
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(RunningOnNetFx)' != 'true'">
+  <PropertyGroup Condition="'$(BuildingNETFxVertical)' != 'true'">
     <XunitRuntimeConfig>$(ToolsDir)\xunit.console.netcore.runtimeconfig.json</XunitRuntimeConfig>
     <TestRuntimeEnvVar Condition="'$(OS)' == 'Windows_NT'">%RUNTIME_PATH%\</TestRuntimeEnvVar>
     <TestRuntimeEnvVar Condition="'$(OS)' != 'Windows_NT'">$RUNTIME_PATH/</TestRuntimeEnvVar>
@@ -39,7 +38,7 @@
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(RunningOnNetFx)' == 'true'">
+  <PropertyGroup Condition="'$(BuildingNETFxVertical)' == 'true'">
     <XunitExecutable Condition="'$(XunitExecutable)' == ''">xunit.console.exe</XunitExecutable>
   </PropertyGroup>
 
@@ -47,7 +46,7 @@
   <PropertyGroup>
     <XunitResultsFileName>testResults.xml</XunitResultsFileName>
 
-    <XunitOptions Condition="'$(RunningOnNetFx)' == 'true'">$(XunitOptions) -noshadow -noappdomain </XunitOptions>
+    <XunitOptions Condition="'$(BuildingNETFxVertical)' == 'true'">$(XunitOptions) -noshadow -noappdomain </XunitOptions>
     <XunitOptions>$(XunitOptions) -xml $(XunitResultsFileName)</XunitOptions>
 
     <XunitOptions Condition="'$(Performance)'!='true'">$(XunitOptions) -notrait Benchmark=true</XunitOptions>
@@ -55,7 +54,7 @@
     <XunitOptions Condition="'$(UseDotNetNativeToolchain)'=='true'">$(XunitOptions) -redirectoutput</XunitOptions>
 
     <!-- Temporary till we fix the whole filtering with  TargetGroup -->
-    <XunitOptions Condition="'$(RunningOnNetFx)' != 'true'">$(XunitOptions) -notrait category=nonnetcoreapp1.1tests</XunitOptions>
+    <XunitOptions Condition="'$(BuildingNETFxVertical)' != 'true'">$(XunitOptions) -notrait category=nonnetcoreapp1.1tests</XunitOptions>
 
     <XunitOptions Condition="'$(XunitMaxThreads)'!=''">$(XunitOptions) -maxthreads $(XunitMaxThreads)</XunitOptions>
     <XunitTestAssembly Condition="'$(XunitTestAssembly)' == ''">$(TargetFileName)</XunitTestAssembly>
@@ -89,11 +88,11 @@
       <RunTestsForProjectInputs Include="@(_DebugSymbolsIntermediatePath)" />
       <RunTestsForProjectInputs Include="@(AllItemsFullPathWithTargetPath)" />
     </ItemGroup>
-    <ItemGroup Condition="'$(RunningOnNetFx)' != 'true'">
+    <ItemGroup Condition="'$(BuildingNETFxVertical)' != 'true'">
       <SupplementalTestData Include="$(XunitRuntimeConfig)" />
       <SupplementalTestData Include="$(RuntimePath)xunit.console.netcore.exe" />
     </ItemGroup>
-    <ItemGroup Condition="'$(RunningOnNetFx)' == 'true'">
+    <ItemGroup Condition="'$(BuildingNETFxVertical)' == 'true'">
       <SupplementalTestData Include="$(RuntimePath)xunit.console.exe" />
       <SupplementalTestData Include="$(RuntimePath)xunit.console.exe.config" />
       <SupplementalTestData Include="$(RuntimePath)xunit.execution.desktop.dll" />
@@ -117,6 +116,16 @@
 
       <DefaultReference Include="%(TargetingPackItems.Filename)" Exclude="@(TargetingPackExclusions)" />
     </ItemGroup>
+  </Target>
+
+  <Target Name="CopyRemoteExecutionConfigFile" 
+          BeforeTargets="GenerateTestExecutionScripts" 
+          Condition="'$(BuildingNETFxVertical)' == 'true' And Exists('$(TestPath)\RemoteExecutorConsoleApp.exe')">
+
+    <Copy SourceFiles="$(RuntimePath)\xunit.console.exe.config"
+          DestinationFiles="$(TestPath)\RemoteExecutorConsoleApp.exe.config" 
+          SkipUnchangedFiles="true"
+          />
   </Target>
 
   <!-- Generate the script to run the tests.  The script performs two high-level steps:

--- a/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -25,9 +25,7 @@ namespace System.Diagnostics
         /// <summary>The exit code returned when the test process exits successfully.</summary>
         internal const int SuccessExitCode = 42;
 
-        internal static bool IsFullFramework => 
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && 
-            typeof(String).Assembly.Location.StartsWith($"{Environment.GetEnvironmentVariable("windir")}\\Microsoft.NET\\Framework", StringComparison.OrdinalIgnoreCase);
+        internal static bool IsFullFramework => RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
 
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>

--- a/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -25,6 +25,10 @@ namespace System.Diagnostics
         /// <summary>The exit code returned when the test process exits successfully.</summary>
         internal const int SuccessExitCode = 42;
 
+        internal static bool IsFullFramework => 
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && 
+            typeof(String).Assembly.Location.StartsWith($"{Environment.GetEnvironmentVariable("windir")}\\Microsoft.NET\\Framework", StringComparison.OrdinalIgnoreCase);
+
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>
         /// <param name="options">Options to use for the invocation.</param>
@@ -133,9 +137,17 @@ namespace System.Diagnostics
             // If we need the host (if it exists), use it, otherwise target the console app directly.
             string testConsoleAppArgs = "\"" + a.FullName + "\" " + t.FullName + " " + method.Name + " " + string.Join(" ", args);
             
-            psi.FileName = HostRunner;
-            psi.Arguments = TestConsoleApp + " " + testConsoleAppArgs;
-            
+            if (IsFullFramework)
+            {
+                psi.FileName = TestConsoleApp;
+                psi.Arguments = testConsoleAppArgs;
+            }
+            else
+            {
+                psi.FileName = HostRunner;
+                psi.Arguments = TestConsoleApp + " " + testConsoleAppArgs;
+            }
+         
             // Return the handle to the process, which may or not be started
             return new RemoteInvokeHandle(options.Start ?
                 Process.Start(psi) :

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
@@ -11,7 +11,7 @@ namespace System.Runtime.InteropServices
     {
 #if netcore50aot
         private const string FrameworkName = ".NET Native";
-#elif net45 || win8
+#elif netfx || win8
         private const string FrameworkName = ".NET Framework";
 #else // netcore50 || wpa81 || other
         private const string FrameworkName = ".NET Core";


### PR DESCRIPTION
All tests using RemoteExecutorConsoleApp having it run under the dotnet host which is not correct for the netfx runs.
The fix here is to allow running RemoteExecutorConsoleApp directly against the full framework and uses the same Netfx runtime bits.
We have to copy the config file too to prevent assembly binding issues