### PR TITLE
Add Attribute ActiveIssue(15844) to WaitChain() Method in class ProcessWaitingTests under System.Diagnostics.Process

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -164,6 +164,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue(15844)]
         public void WaitChain()
         {
             Process root = CreateProcess(() =>

--- a/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -164,7 +164,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        [ActiveIssue(15844)]
+        [ActiveIssue(15844, TestPlatforms.AnyUnix)]
         public void WaitChain()
         {
             Process root = CreateProcess(() =>


### PR DESCRIPTION
Add attribute [ActiveIssue(15844)] to disable test method: System.Diagnostics.Tests.ProcessWaitingTests.WaitChain(). 