### PR TITLE
Remove unnecessary calls to GetTypeInfo() in System.Linq.Expressions.

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
@@ -44,7 +44,7 @@ namespace System.Dynamic.Utils
                 // A check to avoid a bunch of reflection (currently not supported) during cctor
                 if (type.GetTypeInfo().ContainsGenericParameters)
                 {
-                    throw type.GetTypeInfo().IsGenericTypeDefinition ? Error.TypeIsGeneric(type, paramName, index) : Error.TypeContainsGenericParameters(type, paramName, index);
+                    throw type.IsGenericTypeDefinition ? Error.TypeIsGeneric(type, paramName, index) : Error.TypeContainsGenericParameters(type, paramName, index);
                 }
             }
         }
@@ -86,7 +86,7 @@ namespace System.Dynamic.Utils
                 return false;
             }
 
-            if (t.GetTypeInfo().IsGenericType)
+            if (t.IsGenericType)
             {
                 foreach (Type g in t.GetGenericArguments())
                 {

--- a/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
@@ -42,7 +42,7 @@ namespace System.Dynamic.Utils
             if (type != typeof(void))
             {
                 // A check to avoid a bunch of reflection (currently not supported) during cctor
-                if (type.GetTypeInfo().ContainsGenericParameters)
+                if (type.ContainsGenericParameters)
                 {
                     throw type.IsGenericTypeDefinition ? Error.TypeIsGeneric(type, paramName, index) : Error.TypeContainsGenericParameters(type, paramName, index);
                 }

--- a/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
@@ -20,7 +20,7 @@ namespace System.Dynamic.Utils
             {
                 return true;
             }
-            if (!dest.GetTypeInfo().IsValueType && !src.GetTypeInfo().IsValueType && dest.GetTypeInfo().IsAssignableFrom(src.GetTypeInfo()))
+            if (!dest.IsValueType && !src.IsValueType && dest.IsAssignableFrom(src.GetTypeInfo()))
             {
                 return true;
             }

--- a/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
@@ -29,7 +29,7 @@ namespace System.Dynamic.Utils
 
         public static bool IsSameOrSubclass(Type type, Type subType)
         {
-            return AreEquivalent(type, subType) || subType.GetTypeInfo().IsSubclassOf(type);
+            return AreEquivalent(type, subType) || subType.IsSubclassOf(type);
         }
 
         public static void ValidateType(Type type, string paramName)

--- a/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
@@ -20,7 +20,7 @@ namespace System.Dynamic.Utils
             {
                 return true;
             }
-            if (!dest.IsValueType && !src.IsValueType && dest.IsAssignableFrom(src.GetTypeInfo()))
+            if (!dest.IsValueType && !src.IsValueType && dest.IsAssignableFrom(src))
             {
                 return true;
             }
@@ -57,7 +57,7 @@ namespace System.Dynamic.Utils
             {
                 if (s_mscorlib == null)
                 {
-                    s_mscorlib = typeof(object).GetTypeInfo().Assembly;
+                    s_mscorlib = typeof(object).Assembly;
                 }
 
                 return s_mscorlib;
@@ -79,7 +79,7 @@ namespace System.Dynamic.Utils
             // that allows mscorlib types to be specialized by types in other
             // assemblies.
 
-            Assembly asm = t.GetTypeInfo().Assembly;
+            Assembly asm = t.Assembly;
             if (asm != _mscorlib)
             {
                 // Not in mscorlib or our assembly

--- a/src/System.Linq.Expressions/src/System/Dynamic/DynamicMetaObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/DynamicMetaObject.cs
@@ -79,7 +79,7 @@ namespace System.Dynamic
                 {
                     Type ct = Expression.Type;
                     // valuetype at compile time, type cannot change.
-                    if (ct.GetTypeInfo().IsValueType)
+                    if (ct.IsValueType)
                     {
                         return ct;
                     }

--- a/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
@@ -600,7 +600,7 @@ namespace System.Dynamic
 
                     Expression condition;
                     // If the return type can not be assigned null then just check for type assignability otherwise allow null.
-                    if (binder.ReturnType.GetTypeInfo().IsValueType && Nullable.GetUnderlyingType(binder.ReturnType) == null)
+                    if (binder.ReturnType.IsValueType && Nullable.GetUnderlyingType(binder.ReturnType) == null)
                     {
                         condition = Expression.TypeIs(resultMO.Expression, binder.ReturnType);
                     }

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -262,12 +262,12 @@ namespace System.Dynamic.Utils
             Type nnDestType = GetNonNullableType(dest);
 
             // Down conversion
-            if (nnSourceType.IsAssignableFrom(nnDestType.GetTypeInfo()))
+            if (nnSourceType.IsAssignableFrom(nnDestType))
             {
                 return true;
             }
             // Up conversion
-            if (nnDestType.IsAssignableFrom(nnSourceType.GetTypeInfo()))
+            if (nnDestType.IsAssignableFrom(nnSourceType))
             {
                 return true;
             }
@@ -291,19 +291,19 @@ namespace System.Dynamic.Utils
         private static bool IsCovariant(Type t)
         {
             Debug.Assert(t != null);
-            return 0 != (t.GetTypeInfo().GenericParameterAttributes & GenericParameterAttributes.Covariant);
+            return 0 != (t.GenericParameterAttributes & GenericParameterAttributes.Covariant);
         }
 
         private static bool IsContravariant(Type t)
         {
             Debug.Assert(t != null);
-            return 0 != (t.GetTypeInfo().GenericParameterAttributes & GenericParameterAttributes.Contravariant);
+            return 0 != (t.GenericParameterAttributes & GenericParameterAttributes.Contravariant);
         }
 
         private static bool IsInvariant(Type t)
         {
             Debug.Assert(t != null);
-            return 0 == (t.GetTypeInfo().GenericParameterAttributes & GenericParameterAttributes.VarianceMask);
+            return 0 == (t.GenericParameterAttributes & GenericParameterAttributes.VarianceMask);
         }
 
         private static bool IsDelegate(Type t)
@@ -644,7 +644,7 @@ namespace System.Dynamic.Utils
 
         private static bool IsImplicitReferenceConversion(Type source, Type destination)
         {
-            return destination.IsAssignableFrom(source.GetTypeInfo());
+            return destination.IsAssignableFrom(source);
         }
 
         private static bool IsImplicitBoxingConversion(Type source, Type destination)
@@ -680,7 +680,7 @@ namespace System.Dynamic.Utils
                             return found;
                     }
                 }
-                type = type.GetTypeInfo().BaseType;
+                type = type.BaseType;
             }
             return null;
         }
@@ -703,7 +703,7 @@ namespace System.Dynamic.Utils
                 {
                     return result;
                 }
-                type = type.GetTypeInfo().BaseType;
+                type = type.BaseType;
             } while (type != null);
             return null;
         }

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -326,7 +326,7 @@ namespace System.Dynamic.Utils
             //   o If type parameter Xi is declared to be contravariant ("in") then either Si must be identical to Ti,
             //     or Si and Ti must both be reference types.
 
-            if (!IsDelegate(source) || !IsDelegate(dest) || !source.GetTypeInfo().IsGenericType || !dest.GetTypeInfo().IsGenericType)
+            if (!IsDelegate(source) || !IsDelegate(dest) || !source.IsGenericType || !dest.IsGenericType)
                 return false;
 
             Type genericDelegate = source.GetGenericTypeDefinition();

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -47,7 +47,7 @@ namespace System.Dynamic.Utils
         public static bool IsNumeric(this Type type)
         {
             type = GetNonNullableType(type);
-            if (!type.GetTypeInfo().IsEnum)
+            if (!type.IsEnum)
             {
                 switch (type.GetTypeCode())
                 {
@@ -71,7 +71,7 @@ namespace System.Dynamic.Utils
         public static bool IsInteger(this Type type)
         {
             type = GetNonNullableType(type);
-            if (type.GetTypeInfo().IsEnum)
+            if (type.IsEnum)
             {
                 return false;
             }
@@ -94,7 +94,7 @@ namespace System.Dynamic.Utils
         public static bool IsInteger64(this Type type)
         {
             type = GetNonNullableType(type);
-            if (type.GetTypeInfo().IsEnum)
+            if (type.IsEnum)
             {
                 return false;
             }
@@ -111,7 +111,7 @@ namespace System.Dynamic.Utils
         public static bool IsArithmetic(this Type type)
         {
             type = GetNonNullableType(type);
-            if (!type.GetTypeInfo().IsEnum)
+            if (!type.IsEnum)
             {
                 switch (type.GetTypeCode())
                 {
@@ -132,7 +132,7 @@ namespace System.Dynamic.Utils
         public static bool IsUnsignedInt(this Type type)
         {
             type = GetNonNullableType(type);
-            if (!type.GetTypeInfo().IsEnum)
+            if (!type.IsEnum)
             {
                 switch (type.GetTypeCode())
                 {
@@ -148,7 +148,7 @@ namespace System.Dynamic.Utils
         public static bool IsIntegerOrBool(this Type type)
         {
             type = GetNonNullableType(type);
-            if (!type.GetTypeInfo().IsEnum)
+            if (!type.IsEnum)
             {
                 switch (type.GetTypeCode())
                 {
@@ -194,7 +194,7 @@ namespace System.Dynamic.Utils
                 {
                     return true;
                 }
-                if (instanceType.GetTypeInfo().IsEnum && AreReferenceAssignable(targetType, typeof(Enum)))
+                if (instanceType.IsEnum && AreReferenceAssignable(targetType, typeof(Enum)))
                 {
                     return true;
                 }
@@ -387,7 +387,7 @@ namespace System.Dynamic.Utils
         public static bool IsConvertible(this Type type)
         {
             type = GetNonNullableType(type);
-            if (type.GetTypeInfo().IsEnum)
+            if (type.IsEnum)
             {
                 return true;
             }
@@ -462,7 +462,7 @@ namespace System.Dynamic.Utils
             // Equality between struct types is only defined for numerics, bools, enums,
             // and their nullable equivalents.
             Type nnType = GetNonNullableType(left);
-            if (nnType == typeof(bool) || IsNumeric(nnType) || nnType.GetTypeInfo().IsEnum)
+            if (nnType == typeof(bool) || IsNumeric(nnType) || nnType.IsEnum)
             {
                 return true;
             }
@@ -651,7 +651,7 @@ namespace System.Dynamic.Utils
         {
             if (source.IsValueType && (destination == typeof(object) || destination == typeof(ValueType)))
                 return true;
-            if (source.GetTypeInfo().IsEnum && destination == typeof(Enum))
+            if (source.IsEnum && destination == typeof(Enum))
                 return true;
             return false;
         }

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -262,12 +262,12 @@ namespace System.Dynamic.Utils
             Type nnDestType = GetNonNullableType(dest);
 
             // Down conversion
-            if (nnSourceType.GetTypeInfo().IsAssignableFrom(nnDestType.GetTypeInfo()))
+            if (nnSourceType.IsAssignableFrom(nnDestType.GetTypeInfo()))
             {
                 return true;
             }
             // Up conversion
-            if (nnDestType.GetTypeInfo().IsAssignableFrom(nnSourceType.GetTypeInfo()))
+            if (nnDestType.IsAssignableFrom(nnSourceType.GetTypeInfo()))
             {
                 return true;
             }
@@ -644,7 +644,7 @@ namespace System.Dynamic.Utils
 
         private static bool IsImplicitReferenceConversion(Type source, Type destination)
         {
-            return destination.GetTypeInfo().IsAssignableFrom(source.GetTypeInfo());
+            return destination.IsAssignableFrom(source.GetTypeInfo());
         }
 
         private static bool IsImplicitBoxingConversion(Type source, Type destination)

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -200,7 +200,7 @@ namespace System.Dynamic.Utils
                 }
                 // A call to an interface implemented by a struct is legal whether the struct has
                 // been boxed or not.
-                if (targetType.GetTypeInfo().IsInterface)
+                if (targetType.IsInterface)
                 {
                     foreach (Type interfaceType in instanceType.GetTypeInfo().ImplementedInterfaces)
                     {
@@ -272,7 +272,7 @@ namespace System.Dynamic.Utils
                 return true;
             }
             // Interface conversion
-            if (source.GetTypeInfo().IsInterface || dest.GetTypeInfo().IsInterface)
+            if (source.IsInterface || dest.IsInterface)
             {
                 return true;
             }
@@ -424,7 +424,7 @@ namespace System.Dynamic.Utils
             // If we have two reference types and one is assignable to the
             // other then we can do reference equality.
 
-            return left.GetTypeInfo().IsInterface || right.GetTypeInfo().IsInterface ||
+            return left.IsInterface || right.IsInterface ||
                 AreReferenceAssignable(left, right) ||
                 AreReferenceAssignable(right, left);
         }
@@ -433,11 +433,11 @@ namespace System.Dynamic.Utils
         {
             // If we have an interface and a reference type then we can do
             // reference equality.
-            if (left.GetTypeInfo().IsInterface && !right.IsValueType)
+            if (left.IsInterface && !right.IsValueType)
             {
                 return true;
             }
-            if (right.GetTypeInfo().IsInterface && !left.IsValueType)
+            if (right.IsInterface && !left.IsValueType)
             {
                 return true;
             }
@@ -671,7 +671,7 @@ namespace System.Dynamic.Utils
                 {
                     return type;
                 }
-                if (definition.GetTypeInfo().IsInterface)
+                if (definition.IsInterface)
                 {
                     foreach (Type itype in type.GetTypeInfo().ImplementedInterfaces)
                     {

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -22,7 +22,7 @@ namespace System.Dynamic.Utils
         public static Type GetNullableType(this Type type)
         {
             Debug.Assert(type != null, "type cannot be null");
-            if (type.GetTypeInfo().IsValueType && !IsNullableType(type))
+            if (type.IsValueType && !IsNullableType(type))
             {
                 return typeof(Nullable<>).MakeGenericType(type);
             }
@@ -36,7 +36,7 @@ namespace System.Dynamic.Utils
 
         public static bool IsNullableOrReferenceType(this Type type)
         {
-            return !type.GetTypeInfo().IsValueType || IsNullableType(type);
+            return !type.IsValueType || IsNullableType(type);
         }
 
         public static bool IsBool(this Type type)
@@ -184,7 +184,7 @@ namespace System.Dynamic.Utils
             {
                 return false;
             }
-            if (instanceType.GetTypeInfo().IsValueType)
+            if (instanceType.IsValueType)
             {
                 if (AreReferenceAssignable(targetType, typeof(object)))
                 {
@@ -375,7 +375,7 @@ namespace System.Dynamic.Utils
                 }
                 else if (IsContravariant(genericParameter))
                 {
-                    if (sourceArgument.GetTypeInfo().IsValueType || destArgument.GetTypeInfo().IsValueType)
+                    if (sourceArgument.IsValueType || destArgument.IsValueType)
                     {
                         return false;
                     }
@@ -413,7 +413,7 @@ namespace System.Dynamic.Utils
 
         public static bool HasReferenceEquality(Type left, Type right)
         {
-            if (left.GetTypeInfo().IsValueType || right.GetTypeInfo().IsValueType)
+            if (left.IsValueType || right.IsValueType)
             {
                 return false;
             }
@@ -433,17 +433,17 @@ namespace System.Dynamic.Utils
         {
             // If we have an interface and a reference type then we can do
             // reference equality.
-            if (left.GetTypeInfo().IsInterface && !right.GetTypeInfo().IsValueType)
+            if (left.GetTypeInfo().IsInterface && !right.IsValueType)
             {
                 return true;
             }
-            if (right.GetTypeInfo().IsInterface && !left.GetTypeInfo().IsValueType)
+            if (right.GetTypeInfo().IsInterface && !left.IsValueType)
             {
                 return true;
             }
             // If we have two reference types and one is assignable to the
             // other then we can do reference equality.
-            if (!left.GetTypeInfo().IsValueType && !right.GetTypeInfo().IsValueType)
+            if (!left.IsValueType && !right.IsValueType)
             {
                 if (AreReferenceAssignable(left, right) || AreReferenceAssignable(right, left))
                 {
@@ -458,7 +458,7 @@ namespace System.Dynamic.Utils
             }
             // We have two identical value types, modulo nullability.  (If they were both the
             // same reference type then we would have returned true earlier.)
-            Debug.Assert(left.GetTypeInfo().IsValueType);
+            Debug.Assert(left.IsValueType);
             // Equality between struct types is only defined for numerics, bools, enums,
             // and their nullable equivalents.
             Type nnType = GetNonNullableType(left);
@@ -649,7 +649,7 @@ namespace System.Dynamic.Utils
 
         private static bool IsImplicitBoxingConversion(Type source, Type destination)
         {
-            if (source.GetTypeInfo().IsValueType && (destination == typeof(object) || destination == typeof(ValueType)))
+            if (source.IsValueType && (destination == typeof(object) || destination == typeof(ValueType)))
                 return true;
             if (source.GetTypeInfo().IsEnum && destination == typeof(Enum))
                 return true;

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -309,7 +309,7 @@ namespace System.Dynamic.Utils
         private static bool IsDelegate(Type t)
         {
             Debug.Assert(t != null);
-            return t.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate));
+            return t.IsSubclassOf(typeof(MulticastDelegate));
         }
 
         public static bool IsLegalExplicitVariantDelegateConversion(Type source, Type dest)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -1097,7 +1097,7 @@ namespace System.Linq.Expressions
             if (left.Type == right.Type && (left.Type.IsNumeric() ||
                 left.Type == typeof(object) ||
                 left.Type.IsBool() ||
-                left.Type.GetNonNullableType().GetTypeInfo().IsEnum))
+                left.Type.GetNonNullableType().IsEnum))
             {
                 if (left.Type.IsNullableType() && liftToNull)
                 {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -377,7 +377,7 @@ namespace System.Linq.Expressions
                 ExpressionType kind = NodeType;
 
                 return (kind == ExpressionType.Equal || kind == ExpressionType.NotEqual) &&
-                    method == null && !left.GetTypeInfo().IsValueType && !right.GetTypeInfo().IsValueType;
+                    method == null && !left.IsValueType && !right.IsValueType;
             }
         }
 
@@ -615,7 +615,7 @@ namespace System.Linq.Expressions
                 Type nnLeftType = left.Type.GetNonNullableType();
                 Type nnRightType = right.Type.GetNonNullableType();
                 method = GetUserDefinedBinaryOperator(binaryType, nnLeftType, nnRightType, name);
-                if (method != null && method.ReturnType.GetTypeInfo().IsValueType && !method.ReturnType.IsNullableType())
+                if (method != null && method.ReturnType.IsValueType && !method.ReturnType.IsNullableType())
                 {
                     if (method.ReturnType != typeof(bool) || liftToNull)
                     {
@@ -647,7 +647,7 @@ namespace System.Linq.Expressions
             if (left.Type.IsNullableType() && right.Type.IsNullableType() &&
                 ParameterIsAssignable(pms[0], left.Type.GetNonNullableType()) &&
                 ParameterIsAssignable(pms[1], right.Type.GetNonNullableType()) &&
-                method.ReturnType.GetTypeInfo().IsValueType && !method.ReturnType.IsNullableType())
+                method.ReturnType.IsValueType && !method.ReturnType.IsNullableType())
             {
                 if (method.ReturnType != typeof(bool) || liftToNull)
                 {
@@ -1427,7 +1427,7 @@ namespace System.Linq.Expressions
                 return new SimpleBinaryExpression(ExpressionType.Coalesce, left, right, resultType);
             }
 
-            if (left.Type.GetTypeInfo().IsValueType && !left.Type.IsNullableType())
+            if (left.Type.IsValueType && !left.Type.IsNullableType())
             {
                 throw Error.CoalesceUsedOnNonNullType();
             }
@@ -1466,7 +1466,7 @@ namespace System.Linq.Expressions
         private static Type ValidateCoalesceArgTypes(Type left, Type right)
         {
             Type leftStripped = left.GetNonNullableType();
-            if (left.GetTypeInfo().IsValueType && !left.IsNullableType())
+            if (left.IsValueType && !left.IsNullableType())
             {
                 throw Error.CoalesceUsedOnNonNullType();
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/ConstantCheck.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Common/ConstantCheck.cs
@@ -85,7 +85,7 @@ namespace System.Linq.Expressions
             {
                 // If the operand is a value type (other than nullable), we
                 // know the result is always true.
-                if (operandType.GetTypeInfo().IsValueType && !operandType.IsNullableType())
+                if (operandType.IsValueType && !operandType.IsNullableType())
                 {
                     return AnalyzeTypeIsResult.KnownTrue;
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/BoundConstants.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/BoundConstants.cs
@@ -193,7 +193,7 @@ namespace System.Linq.Expressions.Compiler
 
             lc.IL.EmitPrimitive(index);
             lc.IL.Emit(OpCodes.Ldelem_Ref);
-            if (type.GetTypeInfo().IsValueType)
+            if (type.IsValueType)
             {
                 lc.IL.Emit(OpCodes.Unbox_Any, type);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -1159,7 +1159,7 @@ namespace System.Linq.Expressions.Compiler
                     {
                         // Type.GetTypeCode on an enum returns the underlying
                         // integer TypeCode, so we won't get here.
-                        Debug.Assert(!type.GetTypeInfo().IsEnum);
+                        Debug.Assert(!type.IsEnum);
 
                         // This is the IL for default(T) if T is a generic type
                         // parameter, so it should work for any type. It's also

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -321,7 +321,7 @@ namespace System.Linq.Expressions.Compiler
         internal static void EmitNew(this ILGenerator il, ConstructorInfo ci)
         {
             Debug.Assert(ci != null);
-            Debug.Assert(!ci.DeclaringType.GetTypeInfo().ContainsGenericParameters);
+            Debug.Assert(!ci.DeclaringType.ContainsGenericParameters);
 
             il.Emit(OpCodes.Newobj, ci);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -544,7 +544,7 @@ namespace System.Linq.Expressions.Compiler
         {
             // If CompileToMethod is re-enabled, t is TypeBuilder should also return
             // true when not compiling to a DynamicMethod
-            return t.IsGenericParameter || t.GetTypeInfo().IsVisible;
+            return t.IsGenericParameter || t.IsVisible;
         }
 
         internal static bool ShouldLdtoken(MethodBase mb)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -128,7 +128,7 @@ namespace System.Linq.Expressions.Compiler
                     il.Emit(OpCodes.Ldind_R8);
                     break;
                 default:
-                    if (type.GetTypeInfo().IsValueType)
+                    if (type.IsValueType)
                     {
                         il.Emit(OpCodes.Ldobj, type);
                     }
@@ -175,7 +175,7 @@ namespace System.Linq.Expressions.Compiler
                     il.Emit(OpCodes.Stind_R8);
                     break;
                 default:
-                    if (type.GetTypeInfo().IsValueType)
+                    if (type.IsValueType)
                     {
                         il.Emit(OpCodes.Stobj, type);
                     }
@@ -193,7 +193,7 @@ namespace System.Linq.Expressions.Compiler
         {
             Debug.Assert(type != null);
 
-            if (!type.GetTypeInfo().IsValueType)
+            if (!type.IsValueType)
             {
                 il.Emit(OpCodes.Ldelem_Ref);
             }
@@ -272,7 +272,7 @@ namespace System.Linq.Expressions.Compiler
                     il.Emit(OpCodes.Stelem_R8);
                     break;
                 default:
-                    if (type.GetTypeInfo().IsValueType)
+                    if (type.IsValueType)
                     {
                         il.Emit(OpCodes.Stelem, type);
                     }
@@ -682,11 +682,11 @@ namespace System.Linq.Expressions.Compiler
 
         private static void EmitCastToType(this ILGenerator il, Type typeFrom, Type typeTo)
         {
-            if (!typeFrom.GetTypeInfo().IsValueType && typeTo.GetTypeInfo().IsValueType)
+            if (!typeFrom.IsValueType && typeTo.IsValueType)
             {
                 il.Emit(OpCodes.Unbox_Any, typeTo);
             }
-            else if (typeFrom.GetTypeInfo().IsValueType && !typeTo.GetTypeInfo().IsValueType)
+            else if (typeFrom.IsValueType && !typeTo.IsValueType)
             {
                 il.Emit(OpCodes.Box, typeFrom);
                 if (typeTo != typeof(object))
@@ -694,7 +694,7 @@ namespace System.Linq.Expressions.Compiler
                     il.Emit(OpCodes.Castclass, typeTo);
                 }
             }
-            else if (!typeFrom.GetTypeInfo().IsValueType && !typeTo.GetTypeInfo().IsValueType)
+            else if (!typeFrom.IsValueType && !typeTo.IsValueType)
             {
                 il.Emit(OpCodes.Castclass, typeTo);
             }
@@ -932,7 +932,7 @@ namespace System.Linq.Expressions.Compiler
         {
             Debug.Assert(typeFrom.IsNullableType());
             Debug.Assert(!typeTo.IsNullableType());
-            if (typeTo.GetTypeInfo().IsValueType)
+            if (typeTo.IsValueType)
                 il.EmitNullableToNonNullableStructConversion(typeFrom, typeTo, isChecked, locals);
             else
                 il.EmitNullableToReferenceConversion(typeFrom);
@@ -943,7 +943,7 @@ namespace System.Linq.Expressions.Compiler
         {
             Debug.Assert(typeFrom.IsNullableType());
             Debug.Assert(!typeTo.IsNullableType());
-            Debug.Assert(typeTo.GetTypeInfo().IsValueType);
+            Debug.Assert(typeTo.IsValueType);
             LocalBuilder locFrom = locals.GetLocal(typeFrom);
             il.Emit(OpCodes.Stloc, locFrom);
             il.Emit(OpCodes.Ldloca, locFrom);
@@ -980,7 +980,7 @@ namespace System.Linq.Expressions.Compiler
         internal static void EmitHasValue(this ILGenerator il, Type nullableType)
         {
             MethodInfo mi = nullableType.GetMethod("get_HasValue", BindingFlags.Instance | BindingFlags.Public);
-            Debug.Assert(nullableType.GetTypeInfo().IsValueType);
+            Debug.Assert(nullableType.IsValueType);
             il.Emit(OpCodes.Call, mi);
         }
 
@@ -988,7 +988,7 @@ namespace System.Linq.Expressions.Compiler
         internal static void EmitGetValue(this ILGenerator il, Type nullableType)
         {
             MethodInfo mi = nullableType.GetMethod("get_Value", BindingFlags.Instance | BindingFlags.Public);
-            Debug.Assert(nullableType.GetTypeInfo().IsValueType);
+            Debug.Assert(nullableType.IsValueType);
             il.Emit(OpCodes.Call, mi);
         }
 
@@ -996,7 +996,7 @@ namespace System.Linq.Expressions.Compiler
         internal static void EmitGetValueOrDefault(this ILGenerator il, Type nullableType)
         {
             MethodInfo mi = nullableType.GetMethod("GetValueOrDefault", System.Type.EmptyTypes);
-            Debug.Assert(nullableType.GetTypeInfo().IsValueType);
+            Debug.Assert(nullableType.IsValueType);
             il.Emit(OpCodes.Call, mi);
         }
 
@@ -1155,7 +1155,7 @@ namespace System.Linq.Expressions.Compiler
                     break;
 
                 case TypeCode.Object:
-                    if (type.GetTypeInfo().IsValueType)
+                    if (type.IsValueType)
                     {
                         // Type.GetTypeCode on an enum returns the underlying
                         // integer TypeCode, so we won't get here.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -519,7 +519,7 @@ namespace System.Linq.Expressions.Compiler
             {
                 il.Emit(OpCodes.Ldtoken, mb);
                 Type dt = mb.DeclaringType;
-                if (dt != null && dt.GetTypeInfo().IsGenericType)
+                if (dt != null && dt.IsGenericType)
                 {
                     il.Emit(OpCodes.Ldtoken, dt);
                     il.Emit(OpCodes.Call, MethodBase_GetMethodFromHandle_RuntimeMethodHandle_RuntimeTypeHandle);
@@ -647,8 +647,8 @@ namespace System.Linq.Expressions.Compiler
             Type nnExprType = typeFrom.GetNonNullableType();
             Type nnType = typeTo.GetNonNullableType();
 
-            if (typeFrom.GetTypeInfo().IsInterface || // interface cast
-               typeTo.GetTypeInfo().IsInterface ||
+            if (typeFrom.IsInterface || // interface cast
+               typeTo.IsInterface ||
                typeFrom == typeof(object) || // boxing cast
                typeTo == typeof(object) ||
                typeFrom == typeof(System.Enum) ||

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
@@ -222,7 +222,7 @@ namespace System.Linq.Expressions.Compiler
         private void AddressOf(UnaryExpression node, Type type)
         {
             Debug.Assert(node.NodeType == ExpressionType.Unbox);
-            Debug.Assert(type.GetTypeInfo().IsValueType);
+            Debug.Assert(type.IsValueType);
 
             // Unbox leaves a pointer to the boxed value on the stack
             EmitExpression(node.Operand);
@@ -391,7 +391,7 @@ namespace System.Linq.Expressions.Compiler
 
         private LocalBuilder GetInstanceLocal(Type type)
         {
-            Type instanceLocalType = type.GetTypeInfo().IsValueType ? type.MakeByRefType() : type;
+            Type instanceLocalType = type.IsValueType ? type.MakeByRefType() : type;
             return GetLocal(instanceLocalType);
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -338,7 +338,7 @@ namespace System.Linq.Expressions.Compiler
         private void EmitUnliftedEquality(ExpressionType op, Type type)
         {
             Debug.Assert(op == ExpressionType.Equal || op == ExpressionType.NotEqual);
-            if (!type.GetTypeInfo().IsPrimitive && type.IsValueType && !type.GetTypeInfo().IsEnum)
+            if (!type.GetTypeInfo().IsPrimitive && type.IsValueType && !type.IsEnum)
             {
                 throw Error.OperatorNotImplementedForType(op, type);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -175,7 +175,7 @@ namespace System.Linq.Expressions.Compiler
                 EmitUnliftedEquality(op, leftType);
                 return;
             }
-            if (!leftType.GetTypeInfo().IsPrimitive)
+            if (!leftType.IsPrimitive)
             {
                 throw Error.OperatorNotImplementedForType(op, leftType);
             }
@@ -338,7 +338,7 @@ namespace System.Linq.Expressions.Compiler
         private void EmitUnliftedEquality(ExpressionType op, Type type)
         {
             Debug.Assert(op == ExpressionType.Equal || op == ExpressionType.NotEqual);
-            if (!type.GetTypeInfo().IsPrimitive && type.IsValueType && !type.IsEnum)
+            if (!type.IsPrimitive && type.IsValueType && !type.IsEnum)
             {
                 throw Error.OperatorNotImplementedForType(op, type);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -338,7 +338,7 @@ namespace System.Linq.Expressions.Compiler
         private void EmitUnliftedEquality(ExpressionType op, Type type)
         {
             Debug.Assert(op == ExpressionType.Equal || op == ExpressionType.NotEqual);
-            if (!type.GetTypeInfo().IsPrimitive && type.GetTypeInfo().IsValueType && !type.GetTypeInfo().IsEnum)
+            if (!type.GetTypeInfo().IsPrimitive && type.IsValueType && !type.GetTypeInfo().IsEnum)
             {
                 throw Error.OperatorNotImplementedForType(op, type);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -376,7 +376,7 @@ namespace System.Linq.Expressions.Compiler
             }
             // if the obj has a value type, its address is passed to the method call so we cannot destroy the
             // stack by emitting a tail call
-            if (obj != null && obj.Type.GetTypeInfo().IsValueType)
+            if (obj != null && obj.Type.IsValueType)
             {
                 EmitMethodCall(method, methodCallExpr, objectType);
             }
@@ -400,7 +400,7 @@ namespace System.Linq.Expressions.Compiler
 
             // Emit the actual call
             OpCode callOp = UseVirtual(mi) ? OpCodes.Callvirt : OpCodes.Call;
-            if (callOp == OpCodes.Callvirt && objectType.GetTypeInfo().IsValueType)
+            if (callOp == OpCodes.Callvirt && objectType.IsValueType)
             {
                 // This automatically boxes value types if necessary.
                 _ilg.Emit(OpCodes.Constrained, objectType);
@@ -454,7 +454,7 @@ namespace System.Linq.Expressions.Compiler
             }
 
             OpCode callOp = UseVirtual(method) ? OpCodes.Callvirt : OpCodes.Call;
-            if (callOp == OpCodes.Callvirt && objectType.GetTypeInfo().IsValueType)
+            if (callOp == OpCodes.Callvirt && objectType.IsValueType)
             {
                 _ilg.Emit(OpCodes.Constrained, objectType);
             }
@@ -487,7 +487,7 @@ namespace System.Linq.Expressions.Compiler
             {
                 return false;
             }
-            if (mi.DeclaringType.GetTypeInfo().IsValueType)
+            if (mi.DeclaringType.IsValueType)
             {
                 return false;
             }
@@ -628,7 +628,7 @@ namespace System.Linq.Expressions.Compiler
             else
             {
                 Debug.Assert(node.ArgumentCount == 0, "Node with arguments must have a constructor.");
-                Debug.Assert(node.Type.GetTypeInfo().IsValueType, "Only value type may have constructor not set.");
+                Debug.Assert(node.Type.IsValueType, "Only value type may have constructor not set.");
                 LocalBuilder temp = GetLocal(node.Type);
                 _ilg.Emit(OpCodes.Ldloca, temp);
                 _ilg.Emit(OpCodes.Initobj, node.Type);
@@ -673,7 +673,7 @@ namespace System.Linq.Expressions.Compiler
                     return;
                 }
 
-                Debug.Assert(!type.GetTypeInfo().IsValueType);
+                Debug.Assert(!type.IsValueType);
                 EmitExpression(node.Expression);
                 _ilg.Emit(OpCodes.Ldnull);
                 _ilg.Emit(OpCodes.Cgt_Un);
@@ -684,7 +684,7 @@ namespace System.Linq.Expressions.Compiler
 
             // Emit a full runtime "isinst" check
             EmitExpression(node.Expression);
-            if (type.GetTypeInfo().IsValueType)
+            if (type.IsValueType)
             {
                 _ilg.Emit(OpCodes.Box, type);
             }
@@ -874,11 +874,11 @@ namespace System.Linq.Expressions.Compiler
                 type = type.GetElementType();
 
                 Debug.Assert(instance.NodeType == ExpressionType.Parameter);
-                Debug.Assert(type.GetTypeInfo().IsValueType);
+                Debug.Assert(type.IsValueType);
 
                 EmitExpression(instance);
             }
-            else if (type.GetTypeInfo().IsValueType)
+            else if (type.IsValueType)
             {
                 EmitAddress(instance, type);
             }
@@ -987,11 +987,11 @@ namespace System.Linq.Expressions.Compiler
         private void EmitMemberMemberBinding(MemberMemberBinding binding)
         {
             Type type = GetMemberType(binding.Member);
-            if (binding.Member is PropertyInfo && type.GetTypeInfo().IsValueType)
+            if (binding.Member is PropertyInfo && type.IsValueType)
             {
                 throw Error.CannotAutoInitializeValueTypeMemberThroughProperty(binding.Member);
             }
-            if (type.GetTypeInfo().IsValueType)
+            if (type.IsValueType)
             {
                 EmitMemberAddress(binding.Member, binding.Member.DeclaringType);
             }
@@ -1005,11 +1005,11 @@ namespace System.Linq.Expressions.Compiler
         private void EmitMemberListBinding(MemberListBinding binding)
         {
             Type type = GetMemberType(binding.Member);
-            if (binding.Member is PropertyInfo && type.GetTypeInfo().IsValueType)
+            if (binding.Member is PropertyInfo && type.IsValueType)
             {
                 throw Error.CannotAutoInitializeValueTypeElementThroughProperty(binding.Member);
             }
-            if (type.GetTypeInfo().IsValueType)
+            if (type.IsValueType)
             {
                 EmitMemberAddress(binding.Member, binding.Member.DeclaringType);
             }
@@ -1024,7 +1024,7 @@ namespace System.Linq.Expressions.Compiler
         {
             EmitExpression(init.NewExpression);
             LocalBuilder loc = null;
-            if (init.NewExpression.Type.GetTypeInfo().IsValueType && init.Bindings.Count > 0)
+            if (init.NewExpression.Type.IsValueType && init.Bindings.Count > 0)
             {
                 loc = GetLocal(init.NewExpression.Type);
                 _ilg.Emit(OpCodes.Stloc, loc);
@@ -1068,7 +1068,7 @@ namespace System.Linq.Expressions.Compiler
         {
             EmitExpression(init.NewExpression);
             LocalBuilder loc = null;
-            if (init.NewExpression.Type.GetTypeInfo().IsValueType)
+            if (init.NewExpression.Type.IsValueType)
             {
                 loc = GetLocal(init.NewExpression.Type);
                 _ilg.Emit(OpCodes.Stloc, loc);
@@ -1182,7 +1182,7 @@ namespace System.Linq.Expressions.Compiler
                             {
                                 _scope.AddLocal(this, v);
                                 EmitExpression(arg);
-                                if (!arg.Type.GetTypeInfo().IsValueType)
+                                if (!arg.Type.IsValueType)
                                 {
                                     _ilg.Emit(OpCodes.Dup);
                                     _ilg.Emit(OpCodes.Ldnull);
@@ -1204,7 +1204,7 @@ namespace System.Linq.Expressions.Compiler
                         _ilg.MarkLabel(exitNull);
                         if (TypeUtils.AreEquivalent(resultType, mc.Type.GetNullableType()))
                         {
-                            if (resultType.GetTypeInfo().IsValueType)
+                            if (resultType.IsValueType)
                             {
                                 LocalBuilder result = GetLocal(resultType);
                                 _ilg.Emit(OpCodes.Ldloca, result);
@@ -1277,7 +1277,7 @@ namespace System.Linq.Expressions.Compiler
                             else
                             {
                                 EmitExpression(arg);
-                                if (!arg.Type.GetTypeInfo().IsValueType)
+                                if (!arg.Type.IsValueType)
                                 {
                                     _ilg.Emit(OpCodes.Dup);
                                     _ilg.Emit(OpCodes.Ldnull);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -618,7 +618,7 @@ namespace System.Linq.Expressions.Compiler
 
             if (node.Constructor != null)
             {
-                if (node.Constructor.DeclaringType.GetTypeInfo().IsAbstract)
+                if (node.Constructor.DeclaringType.IsAbstract)
                     throw Error.NonAbstractConstructorRequired();
 
                 List<WriteBack> wb = EmitArguments(node.Constructor, node);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Logical.cs
@@ -94,7 +94,7 @@ namespace System.Linq.Expressions.Compiler
             {
                 EmitNullableCoalesce(b);
             }
-            else if (b.Left.Type.GetTypeInfo().IsValueType)
+            else if (b.Left.Type.IsValueType)
             {
                 throw Error.CoalesceUsedOnNonNullType();
             }
@@ -212,7 +212,7 @@ namespace System.Linq.Expressions.Compiler
             EmitExpression(b.Right);
             if (!TypeUtils.AreEquivalent(b.Right.Type, b.Type))
             {
-                if (b.Right.Type.GetTypeInfo().IsValueType)
+                if (b.Right.Type.IsValueType)
                 {
                     _ilg.Emit(OpCodes.Box, b.Right.Type);
                 }
@@ -222,7 +222,7 @@ namespace System.Linq.Expressions.Compiler
             _ilg.MarkLabel(labCast);
             if (!TypeUtils.AreEquivalent(b.Left.Type, b.Type))
             {
-                Debug.Assert(!b.Left.Type.GetTypeInfo().IsValueType);
+                Debug.Assert(!b.Left.Type.IsValueType);
                 _ilg.Emit(OpCodes.Castclass, b.Type);
             }
             _ilg.MarkLabel(labEnd);
@@ -578,7 +578,7 @@ namespace System.Linq.Expressions.Compiler
                 }
                 else
                 {
-                    Debug.Assert(!node.Right.Type.GetTypeInfo().IsValueType);
+                    Debug.Assert(!node.Right.Type.IsValueType);
                     EmitExpression(GetEqualityOperand(node.Right));
                 }
                 EmitBranchOp(!branchWhenEqual, label);
@@ -592,7 +592,7 @@ namespace System.Linq.Expressions.Compiler
                 }
                 else
                 {
-                    Debug.Assert(!node.Left.Type.GetTypeInfo().IsValueType);
+                    Debug.Assert(!node.Left.Type.IsValueType);
                     EmitExpression(GetEqualityOperand(node.Left));
                 }
                 EmitBranchOp(!branchWhenEqual, label);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
@@ -233,7 +233,7 @@ namespace System.Linq.Expressions.Compiler
                         // (integer NegateChecked was rewritten to 0 - operand and doesn't hit here).
                         return;
                     case ExpressionType.TypeAs:
-                        if (operandType.GetTypeInfo().IsValueType)
+                        if (operandType.IsValueType)
                         {
                             _ilg.Emit(OpCodes.Box, operandType);
                         }
@@ -290,7 +290,7 @@ namespace System.Linq.Expressions.Compiler
         private void EmitUnboxUnaryExpression(Expression expr)
         {
             var node = (UnaryExpression)expr;
-            Debug.Assert(node.Type.GetTypeInfo().IsValueType);
+            Debug.Assert(node.Type.IsValueType);
 
             // Unbox_Any leaves the value on the stack
             EmitExpression(node.Operand);
@@ -322,7 +322,7 @@ namespace System.Linq.Expressions.Compiler
                 // an expression tree and then compiling it.  We can live with this
                 // discrepancy however.
 
-                if (node.IsLifted && (!node.Type.GetTypeInfo().IsValueType || !node.Operand.Type.GetTypeInfo().IsValueType))
+                if (node.IsLifted && (!node.Type.IsValueType || !node.Operand.Type.IsValueType))
                 {
                     ParameterInfo[] pis = node.Method.GetParametersCached();
                     Debug.Assert(pis != null && pis.Length == 1);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.cs
@@ -113,7 +113,7 @@ namespace System.Linq.Expressions.Compiler
 
             _tree = tree;
             _lambda = lambda;
-            _typeBuilder = (TypeBuilder)method.DeclaringType.GetTypeInfo();
+            _typeBuilder = (TypeBuilder)method.DeclaringType;
             _method = method;
             _hasClosureArgument = hasClosureArgument;
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Bindings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Bindings.cs
@@ -49,7 +49,7 @@ namespace System.Linq.Expressions.Compiler
             {
                 var property = _binding.Member as PropertyInfo;
 
-                if (property != null && property.PropertyType.GetTypeInfo().IsValueType)
+                if (property != null && property.PropertyType.IsValueType)
                 {
                     throw Error.CannotAutoInitializeValueTypeMemberThroughProperty(property);
                 }
@@ -113,7 +113,7 @@ namespace System.Linq.Expressions.Compiler
                 }
 
                 // We need to copy back value types.
-                if (memberTemp.Type.GetTypeInfo().IsValueType)
+                if (memberTemp.Type.IsValueType)
                 {
                     block[count + 1] = Expression.Block(
                         typeof(void),
@@ -199,7 +199,7 @@ namespace System.Linq.Expressions.Compiler
                 }
 
                 // We need to copy back value types
-                if (memberTemp.Type.GetTypeInfo().IsValueType)
+                if (memberTemp.Type.IsValueType)
                 {
                     block[count + 1] = Expression.Block(
                         typeof(void),

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
@@ -1108,7 +1108,7 @@ namespace System.Linq.Expressions.Compiler
             // Primitive value types are okay because they are all read-only,
             // but we can't rely on this for non-primitive types. So we have
             // to either throw NotSupported or use ref locals.
-            return instance != null && instance.Type.GetTypeInfo().IsValueType && instance.Type.GetTypeCode() == TypeCode.Object;
+            return instance != null && instance.Type.IsValueType && instance.Type.GetTypeCode() == TypeCode.Object;
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ConstantExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ConstantExpression.cs
@@ -115,7 +115,7 @@ namespace System.Linq.Expressions
                     return new ConstantExpression(null);
                 }
 
-                if (!type.GetTypeInfo().IsValueType || type.IsNullableType())
+                if (!type.IsValueType || type.IsNullableType())
                 {
                     return new TypedConstantExpression(null, type);
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs
@@ -690,7 +690,7 @@ namespace System.Linq.Expressions
         // different operation, e.g. adding two doubles vs adding two ints.
         private static void ValidateChildType(Type before, Type after, string methodName)
         {
-            if (before.GetTypeInfo().IsValueType)
+            if (before.IsValueType)
             {
                 if (TypeUtils.AreEquivalent(before, after))
                 {
@@ -698,7 +698,7 @@ namespace System.Linq.Expressions
                     return;
                 }
             }
-            else if (!after.GetTypeInfo().IsValueType)
+            else if (!after.IsValueType)
             {
                 // both are reference types
                 return;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
@@ -42,7 +42,7 @@ namespace System.Linq.Expressions.Interpreter
                 return new ActionCallInstruction(target);
             }
 
-            if (t.GetTypeInfo().IsEnum) return SlowCreate(target, pi);
+            if (t.IsEnum) return SlowCreate(target, pi);
             switch (t.GetTypeCode())
             {
                 case TypeCode.Object:
@@ -85,7 +85,7 @@ namespace System.Linq.Expressions.Interpreter
                 return new FuncCallInstruction<T0>(target);
             }
 
-            if (t.GetTypeInfo().IsEnum) return SlowCreate(target, pi);
+            if (t.IsEnum) return SlowCreate(target, pi);
             switch (t.GetTypeCode())
             {
                 case TypeCode.Object:
@@ -128,7 +128,7 @@ namespace System.Linq.Expressions.Interpreter
                 return new FuncCallInstruction<T0, T1>(target);
             }
 
-            if (t.GetTypeInfo().IsEnum) return SlowCreate(target, pi);
+            if (t.IsEnum) return SlowCreate(target, pi);
             switch (t.GetTypeCode())
             {
                 case TypeCode.Object:

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
@@ -47,7 +47,7 @@ namespace System.Linq.Expressions.Interpreter
             {
                 case TypeCode.Object:
                     {
-                        if (t != typeof(object) && (IndexIsNotReturnType(0, target, pi) || t.GetTypeInfo().IsValueType))
+                        if (t != typeof(object) && (IndexIsNotReturnType(0, target, pi) || t.IsValueType))
                         {
                             // if we're on the return type relaxed delegates makes it ok to use object
                             goto default;
@@ -90,7 +90,7 @@ namespace System.Linq.Expressions.Interpreter
             {
                 case TypeCode.Object:
                     {
-                        if (t != typeof(object) && (IndexIsNotReturnType(1, target, pi) || t.GetTypeInfo().IsValueType))
+                        if (t != typeof(object) && (IndexIsNotReturnType(1, target, pi) || t.IsValueType))
                         {
                             // if we're on the return type relaxed delegates makes it ok to use object
                             goto default;
@@ -134,7 +134,7 @@ namespace System.Linq.Expressions.Interpreter
                 case TypeCode.Object:
                     {
                         Debug.Assert(pi.Length == 2);
-                        if (t.GetTypeInfo().IsValueType) goto default;
+                        if (t.IsValueType) goto default;
 
                         return new FuncCallInstruction<T0, T1, Object>(target);
                     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -52,7 +52,7 @@ namespace System.Linq.Expressions.Interpreter
 #if !FEATURE_DLG_INVOKE
             return new MethodInfoCallInstruction(info, argumentCount);
 #else
-            if (!info.IsStatic && info.DeclaringType.GetTypeInfo().IsValueType)
+            if (!info.IsStatic && info.DeclaringType.IsValueType)
             {
                 return new MethodInfoCallInstruction(info, argumentCount);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DecrementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DecrementInstruction.cs
@@ -156,7 +156,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type type)
         {
-            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            Debug.Assert(!type.IsEnum);
             switch (type.GetNonNullableType().GetTypeCode())
             {
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new DecrementInt16());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DefaultValueInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DefaultValueInstruction.cs
@@ -21,7 +21,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int Run(InterpretedFrame frame)
         {
-            object value = _type.GetTypeInfo().IsValueType ? Activator.CreateInstance(_type) : null;
+            object value = _type.IsValueType ? Activator.CreateInstance(_type) : null;
             frame.Push(value);
             return 1;
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
@@ -172,7 +172,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type type)
         {
-            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            Debug.Assert(!type.IsEnum);
             switch (type.GetNonNullableType().GetTypeCode())
             {
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new DivInt16());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
@@ -278,7 +278,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type type, bool liftedToNull = false)
         {
-            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            Debug.Assert(!type.IsEnum);
             if (liftedToNull)
             {
                 switch (type.GetNonNullableType().GetTypeCode())

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanOrEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanOrEqualInstruction.cs
@@ -278,7 +278,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type type, bool liftedToNull = false)
         {
-            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            Debug.Assert(!type.IsEnum);
             if (liftedToNull)
             {
                 switch (type.GetNonNullableType().GetTypeCode())

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/IncrementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/IncrementInstruction.cs
@@ -156,7 +156,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type type)
         {
-            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            Debug.Assert(!type.IsEnum);
             switch (type.GetNonNullableType().GetTypeCode())
             {
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new IncrementInt16());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InstructionList.cs
@@ -346,7 +346,7 @@ namespace System.Linq.Expressions.Interpreter
                 return;
             }
 
-            if (type == null || type.GetTypeInfo().IsValueType)
+            if (type == null || type.IsValueType)
             {
                 if (value is bool)
                 {
@@ -612,7 +612,7 @@ namespace System.Linq.Expressions.Interpreter
             {
                 Emit(new InitializeLocalInstruction.ImmutableValue(index, value));
             }
-            else if (type.GetTypeInfo().IsValueType)
+            else if (type.IsValueType)
             {
                 Emit(new InitializeLocalInstruction.MutableValue(index, type));
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
@@ -277,7 +277,7 @@ namespace System.Linq.Expressions.Interpreter
         }
         public static Instruction Create(Type type, bool liftedToNull = false)
         {
-            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            Debug.Assert(!type.IsEnum);
             if (liftedToNull)
             {
                 switch (type.GetNonNullableType().GetTypeCode())

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanOrEqualInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanOrEqualInstruction.cs
@@ -278,7 +278,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type type, bool liftedToNull = false)
         {
-            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            Debug.Assert(!type.IsEnum);
             if (liftedToNull)
             {
                 switch (type.GetNonNullableType().GetTypeCode())

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -453,7 +453,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private bool MaybeMutableValueType(Type type)
         {
-            return type.IsValueType && !type.GetTypeInfo().IsEnum && !type.GetTypeInfo().IsPrimitive;
+            return type.IsValueType && !type.IsEnum && !type.GetTypeInfo().IsPrimitive;
         }
 
         private void CompileGetBoxedVariable(ParameterExpression variable)
@@ -1120,16 +1120,16 @@ namespace System.Linq.Expressions.Interpreter
             Type nonNullableTo = typeTo.GetNonNullableType();
 
             // use numeric conversions for both numeric types and enums
-            if ((nonNullableFrom.IsNumericOrBool() || nonNullableFrom.GetTypeInfo().IsEnum)
-                 && (nonNullableTo.IsNumericOrBool() || nonNullableTo.GetTypeInfo().IsEnum || nonNullableTo == typeof(decimal)))
+            if ((nonNullableFrom.IsNumericOrBool() || nonNullableFrom.IsEnum)
+                 && (nonNullableTo.IsNumericOrBool() || nonNullableTo.IsEnum || nonNullableTo == typeof(decimal)))
             {
                 Type enumTypeTo = null;
 
-                if (nonNullableFrom.GetTypeInfo().IsEnum)
+                if (nonNullableFrom.IsEnum)
                 {
                     nonNullableFrom = Enum.GetUnderlyingType(nonNullableFrom);
                 }
-                if (nonNullableTo.GetTypeInfo().IsEnum)
+                if (nonNullableTo.IsEnum)
                 {
                     enumTypeTo = nonNullableTo;
                     nonNullableTo = Enum.GetUnderlyingType(nonNullableTo);
@@ -1179,7 +1179,7 @@ namespace System.Linq.Expressions.Interpreter
                 return;
             }
 
-            if (typeTo.GetTypeInfo().IsEnum)
+            if (typeTo.IsEnum)
             {
                 _instructions.Emit(NullCheckInstruction.Instance);
                 _instructions.EmitCastReferenceToEnum(typeTo);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -362,7 +362,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             if (type != typeof(void))
             {
-                if (type.GetTypeInfo().IsValueType)
+                if (type.IsValueType)
                 {
                     object value = ScriptingRuntimeHelpers.GetPrimitiveDefaultValue(type);
                     if (value != null)
@@ -453,7 +453,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private bool MaybeMutableValueType(Type type)
         {
-            return type.GetTypeInfo().IsValueType && !type.GetTypeInfo().IsEnum && !type.GetTypeInfo().IsPrimitive;
+            return type.IsValueType && !type.GetTypeInfo().IsEnum && !type.GetTypeInfo().IsPrimitive;
         }
 
         private void CompileGetBoxedVariable(ParameterExpression variable)
@@ -985,7 +985,7 @@ namespace System.Linq.Expressions.Interpreter
         private void CompileEqual(Expression left, Expression right, bool liftedToNull)
         {
 #if DEBUG
-            Debug.Assert(IsNullComparison(left, right) || left.Type == right.Type || !left.Type.GetTypeInfo().IsValueType && !right.Type.GetTypeInfo().IsValueType);
+            Debug.Assert(IsNullComparison(left, right) || left.Type == right.Type || !left.Type.IsValueType && !right.Type.IsValueType);
 #endif
             Compile(left);
             Compile(right);
@@ -995,7 +995,7 @@ namespace System.Linq.Expressions.Interpreter
         private void CompileNotEqual(Expression left, Expression right, bool liftedToNull)
         {
 #if DEBUG
-            Debug.Assert(IsNullComparison(left, right) || left.Type == right.Type || !left.Type.GetTypeInfo().IsValueType && !right.Type.GetTypeInfo().IsValueType);
+            Debug.Assert(IsNullComparison(left, right) || left.Type == right.Type || !left.Type.IsValueType && !right.Type.IsValueType);
 #endif
             Compile(left);
             Compile(right);
@@ -1052,7 +1052,7 @@ namespace System.Linq.Expressions.Interpreter
                 Compile(node.Operand);
                 _instructions.EmitStoreLocal(opTemp.Index);
 
-                if (!node.Operand.Type.GetTypeInfo().IsValueType ||
+                if (!node.Operand.Type.IsValueType ||
                     (node.Operand.Type.IsNullableType() && node.IsLiftedToNull))
                 {
                     _instructions.EmitLoadLocal(opTemp.Index);
@@ -1099,7 +1099,7 @@ namespace System.Linq.Expressions.Interpreter
                 return;
             }
 
-            if (typeFrom.GetTypeInfo().IsValueType &&
+            if (typeFrom.IsValueType &&
                 typeTo.IsNullableType() &&
                 typeTo.GetNonNullableType().Equals(typeFrom))
             {
@@ -1107,7 +1107,7 @@ namespace System.Linq.Expressions.Interpreter
                 return;
             }
 
-            if (typeTo.GetTypeInfo().IsValueType &&
+            if (typeTo.IsValueType &&
                 typeFrom.IsNullableType() &&
                 typeFrom.GetNonNullableType().Equals(typeTo))
             {
@@ -2217,7 +2217,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private static bool ShouldWritebackNode(Expression node)
         {
-            if (node.Type.GetTypeInfo().IsValueType)
+            if (node.Type.IsValueType)
             {
                 switch (node.NodeType)
                 {
@@ -2419,7 +2419,7 @@ namespace System.Linq.Expressions.Interpreter
             }
             else
             {
-                Debug.Assert(node.Type.GetTypeInfo().IsValueType);
+                Debug.Assert(node.Type.IsValueType);
                 _instructions.EmitDefaultValue(node.Type);
             }
         }
@@ -2718,7 +2718,7 @@ namespace System.Linq.Expressions.Interpreter
                         var memberMember = (MemberMemberBinding)binding;
                         _instructions.EmitDup();
                         Type type = GetMemberType(memberMember.Member);
-                        if (memberMember.Member is PropertyInfo && type.GetTypeInfo().IsValueType)
+                        if (memberMember.Member is PropertyInfo && type.IsValueType)
                         {
                             throw Error.CannotAutoInitializeValueTypeMemberThroughProperty(memberMember.Bindings);
                         }
@@ -2864,7 +2864,7 @@ namespace System.Linq.Expressions.Interpreter
 
             Compile(node.Operand);
 
-            if (node.Type.GetTypeInfo().IsValueType && !node.Type.IsNullableType())
+            if (node.Type.IsValueType && !node.Type.IsNullableType())
             {
                 _instructions.Emit(NullCheckInstruction.Instance);
             }
@@ -2924,7 +2924,7 @@ namespace System.Linq.Expressions.Interpreter
                     _instructions.EmitNotEqual(typeof(object));
                     break;
                 default:
-                    if (node.TypeOperand.GetTypeInfo().IsValueType)
+                    if (node.TypeOperand.IsValueType)
                     {
                         _instructions.EmitLoad(node.TypeOperand.GetNonNullableType());
                         _instructions.EmitTypeEquals();

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -453,7 +453,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private bool MaybeMutableValueType(Type type)
         {
-            return type.IsValueType && !type.IsEnum && !type.GetTypeInfo().IsPrimitive;
+            return type.IsValueType && !type.IsEnum && !type.IsPrimitive;
         }
 
         private void CompileGetBoxedVariable(ParameterExpression variable)
@@ -2380,7 +2380,7 @@ namespace System.Linq.Expressions.Interpreter
 
             if (node.Constructor != null)
             {
-                if (node.Constructor.DeclaringType.GetTypeInfo().IsAbstract)
+                if (node.Constructor.DeclaringType.IsAbstract)
                     throw Error.NonAbstractConstructorRequired();
 
                 ParameterInfo[] parameters = node.Constructor.GetParametersCached();

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ModuloInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ModuloInstruction.cs
@@ -172,7 +172,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type type)
         {
-            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            Debug.Assert(!type.IsEnum);
             switch (type.GetNonNullableType().GetTypeCode())
             {
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new ModuloInt16());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
@@ -105,7 +105,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type type)
         {
-            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            Debug.Assert(!type.IsEnum);
             switch (type.GetNonNullableType().GetTypeCode())
             {
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new NegateInt16());
@@ -216,7 +216,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type type)
         {
-            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            Debug.Assert(!type.IsEnum);
             switch (type.GetNonNullableType().GetTypeCode())
             {
                 case TypeCode.Int16: return s_Int16 ?? (s_Int16 = new NegateCheckedInt16());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OnesComplementInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OnesComplementInstruction.cs
@@ -156,7 +156,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type type)
         {
-            Debug.Assert(!type.GetTypeInfo().IsEnum);
+            Debug.Assert(!type.IsEnum);
             switch (type.GetNonNullableType().GetTypeCode())
             {
                 case TypeCode.SByte: return s_SByte ?? (s_SByte = new OnesComplementSByte());

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -348,7 +348,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static Instruction Create(Type t)
         {
-            Debug.Assert(!t.GetTypeInfo().IsEnum);
+            Debug.Assert(!t.IsEnum);
             switch (t.GetTypeCode())
             {
                 case TypeCode.Boolean: return s_Boolean ?? (s_Boolean = new CastInstructionT<bool>());
@@ -378,7 +378,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public CastToEnumInstruction(Type t)
         {
-            Debug.Assert(t.GetTypeInfo().IsEnum);
+            Debug.Assert(t.IsEnum);
             _t = t;
         }
 
@@ -402,7 +402,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public CastReferenceToEnumInstruction(Type t)
         {
-            Debug.Assert(t.GetTypeInfo().IsEnum);
+            Debug.Assert(t.IsEnum);
             _t = t;
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -280,7 +280,7 @@ namespace System.Linq.Expressions.Interpreter
 
             public new static CastInstruction Create(Type t)
             {
-                if (t.GetTypeInfo().IsValueType && !t.IsNullableType())
+                if (t.IsValueType && !t.IsNullableType())
                 {
                     return new Value(t);
                 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -154,7 +154,7 @@ namespace System.Linq.Expressions.Interpreter
                     return null;
             }
 
-            if (type.GetTypeInfo().IsEnum)
+            if (type.IsEnum)
             {
                 result = Enum.ToObject(type, result);
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -140,7 +140,7 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(method, nameof(method));
             ContractUtils.Requires(method.IsStatic, nameof(method));
-            var type = method.DeclaringType.GetTypeInfo() as System.Reflection.Emit.TypeBuilder;
+            var type = method.DeclaringType as System.Reflection.Emit.TypeBuilder;
             if (type == null) throw Error.MethodBuilderDoesNotHaveTypeBuilder();
 
             Compiler.LambdaCompiler.Compile(this, method);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -333,7 +333,7 @@ namespace System.Linq.Expressions
             // same as that returned by reflection.
             // Check for this condition and try and get the method from reflection.
             Type type = method.DeclaringType;
-            if (type.GetTypeInfo().IsInterface && method.Name == propertyMethod.Name && type.GetMethod(method.Name) == propertyMethod)
+            if (type.IsInterface && method.Name == propertyMethod.Name && type.GetMethod(method.Name) == propertyMethod)
             {
                 return true;
             }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
@@ -188,7 +188,7 @@ namespace System.Linq.Expressions
             }
             TypeUtils.ValidateType(type, nameof(type));
 
-            if (!type.GetTypeInfo().IsValueType)
+            if (!type.IsValueType)
             {
                 ConstructorInfo ci = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).SingleOrDefault(c => c.GetParametersCached().Length == 0);
                 if (ci == null)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
@@ -27,7 +27,7 @@ namespace System.Linq.Expressions
             }
             else
             {
-                if (!type.GetTypeInfo().IsEnum)
+                if (!type.IsEnum)
                 {
                     switch (type.GetTypeCode())
                     {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
@@ -52,7 +52,7 @@ namespace System.Linq.Expressions
         {
             Type cType = Expression.Type;
 
-            if (cType.GetTypeInfo().IsValueType || TypeOperand.IsPointer)
+            if (cType.IsValueType || TypeOperand.IsPointer)
             {
                 if (cType.IsNullableType())
                 {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
@@ -113,7 +113,7 @@ namespace System.Linq.Expressions
             // causing it to always return false.
             // We workaround this optimization by generating different, less optimal IL
             // if TypeOperand is an interface.
-            if (TypeOperand.GetTypeInfo().IsInterface)
+            if (TypeOperand.IsInterface)
             {
                 ParameterExpression temp = Expression.Parameter(typeof(Type));
                 getType = Expression.Block(

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -391,7 +391,7 @@ namespace System.Linq.Expressions
             {
                 types[0] = nnOperandType;
                 method = nnOperandType.GetAnyStaticMethodValidated(name, types);
-                if (method != null && method.ReturnType.GetTypeInfo().IsValueType && !method.ReturnType.IsNullableType())
+                if (method != null && method.ReturnType.IsValueType && !method.ReturnType.IsNullableType())
                 {
                     return new UnaryExpression(unaryType, operand, method.ReturnType.GetNullableType(), method);
                 }
@@ -414,7 +414,7 @@ namespace System.Linq.Expressions
             // check for lifted call
             if (operand.Type.IsNullableType() &&
                 ParameterIsAssignable(pms[0], operand.Type.GetNonNullableType()) &&
-                method.ReturnType.GetTypeInfo().IsValueType && !method.ReturnType.IsNullableType())
+                method.ReturnType.IsValueType && !method.ReturnType.IsNullableType())
             {
                 return new UnaryExpression(unaryType, operand, method.ReturnType.GetNullableType(), method);
             }
@@ -724,7 +724,7 @@ namespace System.Linq.Expressions
                 throw Error.TypeMustNotBePointer(nameof(type));
             }
 
-            if (type.GetTypeInfo().IsValueType && !type.IsNullableType())
+            if (type.IsValueType && !type.IsNullableType())
             {
                 throw Error.IncorrectTypeForTypeAs(type, nameof(type));
             }
@@ -746,7 +746,7 @@ namespace System.Linq.Expressions
             {
                 throw Error.InvalidUnboxType(nameof(expression));
             }
-            if (!type.GetTypeInfo().IsValueType) throw Error.InvalidUnboxType(nameof(type));
+            if (!type.IsValueType) throw Error.InvalidUnboxType(nameof(type));
             TypeUtils.ValidateType(type, nameof(type));
             return new UnaryExpression(ExpressionType.Unbox, expression, type, null);
         }
@@ -944,7 +944,7 @@ namespace System.Linq.Expressions
             if (value != null)
             {
                 RequiresCanRead(value, nameof(value));
-                if (value.Type.GetTypeInfo().IsValueType) throw Error.ArgumentMustNotHaveValueType(nameof(value));
+                if (value.Type.IsValueType) throw Error.ArgumentMustNotHaveValueType(nameof(value));
             }
             return new UnaryExpression(ExpressionType.Throw, value, type, null);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -742,7 +742,7 @@ namespace System.Linq.Expressions
         {
             RequiresCanRead(expression, nameof(expression));
             ContractUtils.RequiresNotNull(type, nameof(type));
-            if (!expression.Type.GetTypeInfo().IsInterface && expression.Type != typeof(object))
+            if (!expression.Type.IsInterface && expression.Type != typeof(object))
             {
                 throw Error.InvalidUnboxType(nameof(expression));
             }

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
@@ -282,7 +282,7 @@ namespace System.Runtime.CompilerServices
             Type[] args;
             MethodInfo invoke = target.GetMethod("Invoke");
 
-            if (target.GetTypeInfo().IsGenericType && IsSimpleSignature(invoke, out args))
+            if (target.IsGenericType && IsSimpleSignature(invoke, out args))
             {
                 MethodInfo method = null;
                 MethodInfo noMatchMethod = null;

--- a/src/System.Linq.Expressions/tests/Cast/CastTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastTests.cs
@@ -1110,7 +1110,7 @@ namespace System.Linq.Expressions.Tests
 
         private static bool CanBeNull(Type type)
         {
-            return !type.GetTypeInfo().IsValueType || (type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
+            return !type.IsValueType || (type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
         }
 
         private static void VerifyCustomCastCustom2(C value, bool useInterpreter)

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -208,7 +208,7 @@ namespace System.Linq.Expressions.Tests
 
         internal static bool IsNullableType(Type type)
         {
-            return type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
         }
         internal static Type GetNonNullableType(Type type)
         {
@@ -389,20 +389,20 @@ namespace System.Linq.Expressions.Tests
         {
             // 1 type arg Func
             Type type = Expression.GetFuncType(new Type[] { typeof(int) });
-            Assert.True(type.GetTypeInfo().IsGenericType);
+            Assert.True(type.IsGenericType);
             Assert.Equal(1, type.GetGenericArguments().Length);
             Assert.Equal(typeof(int), type.GetGenericArguments()[0]);
 
             // 2 type arg Func
             type = Expression.GetFuncType(new Type[] { typeof(int), typeof(string) });
-            Assert.True(type.GetTypeInfo().IsGenericType);
+            Assert.True(type.IsGenericType);
             Assert.Equal(typeof(Func<,>), type.GetGenericTypeDefinition());
             Assert.Equal(typeof(int), type.GetGenericArguments()[0]);
             Assert.Equal(typeof(string), type.GetGenericArguments()[1]);
 
             // 3 type arg Func
             type = Expression.GetFuncType(new Type[] { typeof(string), typeof(int), typeof(decimal) });
-            Assert.True(type.GetTypeInfo().IsGenericType);
+            Assert.True(type.IsGenericType);
             Assert.Equal(typeof(Func<,,>), type.GetGenericTypeDefinition());
             Assert.Equal(typeof(string), type.GetGenericArguments()[0]);
             Assert.Equal(typeof(int), type.GetGenericArguments()[1]);
@@ -410,7 +410,7 @@ namespace System.Linq.Expressions.Tests
 
             // 4 type arg Func
             type = Expression.GetFuncType(new Type[] { typeof(string), typeof(int), typeof(decimal), typeof(float) });
-            Assert.True(type.GetTypeInfo().IsGenericType);
+            Assert.True(type.IsGenericType);
             Assert.Equal(typeof(Func<,,,>), type.GetGenericTypeDefinition());
             Assert.Equal(typeof(string), type.GetGenericArguments()[0]);
             Assert.Equal(typeof(int), type.GetGenericArguments()[1]);
@@ -419,7 +419,7 @@ namespace System.Linq.Expressions.Tests
 
             // 5 type arg Func
             type = Expression.GetFuncType(new Type[] { typeof(NWindProxy.Customer), typeof(string), typeof(int), typeof(decimal), typeof(float) });
-            Assert.True(type.GetTypeInfo().IsGenericType);
+            Assert.True(type.IsGenericType);
             Assert.Equal(typeof(Func<,,,,>), type.GetGenericTypeDefinition());
             Assert.Equal(typeof(NWindProxy.Customer), type.GetGenericArguments()[0]);
             Assert.Equal(typeof(string), type.GetGenericArguments()[1]);

--- a/src/System.Linq.Expressions/tests/Unary/UnaryConvertTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryConvertTests.cs
@@ -367,7 +367,7 @@ namespace System.Linq.Expressions.Tests
                     {
                         yield return Expression.Convert(c, t);
 
-                        if (t.GetTypeInfo().IsValueType)
+                        if (t.IsValueType)
                         {
                             Type n = typeof(Nullable<>).MakeGenericType(t);
                             yield return Expression.Convert(c, n);

--- a/src/System.Linq.Expressions/tests/Visitor/VisitorTests.cs
+++ b/src/System.Linq.Expressions/tests/Visitor/VisitorTests.cs
@@ -34,7 +34,7 @@ namespace System.Linq.Expressions.Tests
 
             public override Expression Reduce()
             {
-                if (Disposable.Type.GetTypeInfo().IsValueType)
+                if (Disposable.Type.IsValueType)
                 {
                     return TryFinally(
                         Body,

--- a/src/System.Linq.Expressions/tests/Visitor/VisitorTests.cs
+++ b/src/System.Linq.Expressions/tests/Visitor/VisitorTests.cs
@@ -149,7 +149,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void IsAbstract()
         {
-            Assert.True(typeof(ExpressionVisitor).GetTypeInfo().IsAbstract);
+            Assert.True(typeof(ExpressionVisitor).IsAbstract);
         }
 
         [Fact]


### PR DESCRIPTION
Contributes to #16305

I think it *may* be safe to replace `.GetTypeInfo().ImplementedInterfaces` with `.GetInterfaces()` but not being 100% certain I'm leaving that as is. That is now the only calls to `GetTypeInfo()` in the main project, though some remain in the test project.