### PR TITLE
Add F25 & F26 into #16237 "Disable Crypto tests for Fedora\Ubuntu"

### DIFF
--- a/src/Common/tests/System/PlatformDetection.cs
+++ b/src/Common/tests/System/PlatformDetection.cs
@@ -69,6 +69,8 @@ namespace System
         public static bool IsUbuntu1610 { get; } = IsDistroAndVersion("ubuntu", "16.10");
         public static bool IsFedora23 { get; } = IsDistroAndVersion("fedora", "23");
         public static bool IsFedora24 { get; } = IsDistroAndVersion("fedora", "24");
+        public static bool IsFedora25 { get; } = IsDistroAndVersion("fedora", "25");
+        public static bool IsFedora26 { get; } = IsDistroAndVersion("fedora", "26");
         public static bool IsCentos7 { get; } = IsDistroAndVersion("centos", "7");
 
         /// <summary>

--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -15,6 +15,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         internal static bool IsReliableInCI { get; } =
             !PlatformDetection.IsFedora23 &&
             !PlatformDetection.IsFedora24 &&
+            !PlatformDetection.IsFedora25 &&
+            !PlatformDetection.IsFedora26 &&
             !PlatformDetection.IsUbuntu1604 &&
             !PlatformDetection.IsUbuntu1610;
 


### PR DESCRIPTION
ref. #16237

With F23 EOLed and F26 knocking on the door I think that we should consider this to be priority, and not F23/24 - as per adding RIDs in PR #16302
