### PR TITLE
Add RIDs for Fedora 25 and 26

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -497,6 +497,20 @@
             "#import": [ "fedora.24", "fedora-x64" ]
         },
 
+        "fedora.25": {
+            "#import": [ "fedora" ]
+        },
+        "fedora.25-x64": {
+            "#import": [ "fedora.25", "fedora-x64" ]
+        },
+
+        "fedora.26": {
+            "#import": [ "fedora" ]
+        },
+        "fedora.26-x64": {
+            "#import": [ "fedora.26", "fedora-x64" ]
+        },
+
         "opensuse": {
             "#import": [ "linux" ]
         },


### PR DESCRIPTION
With Fedora 23 EOLed we have F25 live now, and we are now working on F26.

ref:
#13937
#14469