### PR TITLE
Delay Random allocation in ConcurrentStack

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
@@ -653,7 +653,7 @@ namespace System.Collections.Concurrent
             Node head;
             Node next;
             int backoff = 1;
-            Random r = new Random(Environment.TickCount & Int32.MaxValue); // avoid the case where TickCount could return Int32.MinValue
+            Random r = null;
             while (true)
             {
                 head = _head;
@@ -694,7 +694,18 @@ namespace System.Collections.Concurrent
                     spin.SpinOnce();
                 }
 
-                backoff = spin.NextSpinWillYield ? r.Next(1, BACKOFF_MAX_YIELDS) : backoff * 2;
+                if (spin.NextSpinWillYield)
+                {
+                    if (r == null)
+                    {
+                        r = new Random();
+                    }
+                    backoff = r.Next(1, BACKOFF_MAX_YIELDS);
+                }
+                else
+                {
+                    backoff *= 2;
+                }
             }
         }
 #pragma warning restore 0420


### PR DESCRIPTION
ConcurrentStack currently uses a randomized-backoff scheme, where under contention it spins for increasingly longer periods of time, with a duration influenced by some randomness.  If the initial attempt at popping an item fails due to contention, it allocates a Random, then tries again one or more times, and then uses the randomness to influence backoff for subsequent attempts.  While it's not clear to me that this scheme is optimal, we can at least delay the allocation of the Random (and the underlying cost it entails, like an int[] in its ctor) until it's actually used.  Since it's typically not used for a few attempts, this significantly decreases the number of instances that get created under heavy contention.

cc: @kouvel, @alexperovich 