### PR TITLE
Include System.Dynamic.Runtime.Tests in coverage report.

### DIFF
--- a/src/System.Dynamic.Runtime/tests/System.Dynamic.Runtime.Tests.csproj
+++ b/src/System.Dynamic.Runtime/tests/System.Dynamic.Runtime.Tests.csproj
@@ -10,6 +10,10 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='netstandard-Release|AnyCPU'" />
   <ItemGroup>
+    <AdditionalCodeCoverageAssemblies Include="Microsoft.CSharp" /> 
+    <AdditionalCodeCoverageAssemblies Include="System.Linq.Expressions" /> 
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="CallInfoTests.cs" />
     <Compile Include="Dynamic.Context\Common.cs" />
     <Compile Include="Dynamic.Context\Conformance.dynamic.context.attribute.cs" />


### PR DESCRIPTION
System.Dynamic.Runtime forwards all its types, mostly to System.Linq.Expressions but its testing of those types, and their base types in Microsoft.CSharp, isn't included in coverage reports.

Update project so that it is.