### PR TITLE
Lighter numeric conversion compiling S.L.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -714,10 +714,11 @@ namespace System.Dynamic.Utils
         }
 
 #if FEATURE_COMPILE
-        internal static bool IsUnsigned(this Type type)
+        internal static bool IsUnsigned(this Type type) => IsUnsigned(GetNonNullableType(type).GetTypeCode());
+
+        internal static bool IsUnsigned(this TypeCode typeCode)
         {
-            type = GetNonNullableType(type);
-            switch (type.GetTypeCode())
+            switch (typeCode)
             {
                 case TypeCode.Byte:
                 case TypeCode.UInt16:
@@ -730,10 +731,11 @@ namespace System.Dynamic.Utils
             }
         }
 
-        internal static bool IsFloatingPoint(this Type type)
+        internal static bool IsFloatingPoint(this Type type) => IsFloatingPoint(GetNonNullableType(type).GetTypeCode());
+
+        internal static bool IsFloatingPoint(this TypeCode typeCode)
         {
-            type = GetNonNullableType(type);
-            switch (type.GetTypeCode())
+            switch (typeCode)
             {
                 case TypeCode.Single:
                 case TypeCode.Double:

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
@@ -272,7 +272,8 @@ namespace System.Linq.Expressions.Compiler
                     break;
                 case TypeCode.Int64:
                 case TypeCode.UInt64:
-                    _ilg.Emit(OpCodes.Ldc_I8, (long)1);
+                    _ilg.Emit(OpCodes.Ldc_I4_1);
+                    _ilg.Emit(OpCodes.Conv_I8);
                     break;
                 case TypeCode.Single:
                     _ilg.Emit(OpCodes.Ldc_R4, 1.0f);


### PR DESCRIPTION
Switch on `TypeCode` instead of if-else ladder on type.

Skip conversions where it will be a nop.

Generate shorter IL when compiling `1L` for increment and decrement.

(Comparison with Roslyn shows it to be taking the same approaches across these changes).