### PR TITLE
Enable exception tests in inner loop

### DIFF
--- a/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
@@ -13,6 +13,7 @@ using Microsoft.SqlServer.TDS;
 using Microsoft.SqlServer.TDS.EndPoint;
 using Microsoft.SqlServer.TDS.SQLBatch;
 using Microsoft.SqlServer.TDS.Error;
+using Microsoft.SqlServer.TDS.Done;
 
 namespace System.Data.SqlClient.Tests
 {
@@ -792,8 +793,9 @@ namespace System.Data.SqlClient.Tests
             
             if (lowerBatchText.Contains("1 / 0")) // SELECT 1/0 
             {
-                TDSErrorToken errorToken = new TDSErrorToken(8134, 1, 11, "Divide by zero error encountered.");
-                TDSMessage responseMessage = new TDSMessage(TDSMessageType.Response, errorToken);
+                TDSErrorToken errorToken = new TDSErrorToken(8134, 1, 16, "Divide by zero error encountered.");
+                TDSDoneToken doneToken = new TDSDoneToken(TDSDoneTokenStatusType.Final | TDSDoneTokenStatusType.Count, TDSDoneTokenCommandType.Select, 1);
+                TDSMessage responseMessage = new TDSMessage(TDSMessageType.Response, errorToken, doneToken);
                 return new TDSMessageCollection(responseMessage);
             }
             else

--- a/src/System.Data.SqlClient/tests/FunctionalTests/ExceptionTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/ExceptionTest.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace System.Data.SqlClient.Tests
 {
-    [OuterLoop("Takes minutes on some networks")]
     public class ExceptionTest
     {
         // test connection string


### PR DESCRIPTION
I have removed the [OuterLoop] attribute from exception tests.
I found from Jenkins runs that ExceptionTests don't take too long to execute.

E.g.
https://ci.dot.net/job/dotnet_corefx/job/master/job/outerloop_rhel7.2_debug/lastCompletedBuild/testReport/System.Data.SqlClient.Tests/ExceptionTest/

Also local execution result
```
 Discovering: System.Data.SqlClient.Tests
 Discovered:  System.Data.SqlClient.Tests
 Starting:    System.Data.SqlClient.Tests
    System.Data.SqlClient.Tests.ExceptionTest.ExceptionTests [STARTING]
    System.Data.SqlClient.Tests.ExceptionTest.ExceptionTests [FINISHED] Time: 5.3308509s
    System.Data.SqlClient.Tests.ExceptionTest.VariousExceptionTests [STARTING]
    System.Data.SqlClient.Tests.ExceptionTest.VariousExceptionTests [FINISHED]
  Time: 0.0242559s
    System.Data.SqlClient.Tests.ExceptionTest.IndependentConnectionExceptionTestExecuteReader [STARTING]
    System.Data.SqlClient.Tests.ExceptionTest.IndependentConnectionExceptionTestExecuteReader [FINISHED] Time: 0.0038109s
    System.Data.SqlClient.Tests.ExceptionTest.IndependentConnectionExceptionTestOpenConnection [STARTING]
    System.Data.SqlClient.Tests.ExceptionTest.IndependentConnectionExceptionTestOpenConnection [FINISHED] Time: 0.0061324s
 Finished:    System.Data.SqlClient.Tests

 === TEST EXECUTION SUMMARY ===
    System.Data.SqlClient.Tests  Total: 4, Errors: 0, Failed: 0, Skipped: 0, Time: 6.016s
```
At the same time https://ci.dot.net/job/dotnet_corefx/job/master/job/outerloop_rhel7.2_debug/105/testReport/System.Data.SqlClient.Tests/DiagnosticTest/ shows that a couple of tests in DiagnosticTest which were taking 30 seconds to complete. 
This was because the test server was not sending a TDS done token in the response. I also changed the error class to what the Sql Server sends for 1 / 0 errors. 


Fixes #16293 