### PR TITLE
SerialPort: Refactor buffer waits

### DIFF
--- a/src/System.IO.Ports/tests/SerialPort/BaseStream.cs
+++ b/src/System.IO.Ports/tests/SerialPort/BaseStream.cs
@@ -33,7 +33,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 SerialPortProperties serPortProp = new SerialPortProperties();
-        
+
                 Debug.WriteLine("Verifying BaseStream after Open() has been called");
                 serPortProp.SetAllPropertiesToOpenDefaults();
                 serPortProp.SetProperty("PortName", TCSupport.LocalMachineSerialInfo.FirstAvailablePortName);

--- a/src/System.IO.Ports/tests/SerialPort/BaudRate.cs
+++ b/src/System.IO.Ports/tests/SerialPort/BaudRate.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -13,14 +14,14 @@ namespace System.IO.Ports.Tests
     {
         //The default ammount of time the a transfer should take at any given baud rate. 
         //The bytes sent should be adjusted to take this ammount of time to transfer at the specified baud rate.
-        public static readonly int DEFAULT_TIME = 750;
+        private const int DEFAULT_TIME = 750;
 
         //If the percentage difference between the expected BaudRate and the actual baudrate
         //found through Stopwatch is greater then 5% then the BaudRate value was not correctly
         //set and the testcase fails.
-        public static readonly double MAX_ACCEPTABLE_PERCENTAGE_DIFFERENCE = .07;
+        private const double MAX_ACCEPTABLE_PERCENTAGE_DIFFERENCE = .07;
 
-        public static readonly int NUM_TRYS = 5;
+        private const int NUM_TRYS = 5;
 
         private enum ThrowAt { Set, Open };
 
@@ -31,7 +32,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 SerialPortProperties serPortProp = new SerialPortProperties();
-            
+
                 Debug.WriteLine("Verifying default BaudRate");
 
                 serPortProp.SetAllPropertiesToOpenDefaults();
@@ -270,13 +271,13 @@ namespace System.IO.Ports.Tests
                 // get all the data buffered so you can't read it back
                 // At 115200 we were seeing numBytesToSend = 8640, however, we only get 8627 waiting in the input buffer
                 // this might be an FTDI bug, but it's not a System.Io.SerialPort bug
-                com2.ReadBufferSize = numBytesToSend+16;
+                com2.ReadBufferSize = numBytesToSend + 16;
                 com2.BaudRate = com1.BaudRate;
                 com2.Open();
 
                 actualTime = 0;
 
-                System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Highest;
+                Thread.CurrentThread.Priority = ThreadPriority.Highest;
 
                 for (int i = 0; i < NUM_TRYS; i++)
                 {
@@ -290,7 +291,7 @@ namespace System.IO.Ports.Tests
                     }
 
                     sw.Start();
-                    while (numBytesToSend > com2.BytesToRead) 
+                    while (numBytesToSend > com2.BytesToRead)
                     {
                         //Wait for all of the bytes to reach the input buffer of com2
                     }
@@ -302,7 +303,7 @@ namespace System.IO.Ports.Tests
                     sw.Reset();
                 }
 
-                System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Normal;
+                Thread.CurrentThread.Priority = ThreadPriority.Normal;
 
                 expectedTime = ((xmitBytes.Length * 10.0) / com1.BaudRate) * 1000;
                 actualTime /= NUM_TRYS;

--- a/src/System.IO.Ports/tests/SerialPort/BreakState.cs
+++ b/src/System.IO.Ports/tests/SerialPort/BreakState.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -12,7 +13,7 @@ namespace System.IO.Ports.Tests
     public class BreakState_Property : PortsTest
     {
         //The maximum time we will wait for the pin changed event to get firered for the break state
-        static readonly int MAX_WAIT_FOR_BREAK = 800;
+        private const int MAX_WAIT_FOR_BREAK = 800;
 
         #region Test Cases
 
@@ -39,7 +40,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 SerialPortProperties serPortProp = new SerialPortProperties();
- 
+
                 Debug.WriteLine("Verifying setting BreakState before open");
                 serPortProp.SetAllPropertiesToDefaults();
                 serPortProp.SetProperty("PortName", TCSupport.LocalMachineSerialInfo.FirstAvailablePortName);
@@ -122,7 +123,6 @@ namespace System.IO.Ports.Tests
             }
 
             Assert.False(GetCurrentBreakState());
-
         }
 
 
@@ -132,7 +132,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 SerialPortProperties serPortProp = new SerialPortProperties();
-        
+
                 Debug.WriteLine("Verifying setting BreakState to true then false then true again");
 
                 serPortProp.SetAllPropertiesToOpenDefaults();
@@ -200,7 +200,7 @@ namespace System.IO.Ports.Tests
                     if (SerialPinChange.Break == e.EventType)
                     {
                         _breakOccurred = true;
-                        System.Threading.Monitor.Pulse(this);
+                        Monitor.Pulse(this);
                     }
                 }
             }
@@ -211,7 +211,7 @@ namespace System.IO.Ports.Tests
                 {
                     if (!_breakOccurred)
                     {
-                        System.Threading.Monitor.Wait(this);
+                        Monitor.Wait(this);
                     }
                 }
             }
@@ -223,7 +223,7 @@ namespace System.IO.Ports.Tests
                 {
                     if (!_breakOccurred)
                     {
-                        return System.Threading.Monitor.Wait(this, timeout);
+                        return Monitor.Wait(this, timeout);
                     }
                     return true;
                 }

--- a/src/System.IO.Ports/tests/SerialPort/BytesToRead.cs
+++ b/src/System.IO.Ports/tests/SerialPort/BytesToRead.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -11,12 +12,9 @@ namespace System.IO.Ports.Tests
 {
     public class BytesToRead_Property : PortsTest
     {
-        static readonly int DEFAULT_NUM_RND_BYTES = 8;
+        private const int DEFAULT_NUM_RND_BYTES = 8;
 
-        delegate void ReadMethodDelegate(SerialPort com, int bufferSize);
-
-        //The default new lint to read from when testing timeout with ReadTo(str)
-        public static readonly string DEFAULT_READ_TO_STRING = "\r\n";
+        private delegate void ReadMethodDelegate(SerialPort com, int bufferSize);
 
         #region Test Cases
 
@@ -26,7 +24,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 SerialPortProperties serPortProp = new SerialPortProperties();
-        
+
                 Debug.WriteLine("Verifying default BytesToRead");
 
                 serPortProp.SetAllPropertiesToOpenDefaults();
@@ -56,7 +54,7 @@ namespace System.IO.Ports.Tests
                 com2.Write(new byte[DEFAULT_NUM_RND_BYTES], 0, DEFAULT_NUM_RND_BYTES);
 
                 serPortProp.SetProperty("BytesToRead", DEFAULT_NUM_RND_BYTES);
-                System.Threading.Thread.Sleep(100); //Wait for com1 to get all of the bytes
+                Thread.Sleep(100); //Wait for com1 to get all of the bytes
 
                 serPortProp.VerifyPropertiesAndPrint(com1);
             }
@@ -139,11 +137,10 @@ namespace System.IO.Ports.Tests
                 }
 
                 while (bufferSize + numNewLineBytes > com1.BytesToRead)
-                    System.Threading.Thread.Sleep(10);
+                    Thread.Sleep(10);
 
                 readMethod(com1, bufferSize + numNewLineBytes);
                 serPortProp.VerifyPropertiesAndPrint(com1);
-
             }
         }
 

--- a/src/System.IO.Ports/tests/SerialPort/BytesToSend.cs
+++ b/src/System.IO.Ports/tests/SerialPort/BytesToSend.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Threading;
 using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
@@ -12,19 +13,19 @@ namespace System.IO.Ports.Tests
 {
     public class BytesToWrite_Property : PortsTest
     {
-        static readonly int DEFAULT_NUM_RND_BYTES = TCSupport.MinimumBlockingByteCount;
+        private static readonly int s_DEFAULT_NUM_RND_BYTES = TCSupport.MinimumBlockingByteCount;
 
         //The default number of chars to write with when testing timeout with Write(char[], int, int)
-        static readonly int DEFAULT_WRITE_CHAR_ARRAY_SIZE = TCSupport.MinimumBlockingByteCount;
+        private static readonly int s_DEFAULT_WRITE_CHAR_ARRAY_SIZE = TCSupport.MinimumBlockingByteCount;
 
         //The default number of bytes to write with when testing timeout with Write(byte[], int, int)
-        static readonly int DEFAULT_WRITE_BYTE_ARRAY_SIZE = TCSupport.MinimumBlockingByteCount;
+        private static readonly int s_DEFAULT_WRITE_BYTE_ARRAY_SIZE = TCSupport.MinimumBlockingByteCount;
 
         //The default string to write with when testing timeout with Write(str)
-        static readonly string DEFAULT_STRING_TO_WRITE = new string('H', TCSupport.MinimumBlockingByteCount);
+        private static readonly string s_DEFAULT_STRING_TO_WRITE = new string('H', TCSupport.MinimumBlockingByteCount);
 
         //Delegate to start asynchronous write on the SerialPort com with buffer of size bufferLength
-        delegate int WriteMethodDelegate(SerialPort com, int bufferSize);
+        private delegate int WriteMethodDelegate(SerialPort com, int bufferSize);
 
         #region Test Cases
 
@@ -48,14 +49,14 @@ namespace System.IO.Ports.Tests
         public void BytesToWrite_Write_byte_int_int()
         {
             Debug.WriteLine("Verifying BytesToWrite with Write(byte[] buffer, int offset, int count)");
-            VerifyBytesToWrite(Write_byte_int_int, DEFAULT_NUM_RND_BYTES, false);
+            VerifyBytesToWrite(Write_byte_int_int, s_DEFAULT_NUM_RND_BYTES, false);
         }
 
         [ConditionalFact(nameof(HasNullModem), nameof(HasHardwareFlowControl))]
         public void BytesToWrite_Write_char_int_int()
         {
             Debug.WriteLine("Verifying BytesToWrite with Write(char[] buffer, int offset, int count)");
-            VerifyBytesToWrite(Write_char_int_int, DEFAULT_NUM_RND_BYTES, false);
+            VerifyBytesToWrite(Write_char_int_int, s_DEFAULT_NUM_RND_BYTES, false);
         }
 
         [ConditionalFact(nameof(HasNullModem), nameof(HasHardwareFlowControl))]
@@ -69,7 +70,7 @@ namespace System.IO.Ports.Tests
         public void BytesToWrite_WriteLine()
         {
             Debug.WriteLine("Verifying BytesToWrite with WriteLine()");
-            VerifyBytesToWrite(WriteLine, DEFAULT_NUM_RND_BYTES, true);
+            VerifyBytesToWrite(WriteLine, s_DEFAULT_NUM_RND_BYTES, true);
         }
         #endregion
 
@@ -94,7 +95,7 @@ namespace System.IO.Ports.Tests
 
                 Task<int> task = Task.Run(() => writeMethod(com1, bufferSize));
 
-                System.Threading.Thread.Sleep(200);
+                Thread.Sleep(200);
 
                 actualBytesToWrite = com1.BytesToWrite;
                 expectedBytesToWrite = task.Result - TCSupport.HardwareTransmitBufferSize;
@@ -106,7 +107,6 @@ namespace System.IO.Ports.Tests
 
                 com2.RtsEnable = false;
                 serPortProp.VerifyPropertiesAndPrint(com1);
-
             }
         }
 
@@ -115,7 +115,7 @@ namespace System.IO.Ports.Tests
         {
             try
             {
-                com.Write(new byte[DEFAULT_WRITE_BYTE_ARRAY_SIZE], 0, DEFAULT_WRITE_BYTE_ARRAY_SIZE);
+                com.Write(new byte[s_DEFAULT_WRITE_BYTE_ARRAY_SIZE], 0, s_DEFAULT_WRITE_BYTE_ARRAY_SIZE);
             }
             catch (TimeoutException)
             {
@@ -126,7 +126,7 @@ namespace System.IO.Ports.Tests
 
         private int Write_char_int_int(SerialPort com, int bufferSize)
         {
-            char[] charsToWrite = new char[DEFAULT_WRITE_CHAR_ARRAY_SIZE];
+            char[] charsToWrite = new char[s_DEFAULT_WRITE_CHAR_ARRAY_SIZE];
 
             try
             {
@@ -143,12 +143,12 @@ namespace System.IO.Ports.Tests
         {
             try
             {
-                com.Write(DEFAULT_STRING_TO_WRITE);
+                com.Write(s_DEFAULT_STRING_TO_WRITE);
             }
             catch (TimeoutException)
             {
             }
-            return com.Encoding.GetByteCount(DEFAULT_STRING_TO_WRITE.ToCharArray());
+            return com.Encoding.GetByteCount(s_DEFAULT_STRING_TO_WRITE.ToCharArray());
         }
 
 
@@ -156,12 +156,12 @@ namespace System.IO.Ports.Tests
         {
             try
             {
-                com.WriteLine(DEFAULT_STRING_TO_WRITE);
+                com.WriteLine(s_DEFAULT_STRING_TO_WRITE);
             }
             catch (TimeoutException)
             {
             }
-            return com.Encoding.GetByteCount(DEFAULT_STRING_TO_WRITE.ToCharArray()) + com.Encoding.GetByteCount(com.NewLine.ToCharArray());
+            return com.Encoding.GetByteCount(s_DEFAULT_STRING_TO_WRITE.ToCharArray()) + com.Encoding.GetByteCount(com.NewLine.ToCharArray());
         }
         #endregion
     }

--- a/src/System.IO.Ports/tests/SerialPort/Close.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Close.cs
@@ -13,8 +13,8 @@ namespace System.IO.Ports.Tests
     public class Close : PortsTest
     {
         // The number of the bytes that should read/write buffers
-        static readonly int numReadBytes = 32;
-        static readonly int numWriteBytes = TCSupport.MinimumBlockingByteCount;
+        private const int numReadBytes = 32;
+        private static readonly int s_numWriteBytes = TCSupport.MinimumBlockingByteCount;
 
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void CloseWithoutOpen()
@@ -37,7 +37,7 @@ namespace System.IO.Ports.Tests
         public void OpenClose()
         {
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
-            { 
+            {
                 SerialPortProperties serPortProp = new SerialPortProperties();
 
                 Debug.WriteLine("Calling Close() after calling Open()");
@@ -68,12 +68,12 @@ namespace System.IO.Ports.Tests
                 com2.Open();
 
                 // BeginWrite is used so we can fill the read buffer then go onto to verify
-                com1.BaseStream.BeginWrite(new byte[numWriteBytes], 0, numWriteBytes, null, null);
+                com1.BaseStream.BeginWrite(new byte[s_numWriteBytes], 0, s_numWriteBytes, null, null);
                 com2.Write(new byte[numReadBytes], 0, numReadBytes);
                 Thread.Sleep(500);
 
                 serPortProp.SetProperty("Handshake", Handshake.RequestToSend);
-                serPortProp.SetProperty("BytesToWrite", numWriteBytes-TCSupport.HardwareTransmitBufferSize);
+                serPortProp.SetProperty("BytesToWrite", s_numWriteBytes - TCSupport.HardwareTransmitBufferSize);
                 serPortProp.SetProperty("BytesToRead", numReadBytes);
 
                 Debug.WriteLine("Verifying properties after port is open and buffers have been filled");

--- a/src/System.IO.Ports/tests/SerialPort/CtsHolding.cs
+++ b/src/System.IO.Ports/tests/SerialPort/CtsHolding.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -118,7 +119,6 @@ namespace System.IO.Ports.Tests
                 serPortProp.SetAllPropertiesToDefaults();
                 serPortProp.SetProperty("PortName", TCSupport.LocalMachineSerialInfo.FirstAvailablePortName);
                 serPortProp.VerifyPropertiesAndPrint(com1);
-
             }
         }
 
@@ -146,7 +146,7 @@ namespace System.IO.Ports.Tests
                 if (com2.IsOpen)
                     com2.Close();
 
-                System.Threading.Thread.Sleep(100);
+                Thread.Sleep(100);
                 serPortProp.SetProperty("CtsHolding", false);
                 serPortProp.VerifyPropertiesAndPrint(com1);
             }

--- a/src/System.IO.Ports/tests/SerialPort/DataBits.cs
+++ b/src/System.IO.Ports/tests/SerialPort/DataBits.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -13,14 +14,14 @@ namespace System.IO.Ports.Tests
     {
         //The default number of bytes to read/write to verify the speed of the port
         //and that the bytes were transfered successfully
-        public static readonly int DEFAULT_BYTE_SIZE = 256;
+        private const int DEFAULT_BYTE_SIZE = 256;
 
         //If the percentage difference between the expected time to transfer with the specified dataBits
         //and the actual time found through Stopwatch is greater then 5% then the DataBits value was not correctly
         //set and the testcase fails.
-        public static readonly double MAX_ACCEPTABLE_PERCENTAGE_DIFFERENCE = .05;
+        private const double MAX_ACCEPTABLE_PERCENTAGE_DIFFERENCE = .05;
 
-        public static readonly int NUM_TRYS = 5;
+        private const int NUM_TRYS = 5;
 
         private enum ThrowAt { Set, Open };
 
@@ -116,7 +117,7 @@ namespace System.IO.Ports.Tests
             Debug.WriteLine("Verifying 4 DataBits");
             VerifyException(4, ThrowAt.Set, typeof(ArgumentOutOfRangeException));
         }
-    
+
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void DataBits_9()
         {
@@ -130,7 +131,7 @@ namespace System.IO.Ports.Tests
             Debug.WriteLine("Verifying Int32.MaxValue DataBits");
             VerifyException(int.MaxValue, ThrowAt.Set, typeof(ArgumentOutOfRangeException));
         }
-    
+
         #endregion
 
         #region Verification for Test Cases
@@ -186,7 +187,7 @@ namespace System.IO.Ports.Tests
         }
 
 
-        private void  VerifyExceptionAfterOpen(SerialPort com, int dataBits, Type expectedException)
+        private void VerifyExceptionAfterOpen(SerialPort com, int dataBits, Type expectedException)
         {
             SerialPortProperties serPortProp = new SerialPortProperties();
 
@@ -286,7 +287,7 @@ namespace System.IO.Ports.Tests
 
                 actualTime = 0;
 
-                System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Highest;
+                Thread.CurrentThread.Priority = ThreadPriority.Highest;
 
                 for (int i = 0; i < NUM_TRYS; i++)
                 {
@@ -297,7 +298,6 @@ namespace System.IO.Ports.Tests
                     beginWriteResult = com1.BaseStream.BeginWrite(xmitBytes, 0, xmitBytes.Length, null, null);
                     while (0 == (bytesToRead = com2.BytesToRead))
                     {
-                
                     }
 
                     sw.Start();
@@ -313,7 +313,7 @@ namespace System.IO.Ports.Tests
                     sw.Reset();
                 }
 
-                System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Normal;
+                Thread.CurrentThread.Priority = ThreadPriority.Normal;
 
                 expectedTime = ((xmitBytes.Length * (2.0 + com1.DataBits)) / com1.BaudRate) * 1000;
                 actualTime /= NUM_TRYS;

--- a/src/System.IO.Ports/tests/SerialPort/DiscardInBuffer.cs
+++ b/src/System.IO.Ports/tests/SerialPort/DiscardInBuffer.cs
@@ -30,8 +30,8 @@ namespace System.IO.Ports.Tests
                 com1.Open();
                 com2.Open();
                 com2.Write(DEFAULT_STRING);
-                while (com1.BytesToRead < DEFAULT_STRING.Length)
-                    System.Threading.Thread.Sleep(50);
+
+                TCSupport.WaitForReadBufferToLoad(com1, DEFAULT_STRING.Length);
 
                 VerifyDiscard(com1);
             }
@@ -47,8 +47,7 @@ namespace System.IO.Ports.Tests
                 com1.Open();
                 com2.Open();
                 com2.Write(DEFAULT_STRING);
-                while (com1.BytesToRead < DEFAULT_STRING.Length)
-                    System.Threading.Thread.Sleep(50);
+                TCSupport.WaitForReadBufferToLoad(com1, DEFAULT_STRING.Length);
 
                 VerifyDiscard(com1);
                 VerifyDiscard(com1);
@@ -72,13 +71,13 @@ namespace System.IO.Ports.Tests
                 com1.Open();
                 com2.Open();
                 com2.Write(DEFAULT_STRING);
-                while (com1.BytesToRead < DEFAULT_STRING.Length)
-                    System.Threading.Thread.Sleep(50);
+
+                TCSupport.WaitForReadBufferToLoad(com1, DEFAULT_STRING.Length);
 
                 VerifyDiscard(com1);
                 com2.Write(DEFAULT_STRING);
-                while (com1.BytesToRead < DEFAULT_STRING.Length)
-                    System.Threading.Thread.Sleep(50);
+
+                TCSupport.WaitForReadBufferToLoad(com1, DEFAULT_STRING.Length);
 
                 VerifyDiscard(com1);
             }

--- a/src/System.IO.Ports/tests/SerialPort/DiscardInBuffer.cs
+++ b/src/System.IO.Ports/tests/SerialPort/DiscardInBuffer.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Threading;
 using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
@@ -13,10 +14,10 @@ namespace System.IO.Ports.Tests
     public class DiscardInBuffer : PortsTest
     {
         //The string used with Write(str) to fill the input buffer
-        public static readonly string DEFAULT_STRING = "Hello World";
+        private const string DEFAULT_STRING = "Hello World";
 
         //The buffer lenght used whe filling the ouput buffer
-        public static readonly int DEFAULT_BUFFER_LENGTH = 8;
+        private const int DEFAULT_BUFFER_LENGTH = 8;
 
         #region Test Cases
 
@@ -96,11 +97,11 @@ namespace System.IO.Ports.Tests
                 com2.Open();
                 com1.WriteTimeout = 500;
                 var task = Task.Run(() => WriteRndByteArray(com1, DEFAULT_BUFFER_LENGTH));
-                System.Threading.Thread.Sleep(100);
+                Thread.Sleep(100);
                 origBytesToWrite = com1.BytesToWrite;
                 VerifyDiscard(com1);
                 Assert.Equal(com1.BytesToWrite, origBytesToWrite);
-            
+
                 //Wait for write method to timeout
                 TCSupport.WaitForTaskCompletion(task);
             }

--- a/src/System.IO.Ports/tests/SerialPort/DiscardNull.cs
+++ b/src/System.IO.Ports/tests/SerialPort/DiscardNull.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
 using Legacy.Support;
 using Xunit;
 
@@ -12,19 +14,16 @@ namespace System.IO.Ports.Tests
     public class DiscardNull_Property : PortsTest
     {
         //The default number of bytes to read/write to verify the DiscardNull
-        public static readonly int DEFAULT_NUM_CHARS_TO_WRITE = 8;
+        private const int DEFAULT_NUM_CHARS_TO_WRITE = 8;
 
         //The default number of null characters to be inserted into the characters written  
-        public static readonly int DEFUALT_NUM_NULL_CHAR = 1;
+        private const int DEFUALT_NUM_NULL_CHAR = 1;
 
         //The default number of chars to write with when testing timeout with Read(char[], int, int)
-        public static readonly int DEFAULT_READ_CHAR_ARRAY_SIZE = 8;
+        private const int DEFAULT_READ_CHAR_ARRAY_SIZE = 8;
 
         //The default number of bytes to write with when testing timeout with Read(byte[], int, int)
-        public static readonly int DEFAULT_READ_BYTE_ARRAY_SIZE = 8;
-
-        //The maximum time to wait for an event to occur
-        public static readonly int MAX_WAIT_TIME = 750;
+        private const int DEFAULT_READ_BYTE_ARRAY_SIZE = 8;
 
         private delegate char[] ReadMethodDelegate(SerialPort com);
 
@@ -175,7 +174,7 @@ namespace System.IO.Ports.Tests
             Debug.WriteLine("Verifying true DiscardNull with ReadChar after open");
             VerifyDiscardNullAfterOpen(true, ReadChar, false);
         }
-    
+
         [ConditionalFact(nameof(HasNullModem))]
         public void DiscardNull_true_ReadLine_Before()
         {
@@ -381,7 +380,7 @@ namespace System.IO.Ports.Tests
 
         private char[] Read_byte_int_int(SerialPort com)
         {
-            System.Collections.ArrayList receivedBytes = new System.Collections.ArrayList();
+            ArrayList receivedBytes = new ArrayList();
             byte[] buffer = new byte[DEFAULT_READ_BYTE_ARRAY_SIZE];
             int totalBytesRead = 0;
             int numBytes;
@@ -410,7 +409,7 @@ namespace System.IO.Ports.Tests
 
         private char[] Read_char_int_int(SerialPort com)
         {
-            System.Collections.ArrayList receivedChars = new System.Collections.ArrayList();
+            ArrayList receivedChars = new ArrayList();
             char[] buffer = new char[DEFAULT_READ_CHAR_ARRAY_SIZE];
             int totalCharsRead = 0;
             int numChars;
@@ -439,7 +438,7 @@ namespace System.IO.Ports.Tests
 
         private char[] ReadByte(SerialPort com)
         {
-            System.Collections.ArrayList receivedBytes = new System.Collections.ArrayList();
+            ArrayList receivedBytes = new ArrayList();
             int rcvByte;
 
             while (true)
@@ -462,7 +461,7 @@ namespace System.IO.Ports.Tests
 
         private char[] ReadChar(SerialPort com)
         {
-            System.Collections.ArrayList receivedChars = new System.Collections.ArrayList();
+            ArrayList receivedChars = new ArrayList();
             int rcvChar;
 
             while (true)
@@ -484,7 +483,7 @@ namespace System.IO.Ports.Tests
 
         private char[] ReadLine(SerialPort com)
         {
-            System.Text.StringBuilder rcvStringBuilder = new System.Text.StringBuilder();
+            StringBuilder rcvStringBuilder = new StringBuilder();
             string rcvString;
 
             while (true)
@@ -507,7 +506,7 @@ namespace System.IO.Ports.Tests
 
         private char[] ReadTo(SerialPort com)
         {
-            System.Text.StringBuilder rcvStringBuilder = new System.Text.StringBuilder();
+            StringBuilder rcvStringBuilder = new StringBuilder();
             string rcvString;
 
             while (true)

--- a/src/System.IO.Ports/tests/SerialPort/DiscardNull.cs
+++ b/src/System.IO.Ports/tests/SerialPort/DiscardNull.cs
@@ -363,13 +363,7 @@ namespace System.IO.Ports.Tests
                 com2.Open();
                 com2.Write(xmitBytes, 0, xmitBytes.Length);
 
-                int timeElapsed = 0;
-
-                while (expectedBytes.Length > com1.BytesToRead && timeElapsed < MAX_WAIT_TIME)
-                {
-                    System.Threading.Thread.Sleep(50);
-                    timeElapsed += 50;
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, expectedBytes.Length);
 
                 if (sendNewLine)
                     com2.WriteLine("");

--- a/src/System.IO.Ports/tests/SerialPort/DiscardOutBuffer.cs
+++ b/src/System.IO.Ports/tests/SerialPort/DiscardOutBuffer.cs
@@ -13,11 +13,11 @@ namespace System.IO.Ports.Tests
     public class DiscardOutBuffer : PortsTest
     {
         //The string used with Write(str) to fill the input buffer
-        private static readonly string DEFAULT_STRING = new string('H', TCSupport.MinimumBlockingByteCount);
+        private static readonly string s_DEFAULT_STRING = new string('H', TCSupport.MinimumBlockingByteCount);
 
         //The buffer length used whe filling the output buffer
         // This was set to 8, but the TX Fifo on a UART can swallow that completely, so you can't then tell if the data has been sent or not.
-        private static readonly int DEFAULT_BUFFER_LENGTH = TCSupport.MinimumBlockingByteCount;
+        private static readonly int s_DEFAULT_BUFFER_LENGTH = TCSupport.MinimumBlockingByteCount;
 
         #region Test Cases
 
@@ -31,9 +31,9 @@ namespace System.IO.Ports.Tests
                 com1.WriteTimeout = 500;
                 com1.Handshake = Handshake.RequestToSend;
 
-                Task task = Task.Run(() => WriteRndByteArray(com1, DEFAULT_BUFFER_LENGTH));
+                Task task = Task.Run(() => WriteRndByteArray(com1, s_DEFAULT_BUFFER_LENGTH));
 
-                TCSupport.WaitForWriteBufferToLoad(com1, DEFAULT_BUFFER_LENGTH);
+                TCSupport.WaitForWriteBufferToLoad(com1, s_DEFAULT_BUFFER_LENGTH);
 
                 VerifyDiscard(com1);
 
@@ -54,9 +54,9 @@ namespace System.IO.Ports.Tests
                 com1.WriteTimeout = 500;
                 com1.Handshake = Handshake.RequestToSend;
 
-                Task task = Task.Run(() => WriteRndByteArray(com1, DEFAULT_BUFFER_LENGTH));
+                Task task = Task.Run(() => WriteRndByteArray(com1, s_DEFAULT_BUFFER_LENGTH));
 
-                TCSupport.WaitForWriteBufferToLoad(com1, DEFAULT_BUFFER_LENGTH);
+                TCSupport.WaitForWriteBufferToLoad(com1, s_DEFAULT_BUFFER_LENGTH);
 
                 VerifyDiscard(com1);
                 VerifyDiscard(com1);
@@ -80,9 +80,9 @@ namespace System.IO.Ports.Tests
                 com1.WriteTimeout = 500;
                 com1.Handshake = Handshake.RequestToSend;
 
-                Task task = Task.Run(() => WriteRndByteArray(com1, DEFAULT_BUFFER_LENGTH));
+                Task task = Task.Run(() => WriteRndByteArray(com1, s_DEFAULT_BUFFER_LENGTH));
 
-                TCSupport.WaitForWriteBufferToLoad(com1, DEFAULT_BUFFER_LENGTH);
+                TCSupport.WaitForWriteBufferToLoad(com1, s_DEFAULT_BUFFER_LENGTH);
 
                 VerifyDiscard(com1);
 
@@ -90,9 +90,9 @@ namespace System.IO.Ports.Tests
                 Assert.Throws<AggregateException>(() => task.Wait(2000));
                 Assert.IsType<IOException>(task.Exception.InnerException);
 
-                Task task2 = Task.Run(() => WriteRndByteArray(com1, DEFAULT_BUFFER_LENGTH));
+                Task task2 = Task.Run(() => WriteRndByteArray(com1, s_DEFAULT_BUFFER_LENGTH));
 
-                TCSupport.WaitForWriteBufferToLoad(com1, DEFAULT_BUFFER_LENGTH);
+                TCSupport.WaitForWriteBufferToLoad(com1, s_DEFAULT_BUFFER_LENGTH);
 
                 VerifyDiscard(com1);
 
@@ -115,19 +115,19 @@ namespace System.IO.Ports.Tests
                 com1.WriteTimeout = 500;
 
                 com1.Handshake = Handshake.RequestToSend;
-                com2.Write(DEFAULT_STRING);
+                com2.Write(s_DEFAULT_STRING);
 
                 // Wait for the data to pass from COM2 to com1
-                TCSupport.WaitForReadBufferToLoad(com1, DEFAULT_STRING.Length);
+                TCSupport.WaitForReadBufferToLoad(com1, s_DEFAULT_STRING.Length);
 
-                Task task = Task.Run(() => WriteRndByteArray(com1, DEFAULT_BUFFER_LENGTH));
+                Task task = Task.Run(() => WriteRndByteArray(com1, s_DEFAULT_BUFFER_LENGTH));
                 int origBytesToRead = com1.BytesToRead;
 
-                TCSupport.WaitForWriteBufferToLoad(com1, DEFAULT_BUFFER_LENGTH);
+                TCSupport.WaitForWriteBufferToLoad(com1, s_DEFAULT_BUFFER_LENGTH);
 
                 VerifyDiscard(com1);
 
-                Assert.Equal(origBytesToRead,com1.BytesToRead);
+                Assert.Equal(origBytesToRead, com1.BytesToRead);
 
                 // Wait for write method to fail with IOException
                 Assert.Throws<AggregateException>(() => task.Wait(2000));
@@ -159,6 +159,6 @@ namespace System.IO.Ports.Tests
         }
         #endregion
 
- 
+
     }
 }

--- a/src/System.IO.Ports/tests/SerialPort/DosDevices.cs
+++ b/src/System.IO.Ports/tests/SerialPort/DosDevices.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
@@ -22,7 +23,7 @@ namespace System.IO.Ports.Tests
             return _dosDevices.GetEnumerator();
         }
 
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        IEnumerator IEnumerable.GetEnumerator()
         {
             return _dosDevices.GetEnumerator();
         }
@@ -39,7 +40,7 @@ namespace System.IO.Ports.Tests
 
         public bool InternalNameContains(string internalName)
         {
-            foreach (String value in _dosDevices.Values)
+            foreach (string value in _dosDevices.Values)
             {
                 if (-1 != value.IndexOf(internalName))
                     return true;
@@ -77,7 +78,7 @@ namespace System.IO.Ports.Tests
                 {
                     // We now have an MS-DOS name (the common name). We call QueryDosDevice again with
                     // this name to get the underlying system name mapped to the MS-DOS name. 
-                    string currentName = TrimTrailingNull((new String(buffer, start, i - start)).Trim());
+                    string currentName = TrimTrailingNull((new string(buffer, start, i - start)).Trim());
                     int nameSize;
                     char[] nameBuffer = CallQueryDosDevice(currentName, out nameSize);
 
@@ -93,7 +94,7 @@ namespace System.IO.Ports.Tests
                     }
                     else
                     {
-                        _dosDevices.Add(currentName, String.Empty);
+                        _dosDevices.Add(currentName, string.Empty);
                     }
                 }
                 i++;

--- a/src/System.IO.Ports/tests/SerialPort/DsrHolding.cs
+++ b/src/System.IO.Ports/tests/SerialPort/DsrHolding.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -19,7 +20,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 SerialPortProperties serPortProp = new SerialPortProperties();
-            
+
                 Debug.WriteLine("Verifying default DsrHolding before Open");
 
                 serPortProp.SetAllPropertiesToDefaults();
@@ -156,7 +157,7 @@ namespace System.IO.Ports.Tests
                 if (com2.IsOpen)
                     com2.Close();
 
-                System.Threading.Thread.Sleep(100);
+                Thread.Sleep(100);
 
                 serPortProp.SetProperty("DsrHolding", false);
                 serPortProp.SetProperty("CDHolding", com1.CDHolding);

--- a/src/System.IO.Ports/tests/SerialPort/DtrEnable.cs
+++ b/src/System.IO.Ports/tests/SerialPort/DtrEnable.cs
@@ -38,14 +38,14 @@ namespace System.IO.Ports.Tests
             Debug.WriteLine("Verifying true DtrEnable before open");
             VerifyDtrEnableBeforeOpen(true);
         }
-    
+
         [ConditionalFact(nameof(HasNullModem))]
         public void DtrEnable_false_BeforeOpen()
         {
             Debug.WriteLine("Verifying false DtrEnable before open");
             VerifyDtrEnableBeforeOpen(false);
         }
-    
+
         [ConditionalFact(nameof(HasNullModem))]
         public void DtrEnable_true_false_BeforeOpen()
         {
@@ -76,14 +76,14 @@ namespace System.IO.Ports.Tests
             Debug.WriteLine("Verifying true DtrEnable after open");
             VerifyDtrEnableAfterOpen(true);
         }
-    
+
         [ConditionalFact(nameof(HasNullModem))]
         public void DtrEnable_false_AfterOpen()
         {
             Debug.WriteLine("Verifying false DtrEnable after open");
             VerifyDtrEnableAfterOpen(false);
         }
-    
+
         [ConditionalFact(nameof(HasNullModem))]
         public void DtrEnable_true_false_AfterOpen()
         {

--- a/src/System.IO.Ports/tests/SerialPort/Encoding.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Encoding.cs
@@ -4,6 +4,8 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -13,10 +15,10 @@ namespace System.IO.Ports.Tests
     {
         //The default number of bytes to read/write to verify the speed of the port
         //and that the bytes were transfered successfully
-        public static readonly int DEFAULT_CHAR_ARRAY_SIZE = 8;
+        private const int DEFAULT_CHAR_ARRAY_SIZE = 8;
 
         //The maximum time we will wait for all of encoded bytes to be received
-        public static readonly int MAX_WAIT_TIME = 1250;
+        private const int MAX_WAIT_TIME = 1250;
 
         private enum ThrowAt { Set, Open };
 
@@ -46,70 +48,70 @@ namespace System.IO.Ports.Tests
         public void Encoding_ASCIIEncoding_BeforeOpen()
         {
             Debug.WriteLine("Verifying ASCIIEncoding Encoding before open");
-            VerifyEncodingBeforeOpen(new System.Text.ASCIIEncoding());
+            VerifyEncodingBeforeOpen(new ASCIIEncoding());
         }
-    
+
         [ConditionalFact(nameof(HasNullModem))]
         public void Encoding_UTF8Encoding_BeforeOpen()
         {
             Debug.WriteLine("Verifying UTF8Encoding Encoding before open");
-            VerifyEncodingBeforeOpen(new System.Text.UTF8Encoding());
+            VerifyEncodingBeforeOpen(new UTF8Encoding());
         }
 
         [ConditionalFact(nameof(HasNullModem))]
         public void Encoding_UTF32Encoding_BeforeOpen()
         {
             Debug.WriteLine("Verifying UTF32Encoding Encoding before open");
-            VerifyEncodingBeforeOpen(new System.Text.UTF32Encoding());
+            VerifyEncodingBeforeOpen(new UTF32Encoding());
         }
-    
+
         [ConditionalFact(nameof(HasNullModem))]
         public void Encoding_UnicodeEncoding_BeforeOpen()
         {
             Debug.WriteLine("Verifying UnicodeEncoding Encoding before open");
-            VerifyEncodingBeforeOpen(new System.Text.UnicodeEncoding());
+            VerifyEncodingBeforeOpen(new UnicodeEncoding());
         }
-    
+
         [ConditionalFact(nameof(HasNullModem))]
         public void Encoding_ASCIIEncoding_AfterOpen()
         {
             Debug.WriteLine("Verifying ASCIIEncoding Encoding after open");
-            VerifyEncodingAfterOpen(new System.Text.ASCIIEncoding());
+            VerifyEncodingAfterOpen(new ASCIIEncoding());
         }
-    
+
         [ConditionalFact(nameof(HasNullModem))]
         public void Encoding_UTF8Encoding_AfterOpen()
         {
             Debug.WriteLine("Verifying UTF8Encoding Encoding after open");
-            VerifyEncodingAfterOpen(new System.Text.UTF8Encoding());
+            VerifyEncodingAfterOpen(new UTF8Encoding());
         }
-    
+
         [ConditionalFact(nameof(HasNullModem))]
         public void Encoding_UTF32Encoding_AfterOpen()
         {
             Debug.WriteLine("Verifying UTF32Encoding Encoding after open");
-            VerifyEncodingAfterOpen(new System.Text.UTF32Encoding());
+            VerifyEncodingAfterOpen(new UTF32Encoding());
         }
-    
+
         [ConditionalFact(nameof(HasNullModem))]
         public void Encoding_UnicodeEncoding_AfterOpen()
         {
             Debug.WriteLine("Verifying UnicodeEncoding Encoding after open");
-            VerifyEncodingAfterOpen(new System.Text.UnicodeEncoding());
+            VerifyEncodingAfterOpen(new UnicodeEncoding());
         }
-    
+
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void Encoding_ISCIIAssemese()
         {
             Debug.WriteLine("Verifying ISCIIAssemese Encoding");
-            VerifyException(System.Text.Encoding.GetEncoding(57006), ThrowAt.Set, typeof(ArgumentException));
+            VerifyException(Encoding.GetEncoding(57006), ThrowAt.Set, typeof(ArgumentException));
         }
 
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void Encoding_UTF7()
         {
             Debug.WriteLine("Verifying UTF7Encoding Encoding");
-            VerifyException(System.Text.Encoding.UTF7, ThrowAt.Set, typeof(ArgumentException));
+            VerifyException(Encoding.UTF7, ThrowAt.Set, typeof(ArgumentException));
         }
 
         [ConditionalFact(nameof(HasOneSerialPort))]
@@ -123,27 +125,27 @@ namespace System.IO.Ports.Tests
         public void Encoding_IBM_Latin1()
         {
             Debug.WriteLine("Verifying IBM Latin-1 Encoding before open");
-            VerifyEncodingBeforeOpen(System.Text.Encoding.GetEncoding(1047));
+            VerifyEncodingBeforeOpen(Encoding.GetEncoding(1047));
         }
 
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void Encoding_Japanese_JIS()
         {
             Debug.WriteLine("Verifying Japanese (JIS) Encoding before open");
-            VerifyException(System.Text.Encoding.GetEncoding(50220), ThrowAt.Set, typeof(ArgumentException));
+            VerifyException(Encoding.GetEncoding(50220), ThrowAt.Set, typeof(ArgumentException));
         }
 
         [ConditionalFact(nameof(HasNullModem))]
         public void Encoding_ChineseSimplified_GB18030()
         {
             Debug.WriteLine("Verifying Chinese Simplified (GB18030) Encoding before open");
-            VerifyEncodingBeforeOpen(System.Text.Encoding.GetEncoding(54936));
+            VerifyEncodingBeforeOpen(Encoding.GetEncoding(54936));
         }
 
         #endregion
 
         #region Verification for Test Cases
-        private void VerifyException(System.Text.Encoding encoding, ThrowAt throwAt, Type expectedException)
+        private void VerifyException(Encoding encoding, ThrowAt throwAt, Type expectedException)
         {
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
@@ -156,9 +158,9 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        private void VerifyExceptionAtOpen(SerialPort com, System.Text.Encoding encoding, ThrowAt throwAt, Type expectedException)
+        private void VerifyExceptionAtOpen(SerialPort com, Encoding encoding, ThrowAt throwAt, Type expectedException)
         {
-            System.Text.Encoding origEncoding = com.Encoding;
+            Encoding origEncoding = com.Encoding;
             SerialPortProperties serPortProp = new SerialPortProperties();
 
             serPortProp.SetAllPropertiesToDefaults();
@@ -198,8 +200,8 @@ namespace System.IO.Ports.Tests
             serPortProp.VerifyPropertiesAndPrint(com);
             com.Encoding = origEncoding;
         }
-    
-        private void VerifyExceptionAfterOpen(SerialPort com, System.Text.Encoding encoding, Type expectedException)
+
+        private void VerifyExceptionAfterOpen(SerialPort com, Encoding encoding, Type expectedException)
         {
             SerialPortProperties serPortProp = new SerialPortProperties();
 
@@ -232,7 +234,7 @@ namespace System.IO.Ports.Tests
         }
 
 
-        private void VerifyEncodingBeforeOpen(System.Text.Encoding encoding)
+        private void VerifyEncodingBeforeOpen(Encoding encoding)
         {
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
@@ -250,8 +252,8 @@ namespace System.IO.Ports.Tests
                 serPortProp.VerifyPropertiesAndPrint(com1);
             }
         }
-    
-        private void VerifyEncodingAfterOpen(System.Text.Encoding encoding)
+
+        private void VerifyEncodingAfterOpen(Encoding encoding)
         {
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
@@ -295,7 +297,7 @@ namespace System.IO.Ports.Tests
 
                 while (com1.BytesToRead < xmitBytes.Length)
                 {
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
                     waitTime += 50;
 
                     if (MAX_WAIT_TIME < waitTime)

--- a/src/System.IO.Ports/tests/SerialPort/ErrorEvent.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ErrorEvent.cs
@@ -12,8 +12,8 @@ namespace System.IO.Ports.Tests
     public class ErrorEvent : PortsTest
     {
         //Maximum time to wait for all of the expected events to be firered
-        static readonly int MAX_TIME_WAIT = 5000;
-        static readonly int NUM_TRYS = 5;
+        private const int MAX_TIME_WAIT = 5000;
+        private const int NUM_TRYS = 5;
 
         #region Test Cases
         /*	

--- a/src/System.IO.Ports/tests/SerialPort/Event_Close_Stress.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Event_Close_Stress.cs
@@ -12,7 +12,7 @@ namespace System.IO.Ports.Tests
     public class Event_Close_Stress : PortsTest
     {
         //Maximum time to wait for all of the expected events to be firered
-        private static readonly TimeSpan TestDuration = TCSupport.RunShortStressTests ? TimeSpan.FromSeconds(10) : TimeSpan.FromMinutes(3);
+        private static readonly TimeSpan s_testDuration = TCSupport.RunShortStressTests ? TimeSpan.FromSeconds(10) : TimeSpan.FromMinutes(3);
 
         #region Test Cases
 
@@ -30,7 +30,7 @@ namespace System.IO.Ports.Tests
                 com2.Open();
 
                 stopwatch.Start();
-                while (count % 100 != 0 || stopwatch.ElapsedMilliseconds < TestDuration.TotalMilliseconds)
+                while (count % 100 != 0 || stopwatch.ElapsedMilliseconds < s_testDuration.TotalMilliseconds)
                 {
                     com1.Open();
 
@@ -62,7 +62,7 @@ namespace System.IO.Ports.Tests
                 com2.Open();
 
                 stopwatch.Start();
-                while (count % 100 != 0 || stopwatch.ElapsedMilliseconds < TestDuration.TotalMilliseconds)
+                while (count % 100 != 0 || stopwatch.ElapsedMilliseconds < s_testDuration.TotalMilliseconds)
                 {
                     com1.Open();
 
@@ -79,7 +79,6 @@ namespace System.IO.Ports.Tests
                 com2.Close();
 
                 Debug.WriteLine("DataReceived={0}", dataReceivedCount);
-
             }
         }
 
@@ -105,7 +104,7 @@ namespace System.IO.Ports.Tests
                 frameErrorBytes[0] = 0x01;
 
                 stopwatch.Start();
-                while (count % 100 != 0 || stopwatch.ElapsedMilliseconds < TestDuration.TotalMilliseconds)
+                while (count % 100 != 0 || stopwatch.ElapsedMilliseconds < s_testDuration.TotalMilliseconds)
                 {
                     com1.Open();
 

--- a/src/System.IO.Ports/tests/SerialPort/Event_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Event_Generic.cs
@@ -73,7 +73,7 @@ namespace System.IO.Ports.Tests
                 //since we are writing some bytes
                 com1.DataBits = 8;
                 com1.Parity = Parity.None;
-                com2.BaseStream.Write(new byte[] {40}, 0, 1);
+                com2.BaseStream.Write(new byte[] { 40 }, 0, 1);
                 Debug.WriteLine("RxEvent Triggered");
                 Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
 
@@ -82,7 +82,7 @@ namespace System.IO.Ports.Tests
                 //com1 expects the stop bit at the 8th bit to be -12v
                 com1.DataBits = 7;
                 com1.Parity = Parity.None;
-                com2.BaseStream.Write(new byte[] {0x01}, 0, 1);
+                com2.BaseStream.Write(new byte[] { 0x01 }, 0, 1);
                 Debug.WriteLine("FrameError Triggered");
                 Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
 
@@ -96,7 +96,7 @@ namespace System.IO.Ports.Tests
                 //since we are writing the EOF char		
                 com1.DataBits = 8;
                 com1.Parity = Parity.None;
-                com2.BaseStream.Write(new byte[] {26}, 0, 1);
+                com2.BaseStream.Write(new byte[] { 26 }, 0, 1);
                 Debug.WriteLine("RxEOF Triggered");
                 Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
 
@@ -179,19 +179,19 @@ namespace System.IO.Ports.Tests
                         }
                     }
                 }
-            
+
                 if (!pinChangedEventHandler.WaitForEvent(MAX_TIME_WAIT, 3))
                 {
                     Fail("Err_2288ajied Expected 3 PinChangedEvents to be fired and only {0} occurred",
                         pinChangedEventHandler.NumEventsHandled);
                 }
-            
+
                 if (!receivedEventHandler.WaitForEvent(MAX_TIME_WAIT, 2))
                 {
                     Fail("Err_122808aoeid Expected 2 ReceivedEvents  to be fired and only {0} occurred",
                         receivedEventHandler.NumEventsHandled);
                 }
-            
+
                 if (!errorEventHandler.WaitForEvent(MAX_TIME_WAIT, 2))
                 {
                     Fail("Err_215887ajeid Expected 3 ErrorEvents to be fired and only {0} occurred",
@@ -206,11 +206,11 @@ namespace System.IO.Ports.Tests
                 //[] Verify all ReceivedEvent should have occurred
                 receivedEventHandler.Validate(SerialData.Chars, 0);
                 receivedEventHandler.Validate(SerialData.Eof, 0);
-            
+
                 //[] Verify all ErrorEvents should have occurred
                 errorEventHandler.Validate(SerialError.RXParity, 0);
                 errorEventHandler.Validate(SerialError.Frame, 0);
-            
+
                 // It's important that we close com1 BEFORE com2 (the using() block would do this the other way around normally)
                 // This is because we have our special blocking event handlers hooked onto com1, and closing com2 is likely to 
                 // cause a pin-change event which then hangs and prevents com1 from closing.
@@ -278,7 +278,7 @@ namespace System.IO.Ports.Tests
                 //since we are writing some bytes
                 com1.DataBits = 8;
                 com1.Parity = Parity.None;
-                com2.BaseStream.Write(new byte[] {40}, 0, 1);
+                com2.BaseStream.Write(new byte[] { 40 }, 0, 1);
                 Thread.Sleep(TRIGERING_EVENTS_WAIT_TIME);
 
                 if (!receivedEventHandler.WaitForEvent(MAX_TIME_WAIT, 1))
@@ -323,7 +323,7 @@ namespace System.IO.Ports.Tests
 
                 if (!errorEventHandler.WaitForEvent(MAX_TIME_WAIT, 1))
                 {
-                    Fail("Err_215887ajeid Expected 1 ErrorEvents to be fired and only {0} occurred",errorEventHandler.NumEventsHandled);
+                    Fail("Err_215887ajeid Expected 1 ErrorEvents to be fired and only {0} occurred", errorEventHandler.NumEventsHandled);
                 }
 
                 Task task = Task.Run(() => com1.Close());
@@ -350,7 +350,7 @@ namespace System.IO.Ports.Tests
         }
 
         private class ErrorEventHandler : TestEventHandler<SerialError>
-        { 
+        {
             public ErrorEventHandler(SerialPort com, bool shouldThrow, bool shouldWait) : base(com, shouldThrow, shouldWait)
             {
             }

--- a/src/System.IO.Ports/tests/SerialPort/GetPortNames.cs
+++ b/src/System.IO.Ports/tests/SerialPort/GetPortNames.cs
@@ -14,7 +14,7 @@ namespace System.IO.Ports.Tests
         #region Test Cases
 
         [Fact]
-        private void  OpenEveryPortName()
+        private void OpenEveryPortName()
         {
             string[] portNames = SerialPort.GetPortNames();
 

--- a/src/System.IO.Ports/tests/SerialPort/Handshake.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Handshake.cs
@@ -23,9 +23,6 @@ namespace System.IO.Ports.Tests
         //The default time to wait after writing some bytes
         private const int DEFAULT_WAIT_AFTER_READ_OR_WRITE = 500;
 
-        private const byte XOFF_BYTE = 19;
-        private const byte XON_BYTE = 17;
-
         private enum ThrowAt { Set, Open };
 
         #region Test Cases
@@ -743,7 +740,7 @@ namespace System.IO.Ports.Tests
                     {
                         Fail("Err_12558aoed Expected XOff to be sent and nothing was sent");
                     }
-                    else if (XOFF_BYTE != (byteRead = com2.ReadByte()))
+                    else if (XOnOff.XOFF != (byteRead = com2.ReadByte()))
                     {
                         Fail("Err_0188598aoepad Expected XOff to be sent actually sent={0}", byteRead);
                     }
@@ -786,7 +783,7 @@ namespace System.IO.Ports.Tests
                     {
                         Fail("Err_6887518adizpa Expected XOn to be sent and nothing was sent");
                     }
-                    else if (XON_BYTE != (byteRead = com2.ReadByte()))
+                    else if (XOnOff.XON != (byteRead = com2.ReadByte()))
                     {
                         Fail("Err_58145auead Expected XOn to be sent actually sent={0}", byteRead);
                     }

--- a/src/System.IO.Ports/tests/SerialPort/Handshake.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Handshake.cs
@@ -14,11 +14,11 @@ namespace System.IO.Ports.Tests
     {
         //The default number of bytes to read/write to verify the speed of the port
         //and that the bytes were transfered successfully
-        private static readonly int DEFAULT_BYTE_SIZE = TCSupport.MinimumBlockingByteCount;
+        private static readonly int s_DEFAULT_BYTE_SIZE = TCSupport.MinimumBlockingByteCount;
 
         //The number of bytes to send when send XOn or XOff, the actual XOn/XOff char will be inserted somewhere
         //in the array of bytes
-        private static readonly int DEFAULT_BYTE_SIZE_XON_XOFF = TCSupport.MinimumBlockingByteCount*2;
+        private static readonly int s_DEFAULT_BYTE_SIZE_XON_XOFF = TCSupport.MinimumBlockingByteCount * 2;
 
         //The default time to wait after writing some bytes
         private const int DEFAULT_WAIT_AFTER_READ_OR_WRITE = 500;
@@ -153,7 +153,7 @@ namespace System.IO.Ports.Tests
         private void VerifyExceptionAtOpen(SerialPort com, int handshake, ThrowAt throwAt, Type expectedException)
         {
             int origHandshake = (int)com.Handshake;
-        
+
             SerialPortProperties serPortProp = new SerialPortProperties();
 
             serPortProp.SetAllPropertiesToDefaults();
@@ -291,7 +291,7 @@ namespace System.IO.Ports.Tests
 
                 try
                 {
-                    com1.Write(new byte[DEFAULT_BYTE_SIZE], 0, DEFAULT_BYTE_SIZE);
+                    com1.Write(new byte[s_DEFAULT_BYTE_SIZE], 0, s_DEFAULT_BYTE_SIZE);
                 }
                 catch (TimeoutException)
                 {
@@ -302,7 +302,7 @@ namespace System.IO.Ports.Tests
 
                 try
                 {
-                    com1.Write(new byte[DEFAULT_BYTE_SIZE], 0, DEFAULT_BYTE_SIZE);
+                    com1.Write(new byte[s_DEFAULT_BYTE_SIZE], 0, s_DEFAULT_BYTE_SIZE);
                     if (Handshake.RequestToSend == com1.Handshake || Handshake.RequestToSendXOnXOff == com1.Handshake)
                     {
                         Fail("Err_15397lkjh!!! TimeoutException NOT thrown when CtsHolding={0} with Handshake={1}", com1.CtsHolding, com1.Handshake);
@@ -320,7 +320,7 @@ namespace System.IO.Ports.Tests
 
                 try
                 {
-                    com1.Write(new byte[DEFAULT_BYTE_SIZE], 0, DEFAULT_BYTE_SIZE);
+                    com1.Write(new byte[s_DEFAULT_BYTE_SIZE], 0, s_DEFAULT_BYTE_SIZE);
                 }
                 catch (TimeoutException)
                 {
@@ -339,8 +339,8 @@ namespace System.IO.Ports.Tests
         {
             bool origRtsEnable = com2.RtsEnable;
             Random rndGen = new Random();
-            byte[] xmitXOnBytes = new byte[DEFAULT_BYTE_SIZE_XON_XOFF];
-            byte[] xmitXOffBytes = new byte[DEFAULT_BYTE_SIZE_XON_XOFF];
+            byte[] xmitXOnBytes = new byte[s_DEFAULT_BYTE_SIZE_XON_XOFF];
+            byte[] xmitXOffBytes = new byte[s_DEFAULT_BYTE_SIZE_XON_XOFF];
 
             try
             {
@@ -389,7 +389,7 @@ namespace System.IO.Ports.Tests
 
                 try
                 {
-                    com1.Write(new byte[DEFAULT_BYTE_SIZE], 0, DEFAULT_BYTE_SIZE);
+                    com1.Write(new byte[s_DEFAULT_BYTE_SIZE], 0, s_DEFAULT_BYTE_SIZE);
                     if (Handshake.RequestToSend == com1.Handshake || Handshake.RequestToSendXOnXOff == com1.Handshake)
                     {
                         Fail("Err_1253aasyo!!! TimeoutException NOT thrown after XOff and XOn char sent when CtsHolding={0} with Handshake={1}", com1.CtsHolding, com1.Handshake);
@@ -420,7 +420,7 @@ namespace System.IO.Ports.Tests
 
                 try
                 {
-                    com1.Write(new byte[DEFAULT_BYTE_SIZE], 0, DEFAULT_BYTE_SIZE);
+                    com1.Write(new byte[s_DEFAULT_BYTE_SIZE], 0, s_DEFAULT_BYTE_SIZE);
                     if (Handshake.XOnXOff == com1.Handshake || Handshake.RequestToSendXOnXOff == com1.Handshake)
                     {
                         Fail("Err_2457awez!!! TimeoutException NOT thrown after RTSEnable set to false then true when CtsHolding={0} with Handshake={1}", com1.CtsHolding, com1.Handshake);
@@ -459,8 +459,8 @@ namespace System.IO.Ports.Tests
         {
             bool origRtsEnable = com2.RtsEnable;
             Random rndGen = new Random();
-            byte[] xmitXOnBytes = new byte[DEFAULT_BYTE_SIZE_XON_XOFF];
-            byte[] xmitXOffBytes = new byte[DEFAULT_BYTE_SIZE_XON_XOFF];
+            byte[] xmitXOnBytes = new byte[s_DEFAULT_BYTE_SIZE_XON_XOFF];
+            byte[] xmitXOffBytes = new byte[s_DEFAULT_BYTE_SIZE_XON_XOFF];
 
             try
             {
@@ -514,7 +514,7 @@ namespace System.IO.Ports.Tests
 
                 try
                 {
-                    com1.Write(new byte[DEFAULT_BYTE_SIZE], 0, DEFAULT_BYTE_SIZE);
+                    com1.Write(new byte[s_DEFAULT_BYTE_SIZE], 0, s_DEFAULT_BYTE_SIZE);
                 }
                 catch (TimeoutException)
                 {
@@ -536,7 +536,7 @@ namespace System.IO.Ports.Tests
 
                 try
                 {
-                    com1.Write(new byte[DEFAULT_BYTE_SIZE], 0, DEFAULT_BYTE_SIZE);
+                    com1.Write(new byte[s_DEFAULT_BYTE_SIZE], 0, s_DEFAULT_BYTE_SIZE);
 
                     if (Handshake.XOnXOff == com1.Handshake || Handshake.RequestToSendXOnXOff == com1.Handshake)
                     {
@@ -566,7 +566,7 @@ namespace System.IO.Ports.Tests
 
                 try
                 {
-                    com1.Write(new byte[DEFAULT_BYTE_SIZE], 0, DEFAULT_BYTE_SIZE);
+                    com1.Write(new byte[s_DEFAULT_BYTE_SIZE], 0, s_DEFAULT_BYTE_SIZE);
                 }
                 catch (TimeoutException)
                 {

--- a/src/System.IO.Ports/tests/SerialPort/NewLine.cs
+++ b/src/System.IO.Ports/tests/SerialPort/NewLine.cs
@@ -54,7 +54,7 @@ namespace System.IO.Ports.Tests
                 VerifyExceptionAfterOpen(com, newLine, expectedException);
             }
         }
-    
+
         private void VerifyExceptionAtOpen(SerialPort com, string newLine, Type expectedException)
         {
             string origNewLine = com.NewLine;

--- a/src/System.IO.Ports/tests/SerialPort/Open_Stress.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Open_Stress.cs
@@ -76,7 +76,7 @@ namespace System.IO.Ports.Tests
 
                 for (int i = 0; i < xmitBytes.Length; ++i)
                     xmitBytes[i] = (byte)i;
-            
+
                 try
                 {
                     int iterationCount = TCSupport.RunShortStressTests ? 10 : 1000;
@@ -102,7 +102,7 @@ namespace System.IO.Ports.Tests
         }
 
 
-        void OpenReceiveDataAndRTS_WorkerThread(object token)
+        private void OpenReceiveDataAndRTS_WorkerThread(object token)
         {
             CancellationToken ct = (CancellationToken)token;
             try

--- a/src/System.IO.Ports/tests/SerialPort/Parity.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Parity.cs
@@ -500,7 +500,9 @@ namespace System.IO.Ports.Tests
                 while (0 == com2.BytesToRead) ;
 
                 sw.Start();
-                while (length > com2.BytesToRead) ; //Wait for all of the bytes to reach the input buffer of com2
+
+                // Wait for all of the bytes to reach the input buffer of com2
+                TCSupport.WaitForReadBufferToLoad(com2, length);
 
                 sw.Stop();
                 actualTime += sw.ElapsedMilliseconds;

--- a/src/System.IO.Ports/tests/SerialPort/Parity.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Parity.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -13,16 +14,16 @@ namespace System.IO.Ports.Tests
     {
         //The default number of bytes to read/write to verify the speed of the port
         //and that the bytes were transfered successfully
-        public static readonly int DEFAULT_BYTE_SIZE = 512;
+        private const int DEFAULT_BYTE_SIZE = 512;
 
         //If the percentage difference between the expected time to transfer with the specified parity
         //and the actual time found through Stopwatch is greater then 10% then the Parity value was not correctly
         //set and the testcase fails.
-        public static readonly double MAX_ACCEPTABEL_PERCENTAGE_DIFFERENCE = .10;
+        private const double MAX_ACCEPTABEL_PERCENTAGE_DIFFERENCE = .10;
 
         //The default number of databits to use when testing Parity
-        public static readonly int DEFUALT_DATABITS = 8;
-        public static readonly int NUM_TRYS = 3;
+        private const int DEFUALT_DATABITS = 8;
+        private const int NUM_TRYS = 3;
 
         private enum ThrowAt { Set, Open };
 
@@ -53,7 +54,7 @@ namespace System.IO.Ports.Tests
             Debug.WriteLine("Verifying None Parity before open");
             VerifyParityBeforeOpen((int)Parity.None, DEFAULT_BYTE_SIZE);
         }
-    
+
         [ConditionalFact(nameof(HasNullModem))]
         public void Parity_Even_BeforeOpen()
         {
@@ -145,7 +146,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 SerialPortProperties serPortProp = new SerialPortProperties();
-        
+
                 Debug.WriteLine("Verifying Parity Even and then Odd");
 
                 serPortProp.SetAllPropertiesToOpenDefaults();
@@ -454,7 +455,6 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
-
                 //Generate some random bytes to read/write for this Parity setting
                 for (int i = 0; i < xmitBytes.Length; i++)
                 {
@@ -480,7 +480,7 @@ namespace System.IO.Ports.Tests
         private void PerformWriteRead(SerialPort com1, SerialPort com2, byte[] xmitBytes, byte[] expectedBytes)
         {
             byte[] rcvBytes = new byte[expectedBytes.Length * 4];
-            System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
+            Stopwatch sw = new Stopwatch();
             double expectedTime, actualTime, percentageDifference;
             int numParityBits = (Parity)com1.Parity == Parity.None ? 0 : 1;
             double numStopBits = GetNumberOfStopBits(com1);
@@ -490,7 +490,7 @@ namespace System.IO.Ports.Tests
             // TODO: Consider removing all of the code to check the time it takes to transfer the bytes. 
             // This was likely just a copy and paste from another test case
             actualTime = 0;
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Highest;
+            Thread.CurrentThread.Priority = ThreadPriority.Highest;
             for (int i = 0; i < NUM_TRYS; i++)
             {
                 com2.DiscardInBuffer();
@@ -510,7 +510,7 @@ namespace System.IO.Ports.Tests
                 sw.Reset();
             }
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Normal;
+            Thread.CurrentThread.Priority = ThreadPriority.Normal;
             actualTime /= NUM_TRYS;
             expectedTime = ((xmitBytes.Length * (1 + numStopBits + com1.DataBits + numParityBits)) / com1.BaudRate) * 1000;
             percentageDifference = Math.Abs((expectedTime - actualTime) / expectedTime);

--- a/src/System.IO.Ports/tests/SerialPort/ParityReplace.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ParityReplace.cs
@@ -269,9 +269,7 @@ namespace System.IO.Ports.Tests
             }
             else
             {
-                while (bytesToWrite.Length > com1.BytesToRead)
-                {
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length);
             }
 
             char[] actualChars = readMethod(com1);

--- a/src/System.IO.Ports/tests/SerialPort/ParityReplace.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ParityReplace.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
 using Legacy.Support;
 using Xunit;
 
@@ -12,13 +14,13 @@ namespace System.IO.Ports.Tests
     public class ParityReplace_Property : PortsTest
     {
         //The default number of chars to write with when testing timeout with Read(char[], int, int)
-        public static readonly int DEFAULT_READ_CHAR_ARRAY_SIZE = 8;
+        private const int DEFAULT_READ_CHAR_ARRAY_SIZE = 8;
 
         //The default number of bytes to write with when testing timeout with Read(byte[], int, int)
-        public static readonly int DEFAULT_READ_BYTE_ARRAY_SIZE = 8;
-        private static readonly int s_numRndBytesPairty = 8;
+        private const int DEFAULT_READ_BYTE_ARRAY_SIZE = 8;
+        private const int s_numRndBytesPairty = 8;
 
-        public delegate char[] ReadMethodDelegate(SerialPort com);
+        private delegate char[] ReadMethodDelegate(SerialPort com);
 
         #region Test Cases
         [Fact]
@@ -101,7 +103,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 SerialPortProperties serPortProp = new SerialPortProperties();
-            
+
                 Debug.WriteLine("Verifying setting ParityReplace after Parity has been set");
 
                 serPortProp.SetAllPropertiesToOpenDefaults();
@@ -128,7 +130,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 SerialPortProperties serPortProp = new SerialPortProperties();
-            
+
                 Debug.WriteLine("Verifying setting ParityReplace after ParityReplace has aready been set");
 
                 serPortProp.SetAllPropertiesToOpenDefaults();
@@ -264,7 +266,6 @@ namespace System.IO.Ports.Tests
                 com2.Write(com1.NewLine);
                 while (bytesToWrite.Length + com1.NewLine.Length > com1.BytesToRead)
                 {
-                
                 }
             }
             else
@@ -296,7 +297,7 @@ namespace System.IO.Ports.Tests
 
         private char[] Read_byte_int_int(SerialPort com)
         {
-            System.Collections.ArrayList receivedBytes = new System.Collections.ArrayList();
+            ArrayList receivedBytes = new ArrayList();
             byte[] buffer = new byte[DEFAULT_READ_BYTE_ARRAY_SIZE];
             int totalBytesRead = 0;
 
@@ -325,7 +326,7 @@ namespace System.IO.Ports.Tests
 
         private char[] Read_char_int_int(SerialPort com)
         {
-            System.Collections.ArrayList receivedChars = new System.Collections.ArrayList();
+            ArrayList receivedChars = new ArrayList();
             char[] buffer = new char[DEFAULT_READ_CHAR_ARRAY_SIZE];
             int totalCharsRead = 0;
             int numChars;
@@ -354,7 +355,7 @@ namespace System.IO.Ports.Tests
 
         private char[] ReadByte(SerialPort com)
         {
-            System.Collections.ArrayList receivedBytes = new System.Collections.ArrayList();
+            ArrayList receivedBytes = new ArrayList();
             int rcvByte;
 
             while (true)
@@ -377,7 +378,7 @@ namespace System.IO.Ports.Tests
 
         private char[] ReadChar(SerialPort com)
         {
-            System.Collections.ArrayList receivedChars = new System.Collections.ArrayList();
+            ArrayList receivedChars = new ArrayList();
             int rcvChar;
 
             while (true)
@@ -400,7 +401,7 @@ namespace System.IO.Ports.Tests
 
         private char[] ReadLine(SerialPort com)
         {
-            System.Text.StringBuilder rcvStringBuilder = new System.Text.StringBuilder();
+            StringBuilder rcvStringBuilder = new StringBuilder();
             string rcvString;
 
             while (true)
@@ -423,7 +424,7 @@ namespace System.IO.Ports.Tests
 
         private char[] ReadTo(SerialPort com)
         {
-            System.Text.StringBuilder rcvStringBuilder = new System.Text.StringBuilder();
+            StringBuilder rcvStringBuilder = new StringBuilder();
             string rcvString;
 
             while (true)

--- a/src/System.IO.Ports/tests/SerialPort/PinChangedEvent.cs
+++ b/src/System.IO.Ports/tests/SerialPort/PinChangedEvent.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -12,8 +13,8 @@ namespace System.IO.Ports.Tests
     public class PinChangedEvent : PortsTest
     {
         // Maximum time to wait for all of the expected events to be fired
-        private static readonly int MAX_TIME_WAIT = 1000;
-        private static readonly int NUM_TRYS = 5;
+        private const int MAX_TIME_WAIT = 1000;
+        private const int NUM_TRYS = 5;
 
         #region Test Cases
 
@@ -62,7 +63,7 @@ namespace System.IO.Ports.Tests
 
                 // Some null-modem cables have a connection between CD and CSR/CTR, so we need to discard CDChanged events
                 eventHandler.EventFilter = eventType => eventType != SerialPinChange.CDChanged;
-            
+
                 Debug.WriteLine("Verifying DsrChanged event");
                 com1.PinChanged += eventHandler.HandleEvent;
                 com1.Open();
@@ -122,7 +123,7 @@ namespace System.IO.Ports.Tests
                 }
             }
         }
-   
+
         [ConditionalFact(nameof(HasNullModem))]
         public void PinChangedEvent_Multiple()
         {
@@ -144,9 +145,9 @@ namespace System.IO.Ports.Tests
                 com2.Open();
 
                 com2.BreakState = true;
-                System.Threading.Thread.Sleep(100);
+                Thread.Sleep(100);
                 com2.DtrEnable = true;
-                System.Threading.Thread.Sleep(100);
+                Thread.Sleep(100);
                 com2.RtsEnable = true;
 
                 eventHandler.WaitForEvent(MAX_TIME_WAIT, 3);

--- a/src/System.IO.Ports/tests/SerialPort/PortName.cs
+++ b/src/System.IO.Ports/tests/SerialPort/PortName.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
 using Legacy.Support;
 using Xunit;
 
@@ -12,7 +13,7 @@ namespace System.IO.Ports.Tests
     public class PortName_Property : PortsTest
     {
         //Determines how long the randomly generated PortName is
-        public static readonly int rndPortNameSize = 255;
+        private const int rndPortNameSize = 255;
 
         private enum ThrowAt { Set, Open };
 
@@ -69,7 +70,7 @@ namespace System.IO.Ports.Tests
         public void PortName_RND()
         {
             Random rndGen = new Random();
-            System.Text.StringBuilder rndStrBuf = new System.Text.StringBuilder();
+            StringBuilder rndStrBuf = new StringBuilder();
 
             for (int i = 0; i < rndPortNameSize; i++)
             {
@@ -84,8 +85,8 @@ namespace System.IO.Ports.Tests
         public void PortName_FileName()
         {
             string fileName = "PortNameEqualToFileName.txt";
-            System.IO.FileStream testFile = System.IO.File.Open(fileName, System.IO.FileMode.Create);
-            System.Text.ASCIIEncoding asciiEncd = new System.Text.ASCIIEncoding();
+            FileStream testFile = File.Open(fileName, FileMode.Create);
+            ASCIIEncoding asciiEncd = new ASCIIEncoding();
             string testStr = "Hello World";
 
             testFile.Write(asciiEncd.GetBytes(testStr), 0, asciiEncd.GetByteCount(testStr));
@@ -94,27 +95,27 @@ namespace System.IO.Ports.Tests
             Debug.WriteLine("Verifying setting PortName={0}", fileName);
 
             VerifyException(fileName, ThrowAt.Open, typeof(ArgumentException), typeof(InvalidOperationException));
-        
+
             Debug.WriteLine("Verifying setting PortName={0}", Environment.CurrentDirectory + fileName);
 
             VerifyException(Environment.CurrentDirectory + fileName, ThrowAt.Open, typeof(ArgumentException),
                 typeof(InvalidOperationException));
 
-            System.IO.File.Delete(fileName);
+            File.Delete(fileName);
         }
 
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void PortName_COM257()
         {
             Debug.WriteLine("Verifying setting PortName=COM257");
-            VerifyException("COM257", ThrowAt.Open, typeof(System.IO.IOException), typeof(InvalidOperationException));
+            VerifyException("COM257", ThrowAt.Open, typeof(IOException), typeof(InvalidOperationException));
         }
 
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void PortName_LPT()
         {
             Type expectedException = _dosDevices.CommonNameExists("LPT") ? typeof(ArgumentException) : typeof(ArgumentException);
-        
+
             Debug.WriteLine("Verifying setting PortName=LPT");
             VerifyException("LPT", ThrowAt.Open, expectedException, typeof(InvalidOperationException));
         }
@@ -152,7 +153,7 @@ namespace System.IO.Ports.Tests
         {
             Debug.WriteLine("Verifying setting PortName=C:");
 
-            VerifyException("C:", ThrowAt.Open, new[] {typeof(ArgumentException), typeof(ArgumentException)}, typeof(InvalidOperationException));
+            VerifyException("C:", ThrowAt.Open, new[] { typeof(ArgumentException), typeof(ArgumentException) }, typeof(InvalidOperationException));
         }
 
         [ConditionalFact(nameof(HasOneSerialPort))]
@@ -163,7 +164,7 @@ namespace System.IO.Ports.Tests
 
             if (!string.IsNullOrEmpty(portName))
             {
-                VerifyException(portName, ThrowAt.Open, new[] {typeof(ArgumentException)}, typeof(InvalidOperationException));
+                VerifyException(portName, ThrowAt.Open, new[] { typeof(ArgumentException) }, typeof(InvalidOperationException));
             }
         }
         #endregion
@@ -197,7 +198,7 @@ namespace System.IO.Ports.Tests
         private void VerifyExceptionAtOpen(SerialPort com, string portName, ThrowAt throwAt, Type[] expectedExceptions)
         {
             string origPortName = com.PortName;
-        
+
             SerialPortProperties serPortProp = new SerialPortProperties();
 
             if (null != expectedExceptions && 0 < expectedExceptions.Length)
@@ -226,7 +227,6 @@ namespace System.IO.Ports.Tests
                     Fail("ERROR!!! Expected Open() to throw ");
                     for (int i = 0; i < expectedExceptions.Length; ++i) Console.Write(expectedExceptions[i] + " ");
                     Debug.WriteLine(" and nothing was thrown");
-                
                 }
             }
             catch (Exception e)

--- a/src/System.IO.Ports/tests/SerialPort/ReadBufferSize.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadBufferSize.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Linq;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -12,8 +13,8 @@ namespace System.IO.Ports.Tests
 {
     public class ReadBufferSize_Property : PortsTest
     {
-        private static readonly int MAX_RANDOM_BUFFER_SIZE = 1024 * 16;
-        private static readonly int LARGE_BUFFER_SIZE = 1024 * 128;
+        private const int MAX_RANDOM_BUFFER_SIZE = 1024 * 16;
+        private const int LARGE_BUFFER_SIZE = 1024 * 128;
 
         #region Test Cases
 
@@ -257,7 +258,7 @@ namespace System.IO.Ports.Tests
 
                     TCSupport.WaitForReadBufferToLoad(com1, newBytesToRead);
 
-                    System.Threading.Thread.Sleep(250);
+                    Thread.Sleep(250);
                     //This is to wait for the bytes to be received after the buffer is full
 
                     serPortProp.SetProperty("BytesToRead", newBytesToRead);
@@ -328,7 +329,7 @@ namespace System.IO.Ports.Tests
 
                 TCSupport.WaitForReadBufferToLoad(com1, bytesToRead);
 
-                System.Threading.Thread.Sleep(250); //This is to wait for the bytes to be received after the buffer is full
+                Thread.Sleep(250); //This is to wait for the bytes to be received after the buffer is full
 
                 var rcvBytes = new byte[(int)(bytesToRead * 1.5)];
                 if (bytesToRead != (bytesRead = com1.Read(rcvBytes, 0, rcvBytes.Length)))

--- a/src/System.IO.Ports/tests/SerialPort/ReadByte.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadByte.cs
@@ -4,6 +4,8 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -12,54 +14,54 @@ namespace System.IO.Ports.Tests
     public class ReadByte : PortsTest
     {
         //The number of random bytes to receive
-        static int numRndByte = 8;
+        private const int numRndByte = 8;
 
-        enum ReadDataFromEnum { NonBuffered, Buffered, BufferedAndNonBuffered };
+        private enum ReadDataFromEnum { NonBuffered, Buffered, BufferedAndNonBuffered };
 
         #region Test Cases
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void ASCIIEncoding()
         {
             Debug.WriteLine("Verifying read with bytes encoded with ASCIIEncoding");
-            VerifyRead(new System.Text.ASCIIEncoding());
+            VerifyRead(new ASCIIEncoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void UTF8Encoding()
         {
             Debug.WriteLine("Verifying read with bytes encoded with UTF8Encoding");
-            VerifyRead(new System.Text.UTF8Encoding());
+            VerifyRead(new UTF8Encoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void UTF32Encoding()
         {
             Debug.WriteLine("Verifying read with bytes encoded with UTF32Encoding");
-            VerifyRead(new System.Text.UTF32Encoding());
+            VerifyRead(new UTF32Encoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void SerialPort_ReadBufferedData()
         {
-            VerifyRead(System.Text.Encoding.ASCII, ReadDataFromEnum.Buffered);
+            VerifyRead(Encoding.ASCII, ReadDataFromEnum.Buffered);
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void SerialPort_IterativeReadBufferedData()
         {
-            VerifyRead(System.Text.Encoding.ASCII, ReadDataFromEnum.Buffered);
+            VerifyRead(Encoding.ASCII, ReadDataFromEnum.Buffered);
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void SerialPort_ReadBufferedAndNonBufferedData()
         {
-            VerifyRead(System.Text.Encoding.ASCII, ReadDataFromEnum.BufferedAndNonBuffered);
+            VerifyRead(Encoding.ASCII, ReadDataFromEnum.BufferedAndNonBuffered);
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void SerialPort_IterativeReadBufferedAndNonBufferedData()
         {
-            VerifyRead(System.Text.Encoding.ASCII, ReadDataFromEnum.BufferedAndNonBuffered);
+            VerifyRead(Encoding.ASCII, ReadDataFromEnum.BufferedAndNonBuffered);
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
@@ -71,13 +73,13 @@ namespace System.IO.Ports.Tests
                 byte[] byteXmitBuffer = TCSupport.GetRandomBytes(512);
                 byte[] byteRcvBuffer = new byte[byteXmitBuffer.Length];
                 ASyncRead asyncRead = new ASyncRead(com1);
-                System.Threading.Thread asyncReadThread = new System.Threading.Thread(asyncRead.Read);
+                Thread asyncReadThread = new Thread(asyncRead.Read);
 
                 Debug.WriteLine(
                     "Verifying that ReadByte() will read bytes that have been received after the call to Read was made");
 
-                com1.Encoding = System.Text.Encoding.UTF8;
-                com2.Encoding = System.Text.Encoding.UTF8;
+                com1.Encoding = Encoding.UTF8;
+                com2.Encoding = Encoding.UTF8;
                 com1.ReadTimeout = 20000; // 20 seconds
 
                 com1.Open();
@@ -88,7 +90,7 @@ namespace System.IO.Ports.Tests
                 asyncReadThread.Start();
                 asyncRead.ReadStartedEvent.WaitOne();
                 //This only tells us that the thread has started to execute code in the method
-                System.Threading.Thread.Sleep(2000); //We need to wait to guarentee that we are executing code in SerialPort
+                Thread.Sleep(2000); //We need to wait to guarentee that we are executing code in SerialPort
                 com2.Write(byteXmitBuffer, 0, byteXmitBuffer.Length);
 
                 asyncRead.ReadCompletedEvent.WaitOne();
@@ -103,7 +105,7 @@ namespace System.IO.Ports.Tests
                 }
                 else
                 {
-                    System.Threading.Thread.Sleep(1000); //We need to wait for all of the bytes to be received
+                    Thread.Sleep(1000); //We need to wait for all of the bytes to be received
                     byteRcvBuffer[0] = (byte)asyncRead.Result;
                     int readResult = com1.Read(byteRcvBuffer, 1, byteRcvBuffer.Length - 1);
 
@@ -130,13 +132,13 @@ namespace System.IO.Ports.Tests
         #endregion
 
         #region Verification for Test Cases
-        private void VerifyRead(System.Text.Encoding encoding)
+        private void VerifyRead(Encoding encoding)
         {
             VerifyRead(encoding, ReadDataFromEnum.NonBuffered);
         }
 
 
-        private void VerifyRead(System.Text.Encoding encoding, ReadDataFromEnum readDataFrom)
+        private void VerifyRead(Encoding encoding, ReadDataFromEnum readDataFrom)
         {
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
@@ -227,7 +229,7 @@ namespace System.IO.Ports.Tests
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
             com1.ReadTimeout = 500;
 
-            System.Threading.Thread.Sleep((int)(((bytesToWrite.Length * 10.0) / com1.BaudRate) * 1000) + 250);
+            Thread.Sleep((int)(((bytesToWrite.Length * 10.0) / com1.BaudRate) * 1000) + 250);
 
             PerformReadOnCom1FromCom2(com1, com2, expectedBytes);
         }
@@ -288,11 +290,11 @@ namespace System.IO.Ports.Tests
 
         public class ASyncRead
         {
-            private SerialPort _com;
+            private readonly SerialPort _com;
             private int _result;
 
-            private System.Threading.AutoResetEvent _readCompletedEvent;
-            private System.Threading.AutoResetEvent _readStartedEvent;
+            private readonly AutoResetEvent _readCompletedEvent;
+            private readonly AutoResetEvent _readStartedEvent;
 
             private Exception _exception;
 
@@ -301,8 +303,8 @@ namespace System.IO.Ports.Tests
                 _com = com;
                 _result = int.MinValue;
 
-                _readCompletedEvent = new System.Threading.AutoResetEvent(false);
-                _readStartedEvent = new System.Threading.AutoResetEvent(false);
+                _readCompletedEvent = new AutoResetEvent(false);
+                _readStartedEvent = new AutoResetEvent(false);
 
                 _exception = null;
             }
@@ -324,7 +326,7 @@ namespace System.IO.Ports.Tests
                 }
             }
 
-            public System.Threading.AutoResetEvent ReadStartedEvent
+            public AutoResetEvent ReadStartedEvent
             {
                 get
                 {
@@ -332,7 +334,7 @@ namespace System.IO.Ports.Tests
                 }
             }
 
-            public System.Threading.AutoResetEvent ReadCompletedEvent
+            public AutoResetEvent ReadCompletedEvent
             {
                 get
                 {

--- a/src/System.IO.Ports/tests/SerialPort/ReadByte.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadByte.cs
@@ -212,10 +212,7 @@ namespace System.IO.Ports.Tests
             com2.Write(bytesToWrite, 0, 1); // Write one byte at the begining because we are going to read this to buffer the rest of the data
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
 
-            while (com1.BytesToRead < bytesToWrite.Length)
-            {
-                System.Threading.Thread.Sleep(50);
-            }
+            TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length);
 
             com1.Read(new char[1], 0, 1); // This should put the rest of the bytes in SerialPorts own internal buffer
 

--- a/src/System.IO.Ports/tests/SerialPort/ReadByte_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadByte_Generic.cs
@@ -4,6 +4,8 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -13,19 +15,19 @@ namespace System.IO.Ports.Tests
     {
         //Set bounds fore random timeout values.
         //If the min is to low read will not timeout accurately and the testcase will fail
-        public static int minRandomTimeout = 250;
+        private const int minRandomTimeout = 250;
 
         //If the max is to large then the testcase will take forever to run
-        public static int maxRandomTimeout = 2000;
+        private const int maxRandomTimeout = 2000;
 
         //If the percentage difference between the expected timeout and the actual timeout
         //found through Stopwatch is greater then 10% then the timeout value was not correctly
         //to the read method and the testcase fails.
-        public static double maxPercentageDifference = .15;
-        public static readonly int NUM_TRYS = 5;
+        private static double s_maxPercentageDifference = .15;
+        private const int NUM_TRYS = 5;
 
         //The number of random bytes to receive
-        public static int numRndByte = 8;
+        private const int numRndByte = 8;
 
         #region Test Cases
 
@@ -93,7 +95,7 @@ namespace System.IO.Ports.Tests
 
                 com.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 //		com.Encoding = new System.Text.UTF7Encoding();
-                com.Encoding = System.Text.Encoding.Unicode;
+                com.Encoding = Encoding.Unicode;
 
                 Debug.WriteLine("Verifying ReadTimeout={0} with successive call to read method and no data", com.ReadTimeout);
                 com.Open();
@@ -110,10 +112,10 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 Random rndGen = new Random(-55);
-                System.Threading.Thread t = new System.Threading.Thread(WriteToCom1);
-        
+                Thread t = new Thread(WriteToCom1);
+
                 com1.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
-                com1.Encoding = new System.Text.UTF8Encoding();
+                com1.Encoding = new UTF8Encoding();
 
                 Debug.WriteLine("Verifying ReadTimeout={0} with successive call to read method and some data being received in the first call", com1.ReadTimeout);
                 com1.Open();
@@ -131,7 +133,7 @@ namespace System.IO.Ports.Tests
 
                 //Wait for the thread to finish
                 while (t.IsAlive)
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
 
                 //Make sure there is no bytes in the buffer so the next call to read will timeout
                 com1.DiscardInBuffer();
@@ -149,26 +151,26 @@ namespace System.IO.Ports.Tests
                 int sleepPeriod = rndGen.Next(minRandomTimeout, maxRandomTimeout / 2);
 
                 //Sleep some random period with of a maximum duration of half the largest possible timeout value for a read method on COM1
-                System.Threading.Thread.Sleep(sleepPeriod);
+                Thread.Sleep(sleepPeriod);
 
                 com2.Open();
                 com2.Write(xmitBuffer, 0, xmitBuffer.Length);
             }
         }
-    
+
         [ConditionalFact(nameof(HasNullModem))]
         public void DefaultParityReplaceByte()
         {
             VerifyParityReplaceByte(-1, numRndByte - 2);
         }
-    
+
         [ConditionalFact(nameof(HasNullModem))]
         public void NoParityReplaceByte()
         {
             Random rndGen = new Random(-55);
 
             //		if(!VerifyParityReplaceByte((int)'\0', rndGen.Next(0, numRndByte - 1), new System.Text.UTF7Encoding())){
-            VerifyParityReplaceByte('\0', rndGen.Next(0, numRndByte - 1), new System.Text.UTF32Encoding());
+            VerifyParityReplaceByte('\0', rndGen.Next(0, numRndByte - 1), new UTF32Encoding());
         }
 
 
@@ -177,7 +179,7 @@ namespace System.IO.Ports.Tests
         {
             Random rndGen = new Random(-55);
 
-            VerifyParityReplaceByte(rndGen.Next(0, 128), 0, new System.Text.UTF8Encoding());
+            VerifyParityReplaceByte(rndGen.Next(0, 128), 0, new UTF8Encoding());
         }
 
 
@@ -257,7 +259,7 @@ namespace System.IO.Ports.Tests
                 //Clear the parity error on the last byte
                 expectedBytes[expectedBytes.Length - 1] = bytesToWrite[bytesToWrite.Length - 1];
 
-                VerifyRead(com1, com2, bytesToWrite, expectedBytes, System.Text.Encoding.ASCII);
+                VerifyRead(com1, com2, bytesToWrite, expectedBytes, Encoding.ASCII);
             }
         }
         #endregion
@@ -273,7 +275,7 @@ namespace System.IO.Ports.Tests
             //Warm up read method
             Assert.Throws<TimeoutException>(() => com.ReadByte());
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Highest;
+            Thread.CurrentThread.Priority = ThreadPriority.Highest;
 
             for (int i = 0; i < NUM_TRYS; i++)
             {
@@ -286,12 +288,12 @@ namespace System.IO.Ports.Tests
                 timer.Reset();
             }
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Normal;
+            Thread.CurrentThread.Priority = ThreadPriority.Normal;
             actualTime /= NUM_TRYS;
             percentageDifference = Math.Abs((expectedTime - actualTime) / (double)expectedTime);
 
             //Verify that the percentage difference between the expected and actual timeout is less then maxPercentageDifference
-            if (maxPercentageDifference < percentageDifference)
+            if (s_maxPercentageDifference < percentageDifference)
             {
                 Fail("ERROR!!!: The read method timed-out in {0} expected {1} percentage difference: {2}", actualTime, expectedTime, percentageDifference);
             }
@@ -304,10 +306,10 @@ namespace System.IO.Ports.Tests
 
         private void VerifyParityReplaceByte(int parityReplace, int parityErrorIndex)
         {
-            VerifyParityReplaceByte(parityReplace, parityErrorIndex, new System.Text.ASCIIEncoding());
+            VerifyParityReplaceByte(parityReplace, parityErrorIndex, new ASCIIEncoding());
         }
 
-        private void VerifyParityReplaceByte(int parityReplace, int parityErrorIndex, System.Text.Encoding encoding)
+        private void VerifyParityReplaceByte(int parityReplace, int parityErrorIndex, Encoding encoding)
         {
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
@@ -363,7 +365,7 @@ namespace System.IO.Ports.Tests
 
 
         private void VerifyRead(SerialPort com1, SerialPort com2, byte[] bytesToWrite, byte[] expectedBytes,
-            System.Text.Encoding encoding)
+            Encoding encoding)
         {
             byte[] byteRcvBuffer = new byte[expectedBytes.Length];
             int rcvBufferSize = 0;

--- a/src/System.IO.Ports/tests/SerialPort/ReadByte_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadByte_Generic.cs
@@ -193,8 +193,6 @@ namespace System.IO.Ports.Tests
                 byte[] actualBytes = new byte[numRndByte + 1];
                 int actualByteIndex = 0;
 
-                int waitTime;
-
                 /* 1 Additional character gets added to the input buffer when the parity error occurs on the last byte of a stream
                  We are verifying that besides this everything gets read in correctly. See NDP Whidbey: 24216 for more info on this */
                 Debug.WriteLine("Verifying default ParityReplace byte with a parity error on the last byte");
@@ -221,13 +219,8 @@ namespace System.IO.Ports.Tests
                 com2.Open();
 
                 com2.Write(bytesToWrite, 0, bytesToWrite.Length);
-                waitTime = 0;
 
-                while (bytesToWrite.Length + 1 > com1.BytesToRead && waitTime < 500)
-                {
-                    System.Threading.Thread.Sleep(50);
-                    waitTime += 50;
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length + 1);
 
                 while (true)
                 {
@@ -375,17 +368,12 @@ namespace System.IO.Ports.Tests
             byte[] byteRcvBuffer = new byte[expectedBytes.Length];
             int rcvBufferSize = 0;
             int i;
-            int waitTime = 0;
 
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
             com1.ReadTimeout = 250;
             com1.Encoding = encoding;
 
-            while (com1.BytesToRead < bytesToWrite.Length && waitTime < 500)
-            {
-                System.Threading.Thread.Sleep(50);
-                waitTime += 50;
-            }
+            TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length);
 
             i = 0;
             while (true)

--- a/src/System.IO.Ports/tests/SerialPort/ReadChar.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadChar.cs
@@ -105,8 +105,7 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(byteXmitBuffer, 0, byteXmitBuffer.Length);
 
-                while (com1.BytesToRead < byteXmitBuffer.Length)
-                    System.Threading.Thread.Sleep(50);
+                TCSupport.WaitForReadBufferToLoad(com1, byteXmitBuffer.Length);
 
                 //Read Every Byte except the last one. The last bye should be left in the last position of SerialPort's
                 //internal buffer. When we try to read this char as UTF32 the buffer should have to be resized so 
@@ -125,10 +124,7 @@ namespace System.IO.Ports.Tests
                 com2.Write(utf32CharBytes, 1, 3);
                 com2.Write(byteXmitBuffer, 0, byteXmitBuffer.Length);
 
-                while (com1.BytesToRead < 4 + byteXmitBuffer.Length)
-                {
-                    System.Threading.Thread.Sleep(50);
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, 4+ byteXmitBuffer.Length);
 
                 PerformReadOnCom1FromCom2(com1, com2, expectedChars);
             }
@@ -163,9 +159,8 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(byteXmitBuffer, 0, byteXmitBuffer.Length);
 
-                while (com1.BytesToRead < byteXmitBuffer.Length)
-                    System.Threading.Thread.Sleep(50);
-
+                TCSupport.WaitForReadBufferToLoad(com1, byteXmitBuffer.Length);
+                
                 //Read Every Byte except the last one. The last bye should be left in the last position of SerialPort's
                 //internal buffer. When we try to read this char as UTF32 the buffer should have to be resized so 
                 //the other 3 bytes of the ut32 encoded char can be in the buffer
@@ -183,10 +178,7 @@ namespace System.IO.Ports.Tests
                 com2.Write(utf32CharBytes, 1, 3);
                 com2.Write(byteXmitBuffer, 0, byteXmitBuffer.Length);
 
-                while (com1.BytesToRead < 4 + byteXmitBuffer.Length)
-                {
-                    System.Threading.Thread.Sleep(50);
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, 4 + byteXmitBuffer.Length);
 
                 PerformReadOnCom1FromCom2(com1, com2, expectedChars);
             }
@@ -218,8 +210,7 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(byteXmitBuffer, 0, byteXmitBuffer.Length);
 
-                while (com1.BytesToRead < byteXmitBuffer.Length)
-                    System.Threading.Thread.Sleep(50);
+                TCSupport.WaitForReadBufferToLoad(com1, byteXmitBuffer.Length);
 
                 //Read Every Byte except the last one. The last bye should be left in the last position of SerialPort's
                 //internal buffer. When we try to read this char as UTF32 the buffer should have to be resized so 
@@ -231,10 +222,7 @@ namespace System.IO.Ports.Tests
                 com1.Encoding = System.Text.Encoding.UTF32;
                 com2.Write(utf32CharBytes, 1, 3);
 
-                while (com1.BytesToRead < 4)
-                {
-                    System.Threading.Thread.Sleep(50);
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, 4);
 
                 if (utf32Char != (charRead = com1.ReadChar()))
                 {
@@ -560,10 +548,7 @@ namespace System.IO.Ports.Tests
             com2.Write(bytesToWrite, 0, 1); // Write one byte at the begining because we are going to read this to buffer the rest of the data
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
 
-            while (com1.BytesToRead < bytesToWrite.Length)
-            {
-                System.Threading.Thread.Sleep(50);
-            }
+            TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length);
 
             com1.Read(new char[1], 0, 1); // This should put the rest of the bytes in SerialPorts own internal buffer
 

--- a/src/System.IO.Ports/tests/SerialPort/ReadChar.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadChar.cs
@@ -4,6 +4,8 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -11,23 +13,16 @@ namespace System.IO.Ports.Tests
 {
     public class ReadChar : PortsTest
     {
-        //Set bounds fore random timeout values.
-        //If the min is to low read will not timeout accurately and the testcase will fail
-        public static int minRandomTimeout = 100;
-
-        //If the max is to large then the testcase will take forever to run
-        public static int maxRandomTimeout = 2000;
-
         //The number of random bytes to receive for large input buffer testing
         // This was 4096, but the largest buffer setting on FTDI USB-Serial devices is "4096", which actually only allows a read of 4094 or 4095 bytes
         // The test code assumes that we will be able to do this transfer as a single read, so 4000 is safer and would seem to be about 
         // as rigourous a test
-        public static readonly int largeNumRndBytesToRead = 4000;
+        private const int largeNumRndBytesToRead = 4000;
 
         //The number of random characters to receive
-        public static int numRndChar = 8;
+        private const int numRndChar = 8;
 
-        public enum ReadDataFromEnum { NonBuffered, Buffered, BufferedAndNonBuffered };
+        private enum ReadDataFromEnum { NonBuffered, Buffered, BufferedAndNonBuffered };
 
         #region Test Cases
 
@@ -35,45 +30,45 @@ namespace System.IO.Ports.Tests
         public void ASCIIEncoding()
         {
             Debug.WriteLine("Verifying read with bytes encoded with ASCIIEncoding");
-            VerifyRead(new System.Text.ASCIIEncoding());
+            VerifyRead(new ASCIIEncoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void UTF8Encoding()
         {
             Debug.WriteLine("Verifying read with bytes encoded with UTF8Encoding");
-            VerifyRead(new System.Text.UTF8Encoding());
+            VerifyRead(new UTF8Encoding());
         }
-    
+
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void UTF32Encoding()
         {
             Debug.WriteLine("Verifying read with bytes encoded with UTF32Encoding");
-            VerifyRead(new System.Text.UTF32Encoding());
+            VerifyRead(new UTF32Encoding());
         }
-    
+
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void SerialPort_ReadBufferedData()
         {
-            VerifyRead(System.Text.Encoding.ASCII, ReadDataFromEnum.Buffered);
+            VerifyRead(Encoding.ASCII, ReadDataFromEnum.Buffered);
         }
-    
+
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void SerialPort_IterativeReadBufferedData()
         {
-            VerifyRead(System.Text.Encoding.ASCII, ReadDataFromEnum.Buffered);
+            VerifyRead(Encoding.ASCII, ReadDataFromEnum.Buffered);
         }
-    
+
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void SerialPort_ReadBufferedAndNonBufferedData()
         {
-            VerifyRead(System.Text.Encoding.ASCII, ReadDataFromEnum.BufferedAndNonBuffered);
+            VerifyRead(Encoding.ASCII, ReadDataFromEnum.BufferedAndNonBuffered);
         }
-    
+
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void SerialPort_IterativeReadBufferedAndNonBufferedData()
         {
-            VerifyRead(System.Text.Encoding.ASCII, ReadDataFromEnum.BufferedAndNonBuffered);
+            VerifyRead(Encoding.ASCII, ReadDataFromEnum.BufferedAndNonBuffered);
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
@@ -84,7 +79,7 @@ namespace System.IO.Ports.Tests
             {
                 byte[] byteXmitBuffer = new byte[1024];
                 char utf32Char = 'A';
-                byte[] utf32CharBytes = System.Text.Encoding.UTF32.GetBytes(new[] {utf32Char});
+                byte[] utf32CharBytes = Encoding.UTF32.GetBytes(new[] { utf32Char });
                 char[] charXmitBuffer = TCSupport.GetRandomChars(16, false);
                 char[] expectedChars = new char[charXmitBuffer.Length + 1];
 
@@ -114,17 +109,17 @@ namespace System.IO.Ports.Tests
 
                 Assert.Equal(1, com1.BytesToRead);
 
-                com1.Encoding = System.Text.Encoding.UTF32;
-                byteXmitBuffer = System.Text.Encoding.UTF32.GetBytes(charXmitBuffer);
+                com1.Encoding = Encoding.UTF32;
+                byteXmitBuffer = Encoding.UTF32.GetBytes(charXmitBuffer);
 
                 Assert.Throws<TimeoutException>(() => com1.ReadChar());
-            
+
                 Assert.Equal(1, com1.BytesToRead);
 
                 com2.Write(utf32CharBytes, 1, 3);
                 com2.Write(byteXmitBuffer, 0, byteXmitBuffer.Length);
 
-                TCSupport.WaitForReadBufferToLoad(com1, 4+ byteXmitBuffer.Length);
+                TCSupport.WaitForReadBufferToLoad(com1, 4 + byteXmitBuffer.Length);
 
                 PerformReadOnCom1FromCom2(com1, com2, expectedChars);
             }
@@ -138,7 +133,7 @@ namespace System.IO.Ports.Tests
             {
                 byte[] byteXmitBuffer = new byte[1024];
                 char utf32Char = 'A';
-                byte[] utf32CharBytes = System.Text.Encoding.UTF32.GetBytes(new [] {utf32Char});
+                byte[] utf32CharBytes = Encoding.UTF32.GetBytes(new[] { utf32Char });
                 char[] charXmitBuffer = TCSupport.GetRandomChars(16, false);
                 char[] expectedChars = new char[charXmitBuffer.Length + 1];
 
@@ -160,7 +155,7 @@ namespace System.IO.Ports.Tests
                 com2.Write(byteXmitBuffer, 0, byteXmitBuffer.Length);
 
                 TCSupport.WaitForReadBufferToLoad(com1, byteXmitBuffer.Length);
-                
+
                 //Read Every Byte except the last one. The last bye should be left in the last position of SerialPort's
                 //internal buffer. When we try to read this char as UTF32 the buffer should have to be resized so 
                 //the other 3 bytes of the ut32 encoded char can be in the buffer
@@ -168,8 +163,8 @@ namespace System.IO.Ports.Tests
 
                 Assert.Equal(1, com1.BytesToRead);
 
-                com1.Encoding = System.Text.Encoding.UTF32;
-                byteXmitBuffer = System.Text.Encoding.UTF32.GetBytes(charXmitBuffer);
+                com1.Encoding = Encoding.UTF32;
+                byteXmitBuffer = Encoding.UTF32.GetBytes(charXmitBuffer);
 
                 Assert.Throws<TimeoutException>(() => com1.ReadChar());
 
@@ -192,7 +187,7 @@ namespace System.IO.Ports.Tests
             {
                 byte[] byteXmitBuffer = new byte[1024];
                 char utf32Char = TCSupport.GenerateRandomCharNonSurrogate();
-                byte[] utf32CharBytes = System.Text.Encoding.UTF32.GetBytes(new[] {utf32Char});
+                byte[] utf32CharBytes = Encoding.UTF32.GetBytes(new[] { utf32Char });
                 int charRead;
 
                 Debug.WriteLine("Verifying that ReadChar() will read everything from internal buffer and drivers buffer");
@@ -219,7 +214,7 @@ namespace System.IO.Ports.Tests
 
                 Assert.Equal(1, com1.BytesToRead);
 
-                com1.Encoding = System.Text.Encoding.UTF32;
+                com1.Encoding = Encoding.UTF32;
                 com2.Write(utf32CharBytes, 1, 3);
 
                 TCSupport.WaitForReadBufferToLoad(com1, 4);
@@ -237,7 +232,7 @@ namespace System.IO.Ports.Tests
         public void LargeInputBuffer()
         {
             Debug.WriteLine("Verifying read with large input buffer");
-            VerifyRead(System.Text.Encoding.ASCII, largeNumRndBytesToRead);
+            VerifyRead(Encoding.ASCII, largeNumRndBytesToRead);
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
@@ -247,13 +242,13 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
             {
                 char utf32Char = (char)0x254b; //Box drawing char
-                byte[] utf32CharBytes = System.Text.Encoding.UTF32.GetBytes(new[] {utf32Char});
+                byte[] utf32CharBytes = Encoding.UTF32.GetBytes(new[] { utf32Char });
 
                 int readChar;
 
                 Debug.WriteLine("Verifying Read method with zero timeout that resizes SerialPort's buffer");
 
-                com1.Encoding = System.Text.Encoding.UTF32;
+                com1.Encoding = Encoding.UTF32;
                 com1.ReadTimeout = 0;
 
                 com1.Open();
@@ -297,15 +292,15 @@ namespace System.IO.Ports.Tests
                 char[] charXmitBuffer = TCSupport.GetRandomChars(512, TCSupport.CharacterOptions.None);
                 char[] charRcvBuffer = new char[charXmitBuffer.Length];
                 ASyncRead asyncRead = new ASyncRead(com1);
-                System.Threading.Thread asyncReadThread =
-                    new System.Threading.Thread(asyncRead.Read);
+                Thread asyncReadThread =
+                    new Thread(asyncRead.Read);
 
 
                 Debug.WriteLine(
                     "Verifying that ReadChar will read characters that have been received after the call to Read was made");
 
-                com1.Encoding = System.Text.Encoding.UTF8;
-                com2.Encoding = System.Text.Encoding.UTF8;
+                com1.Encoding = Encoding.UTF8;
+                com2.Encoding = Encoding.UTF8;
                 com1.ReadTimeout = 20000; // 20 seconds
 
                 com1.Open();
@@ -316,7 +311,7 @@ namespace System.IO.Ports.Tests
                 asyncReadThread.Start();
                 asyncRead.ReadStartedEvent.WaitOne();
                 //This only tells us that the thread has started to execute code in the method
-                System.Threading.Thread.Sleep(2000); //We need to wait to guarentee that we are executing code in SerialPort
+                Thread.Sleep(2000); //We need to wait to guarentee that we are executing code in SerialPort
                 com2.Write(charXmitBuffer, 0, charXmitBuffer.Length);
 
                 asyncRead.ReadCompletedEvent.WaitOne();
@@ -350,7 +345,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
             {
                 char[] charXmitBuffer = TCSupport.GetRandomChars(512, TCSupport.CharacterOptions.None);
-                byte[] byteXmitBuffer = new System.Text.UTF32Encoding().GetBytes(charXmitBuffer);
+                byte[] byteXmitBuffer = new UTF32Encoding().GetBytes(charXmitBuffer);
                 char[] charRcvBuffer = new char[charXmitBuffer.Length];
 
                 int result;
@@ -358,8 +353,8 @@ namespace System.IO.Ports.Tests
                 Debug.WriteLine(
                     "Verifying that Read(char[], int, int) works appropriately after TimeoutException has been thrown");
 
-                com1.Encoding = new System.Text.UTF32Encoding();
-                com2.Encoding = new System.Text.UTF32Encoding();
+                com1.Encoding = new UTF32Encoding();
+                com2.Encoding = new UTF32Encoding();
                 com1.ReadTimeout = 500; // 20 seconds
 
                 com1.Open();
@@ -416,14 +411,14 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
             {
-                char[] surrogateChars = {(char)0xDB26, (char)0xDC49};
+                char[] surrogateChars = { (char)0xDB26, (char)0xDC49 };
                 char[] additionalChars = TCSupport.GetRandomChars(32, TCSupport.CharacterOptions.None);
                 char[] charRcvBuffer = new char[2];
 
                 Debug.WriteLine("Verifying that ReadChar works correctly when trying to read surrogate characters");
 
-                com1.Encoding = new System.Text.UTF32Encoding();
-                com2.Encoding = new System.Text.UTF32Encoding();
+                com1.Encoding = new UTF32Encoding();
+                com2.Encoding = new UTF32Encoding();
                 com1.ReadTimeout = 500; // 20 seconds
 
                 com1.Open();
@@ -464,22 +459,22 @@ namespace System.IO.Ports.Tests
         #endregion
 
         #region Verification for Test Cases
-        private void VerifyRead(System.Text.Encoding encoding)
+        private void VerifyRead(Encoding encoding)
         {
             VerifyRead(encoding, ReadDataFromEnum.NonBuffered);
         }
 
-        private void VerifyRead(System.Text.Encoding encoding, int bufferSize)
+        private void VerifyRead(Encoding encoding, int bufferSize)
         {
             VerifyRead(encoding, ReadDataFromEnum.NonBuffered, bufferSize);
         }
 
-        private void VerifyRead(System.Text.Encoding encoding, ReadDataFromEnum readDataFrom)
+        private void VerifyRead(Encoding encoding, ReadDataFromEnum readDataFrom)
         {
             VerifyRead(encoding, readDataFrom, numRndChar);
         }
 
-        private void VerifyRead(System.Text.Encoding encoding, ReadDataFromEnum readDataFrom, int bufferSize)
+        private void VerifyRead(Encoding encoding, ReadDataFromEnum readDataFrom, int bufferSize)
         {
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
@@ -490,7 +485,7 @@ namespace System.IO.Ports.Tests
                 com1.ReadTimeout = 500;
                 com1.Encoding = encoding;
 
-                TCSupport.SetHighSpeed(com1,com2);
+                TCSupport.SetHighSpeed(com1, com2);
 
                 com1.Open();
 
@@ -513,7 +508,7 @@ namespace System.IO.Ports.Tests
                 }
             }
         }
-    
+
         private void VerifyReadNonBuffered(SerialPort com1, SerialPort com2, byte[] bytesToWrite)
         {
             char[] expectedChars = com1.Encoding.GetChars(bytesToWrite, 0, bytesToWrite.Length);
@@ -529,7 +524,7 @@ namespace System.IO.Ports.Tests
 
             PerformReadOnCom1FromCom2(com1, com2, expectedChars);
         }
-    
+
         private void VerifyReadBufferedAndNonBuffered(SerialPort com1, SerialPort com2, byte[] bytesToWrite)
         {
             char[] expectedChars = new char[com1.Encoding.GetCharCount(bytesToWrite, 0, bytesToWrite.Length) * 2];
@@ -560,7 +555,7 @@ namespace System.IO.Ports.Tests
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
             com1.ReadTimeout = 500;
 
-            System.Threading.Thread.Sleep((int)(((bytesToWrite.Length * 10.0) / com1.BaudRate) * 1000) + 250);
+            Thread.Sleep((int)(((bytesToWrite.Length * 10.0) / com1.BaudRate) * 1000) + 250);
 
             PerformReadOnCom1FromCom2(com1, com2, expectedChars);
         }
@@ -617,11 +612,11 @@ namespace System.IO.Ports.Tests
 
         public class ASyncRead
         {
-            private SerialPort _com;
+            private readonly SerialPort _com;
             private int _result;
 
-            private System.Threading.AutoResetEvent _readCompletedEvent;
-            private System.Threading.AutoResetEvent _readStartedEvent;
+            private readonly AutoResetEvent _readCompletedEvent;
+            private readonly AutoResetEvent _readStartedEvent;
 
             private Exception _exception;
 
@@ -630,8 +625,8 @@ namespace System.IO.Ports.Tests
                 _com = com;
                 _result = int.MinValue;
 
-                _readCompletedEvent = new System.Threading.AutoResetEvent(false);
-                _readStartedEvent = new System.Threading.AutoResetEvent(false);
+                _readCompletedEvent = new AutoResetEvent(false);
+                _readStartedEvent = new AutoResetEvent(false);
 
                 _exception = null;
             }
@@ -653,9 +648,9 @@ namespace System.IO.Ports.Tests
                 }
             }
 
-            public System.Threading.AutoResetEvent ReadStartedEvent => _readStartedEvent;
+            public AutoResetEvent ReadStartedEvent => _readStartedEvent;
 
-            public System.Threading.AutoResetEvent ReadCompletedEvent => _readCompletedEvent;
+            public AutoResetEvent ReadCompletedEvent => _readCompletedEvent;
 
             public int Result => _result;
 

--- a/src/System.IO.Ports/tests/SerialPort/ReadChar_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadChar_Generic.cs
@@ -5,6 +5,8 @@
 using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Linq;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -14,19 +16,19 @@ namespace System.IO.Ports.Tests
     {
         //Set bounds fore random timeout values.
         //If the min is to low read will not timeout accurately and the testcase will fail
-        public static int minRandomTimeout = 250;
+        private const int minRandomTimeout = 250;
 
         //If the max is to large then the testcase will take forever to run
-        public static int maxRandomTimeout = 2000;
+        private const int maxRandomTimeout = 2000;
 
         //If the percentage difference between the expected timeout and the actual timeout
         //found through Stopwatch is greater then 10% then the timeout value was not correctly
         //to the read method and the testcase fails.
-        public static double maxPercentageDifference = .15;
+        private const double maxPercentageDifference = .15;
 
         //The number of random characters to receive
-        public static int numRndChar = 8;
-        public static readonly int NUM_TRYS = 5;
+        private const int numRndChar = 8;
+        private const int NUM_TRYS = 5;
 
         #region Test Cases
 
@@ -94,7 +96,7 @@ namespace System.IO.Ports.Tests
 
                 com.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 //		com.Encoding = new System.Text.UTF7Encoding();
-                com.Encoding = System.Text.Encoding.Unicode;
+                com.Encoding = Encoding.Unicode;
 
                 Debug.WriteLine("Verifying ReadTimeout={0} with successive call to read method and no data", com.ReadTimeout);
                 com.Open();
@@ -111,10 +113,10 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 Random rndGen = new Random(-55);
-                System.Threading.Thread t = new System.Threading.Thread(WriteToCom1);
+                Thread t = new Thread(WriteToCom1);
 
                 com1.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
-                com1.Encoding = new System.Text.UTF8Encoding();
+                com1.Encoding = new UTF8Encoding();
 
                 Debug.WriteLine(
                     "Verifying ReadTimeout={0} with successive call to read method and some data being received in the first call",
@@ -134,7 +136,7 @@ namespace System.IO.Ports.Tests
 
                 //Wait for the thread to finish
                 while (t.IsAlive)
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
 
                 //Make sure there is no bytes in the buffer so the next call to read will timeout
                 com1.DiscardInBuffer();
@@ -151,7 +153,7 @@ namespace System.IO.Ports.Tests
                 int sleepPeriod = rndGen.Next(minRandomTimeout, maxRandomTimeout / 2);
 
                 //Sleep some random period with of a maximum duration of half the largest possible timeout value for a read method on COM1
-                System.Threading.Thread.Sleep(sleepPeriod);
+                Thread.Sleep(sleepPeriod);
 
                 com2.Open();
                 com2.Write(xmitBuffer, 0, xmitBuffer.Length);
@@ -192,7 +194,7 @@ namespace System.IO.Ports.Tests
                 char[] actualChars = new char[numRndChar + 1];
 
                 int actualCharIndex = 0;
-                
+
                 /* 1 Additional character gets added to the input buffer when the parity error occurs on the last byte of a stream
                  We are verifying that besides this everything gets read in correctly. See NDP Whidbey: 24216 for more info on this */
                 Debug.WriteLine("Verifying default ParityReplace byte with a parity errro on the last byte");
@@ -263,8 +265,8 @@ namespace System.IO.Ports.Tests
             double percentageDifference;
 
             Assert.Throws<TimeoutException>(() => com.ReadChar());
-        
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Highest;
+
+            Thread.CurrentThread.Priority = ThreadPriority.Highest;
 
             for (int i = 0; i < NUM_TRYS; i++)
             {
@@ -277,7 +279,7 @@ namespace System.IO.Ports.Tests
                 timer.Reset();
             }
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Normal;
+            Thread.CurrentThread.Priority = ThreadPriority.Normal;
             actualTime /= NUM_TRYS;
             percentageDifference = Math.Abs((expectedTime - actualTime) / (double)expectedTime);
 

--- a/src/System.IO.Ports/tests/SerialPort/ReadChar_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadChar_Generic.cs
@@ -192,8 +192,7 @@ namespace System.IO.Ports.Tests
                 char[] actualChars = new char[numRndChar + 1];
 
                 int actualCharIndex = 0;
-                int waitTime;
-
+                
                 /* 1 Additional character gets added to the input buffer when the parity error occurs on the last byte of a stream
                  We are verifying that besides this everything gets read in correctly. See NDP Whidbey: 24216 for more info on this */
                 Debug.WriteLine("Verifying default ParityReplace byte with a parity errro on the last byte");
@@ -221,13 +220,7 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(bytesToWrite, 0, bytesToWrite.Length);
 
-                waitTime = 0;
-
-                while (bytesToWrite.Length + 1 > com1.BytesToRead && waitTime < 500)
-                {
-                    System.Threading.Thread.Sleep(50);
-                    waitTime += 50;
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length + 1);
 
                 while (true)
                 {
@@ -358,16 +351,11 @@ namespace System.IO.Ports.Tests
             char[] charRcvBuffer = new char[expectedChars.Length];
             int rcvBufferSize = 0;
             int i;
-            int waitTime = 0;
 
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
             com1.ReadTimeout = 250;
 
-            while (com1.BytesToRead < bytesToWrite.Length && waitTime < 500)
-            {
-                System.Threading.Thread.Sleep(50);
-                waitTime += 50;
-            }
+            TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length);
 
             i = 0;
             while (true)

--- a/src/System.IO.Ports/tests/SerialPort/ReadExisting.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadExisting.cs
@@ -4,6 +4,8 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -12,55 +14,45 @@ namespace System.IO.Ports.Tests
     public class ReadExisting : PortsTest
     {
         //The number of random bytes to receive for read method testing
-        public static readonly int numRndBytesToRead = 8;
+        private const int numRndBytesToRead = 8;
 
         //The number of random bytes to receive for large input buffer testing
-        public static readonly int largeNumRndBytesToRead = 2048;
+        private const int largeNumRndBytesToRead = 2048;
 
-        //When we test Read and do not care about actually reading anything we must still
-        //create an byte array to pass into the method the following is the size of the 
-        //byte array used in this situation
-        public static readonly int defaultCharArraySize = 1;
-        public static readonly int defaultCharOffset = 0;
-        public static readonly int defaultCharCount = 1;
-
-        //The maximum buffer size when a exception is not expected
-        public static readonly int maxBufferSize = 8;
-
-        public enum ReadDataFromEnum { NonBuffered, Buffered, BufferedAndNonBuffered };
+        private enum ReadDataFromEnum { NonBuffered, Buffered, BufferedAndNonBuffered };
 
         #region Test Cases
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         private void ASCIIEncoding()
         {
-            VerifyRead(new System.Text.ASCIIEncoding());
+            VerifyRead(new ASCIIEncoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         private void UTF8Encoding()
         {
-            VerifyRead(new System.Text.UTF8Encoding());
+            VerifyRead(new UTF8Encoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         private void UTF32Encoding()
         {
-            VerifyRead(new System.Text.UTF32Encoding());
+            VerifyRead(new UTF32Encoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         private void SerialPort_ReadBufferedData()
         {
             int numberOfBytesToRead = 32;
-            VerifyRead(System.Text.Encoding.ASCII, numberOfBytesToRead, ReadDataFromEnum.Buffered);
+            VerifyRead(Encoding.ASCII, numberOfBytesToRead, ReadDataFromEnum.Buffered);
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         private void SerialPort_IterativeReadBufferedData()
         {
             int numberOfBytesToRead = 32;
-            VerifyRead(System.Text.Encoding.ASCII, numberOfBytesToRead, ReadDataFromEnum.Buffered);
+            VerifyRead(Encoding.ASCII, numberOfBytesToRead, ReadDataFromEnum.Buffered);
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
@@ -68,7 +60,7 @@ namespace System.IO.Ports.Tests
         {
             int numberOfBytesToRead = 64;
 
-            VerifyRead(System.Text.Encoding.ASCII, numberOfBytesToRead, ReadDataFromEnum.BufferedAndNonBuffered);
+            VerifyRead(Encoding.ASCII, numberOfBytesToRead, ReadDataFromEnum.BufferedAndNonBuffered);
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
@@ -76,7 +68,7 @@ namespace System.IO.Ports.Tests
         {
             int numberOfBytesToRead = 3;
 
-            VerifyRead(System.Text.Encoding.ASCII, numberOfBytesToRead, ReadDataFromEnum.BufferedAndNonBuffered);
+            VerifyRead(Encoding.ASCII, numberOfBytesToRead, ReadDataFromEnum.BufferedAndNonBuffered);
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
@@ -88,7 +80,7 @@ namespace System.IO.Ports.Tests
                 char[] charXmitBuffer = TCSupport.GetRandomChars(128, true);
                 byte[] byteXmitBuffer = new byte[1024];
                 char utf32Char = TCSupport.GenerateRandomCharNonSurrogate();
-                byte[] utf32CharBytes = System.Text.Encoding.UTF32.GetBytes(new[] {utf32Char});
+                byte[] utf32CharBytes = Encoding.UTF32.GetBytes(new[] { utf32Char });
                 int numBytes;
 
                 Debug.WriteLine("Verifying that ReadExisting() will read everything from internal buffer and drivers buffer");
@@ -113,20 +105,20 @@ namespace System.IO.Ports.Tests
 
                 Assert.Equal(1, com1.BytesToRead);
 
-                com1.Encoding = System.Text.Encoding.UTF32;
-                com2.Encoding = System.Text.Encoding.UTF32;
+                com1.Encoding = Encoding.UTF32;
+                com2.Encoding = Encoding.UTF32;
 
                 com2.Write(utf32CharBytes, 1, 3);
                 com2.Write(charXmitBuffer, 0, charXmitBuffer.Length);
 
-                numBytes = System.Text.Encoding.UTF32.GetByteCount(charXmitBuffer);
+                numBytes = Encoding.UTF32.GetByteCount(charXmitBuffer);
 
-                byte[] byteBuffer = System.Text.Encoding.UTF32.GetBytes(charXmitBuffer);
+                byte[] byteBuffer = Encoding.UTF32.GetBytes(charXmitBuffer);
 
-                var expectedChars = new char[1 + System.Text.Encoding.UTF32.GetCharCount(byteBuffer)];
+                var expectedChars = new char[1 + Encoding.UTF32.GetCharCount(byteBuffer)];
                 expectedChars[0] = utf32Char;
 
-                System.Text.Encoding.UTF32.GetChars(byteBuffer, 0, byteBuffer.Length, expectedChars, 1);
+                Encoding.UTF32.GetChars(byteBuffer, 0, byteBuffer.Length, expectedChars, 1);
 
                 TCSupport.WaitForReadBufferToLoad(com1, 4 + numBytes);
 
@@ -153,25 +145,25 @@ namespace System.IO.Ports.Tests
 
         private void VerifyRead()
         {
-            VerifyRead(new System.Text.ASCIIEncoding(), numRndBytesToRead);
+            VerifyRead(new ASCIIEncoding(), numRndBytesToRead);
         }
 
         private void VerifyRead(int numberOfBytesToRead)
         {
-            VerifyRead(new System.Text.ASCIIEncoding(), numberOfBytesToRead);
+            VerifyRead(new ASCIIEncoding(), numberOfBytesToRead);
         }
 
-        private void VerifyRead(System.Text.Encoding encoding)
+        private void VerifyRead(Encoding encoding)
         {
             VerifyRead(encoding, numRndBytesToRead);
         }
 
-        private void VerifyRead(System.Text.Encoding encoding, int numberOfBytesToRead)
+        private void VerifyRead(Encoding encoding, int numberOfBytesToRead)
         {
             VerifyRead(encoding, numberOfBytesToRead, ReadDataFromEnum.NonBuffered);
         }
 
-        private void VerifyRead(System.Text.Encoding encoding, int numberOfBytesToRead, ReadDataFromEnum readDataFrom)
+        private void VerifyRead(Encoding encoding, int numberOfBytesToRead, ReadDataFromEnum readDataFrom)
         {
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
@@ -194,7 +186,7 @@ namespace System.IO.Ports.Tests
                 com1.ReadTimeout = 500;
                 com1.Encoding = encoding;
 
-                TCSupport.SetHighSpeed(com1,com2);
+                TCSupport.SetHighSpeed(com1, com2);
 
                 com1.Open();
 
@@ -266,7 +258,7 @@ namespace System.IO.Ports.Tests
         {
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
             com1.ReadTimeout = 500;
-            System.Threading.Thread.Sleep((int)(((bytesToWrite.Length * 10.0) / com1.BaudRate) * 1000) + 250);
+            Thread.Sleep((int)(((bytesToWrite.Length * 10.0) / com1.BaudRate) * 1000) + 250);
             PerformReadOnCom1FromCom2(com1, com2, expectedChars);
         }
 

--- a/src/System.IO.Ports/tests/SerialPort/ReadExisting.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadExisting.cs
@@ -104,8 +104,7 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(byteXmitBuffer, 0, byteXmitBuffer.Length);
 
-                while (com1.BytesToRead < byteXmitBuffer.Length)
-                    System.Threading.Thread.Sleep(50);
+                TCSupport.WaitForReadBufferToLoad(com1, byteXmitBuffer.Length);
 
                 //Read Every Byte except the last one. The last bye should be left in the last position of SerialPort's
                 //internal buffer. When we try to read this char as UTF32 the buffer should have to be resized so 
@@ -129,10 +128,7 @@ namespace System.IO.Ports.Tests
 
                 System.Text.Encoding.UTF32.GetChars(byteBuffer, 0, byteBuffer.Length, expectedChars, 1);
 
-                while (com1.BytesToRead < 4 + numBytes)
-                {
-                    System.Threading.Thread.Sleep(50);
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, 4 + numBytes);
 
                 string rcvString = com1.ReadExisting();
 
@@ -259,10 +255,7 @@ namespace System.IO.Ports.Tests
             com2.Write(bytesToWrite, 0, 1); // Write one byte at the begining because we are going to read this to buffer the rest of the data
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
 
-            while (com1.BytesToRead < bytesToWrite.Length)
-            {
-                System.Threading.Thread.Sleep(50);
-            }
+            TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length);
 
             com1.Read(new char[1], 0, 1); // This should put the rest of the bytes in SerialPorts own internal buffer
 

--- a/src/System.IO.Ports/tests/SerialPort/ReadExisting_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadExisting_Generic.cs
@@ -5,6 +5,8 @@
 using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Linq;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -14,18 +16,18 @@ namespace System.IO.Ports.Tests
     {
         //Set bounds fore random timeout values.
         //If the min is to low read will not timeout accurately and the testcase will fail
-        public static int minRandomTimeout = 250;
+        private const int minRandomTimeout = 250;
 
         //If the max is to large then the testcase will take forever to run
-        public static int maxRandomTimeout = 2000;
+        private const int maxRandomTimeout = 2000;
 
         //Since ReadExisting should return immediately this is the maximum time in ms that ReadExisting should take
         //before we consider ReadExisting to be blocking and cause the test case to fail
-        public static double maxTimeout = 50;
+        private const double maxTimeout = 50;
 
         //The number of random characters to receive
-        public static int numRndChar = 8;
-        public static readonly int NUM_TRYS = 5;
+        private const int numRndChar = 8;
+        private const int NUM_TRYS = 5;
 
         #region Test Cases
 
@@ -100,7 +102,7 @@ namespace System.IO.Ports.Tests
                 Random rndGen = new Random(-55);
 
                 com.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
-                com.Encoding = System.Text.Encoding.Unicode;
+                com.Encoding = Encoding.Unicode;
 
                 Debug.WriteLine("Verifying ReadTimeout={0} with successive call to read method and no data", com.ReadTimeout);
                 com.Open();
@@ -201,7 +203,7 @@ namespace System.IO.Ports.Tests
 
             Assert.Equal("", strReadReturn);
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Highest;
+            Thread.CurrentThread.Priority = ThreadPriority.Highest;
 
             for (int i = 0; i < NUM_TRYS; i++)
             {
@@ -215,7 +217,7 @@ namespace System.IO.Ports.Tests
                 timer.Reset();
             }
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Normal;
+            Thread.CurrentThread.Priority = ThreadPriority.Normal;
             actualTime /= NUM_TRYS;
 
             //Verify that the percentage difference between the expected and actual timeout is less then maxPercentageDifference

--- a/src/System.IO.Ports/tests/SerialPort/ReadLine.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadLine.cs
@@ -14,15 +14,15 @@ namespace System.IO.Ports.Tests
     public class ReadLine : PortsTest
     {
         //The number of random bytes to receive for read method testing
-        public static readonly int DEFAULT_NUM_CHARS_TO_READ = 8;
+        private const int DEFAULT_NUM_CHARS_TO_READ = 8;
 
         //The number of new lines to insert into the string not including the one at the end
-        public static readonly int DEFAULT_NUMBER_NEW_LINES = 2;
+        private const int DEFAULT_NUMBER_NEW_LINES = 2;
 
         //The number of random bytes to receive for large input buffer testing
-        public static readonly int LARGE_NUM_CHARS_TO_READ = 2048;
-        public static readonly int MIN_NUM_NEWLINE_CHARS = 1;
-        public static readonly int MAX_NUM_NEWLINE_CHARS = 5;
+        private const int LARGE_NUM_CHARS_TO_READ = 2048;
+        private const int MIN_NUM_NEWLINE_CHARS = 1;
+        private const int MAX_NUM_NEWLINE_CHARS = 5;
 
         private enum ReadDataFromEnum
         {
@@ -95,7 +95,7 @@ namespace System.IO.Ports.Tests
                 VerifyReadLine(com1, com2, "TEST\n");
             }
         }
-    
+
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void NewLine_END()
         {
@@ -119,7 +119,7 @@ namespace System.IO.Ports.Tests
         {
             VerifyRead(new UTF8Encoding(), GenRandomNewLine(false));
         }
-    
+
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void UTF32Encoding()
         {
@@ -256,7 +256,7 @@ namespace System.IO.Ports.Tests
 
             VerifyRead(Encoding.ASCII, GenRandomNewLine(true), numBytesToRead, 1, ReadDataFromEnum.BufferedAndNonBuffered);
         }
-    
+
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void GreedyRead()
         {
@@ -269,7 +269,7 @@ namespace System.IO.Ports.Tests
                 string rcvString;
                 char[] actualChars;
                 char utf32Char = TCSupport.GenerateRandomCharNonSurrogate();
-                byte[] utf32CharBytes = Encoding.UTF32.GetBytes(new char[] {utf32Char});
+                byte[] utf32CharBytes = Encoding.UTF32.GetBytes(new char[] { utf32Char });
                 int numBytes;
 
 
@@ -280,7 +280,7 @@ namespace System.IO.Ports.Tests
                 byteXmitBuffer[byteXmitBuffer.Length - 1] = utf32CharBytes[0];
 
                 com1.Open();
-            
+
                 if (!com2.IsOpen) //This is necessary since com1 and com2 might be the same port if we are using a loopback
                     com2.Open();
 
@@ -293,7 +293,7 @@ namespace System.IO.Ports.Tests
                 //the other 3 bytes of the ut32 encoded char can be in the buffer
                 com1.Read(new char[1023], 0, 1023);
                 Assert.Equal(1, com1.BytesToRead);
-            
+
 
                 com1.Encoding = Encoding.UTF32;
                 com2.Encoding = Encoding.UTF32;
@@ -330,7 +330,6 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
             {
-
                 Debug.WriteLine("Verifying read method with sub strings of the new line appearing in the string being read");
                 com1.Open();
 
@@ -430,7 +429,7 @@ namespace System.IO.Ports.Tests
 
                 com1.Encoding = Encoding.Unicode;
                 com2.Encoding = Encoding.Unicode;
-                com1.ReadTimeout = 1500; 
+                com1.ReadTimeout = 1500;
 
                 com1.Open();
 
@@ -463,7 +462,7 @@ namespace System.IO.Ports.Tests
 
                 var continueRunning = true;
                 var numberOfIterations = 0;
-                var writeToCom2Thread = new Thread(delegate()
+                var writeToCom2Thread = new Thread(delegate ()
                 {
                     while (continueRunning)
                     {
@@ -525,7 +524,6 @@ namespace System.IO.Ports.Tests
                     Fail("Err_292haie Expected to read {0} characters actually read {1}",
                         charXmitBuffer.Length * numberOfIterations, stringRcvBuffer.Length);
                 }
-
             }
         }
 
@@ -658,7 +656,7 @@ namespace System.IO.Ports.Tests
             // Write one byte at the begining because we are going to read this to buffer the rest of the data    
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
 
-            TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length+1);
+            TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length + 1);
 
             com1.Read(new char[1], 0, 1); // This should put the rest of the bytes in SerialPorts own internal buffer
 
@@ -677,7 +675,7 @@ namespace System.IO.Ports.Tests
         }
 
 
-        private void VerifyReadLine(SerialPort com1, SerialPort com2, string strToWrite, string expectedString,string newLine)
+        private void VerifyReadLine(SerialPort com1, SerialPort com2, string strToWrite, string expectedString, string newLine)
         {
             char[] charsToWrite = strToWrite.ToCharArray();
             byte[] bytesToWrite = com1.Encoding.GetBytes(charsToWrite);

--- a/src/System.IO.Ports/tests/SerialPort/ReadLine.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadLine.cs
@@ -286,8 +286,7 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(byteXmitBuffer, 0, byteXmitBuffer.Length);
 
-                while (com1.BytesToRead < byteXmitBuffer.Length)
-                    Thread.Sleep(50);
+                TCSupport.WaitForReadBufferToLoad(com1, byteXmitBuffer.Length);
 
                 //Read Every Byte except the last one. The last bye should be left in the last position of SerialPort's
                 //internal buffer. When we try to read this char as UTF32 the buffer should have to be resized so 
@@ -312,10 +311,7 @@ namespace System.IO.Ports.Tests
 
                 Encoding.UTF32.GetChars(byteBuffer, 0, byteBuffer.Length, expectedChars, 1);
 
-                while (com1.BytesToRead < 4 + numBytes)
-                {
-                    Thread.Sleep(50);
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, 4 + numBytes);
 
                 rcvString = com1.ReadLine();
 
@@ -662,10 +658,7 @@ namespace System.IO.Ports.Tests
             // Write one byte at the begining because we are going to read this to buffer the rest of the data    
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
 
-            while (com1.BytesToRead < bytesToWrite.Length+1)
-            {
-                Thread.Sleep(50);
-            }
+            TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length+1);
 
             com1.Read(new char[1], 0, 1); // This should put the rest of the bytes in SerialPorts own internal buffer
 

--- a/src/System.IO.Ports/tests/SerialPort/ReadLine_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadLine_Generic.cs
@@ -4,6 +4,8 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -13,35 +15,31 @@ namespace System.IO.Ports.Tests
     {
         //Set bounds fore random timeout values.
         //If the min is to low read will not timeout accurately and the testcase will fail
-        public static readonly int minRandomTimeout = 250;
+        private const int minRandomTimeout = 250;
 
         //If the max is to large then the testcase will take forever to run
-        public static readonly int maxRandomTimeout = 2000;
+        private const int maxRandomTimeout = 2000;
 
         //If the percentage difference between the expected timeout and the actual timeout
         //found through Stopwatch is greater then 10% then the timeout value was not correctly
         //to the read method and the testcase fails.
-        public static readonly double maxPercentageDifference = .15;
+        private const double maxPercentageDifference = .15;
 
         //The number of random bytes to receive for parity testing
-        public static readonly int numRndBytesPairty = 8;
+        private const int numRndBytesPairty = 8;
 
         //The number of characters to read at a time for parity testing
-        public static readonly int numBytesReadPairty = 2;
+        private const int numBytesReadPairty = 2;
 
         //The number of random bytes to receive for BytesToRead testing
-        public static readonly int numRndBytesToRead = 16;
+        private const int numRndBytesToRead = 16;
 
         //The number of new lines to insert into the string not including the one at the end
         //For BytesToRead testing
-        public static readonly int DEFAULT_NUMBER_NEW_LINES = 2;
-        public static readonly byte DEFAULT_NEW_LINE = (byte)'\n';
+        private const int DEFAULT_NUMBER_NEW_LINES = 2;
+        private const byte DEFAULT_NEW_LINE = (byte)'\n';
 
-        //When we test Read and do not care about actually reading anything we must still
-        //create an byte array to pass into the method the following is the size of the 
-        //byte array used in this situation
-        public static readonly int defaultCharArraySize = 1;
-        public static readonly int NUM_TRYS = 5;
+        private const int NUM_TRYS = 5;
 
         #region Test Cases
 
@@ -107,7 +105,7 @@ namespace System.IO.Ports.Tests
 
                 com.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 //		com.Encoding = new System.Text.UTF7Encoding();
-                com.Encoding = System.Text.Encoding.Unicode;
+                com.Encoding = Encoding.Unicode;
                 Debug.WriteLine("Verifying ReadTimeout={0} with successive call to read method and no data", com.ReadTimeout);
                 com.Open();
 
@@ -123,10 +121,10 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 Random rndGen = new Random(-55);
-                System.Threading.Thread t = new System.Threading.Thread(WriteToCom1);
+                Thread t = new Thread(WriteToCom1);
 
                 com1.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
-                com1.Encoding = new System.Text.UTF8Encoding();
+                com1.Encoding = new UTF8Encoding();
                 Debug.WriteLine("Verifying ReadTimeout={0} with successive call to read method and some data being received in the first call", com1.ReadTimeout);
                 com1.Open();
 
@@ -144,7 +142,7 @@ namespace System.IO.Ports.Tests
 
                 //Wait for the thread to finish
                 while (t.IsAlive)
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
 
                 //Make sure there is no bytes in the buffer so the next call to read will timeout
                 com1.DiscardInBuffer();
@@ -160,7 +158,7 @@ namespace System.IO.Ports.Tests
                 int sleepPeriod = rndGen.Next(minRandomTimeout, maxRandomTimeout / 2);
 
                 //Sleep some random period with of a maximum duration of half the largest possible timeout value for a read method on COM1
-                System.Threading.Thread.Sleep(sleepPeriod);
+                Thread.Sleep(sleepPeriod);
 
                 com2.Open();
                 com2.WriteLine("");
@@ -277,7 +275,7 @@ namespace System.IO.Ports.Tests
 
             Assert.Throws<TimeoutException>(() => com.ReadLine());
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Highest;
+            Thread.CurrentThread.Priority = ThreadPriority.Highest;
 
             for (int i = 0; i < NUM_TRYS; i++)
             {
@@ -289,7 +287,7 @@ namespace System.IO.Ports.Tests
                 timer.Reset();
             }
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Normal;
+            Thread.CurrentThread.Priority = ThreadPriority.Normal;
             actualTime /= NUM_TRYS;
             percentageDifference = Math.Abs((expectedTime - actualTime) / (double)expectedTime);
 
@@ -375,7 +373,7 @@ namespace System.IO.Ports.Tests
             {
                 Random rndGen = new Random(-55);
                 byte[] bytesToWrite = new byte[numBytesRead + 1]; //Plus one to accomidate the NewLineByte
-                System.Text.ASCIIEncoding encoding = new System.Text.ASCIIEncoding();
+                ASCIIEncoding encoding = new ASCIIEncoding();
 
                 //Genrate random characters
                 for (int i = 0; i < numBytesRead; i++)

--- a/src/System.IO.Ports/tests/SerialPort/ReadLine_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadLine_Generic.cs
@@ -197,8 +197,6 @@ namespace System.IO.Ports.Tests
                 byte[] bytesToWrite = new byte[numRndBytesPairty];
                 char[] expectedChars = new char[numRndBytesPairty];
 
-                int waitTime;
-
                 /* 1 Additional character gets added to the input buffer when the parity error occurs on the last byte of a stream
                  We are verifying that besides this everything gets read in correctly. See NDP Whidbey: 24216 for more info on this */
                 Debug.WriteLine("Verifying default ParityReplace byte with a parity errro on the last byte");
@@ -227,13 +225,7 @@ namespace System.IO.Ports.Tests
                 com2.Write(bytesToWrite, 0, bytesToWrite.Length);
                 com2.Write(com1.NewLine);
 
-                waitTime = 0;
-
-                while (bytesToWrite.Length + 2 > com1.BytesToRead && waitTime < 500)
-                {
-                    System.Threading.Thread.Sleep(50);
-                    waitTime += 50;
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length + com1.NewLine.Length);
 
                 string strRead = com1.ReadLine();
                 char[] actualChars = strRead.ToCharArray();
@@ -423,16 +415,11 @@ namespace System.IO.Ports.Tests
             int totalCharsRead;
             int bytesToRead;
             int lastIndexOfNewLine = -1;
-            int waitTime = 0;
 
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
             com1.ReadTimeout = 250;
 
-            while (com1.BytesToRead < bytesToWrite.Length && waitTime < 500)
-            {
-                System.Threading.Thread.Sleep(50);
-                waitTime += 50;
-            }
+            TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length);
 
             totalBytesRead = 0;
             totalCharsRead = 0;

--- a/src/System.IO.Ports/tests/SerialPort/ReadTimeout.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadTimeout.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Threading;
 using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
@@ -13,23 +14,20 @@ namespace System.IO.Ports.Tests
     public class ReadTimeout_Property : PortsTest
     {
         //The default number of chars to write with when testing timeout with Read(char[], int, int)
-        public static readonly int DEFAULT_READ_CHAR_ARRAY_SIZE = 8;
+        private const int DEFAULT_READ_CHAR_ARRAY_SIZE = 8;
 
         //The default number of bytes to write with when testing timeout with Read(byte[], int, int)
-        public static readonly int DEFAULT_READ_BYTE_ARRAY_SIZE = 8;
+        private const int DEFAULT_READ_BYTE_ARRAY_SIZE = 8;
 
         //The ammount of time to wait when expecting an infinite timeout
-        public static readonly int DEFAULT_WAIT_INFINITE_TIMEOUT = 250;
+        private const int DEFAULT_WAIT_INFINITE_TIMEOUT = 250;
 
         //The maximum acceptable time allowed when a read method should timeout immediately
-        public static readonly int MAX_ACCEPTABLE_ZERO_TIMEOUT = 100;
+        private const int MAX_ACCEPTABLE_ZERO_TIMEOUT = 100;
 
         //The maximum acceptable time allowed when a read method should timeout immediately when it is called for the first time
-        public static readonly int MAX_ACCEPTABLE_WARMUP_ZERO_TIMEOUT = 1000;
-        public static readonly int NUM_TRYS = 5;
-
-        //The default new lint to read from when testing timeout with ReadTo(str)
-        public static readonly string DEFAULT_READ_TO_STRING = "\r\n";
+        private const int MAX_ACCEPTABLE_WARMUP_ZERO_TIMEOUT = 1000;
+        private const int NUM_TRYS = 5;
 
         private enum ThrowAt { Set, Open };
 
@@ -242,7 +240,7 @@ namespace System.IO.Ports.Tests
 
                 Task task = Task.Run(() => readMethod(com1));
 
-                System.Threading.Thread.Sleep(DEFAULT_WAIT_INFINITE_TIMEOUT);
+                Thread.Sleep(DEFAULT_WAIT_INFINITE_TIMEOUT);
 
                 Assert.True(!task.IsCompleted);
 
@@ -280,7 +278,7 @@ namespace System.IO.Ports.Tests
         {
             SerialPortProperties serPortProp = new SerialPortProperties();
             Stopwatch sw = new Stopwatch();
-        
+
             int actualTime = 0;
 
             serPortProp.SetAllPropertiesToOpenDefaults();
@@ -291,7 +289,7 @@ namespace System.IO.Ports.Tests
 
             com.WriteTimeout = 1000;
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Highest;
+            Thread.CurrentThread.Priority = ThreadPriority.Highest;
 
             sw.Start();
             readMethod(com);
@@ -314,7 +312,7 @@ namespace System.IO.Ports.Tests
                 sw.Reset();
             }
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Normal;
+            Thread.CurrentThread.Priority = ThreadPriority.Normal;
             actualTime /= NUM_TRYS;
 
             if (MAX_ACCEPTABLE_ZERO_TIMEOUT < actualTime)
@@ -344,7 +342,7 @@ namespace System.IO.Ports.Tests
         private void VerifyExceptionAtOpen(SerialPort com, int readTimeout, ThrowAt throwAt, Type expectedException)
         {
             int origReadTimeout = com.ReadTimeout;
-        
+
             SerialPortProperties serPortProp = new SerialPortProperties();
 
             serPortProp.SetAllPropertiesToDefaults();

--- a/src/System.IO.Ports/tests/SerialPort/ReadTo.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadTo.cs
@@ -272,8 +272,7 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(byteXmitBuffer, 0, byteXmitBuffer.Length);
 
-                while (com1.BytesToRead < byteXmitBuffer.Length)
-                    System.Threading.Thread.Sleep(50);
+                TCSupport.WaitForReadBufferToLoad(com1, byteXmitBuffer.Length);
 
                 //Read Every Byte except the last one. The last bye should be left in the last position of SerialPort's
                 //internal buffer. When we try to read this char as UTF32 the buffer should have to be resized so 
@@ -298,10 +297,7 @@ namespace System.IO.Ports.Tests
 
                 Encoding.UTF32.GetChars(byteBuffer, 0, byteBuffer.Length, expectedChars, 1);
 
-                while (com1.BytesToRead < 4 + numBytes)
-                {
-                    System.Threading.Thread.Sleep(50);
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, 4 + numBytes);
 
                 string rcvString = com1.ReadTo(com2.NewLine);
                 Assert.NotNull(rcvString);

--- a/src/System.IO.Ports/tests/SerialPort/ReadTo.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadTo.cs
@@ -14,17 +14,17 @@ namespace System.IO.Ports.Tests
     public class ReadTo : PortsTest
     {
         //The number of random bytes to receive for read method testing
-        public static readonly int DEFAULT_NUM_CHARS_TO_READ = 8;
+        private const int DEFAULT_NUM_CHARS_TO_READ = 8;
 
         //The number of new lines to insert into the string not including the one at the end
-        public static readonly int DEFAULT_NUMBER_NEW_LINES = 2;
+        private const int DEFAULT_NUMBER_NEW_LINES = 2;
 
         //The number of random bytes to receive for large input buffer testing
-        public static readonly int LARGE_NUM_CHARS_TO_READ = 2048;
-        public static readonly int MIN_NUM_NEWLINE_CHARS = 1;
-        public static readonly int MAX_NUM_NEWLINE_CHARS = 5;
+        private const int LARGE_NUM_CHARS_TO_READ = 2048;
+        private const int MIN_NUM_NEWLINE_CHARS = 1;
+        private const int MAX_NUM_NEWLINE_CHARS = 5;
 
-        public enum ReadDataFromEnum { NonBuffered, Buffered, BufferedAndNonBuffered };
+        private enum ReadDataFromEnum { NonBuffered, Buffered, BufferedAndNonBuffered };
 
         #region Test Cases
 
@@ -160,7 +160,7 @@ namespace System.IO.Ports.Tests
             {
                 Random rndGen = new Random(-55);
                 StringBuilder strBldrToWrite = new StringBuilder();
-        
+
                 //Genrate random characters
                 for (int i = 0; i < numBytesToRead; i++)
                 {
@@ -256,7 +256,7 @@ namespace System.IO.Ports.Tests
                 char[] charXmitBuffer = TCSupport.GetRandomChars(128, TCSupport.CharacterOptions.Surrogates);
                 byte[] byteXmitBuffer = new byte[1024];
                 char utf32Char = TCSupport.GenerateRandomCharNonSurrogate();
-                byte[] utf32CharBytes = Encoding.UTF32.GetBytes(new [] {utf32Char});
+                byte[] utf32CharBytes = Encoding.UTF32.GetBytes(new[] { utf32Char });
                 int numBytes;
 
                 Debug.WriteLine("Verifying that ReadTo() will read everything from internal buffer and drivers buffer");
@@ -361,8 +361,8 @@ namespace System.IO.Ports.Tests
                 char[] charXmitBuffer = TCSupport.GetRandomChars(512, TCSupport.CharacterOptions.None);
                 string endString = "END";
                 ASyncRead asyncRead = new ASyncRead(com1, endString);
-                System.Threading.Thread asyncReadThread =
-                    new System.Threading.Thread(asyncRead.Read);
+                Thread asyncReadThread =
+                    new Thread(asyncRead.Read);
 
                 char endChar = endString[0];
                 char notEndChar = TCSupport.GetRandomOtherChar(endChar, TCSupport.CharacterOptions.None);
@@ -373,7 +373,7 @@ namespace System.IO.Ports.Tests
                 //Ensure the new line is not in charXmitBuffer
                 for (int i = 0; i < charXmitBuffer.Length; ++i)
                 {
-//Se any appearances of a character in the new line string to some other char
+                    //Se any appearances of a character in the new line string to some other char
                     if (endChar == charXmitBuffer[i])
                     {
                         charXmitBuffer[i] = notEndChar;
@@ -392,7 +392,7 @@ namespace System.IO.Ports.Tests
                 asyncReadThread.Start();
                 asyncRead.ReadStartedEvent.WaitOne();
                 //This only tells us that the thread has started to execute code in the method
-                System.Threading.Thread.Sleep(2000); //We need to wait to guarentee that we are executing code in SerialPort
+                Thread.Sleep(2000); //We need to wait to guarentee that we are executing code in SerialPort
                 com2.Write(charXmitBuffer, 0, charXmitBuffer.Length);
                 com2.Write(endString);
 
@@ -489,7 +489,7 @@ namespace System.IO.Ports.Tests
 
                 bool continueRunning = true;
                 int numberOfIterations = 0;
-                System.Threading.Thread writeToCom2Thread = new System.Threading.Thread(delegate()
+                Thread writeToCom2Thread = new Thread(delegate ()
                 {
                     while (continueRunning)
                     {
@@ -504,7 +504,7 @@ namespace System.IO.Ports.Tests
                 //Ensure the new line is not in charXmitBuffer
                 for (int i = 0; i < charXmitBuffer.Length; ++i)
                 {
-//Se any appearances of a character in the new line string to some other char
+                    //Se any appearances of a character in the new line string to some other char
                     if (endChar == charXmitBuffer[i])
                     {
                         charXmitBuffer[i] = notEndChar;
@@ -560,7 +560,6 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
             {
-
                 Debug.WriteLine(
                     "Verifying read method with surrogate pair in the input and a surrogate pair for the newline");
                 com1.Open();
@@ -634,7 +633,7 @@ namespace System.IO.Ports.Tests
                 com1.ReadTimeout = 500;
                 com1.Encoding = encoding;
 
-                TCSupport.SetHighSpeed(com1,com2);
+                TCSupport.SetHighSpeed(com1, com2);
 
                 com1.Open();
 
@@ -687,7 +686,7 @@ namespace System.IO.Ports.Tests
             com2.Write(bytesToWrite, 0, 1); // Write one byte at the beginning because we are going to read this to buffer the rest of the data    
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
 
-            while (com1.BytesToRead < bytesToWrite.Length+1)
+            while (com1.BytesToRead < bytesToWrite.Length + 1)
             {
                 Thread.Sleep(50);
             }
@@ -708,7 +707,7 @@ namespace System.IO.Ports.Tests
 
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
             com1.ReadTimeout = 500;
-            System.Threading.Thread.Sleep((int)((((bytesToWrite.Length + 1) * 10.0) / com1.BaudRate) * 1000) + 250);
+            Thread.Sleep((int)((((bytesToWrite.Length + 1) * 10.0) / com1.BaudRate) * 1000) + 250);
 
             PerformReadOnCom1FromCom2(com1, com2, expectedString, newLine);
         }
@@ -817,16 +816,16 @@ namespace System.IO.Ports.Tests
                 Fail("Err_7797ajpba!!!: Expected to read \"{0}\"  actual read  \"{1}\"", expectedString, strBldrRead.ToString());
             }
 
-/*
-        if (!retValue)
-        {
-            Debug.WriteLine("\nstrToWrite = ");
-            TCSupport.PrintChars(strToWrite.ToCharArray());
+            /*
+                    if (!retValue)
+                    {
+                        Debug.WriteLine("\nstrToWrite = ");
+                        TCSupport.PrintChars(strToWrite.ToCharArray());
 
-            Debug.WriteLine("\nnewLine = ");
-            TCSupport.PrintChars(newLine.ToCharArray());
-        }
-*/
+                        Debug.WriteLine("\nnewLine = ");
+                        TCSupport.PrintChars(newLine.ToCharArray());
+                    }
+            */
         }
 
 
@@ -907,12 +906,12 @@ namespace System.IO.Ports.Tests
 
         private class ASyncRead
         {
-            private SerialPort _com;
-            private string _value;
+            private readonly SerialPort _com;
+            private readonly string _value;
             private string _result;
 
-            private System.Threading.AutoResetEvent _readCompletedEvent;
-            private System.Threading.AutoResetEvent _readStartedEvent;
+            private readonly AutoResetEvent _readCompletedEvent;
+            private readonly AutoResetEvent _readStartedEvent;
 
             private Exception _exception;
 
@@ -923,8 +922,8 @@ namespace System.IO.Ports.Tests
 
                 _result = null;
 
-                _readCompletedEvent = new System.Threading.AutoResetEvent(false);
-                _readStartedEvent = new System.Threading.AutoResetEvent(false);
+                _readCompletedEvent = new AutoResetEvent(false);
+                _readStartedEvent = new AutoResetEvent(false);
 
                 _exception = null;
             }
@@ -946,9 +945,9 @@ namespace System.IO.Ports.Tests
                 }
             }
 
-            public System.Threading.AutoResetEvent ReadStartedEvent => _readStartedEvent;
+            public AutoResetEvent ReadStartedEvent => _readStartedEvent;
 
-            public System.Threading.AutoResetEvent ReadCompletedEvent => _readCompletedEvent;
+            public AutoResetEvent ReadCompletedEvent => _readCompletedEvent;
 
             public string Result => _result;
 

--- a/src/System.IO.Ports/tests/SerialPort/ReadTo_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadTo_Generic.cs
@@ -203,8 +203,6 @@ namespace System.IO.Ports.Tests
                 byte[] bytesToWrite = new byte[numRndBytesPairty];
                 char[] expectedChars = new char[numRndBytesPairty];
 
-                int waitTime;
-
                 /* 1 Additional character gets added to the input buffer when the parity error occurs on the last byte of a stream
                  We are verifying that besides this everything gets read in correctly. See NDP Whidbey: 24216 for more info on this */
                 Debug.WriteLine("Verifying default ParityReplace byte with a parity errro on the last byte");
@@ -233,13 +231,7 @@ namespace System.IO.Ports.Tests
                 com2.Write(bytesToWrite, 0, bytesToWrite.Length);
                 com2.Write(com1.NewLine);
 
-                waitTime = 0;
-
-                while (bytesToWrite.Length + 2 > com1.BytesToRead && waitTime < 500)
-                {
-                    System.Threading.Thread.Sleep(50);
-                    waitTime += 50;
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length + com1.NewLine.Length);
 
                 string strRead = com1.ReadTo(com1.NewLine);
                 char[] actualChars = strRead.ToCharArray();
@@ -429,16 +421,11 @@ namespace System.IO.Ports.Tests
             int totalCharsRead;
             int bytesToRead;
             int lastIndexOfNewLine = -1;
-            int waitTime = 0;
 
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
             com1.ReadTimeout = 250;
 
-            while (com1.BytesToRead < bytesToWrite.Length && waitTime < 500)
-            {
-                System.Threading.Thread.Sleep(50);
-                waitTime += 50;
-            }
+            TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length);
 
             totalBytesRead = 0;
             totalCharsRead = 0;

--- a/src/System.IO.Ports/tests/SerialPort/ReadTo_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadTo_Generic.cs
@@ -4,6 +4,8 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -13,35 +15,28 @@ namespace System.IO.Ports.Tests
     {
         //Set bounds fore random timeout values.
         //If the min is to low read will not timeout accurately and the testcase will fail
-        public static readonly int minRandomTimeout = 250;
+        private const int minRandomTimeout = 250;
 
         //If the max is to large then the testcase will take forever to run
-        public static readonly int maxRandomTimeout = 2000;
+        private const int maxRandomTimeout = 2000;
 
         //If the percentage difference between the expected timeout and the actual timeout
         //found through Stopwatch is greater then 10% then the timeout value was not correctly
         //to the read method and the testcase fails.
-        public static readonly double maxPercentageDifference = .15;
+        private const double maxPercentageDifference = .15;
 
         //The number of random bytes to receive for parity testing
-        public static readonly int numRndBytesPairty = 8;
-
-        //The number of characters to read at a time for parity testing
-        public static readonly int numBytesReadPairty = 2;
+        private const int numRndBytesParity = 8;
 
         //The number of random bytes to receive for BytesToRead testing
-        public static readonly int numRndBytesToRead = 16;
+        private const int numRndBytesToRead = 16;
 
         //The number of new lines to insert into the string not including the one at the end
         //For BytesToRead testing
-        public static readonly int DEFAULT_NUMBER_NEW_LINES = 2;
-        public static readonly byte DEFAULT_NEW_LINE = (byte)'\n';
+        private const int DEFAULT_NUMBER_NEW_LINES = 2;
+        private const byte DEFAULT_NEW_LINE = (byte)'\n';
 
-        //When we test Read and do not care about actually reading anything we must still
-        //create an byte array to pass into the method the following is the size of the 
-        //byte array used in this situation
-        public static readonly int defaultCharArraySize = 1;
-        public static readonly int NUM_TRYS = 5;
+        private const int NUM_TRYS = 5;
 
         #region Test Cases
 
@@ -109,7 +104,7 @@ namespace System.IO.Ports.Tests
 
                 com.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 //		com.Encoding = new System.Text.UTF7Encoding();
-                com.Encoding = System.Text.Encoding.Unicode;
+                com.Encoding = Encoding.Unicode;
 
                 Debug.WriteLine("Verifying ReadTimeout={0} with successive call to read method and no data", com.ReadTimeout);
                 com.Open();
@@ -126,10 +121,10 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 Random rndGen = new Random(-55);
-                System.Threading.Thread t = new System.Threading.Thread(WriteToCom1);     
+                Thread t = new Thread(WriteToCom1);
 
                 com1.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
-                com1.Encoding = new System.Text.UTF8Encoding();
+                com1.Encoding = new UTF8Encoding();
 
                 Debug.WriteLine("Verifying ReadTimeout={0} with successive call to read method and some data being received in the first call", com1.ReadTimeout);
                 com1.Open();
@@ -148,7 +143,7 @@ namespace System.IO.Ports.Tests
 
                 //Wait for the thread to finish
                 while (t.IsAlive)
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
 
                 //Make sure there is no bytes in the buffer so the next call to read will timeout
                 com1.DiscardInBuffer();
@@ -164,7 +159,7 @@ namespace System.IO.Ports.Tests
                 int sleepPeriod = rndGen.Next(minRandomTimeout, maxRandomTimeout / 2);
 
                 //Sleep some random period with of a maximum duration of half the largest possible timeout value for a read method on COM1
-                System.Threading.Thread.Sleep(sleepPeriod);
+                Thread.Sleep(sleepPeriod);
                 com2.Open();
                 com2.WriteLine("");
                 if (com2.IsOpen)
@@ -175,14 +170,14 @@ namespace System.IO.Ports.Tests
         [ConditionalFact(nameof(HasNullModem))]
         public void DefaultParityReplaceByte()
         {
-            VerifyParityReplaceByte(-1, numRndBytesPairty - 2);
+            VerifyParityReplaceByte(-1, numRndBytesParity - 2);
         }
 
         [ConditionalFact(nameof(HasNullModem))]
         public void NoParityReplaceByte()
         {
             Random rndGen = new Random(-55);
-            VerifyParityReplaceByte('\0', rndGen.Next(0, numRndBytesPairty - 1));
+            VerifyParityReplaceByte('\0', rndGen.Next(0, numRndBytesParity - 1));
         }
 
         [ConditionalFact(nameof(HasNullModem))]
@@ -200,8 +195,8 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 Random rndGen = new Random(15);
-                byte[] bytesToWrite = new byte[numRndBytesPairty];
-                char[] expectedChars = new char[numRndBytesPairty];
+                byte[] bytesToWrite = new byte[numRndBytesParity];
+                char[] expectedChars = new char[numRndBytesParity];
 
                 /* 1 Additional character gets added to the input buffer when the parity error occurs on the last byte of a stream
                  We are verifying that besides this everything gets read in correctly. See NDP Whidbey: 24216 for more info on this */
@@ -284,7 +279,7 @@ namespace System.IO.Ports.Tests
 
             Assert.Throws<TimeoutException>(() => com.ReadTo(com.NewLine));
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Highest;
+            Thread.CurrentThread.Priority = ThreadPriority.Highest;
 
             for (int i = 0; i < NUM_TRYS; i++)
             {
@@ -297,7 +292,7 @@ namespace System.IO.Ports.Tests
                 timer.Reset();
             }
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Normal;
+            Thread.CurrentThread.Priority = ThreadPriority.Normal;
             actualTime /= NUM_TRYS;
             percentageDifference = Math.Abs((expectedTime - actualTime) / (double)expectedTime);
 
@@ -319,12 +314,12 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 Random rndGen = new Random(-55);
-                byte[] bytesToWrite = new byte[numRndBytesPairty + 1]; //Plus one to accomidate the NewLineByte
-                char[] expectedChars = new char[numRndBytesPairty + 1]; //Plus one to accomidate the NewLineByte
+                byte[] bytesToWrite = new byte[numRndBytesParity + 1]; //Plus one to accomidate the NewLineByte
+                char[] expectedChars = new char[numRndBytesParity + 1]; //Plus one to accomidate the NewLineByte
                 byte expectedByte;
 
                 //Genrate random characters without an parity error
-                for (int i = 0; i < numRndBytesPairty; i++)
+                for (int i = 0; i < numRndBytesParity; i++)
                 {
                     byte randByte = (byte)rndGen.Next(0, 128);
 
@@ -363,8 +358,8 @@ namespace System.IO.Ports.Tests
                 com1.Open();
                 com2.Open();
 
-                bytesToWrite[numRndBytesPairty] = DEFAULT_NEW_LINE;
-                expectedChars[numRndBytesPairty] = (char)DEFAULT_NEW_LINE;
+                bytesToWrite[numRndBytesParity] = DEFAULT_NEW_LINE;
+                expectedChars[numRndBytesParity] = (char)DEFAULT_NEW_LINE;
 
                 VerifyRead(com1, com2, bytesToWrite, expectedChars);
             }
@@ -382,7 +377,7 @@ namespace System.IO.Ports.Tests
             {
                 Random rndGen = new Random(-55);
                 byte[] bytesToWrite = new byte[numBytesRead + 1]; //Plus one to accomidate the NewLineByte
-                System.Text.ASCIIEncoding encoding = new System.Text.ASCIIEncoding();
+                ASCIIEncoding encoding = new ASCIIEncoding();
 
                 //Genrate random characters
                 for (int i = 0; i < numBytesRead; i++)

--- a/src/System.IO.Ports/tests/SerialPort/Read_byte_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_byte_int_int.cs
@@ -239,8 +239,7 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(byteXmitBuffer, 0, byteXmitBuffer.Length);
 
-                while (com1.BytesToRead < byteXmitBuffer.Length)
-                    System.Threading.Thread.Sleep(50);
+                TCSupport.WaitForReadBufferToLoad(com1, byteXmitBuffer.Length);
 
                 //Read Every Byte except the last one. The last bye should be left in the last position of SerialPort's
                 //internal buffer. When we try to read this char as UTF32 the buffer should have to be resized so 
@@ -257,10 +256,7 @@ namespace System.IO.Ports.Tests
 
                 byteRcvBuffer = new byte[(int)(expectedBytes.Length * 1.5)];
 
-                while (com1.BytesToRead < 4 + byteXmitBuffer.Length)
-                {
-                    System.Threading.Thread.Sleep(50);
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, 4 + byteXmitBuffer.Length);
 
                 if (expectedBytes.Length != (numBytesRead = com1.Read(byteRcvBuffer, 0, byteRcvBuffer.Length)))
                 {

--- a/src/System.IO.Ports/tests/SerialPort/Read_byte_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_byte_int_int.cs
@@ -4,6 +4,8 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -12,25 +14,25 @@ namespace System.IO.Ports.Tests
     public class Read_byte_int_int : PortsTest
     {
         //The number of random bytes to receive for read method testing
-        public static readonly int numRndBytesToRead = 16;
+        private const int numRndBytesToRead = 16;
 
         //The number of random bytes to receive for large input buffer testing
-        public static readonly int largeNumRndBytesToRead = 2048;
+        private const int largeNumRndBytesToRead = 2048;
 
         //When we test Read and do not care about actually reading anything we must still
         //create an byte array to pass into the method the following is the size of the 
         //byte array used in this situation
-        public static readonly int defaultByteArraySize = 1;
-        public static readonly int defaultByteOffset = 0;
-        public static readonly int defaultByteCount = 1;
+        private const int defaultByteArraySize = 1;
+        private const int defaultByteOffset = 0;
+        private const int defaultByteCount = 1;
 
         //The maximum buffer size when a exception occurs
-        public static readonly int maxBufferSizeForException = 255;
+        private const int maxBufferSizeForException = 255;
 
         //The maximum buffer size when a exception is not expected
-        public static readonly int maxBufferSize = 8;
+        private const int maxBufferSize = 8;
 
-        public enum ReadDataFromEnum { NonBuffered, Buffered, BufferedAndNonBuffered };
+        private enum ReadDataFromEnum { NonBuffered, Buffered, BufferedAndNonBuffered };
 
         #region Test Cases
         [ConditionalFact(nameof(HasOneSerialPort))]
@@ -211,7 +213,7 @@ namespace System.IO.Ports.Tests
                 byte[] expectedBytes = new byte[byteXmitBuffer.Length + 4];
                 byte[] byteRcvBuffer;
                 char utf32Char = (char)8169;
-                byte[] utf32CharBytes = System.Text.Encoding.UTF32.GetBytes(new[] {utf32Char});
+                byte[] utf32CharBytes = Encoding.UTF32.GetBytes(new[] { utf32Char });
                 int numBytesRead;
 
                 Debug.WriteLine(
@@ -297,15 +299,15 @@ namespace System.IO.Ports.Tests
                 byte[] byteXmitBuffer = TCSupport.GetRandomBytes(512);
                 byte[] byteRcvBuffer = new byte[byteXmitBuffer.Length];
                 ASyncRead asyncRead = new ASyncRead(com1, byteRcvBuffer, 0, byteRcvBuffer.Length);
-                System.Threading.Thread asyncReadThread =
-                    new System.Threading.Thread(asyncRead.Read);
-            
+                Thread asyncReadThread =
+                    new Thread(asyncRead.Read);
+
 
                 Debug.WriteLine(
                     "Verifying that Read(byte[], int, int) will read characters that have been received after the call to Read was made");
 
-                com1.Encoding = System.Text.Encoding.UTF8;
-                com2.Encoding = System.Text.Encoding.UTF8;
+                com1.Encoding = Encoding.UTF8;
+                com2.Encoding = Encoding.UTF8;
                 com1.ReadTimeout = 20000; // 20 seconds
 
                 com1.Open();
@@ -316,7 +318,7 @@ namespace System.IO.Ports.Tests
                 asyncReadThread.Start();
                 asyncRead.ReadStartedEvent.WaitOne();
                 //This only tells us that the thread has started to execute code in the method
-                System.Threading.Thread.Sleep(2000); //We need to wait to guarentee that we are executing code in SerialPort
+                Thread.Sleep(2000); //We need to wait to guarentee that we are executing code in SerialPort
                 com2.Write(byteXmitBuffer, 0, byteXmitBuffer.Length);
 
                 asyncRead.ReadCompletedEvent.WaitOne();
@@ -331,7 +333,7 @@ namespace System.IO.Ports.Tests
                 }
                 else
                 {
-                    System.Threading.Thread.Sleep(1000); //We need to wait for all of the bytes to be received
+                    Thread.Sleep(1000); //We need to wait for all of the bytes to be received
                     int readResult = com1.Read(byteRcvBuffer, asyncRead.Result, byteRcvBuffer.Length - asyncRead.Result);
 
                     if (asyncRead.Result + readResult != byteXmitBuffer.Length)
@@ -464,7 +466,7 @@ namespace System.IO.Ports.Tests
 
             while (com1.BytesToRead < bytesToWrite.Length)
             {
-                System.Threading.Thread.Sleep(50);
+                Thread.Sleep(50);
             }
 
             com1.Read(new char[1], 0, 1); // This should put the rest of the bytes in SerialPorts own internal buffer
@@ -484,7 +486,7 @@ namespace System.IO.Ports.Tests
 
             com1.ReadTimeout = 500;
 
-            System.Threading.Thread.Sleep((int)(((bytesToWrite.Length * 10.0) / com1.BaudRate) * 1000) + 250);
+            Thread.Sleep((int)(((bytesToWrite.Length * 10.0) / com1.BaudRate) * 1000) + 250);
 
             PerformReadOnCom1FromCom2(com1, com2, expectedBytes, rcvBuffer, offset, count);
         }
@@ -590,8 +592,8 @@ namespace System.IO.Ports.Tests
             private readonly int _count;
             private int _result;
 
-            private readonly System.Threading.AutoResetEvent _readCompletedEvent;
-            private readonly System.Threading.AutoResetEvent _readStartedEvent;
+            private readonly AutoResetEvent _readCompletedEvent;
+            private readonly AutoResetEvent _readStartedEvent;
 
             private Exception _exception;
 
@@ -604,8 +606,8 @@ namespace System.IO.Ports.Tests
 
                 _result = -1;
 
-                _readCompletedEvent = new System.Threading.AutoResetEvent(false);
-                _readStartedEvent = new System.Threading.AutoResetEvent(false);
+                _readCompletedEvent = new AutoResetEvent(false);
+                _readStartedEvent = new AutoResetEvent(false);
 
                 _exception = null;
             }
@@ -627,9 +629,9 @@ namespace System.IO.Ports.Tests
                 }
             }
 
-            public System.Threading.AutoResetEvent ReadStartedEvent => _readStartedEvent;
+            public AutoResetEvent ReadStartedEvent => _readStartedEvent;
 
-            public System.Threading.AutoResetEvent ReadCompletedEvent => _readCompletedEvent;
+            public AutoResetEvent ReadCompletedEvent => _readCompletedEvent;
 
             public int Result => _result;
 

--- a/src/System.IO.Ports/tests/SerialPort/Read_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_byte_int_int_Generic.cs
@@ -412,16 +412,11 @@ namespace System.IO.Ports.Tests
             byte[] buffer = new byte[bytesToWrite.Length];
             int totalBytesRead;
             int bytesToRead;
-            int waitTime = 0;
 
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
             com1.ReadTimeout = 250;
 
-            while (com1.BytesToRead < bytesToWrite.Length && waitTime < 500)
-            {
-                System.Threading.Thread.Sleep(50);
-                waitTime += 50;
-            }
+            TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length);
 
             totalBytesRead = 0;
             bytesToRead = com1.BytesToRead;

--- a/src/System.IO.Ports/tests/SerialPort/Read_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_byte_int_int_Generic.cs
@@ -5,6 +5,8 @@
 using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Linq;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -14,30 +16,30 @@ namespace System.IO.Ports.Tests
     {
         //Set bounds fore random timeout values.
         //If the min is to low read will not timeout accurately and the testcase will fail
-        public static readonly int minRandomTimeout = 250;
+        private const int minRandomTimeout = 250;
 
         //If the max is to large then the testcase will take forever to run
-        public static readonly int maxRandomTimeout = 2000;
+        private const int maxRandomTimeout = 2000;
 
         //If the percentage difference between the expected timeout and the actual timeout
         //found through Stopwatch is greater then 10% then the timeout value was not correctly
         //to the read method and the testcase fails.
-        public static readonly double maxPercentageDifference = .15;
+        private const double maxPercentageDifference = .15;
 
         //The number of random bytes to receive for parity testing
-        public static readonly int numRndBytesPairty = 8;
+        private const int numRndBytesPairty = 8;
 
         //The number of characters to read at a time for parity testing
-        public static readonly int numBytesReadPairty = 2;
+        private const int numBytesReadPairty = 2;
 
         //The number of random bytes to receive for BytesToRead testing
-        public static readonly int numRndBytesToRead = 16;
+        private const int numRndBytesToRead = 16;
 
         //When we test Read and do not care about actually reading anything we must still
         //create an byte array to pass into the method the following is the size of the 
         //byte array used in this situation
-        public static readonly int defaultByteArraySize = 1;
-        public static readonly int NUM_TRYS = 5;
+        private const int defaultByteArraySize = 1;
+        private const int NUM_TRYS = 5;
 
         #region Test Cases
 
@@ -104,7 +106,7 @@ namespace System.IO.Ports.Tests
 
                 com.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 //		com.Encoding = new System.Text.UTF7Encoding();
-                com.Encoding = System.Text.Encoding.Unicode;
+                com.Encoding = Encoding.Unicode;
 
                 Debug.WriteLine("Verifying ReadTimeout={0} with successive call to read method and no data", com.ReadTimeout);
                 com.Open();
@@ -121,10 +123,10 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 Random rndGen = new Random();
-                System.Threading.Thread t = new System.Threading.Thread(WriteToCom1);
+                Thread t = new Thread(WriteToCom1);
 
                 com1.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
-                com1.Encoding = new System.Text.UTF8Encoding();
+                com1.Encoding = new UTF8Encoding();
 
                 Debug.WriteLine("Verifying ReadTimeout={0} with successive call to read method and some data being received in the first call", com1.ReadTimeout);
                 com1.Open();
@@ -143,7 +145,7 @@ namespace System.IO.Ports.Tests
 
                 //Wait for the thread to finish
                 while (t.IsAlive)
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
 
                 //Make sure there is no bytes in the buffer so the next call to read will timeout
                 com1.DiscardInBuffer();
@@ -160,7 +162,7 @@ namespace System.IO.Ports.Tests
                 int sleepPeriod = rndGen.Next(minRandomTimeout, maxRandomTimeout / 2);
 
                 //Sleep some random period with of a maximum duration of half the largest possible timeout value for a read method on COM1
-                System.Threading.Thread.Sleep(sleepPeriod);
+                Thread.Sleep(sleepPeriod);
 
                 com2.Open();
                 com2.Write(xmitBuffer, 0, xmitBuffer.Length);
@@ -180,7 +182,7 @@ namespace System.IO.Ports.Tests
         public void NoParityReplaceByte()
         {
             Random rndGen = new Random();
-            VerifyParityReplaceByte('\0', rndGen.Next(0, numRndBytesPairty - 1), System.Text.Encoding.UTF32);
+            VerifyParityReplaceByte('\0', rndGen.Next(0, numRndBytesPairty - 1), Encoding.UTF32);
         }
 
 
@@ -189,9 +191,9 @@ namespace System.IO.Ports.Tests
         {
             Random rndGen = new Random();
 
-            VerifyParityReplaceByte(rndGen.Next(0, 128), 0, new System.Text.UTF8Encoding());
+            VerifyParityReplaceByte(rndGen.Next(0, 128), 0, new UTF8Encoding());
         }
-    
+
         [ConditionalFact(nameof(HasNullModem))]
         public void ParityErrorOnLastByte()
         {
@@ -235,7 +237,7 @@ namespace System.IO.Ports.Tests
 
                 while (bytesToWrite.Length + 1 > com1.BytesToRead && waitTime < 500)
                 {
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
                     waitTime += 50;
                 }
 
@@ -267,13 +269,13 @@ namespace System.IO.Ports.Tests
         [ConditionalFact(nameof(HasNullModem))]
         public void BytesToRead_1_Buffer_Size()
         {
-            VerifyBytesToRead(1, System.Text.Encoding.Unicode);
+            VerifyBytesToRead(1, Encoding.Unicode);
         }
 
         [ConditionalFact(nameof(HasNullModem))]
         public void BytesToRead_Equal_Buffer_Size()
         {
-            VerifyBytesToRead(numRndBytesToRead, new System.Text.UTF8Encoding());
+            VerifyBytesToRead(numRndBytesToRead, new UTF8Encoding());
         }
         #endregion
 
@@ -288,7 +290,7 @@ namespace System.IO.Ports.Tests
             // Warm up read method
             Assert.Throws<TimeoutException>(() => com.Read(new byte[defaultByteArraySize], 0, defaultByteArraySize));
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Highest;
+            Thread.CurrentThread.Priority = ThreadPriority.Highest;
 
             for (int i = 0; i < NUM_TRYS; i++)
             {
@@ -300,7 +302,7 @@ namespace System.IO.Ports.Tests
                 timer.Reset();
             }
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Normal;
+            Thread.CurrentThread.Priority = ThreadPriority.Normal;
             actualTime /= NUM_TRYS;
             percentageDifference = Math.Abs((expectedTime - actualTime) / (double)expectedTime);
 
@@ -318,10 +320,10 @@ namespace System.IO.Ports.Tests
 
         private void VerifyParityReplaceByte(int parityReplace, int parityErrorIndex)
         {
-            VerifyParityReplaceByte(parityReplace, parityErrorIndex, new System.Text.ASCIIEncoding());
+            VerifyParityReplaceByte(parityReplace, parityErrorIndex, new ASCIIEncoding());
         }
 
-        private void VerifyParityReplaceByte(int parityReplace, int parityErrorIndex, System.Text.Encoding encoding)
+        private void VerifyParityReplaceByte(int parityReplace, int parityErrorIndex, Encoding encoding)
         {
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
@@ -378,10 +380,10 @@ namespace System.IO.Ports.Tests
 
         private void VerifyBytesToRead(int numBytesRead)
         {
-            VerifyBytesToRead(numBytesRead, new System.Text.ASCIIEncoding());
+            VerifyBytesToRead(numBytesRead, new ASCIIEncoding());
         }
 
-        private void VerifyBytesToRead(int numBytesRead, System.Text.Encoding encoding)
+        private void VerifyBytesToRead(int numBytesRead, Encoding encoding)
         {
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))

--- a/src/System.IO.Ports/tests/SerialPort/Read_char_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_char_int_int.cs
@@ -5,6 +5,8 @@
 using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Linq;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -13,23 +15,23 @@ namespace System.IO.Ports.Tests
     public class Read_char_int_int : PortsTest
     {
         //The number of random bytes to receive for read method testing
-        public static readonly int numRndBytesToRead = 8;
+        private const int numRndBytesToRead = 8;
 
         //The number of random bytes to receive for large input buffer testing
-        public static readonly int largeNumRndCharsToRead = 2048;
+        private const int largeNumRndCharsToRead = 2048;
 
         //When we test Read and do not care about actually reading anything we must still
         //create an byte array to pass into the method the following is the size of the 
         //byte array used in this situation
-        public static readonly int defaultCharArraySize = 1;
-        public static readonly int defaultCharOffset = 0;
-        public static readonly int defaultCharCount = 1;
+        private const int defaultCharArraySize = 1;
+        private const int defaultCharOffset = 0;
+        private const int defaultCharCount = 1;
 
         //The maximum buffer size when a exception occurs
-        public static readonly int maxBufferSizeForException = 255;
+        private const int maxBufferSizeForException = 255;
 
         //The maximum buffer size when a exception is not expected
-        public static readonly int maxBufferSize = 8;
+        private const int maxBufferSize = 8;
 
         public enum ReadDataFromEnum { NonBuffered, Buffered, BufferedAndNonBuffered };
 
@@ -148,7 +150,7 @@ namespace System.IO.Ports.Tests
             int bufferLength = rndGen.Next(1, maxBufferSize);
             int offset = bufferLength - 1;
             int count = 1;
-        
+
             VerifyRead(new char[bufferLength], offset, count);
         }
 
@@ -159,7 +161,7 @@ namespace System.IO.Ports.Tests
             int bufferLength = rndGen.Next(1, maxBufferSize);
             int offset = 0;
             int count = bufferLength;
-        
+
             VerifyRead(new char[bufferLength], offset, count);
         }
 
@@ -186,7 +188,7 @@ namespace System.IO.Ports.Tests
             int offset = rndGen.Next(0, bufferLength - 1);
             int count = rndGen.Next(1, bufferLength - offset);
 
-            VerifyRead(new char[bufferLength], offset, count, new System.Text.ASCIIEncoding());
+            VerifyRead(new char[bufferLength], offset, count, new ASCIIEncoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
@@ -197,7 +199,7 @@ namespace System.IO.Ports.Tests
             int offset = rndGen.Next(0, bufferLength - 1);
             int count = rndGen.Next(1, bufferLength - offset);
 
-            VerifyRead(new char[bufferLength], offset, count, new System.Text.UTF8Encoding());
+            VerifyRead(new char[bufferLength], offset, count, new UTF8Encoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
@@ -208,25 +210,25 @@ namespace System.IO.Ports.Tests
             int offset = rndGen.Next(0, bufferLength - 1);
             int count = rndGen.Next(1, bufferLength - offset);
 
-            VerifyRead(new char[bufferLength], offset, count, new System.Text.UTF32Encoding());
+            VerifyRead(new char[bufferLength], offset, count, new UTF32Encoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void ASCIIEncoding_1Char()
         {
-            VerifyRead(new char[1], 0, 1, new System.Text.ASCIIEncoding());
+            VerifyRead(new char[1], 0, 1, new ASCIIEncoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void UTF8Encoding_1Char()
         {
-            VerifyRead(new char[1], 0, 1, new System.Text.UTF8Encoding());
+            VerifyRead(new char[1], 0, 1, new UTF8Encoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void UTF32Encoding_1Char()
         {
-            VerifyRead(new char[1], 0, 1, new System.Text.UTF32Encoding());
+            VerifyRead(new char[1], 0, 1, new UTF32Encoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
@@ -242,19 +244,19 @@ namespace System.IO.Ports.Tests
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void BytesFollowedByCharsASCII()
         {
-            VerifyBytesFollowedByChars(new System.Text.ASCIIEncoding());
+            VerifyBytesFollowedByChars(new ASCIIEncoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void BytesFollowedByCharsUTF8()
         {
-            VerifyBytesFollowedByChars(new System.Text.UTF8Encoding());
+            VerifyBytesFollowedByChars(new UTF8Encoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void BytesFollowedByCharsUTF32()
         {
-            VerifyBytesFollowedByChars(new System.Text.UTF32Encoding());
+            VerifyBytesFollowedByChars(new UTF32Encoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
@@ -307,7 +309,7 @@ namespace System.IO.Ports.Tests
                 char[] charXmitBuffer = TCSupport.GetRandomChars(512, TCSupport.CharacterOptions.Surrogates);
                 byte[] byteXmitBuffer = new byte[1024];
                 char utf32Char = (char)8169;
-                byte[] utf32CharBytes = System.Text.Encoding.UTF32.GetBytes(new[] {utf32Char});
+                byte[] utf32CharBytes = Encoding.UTF32.GetBytes(new[] { utf32Char });
                 int numCharsRead;
 
                 Debug.WriteLine(
@@ -322,7 +324,7 @@ namespace System.IO.Ports.Tests
                 //when we read this later the buffer will have to be resized
                 byteXmitBuffer[byteXmitBuffer.Length - 1] = utf32CharBytes[0];
 
-                TCSupport.SetHighSpeed(com1,com2);
+                TCSupport.SetHighSpeed(com1, com2);
 
                 com1.Open();
 
@@ -339,23 +341,23 @@ namespace System.IO.Ports.Tests
                 com1.Read(new char[1023], 0, 1023);
                 Assert.Equal(1, com1.BytesToRead);
 
-                com1.Encoding = System.Text.Encoding.UTF32;
-                com2.Encoding = System.Text.Encoding.UTF32;
+                com1.Encoding = Encoding.UTF32;
+                com2.Encoding = Encoding.UTF32;
 
                 com2.Write(utf32CharBytes, 1, 3);
                 com2.Write(charXmitBuffer, 0, charXmitBuffer.Length);
 
-                int numBytes = System.Text.Encoding.UTF32.GetByteCount(charXmitBuffer);
+                int numBytes = Encoding.UTF32.GetByteCount(charXmitBuffer);
 
-                byte[] byteBuffer = System.Text.Encoding.UTF32.GetBytes(charXmitBuffer);
+                byte[] byteBuffer = Encoding.UTF32.GetBytes(charXmitBuffer);
 
-                var expectedChars = new char[1 + System.Text.Encoding.UTF32.GetCharCount(byteBuffer)];
+                var expectedChars = new char[1 + Encoding.UTF32.GetCharCount(byteBuffer)];
                 expectedChars[0] = utf32Char;
 
-                System.Text.Encoding.UTF32.GetChars(byteBuffer, 0, byteBuffer.Length, expectedChars, 1);
+                Encoding.UTF32.GetChars(byteBuffer, 0, byteBuffer.Length, expectedChars, 1);
                 var charRcvBuffer = new char[(int)(expectedChars.Length * 1.5)];
 
-                TCSupport.WaitForReadBufferToLoad(com1, 4+numBytes);
+                TCSupport.WaitForReadBufferToLoad(com1, 4 + numBytes);
 
                 if (expectedChars.Length != (numCharsRead = com1.Read(charRcvBuffer, 0, charRcvBuffer.Length)))
                 {
@@ -378,14 +380,14 @@ namespace System.IO.Ports.Tests
                 char[] charXmitBuffer = TCSupport.GetRandomChars(512, TCSupport.CharacterOptions.None);
                 char[] charRcvBuffer = new char[charXmitBuffer.Length];
                 ASyncRead asyncRead = new ASyncRead(com1, charRcvBuffer, 0, charRcvBuffer.Length);
-                System.Threading.Thread asyncReadThread = new System.Threading.Thread(asyncRead.Read);
+                Thread asyncReadThread = new Thread(asyncRead.Read);
 
 
                 Debug.WriteLine(
                     "Verifying that Read(char[], int, int) will read characters that have been received after the call to Read was made");
 
-                com1.Encoding = System.Text.Encoding.UTF8;
-                com2.Encoding = System.Text.Encoding.UTF8;
+                com1.Encoding = Encoding.UTF8;
+                com2.Encoding = Encoding.UTF8;
                 com1.ReadTimeout = 20000; // 20 seconds
 
                 com1.Open();
@@ -396,7 +398,7 @@ namespace System.IO.Ports.Tests
                 asyncReadThread.Start();
                 asyncRead.ReadStartedEvent.WaitOne();
                 // The WaitOne only tells us that the thread has started to execute code in the method
-                System.Threading.Thread.Sleep(2000); // We need to wait to guarantee that we are executing code in SerialPort
+                Thread.Sleep(2000); // We need to wait to guarantee that we are executing code in SerialPort
                 com2.Write(charXmitBuffer, 0, charXmitBuffer.Length);
 
                 asyncRead.ReadCompletedEvent.WaitOne();
@@ -431,8 +433,8 @@ namespace System.IO.Ports.Tests
 
                 Debug.WriteLine("Verifying that Read(char[], int, int) will compact data in the buffer buffer");
 
-                com1.Encoding = System.Text.Encoding.ASCII;
-                com2.Encoding = System.Text.Encoding.ASCII;
+                com1.Encoding = Encoding.ASCII;
+                com2.Encoding = Encoding.ASCII;
 
                 com1.Open();
 
@@ -456,7 +458,7 @@ namespace System.IO.Ports.Tests
                 }
 
                 TCSupport.VerifyArray(expectedChars, charRcvBuffer);
-                
+
                 //[] Write 16 more cahrs and read in 16 chars
                 expectedChars = new char[16];
                 charRcvBuffer = new char[16];
@@ -473,7 +475,7 @@ namespace System.IO.Ports.Tests
                 }
 
                 Assert.Equal(expectedChars, charRcvBuffer);
-            
+
                 //[] Write more chars and read in all of the chars
                 expectedChars = new char[charXmitBuffer.Length + 1];
                 charRcvBuffer = new char[charXmitBuffer.Length + 1];
@@ -499,7 +501,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
             {
                 char[] charXmitBuffer = TCSupport.GetRandomChars(512, TCSupport.CharacterOptions.None);
-                byte[] byteXmitBuffer = new System.Text.UTF32Encoding().GetBytes(charXmitBuffer);
+                byte[] byteXmitBuffer = new UTF32Encoding().GetBytes(charXmitBuffer);
                 char[] charRcvBuffer = new char[charXmitBuffer.Length];
 
                 int result;
@@ -507,8 +509,8 @@ namespace System.IO.Ports.Tests
                 Debug.WriteLine(
                     "Verifying that Read(char[], int, int) works appropriately after TimeoutException has been thrown");
 
-                com1.Encoding = new System.Text.UTF32Encoding();
-                com2.Encoding = new System.Text.UTF32Encoding();
+                com1.Encoding = new UTF32Encoding();
+                com2.Encoding = new UTF32Encoding();
                 com1.ReadTimeout = 500; // 20 seconds
 
                 com1.Open();
@@ -554,15 +556,15 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
             {
                 char utf32Char = (char)0x254b; //Box drawing char
-                byte[] utf32CharBytes = System.Text.Encoding.UTF32.GetBytes(new[] {utf32Char});
+                byte[] utf32CharBytes = Encoding.UTF32.GetBytes(new[] { utf32Char });
                 char[] charRcvBuffer = new char[3];
 
                 int result;
 
                 Debug.WriteLine("Verifying that Read(char[], int, int) works when reading partial characters");
 
-                com1.Encoding = new System.Text.UTF32Encoding();
-                com2.Encoding = new System.Text.UTF32Encoding();
+                com1.Encoding = new UTF32Encoding();
+                com2.Encoding = new UTF32Encoding();
                 com1.ReadTimeout = 500;
 
                 com1.Open();
@@ -587,7 +589,7 @@ namespace System.IO.Ports.Tests
                 Assert.Equal(utf32Char, charRcvBuffer[0]);
                 Assert.Equal(utf32Char, charRcvBuffer[1]);
 
-                VerifyBytesReadOnCom1FromCom2(com1, com2, utf32CharBytes, new[] {utf32Char}, charRcvBuffer, 0,
+                VerifyBytesReadOnCom1FromCom2(com1, com2, utf32CharBytes, new[] { utf32Char }, charRcvBuffer, 0,
                     charRcvBuffer.Length);
             }
         }
@@ -608,8 +610,8 @@ namespace System.IO.Ports.Tests
                 charXmitBuffer[charXmitBuffer.Length - 2] = TCSupport.GenerateRandomHighSurrogate();
                 charXmitBuffer[charXmitBuffer.Length - 1] = TCSupport.GenerateRandomLowSurrogate();
 
-                com1.Encoding = System.Text.Encoding.Unicode;
-                com2.Encoding = System.Text.Encoding.Unicode;
+                com1.Encoding = Encoding.Unicode;
+                com2.Encoding = Encoding.Unicode;
                 com1.ReadTimeout = 500;
 
                 com1.Open();
@@ -654,7 +656,6 @@ namespace System.IO.Ports.Tests
 
                 Assert.Equal(2, result);
                 Assert.Equal(charXmitBuffer, actualChars);
-
             }
         }
 
@@ -676,29 +677,29 @@ namespace System.IO.Ports.Tests
 
         private void VerifyRead(char[] buffer, int offset, int count)
         {
-            VerifyRead(buffer, offset, count, new System.Text.ASCIIEncoding(), numRndBytesToRead, ReadDataFromEnum.NonBuffered);
+            VerifyRead(buffer, offset, count, new ASCIIEncoding(), numRndBytesToRead, ReadDataFromEnum.NonBuffered);
         }
 
 
         private void VerifyRead(char[] buffer, int offset, int count, int numberOfBytesToRead)
         {
-            VerifyRead(buffer, offset, count, new System.Text.ASCIIEncoding(), numberOfBytesToRead, ReadDataFromEnum.NonBuffered);
+            VerifyRead(buffer, offset, count, new ASCIIEncoding(), numberOfBytesToRead, ReadDataFromEnum.NonBuffered);
         }
 
 
         private void VerifyRead(char[] buffer, int offset, int count, int numberOfBytesToRead, ReadDataFromEnum readDataFrom)
         {
-            VerifyRead(buffer, offset, count, new System.Text.ASCIIEncoding(), numberOfBytesToRead, readDataFrom);
+            VerifyRead(buffer, offset, count, new ASCIIEncoding(), numberOfBytesToRead, readDataFrom);
         }
 
 
-        private void VerifyRead(char[] buffer, int offset, int count, System.Text.Encoding encoding)
+        private void VerifyRead(char[] buffer, int offset, int count, Encoding encoding)
         {
             VerifyRead(buffer, offset, count, encoding, numRndBytesToRead, ReadDataFromEnum.NonBuffered);
         }
 
 
-        private void VerifyRead(char[] buffer, int offset, int count, System.Text.Encoding encoding, int numberOfBytesToRead,
+        private void VerifyRead(char[] buffer, int offset, int count, Encoding encoding, int numberOfBytesToRead,
             ReadDataFromEnum readDataFrom)
         {
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
@@ -810,7 +811,7 @@ namespace System.IO.Ports.Tests
 
             //This is pretty lame but we will have to live with if for now becuase we can not 
             //gaurentee the number of bytes Write will add
-            System.Threading.Thread.Sleep((int)(((bytesToWrite.Length * 10.0) / com1.BaudRate) * 1000) + 250);
+            Thread.Sleep((int)(((bytesToWrite.Length * 10.0) / com1.BaudRate) * 1000) + 250);
 
             PerformReadOnCom1FromCom2(com1, com2, expectedChars, rcvBuffer, offset, count);
         }
@@ -902,7 +903,7 @@ namespace System.IO.Ports.Tests
             Assert.Equal(0, com1.BytesToRead);
         }
 
-        private void VerifyBytesFollowedByChars(System.Text.Encoding encoding)
+        private void VerifyBytesFollowedByChars(Encoding encoding)
         {
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
@@ -935,20 +936,20 @@ namespace System.IO.Ports.Tests
                 com2.Write(xmitCharBuffer, 0, xmitCharBuffer.Length);
                 com2.Write(xmitByteBuffer, 0, xmitByteBuffer.Length);
 
-                System.Threading.Thread.Sleep(
+                Thread.Sleep(
                     (int)
                     (((xmitByteBuffer.Length + com2.Encoding.GetByteCount(xmitCharBuffer) * 10.0) / com1.BaudRate) * 1000) +
                     500);
-                System.Threading.Thread.Sleep(500);
+                Thread.Sleep(500);
 
                 if (xmitCharBuffer.Length != (numRead = com1.Read(rcvCharBuffer, 0, rcvCharBuffer.Length)))
                 {
                     Fail("ERROR!!!: Expected to read {0} chars actually read {1}", xmitCharBuffer.Length, numRead);
                 }
 
-                if (encoding.EncodingName == System.Text.Encoding.UTF7.EncodingName)
+                if (encoding.EncodingName == Encoding.UTF7.EncodingName)
                 {
-//If UTF7Encoding is being used we we might leave a - in the stream
+                    //If UTF7Encoding is being used we we might leave a - in the stream
                     if (com1.BytesToRead == xmitByteBuffer.Length + 1)
                     {
                         int byteRead;
@@ -962,7 +963,7 @@ namespace System.IO.Ports.Tests
 
                 if (xmitByteBuffer.Length != (numRead = com1.Read(rcvByteBuffer, 0, rcvByteBuffer.Length)))
                 {
-                    Fail("ERROR!!!: Expected to read {0} bytes actually read {1}", xmitByteBuffer.Length,numRead);
+                    Fail("ERROR!!!: Expected to read {0} bytes actually read {1}", xmitByteBuffer.Length, numRead);
                 }
 
                 for (int i = 0; i < xmitByteBuffer.Length; i++)
@@ -1007,7 +1008,6 @@ namespace System.IO.Ports.Tests
                     Fail("ERROR!!!: Expected {0} in buffer at {1} actual {2}", (int)expectedBuffer[i], i, (int)actualBuffer[i]);
                 }
             }
-
         }
 
         private class ASyncRead
@@ -1018,8 +1018,8 @@ namespace System.IO.Ports.Tests
             private readonly int _count;
             private int _result;
 
-            private readonly System.Threading.AutoResetEvent _readCompletedEvent;
-            private readonly System.Threading.AutoResetEvent _readStartedEvent;
+            private readonly AutoResetEvent _readCompletedEvent;
+            private readonly AutoResetEvent _readStartedEvent;
 
             private Exception _exception;
 
@@ -1032,8 +1032,8 @@ namespace System.IO.Ports.Tests
 
                 _result = -1;
 
-                _readCompletedEvent = new System.Threading.AutoResetEvent(false);
-                _readStartedEvent = new System.Threading.AutoResetEvent(false);
+                _readCompletedEvent = new AutoResetEvent(false);
+                _readStartedEvent = new AutoResetEvent(false);
 
                 _exception = null;
             }
@@ -1055,9 +1055,9 @@ namespace System.IO.Ports.Tests
                 }
             }
 
-            public System.Threading.AutoResetEvent ReadStartedEvent => _readStartedEvent;
+            public AutoResetEvent ReadStartedEvent => _readStartedEvent;
 
-            public System.Threading.AutoResetEvent ReadCompletedEvent => _readCompletedEvent;
+            public AutoResetEvent ReadCompletedEvent => _readCompletedEvent;
 
             public int Result => _result;
 

--- a/src/System.IO.Ports/tests/SerialPort/Read_char_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_char_int_int.cs
@@ -331,8 +331,7 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(byteXmitBuffer, 0, byteXmitBuffer.Length);
 
-                while (com1.BytesToRead < byteXmitBuffer.Length)
-                    System.Threading.Thread.Sleep(50);
+                TCSupport.WaitForReadBufferToLoad(com1, byteXmitBuffer.Length);
 
                 //Read Every Byte except the last one. The last bye should be left in the last position of SerialPort's
                 //internal buffer. When we try to read this char as UTF32 the buffer should have to be resized so 
@@ -356,10 +355,7 @@ namespace System.IO.Ports.Tests
                 System.Text.Encoding.UTF32.GetChars(byteBuffer, 0, byteBuffer.Length, expectedChars, 1);
                 var charRcvBuffer = new char[(int)(expectedChars.Length * 1.5)];
 
-                while (com1.BytesToRead < 4 + numBytes)
-                {
-                    System.Threading.Thread.Sleep(50);
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, 4+numBytes);
 
                 if (expectedChars.Length != (numCharsRead = com1.Read(charRcvBuffer, 0, charRcvBuffer.Length)))
                 {
@@ -800,10 +796,7 @@ namespace System.IO.Ports.Tests
             com2.Write(bytesForSingleChar, 0, bytesForSingleChar.Length); // Write one byte at the begining because we are going to read this to buffer the rest of the data
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
 
-            while (com1.BytesToRead < bytesToWrite.Length)
-            {
-                System.Threading.Thread.Sleep(50);
-            }
+            TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length);
 
             com1.Read(new char[1], 0, 1); // This should put the rest of the bytes in SerialPorts own internal buffer
 

--- a/src/System.IO.Ports/tests/SerialPort/Read_char_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_char_int_int_Generic.cs
@@ -202,8 +202,6 @@ namespace System.IO.Ports.Tests
                 char[] expectedChars = new char[numRndBytesPairty];
                 char[] actualChars = new char[numRndBytesPairty + 1];
 
-                int waitTime;
-
                 /* 1 Additional character gets added to the input buffer when the parity error occurs on the last byte of a stream
                  We are verifying that besides this everything gets read in correctly. See NDP Whidbey: 24216 for more info on this */
                 Debug.WriteLine("Verifying default ParityReplace byte with a parity errro on the last byte");
@@ -230,13 +228,7 @@ namespace System.IO.Ports.Tests
                 com2.Open();
                 com2.Write(bytesToWrite, 0, bytesToWrite.Length);
 
-                waitTime = 0;
-
-                while (bytesToWrite.Length + 1 > com1.BytesToRead && waitTime < 500)
-                {
-                    System.Threading.Thread.Sleep(50);
-                    waitTime += 50;
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length + 1);
 
                 com1.Read(actualChars, 0, actualChars.Length);
 
@@ -414,15 +406,11 @@ namespace System.IO.Ports.Tests
             int totalBytesRead;
             int totalCharsRead;
             int bytesToRead;
-            int waitTime = 0;
 
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
             com1.ReadTimeout = 250;
-            while (com1.BytesToRead < bytesToWrite.Length && waitTime < 500)
-            {
-                System.Threading.Thread.Sleep(50);
-                waitTime += 50;
-            }
+
+            TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length);
 
             totalBytesRead = 0;
             totalCharsRead = 0;

--- a/src/System.IO.Ports/tests/SerialPort/Read_char_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_char_int_int_Generic.cs
@@ -4,6 +4,8 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -13,30 +15,30 @@ namespace System.IO.Ports.Tests
     {
         //Set bounds fore random timeout values.
         //If the min is to low read will not timeout accurately and the testcase will fail
-        public static readonly int minRandomTimeout = 250;
+        private const int minRandomTimeout = 250;
 
         //If the max is to large then the testcase will take forever to run
-        public static readonly int maxRandomTimeout = 2000;
+        private const int maxRandomTimeout = 2000;
 
         //If the percentage difference between the expected timeout and the actual timeout
         //found through Stopwatch is greater then 10% then the timeout value was not correctly
         //to the read method and the testcase fails.
-        public static readonly double maxPercentageDifference = .15;
+        private const double maxPercentageDifference = .15;
 
         //The number of random bytes to receive for parity testing
-        public static readonly int numRndBytesPairty = 8;
+        private const int numRndBytesPairty = 8;
 
         //The number of characters to read at a time for parity testing
-        public static readonly int numBytesReadPairty = 2;
+        private const int numBytesReadPairty = 2;
 
         //The number of random bytes to receive for BytesToRead testing
-        public static readonly int numRndBytesToRead = 16;
+        private const int numRndBytesToRead = 16;
 
         //When we test Read and do not care about actually reading anything we must still
         //create an byte array to pass into the method the following is the size of the 
         //byte array used in this situation
-        public static readonly int defaultCharArraySize = 1;
-        public static readonly int NUM_TRYS = 5;
+        private const int defaultCharArraySize = 1;
+        private const int NUM_TRYS = 5;
 
         #region Test Cases
 
@@ -103,11 +105,11 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 Random rndGen = new Random(-55);
-        
+
 
                 com.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 //		com.Encoding = new System.Text.UTF7Encoding();
-                com.Encoding = System.Text.Encoding.Unicode;
+                com.Encoding = Encoding.Unicode;
 
                 Debug.WriteLine("Verifying ReadTimeout={0} with successive call to read method and no data", com.ReadTimeout);
                 com.Open();
@@ -124,10 +126,10 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 Random rndGen = new Random(-55);
-                System.Threading.Thread t = new System.Threading.Thread(WriteToCom1);
+                Thread t = new Thread(WriteToCom1);
 
                 com1.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
-                com1.Encoding = new System.Text.UTF8Encoding();
+                com1.Encoding = new UTF8Encoding();
 
                 Debug.WriteLine("Verifying ReadTimeout={0} with successive call to read method and some data being received in the first call", com1.ReadTimeout);
                 com1.Open();
@@ -146,7 +148,7 @@ namespace System.IO.Ports.Tests
 
                 //Wait for the thread to finish
                 while (t.IsAlive)
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
 
                 //Make sure there is no bytes in the buffer so the next call to read will timeout
                 com1.DiscardInBuffer();
@@ -163,7 +165,7 @@ namespace System.IO.Ports.Tests
                 int sleepPeriod = rndGen.Next(minRandomTimeout, maxRandomTimeout / 2);
 
                 //Sleep some random period with of a maximum duration of half the largest possible timeout value for a read method on COM1
-                System.Threading.Thread.Sleep(sleepPeriod);
+                Thread.Sleep(sleepPeriod);
                 com2.Open();
                 com2.Write(xmitBuffer, 0, xmitBuffer.Length);
             }
@@ -288,7 +290,7 @@ namespace System.IO.Ports.Tests
             //Warm up read method
             Assert.Throws<TimeoutException>(() => com.Read(new char[defaultCharArraySize], 0, defaultCharArraySize));
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Highest;
+            Thread.CurrentThread.Priority = ThreadPriority.Highest;
             for (int i = 0; i < NUM_TRYS; i++)
             {
                 timer.Start();
@@ -301,7 +303,7 @@ namespace System.IO.Ports.Tests
                 timer.Reset();
             }
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Normal;
+            Thread.CurrentThread.Priority = ThreadPriority.Normal;
             actualTime /= NUM_TRYS;
             percentageDifference = Math.Abs((expectedTime - actualTime) / (double)expectedTime);
 
@@ -378,7 +380,7 @@ namespace System.IO.Ports.Tests
                 Random rndGen = new Random(-55);
                 byte[] bytesToWrite = new byte[numRndBytesToRead];
                 char[] expectedChars;
-                System.Text.ASCIIEncoding encoding = new System.Text.ASCIIEncoding();
+                ASCIIEncoding encoding = new ASCIIEncoding();
 
                 //Genrate random characters
                 for (int i = 0; i < bytesToWrite.Length; i++)

--- a/src/System.IO.Ports/tests/SerialPort/ReceivedBytesThreshold.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReceivedBytesThreshold.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -13,13 +14,13 @@ namespace System.IO.Ports.Tests
     public class ReceivedBytesThreshold_Property : PortsTest
     {
         //Maximum random value to use for ReceivedBytesThreshold
-        public static readonly int MAX_RND_THRESHOLD = 16;
+        private const int MAX_RND_THRESHOLD = 16;
 
         //Minimum random value to use for ReceivedBytesThreshold
-        public static readonly int MIN_RND_THRESHOLD = 2;
+        private const int MIN_RND_THRESHOLD = 2;
 
         //Maximum time to wait for all of the expected events to be firered
-        public static readonly int MAX_TIME_WAIT = 2000;
+        private const int MAX_TIME_WAIT = 2000;
 
         #region Test Cases
 
@@ -117,7 +118,7 @@ namespace System.IO.Ports.Tests
                     (int)Math.Ceiling(com1.ReceivedBytesThreshold / 2.0));
 
                 rcvEventHandler.WaitForEvent(SerialData.Chars, MAX_TIME_WAIT);
-            
+
                 com1.DiscardInBuffer();
 
                 serPortProp.VerifyPropertiesAndPrint(com1);
@@ -304,7 +305,7 @@ namespace System.IO.Ports.Tests
         private void VerifyExceptionAtOpen(SerialPort com, int receivedBytesThreshold, Type expectedException)
         {
             int origReceivedBytesThreshold = com.ReceivedBytesThreshold;
-        
+
             SerialPortProperties serPortProp = new SerialPortProperties();
 
             serPortProp.SetAllPropertiesToDefaults();
@@ -381,7 +382,7 @@ namespace System.IO.Ports.Tests
                 _com = com;
                 NumEventsHandled = 0;
             }
-        
+
             public void HandleEvent(object source, SerialDataReceivedEventArgs e)
             {
                 lock (this)
@@ -399,7 +400,7 @@ namespace System.IO.Ports.Tests
                         Debug.WriteLine(exp);
                         Debug.WriteLine(exp.StackTrace);
                     }
-                    System.Threading.Monitor.Pulse(this);
+                    Monitor.Pulse(this);
                 }
             }
 
@@ -445,7 +446,7 @@ namespace System.IO.Ports.Tests
                     sw.Start();
                     do
                     {
-                        System.Threading.Monitor.Wait(this, (int)(timeout - sw.ElapsedMilliseconds));
+                        Monitor.Wait(this, (int)(timeout - sw.ElapsedMilliseconds));
 
                         if (EventExists(eventType, numEvents))
                         {

--- a/src/System.IO.Ports/tests/SerialPort/ReceivedBytesThreshold.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReceivedBytesThreshold.cs
@@ -152,8 +152,7 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(new byte[receivedBytesThreshold], 0, receivedBytesThreshold);
 
-                while (com1.BytesToRead < receivedBytesThreshold)
-                    System.Threading.Thread.Sleep(100);
+                TCSupport.WaitForReadBufferToLoad(com1, receivedBytesThreshold);
 
                 if (0 != rcvEventHandler.NumEventsHandled)
                 {
@@ -200,8 +199,7 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(new byte[receivedBytesThreshold], 0, receivedBytesThreshold);
 
-                while (com1.BytesToRead < receivedBytesThreshold)
-                    System.Threading.Thread.Sleep(100);
+                TCSupport.WaitForReadBufferToLoad(com1, receivedBytesThreshold);
 
                 if (0 != rcvEventHandler.NumEventsHandled)
                 {
@@ -247,8 +245,7 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(new byte[receivedBytesThreshold], 0, receivedBytesThreshold);
 
-                while (com1.BytesToRead < receivedBytesThreshold)
-                    System.Threading.Thread.Sleep(100);
+                TCSupport.WaitForReadBufferToLoad(com1, receivedBytesThreshold);
 
                 if (0 != rcvEventHandler.NumEventsHandled)
                 {

--- a/src/System.IO.Ports/tests/SerialPort/ReceivedEvent.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReceivedEvent.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -11,17 +13,9 @@ namespace System.IO.Ports.Tests
 {
     public class ReceivedEvent : PortsTest
     {
-        //Maximum random value to use for ReceivedBytesThreshold
-        public static readonly int MAX_RND_THRESHOLD = 16;
-
-        //Minimum random value to use for ReceivedBytesThreshold
-        public static readonly int MIN_RND_THRESHOLD = 2;
-
         //Maximum time to wait for all of the expected events to be firered
-        public static readonly int MAX_TIME_WAIT = 500;
-        public static readonly int ITERATION_TIME_WAIT = 10;
-        public static readonly int NUM_TRYS = 5;
-
+        private const int MAX_TIME_WAIT = 500;
+        private const int NUM_TRYS = 5;
 
         #region Test Cases
         [ConditionalFact(nameof(HasNullModem))]
@@ -207,9 +201,9 @@ namespace System.IO.Ports.Tests
         #region Verification for Test Cases
         public class ReceivedEventHandler
         {
-            public System.Collections.ArrayList EventType;
-            public System.Collections.ArrayList BytesToRead;
-            public System.Collections.ArrayList Source;
+            public ArrayList EventType;
+            public ArrayList BytesToRead;
+            public ArrayList Source;
             public int NumEventsHandled;
             protected SerialPort com;
 
@@ -218,9 +212,9 @@ namespace System.IO.Ports.Tests
                 this.com = com;
                 NumEventsHandled = 0;
 
-                EventType = new System.Collections.ArrayList();
-                BytesToRead = new System.Collections.ArrayList();
-                Source = new System.Collections.ArrayList();
+                EventType = new ArrayList();
+                BytesToRead = new ArrayList();
+                Source = new ArrayList();
             }
 
             public void HandleEvent(object source, SerialDataReceivedEventArgs e)
@@ -235,7 +229,7 @@ namespace System.IO.Ports.Tests
 
                     NumEventsHandled++;
 
-                    System.Threading.Monitor.Pulse(this);
+                    Monitor.Pulse(this);
                 }
             }
 
@@ -262,10 +256,10 @@ namespace System.IO.Ports.Tests
 
                     while (maxMilliseconds > sw.ElapsedMilliseconds && NumEventsHandled < totalNumberOfEvents)
                     {
-                        System.Threading.Monitor.Wait(this, (int)(maxMilliseconds - sw.ElapsedMilliseconds));
+                        Monitor.Wait(this, (int)(maxMilliseconds - sw.ElapsedMilliseconds));
                     }
 
-                    Assert.Equal(totalNumberOfEvents,NumEventsHandled);
+                    Assert.Equal(totalNumberOfEvents, NumEventsHandled);
                 }
             }
 
@@ -279,7 +273,7 @@ namespace System.IO.Ports.Tests
 
                     while (maxMilliseconds > sw.ElapsedMilliseconds)
                     {
-                        System.Threading.Monitor.Wait(this, (int)(maxMilliseconds - sw.ElapsedMilliseconds));
+                        Monitor.Wait(this, (int)(maxMilliseconds - sw.ElapsedMilliseconds));
 
                         for (int i = 0; i < EventType.Count; i++)
                         {
@@ -365,7 +359,7 @@ namespace System.IO.Ports.Tests
                 }
             }
 
-            new public void HandleEvent(object source, SerialDataReceivedEventArgs e)
+            public new void HandleEvent(object source, SerialDataReceivedEventArgs e)
             {
                 base.HandleEvent(source, e);
 

--- a/src/System.IO.Ports/tests/SerialPort/RtsEnable.cs
+++ b/src/System.IO.Ports/tests/SerialPort/RtsEnable.cs
@@ -280,7 +280,7 @@ namespace System.IO.Ports.Tests
                 SerialPortProperties serPortProp = new SerialPortProperties();
                 Handshake originalHandshake;
                 bool expetectedRtsEnable;
-        
+
                 serPortProp.SetAllPropertiesToOpenDefaults();
                 serPortProp.SetProperty("PortName", TCSupport.LocalMachineSerialInfo.FirstAvailablePortName);
 

--- a/src/System.IO.Ports/tests/SerialPort/SerialPortRegressions.cs
+++ b/src/System.IO.Ports/tests/SerialPort/SerialPortRegressions.cs
@@ -17,7 +17,7 @@ namespace System.IO.Ports.Tests
             VerifyReadExisting(new UTF8Encoding());
         }
 
-        void VerifyReadExisting(Encoding encoding)
+        private void VerifyReadExisting(Encoding encoding)
         {
             // TODO - this test text did not come across from legacy properly.
             string text = "????????????4??????????????????,?11????????????????????????????????????????????????,????????????,??????????";
@@ -32,7 +32,7 @@ namespace System.IO.Ports.Tests
                 com1.Encoding = encoding;
                 com2.Encoding = encoding;
 
-                TCSupport.SetHighSpeed(com1,com2);
+                TCSupport.SetHighSpeed(com1, com2);
 
                 com1.Open();
 
@@ -40,7 +40,8 @@ namespace System.IO.Ports.Tests
                     //This is necessary since com1 and com2 might be the same port if we are using a loopback
                     com2.Open();
 
-                com2.DataReceived += (sender, args) => {
+                com2.DataReceived += (sender, args) =>
+                {
                     receivedstr += com2.ReadExisting();
                 };
 

--- a/src/System.IO.Ports/tests/SerialPort/StopBits.cs
+++ b/src/System.IO.Ports/tests/SerialPort/StopBits.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -13,19 +14,19 @@ namespace System.IO.Ports.Tests
     {
         //The default ammount of time the a transfer should take at any given baud rate and stop bits combination. 
         //The bytes sent should be adjusted to take this ammount of time to transfer at the specified baud rate and stop bits combination.
-        public static readonly int DEFAULT_TIME = 750;
+        private const int DEFAULT_TIME = 750;
 
         //If the percentage difference between the expected time to transfer with the specified stopBits
         //and the actual time found through Stopwatch is greater then 5% then the StopBits value was not correctly
         //set and the testcase fails.
-        public static readonly double MAX_ACCEPTABEL_PERCENTAGE_DIFFERENCE = .07;
+        private const double MAX_ACCEPTABEL_PERCENTAGE_DIFFERENCE = .07;
 
         //The default number of databits to use when testing StopBits
-        public static readonly int DEFAULT_DATABITS = 8;
-        public static readonly int NUM_TRYS = 5;
+        private const int DEFAULT_DATABITS = 8;
+        private const int NUM_TRYS = 5;
 
         private enum ThrowAt { Set, Open };
-    
+
         #region Test Cases
         [ConditionalFact(nameof(HasNullModem))]
         public void StopBits_Default()
@@ -307,7 +308,7 @@ namespace System.IO.Ports.Tests
                 com2.Open();
                 actualTime = 0;
 
-                System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Highest;
+                Thread.CurrentThread.Priority = ThreadPriority.Highest;
 
                 int initialNumBytes;
 
@@ -330,7 +331,7 @@ namespace System.IO.Ports.Tests
                     sw.Reset();
                 }
 
-                System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Normal;
+                Thread.CurrentThread.Priority = ThreadPriority.Normal;
                 actualTime /= NUM_TRYS;
                 expectedTime = ((xmitBytes.Length * (stopBits + com1.DataBits + 1)) / com1.BaudRate) * 1000;
                 percentageDifference = Math.Abs((expectedTime - actualTime) / expectedTime);

--- a/src/System.IO.Ports/tests/SerialPort/StopBits.cs
+++ b/src/System.IO.Ports/tests/SerialPort/StopBits.cs
@@ -320,7 +320,7 @@ namespace System.IO.Ports.Tests
                     { }
 
                     sw.Start();
-                    while (numBytesToSend > com2.BytesToRead) ; //Wait for all of the bytes to reach the input buffer of com2
+                    TCSupport.WaitForReadBufferToLoad(com2, numBytesToSend);
                     sw.Stop();
 
                     actualTime += sw.ElapsedMilliseconds;

--- a/src/System.IO.Ports/tests/SerialPort/Stress01.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Stress01.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO.Ports;
 using System.IO.PortsTests;
+using System.Text;
 using Legacy.Support;
 using Xunit;
 
@@ -18,7 +17,7 @@ namespace System.IO.Ports.Tests
         private const int TRANSMIT_BUFFER_SIZE = 4096;
         private const int MAX_BUFFER_SIZE = 4096;
 
-        private static readonly TimeSpan TestDuration = TCSupport.RunShortStressTests ? TimeSpan.FromSeconds(10) : TimeSpan.FromMinutes(20);
+        private static readonly TimeSpan s_testDuration = TCSupport.RunShortStressTests ? TimeSpan.FromSeconds(10) : TimeSpan.FromMinutes(20);
 
         [ConditionalFact(nameof(HasNullModem))]
         public void WriteChars()
@@ -32,8 +31,8 @@ namespace System.IO.Ports.Tests
                 Stopwatch sw = new Stopwatch();
                 Buffer<char> buffer = new Buffer<char>(MAX_BUFFER_SIZE);
 
-                com1.Encoding = System.Text.Encoding.Unicode;
-                com2.Encoding = System.Text.Encoding.Unicode;
+                com1.Encoding = Encoding.Unicode;
+                com2.Encoding = Encoding.Unicode;
 
                 com1.BaudRate = 115200;
                 com2.BaudRate = 115200;
@@ -44,7 +43,7 @@ namespace System.IO.Ports.Tests
                     com2.Open();
 
                 sw.Start();
-                while (sw.ElapsedMilliseconds < TestDuration.TotalMilliseconds)
+                while (sw.ElapsedMilliseconds < s_testDuration.TotalMilliseconds)
                 {
                     switch (random.Next(0, 2))
                     {
@@ -60,7 +59,7 @@ namespace System.IO.Ports.Tests
                                 com1.Write(xmitCharBuffer, 0, numberOfCharacters);
                                 buffer.Append(xmitCharBuffer, 0, numberOfCharacters);
 
-                                TCSupport.WaitForPredicate(delegate() { return com2.BytesToRead == expectedBytesToRead; },
+                                TCSupport.WaitForPredicate(delegate () { return com2.BytesToRead == expectedBytesToRead; },
                                     60000,
                                     "Err_29829haie Expected to received {0} bytes actual={1}", expectedBytesToRead,
                                     com2.BytesToRead);
@@ -103,8 +102,8 @@ namespace System.IO.Ports.Tests
 
     public class Buffer<T>
     {
-        private Queue<T> _queue;
-        private EqualityComparer<T> _comparer;
+        private readonly Queue<T> _queue;
+        private readonly EqualityComparer<T> _comparer;
 
         public Buffer()
         {

--- a/src/System.IO.Ports/tests/SerialPort/WriteBufferSize.cs
+++ b/src/System.IO.Ports/tests/SerialPort/WriteBufferSize.cs
@@ -257,8 +257,7 @@ namespace System.IO.Ports.Tests
 
                 com1.Write(xmitBytes, 0, xmitBytes.Length);
 
-                while (xmitBytes.Length > com2.BytesToRead)
-                    System.Threading.Thread.Sleep(50);
+                TCSupport.WaitForReadBufferToLoad(com2, xmitBytes.Length);
 
                 Debug.WriteLine("Verifying properties after changing WriteBufferSize");
                 serPortProp.VerifyPropertiesAndPrint(com1);

--- a/src/System.IO.Ports/tests/SerialPort/WriteBufferSize.cs
+++ b/src/System.IO.Ports/tests/SerialPort/WriteBufferSize.cs
@@ -11,13 +11,13 @@ namespace System.IO.Ports.Tests
 {
     public class WriteBufferSize_Property : PortsTest
     {
-        public static readonly int MAX_RANDMOM_BUFFER_SIZE = 1024 * 16;
-        public static readonly int LARGE_BUFFER_SIZE = 1024 * 128;
+        private const int MAX_RANDMOM_BUFFER_SIZE = 1024 * 16;
+        private const int LARGE_BUFFER_SIZE = 1024 * 128;
 
         #region Test Cases
 
         [ConditionalFact(nameof(HasOneSerialPort))]
-        void WriteBufferSize_Default()
+        private void WriteBufferSize_Default()
         {
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {

--- a/src/System.IO.Ports/tests/SerialPort/WriteLine.cs
+++ b/src/System.IO.Ports/tests/SerialPort/WriteLine.cs
@@ -4,6 +4,8 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -12,47 +14,47 @@ namespace System.IO.Ports.Tests
     public class WriteLine : PortsTest
     {
         //The string size used when verifying NewLine
-        public static readonly int NEWLINE_TESTING_STRING_SIZE = 4;
+        private const int NEWLINE_TESTING_STRING_SIZE = 4;
 
         //The string size used when veryifying encoding 
-        public static readonly int ENCODING_STRING_SIZE = 4;
+        private const int ENCODING_STRING_SIZE = 4;
 
         //The string size used for large string testing
-        public static readonly int LARGE_STRING_SIZE = 2048;
+        private const int LARGE_STRING_SIZE = 2048;
 
         //The default number of times the write method is called when verifying write
-        public static readonly int DEFAULT_NUM_WRITES = 3;
-        public static readonly string DEFAULT_NEW_LINE = "\n";
-        public static readonly int MIN_NUM_NEWLINE_CHARS = 1;
-        public static readonly int MAX_NUM_NEWLINE_CHARS = 5;
+        private const int DEFAULT_NUM_WRITES = 3;
+        private const string DEFAULT_NEW_LINE = "\n";
+        private const int MIN_NUM_NEWLINE_CHARS = 1;
+        private const int MAX_NUM_NEWLINE_CHARS = 5;
 
         #region Test Cases
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         private void ASCIIEncoding()
         {
             Debug.WriteLine("Verifying write method with ASCIIEncoding");
-            VerifyWrite(new System.Text.ASCIIEncoding(), ENCODING_STRING_SIZE, GenRandomNewLine(true));
+            VerifyWrite(new ASCIIEncoding(), ENCODING_STRING_SIZE, GenRandomNewLine(true));
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         private void UTF8Encoding()
         {
             Debug.WriteLine("Verifying write method with UTF8Encoding");
-            VerifyWrite(new System.Text.UTF8Encoding(), ENCODING_STRING_SIZE, GenRandomNewLine(false));
+            VerifyWrite(new UTF8Encoding(), ENCODING_STRING_SIZE, GenRandomNewLine(false));
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         private void UTF32Encoding()
         {
             Debug.WriteLine("Verifying write method with UTF32Encoding");
-            VerifyWrite(new System.Text.UTF32Encoding(), ENCODING_STRING_SIZE, GenRandomNewLine(false));
+            VerifyWrite(new UTF32Encoding(), ENCODING_STRING_SIZE, GenRandomNewLine(false));
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         private void UnicodeEncoding()
         {
             Debug.WriteLine("Verifying write method with UnicodeEncoding");
-            VerifyWrite(new System.Text.UnicodeEncoding(), ENCODING_STRING_SIZE, GenRandomNewLine(false));
+            VerifyWrite(new UnicodeEncoding(), ENCODING_STRING_SIZE, GenRandomNewLine(false));
         }
 
         [ConditionalFact(nameof(HasOneSerialPort))]
@@ -89,7 +91,7 @@ namespace System.IO.Ports.Tests
                 VerifyWriteLine(com1, com2, "");
             }
         }
-    
+
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         private void String_Null_Char()
         {
@@ -112,7 +114,7 @@ namespace System.IO.Ports.Tests
         private void LargeString()
         {
             Debug.WriteLine("Verifying write method with a large string size");
-            VerifyWrite(new System.Text.UnicodeEncoding(), LARGE_STRING_SIZE, DEFAULT_NEW_LINE, 1);
+            VerifyWrite(new UnicodeEncoding(), LARGE_STRING_SIZE, DEFAULT_NEW_LINE, 1);
         }
 
 
@@ -123,7 +125,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
             {
                 Random rndGen = new Random(-55);
-                System.Text.StringBuilder strBldrToWrite = TCSupport.GetRandomStringBuilder(NEWLINE_TESTING_STRING_SIZE,
+                StringBuilder strBldrToWrite = TCSupport.GetRandomStringBuilder(NEWLINE_TESTING_STRING_SIZE,
                     TCSupport.CharacterOptions.None);
 
                 string newLine = GenRandomNewLine(true);
@@ -150,7 +152,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
             {
                 Random rndGen = new Random(-55);
-                System.Text.StringBuilder strBldrToWrite = TCSupport.GetRandomStringBuilder(NEWLINE_TESTING_STRING_SIZE,
+                StringBuilder strBldrToWrite = TCSupport.GetRandomStringBuilder(NEWLINE_TESTING_STRING_SIZE,
                     TCSupport.CharacterOptions.None);
 
                 string newLine = "\r\n";
@@ -169,7 +171,7 @@ namespace System.IO.Ports.Tests
                 VerifyWriteLine(com1, com2, strBldrToWrite.ToString());
             }
         }
-    
+
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         private void StrContains_NewLine_null()
         {
@@ -177,7 +179,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
             {
                 Random rndGen = new Random(-55);
-                System.Text.StringBuilder strBldrToWrite = TCSupport.GetRandomStringBuilder(NEWLINE_TESTING_STRING_SIZE,
+                StringBuilder strBldrToWrite = TCSupport.GetRandomStringBuilder(NEWLINE_TESTING_STRING_SIZE,
                     TCSupport.CharacterOptions.None);
 
                 string newLine = "\0";
@@ -200,19 +202,19 @@ namespace System.IO.Ports.Tests
 
         #region Verification for Test Cases
 
-        private void VerifyWrite(System.Text.Encoding encoding, int strSize, string newLine)
+        private void VerifyWrite(Encoding encoding, int strSize, string newLine)
         {
             VerifyWrite(encoding, strSize, newLine, DEFAULT_NUM_WRITES);
         }
 
-        private void VerifyWrite(System.Text.Encoding encoding, int strSize, string newLine, int numWrites)
+        private void VerifyWrite(Encoding encoding, int strSize, string newLine, int numWrites)
         {
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
             {
-                string stringToWrite = TCSupport.GetRandomString(NEWLINE_TESTING_STRING_SIZE,TCSupport.CharacterOptions.None);
+                string stringToWrite = TCSupport.GetRandomString(NEWLINE_TESTING_STRING_SIZE, TCSupport.CharacterOptions.None);
 
-                TCSupport.SetHighSpeed(com1,com2);
+                TCSupport.SetHighSpeed(com1, com2);
 
                 com1.Encoding = encoding;
                 com1.Open();
@@ -239,7 +241,7 @@ namespace System.IO.Ports.Tests
             int index = 0;
             int numNewLineBytes;
             char[] newLineChars = com1.NewLine.ToCharArray();
-            System.Text.StringBuilder expectedStrBldr = new System.Text.StringBuilder();
+            StringBuilder expectedStrBldr = new StringBuilder();
             string expectedString;
 
             expectedBytes = com1.Encoding.GetBytes(stringToWrite.ToCharArray());
@@ -259,7 +261,7 @@ namespace System.IO.Ports.Tests
 
             com2.ReadTimeout = 500;
 
-            System.Threading.Thread.Sleep((int)(((expectedBytes.Length * 10.0) / com1.BaudRate) * 1000) + 250);
+            Thread.Sleep((int)(((expectedBytes.Length * 10.0) / com1.BaudRate) * 1000) + 250);
 
             while (true)
             {

--- a/src/System.IO.Ports/tests/SerialPort/WriteTimeout.cs
+++ b/src/System.IO.Ports/tests/SerialPort/WriteTimeout.cs
@@ -14,25 +14,25 @@ namespace System.IO.Ports.Tests
     public class WriteTimeout_Property : PortsTest
     {
         //The default number of chars to write with when testing timeout with Write(char[], int, int)
-        public static readonly int DEFAULT_WRITE_CHAR_ARRAY_SIZE = TCSupport.MinimumBlockingByteCount;
+        private static readonly int s_DEFAULT_WRITE_CHAR_ARRAY_SIZE = TCSupport.MinimumBlockingByteCount;
 
         //The default number of bytes to write with when testing timeout with Write(byte[], int, int)
-        public static readonly int DEFAULT_WRITE_BYTE_ARRAY_SIZE = TCSupport.MinimumBlockingByteCount;
+        private static readonly int s_DEFAULT_WRITE_BYTE_ARRAY_SIZE = TCSupport.MinimumBlockingByteCount;
 
         //The ammount of time to wait when expecting an infinite timeout
-        public static readonly int DEFAULT_WAIT_INFINITE_TIMEOUT = 250;
+        private const int DEFAULT_WAIT_INFINITE_TIMEOUT = 250;
 
         //The maximum acceptable time allowed when a write method should timeout immediately
-        public static readonly int MAX_ACCEPTABLE_ZERO_TIMEOUT = 100;
+        private const int MAX_ACCEPTABLE_ZERO_TIMEOUT = 100;
 
         //The maximum acceptable time allowed when a write method should timeout immediately when it is called for the first time
-        public static readonly int MAX_ACCEPTABLE_WARMUP_ZERO_TIMEOUT = 5000;
+        private const int MAX_ACCEPTABLE_WARMUP_ZERO_TIMEOUT = 5000;
 
         //The default string to write with when testing timeout with Write(str)
-        public static readonly string DEFAULT_STRING_TO_WRITE = new string('H', TCSupport.MinimumBlockingByteCount);
-        public static readonly int NUM_TRYS = 5;
+        private static readonly string s_DEFAULT_STRING_TO_WRITE = new string('H', TCSupport.MinimumBlockingByteCount);
+        private const int NUM_TRYS = 5;
 
-        public delegate void WriteMethodDelegate(SerialPort com);
+        private delegate void WriteMethodDelegate(SerialPort com);
 
         private enum ThrowAt { Set, Open };
 
@@ -174,7 +174,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             {
                 SerialPortProperties serPortProp = new SerialPortProperties();
-        
+
                 serPortProp.SetAllPropertiesToOpenDefaults();
                 serPortProp.SetProperty("PortName", TCSupport.LocalMachineSerialInfo.FirstAvailablePortName);
 
@@ -233,7 +233,7 @@ namespace System.IO.Ports.Tests
         {
             SerialPortProperties serPortProp = new SerialPortProperties();
             Stopwatch sw = new Stopwatch();
-        
+
             int actualTime = 0;
 
             serPortProp.SetAllPropertiesToOpenDefaults();
@@ -246,7 +246,7 @@ namespace System.IO.Ports.Tests
             serPortProp.SetProperty("ReadTimeout", 1000);
             com.ReadTimeout = 1000;
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Highest;
+            Thread.CurrentThread.Priority = ThreadPriority.Highest;
             sw.Start();
             writeMethod(com);
             sw.Stop();
@@ -267,7 +267,7 @@ namespace System.IO.Ports.Tests
                 sw.Reset();
             }
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Normal;
+            Thread.CurrentThread.Priority = ThreadPriority.Normal;
             actualTime /= NUM_TRYS;
 
             if (MAX_ACCEPTABLE_ZERO_TIMEOUT < actualTime)
@@ -295,7 +295,7 @@ namespace System.IO.Ports.Tests
         private void VerifyExceptionAtOpen(SerialPort com, int writeTimeout, ThrowAt throwAt, Type expectedException)
         {
             int origWriteTimeout = com.WriteTimeout;
-        
+
             SerialPortProperties serPortProp = new SerialPortProperties();
 
             serPortProp.SetAllPropertiesToDefaults();
@@ -369,7 +369,7 @@ namespace System.IO.Ports.Tests
         {
             try
             {
-                com.Write(new byte[DEFAULT_WRITE_BYTE_ARRAY_SIZE], 0, DEFAULT_WRITE_BYTE_ARRAY_SIZE);
+                com.Write(new byte[s_DEFAULT_WRITE_BYTE_ARRAY_SIZE], 0, s_DEFAULT_WRITE_BYTE_ARRAY_SIZE);
             }
             catch (TimeoutException)
             {
@@ -381,7 +381,7 @@ namespace System.IO.Ports.Tests
         {
             try
             {
-                com.Write(new char[DEFAULT_WRITE_CHAR_ARRAY_SIZE], 0, DEFAULT_WRITE_CHAR_ARRAY_SIZE);
+                com.Write(new char[s_DEFAULT_WRITE_CHAR_ARRAY_SIZE], 0, s_DEFAULT_WRITE_CHAR_ARRAY_SIZE);
             }
             catch (TimeoutException)
             {
@@ -393,7 +393,7 @@ namespace System.IO.Ports.Tests
         {
             try
             {
-                com.Write(DEFAULT_STRING_TO_WRITE);
+                com.Write(s_DEFAULT_STRING_TO_WRITE);
             }
             catch (TimeoutException)
             {
@@ -405,7 +405,7 @@ namespace System.IO.Ports.Tests
         {
             try
             {
-                com.WriteLine(DEFAULT_STRING_TO_WRITE);
+                com.WriteLine(s_DEFAULT_STRING_TO_WRITE);
             }
             catch (TimeoutException)
             {

--- a/src/System.IO.Ports/tests/SerialPort/Write_byte_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Write_byte_int_int.cs
@@ -4,6 +4,8 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -11,27 +13,24 @@ namespace System.IO.Ports.Tests
 {
     public class Write_byte_int_int : PortsTest
     {
-        //The string size used when veryifying encoding 
-        public static readonly int ENCODING_BUFFER_SIZE = 4;
-
         //The string size used for large byte array testing
-        public static readonly int LARGE_BUFFER_SIZE = 2048;
+        private const int LARGE_BUFFER_SIZE = 2048;
 
         //When we test Write and do not care about actually writing anything we must still
         //create an byte array to pass into the method the following is the size of the 
         //byte array used in this situation
-        public static readonly int DEFAULT_BUFFER_SIZE = 1;
-        public static readonly int DEFAULT_BUFFER_OFFSET = 0;
-        public static readonly int DEFAULT_BUFFER_COUNT = 1;
+        private const int DEFAULT_BUFFER_SIZE = 1;
+        private const int DEFAULT_BUFFER_OFFSET = 0;
+        private const int DEFAULT_BUFFER_COUNT = 1;
 
         //The maximum buffer size when a exception occurs
-        public static readonly int MAX_BUFFER_SIZE_FOR_EXCEPTION = 255;
+        private const int MAX_BUFFER_SIZE_FOR_EXCEPTION = 255;
 
         //The maximum buffer size when a exception is not expected
-        public static readonly int MAX_BUFFER_SIZE = 8;
+        private const int MAX_BUFFER_SIZE = 8;
 
         //The default number of times the write method is called when verifying write
-        public static readonly int DEFAULT_NUM_WRITES = 3;
+        private const int DEFAULT_NUM_WRITES = 3;
 
         #region Test Cases
 
@@ -183,7 +182,7 @@ namespace System.IO.Ports.Tests
             int offset = rndGen.Next(0, bufferLength - 1);
             int count = rndGen.Next(1, bufferLength - offset);
 
-            VerifyWrite(new byte[bufferLength], offset, count, new System.Text.ASCIIEncoding());
+            VerifyWrite(new byte[bufferLength], offset, count, new ASCIIEncoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
@@ -194,7 +193,7 @@ namespace System.IO.Ports.Tests
             int offset = rndGen.Next(0, bufferLength - 1);
             int count = rndGen.Next(1, bufferLength - offset);
 
-            VerifyWrite(new byte[bufferLength], offset, count, new System.Text.UTF8Encoding());
+            VerifyWrite(new byte[bufferLength], offset, count, new UTF8Encoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
@@ -205,7 +204,7 @@ namespace System.IO.Ports.Tests
             int offset = rndGen.Next(0, bufferLength - 1);
             int count = rndGen.Next(1, bufferLength - offset);
 
-            VerifyWrite(new byte[bufferLength], offset, count, new System.Text.UTF32Encoding());
+            VerifyWrite(new byte[bufferLength], offset, count, new UTF32Encoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
@@ -216,7 +215,7 @@ namespace System.IO.Ports.Tests
             int offset = rndGen.Next(0, bufferLength - 1);
             int count = rndGen.Next(1, bufferLength - offset);
 
-            VerifyWrite(new byte[bufferLength], offset, count, new System.Text.UnicodeEncoding());
+            VerifyWrite(new byte[bufferLength], offset, count, new UnicodeEncoding());
         }
 
 
@@ -259,28 +258,27 @@ namespace System.IO.Ports.Tests
 
         private void VerifyWrite(byte[] buffer, int offset, int count)
         {
-            VerifyWrite(buffer, offset, count, new System.Text.ASCIIEncoding());
+            VerifyWrite(buffer, offset, count, new ASCIIEncoding());
         }
 
 
         private void VerifyWrite(byte[] buffer, int offset, int count, int numWrites)
         {
-            VerifyWrite(buffer, offset, count, new System.Text.ASCIIEncoding(), numWrites);
+            VerifyWrite(buffer, offset, count, new ASCIIEncoding(), numWrites);
         }
 
 
-        private void VerifyWrite(byte[] buffer, int offset, int count, System.Text.Encoding encoding)
+        private void VerifyWrite(byte[] buffer, int offset, int count, Encoding encoding)
         {
             VerifyWrite(buffer, offset, count, encoding, DEFAULT_NUM_WRITES);
         }
 
 
-        private void VerifyWrite(byte[] buffer, int offset, int count, System.Text.Encoding encoding, int numWrites)
+        private void VerifyWrite(byte[] buffer, int offset, int count, Encoding encoding, int numWrites)
         {
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
             {
-
                 Random rndGen = new Random(-55);
 
                 Debug.WriteLine("Verifying write method buffer.Lenght={0}, offset={1}, count={2}, endocing={3}",
@@ -330,7 +328,7 @@ namespace System.IO.Ports.Tests
             }
 
             com2.ReadTimeout = 500;
-            System.Threading.Thread.Sleep((int)(((expectedBytes.Length * numWrites * 10.0) / com1.BaudRate) * 1000) + 250);
+            Thread.Sleep((int)(((expectedBytes.Length * numWrites * 10.0) / com1.BaudRate) * 1000) + 250);
 
             //Make sure buffer was not altered during the write call
             for (int i = 0; i < buffer.Length; i++)

--- a/src/System.IO.Ports/tests/SerialPort/Write_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Write_byte_int_int_Generic.cs
@@ -204,18 +204,8 @@ namespace System.IO.Ports.Tests
                     waitTime += 50;
                 }
 
-                waitTime = 0;
-                while (BYTE_SIZE_BYTES_TO_WRITE > com.BytesToWrite && waitTime < 500)
-                {
-                    System.Threading.Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                if (BYTE_SIZE_BYTES_TO_WRITE != com.BytesToWrite)
-                {
-                    Fail("ERROR!!! Expcted BytesToWrite={0} actual {1} after first write", BYTE_SIZE_BYTES_TO_WRITE, com.BytesToWrite);
-                }
-
+                TCSupport.WaitForExactWriteBufferLoad(com, BYTE_SIZE_BYTES_TO_WRITE);
+                
                 //Wait for write method to timeout
                 while (t.IsAlive)
                     System.Threading.Thread.Sleep(100);
@@ -249,17 +239,7 @@ namespace System.IO.Ports.Tests
                     waitTime += 50;
                 }
 
-                waitTime = 0;
-                while (BYTE_SIZE_BYTES_TO_WRITE > com.BytesToWrite && waitTime < 500)
-                {
-                    System.Threading.Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                if (BYTE_SIZE_BYTES_TO_WRITE != com.BytesToWrite)
-                {
-                    Fail("ERROR!!! Expcted BytesToWrite={0} actual {1} after first write", BYTE_SIZE_BYTES_TO_WRITE, com.BytesToWrite);
-                }
+                TCSupport.WaitForExactWriteBufferLoad(com, BYTE_SIZE_BYTES_TO_WRITE);
 
                 //Write a random byte[] asynchronously so we can verify some things while the write call is blocking
                 t2.Start();
@@ -270,17 +250,7 @@ namespace System.IO.Ports.Tests
                     waitTime += 50;
                 }
 
-                waitTime = 0;
-                while (BYTE_SIZE_BYTES_TO_WRITE * 2 > com.BytesToWrite && waitTime < 500)
-                {
-                    System.Threading.Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                if (BYTE_SIZE_BYTES_TO_WRITE * 2 != com.BytesToWrite)
-                {
-                    Fail("ERROR!!! Expcted BytesToWrite={0} actual {1} after second write", BYTE_SIZE_BYTES_TO_WRITE * 2, com.BytesToWrite);
-                }
+                TCSupport.WaitForExactWriteBufferLoad(com, BYTE_SIZE_BYTES_TO_WRITE * 2);
 
                 //Wait for both write methods to timeout
                 while (t1.IsAlive || t2.IsAlive)
@@ -500,17 +470,8 @@ namespace System.IO.Ports.Tests
                 }
 
                 waitTime = 0;
-                while (BYTE_SIZE_HANDSHAKE > com1.BytesToWrite && waitTime < 500)
-                {
-                    System.Threading.Thread.Sleep(50);
-                    waitTime += 50;
-                }
 
-                //Verify that the correct number of bytes are in the buffer
-                if (BYTE_SIZE_HANDSHAKE != com1.BytesToWrite)
-                {
-                    Fail("ERROR!!! Expcted BytesToWrite={0} actual {1}", BYTE_SIZE_HANDSHAKE, com1.BytesToWrite);
-                }
+                TCSupport.WaitForExactWriteBufferLoad(com1, BYTE_SIZE_HANDSHAKE);
 
                 //Verify that CtsHolding is false if the RequestToSend or RequestToSendXOnXOff handshake method is used
                 if ((Handshake.RequestToSend == handshake || Handshake.RequestToSendXOnXOff == handshake) && com1.CtsHolding)

--- a/src/System.IO.Ports/tests/SerialPort/Write_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Write_byte_int_int_Generic.cs
@@ -4,8 +4,11 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
+using ThreadState = System.Threading.ThreadState;
 
 namespace System.IO.Ports.Tests
 {
@@ -13,28 +16,28 @@ namespace System.IO.Ports.Tests
     {
         //Set bounds fore random timeout values.
         //If the min is to low write will not timeout accurately and the testcase will fail
-        public static int minRandomTimeout = 250;
+        private const int minRandomTimeout = 250;
 
         //If the max is to large then the testcase will take forever to run
-        public static int maxRandomTimeout = 2000;
+        private const int maxRandomTimeout = 2000;
 
         //If the percentage difference between the expected timeout and the actual timeout
         //found through Stopwatch is greater then 10% then the timeout value was not correctly
         //to the write method and the testcase fails.
-        public static double maxPercentageDifference = .15;
+        private const double maxPercentageDifference = .15;
 
         //The byte size used when veryifying exceptions that write will throw 
-        public static readonly int BYTE_SIZE_EXCEPTION = 4;
+        private const int BYTE_SIZE_EXCEPTION = 4;
 
         //The byte size used when veryifying timeout 
-        public static readonly int BYTE_SIZE_TIMEOUT = 4;
+        private const int BYTE_SIZE_TIMEOUT = 4;
 
         //The byte size used when veryifying BytesToWrite 
-        public static readonly int BYTE_SIZE_BYTES_TO_WRITE = 4;
+        private const int BYTE_SIZE_BYTES_TO_WRITE = 4;
 
         //The bytes size used when veryifying Handshake 
-        public static readonly int BYTE_SIZE_HANDSHAKE = 8;
-        public static readonly int NUM_TRYS = 5;
+        private const int BYTE_SIZE_HANDSHAKE = 8;
+        private const int NUM_TRYS = 5;
 
         #region Test Cases
 
@@ -97,7 +100,7 @@ namespace System.IO.Ports.Tests
                 com2.Open();
 
                 com2.Write(XOffBuffer, 0, 1);
-                System.Threading.Thread.Sleep(250);
+                Thread.Sleep(250);
                 com2.Close();
 
                 VerifyTimeout(com1);
@@ -114,7 +117,7 @@ namespace System.IO.Ports.Tests
 
                 com.WriteTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com.Handshake = Handshake.RequestToSendXOnXOff;
-                com.Encoding = System.Text.Encoding.Unicode;
+                com.Encoding = Encoding.Unicode;
 
                 Debug.WriteLine("Verifying WriteTimeout={0} with successive call to write method", com.WriteTimeout);
                 com.Open();
@@ -138,13 +141,13 @@ namespace System.IO.Ports.Tests
             {
                 Random rndGen = new Random(-55);
                 AsyncEnableRts asyncEnableRts = new AsyncEnableRts();
-                System.Threading.Thread t = new System.Threading.Thread(asyncEnableRts.EnableRTS);
-        
+                Thread t = new Thread(asyncEnableRts.EnableRTS);
+
                 int waitTime;
 
                 com1.WriteTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com1.Handshake = Handshake.RequestToSend;
-                com1.Encoding = new System.Text.UTF8Encoding();
+                com1.Encoding = new UTF8Encoding();
 
                 Debug.WriteLine("Verifying WriteTimeout={0} with successive call to write method with the write succeeding sometime before its timeout", com1.WriteTimeout);
                 com1.Open();
@@ -154,10 +157,10 @@ namespace System.IO.Ports.Tests
                 t.Start();
                 waitTime = 0;
 
-                while (t.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 {
                     //Wait for the thread to start
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
                     waitTime += 50;
                 }
 
@@ -168,11 +171,11 @@ namespace System.IO.Ports.Tests
                 catch (TimeoutException)
                 {
                 }
-         
+
                 asyncEnableRts.Stop();
 
                 while (t.IsAlive)
-                    System.Threading.Thread.Sleep(100);
+                    Thread.Sleep(100);
 
                 VerifyTimeout(com1);
             }
@@ -184,8 +187,8 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 AsyncWriteRndByteArray asyncWriteRndByteArray = new AsyncWriteRndByteArray(com, BYTE_SIZE_BYTES_TO_WRITE);
-                System.Threading.Thread t = new System.Threading.Thread(asyncWriteRndByteArray.WriteRndByteArray);
-        
+                Thread t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
+
                 int waitTime;
 
                 Debug.WriteLine("Verifying BytesToWrite with one call to Write");
@@ -198,17 +201,17 @@ namespace System.IO.Ports.Tests
                 t.Start();
                 waitTime = 0;
 
-                while (t.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 { //Wait for the thread to start
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
                     waitTime += 50;
                 }
 
                 TCSupport.WaitForExactWriteBufferLoad(com, BYTE_SIZE_BYTES_TO_WRITE);
-                
+
                 //Wait for write method to timeout
                 while (t.IsAlive)
-                    System.Threading.Thread.Sleep(100);
+                    Thread.Sleep(100);
             }
         }
 
@@ -219,9 +222,9 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 AsyncWriteRndByteArray asyncWriteRndByteArray = new AsyncWriteRndByteArray(com, BYTE_SIZE_BYTES_TO_WRITE);
-                System.Threading.Thread t1 = new System.Threading.Thread(asyncWriteRndByteArray.WriteRndByteArray);
-                System.Threading.Thread t2 = new System.Threading.Thread(asyncWriteRndByteArray.WriteRndByteArray);
-        
+                Thread t1 = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
+                Thread t2 = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
+
                 int waitTime;
 
                 Debug.WriteLine("Verifying BytesToWrite with successive calls to Write");
@@ -233,9 +236,9 @@ namespace System.IO.Ports.Tests
                 t1.Start();
                 waitTime = 0;
 
-                while (t1.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t1.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 { //Wait for the thread to start
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
                     waitTime += 50;
                 }
 
@@ -244,9 +247,9 @@ namespace System.IO.Ports.Tests
                 //Write a random byte[] asynchronously so we can verify some things while the write call is blocking
                 t2.Start();
                 waitTime = 0;
-                while (t2.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t2.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 { //Wait for the thread to start
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
                     waitTime += 50;
                 }
 
@@ -254,7 +257,7 @@ namespace System.IO.Ports.Tests
 
                 //Wait for both write methods to timeout
                 while (t1.IsAlive || t2.IsAlive)
-                    System.Threading.Thread.Sleep(100);
+                    Thread.Sleep(100);
             }
         }
 
@@ -264,8 +267,8 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 AsyncWriteRndByteArray asyncWriteRndByteArray = new AsyncWriteRndByteArray(com, BYTE_SIZE_HANDSHAKE);
-                System.Threading.Thread t = new System.Threading.Thread(asyncWriteRndByteArray.WriteRndByteArray);
-        
+                Thread t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
+
                 int waitTime;
 
                 //Write a random byte[] asynchronously so we can verify some things while the write call is blocking
@@ -275,15 +278,15 @@ namespace System.IO.Ports.Tests
                 t.Start();
                 waitTime = 0;
 
-                while (t.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 { //Wait for the thread to start
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
                     waitTime += 50;
                 }
 
                 //Wait for write method to timeout
                 while (t.IsAlive)
-                    System.Threading.Thread.Sleep(100);
+                    Thread.Sleep(100);
 
                 if (0 != com.BytesToWrite)
                 {
@@ -324,13 +327,13 @@ namespace System.IO.Ports.Tests
                         int sleepPeriod = rndGen.Next(minRandomTimeout, maxRandomTimeout / 2);
 
                         //Sleep some random period with of a maximum duration of half the largest possible timeout value for a write method on COM1
-                        System.Threading.Thread.Sleep(sleepPeriod);
+                        Thread.Sleep(sleepPeriod);
 
                         com2.Open();
                         com2.RtsEnable = true;
 
                         while (!_stop)
-                            System.Threading.Monitor.Wait(this);
+                            Monitor.Wait(this);
 
                         com2.RtsEnable = false;
                     }
@@ -343,12 +346,12 @@ namespace System.IO.Ports.Tests
                 lock (this)
                 {
                     _stop = true;
-                    System.Threading.Monitor.Pulse(this);
+                    Monitor.Pulse(this);
                 }
             }
         }
 
-        class AsyncWriteRndByteArray
+        private class AsyncWriteRndByteArray
         {
             private readonly SerialPort _com;
             private readonly int _byteLength;
@@ -399,7 +402,7 @@ namespace System.IO.Ports.Tests
             }
             catch (TimeoutException) { }
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Highest;
+            Thread.CurrentThread.Priority = ThreadPriority.Highest;
 
             for (int i = 0; i < NUM_TRYS; i++)
             {
@@ -415,7 +418,7 @@ namespace System.IO.Ports.Tests
                 timer.Reset();
             }
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Normal;
+            Thread.CurrentThread.Priority = ThreadPriority.Normal;
             actualTime /= NUM_TRYS;
             percentageDifference = Math.Abs((expectedTime - actualTime) / (double)expectedTime);
 
@@ -432,7 +435,7 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 AsyncWriteRndByteArray asyncWriteRndByteArray = new AsyncWriteRndByteArray(com1, BYTE_SIZE_HANDSHAKE);
-                System.Threading.Thread t = new System.Threading.Thread(asyncWriteRndByteArray.WriteRndByteArray);
+                Thread t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
 
                 byte[] XOffBuffer = new byte[1];
                 byte[] XOnBuffer = new byte[1];
@@ -456,16 +459,16 @@ namespace System.IO.Ports.Tests
                 if (Handshake.XOnXOff == handshake || Handshake.RequestToSendXOnXOff == handshake)
                 {
                     com2.Write(XOffBuffer, 0, 1);
-                    System.Threading.Thread.Sleep(250);
+                    Thread.Sleep(250);
                 }
 
                 //Write a random byte asynchronously so we can verify some things while the write call is blocking
                 t.Start();
                 waitTime = 0;
-                while (t.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 {
                     //Wait for the thread to start
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
                     waitTime += 50;
                 }
 
@@ -492,7 +495,7 @@ namespace System.IO.Ports.Tests
 
                 //Wait till write finishes
                 while (t.IsAlive)
-                    System.Threading.Thread.Sleep(100);
+                    Thread.Sleep(100);
 
                 Assert.Equal(0, com1.BytesToWrite);
 

--- a/src/System.IO.Ports/tests/SerialPort/Write_char_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Write_char_int_int.cs
@@ -4,6 +4,8 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -11,27 +13,24 @@ namespace System.IO.Ports.Tests
 {
     public class Write_char_int_int : PortsTest
     {
-        //The string size used when veryifying encoding 
-        public static readonly int ENCODING_BUFFER_SIZE = 4;
-
         //The string size used for large char array testing
-        public static readonly int LARGE_BUFFER_SIZE = 2048;
+        private const int LARGE_BUFFER_SIZE = 2048;
 
         //When we test Write and do not care about actually writing anything we must still
         //create an cahr array to pass into the method the following is the size of the 
         //char array used in this situation
-        public static readonly int DEFAULT_BUFFER_SIZE = 1;
-        public static readonly int DEFAULT_CHAR_OFFSET = 0;
-        public static readonly int DEFAULT_CHAR_COUNT = 1;
+        private const int DEFAULT_BUFFER_SIZE = 1;
+        private const int DEFAULT_CHAR_OFFSET = 0;
+        private const int DEFAULT_CHAR_COUNT = 1;
 
         //The maximum buffer size when a exception occurs
-        public static readonly int MAX_BUFFER_SIZE_FOR_EXCEPTION = 255;
+        private const int MAX_BUFFER_SIZE_FOR_EXCEPTION = 255;
 
         //The maximum buffer size when a exception is not expected
-        public static readonly int MAX_BUFFER_SIZE = 8;
+        private const int MAX_BUFFER_SIZE = 8;
 
         //The default number of times the write method is called when verifying write
-        public static readonly int DEFAULT_NUM_WRITES = 3;
+        private const int DEFAULT_NUM_WRITES = 3;
 
         #region Test Cases
 
@@ -137,10 +136,10 @@ namespace System.IO.Ports.Tests
             int bufferLength = rndGen.Next(1, MAX_BUFFER_SIZE);
             int offset = rndGen.Next(0, bufferLength - 1);
             int count = bufferLength - offset;
-        
+
             VerifyWrite(new char[bufferLength], offset, count);
         }
-    
+
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void Offset_EQ_Length_Minus_1()
         {
@@ -148,10 +147,10 @@ namespace System.IO.Ports.Tests
             int bufferLength = rndGen.Next(1, MAX_BUFFER_SIZE);
             int offset = bufferLength - 1;
             int count = 1;
-    
+
             VerifyWrite(new char[bufferLength], offset, count);
         }
-    
+
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void Count_EQ_Length()
         {
@@ -159,17 +158,17 @@ namespace System.IO.Ports.Tests
             int bufferLength = rndGen.Next(1, MAX_BUFFER_SIZE);
             int offset = 0;
             int count = bufferLength;
-        
+
             VerifyWrite(new char[bufferLength], offset, count);
         }
-    
+
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void Count_EQ_Zero()
         {
             int bufferLength = 0;
             int offset = 0;
             int count = bufferLength;
-        
+
             VerifyWrite(new char[bufferLength], offset, count);
         }
 
@@ -181,7 +180,7 @@ namespace System.IO.Ports.Tests
             int offset = rndGen.Next(0, bufferLength - 1);
             int count = rndGen.Next(1, bufferLength - offset);
 
-            VerifyWrite(new char[bufferLength], offset, count, new System.Text.ASCIIEncoding());
+            VerifyWrite(new char[bufferLength], offset, count, new ASCIIEncoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
@@ -192,7 +191,7 @@ namespace System.IO.Ports.Tests
             int offset = rndGen.Next(0, bufferLength - 1);
             int count = rndGen.Next(1, bufferLength - offset);
 
-            VerifyWrite(new char[bufferLength], offset, count, new System.Text.UTF8Encoding());
+            VerifyWrite(new char[bufferLength], offset, count, new UTF8Encoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
@@ -203,7 +202,7 @@ namespace System.IO.Ports.Tests
             int offset = rndGen.Next(0, bufferLength - 1);
             int count = rndGen.Next(1, bufferLength - offset);
 
-            VerifyWrite(new char[bufferLength], offset, count, new System.Text.UTF32Encoding());
+            VerifyWrite(new char[bufferLength], offset, count, new UTF32Encoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
@@ -214,7 +213,7 @@ namespace System.IO.Ports.Tests
             int offset = rndGen.Next(0, bufferLength - 1);
             int count = rndGen.Next(1, bufferLength - offset);
 
-            VerifyWrite(new char[bufferLength], offset, count, new System.Text.UnicodeEncoding());
+            VerifyWrite(new char[bufferLength], offset, count, new UnicodeEncoding());
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
@@ -259,20 +258,20 @@ namespace System.IO.Ports.Tests
 
         private void VerifyWrite(char[] buffer, int offset, int count)
         {
-            VerifyWrite(buffer, offset, count, new System.Text.ASCIIEncoding());
+            VerifyWrite(buffer, offset, count, new ASCIIEncoding());
         }
 
         private void VerifyWrite(char[] buffer, int offset, int count, int numWrites)
         {
-            VerifyWrite(buffer, offset, count, new System.Text.ASCIIEncoding(), numWrites);
+            VerifyWrite(buffer, offset, count, new ASCIIEncoding(), numWrites);
         }
 
-        private void VerifyWrite(char[] buffer, int offset, int count, System.Text.Encoding encoding)
+        private void VerifyWrite(char[] buffer, int offset, int count, Encoding encoding)
         {
             VerifyWrite(buffer, offset, count, encoding, DEFAULT_NUM_WRITES);
         }
 
-        private void VerifyWrite(char[] buffer, int offset, int count, System.Text.Encoding encoding, int numWrites)
+        private void VerifyWrite(char[] buffer, int offset, int count, Encoding encoding, int numWrites)
         {
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
@@ -316,7 +315,7 @@ namespace System.IO.Ports.Tests
             }
 
             com2.ReadTimeout = 500;
-            System.Threading.Thread.Sleep((int)(((expectedBytes.Length * numWrites * 10.0) / com1.BaudRate) * 1000) + 250);
+            Thread.Sleep((int)(((expectedBytes.Length * numWrites * 10.0) / com1.BaudRate) * 1000) + 250);
 
             Assert.Equal(oldBuffer, buffer);
 

--- a/src/System.IO.Ports/tests/SerialPort/Write_char_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Write_char_int_int_Generic.cs
@@ -209,18 +209,7 @@ namespace System.IO.Ports.Tests
                     waitTime += 50;
                 }
 
-                waitTime = 0;
-
-                while (CHAR_SIZE_BYTES_TO_WRITE > com.BytesToWrite && waitTime < 500)
-                {
-                    System.Threading.Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                if (CHAR_SIZE_BYTES_TO_WRITE != com.BytesToWrite)
-                {
-                    Fail("ERROR!!! Expcted BytesToWrite={0} actual {1} after first write", CHAR_SIZE_BYTES_TO_WRITE, com.BytesToWrite);
-                }
+                TCSupport.WaitForExactWriteBufferLoad(com, CHAR_SIZE_BYTES_TO_WRITE);
 
                 //Wait for write method to timeout
                 while (t.IsAlive)
@@ -255,18 +244,7 @@ namespace System.IO.Ports.Tests
                     waitTime += 50;
                 }
 
-                waitTime = 0;
-
-                while (CHAR_SIZE_BYTES_TO_WRITE > com.BytesToWrite && waitTime < 500)
-                {
-                    System.Threading.Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                if (CHAR_SIZE_BYTES_TO_WRITE != com.BytesToWrite)
-                {
-                    Fail("ERROR!!! Expcted BytesToWrite={0} actual {1} after first write", CHAR_SIZE_BYTES_TO_WRITE, com.BytesToWrite);
-                }
+                TCSupport.WaitForExactWriteBufferLoad(com, CHAR_SIZE_BYTES_TO_WRITE);
 
                 //Write a random char[] asynchronously so we can verify some things while the write call is blocking
                 t2.Start();
@@ -278,18 +256,7 @@ namespace System.IO.Ports.Tests
                     waitTime += 50;
                 }
 
-                waitTime = 0;
-
-                while (CHAR_SIZE_BYTES_TO_WRITE * 2 > com.BytesToWrite && waitTime < 500)
-                {
-                    System.Threading.Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                if (CHAR_SIZE_BYTES_TO_WRITE * 2 != com.BytesToWrite)
-                {
-                    Fail("ERROR!!! Expcted BytesToWrite={0} actual {1} after second write", CHAR_SIZE_BYTES_TO_WRITE * 2, com.BytesToWrite);
-                }
+                TCSupport.WaitForExactWriteBufferLoad(com, CHAR_SIZE_BYTES_TO_WRITE * 2);
 
                 //Wait for both write methods to timeout
                 while (t1.IsAlive || t2.IsAlive)
@@ -508,19 +475,7 @@ namespace System.IO.Ports.Tests
                     waitTime += 50;
                 }
 
-                waitTime = 0;
-
-                while (CHAR_SIZE_HANDSHAKE > com1.BytesToWrite && waitTime < 500)
-                {
-                    System.Threading.Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                //Verify that the correct number of bytes are in the buffer
-                if (CHAR_SIZE_HANDSHAKE != com1.BytesToWrite)
-                {
-                    Fail("ERROR!!! Expcted BytesToWrite={0} actual {1}", CHAR_SIZE_HANDSHAKE, com1.BytesToWrite);
-                }
+                TCSupport.WaitForExactWriteBufferLoad(com1, CHAR_SIZE_HANDSHAKE);
 
                 //Verify that CtsHolding is false if the RequestToSend or RequestToSendXOnXOff handshake method is used
                 if ((Handshake.RequestToSend == handshake || Handshake.RequestToSendXOnXOff == handshake) && com1.CtsHolding)

--- a/src/System.IO.Ports/tests/SerialPort/Write_char_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Write_char_int_int_Generic.cs
@@ -4,8 +4,11 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
+using ThreadState = System.Threading.ThreadState;
 
 namespace System.IO.Ports.Tests
 {
@@ -13,28 +16,28 @@ namespace System.IO.Ports.Tests
     {
         //Set bounds fore random timeout values.
         //If the min is to low write will not timeout accurately and the testcase will fail
-        public static int minRandomTimeout = 250;
+        private const int minRandomTimeout = 250;
 
         //If the max is to large then the testcase will take forever to run
-        public static int maxRandomTimeout = 2000;
+        private const int maxRandomTimeout = 2000;
 
         //If the percentage difference between the expected timeout and the actual timeout
         //found through Stopwatch is greater then 10% then the timeout value was not correctly
         //to the write method and the testcase fails.
-        public static double maxPercentageDifference = .15;
+        private static double s_maxPercentageDifference = .15;
 
         //The char size used when veryifying exceptions that write will throw 
-        public static readonly int CHAR_SIZE_EXCEPTION = 4;
+        private const int CHAR_SIZE_EXCEPTION = 4;
 
         //The char size used when veryifying timeout 
-        public static readonly int CHAR_SIZE_TIMEOUT = 4;
+        private const int CHAR_SIZE_TIMEOUT = 4;
 
         //The char size used when veryifying BytesToWrite 
-        public static readonly int CHAR_SIZE_BYTES_TO_WRITE = 4;
+        private const int CHAR_SIZE_BYTES_TO_WRITE = 4;
 
         //The char size used when veryifying Handshake 
-        public static readonly int CHAR_SIZE_HANDSHAKE = 8;
-        public static readonly int NUM_TRYS = 5;
+        private const int CHAR_SIZE_HANDSHAKE = 8;
+        private const int NUM_TRYS = 5;
 
         #region Test Cases
 
@@ -98,7 +101,7 @@ namespace System.IO.Ports.Tests
                 com2.Open();
 
                 com2.Write(XOffBuffer, 0, 1);
-                System.Threading.Thread.Sleep(250);
+                Thread.Sleep(250);
 
                 com2.Close();
 
@@ -113,12 +116,12 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 Random rndGen = new Random(-55);
-        
+
 
                 com.WriteTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com.Handshake = Handshake.RequestToSendXOnXOff;
                 //		com.Encoding = new System.Text.UTF7Encoding();
-                com.Encoding = System.Text.Encoding.Unicode;
+                com.Encoding = Encoding.Unicode;
 
                 Debug.WriteLine("Verifying WriteTimeout={0} with successive call to write method", com.WriteTimeout);
 
@@ -143,13 +146,13 @@ namespace System.IO.Ports.Tests
             {
                 Random rndGen = new Random(-55);
                 AsyncEnableRts asyncEnableRts = new AsyncEnableRts();
-                System.Threading.Thread t = new System.Threading.Thread(asyncEnableRts.EnableRTS);
-        
+                Thread t = new Thread(asyncEnableRts.EnableRTS);
+
                 int waitTime = 0;
 
                 com1.WriteTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com1.Handshake = Handshake.RequestToSend;
-                com1.Encoding = new System.Text.UTF8Encoding();
+                com1.Encoding = new UTF8Encoding();
 
                 Debug.WriteLine("Verifying WriteTimeout={0} with successive call to write method with the write succeeding sometime before its timeout", com1.WriteTimeout);
                 com1.Open();
@@ -159,10 +162,10 @@ namespace System.IO.Ports.Tests
                 t.Start();
                 waitTime = 0;
 
-                while (t.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 {
                     //Wait for the thread to start
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
                     waitTime += 50;
                 }
 
@@ -177,7 +180,7 @@ namespace System.IO.Ports.Tests
                 asyncEnableRts.Stop();
 
                 while (t.IsAlive)
-                    System.Threading.Thread.Sleep(100);
+                    Thread.Sleep(100);
 
                 VerifyTimeout(com1);
             }
@@ -189,8 +192,8 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 AsyncWriteRndCharArray asyncWriteRndCharArray = new AsyncWriteRndCharArray(com, CHAR_SIZE_BYTES_TO_WRITE);
-                System.Threading.Thread t = new System.Threading.Thread(asyncWriteRndCharArray.WriteRndCharArray);
-        
+                Thread t = new Thread(asyncWriteRndCharArray.WriteRndCharArray);
+
                 int waitTime = 0;
 
                 Debug.WriteLine("Verifying BytesToWrite with one call to Write");
@@ -203,9 +206,9 @@ namespace System.IO.Ports.Tests
                 t.Start();
                 waitTime = 0;
 
-                while (t.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 { //Wait for the thread to start
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
                     waitTime += 50;
                 }
 
@@ -213,7 +216,7 @@ namespace System.IO.Ports.Tests
 
                 //Wait for write method to timeout
                 while (t.IsAlive)
-                    System.Threading.Thread.Sleep(100);
+                    Thread.Sleep(100);
             }
         }
 
@@ -223,9 +226,9 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 AsyncWriteRndCharArray asyncWriteRndCharArray = new AsyncWriteRndCharArray(com, CHAR_SIZE_BYTES_TO_WRITE);
-                System.Threading.Thread t1 = new System.Threading.Thread(asyncWriteRndCharArray.WriteRndCharArray);
-                System.Threading.Thread t2 = new System.Threading.Thread(asyncWriteRndCharArray.WriteRndCharArray);
-        
+                Thread t1 = new Thread(asyncWriteRndCharArray.WriteRndCharArray);
+                Thread t2 = new Thread(asyncWriteRndCharArray.WriteRndCharArray);
+
                 int waitTime = 0;
 
                 Debug.WriteLine("Verifying BytesToWrite with successive calls to Write");
@@ -238,9 +241,9 @@ namespace System.IO.Ports.Tests
                 t1.Start();
                 waitTime = 0;
 
-                while (t1.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t1.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 { //Wait for the thread to start
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
                     waitTime += 50;
                 }
 
@@ -250,9 +253,9 @@ namespace System.IO.Ports.Tests
                 t2.Start();
                 waitTime = 0;
 
-                while (t2.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t2.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 { //Wait for the thread to start
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
                     waitTime += 50;
                 }
 
@@ -260,7 +263,7 @@ namespace System.IO.Ports.Tests
 
                 //Wait for both write methods to timeout
                 while (t1.IsAlive || t2.IsAlive)
-                    System.Threading.Thread.Sleep(100);
+                    Thread.Sleep(100);
             }
         }
 
@@ -270,8 +273,8 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 AsyncWriteRndCharArray asyncWriteRndCharArray = new AsyncWriteRndCharArray(com, CHAR_SIZE_HANDSHAKE);
-                System.Threading.Thread t = new System.Threading.Thread(asyncWriteRndCharArray.WriteRndCharArray);
-        
+                Thread t = new Thread(asyncWriteRndCharArray.WriteRndCharArray);
+
                 int waitTime;
 
                 //Write a random char[] asynchronously so we can verify some things while the write call is blocking
@@ -282,15 +285,15 @@ namespace System.IO.Ports.Tests
                 t.Start();
                 waitTime = 0;
 
-                while (t.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 { //Wait for the thread to start
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
                     waitTime += 50;
                 }
 
                 //Wait for both write methods to timeout
                 while (t.IsAlive)
-                    System.Threading.Thread.Sleep(100);
+                    Thread.Sleep(100);
 
                 Assert.Equal(0, com.BytesToWrite);
             }
@@ -316,7 +319,7 @@ namespace System.IO.Ports.Tests
 
         public class AsyncEnableRts
         {
-            private bool _stop = false;
+            private bool _stop;
 
             public void EnableRTS()
             {
@@ -328,13 +331,13 @@ namespace System.IO.Ports.Tests
                         int sleepPeriod = rndGen.Next(minRandomTimeout, maxRandomTimeout / 2);
 
                         //Sleep some random period with of a maximum duration of half the largest possible timeout value for a write method on COM1
-                        System.Threading.Thread.Sleep(sleepPeriod);
+                        Thread.Sleep(sleepPeriod);
 
                         com2.Open();
                         com2.RtsEnable = true;
 
                         while (!_stop)
-                            System.Threading.Monitor.Wait(this);
+                            Monitor.Wait(this);
 
                         com2.RtsEnable = false;
                     }
@@ -347,7 +350,7 @@ namespace System.IO.Ports.Tests
                 lock (this)
                 {
                     _stop = true;
-                    System.Threading.Monitor.Pulse(this);
+                    Monitor.Pulse(this);
                 }
             }
         }
@@ -356,8 +359,8 @@ namespace System.IO.Ports.Tests
 
         public class AsyncWriteRndCharArray
         {
-            private SerialPort _com;
-            private int _charLength;
+            private readonly SerialPort _com;
+            private readonly int _charLength;
 
 
             public AsyncWriteRndCharArray(SerialPort com, int charLength)
@@ -394,14 +397,14 @@ namespace System.IO.Ports.Tests
             int expectedTime = com.WriteTimeout;
             int actualTime = 0;
             double percentageDifference;
-        
+
             try
             {
                 com.Write(new char[CHAR_SIZE_TIMEOUT], 0, CHAR_SIZE_TIMEOUT); //Warm up write method
             }
             catch (TimeoutException) { }
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Highest;
+            Thread.CurrentThread.Priority = ThreadPriority.Highest;
 
             for (int i = 0; i < NUM_TRYS; i++)
             {
@@ -412,21 +415,20 @@ namespace System.IO.Ports.Tests
                     com.Write(new char[CHAR_SIZE_TIMEOUT], 0, CHAR_SIZE_TIMEOUT);
                 }
                 catch (TimeoutException) { }
-    
+
                 timer.Stop();
                 actualTime += (int)timer.ElapsedMilliseconds;
                 timer.Reset();
             }
 
-            System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.Normal;
+            Thread.CurrentThread.Priority = ThreadPriority.Normal;
             actualTime /= NUM_TRYS;
             percentageDifference = Math.Abs((expectedTime - actualTime) / (double)expectedTime);
 
             //Verify that the percentage difference between the expected and actual timeout is less then maxPercentageDifference
-            if (maxPercentageDifference < percentageDifference)
+            if (s_maxPercentageDifference < percentageDifference)
             {
                 Fail("ERROR!!!: The write method timedout in {0} expected {1} percentage difference: {2}", actualTime, expectedTime, percentageDifference);
-            
             }
         }
 
@@ -436,8 +438,8 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 AsyncWriteRndCharArray asyncWriteRndCharArray = new AsyncWriteRndCharArray(com1, CHAR_SIZE_HANDSHAKE);
-                System.Threading.Thread t =
-                    new System.Threading.Thread(asyncWriteRndCharArray.WriteRndCharArray);
+                Thread t =
+                    new Thread(asyncWriteRndCharArray.WriteRndCharArray);
 
                 byte[] XOffBuffer = new byte[1];
                 byte[] XOnBuffer = new byte[1];
@@ -461,17 +463,17 @@ namespace System.IO.Ports.Tests
                 if (Handshake.XOnXOff == handshake || Handshake.RequestToSendXOnXOff == handshake)
                 {
                     com2.Write(XOffBuffer, 0, 1);
-                    System.Threading.Thread.Sleep(250);
+                    Thread.Sleep(250);
                 }
 
                 //Write a random char array asynchronously so we can verify some things while the write call is blocking
                 t.Start();
                 waitTime = 0;
 
-                while (t.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 {
                     //Wait for the thread to start
-                    System.Threading.Thread.Sleep(50);
+                    Thread.Sleep(50);
                     waitTime += 50;
                 }
 
@@ -496,7 +498,7 @@ namespace System.IO.Ports.Tests
 
                 //Wait till write finishes
                 while (t.IsAlive)
-                    System.Threading.Thread.Sleep(100);
+                    Thread.Sleep(100);
 
                 //Verify that the correct number of bytes are in the buffer
                 Assert.Equal(0, com1.BytesToWrite);

--- a/src/System.IO.Ports/tests/SerialPort/Write_str.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Write_str.cs
@@ -4,6 +4,8 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
+using System.Threading;
 using Legacy.Support;
 using Xunit;
 
@@ -12,15 +14,15 @@ namespace System.IO.Ports.Tests
     public class Write_str : PortsTest
     {
         // The string size used when verifying encoding 
-        public static readonly int ENCODING_STRING_SIZE = 4;
+        private const int ENCODING_STRING_SIZE = 4;
 
         // The string size used for large string testing
         // This has been reduced from 2048 to 2000 because the associated byte buffer size (i.e. 4096 bytes) is too large
         // to allow single read/write transactions on a FTDI USB-Serial device
-        public static readonly int LARGE_STRING_SIZE = 2000;
+        private const int LARGE_STRING_SIZE = 2000;
 
         //The default number of times the write method is called when verifying write
-        public static readonly int DEFAULT_NUM_WRITES = 3;
+        private const int DEFAULT_NUM_WRITES = 3;
 
         #region Test Cases
 
@@ -28,14 +30,14 @@ namespace System.IO.Ports.Tests
         public void ASCIIEncoding()
         {
             Debug.WriteLine("Verifying write method with ASCIIEncoding");
-            VerifyWrite(new System.Text.ASCIIEncoding(), ENCODING_STRING_SIZE);
+            VerifyWrite(new ASCIIEncoding(), ENCODING_STRING_SIZE);
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void UTF8Encoding()
         {
             Debug.WriteLine("Verifying write method with UTF8Encoding");
-            VerifyWrite(new System.Text.UTF8Encoding(), ENCODING_STRING_SIZE);
+            VerifyWrite(new UTF8Encoding(), ENCODING_STRING_SIZE);
         }
 
 
@@ -43,14 +45,14 @@ namespace System.IO.Ports.Tests
         public void UTF32Encoding()
         {
             Debug.WriteLine("Verifying write method with UTF32Encoding");
-            VerifyWrite(new System.Text.UTF32Encoding(), ENCODING_STRING_SIZE);
+            VerifyWrite(new UTF32Encoding(), ENCODING_STRING_SIZE);
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void UnicodeEncoding()
         {
             Debug.WriteLine("Verifying write method with UnicodeEncoding");
-            VerifyWrite(new System.Text.UnicodeEncoding(), ENCODING_STRING_SIZE);
+            VerifyWrite(new UnicodeEncoding(), ENCODING_STRING_SIZE);
         }
 
         [ConditionalFact(nameof(HasOneSerialPort))]
@@ -94,7 +96,6 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
             {
-
                 Debug.WriteLine("Verifying Write with an string containing only the null character");
 
                 com1.Open();
@@ -110,18 +111,18 @@ namespace System.IO.Ports.Tests
         public void LargeString()
         {
             Debug.WriteLine("Verifying write method with a large string size");
-            VerifyWrite(new System.Text.UnicodeEncoding(), LARGE_STRING_SIZE, 1);
+            VerifyWrite(new UnicodeEncoding(), LARGE_STRING_SIZE, 1);
         }
         #endregion
 
         #region Verification for Test Cases
 
-        public void VerifyWrite(System.Text.Encoding encoding, int strSize)
+        public void VerifyWrite(Encoding encoding, int strSize)
         {
             VerifyWrite(encoding, strSize, DEFAULT_NUM_WRITES);
         }
 
-        public void VerifyWrite(System.Text.Encoding encoding, int strSize, int numWrites)
+        public void VerifyWrite(Encoding encoding, int strSize, int numWrites)
         {
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
@@ -142,7 +143,7 @@ namespace System.IO.Ports.Tests
         {
             VerifyWriteStr(com1, com2, stringToWrite, DEFAULT_NUM_WRITES);
         }
-    
+
         public void VerifyWriteStr(SerialPort com1, SerialPort com2, string stringToWrite, int numWrites)
         {
             char[] actualChars;
@@ -162,7 +163,7 @@ namespace System.IO.Ports.Tests
             com2.ReadTimeout = 500;
 
             //com2.Encoding = com1.Encoding;
-            System.Threading.Thread.Sleep((int)(((expectedBytes.Length * 10.0) / com1.BaudRate) * 1000) + 250);
+            Thread.Sleep((int)(((expectedBytes.Length * 10.0) / com1.BaudRate) * 1000) + 250);
 
             while (true)
             {

--- a/src/System.IO.Ports/tests/SerialPort/Write_str_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Write_str_Generic.cs
@@ -4,9 +4,11 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
 using System.Threading;
 using Legacy.Support;
 using Xunit;
+using ThreadState = System.Threading.ThreadState;
 
 namespace System.IO.Ports.Tests
 {
@@ -14,26 +16,26 @@ namespace System.IO.Ports.Tests
     {
         //Set bounds fore random timeout values.
         //If the min is to low write will not timeout accurately and the testcase will fail
-        public static int minRandomTimeout = 250;
+        private const int minRandomTimeout = 250;
 
         //If the max is to large then the testcase will take forever to run
-        public static int maxRandomTimeout = 2000;
+        private const int maxRandomTimeout = 2000;
 
         //If the percentage difference between the expected timeout and the actual timeout
         //found through Stopwatch is greater then 10% then the timeout value was not correctly
         //to the write method and the testcase fails.
-        public static double maxPercentageDifference = .15;
+        private const double maxPercentageDifference = .15;
 
         //The string used when we expect the ReadCall to throw an exception for something other
         //then the contents of the string itself
-        public static readonly string DEFAULT_STRING = "DEFAULT_STRING";
+        private const string DEFAULT_STRING = "DEFAULT_STRING";
 
         //The string size used when verifying BytesToWrite 
-        public static readonly int STRING_SIZE_BYTES_TO_WRITE = 2*TCSupport.MinimumBlockingByteCount;
+        private static readonly int s_STRING_SIZE_BYTES_TO_WRITE = 2 * TCSupport.MinimumBlockingByteCount;
 
         //The string size used when verifying Handshake 
-        public static readonly int STRING_SIZE_HANDSHAKE = 8;
-        public static readonly int NUM_TRYS = 5;
+        private const int STRING_SIZE_HANDSHAKE = 8;
+        private const int NUM_TRYS = 5;
 
         #region Test Cases
 
@@ -111,11 +113,11 @@ namespace System.IO.Ports.Tests
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 Random rndGen = new Random(-55);
-        
+
                 com.WriteTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com.Handshake = Handshake.RequestToSendXOnXOff;
                 //		com.Encoding = new System.Text.UTF7Encoding();
-                com.Encoding = System.Text.Encoding.Unicode;
+                com.Encoding = Encoding.Unicode;
 
                 Debug.WriteLine("Verifying WriteTimeout={0} with successive call to write method", com.WriteTimeout);
                 com.Open();
@@ -141,11 +143,11 @@ namespace System.IO.Ports.Tests
                 AsyncEnableRts asyncEnableRts = new AsyncEnableRts();
                 Thread t = new Thread(asyncEnableRts.EnableRTS);
 
-                int waitTime = 0;
+                int waitTime;
 
                 com1.WriteTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com1.Handshake = Handshake.RequestToSend;
-                com1.Encoding = new System.Text.UTF8Encoding();
+                com1.Encoding = new UTF8Encoding();
 
                 Debug.WriteLine(
                     "Verifying WriteTimeout={0} with successive call to write method with the write succeeding sometime before its timeout",
@@ -157,7 +159,7 @@ namespace System.IO.Ports.Tests
                 t.Start();
                 waitTime = 0;
 
-                while (t.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 {
                     //Wait for the thread to start
                     Thread.Sleep(50);
@@ -171,7 +173,7 @@ namespace System.IO.Ports.Tests
                 catch (TimeoutException)
                 {
                 }
-         
+
                 asyncEnableRts.Stop();
 
                 while (t.IsAlive)
@@ -186,10 +188,10 @@ namespace System.IO.Ports.Tests
         {
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
-                AsyncWriteRndStr asyncWriteRndStr = new AsyncWriteRndStr(com, STRING_SIZE_BYTES_TO_WRITE);
+                AsyncWriteRndStr asyncWriteRndStr = new AsyncWriteRndStr(com, s_STRING_SIZE_BYTES_TO_WRITE);
                 Thread t = new Thread(asyncWriteRndStr.WriteRndStr);
 
-                int waitTime = 0;
+                int waitTime;
 
                 Debug.WriteLine("Verifying BytesToWrite with one call to Write");
                 com.Handshake = Handshake.RequestToSend;
@@ -200,14 +202,14 @@ namespace System.IO.Ports.Tests
                 t.Start();
                 waitTime = 0;
 
-                while (t.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 {
                     //Wait for the thread to start
                     Thread.Sleep(50);
                     waitTime += 50;
                 }
 
-                TCSupport.WaitForWriteBufferToLoad(com, STRING_SIZE_BYTES_TO_WRITE);
+                TCSupport.WaitForWriteBufferToLoad(com, s_STRING_SIZE_BYTES_TO_WRITE);
 
                 //Wait for write method to timeout
                 while (t.IsAlive)
@@ -220,11 +222,11 @@ namespace System.IO.Ports.Tests
         {
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
-                AsyncWriteRndStr asyncWriteRndStr = new AsyncWriteRndStr(com, STRING_SIZE_BYTES_TO_WRITE);
+                AsyncWriteRndStr asyncWriteRndStr = new AsyncWriteRndStr(com, s_STRING_SIZE_BYTES_TO_WRITE);
                 var t1 = new Thread(asyncWriteRndStr.WriteRndStr);
                 var t2 = new Thread(asyncWriteRndStr.WriteRndStr);
 
-                int waitTime = 0;
+                int waitTime;
 
                 Debug.WriteLine("Verifying BytesToWrite with successive calls to Write");
                 com.Handshake = Handshake.RequestToSend;
@@ -235,28 +237,28 @@ namespace System.IO.Ports.Tests
                 t1.Start();
                 waitTime = 0;
 
-                while (t1.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t1.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 {
                     //Wait for the thread to start
                     Thread.Sleep(50);
                     waitTime += 50;
                 }
 
-                TCSupport.WaitForWriteBufferToLoad(com, STRING_SIZE_BYTES_TO_WRITE);
+                TCSupport.WaitForWriteBufferToLoad(com, s_STRING_SIZE_BYTES_TO_WRITE);
 
                 //Write a random string asynchronously so we can verify some things while the write call is blocking
                 t2.Start();
                 waitTime = 0;
 
-                while (t2.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t2.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 {
                     //Wait for the thread to start
                     Thread.Sleep(50);
                     waitTime += 50;
                 }
 
-                TCSupport.WaitForWriteBufferToLoad(com, STRING_SIZE_BYTES_TO_WRITE*2);
-            
+                TCSupport.WaitForWriteBufferToLoad(com, s_STRING_SIZE_BYTES_TO_WRITE * 2);
+
                 //Wait for both write methods to timeout
                 while (t1.IsAlive || t2.IsAlive)
                     Thread.Sleep(100);
@@ -270,8 +272,8 @@ namespace System.IO.Ports.Tests
             {
                 AsyncWriteRndStr asyncWriteRndStr = new AsyncWriteRndStr(com, STRING_SIZE_HANDSHAKE);
                 Thread t = new Thread(asyncWriteRndStr.WriteRndStr);
-        
-                int waitTime = 0;
+
+                int waitTime;
 
                 //Write a random string asynchronously so we can verify some things while the write call is blocking
                 Debug.WriteLine("Verifying Handshake=None");
@@ -280,7 +282,7 @@ namespace System.IO.Ports.Tests
                 t.Start();
                 waitTime = 0;
 
-                while (t.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 { //Wait for the thread to start
                     Thread.Sleep(50);
                     waitTime += 50;
@@ -314,7 +316,7 @@ namespace System.IO.Ports.Tests
 
         private class AsyncEnableRts
         {
-            private bool _stop = false;
+            private bool _stop;
 
 
             public void EnableRTS()
@@ -356,8 +358,8 @@ namespace System.IO.Ports.Tests
 
         public class AsyncWriteRndStr
         {
-            private SerialPort _com;
-            private int _strSize;
+            private readonly SerialPort _com;
+            private readonly int _strSize;
 
 
             public AsyncWriteRndStr(SerialPort com, int strSize)
@@ -394,7 +396,7 @@ namespace System.IO.Ports.Tests
             int expectedTime = com.WriteTimeout;
             int actualTime = 0;
             double percentageDifference;
-        
+
             try
             {
                 com.Write(DEFAULT_STRING); //Warm up write method
@@ -439,7 +441,7 @@ namespace System.IO.Ports.Tests
 
                 byte[] XOffBuffer = new byte[1];
                 byte[] XOnBuffer = new byte[1];
-                int waitTime = 0;
+                int waitTime;
 
                 XOffBuffer[0] = 19;
                 XOnBuffer[0] = 17;
@@ -466,7 +468,7 @@ namespace System.IO.Ports.Tests
                 t.Start();
                 waitTime = 0;
 
-                while (t.ThreadState == System.Threading.ThreadState.Unstarted && waitTime < 2000)
+                while (t.ThreadState == ThreadState.Unstarted && waitTime < 2000)
                 {
                     //Wait for the thread to start
                     Thread.Sleep(50);

--- a/src/System.IO.Ports/tests/SerialPort/Write_str_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Write_str_Generic.cs
@@ -473,18 +473,7 @@ namespace System.IO.Ports.Tests
                     waitTime += 50;
                 }
 
-                waitTime = 0;
-                while (STRING_SIZE_HANDSHAKE > com1.BytesToWrite && waitTime < 500)
-                {
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                //Verify that the correct number of bytes are in the buffer
-                if (STRING_SIZE_HANDSHAKE != com1.BytesToWrite)
-                {
-                    Fail("ERROR!!! Expcted BytesToWrite={0} actual {1}", STRING_SIZE_HANDSHAKE, com1.BytesToWrite);
-                }
+                TCSupport.WaitForExactWriteBufferLoad(com1, STRING_SIZE_HANDSHAKE);
 
                 //Verify that CtsHolding is false if the RequestToSend or RequestToSendXOnXOff handshake method is used
                 if ((Handshake.RequestToSend == handshake || Handshake.RequestToSendXOnXOff == handshake) && com1.CtsHolding)

--- a/src/System.IO.Ports/tests/SerialPort/ctor_IContainer.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ctor_IContainer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO.PortsTests;
 using Legacy.Support;
@@ -15,7 +16,7 @@ namespace System.IO.Ports.Tests
         public void Verify()
         {
             SerialPortProperties serPortProp = new SerialPortProperties();
-            System.ComponentModel.Container container = new System.ComponentModel.Container();
+            Container container = new Container();
             using (SerialPort com = new SerialPort(container))
             {
                 Assert.Equal(1, container.Components.Count);

--- a/src/System.IO.Ports/tests/SerialPort/ctor_str.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ctor_str.cs
@@ -7,6 +7,7 @@ using System.IO.PortsTests;
 using System.Text;
 using Legacy.Support;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.IO.Ports.Tests
 {
@@ -128,7 +129,7 @@ namespace System.IO.Ports.Tests
                     serPortProp.VerifyPropertiesAndPrint(com);
                 }
             }
-            catch (Xunit.Sdk.TrueException)
+            catch (TrueException)
             {
                 // This is an inner failure
                 throw;

--- a/src/System.IO.Ports/tests/SerialPort/ctor_str_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ctor_str_int.cs
@@ -4,15 +4,17 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
 using Legacy.Support;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.IO.Ports.Tests
 {
     public class ctor_str_int : PortsTest
     {
         private enum ThrowAt { Set, Open };
-    
+
         [Fact]
         public void COM1_9600()
         {
@@ -72,7 +74,7 @@ namespace System.IO.Ports.Tests
 
             VerifyCtor(portName, baudRate, typeof(ArgumentException), ThrowAt.Set);
         }
-    
+
         [Fact]
         public void Null_14400()
         {
@@ -97,8 +99,8 @@ namespace System.IO.Ports.Tests
             string portName;
             int baudRate = 9600;
             string fileName = portName = "PortNameEqualToFileName.txt";
-            System.IO.FileStream testFile = System.IO.File.Open(fileName, System.IO.FileMode.Create);
-            System.Text.ASCIIEncoding asciiEncd = new System.Text.ASCIIEncoding();
+            FileStream testFile = File.Open(fileName, FileMode.Create);
+            ASCIIEncoding asciiEncd = new ASCIIEncoding();
             string testStr = "Hello World";
 
             testFile.Write(asciiEncd.GetBytes(testStr), 0, asciiEncd.GetByteCount(testStr));
@@ -113,7 +115,7 @@ namespace System.IO.Ports.Tests
             }
             finally
             {
-                System.IO.File.Delete(fileName);
+                File.Delete(fileName);
             }
         }
 
@@ -197,7 +199,7 @@ namespace System.IO.Ports.Tests
                     serPortProp.VerifyPropertiesAndPrint(com);
                 }
             }
-            catch (Xunit.Sdk.TrueException)
+            catch (TrueException)
             {
                 // This is an inner failure
                 throw;

--- a/src/System.IO.Ports/tests/SerialPort/ctor_str_int_parity.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ctor_str_int_parity.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
 using Legacy.Support;
 using Xunit;
 
@@ -105,8 +106,8 @@ namespace System.IO.Ports.Tests
             int baudRate = 9600;
             int parity = (int)Parity.Space;
             string fileName = portName = "PortNameEqualToFileName.txt";
-            System.IO.FileStream testFile = System.IO.File.Open(fileName, System.IO.FileMode.Create);
-            System.Text.ASCIIEncoding asciiEncd = new System.Text.ASCIIEncoding();
+            FileStream testFile = File.Open(fileName, FileMode.Create);
+            ASCIIEncoding asciiEncd = new ASCIIEncoding();
             string testStr = "Hello World";
 
             testFile.Write(asciiEncd.GetBytes(testStr), 0, asciiEncd.GetByteCount(testStr));
@@ -121,7 +122,7 @@ namespace System.IO.Ports.Tests
             }
             finally
             {
-                System.IO.File.Delete(fileName);
+                File.Delete(fileName);
             }
         }
 

--- a/src/System.IO.Ports/tests/SerialPort/ctor_str_int_parity_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ctor_str_int_parity_int.cs
@@ -5,6 +5,7 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
 using Legacy.Support;
 using Xunit;
 
@@ -119,7 +120,7 @@ namespace System.IO.Ports.Tests
 
             VerifyCtor(portName, baudRate, parity, dataBits);
         }
-    
+
         [Fact]
         public void Filename_9600_Space_8()
         {
@@ -128,8 +129,8 @@ namespace System.IO.Ports.Tests
             int parity = (int)Parity.Space;
             int dataBits = 8;
             string fileName = portName = "PortNameEqualToFileName.txt";
-            System.IO.FileStream testFile = System.IO.File.Open(fileName, System.IO.FileMode.Create);
-            System.Text.ASCIIEncoding asciiEncd = new System.Text.ASCIIEncoding();
+            FileStream testFile = File.Open(fileName, FileMode.Create);
+            ASCIIEncoding asciiEncd = new ASCIIEncoding();
             string testStr = "Hello World";
 
             testFile.Write(asciiEncd.GetBytes(testStr), 0, asciiEncd.GetByteCount(testStr));
@@ -144,7 +145,7 @@ namespace System.IO.Ports.Tests
             }
             finally
             {
-                System.IO.File.Delete(fileName);
+                File.Delete(fileName);
             }
         }
 

--- a/src/System.IO.Ports/tests/SerialPort/ctor_str_int_parity_int_stopbits.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ctor_str_int_parity_int_stopbits.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO.PortsTests;
+using System.Text;
 using Legacy.Support;
 using Xunit;
 
@@ -206,7 +207,7 @@ namespace System.IO.Ports.Tests
 
             VerifyCtor(portName, baudRate, parity, dataBits, stopBits);
         }
-    
+
         [Fact]
         public void Filename_9600_Space_8_1()
         {
@@ -216,8 +217,8 @@ namespace System.IO.Ports.Tests
             int dataBits = 8;
             int stopBits = (int)StopBits.One;
             string fileName = portName = "PortNameEqualToFileName.txt";
-            System.IO.FileStream testFile = System.IO.File.Open(fileName, System.IO.FileMode.Create);
-            System.Text.ASCIIEncoding asciiEncd = new System.Text.ASCIIEncoding();
+            FileStream testFile = File.Open(fileName, FileMode.Create);
+            ASCIIEncoding asciiEncd = new ASCIIEncoding();
             string testStr = "Hello World";
 
             testFile.Write(asciiEncd.GetBytes(testStr), 0, asciiEncd.GetByteCount(testStr));
@@ -232,7 +233,7 @@ namespace System.IO.Ports.Tests
             }
             finally
             {
-                System.IO.File.Delete(fileName);
+                File.Delete(fileName);
             }
         }
 
@@ -443,7 +444,7 @@ namespace System.IO.Ports.Tests
 
             VerifyCtor(portName, baudRate, parity, dataBits, stopBits, typeof(ArgumentOutOfRangeException), ThrowAt.Set);
         }
-    
+
         [Fact]
         public void COM4_57600_Mark_8_4()
         {
@@ -455,7 +456,7 @@ namespace System.IO.Ports.Tests
 
             VerifyCtor(portName, baudRate, parity, dataBits, stopBits, typeof(ArgumentOutOfRangeException), ThrowAt.Set);
         }
-    
+
         [Fact]
         public void COM255_115200_Space_8_Int32MaxValue()
         {
@@ -467,12 +468,12 @@ namespace System.IO.Ports.Tests
 
             VerifyCtor(portName, baudRate, parity, dataBits, stopBits, typeof(ArgumentOutOfRangeException), ThrowAt.Set);
         }
-    
+
         private void VerifyCtor(string portName, int baudRate, int parity, int dataBits, int stopBits)
         {
             VerifyCtor(portName, baudRate, parity, dataBits, stopBits, null, ThrowAt.Set);
         }
-    
+
         private void VerifyCtor(string portName, int baudRate, int parity, int dataBits, int stopBits, Type expectedException, ThrowAt throwAt)
         {
             SerialPortProperties serPortProp = new SerialPortProperties();

--- a/src/System.IO.Ports/tests/SerialStream/BeginRead.cs
+++ b/src/System.IO.Ports/tests/SerialStream/BeginRead.cs
@@ -14,23 +14,23 @@ namespace System.IO.Ports.Tests
     public class SerialStream_BeginRead : PortsTest
     {
         // The number of random bytes to receive for read method testing
-        private static readonly int numRndBytesToRead = 16;
+        private const int numRndBytesToRead = 16;
 
         // The number of random bytes to receive for large input buffer testing
-        private static readonly int largeNumRndBytesToRead = 2048;
+        private const int largeNumRndBytesToRead = 2048;
 
         // When we test Read and do not care about actually reading anything we must still
         // create an byte array to pass into the method the following is the size of the 
         // byte array used in this situation
-        private static readonly int defaultByteArraySize = 1;
-        private static readonly int defaultByteOffset = 0;
-        private static readonly int defaultByteCount = 1;
+        private const int defaultByteArraySize = 1;
+        private const int defaultByteOffset = 0;
+        private const int defaultByteCount = 1;
 
         // The maximum buffer size when a exception occurs
-        private static readonly int maxBufferSizeForException = 255;
+        private const int maxBufferSizeForException = 255;
 
         // The maximum buffer size when a exception is not expected
-        private static readonly int maxBufferSize = 8;
+        private const int maxBufferSize = 8;
 
         // Maximum time to wait for processing the read command to complete
         private const int MAX_WAIT_READ_COMPLETE = 1000;
@@ -131,7 +131,7 @@ namespace System.IO.Ports.Tests
 
             VerifyReadException(new byte[bufferLength], offset, count, expectedException);
         }
-        
+
         [ConditionalFact(nameof(HasNullModem))]
         public void OffsetCount_EQ_Length()
         {
@@ -139,7 +139,7 @@ namespace System.IO.Ports.Tests
             int bufferLength = rndGen.Next(1, maxBufferSize);
             int offset = rndGen.Next(0, bufferLength - 1);
             int count = bufferLength - offset;
-            
+
             VerifyRead(new byte[bufferLength], offset, count);
         }
 
@@ -197,7 +197,7 @@ namespace System.IO.Ports.Tests
                 Assert.Equal(null, readAsyncResult.AsyncState);
                 Assert.False(readAsyncResult.CompletedSynchronously, "Should not have completed sync (read)");
                 Assert.False(readAsyncResult.IsCompleted, "Should not have completed yet");
-                
+
                 com2.Write(new byte[numRndBytesToRead], 0, numRndBytesToRead);
 
                 // callbackHandler.ReadAsyncResult  guarantees that the callback has been calledhowever it does not gauarentee that 
@@ -218,10 +218,9 @@ namespace System.IO.Ports.Tests
                 Assert.Equal(null, readAsyncResult.AsyncState);
                 Assert.False(readAsyncResult.CompletedSynchronously, "Should not have completed sync (read)");
                 Assert.True(readAsyncResult.IsCompleted, "Should have completed (read)");
-
             }
         }
-        
+
         [ConditionalFact(nameof(HasNullModem))]
         public void Callback_EndReadonCallback()
         {
@@ -427,7 +426,7 @@ namespace System.IO.Ports.Tests
             // Compare the bytes that were written with the ones we read
             Assert.Equal(bytesToWrite, buffer.Take(bytesToWrite.Length).ToArray());
         }
-        
+
         private void VerifyBuffer(byte[] actualBuffer, byte[] expectedBuffer, int offset, int count)
         {
             // Verify all character before the offset

--- a/src/System.IO.Ports/tests/SerialStream/BeginRead_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/BeginRead_Generic.cs
@@ -144,7 +144,6 @@ namespace System.IO.Ports.Tests
                 var expectedBytes = new byte[numRndBytesPairty];
                 var actualBytes = new byte[numRndBytesPairty + 1];
 
-                int waitTime;
                 IAsyncResult readAsyncResult;
 
                 /* 1 Additional character gets added to the input buffer when the parity error occurs on the last byte of a stream
@@ -175,13 +174,7 @@ namespace System.IO.Ports.Tests
                 readAsyncResult = com2.BaseStream.BeginWrite(bytesToWrite, 0, bytesToWrite.Length, null, null);
                 readAsyncResult.AsyncWaitHandle.WaitOne();
 
-                waitTime = 0;
-
-                while (bytesToWrite.Length + 1 > com1.BytesToRead && waitTime < 500)
-                {
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length + 1);
 
                 com1.Read(actualBytes, 0, actualBytes.Length);
 
@@ -432,15 +425,11 @@ namespace System.IO.Ports.Tests
             var buffer = new byte[bytesToWrite.Length];
             int totalBytesRead;
             int bytesToRead;
-            var waitTime = 0;
 
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
             com1.ReadTimeout = 250;
-            while (com1.BytesToRead < bytesToWrite.Length && waitTime < 500)
-            {
-                Thread.Sleep(50);
-                waitTime += 50;
-            }
+
+            TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length);
 
             totalBytesRead = 0;
             bytesToRead = com1.BytesToRead;

--- a/src/System.IO.Ports/tests/SerialStream/BeginRead_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/BeginRead_Generic.cs
@@ -16,31 +16,31 @@ namespace System.IO.Ports.Tests
     {
         // Set bounds fore random timeout values.
         // If the min is to low read will not timeout accurately and the testcase will fail
-        public static readonly int minRandomTimeout = 250;
+        private const int minRandomTimeout = 250;
 
         // If the max is to large then the testcase will take forever to run
-        public static readonly int maxRandomTimeout = 2000;
+        private const int maxRandomTimeout = 2000;
 
         // If the percentage difference between the expected timeout and the actual timeout
         // found through Stopwatch is greater then 10% then the timeout value was not correctly
         // to the read method and the testcase fails.
-        public static readonly double maxPercentageDifference = .15;
+        public const double maxPercentageDifference = .15;
 
         // The number of random bytes to receive for parity testing
-        public static readonly int numRndBytesPairty = 8;
+        private const int numRndBytesPairty = 8;
 
         // The number of characters to read at a time for parity testing
-        public static readonly int numBytesReadPairty = 2;
+        private const int numBytesReadPairty = 2;
 
         // The number of random bytes to receive for BytesToRead testing
-        public static readonly int numRndBytesToRead = 16;
+        private const int numRndBytesToRead = 16;
 
         // When we test Read and do not care about actually reading anything we must still
         // create an byte array to pass into the method the following is the size of the 
         // byte array used in this situation
-        public static readonly int defaultByteArraySize = 1;
+        private const int defaultByteArraySize = 1;
 
-        public static readonly int NUM_TRYS = 5;
+        private const int NUM_TRYS = 5;
 
         private const int MAX_WAIT_THREAD = 1000;
 
@@ -200,7 +200,6 @@ namespace System.IO.Ports.Tests
 
                 VerifyRead(com1, com2, bytesToWrite, expectedBytes, expectedBytes.Length / 2);
             }
-
         }
 
 
@@ -236,7 +235,6 @@ namespace System.IO.Ports.Tests
             using (var com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (var com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
-
                 IAsyncResult readAsyncResult;
 
                 var asyncRead = new AsyncRead(com1);

--- a/src/System.IO.Ports/tests/SerialStream/BeginWrite.cs
+++ b/src/System.IO.Ports/tests/SerialStream/BeginWrite.cs
@@ -14,26 +14,26 @@ namespace System.IO.Ports.Tests
     public class SerialStream_BeginWrite : PortsTest
     {
         // The string size used for large byte array testing
-        private static readonly int LARGE_BUFFER_SIZE = 2048;
+        private const int LARGE_BUFFER_SIZE = 2048;
 
         // When we test Write and do not care about actually writing anything we must still
         // create an byte array to pass into the method the following is the size of the 
         // byte array used in this situation
-        private static readonly int DEFAULT_BUFFER_SIZE = 1;
-        private static readonly int DEFAULT_BUFFER_OFFSET = 0;
-        private static readonly int DEFAULT_BUFFER_COUNT = 1;
+        private const int DEFAULT_BUFFER_SIZE = 1;
+        private const int DEFAULT_BUFFER_OFFSET = 0;
+        private const int DEFAULT_BUFFER_COUNT = 1;
 
         // The maximum buffer size when a exception occurs
-        private static readonly int MAX_BUFFER_SIZE_FOR_EXCEPTION = 255;
+        private const int MAX_BUFFER_SIZE_FOR_EXCEPTION = 255;
 
         // The maximum buffer size when a exception is not expected
-        private static readonly int MAX_BUFFER_SIZE = 8;
+        private const int MAX_BUFFER_SIZE = 8;
 
         // The default number of times the write method is called when verifying write
-        private static readonly int DEFAULT_NUM_WRITES = 3;
+        private const int DEFAULT_NUM_WRITES = 3;
 
         // The default number of bytes to write
-        private static readonly int DEFAULT_NUM_BYTES_TO_WRITE = 128;
+        private const int DEFAULT_NUM_BYTES_TO_WRITE = 128;
 
         // Maximum time to wait for processing the read command to complete
         private const int MAX_WAIT_WRITE_COMPLETE = 1000;
@@ -151,7 +151,7 @@ namespace System.IO.Ports.Tests
             int bufferLength = rndGen.Next(1, MAX_BUFFER_SIZE);
             int offset = bufferLength - 1;
             int count = 1;
-            
+
             VerifyWrite(new byte[bufferLength], offset, count);
         }
 
@@ -162,7 +162,7 @@ namespace System.IO.Ports.Tests
             int bufferLength = rndGen.Next(1, MAX_BUFFER_SIZE);
             int offset = 0;
             int count = bufferLength;
-            
+
             VerifyWrite(new byte[bufferLength], offset, count);
         }
 
@@ -406,7 +406,6 @@ namespace System.IO.Ports.Tests
                 Assert.Equal(this, writeAsyncResult.AsyncState);
                 Assert.False(writeAsyncResult.CompletedSynchronously, "Should not have completed sync (write)");
                 Assert.True(writeAsyncResult.IsCompleted, "Should have completed (write)");
-
             }
 
             com2.ReadTimeout = 500;
@@ -459,7 +458,6 @@ namespace System.IO.Ports.Tests
                     }
                 }
             }
-
         }
 
         private class CallbackHandler

--- a/src/System.IO.Ports/tests/SerialStream/BeginWrite_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/BeginWrite_Generic.cs
@@ -15,10 +15,10 @@ namespace System.IO.Ports.Tests
     {
         // Set bounds fore random timeout values.
         // If the min is to low write will not timeout accurately and the testcase will fail
-        public static int minRandomTimeout = 250;
+        private const int minRandomTimeout = 250;
 
         // If the max is to large then the testcase will take forever to run
-        public static int maxRandomTimeout = 2000;
+        private const int maxRandomTimeout = 2000;
 
         // If the percentage difference between the expected timeout and the actual timeout
         // found through Stopwatch is greater then 10% then the timeout value was not correctly
@@ -26,19 +26,19 @@ namespace System.IO.Ports.Tests
         public static double maxPercentageDifference = .15;
 
         // The byte size used when veryifying exceptions that write will throw 
-        public static readonly int BYTE_SIZE_EXCEPTION = 4;
+        private const int BYTE_SIZE_EXCEPTION = 4;
 
         // The byte size used when veryifying timeout 
-        public static readonly int BYTE_SIZE_TIMEOUT = 4;
+        private const int BYTE_SIZE_TIMEOUT = 4;
 
         // The byte size used when veryifying BytesToWrite 
-        public static readonly int BYTE_SIZE_BYTES_TO_WRITE = 4;
+        private const int BYTE_SIZE_BYTES_TO_WRITE = 4;
 
         // The bytes size used when veryifying Handshake 
-        public static readonly int BYTE_SIZE_HANDSHAKE = 8;
-        public static readonly int MAX_WAIT = 250;
-        public static readonly int ITERATION_WAIT = 50;
-        public static readonly int NUM_TRYS = 5;
+        private const int BYTE_SIZE_HANDSHAKE = 8;
+        private const int MAX_WAIT = 250;
+        private const int ITERATION_WAIT = 50;
+        private const int NUM_TRYS = 5;
 
         private const int MAX_WAIT_THREAD = 1000;
 
@@ -112,7 +112,6 @@ namespace System.IO.Ports.Tests
 
                 if (elapsedTime >= MAX_WAIT)
                 {
-
                     Fail("Err_2257asap!!! Expcted BytesToWrite={0} actual {1} after first write",
                                             BYTE_SIZE_BYTES_TO_WRITE, com1.BytesToWrite);
                 }
@@ -353,7 +352,6 @@ namespace System.IO.Ports.Tests
             using (var com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (var com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
-
                 var XOffBuffer = new byte[1];
                 var XOnBuffer = new byte[1];
                 var waitTime = 0;
@@ -390,7 +388,6 @@ namespace System.IO.Ports.Tests
                 // Verify that the correct number of bytes are in the buffer
                 if (BYTE_SIZE_HANDSHAKE != com1.BytesToWrite)
                 {
-
                     Fail("ERROR!!! Expcted BytesToWrite={0} actual {1}", BYTE_SIZE_HANDSHAKE,
                         com1.BytesToWrite);
                 }
@@ -399,7 +396,6 @@ namespace System.IO.Ports.Tests
                 if ((Handshake.RequestToSend == handshake || Handshake.RequestToSendXOnXOff == handshake) &&
                     com1.CtsHolding)
                 {
-
                     Fail("ERROR!!! Expcted CtsHolding={0} actual {1}", false, com1.CtsHolding);
                 }
 
@@ -421,7 +417,6 @@ namespace System.IO.Ports.Tests
                 // Verify that the correct number of bytes are in the buffer
                 if (0 != com1.BytesToWrite)
                 {
-
                     Fail("ERROR!!! Expcted BytesToWrite=0 actual {0}", com1.BytesToWrite);
                 }
 
@@ -429,12 +424,9 @@ namespace System.IO.Ports.Tests
                 if ((Handshake.RequestToSend == handshake || Handshake.RequestToSendXOnXOff == handshake) &&
                     !com1.CtsHolding)
                 {
-
                     Fail("ERROR!!! Expcted CtsHolding={0} actual {1}", true, com1.CtsHolding);
                 }
-
             }
-
         }
 
         private class AsyncWrite

--- a/src/System.IO.Ports/tests/SerialStream/Close.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Close.cs
@@ -13,9 +13,9 @@ namespace System.IO.Ports.Tests
     public class SerialStream_Close : PortsTest
     {
         // The number of the bytes that should read/write buffers
-        private static readonly int numReadBytes = 32;
-        private static readonly int numWriteBytes = 32;
-        
+        private const int numReadBytes = 32;
+        private const int numWriteBytes = 32;
+
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void OpenClose_WriteMethods()
         {
@@ -40,7 +40,7 @@ namespace System.IO.Ports.Tests
                 catch (InvalidOperationException)
                 {
                 }
-              
+
                 try
                 {
                     com.Write("A");
@@ -48,7 +48,7 @@ namespace System.IO.Ports.Tests
                 catch (InvalidOperationException)
                 {
                 }
-              
+
                 try
                 {
                     com.WriteLine("A");
@@ -58,7 +58,7 @@ namespace System.IO.Ports.Tests
                 }
             }
         }
-        
+
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void OpenClose_ReadMethods()
         {
@@ -117,7 +117,7 @@ namespace System.IO.Ports.Tests
                 }
             }
         }
-        
+
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void OpenClose_DiscardMethods()
         {
@@ -134,7 +134,7 @@ namespace System.IO.Ports.Tests
                 catch (InvalidOperationException)
                 {
                 }
-        
+
                 try
                 {
                     com.DiscardOutBuffer();
@@ -145,7 +145,7 @@ namespace System.IO.Ports.Tests
             }
         }
 
-        
+
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void OpenClose_OpenClose()
         {
@@ -164,7 +164,7 @@ namespace System.IO.Ports.Tests
                 }
 
                 com.Open();
-        
+
                 try
                 {
                     if (com.IsOpen)
@@ -193,11 +193,11 @@ namespace System.IO.Ports.Tests
                 serPortProp.VerifyPropertiesAndPrint(com);
             }
         }
-        
+
         [ConditionalFact(nameof(HasNullModem), nameof(HasHardwareFlowControl))]
         public void OpenFillBuffersClose()
         {
-            using(var com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
+            using (var com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (var com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 SerialPortProperties serPortProp = new SerialPortProperties();
@@ -232,7 +232,7 @@ namespace System.IO.Ports.Tests
                 serPortProp.VerifyPropertiesAndPrint(com1);
 
                 com1.Open();
-                
+
                 serPortProp.SetAllPropertiesToOpenDefaults();
                 serPortProp.SetProperty("PortName", TCSupport.LocalMachineSerialInfo.FirstAvailablePortName);
 
@@ -251,14 +251,14 @@ namespace System.IO.Ports.Tests
             // Give the port time to finish closing since we potentially have an unclosed BeginRead/BeginWrite
             Thread.Sleep(200);
         }
-        
+
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void OpenCloseNewInstanceOpen()
         {
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
                 SerialPortProperties serPortProp = new SerialPortProperties();
-                
+
                 Debug.WriteLine(
                     "Calling Close() after calling Open() then create a new instance of SerialPort and call Open() again");
                 com.Open();
@@ -289,7 +289,7 @@ namespace System.IO.Ports.Tests
                 }
             }
         }
-        
+
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void Open_BaseStreamClose_Open()
         {
@@ -308,7 +308,7 @@ namespace System.IO.Ports.Tests
                 serPortProp.VerifyPropertiesAndPrint(com);
             }
         }
-        
+
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void Open_BaseStreamClose_Close()
         {
@@ -334,7 +334,6 @@ namespace System.IO.Ports.Tests
         {
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
-
                 SerialPortProperties serPortProp = new SerialPortProperties();
 
                 Debug.WriteLine("Verifying Properites after calling Open(), BaseStream.Close() multiple times");

--- a/src/System.IO.Ports/tests/SerialStream/EndRead.cs
+++ b/src/System.IO.Ports/tests/SerialStream/EndRead.cs
@@ -29,10 +29,8 @@ namespace System.IO.Ports.Tests
                 IAsyncResult asyncResult = com1.BaseStream.BeginRead(new byte[8], 0, 8, null, null);
 
                 com2.Write(new byte[16], 0, 16);
-                while (com1.BytesToRead == 0)
-                {
-                    Thread.Sleep(50);
-                }
+
+                TCSupport.WaitForReadBufferToLoad(com1, 1);
 
                 com1.Close();
 
@@ -57,10 +55,8 @@ namespace System.IO.Ports.Tests
                 IAsyncResult asyncResult = com1.BaseStream.BeginRead(new byte[8], 0, 8, null, null);
 
                 com2.Write(new byte[16], 0, 16);
-                while (com1.BytesToRead == 0)
-                {
-                    Thread.Sleep(50);
-                }
+
+                TCSupport.WaitForReadBufferToLoad(com1, 1);
 
                 com1.BaseStream.Close();
 
@@ -142,8 +138,7 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(new byte[totalBytesToRead], 0, totalBytesToRead);
 
-                while (totalBytesToRead > com1.BytesToRead)
-                    Thread.Sleep(50);
+                TCSupport.WaitForReadBufferToLoad(com1, totalBytesToRead);
 
                 IAsyncResult readAsyncResult1 = com1.BaseStream.BeginRead(new byte[numBytesToRead1], 0, numBytesToRead1, null, null);
                 IAsyncResult readAsyncResult2 = com1.BaseStream.BeginRead(new byte[numBytesToRead2], 0, numBytesToRead2, null, null);
@@ -191,8 +186,7 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(new byte[totalBytesToRead], 0, totalBytesToRead);
 
-                while (totalBytesToRead > com1.BytesToRead)
-                    Thread.Sleep(50);
+                TCSupport.WaitForReadBufferToLoad(com1, totalBytesToRead);
 
                 IAsyncResult readAsyncResult1 = com1.BaseStream.BeginRead(new byte[numBytesToRead1], 0, numBytesToRead1, null, null);
                 IAsyncResult readAsyncResult2 = com1.BaseStream.BeginRead(new byte[numBytesToRead2], 0, numBytesToRead2, null, null);

--- a/src/System.IO.Ports/tests/SerialStream/EndRead.cs
+++ b/src/System.IO.Ports/tests/SerialStream/EndRead.cs
@@ -14,7 +14,7 @@ namespace System.IO.Ports.Tests
     {
         #region Test Cases
 
-       [ConditionalFact(nameof(HasNullModem))]
+        [ConditionalFact(nameof(HasNullModem))]
         public void EndReadAfterClose()
         {
             using (var com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
@@ -173,7 +173,6 @@ namespace System.IO.Ports.Tests
             using (var com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (var com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
-
                 int endReadReturnValue;
                 int numBytesToRead1 = 8, numBytesToRead2 = 16, numBytesToRead3 = 10;
                 int totalBytesToRead = numBytesToRead1 + numBytesToRead2 + numBytesToRead3;

--- a/src/System.IO.Ports/tests/SerialStream/EndWrite.cs
+++ b/src/System.IO.Ports/tests/SerialStream/EndWrite.cs
@@ -13,7 +13,7 @@ namespace System.IO.Ports.Tests
     public class SerialStream_EndWrite : PortsTest
     {
         #region Test Cases
-        
+
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void EndWriteAfterClose()
         {
@@ -78,12 +78,11 @@ namespace System.IO.Ports.Tests
 
                 IAsyncResult readAsyncResult = com.BaseStream.BeginRead(new byte[8], 0, 8, null, null);
                 VerifyEndWriteException(com.BaseStream, readAsyncResult, typeof(ArgumentException));
-
             }
             // Give the port time to finish closing since we have an unclosed BeginRead/BeginWrite
             Thread.Sleep(200);
         }
-        
+
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void AsyncResult_MultipleSameResult()
         {

--- a/src/System.IO.Ports/tests/SerialStream/Flush.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Flush.cs
@@ -13,12 +13,12 @@ namespace System.IO.Ports.Tests
     public class SerialStream_Flush : PortsTest
     {
         // The string used with Write(str) to fill the input buffer
-        private static readonly int DEFAULT_BUFFER_SIZE = 32;
-        private static readonly int MAX_WAIT_TIME = 500;
+        private const int DEFAULT_BUFFER_SIZE = 32;
+        private const int MAX_WAIT_TIME = 500;
 
         // The buffer lenght used whe filling the ouput buffer
-        private static readonly int DEFAULT_BUFFER_LENGTH = 8;
-        
+        private const int DEFAULT_BUFFER_LENGTH = 8;
+
         #region Test Cases
 
         [ConditionalFact(nameof(HasOneSerialPort))]
@@ -168,7 +168,7 @@ namespace System.IO.Ports.Tests
                 com1.Handshake = Handshake.RequestToSend;
 
                 t.Start();
-                
+
                 TCSupport.WaitForWriteBufferToLoad(com1, DEFAULT_BUFFER_LENGTH);
 
                 VerifyFlush(com1);
@@ -219,7 +219,7 @@ namespace System.IO.Ports.Tests
                 TCSupport.WaitForWriteBufferToLoad(com1, DEFAULT_BUFFER_LENGTH);
 
                 VerifyFlush(com1);
-                
+
                 // Wait for write method to timeout
                 while (t2.IsAlive)
                     Thread.Sleep(100);

--- a/src/System.IO.Ports/tests/SerialStream/Flush.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Flush.cs
@@ -57,7 +57,6 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
-                int elapsedTime = 0;
                 byte[] xmitBytes = new byte[DEFAULT_BUFFER_SIZE];
 
                 Debug.WriteLine("Verifying Flush method after input buffer has been filled");
@@ -68,11 +67,7 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(xmitBytes, 0, xmitBytes.Length);
 
-                while (com1.BytesToRead < DEFAULT_BUFFER_SIZE && elapsedTime < MAX_WAIT_TIME)
-                {
-                    Thread.Sleep(50);
-                    elapsedTime += 50;
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, DEFAULT_BUFFER_SIZE);
 
                 VerifyFlush(com1);
             }
@@ -84,7 +79,6 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
-                int elapsedTime = 0;
                 byte[] xmitBytes = new byte[DEFAULT_BUFFER_SIZE];
 
                 Debug.WriteLine("Verifying call Flush method several times after input buffer has been filled");
@@ -95,11 +89,7 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(xmitBytes, 0, xmitBytes.Length);
 
-                while (com1.BytesToRead < DEFAULT_BUFFER_SIZE && elapsedTime < MAX_WAIT_TIME)
-                {
-                    Thread.Sleep(50);
-                    elapsedTime += 50;
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, DEFAULT_BUFFER_SIZE);
 
                 VerifyFlush(com1);
                 VerifyFlush(com1);
@@ -113,8 +103,6 @@ namespace System.IO.Ports.Tests
             using (SerialPort com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
-
-                int elapsedTime = 0;
                 byte[] xmitBytes = new byte[DEFAULT_BUFFER_SIZE];
 
                 Debug.WriteLine(
@@ -127,22 +115,13 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(xmitBytes, 0, xmitBytes.Length);
 
-                while (com1.BytesToRead < DEFAULT_BUFFER_SIZE && elapsedTime < MAX_WAIT_TIME)
-                {
-                    Thread.Sleep(50);
-                    elapsedTime += 50;
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, DEFAULT_BUFFER_SIZE);
 
                 VerifyFlush(com1);
 
                 com2.Write(xmitBytes, 0, xmitBytes.Length);
-                elapsedTime = 0;
 
-                while (com1.BytesToRead < DEFAULT_BUFFER_SIZE * 2 && elapsedTime < MAX_WAIT_TIME)
-                {
-                    Thread.Sleep(50);
-                    elapsedTime += 50;
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, DEFAULT_BUFFER_SIZE);
 
                 VerifyFlush(com1);
             }
@@ -156,8 +135,6 @@ namespace System.IO.Ports.Tests
                 AsyncWriteRndByteArray asyncWriteRndByteArray = new AsyncWriteRndByteArray(com1, DEFAULT_BUFFER_SIZE);
                 Thread t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
 
-                int elapsedTime;
-
                 Debug.WriteLine("Verifying Flush method after output buffer has been filled");
 
                 com1.Open();
@@ -165,13 +142,8 @@ namespace System.IO.Ports.Tests
                 com1.Handshake = Handshake.RequestToSend;
 
                 t.Start();
-                elapsedTime = 0;
 
-                while (com1.BytesToWrite < DEFAULT_BUFFER_LENGTH && elapsedTime < MAX_WAIT_TIME)
-                {
-                    Thread.Sleep(50);
-                    elapsedTime += 50;
-                }
+                TCSupport.WaitForWriteBufferToLoad(com1, DEFAULT_BUFFER_LENGTH);
 
                 VerifyFlush(com1);
 
@@ -189,8 +161,6 @@ namespace System.IO.Ports.Tests
                 AsyncWriteRndByteArray asyncWriteRndByteArray = new AsyncWriteRndByteArray(com1, DEFAULT_BUFFER_SIZE);
                 Thread t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
 
-                int elapsedTime;
-
                 Debug.WriteLine("Verifying call Flush method several times after output buffer has been filled");
 
                 com1.Open();
@@ -198,13 +168,8 @@ namespace System.IO.Ports.Tests
                 com1.Handshake = Handshake.RequestToSend;
 
                 t.Start();
-                elapsedTime = 0;
-
-                while (com1.BytesToWrite < DEFAULT_BUFFER_LENGTH && elapsedTime < MAX_WAIT_TIME)
-                {
-                    Thread.Sleep(50);
-                    elapsedTime += 50;
-                }
+                
+                TCSupport.WaitForWriteBufferToLoad(com1, DEFAULT_BUFFER_LENGTH);
 
                 VerifyFlush(com1);
                 VerifyFlush(com1);
@@ -250,13 +215,8 @@ namespace System.IO.Ports.Tests
                     Thread.Sleep(100);
 
                 t2.Start();
-                elapsedTime = 0;
 
-                while (com1.BytesToWrite < DEFAULT_BUFFER_LENGTH && elapsedTime < MAX_WAIT_TIME)
-                {
-                    Thread.Sleep(50);
-                    elapsedTime += 50;
-                }
+                TCSupport.WaitForWriteBufferToLoad(com1, DEFAULT_BUFFER_LENGTH);
 
                 VerifyFlush(com1);
                 
@@ -275,7 +235,6 @@ namespace System.IO.Ports.Tests
                 AsyncWriteRndByteArray asyncWriteRndByteArray = new AsyncWriteRndByteArray(com1, DEFAULT_BUFFER_SIZE);
                 Thread t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
 
-                int elapsedTime = 0;
                 byte[] xmitBytes = new byte[DEFAULT_BUFFER_SIZE];
 
                 Debug.WriteLine("Verifying Flush method after input and output buffer has been filled");
@@ -289,20 +248,11 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(xmitBytes, 0, xmitBytes.Length);
 
-                while (com1.BytesToRead < DEFAULT_BUFFER_SIZE && elapsedTime < MAX_WAIT_TIME)
-                {
-                    Thread.Sleep(50);
-                    elapsedTime += 50;
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, DEFAULT_BUFFER_SIZE);
 
                 t.Start();
-                elapsedTime = 0;
 
-                while (com1.BytesToWrite < DEFAULT_BUFFER_LENGTH && elapsedTime < MAX_WAIT_TIME)
-                {
-                    Thread.Sleep(50);
-                    elapsedTime += 50;
-                }
+                TCSupport.WaitForWriteBufferToLoad(com1, DEFAULT_BUFFER_LENGTH);
 
                 VerifyFlush(com1);
 
@@ -336,11 +286,7 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(xmitBytes, 0, xmitBytes.Length);
 
-                while (com1.BytesToRead < DEFAULT_BUFFER_SIZE && elapsedTime < MAX_WAIT_TIME)
-                {
-                    Thread.Sleep(50);
-                    elapsedTime += 50;
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, DEFAULT_BUFFER_SIZE);
 
                 t.Start();
                 elapsedTime = 0;
@@ -371,7 +317,6 @@ namespace System.IO.Ports.Tests
                 Thread t1 = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
                 Thread t2 = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
 
-                int elapsedTime = 0;
                 byte[] xmitBytes = new byte[DEFAULT_BUFFER_SIZE];
 
                 Debug.WriteLine(
@@ -386,20 +331,11 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(xmitBytes, 0, xmitBytes.Length);
 
-                while (com1.BytesToRead < DEFAULT_BUFFER_SIZE && elapsedTime < MAX_WAIT_TIME)
-                {
-                    Thread.Sleep(50);
-                    elapsedTime += 50;
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, DEFAULT_BUFFER_SIZE);
 
                 t1.Start();
-                elapsedTime = 0;
 
-                while (com1.BytesToWrite < DEFAULT_BUFFER_LENGTH && elapsedTime < MAX_WAIT_TIME)
-                {
-                    Thread.Sleep(50);
-                    elapsedTime += 50;
-                }
+                TCSupport.WaitForWriteBufferToLoad(com1, DEFAULT_BUFFER_LENGTH);
 
                 VerifyFlush(com1);
 
@@ -408,22 +344,12 @@ namespace System.IO.Ports.Tests
                     Thread.Sleep(100);
 
                 t2.Start();
-                elapsedTime = 0;
 
-                while (com1.BytesToWrite < DEFAULT_BUFFER_LENGTH && elapsedTime < MAX_WAIT_TIME)
-                {
-                    Thread.Sleep(50);
-                    elapsedTime += 50;
-                }
+                TCSupport.WaitForWriteBufferToLoad(com1, DEFAULT_BUFFER_LENGTH);
 
                 com2.Write(xmitBytes, 0, xmitBytes.Length);
-                elapsedTime = 0;
 
-                while (com1.BytesToRead < DEFAULT_BUFFER_SIZE && elapsedTime < MAX_WAIT_TIME)
-                {
-                    Thread.Sleep(50);
-                    elapsedTime += 50;
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, DEFAULT_BUFFER_SIZE);
 
                 VerifyFlush(com1);
 
@@ -478,7 +404,6 @@ namespace System.IO.Ports.Tests
 
         private void VerifyFlush(SerialPort com)
         {
-
             int origBytesToRead = com.BytesToRead;
             int i = 0;
 
@@ -523,8 +448,6 @@ namespace System.IO.Ports.Tests
                     Fail("Err_09778asdh Expected to read {0} bytes actually read {1}", DEFAULT_BUFFER_SIZE, i);
                 }
             }
-
-
         }
         #endregion
     }

--- a/src/System.IO.Ports/tests/SerialStream/Length.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Length.cs
@@ -50,7 +50,6 @@ namespace System.IO.Ports.Tests
         {
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
-
                 com.Open();
 
                 Debug.WriteLine("Verifying Length property throws exception after a call to Open()");

--- a/src/System.IO.Ports/tests/SerialStream/Position.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Position.cs
@@ -11,8 +11,8 @@ namespace System.IO.Ports.Tests
 {
     public class SerialStream_Position : PortsTest
     {
-        private static readonly int DEFAULT_VALUE = 0;
-        private static readonly int BAD_VALUE = -1;
+        private const int DEFAULT_VALUE = 0;
+        private const int BAD_VALUE = -1;
 
         #region Test Cases
 
@@ -64,7 +64,6 @@ namespace System.IO.Ports.Tests
         {
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
-
                 com.Open();
                 Debug.WriteLine("Verifying Position property throws exception with a bad value after a call to Open()");
 

--- a/src/System.IO.Ports/tests/SerialStream/ReadByte.cs
+++ b/src/System.IO.Ports/tests/SerialStream/ReadByte.cs
@@ -14,8 +14,8 @@ namespace System.IO.Ports.Tests
     public class SerialStream_ReadByte : PortsTest
     {
         // The number of random bytes to receive
-        private static int numRndByte = 8;
-        
+        private const int numRndByte = 8;
+
         #region Test Cases
 
         [ConditionalFact(nameof(HasNullModem))]

--- a/src/System.IO.Ports/tests/SerialStream/ReadByte_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/ReadByte_Generic.cs
@@ -15,19 +15,19 @@ namespace System.IO.Ports.Tests
     {
         // Set bounds fore random timeout values.
         // If the min is to low read will not timeout accurately and the testcase will fail
-        private static int minRandomTimeout = 250;
+        private const int minRandomTimeout = 250;
 
         // If the max is to large then the testcase will take forever to run
-        private static int maxRandomTimeout = 2000;
+        private const int maxRandomTimeout = 2000;
 
         // If the percentage difference between the expected timeout and the actual timeout
         // found through Stopwatch is greater then 10% then the timeout value was not correctly
         // to the read method and the testcase fails.
-        private static double maxPercentageDifference = .15;
+        private const double maxPercentageDifference = .15;
 
         // The number of random bytes to receive
-        private static int numRndByte = 8;
-        private static readonly int NUM_TRYS = 5;
+        private const int numRndByte = 8;
+        private const int NUM_TRYS = 5;
 
         #region Test Cases
 
@@ -301,8 +301,6 @@ namespace System.IO.Ports.Tests
 
             if (com.IsOpen)
                 com.Close();
-
-
         }
 
 

--- a/src/System.IO.Ports/tests/SerialStream/ReadByte_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/ReadByte_Generic.cs
@@ -186,8 +186,6 @@ namespace System.IO.Ports.Tests
                 var actualBytes = new byte[numRndByte + 1];
                 var actualByteIndex = 0;
 
-                int waitTime;
-
                 /* 1 Additional character gets added to the input buffer when the parity error occurs on the last byte of a stream
                  We are verifying that besides this everything gets read in correctly. See NDP Whidbey: 24216 for more info on this */
                 Debug.WriteLine("Verifying default ParityReplace byte with a parity error on the last byte");
@@ -214,13 +212,8 @@ namespace System.IO.Ports.Tests
                 com2.Open();
 
                 com2.Write(bytesToWrite, 0, bytesToWrite.Length);
-                waitTime = 0;
 
-                while (bytesToWrite.Length + 1 > com1.BytesToRead && waitTime < 500)
-                {
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length + 1);
 
                 while (true)
                 {
@@ -382,17 +375,12 @@ namespace System.IO.Ports.Tests
             var byteRcvBuffer = new byte[expectedBytes.Length];
             var rcvBufferSize = 0;
             int i;
-            var waitTime = 0;
 
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
             com1.ReadTimeout = 250;
             com1.Encoding = encoding;
 
-            while (com1.BytesToRead < bytesToWrite.Length && waitTime < 500)
-            {
-                Thread.Sleep(50);
-                waitTime += 50;
-            }
+            TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length);
 
             i = 0;
             while (true)

--- a/src/System.IO.Ports/tests/SerialStream/ReadTimeout.cs
+++ b/src/System.IO.Ports/tests/SerialStream/ReadTimeout.cs
@@ -13,23 +13,23 @@ namespace System.IO.Ports.Tests
     public class SerialStream_ReadTimeout_Property : PortsTest
     {
         // The default number of bytes to write with when testing timeout with Read(byte[], int, int)
-        private static readonly int DEFAULT_READ_BYTE_ARRAY_SIZE = 8;
+        private const int DEFAULT_READ_BYTE_ARRAY_SIZE = 8;
 
         // The amount of time to wait when expecting an long timeout
-        private static readonly int DEFAULT_WAIT_LONG_TIMEOUT = 250;
+        private const int DEFAULT_WAIT_LONG_TIMEOUT = 250;
 
         // The maximum acceptable time allowed when a read method should timeout immediately when it is called for the first time
-        private static readonly int MAX_ACCEPTABLE_WARMUP_ZERO_TIMEOUT = 1000;
+        private const int MAX_ACCEPTABLE_WARMUP_ZERO_TIMEOUT = 1000;
 
         // The maximum acceptable percentage difference allowed when a read method is called for the first time
-        private static readonly double MAX_ACCEPTABLE_WARMUP_PERCENTAGE_DIFFERENCE = .5;
+        private const double MAX_ACCEPTABLE_WARMUP_PERCENTAGE_DIFFERENCE = .5;
 
         // The maximum acceptable percentage difference allowed
-        private static readonly double MAX_ACCEPTABLE_PERCENTAGE_DIFFERENCE = .15;
+        private const double MAX_ACCEPTABLE_PERCENTAGE_DIFFERENCE = .15;
 
-        private static readonly int SUCCESSIVE_READTIMEOUT_SOMEDATA = 950;
+        private const int SUCCESSIVE_READTIMEOUT_SOMEDATA = 950;
 
-        private static readonly int NUM_TRYS = 5;
+        private const int NUM_TRYS = 5;
 
         private delegate void ReadMethodDelegate(Stream stream);
 
@@ -270,7 +270,7 @@ namespace System.IO.Ports.Tests
         [ConditionalFact(nameof(HasNullModem))]
         public void ReadTimeout_0_1ByteAvailable_Read_byte_int_int()
         {
-            using(var com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
+            using (var com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (var com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 var rcvBytes = new byte[128];
@@ -284,7 +284,7 @@ namespace System.IO.Ports.Tests
                 Stream stream = com1.BaseStream;
                 stream.ReadTimeout = 0;
 
-                com2.Write(new byte[] {50}, 0, 1);
+                com2.Write(new byte[] { 50 }, 0, 1);
 
                 TCSupport.WaitForReadBufferToLoad(com1, 1);
 
@@ -293,14 +293,13 @@ namespace System.IO.Ports.Tests
 
                 Assert.True(50 == rcvBytes[0],
                     string.Format("Err_778946ahba, Expected to read 50 actual={0}", rcvBytes[0]));
-
             }
         }
 
         [ConditionalFact(nameof(HasNullModem))]
         public void ReadTimeout_0_1ByteAvailable_ReadByte()
         {
-            using(var com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
+            using (var com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (var com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 int byteRead;
@@ -312,7 +311,7 @@ namespace System.IO.Ports.Tests
                 Stream stream = com1.BaseStream;
                 stream.ReadTimeout = 0;
 
-                com2.Write(new byte[] {50}, 0, 1);
+                com2.Write(new byte[] { 50 }, 0, 1);
 
                 TCSupport.WaitForReadBufferToLoad(com1, 1);
 
@@ -333,7 +332,6 @@ namespace System.IO.Ports.Tests
 
                 com2.Open();
                 com2.Write(xmitBuffer, 0, xmitBuffer.Length);
-
             }
         }
         #endregion
@@ -360,7 +358,7 @@ namespace System.IO.Ports.Tests
 
         private void VerifyLongTimeout(ReadMethodDelegate readMethod, int readTimeout)
         {
-            using(var com1 = TCSupport.InitFirstSerialPort())
+            using (var com1 = TCSupport.InitFirstSerialPort())
             using (var com2 = TCSupport.InitSecondSerialPort(com1))
             {
                 com1.Open();
@@ -385,7 +383,7 @@ namespace System.IO.Ports.Tests
         {
             var readThread = new ReadDelegateThread(com1.BaseStream, readMethod);
             var t = new Thread(readThread.CallRead);
-            
+
 
             t.Start();
             Thread.Sleep(DEFAULT_WAIT_LONG_TIMEOUT);
@@ -397,15 +395,12 @@ namespace System.IO.Ports.Tests
 
             while (t.IsAlive)
                 Thread.Sleep(10);
-
-            
         }
 
         private void VerifyTimeout(ReadMethodDelegate readMethod, int readTimeout)
         {
             using (var com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
-
                 com1.Open();
                 com1.BaseStream.WriteTimeout = 1;
                 com1.BaseStream.ReadTimeout = 1;
@@ -417,9 +412,7 @@ namespace System.IO.Ports.Tests
                         com1.BaseStream.ReadTimeout));
 
                 VerifyTimeout(readMethod, com1.BaseStream);
-
             }
-            
         }
 
         private void VerifyTimeout(ReadMethodDelegate readMethod, Stream stream)
@@ -428,7 +421,7 @@ namespace System.IO.Ports.Tests
             int expectedTime = stream.ReadTimeout;
             int actualTime;
             double percentageDifference;
-            
+
 
             // Warmup the read method. When called for the first time the read method seems to take much longer then subsequent calls
             timer.Start();
@@ -470,8 +463,6 @@ namespace System.IO.Ports.Tests
             // Verify that the percentage difference between the expected and actual timeout is less then maxPercentageDifference
             Assert.True(percentageDifference <= MAX_ACCEPTABLE_PERCENTAGE_DIFFERENCE,
                 string.Format("Err_56485ahpbz!!!: The read method timedout in {0} expected {1} percentage difference: {2}", actualTime, expectedTime, percentageDifference));
-
-            
         }
 
         private void Verify0Timeout(ReadMethodDelegate readMethod)

--- a/src/System.IO.Ports/tests/SerialStream/ReadTimeout.cs
+++ b/src/System.IO.Ports/tests/SerialStream/ReadTimeout.cs
@@ -286,10 +286,7 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(new byte[] {50}, 0, 1);
 
-                while (com1.BytesToRead == 0)
-                {
-                    Thread.Sleep(50);
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, 1);
 
                 Assert.True(1 == (bytesRead = com1.Read(rcvBytes, 0, rcvBytes.Length)),
                     string.Format("Err_31597ahpba, Expected to Read to return 1 actual={0}", bytesRead));
@@ -317,14 +314,10 @@ namespace System.IO.Ports.Tests
 
                 com2.Write(new byte[] {50}, 0, 1);
 
-                while (com1.BytesToRead == 0)
-                {
-                    Thread.Sleep(50);
-                }
+                TCSupport.WaitForReadBufferToLoad(com1, 1);
 
                 Assert.True(50 == (byteRead = com1.ReadByte()),
                     string.Format("Err_05949aypa, Expected to Read to return 50 actual={0}", byteRead));
-
             }
         }
 

--- a/src/System.IO.Ports/tests/SerialStream/Read_byte_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Read_byte_int_int.cs
@@ -13,23 +13,23 @@ namespace System.IO.Ports.Tests
     public class SerialStream_Read_byte_int_int : PortsTest
     {
         // The number of random bytes to receive for read method testing
-        private static readonly int numRndBytesToRead = 16;
+        private const int numRndBytesToRead = 16;
 
         // The number of random bytes to receive for large input buffer testing
-        private static readonly int largeNumRndBytesToRead = 2048;
+        private const int largeNumRndBytesToRead = 2048;
 
         // When we test Read and do not care about actually reading anything we must still
         // create an byte array to pass into the method the following is the size of the 
         // byte array used in this situation
-        private static readonly int defaultByteArraySize = 1;
-        private static readonly int defaultByteOffset = 0;
-        private static readonly int defaultByteCount = 1;
+        private const int defaultByteArraySize = 1;
+        private const int defaultByteOffset = 0;
+        private const int defaultByteCount = 1;
 
         // The maximum buffer size when a exception occurs
-        private static readonly int maxBufferSizeForException = 255;
+        private const int maxBufferSizeForException = 255;
 
         // The maximum buffer size when a exception is not expected
-        private static readonly int maxBufferSize = 8;
+        private const int maxBufferSize = 8;
 
         #region Test Cases
 
@@ -271,7 +271,7 @@ namespace System.IO.Ports.Tests
 
                 VerifyBuffer(rcvBuffer, oldRcvBuffer, offset, bytesRead);
 
-                    Array.Copy(rcvBuffer, offset, buffer, totalBytesRead, bytesRead);
+                Array.Copy(rcvBuffer, offset, buffer, totalBytesRead, bytesRead);
                 totalBytesRead += bytesRead;
 
                 if (bytesToWrite.Length - totalBytesRead != com1.BytesToRead)

--- a/src/System.IO.Ports/tests/SerialStream/Read_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Read_byte_int_int_Generic.cs
@@ -15,31 +15,31 @@ namespace System.IO.Ports.Tests
     {
         // Set bounds fore random timeout values.
         // If the min is to low read will not timeout accurately and the testcase will fail
-        private static readonly int minRandomTimeout = 250;
+        private const int minRandomTimeout = 250;
 
         // If the max is to large then the testcase will take forever to run
-        private static readonly int maxRandomTimeout = 2000;
+        private const int maxRandomTimeout = 2000;
 
         // If the percentage difference between the expected timeout and the actual timeout
         // found through Stopwatch is greater then 10% then the timeout value was not correctly
         // to the read method and the testcase fails.
-        private static readonly double maxPercentageDifference = .15;
+        private const double maxPercentageDifference = .15;
 
         // The number of random bytes to receive for parity testing
-        private static readonly int numRndBytesPairty = 8;
+        private const int numRndBytesPairty = 8;
 
         // The number of characters to read at a time for parity testing
-        private static readonly int numBytesReadPairty = 2;
+        private const int numBytesReadPairty = 2;
 
         // The number of random bytes to receive for BytesToRead testing
-        private static readonly int numRndBytesToRead = 16;
+        private const int numRndBytesToRead = 16;
 
         // When we test Read and do not care about actually reading anything we must still
         // create an byte array to pass into the method the following is the size of the 
         // byte array used in this situation
-        private static readonly int defaultByteArraySize = 1;
+        private const int defaultByteArraySize = 1;
 
-        private static readonly int NUM_TRYS = 5;
+        private const int NUM_TRYS = 5;
 
         #region Test Cases
 
@@ -117,7 +117,7 @@ namespace System.IO.Ports.Tests
             {
                 var rndGen = new Random(-55);
                 var t = new Thread(WriteToCom1);
-                
+
                 com1.ReadTimeout = rndGen.Next(minRandomTimeout, maxRandomTimeout);
                 com1.Encoding = new UTF8Encoding();
 
@@ -176,7 +176,7 @@ namespace System.IO.Ports.Tests
 
             VerifyParityReplaceByte('\0', rndGen.Next(0, numRndBytesPairty - 1), Encoding.UTF32);
         }
-        
+
         [ConditionalFact(nameof(HasNullModem))]
         public void RNDParityReplaceByte()
         {
@@ -195,7 +195,7 @@ namespace System.IO.Ports.Tests
                 var bytesToWrite = new byte[numRndBytesPairty];
                 var expectedBytes = new byte[numRndBytesPairty];
                 var actualBytes = new byte[numRndBytesPairty + 1];
-                
+
                 /* 1 Additional character gets added to the input buffer when the parity error occurs on the last byte of a stream
            We are verifying that besides this everything gets read in correctly. See NDP Whidbey: 24216 for more info on this */
                 Debug.WriteLine("Verifying default ParityReplace byte with a parity errro on the last byte");
@@ -224,7 +224,7 @@ namespace System.IO.Ports.Tests
                 com2.Write(bytesToWrite, 0, bytesToWrite.Length);
 
                 TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length + 1);
-                
+
                 com1.BaseStream.Read(actualBytes, 0, actualBytes.Length);
 
                 // Compare the chars that were written with the ones we expected to read
@@ -250,7 +250,7 @@ namespace System.IO.Ports.Tests
                 VerifyRead(com1, com2, bytesToWrite, expectedBytes, expectedBytes.Length / 2);
             }
         }
-        
+
         [ConditionalFact(nameof(HasNullModem))]
         public void BytesToRead_RND_Buffer_Size()
         {
@@ -318,8 +318,6 @@ namespace System.IO.Ports.Tests
 
             if (com.IsOpen)
                 com.Close();
-
-
         }
 
 

--- a/src/System.IO.Ports/tests/SerialStream/Read_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Read_byte_int_int_Generic.cs
@@ -195,9 +195,7 @@ namespace System.IO.Ports.Tests
                 var bytesToWrite = new byte[numRndBytesPairty];
                 var expectedBytes = new byte[numRndBytesPairty];
                 var actualBytes = new byte[numRndBytesPairty + 1];
-
-                int waitTime;
-
+                
                 /* 1 Additional character gets added to the input buffer when the parity error occurs on the last byte of a stream
            We are verifying that besides this everything gets read in correctly. See NDP Whidbey: 24216 for more info on this */
                 Debug.WriteLine("Verifying default ParityReplace byte with a parity errro on the last byte");
@@ -224,14 +222,9 @@ namespace System.IO.Ports.Tests
                 com2.Open();
 
                 com2.Write(bytesToWrite, 0, bytesToWrite.Length);
-                waitTime = 0;
 
-                while (bytesToWrite.Length + 1 > com1.BytesToRead && waitTime < 500)
-                {
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
+                TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length + 1);
+                
                 com1.BaseStream.Read(actualBytes, 0, actualBytes.Length);
 
                 // Compare the chars that were written with the ones we expected to read
@@ -429,21 +422,15 @@ namespace System.IO.Ports.Tests
 
         private void VerifyRead(SerialPort com1, SerialPort com2, byte[] bytesToWrite, byte[] expectedBytes, int rcvBufferSize)
         {
-
             var rcvBuffer = new byte[rcvBufferSize];
             var buffer = new byte[bytesToWrite.Length];
             int totalBytesRead;
             int bytesToRead;
-            var waitTime = 0;
 
             com2.Write(bytesToWrite, 0, bytesToWrite.Length);
             com1.ReadTimeout = 250;
 
-            while (com1.BytesToRead < bytesToWrite.Length && waitTime < 500)
-            {
-                Thread.Sleep(50);
-                waitTime += 50;
-            }
+            TCSupport.WaitForReadBufferToLoad(com1, bytesToWrite.Length);
 
             totalBytesRead = 0;
             bytesToRead = com1.BytesToRead;

--- a/src/System.IO.Ports/tests/SerialStream/Seek.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Seek.cs
@@ -11,10 +11,10 @@ namespace System.IO.Ports.Tests
 {
     public class SerialStream_Seek : PortsTest
     {
-        private static readonly int DEFAULT_OFFSET = 0;
-        private static readonly int DEFAULT_ORIGIN = (int)SeekOrigin.Begin;
-        private static readonly int BAD_OFFSET = -1;
-        private static readonly int BAD_ORIGIN = -1;
+        private const int DEFAULT_OFFSET = 0;
+        private const int DEFAULT_ORIGIN = (int)SeekOrigin.Begin;
+        private const int BAD_OFFSET = -1;
+        private const int BAD_ORIGIN = -1;
 
         #region Test Cases
 

--- a/src/System.IO.Ports/tests/SerialStream/SetLength.cs
+++ b/src/System.IO.Ports/tests/SerialStream/SetLength.cs
@@ -11,9 +11,9 @@ namespace System.IO.Ports.Tests
 {
     public class SerialStream_SetLength : PortsTest
     {
-        private static readonly int DEFAULT_VALUE = 0;
-        private static readonly int BAD_VALUE = -1;
-        
+        private const int DEFAULT_VALUE = 0;
+        private const int BAD_VALUE = -1;
+
         #region Test Cases
 
         [ConditionalFact(nameof(HasOneSerialPort))]
@@ -51,7 +51,6 @@ namespace System.IO.Ports.Tests
         {
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
-
                 com.Open();
                 Debug.WriteLine("Verifying SetLength method throws exception after a call to Open()");
 
@@ -74,7 +73,7 @@ namespace System.IO.Ports.Tests
 
         #endregion
 
-            #region Verification for Test Cases
+        #region Verification for Test Cases
 
         #endregion
     }

--- a/src/System.IO.Ports/tests/SerialStream/WriteByte.cs
+++ b/src/System.IO.Ports/tests/SerialStream/WriteByte.cs
@@ -14,10 +14,10 @@ namespace System.IO.Ports.Tests
     public class SerialStream_WriteByte : PortsTest
     {
         // The large number of times the write method is called when verifying write
-        private static readonly int LARGE_NUM_WRITES = 2048;
+        private const int LARGE_NUM_WRITES = 2048;
 
         // The default number of times the write method is called when verifying write
-        private static readonly int DEFAULT_NUM_WRITES = 8;
+        private const int DEFAULT_NUM_WRITES = 8;
 
         #region Test Cases
 

--- a/src/System.IO.Ports/tests/SerialStream/WriteByte_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/WriteByte_Generic.cs
@@ -17,17 +17,17 @@ namespace System.IO.Ports.Tests
     {
         // Set bounds fore random timeout values.
         // If the min is to low write will not timeout accurately and the testcase will fail
-        private static int minRandomTimeout = 250;
+        private const int minRandomTimeout = 250;
 
         // If the max is to large then the testcase will take forever to run
-        private static int maxRandomTimeout = 2000;
+        private const int maxRandomTimeout = 2000;
 
         // If the percentage difference between the expected timeout and the actual timeout
         // found through Stopwatch is greater then 10% then the timeout value was not correctly
         // to the write method and the testcase fails.
-        private static double maxPercentageDifference = .15;
-        private static readonly int NUM_TRYS = 5;
-        private static readonly byte DEFAULT_BYTE = 0;
+        private const double maxPercentageDifference = .15;
+        private const int NUM_TRYS = 5;
+        private const byte DEFAULT_BYTE = 0;
 
         #region Test Cases
 
@@ -162,7 +162,6 @@ namespace System.IO.Ports.Tests
                     Thread.Sleep(100);
 
                 VerifyTimeout(com1);
-
             }
         }
 
@@ -186,8 +185,6 @@ namespace System.IO.Ports.Tests
                 // Wait for write method to timeout and complete the task
                 TCSupport.WaitForTaskCompletion(task);
             }
-
-
         }
 
         [OuterLoop("Slow Test")]
@@ -216,7 +213,7 @@ namespace System.IO.Ports.Tests
 
                 TCSupport.WaitForTaskToStart(t2);
 
-                TCSupport.WaitForWriteBufferToLoad(com, blockLength*2);
+                TCSupport.WaitForWriteBufferToLoad(com, blockLength * 2);
 
                 // Wait for both write methods to timeout
                 TCSupport.WaitForTaskCompletion(t1);

--- a/src/System.IO.Ports/tests/SerialStream/WriteByte_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/WriteByte_Generic.cs
@@ -78,7 +78,7 @@ namespace System.IO.Ports.Tests
                 com1.Open();
                 com2.Open();
 
-                com2.BaseStream.WriteByte(19);
+                com2.BaseStream.WriteByte(XOnOff.XOFF);
                 Thread.Sleep(250);
                 com2.Close();
 
@@ -372,7 +372,7 @@ namespace System.IO.Ports.Tests
 
                 if (Handshake.XOnXOff == handshake || Handshake.RequestToSendXOnXOff == handshake)
                 {
-                    com2.BaseStream.WriteByte(19);
+                    com2.BaseStream.WriteByte(XOnOff.XOFF);
                     Thread.Sleep(250);
                 }
 
@@ -398,7 +398,7 @@ namespace System.IO.Ports.Tests
 
                 if (Handshake.XOnXOff == handshake || Handshake.RequestToSendXOnXOff == handshake)
                 {
-                    com2.BaseStream.WriteByte(17);
+                    com2.BaseStream.WriteByte(XOnOff.XON);
                 }
 
                 // Wait till write finishes

--- a/src/System.IO.Ports/tests/SerialStream/WriteTimeout.cs
+++ b/src/System.IO.Ports/tests/SerialStream/WriteTimeout.cs
@@ -240,7 +240,7 @@ namespace System.IO.Ports.Tests
         }
 
         [OuterLoop("Slow test")]
-        [ConditionalFact(nameof(HasOneSerialPort), nameof(HasHardwareFlowControl))]
+        [ConditionalFact(nameof(HasOneSerialPort), nameof(HasSingleByteTransmitBlocking))]
         public void SuccessiveWriteTimeoutNoData_WriteByte()
         {
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))

--- a/src/System.IO.Ports/tests/SerialStream/WriteTimeout.cs
+++ b/src/System.IO.Ports/tests/SerialStream/WriteTimeout.cs
@@ -14,42 +14,42 @@ namespace System.IO.Ports.Tests
     public class SerialStream_WriteTimeout_Property : PortsTest
     {
         // The default number of bytes to write with when testing timeout with Write(byte[], int, int)
-        private static readonly int DEFAULT_WRITE_BYTE_ARRAY_SIZE = TCSupport.MinimumBlockingByteCount;
+        private static readonly int s_DEFAULT_WRITE_BYTE_ARRAY_SIZE = TCSupport.MinimumBlockingByteCount;
 
         // The large number of bytes to write with when testing timeout with Write(byte[], int, int)
         // This needs to be large enough for Write timeout
-        private static readonly int DEFAULT_WRITE_BYTE_LARGE_ARRAY_SIZE = 1024 * 100;
+        private const int DEFAULT_WRITE_BYTE_LARGE_ARRAY_SIZE = 1024 * 100;
 
         // The BaudRate to use to make Write timeout when writing DEFAULT_WRITE_BYTE_LARGE_ARRAY_SIZE bytes 
-        private static readonly int LARGEWRITE_BAUDRATE = 1200;
+        private const int LARGEWRITE_BAUDRATE = 1200;
 
         // The timeout to use to make Write timeout when writing DEFAULT_WRITE_BYTE_LARGE_ARRAY_SIZE
-        private static readonly int LARGEWRITE_TIMEOUT = 750;
+        private const int LARGEWRITE_TIMEOUT = 750;
 
         // The default byte to call with WriteByte
-        private static readonly byte DEFAULT_WRITE_BYTE = 33;
+        private const byte DEFAULT_WRITE_BYTE = 33;
 
         // The amount of time to wait when expecting an long timeout
-        private static readonly int DEFAULT_WAIT_LONG_TIMEOUT = 250;
+        private const int DEFAULT_WAIT_LONG_TIMEOUT = 250;
 
         // The maximum acceptable time allowed when a write method should timeout immediately
-        private static readonly int MAX_ACCEPTABLE_ZERO_TIMEOUT = 100;
+        private const int MAX_ACCEPTABLE_ZERO_TIMEOUT = 100;
 
         // The maximum acceptable time allowed when a write method should timeout immediately when it is called for the first time
-        private static readonly int MAX_ACCEPTABLE_WARMUP_ZERO_TIMEOUT = 1000;
+        private const int MAX_ACCEPTABLE_WARMUP_ZERO_TIMEOUT = 1000;
 
         // The maximum acceptable percentage difference allowed when a write method is called for the first time
-        private static readonly double MAX_ACCEPTABLE_WARMUP_PERCENTAGE_DIFFERENCE = .5;
+        private const double MAX_ACCEPTABLE_WARMUP_PERCENTAGE_DIFFERENCE = .5;
 
         // The maximum acceptable percentage difference allowed
-        private static readonly double MAX_ACCEPTABLE_PERCENTAGE_DIFFERENCE = .15;
+        private const double MAX_ACCEPTABLE_PERCENTAGE_DIFFERENCE = .15;
 
-        private static readonly int SUCCESSIVE_WriteTimeout_SOMEDATA = 950;
+        private const int SUCCESSIVE_WriteTimeout_SOMEDATA = 950;
 
-        private static readonly int NUM_TRYS = 5;
+        private const int NUM_TRYS = 5;
 
         private delegate void WriteMethodDelegate(Stream stream);
-        
+
         #region Test Cases
 
         [ConditionalFact(nameof(HasOneSerialPort))]
@@ -66,7 +66,6 @@ namespace System.IO.Ports.Tests
                     string.Format(
                         "Err_1707azhpbn Verifying the default value of WriteTimeout Expected={0} Actual={1} FAILED", -1,
                         stream.WriteTimeout));
-
             }
         }
 
@@ -181,7 +180,7 @@ namespace System.IO.Ports.Tests
 
                 Debug.WriteLine("Verifying WriteTimeout={0} with successive call to Write(byte[], int, int) and no data", stream.WriteTimeout);
 
-                Assert.Throws<TimeoutException>(() => stream.Write(new byte[DEFAULT_WRITE_BYTE_ARRAY_SIZE], 0, DEFAULT_WRITE_BYTE_ARRAY_SIZE));
+                Assert.Throws<TimeoutException>(() => stream.Write(new byte[s_DEFAULT_WRITE_BYTE_ARRAY_SIZE], 0, s_DEFAULT_WRITE_BYTE_ARRAY_SIZE));
 
                 VerifyTimeout(Write_byte_int_int, stream);
             }
@@ -220,7 +219,7 @@ namespace System.IO.Ports.Tests
 
                 try
                 {
-                    stream.Write(new byte[DEFAULT_WRITE_BYTE_ARRAY_SIZE], 0, DEFAULT_WRITE_BYTE_ARRAY_SIZE);
+                    stream.Write(new byte[s_DEFAULT_WRITE_BYTE_ARRAY_SIZE], 0, s_DEFAULT_WRITE_BYTE_ARRAY_SIZE);
                 }
                 catch (TimeoutException)
                 {
@@ -257,7 +256,6 @@ namespace System.IO.Ports.Tests
 
                 VerifyTimeout(WriteByte, stream);
             }
-
         }
 
         [ConditionalFact(nameof(HasNullModem), nameof(HasHardwareFlowControl))]
@@ -368,7 +366,7 @@ namespace System.IO.Ports.Tests
                     }
                 }
             }
-            
+
             public void Stop()
             {
                 lock (this)
@@ -393,7 +391,7 @@ namespace System.IO.Ports.Tests
                 com1.Handshake = Handshake.RequestToSend;
                 com1.BaseStream.ReadTimeout = 1;
 
-                Assert.Equal(-1,com1.BaseStream.WriteTimeout);
+                Assert.Equal(-1, com1.BaseStream.WriteTimeout);
 
                 VerifyLongTimeout(writeMethod, com1);
             }
@@ -420,7 +418,7 @@ namespace System.IO.Ports.Tests
         {
             var writeThread = new WriteDelegateThread(com1.BaseStream, writeMethod);
             var t = new Thread(writeThread.CallWrite);
-            
+
             t.Start();
             Thread.Sleep(DEFAULT_WAIT_LONG_TIMEOUT);
             Assert.True(t.IsAlive,
@@ -428,7 +426,6 @@ namespace System.IO.Ports.Tests
             com1.Handshake = Handshake.None;
             while (t.IsAlive)
                 Thread.Sleep(10);
-            
         }
 
         private void VerifyTimeout(WriteMethodDelegate writeMethod, int WriteTimeout)
@@ -455,7 +452,7 @@ namespace System.IO.Ports.Tests
             int expectedTime = stream.WriteTimeout;
             int actualTime;
             double percentageDifference;
-            
+
 
             // Warmup the write method. When called for the first time the write method seems to take much longer then subsequent calls
             timer.Start();
@@ -497,8 +494,6 @@ namespace System.IO.Ports.Tests
             // Verify that the percentage difference between the expected and actual timeout is less then maxPercentageDifference
             Assert.True(percentageDifference <= MAX_ACCEPTABLE_PERCENTAGE_DIFFERENCE,
                 string.Format("Err_56485ahpbz!!!: The write method timedout in {0} expected {1} percentage difference: {2}", actualTime, expectedTime, percentageDifference));
-
-            
         }
 
         private void Verify0Timeout(WriteMethodDelegate writeMethod)
@@ -516,7 +511,6 @@ namespace System.IO.Ports.Tests
                 Assert.Equal(1, com1.BaseStream.WriteTimeout);
 
                 Verify0Timeout(writeMethod, com1.BaseStream);
-
             }
         }
 
@@ -583,7 +577,6 @@ namespace System.IO.Ports.Tests
                 com.Close();
 
                 VerifyException(stream, readTimeout, expectedExceptionAfterClose);
-
             }
         }
 
@@ -605,7 +598,7 @@ namespace System.IO.Ports.Tests
 
         private void Write_byte_int_int(Stream stream)
         {
-            stream.Write(new byte[DEFAULT_WRITE_BYTE_ARRAY_SIZE], 0, DEFAULT_WRITE_BYTE_ARRAY_SIZE);
+            stream.Write(new byte[s_DEFAULT_WRITE_BYTE_ARRAY_SIZE], 0, s_DEFAULT_WRITE_BYTE_ARRAY_SIZE);
         }
 
         private void Write_byte_int_int_Large(Stream stream)

--- a/src/System.IO.Ports/tests/SerialStream/Write_byte_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Write_byte_int_int.cs
@@ -14,23 +14,23 @@ namespace System.IO.Ports.Tests
     public class SerialStream_Write_byte_int_int : PortsTest
     {
         // The string size used for large byte array testing
-        private static readonly int LARGE_BUFFER_SIZE = 2048;
+        private const int LARGE_BUFFER_SIZE = 2048;
 
         // When we test Write and do not care about actually writing anything we must still
         // create an byte array to pass into the method the following is the size of the 
         // byte array used in this situation
-        private static readonly int DEFAULT_BUFFER_SIZE = 1;
-        private static readonly int DEFAULT_BUFFER_OFFSET = 0;
-        private static readonly int DEFAULT_BUFFER_COUNT = 1;
+        private const int DEFAULT_BUFFER_SIZE = 1;
+        private const int DEFAULT_BUFFER_OFFSET = 0;
+        private const int DEFAULT_BUFFER_COUNT = 1;
 
         // The maximum buffer size when a exception occurs
-        private static readonly int MAX_BUFFER_SIZE_FOR_EXCEPTION = 255;
+        private const int MAX_BUFFER_SIZE_FOR_EXCEPTION = 255;
 
         // The maximum buffer size when a exception is not expected
-        private static readonly int MAX_BUFFER_SIZE = 8;
+        private const int MAX_BUFFER_SIZE = 8;
 
         // The default number of times the write method is called when verifying write
-        private static readonly int DEFAULT_NUM_WRITES = 3;
+        private const int DEFAULT_NUM_WRITES = 3;
 
         #region Test Cases
         [ConditionalFact(nameof(HasOneSerialPort))]
@@ -155,7 +155,7 @@ namespace System.IO.Ports.Tests
             int bufferLength = rndGen.Next(1, MAX_BUFFER_SIZE);
             int offset = bufferLength - 1;
             var count = 1;
-            
+
             VerifyWrite(new byte[bufferLength], offset, count);
         }
 
@@ -257,7 +257,6 @@ namespace System.IO.Ports.Tests
         {
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
-
                 int bufferLength = null == buffer ? 0 : buffer.Length;
 
                 Debug.WriteLine("Verifying write method throws {0} buffer.Lenght={1}, offset={2}, count={3}",
@@ -382,8 +381,6 @@ namespace System.IO.Ports.Tests
 
             if (com2.IsOpen)
                 com2.Close();
-
-
         }
         #endregion
     }

--- a/src/System.IO.Ports/tests/SerialStream/Write_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Write_byte_int_int_Generic.cs
@@ -17,29 +17,29 @@ namespace System.IO.Ports.Tests
     {
         // Set bounds fore random timeout values.
         // If the min is to low write will not timeout accurately and the testcase will fail
-        private static int minRandomTimeout = 250;
+        private const int minRandomTimeout = 250;
 
         // If the max is to large then the testcase will take forever to run
-        private static int maxRandomTimeout = 2000;
+        private const int maxRandomTimeout = 2000;
 
         // If the percentage difference between the expected timeout and the actual timeout
         // found through Stopwatch is greater then 10% then the timeout value was not correctly
         // to the write method and the testcase fails.
-        private static double maxPercentageDifference = .15;
+        private const double maxPercentageDifference = .15;
 
         // The byte size used when veryifying exceptions that write will throw 
-        private static readonly int BYTE_SIZE_EXCEPTION = 4;
+        private const int BYTE_SIZE_EXCEPTION = 4;
 
         // The byte size used when veryifying timeout 
-        private static readonly int BYTE_SIZE_TIMEOUT = TCSupport.MinimumBlockingByteCount;
+        private static readonly int s_BYTE_SIZE_TIMEOUT = TCSupport.MinimumBlockingByteCount;
 
         // The byte size used when veryifying BytesToWrite 
-        private static readonly int BYTE_SIZE_BYTES_TO_WRITE = TCSupport.MinimumBlockingByteCount;
+        private static readonly int s_BYTE_SIZE_BYTES_TO_WRITE = TCSupport.MinimumBlockingByteCount;
 
         // The bytes size used when veryifying Handshake 
-        private static readonly int BYTE_SIZE_HANDSHAKE = TCSupport.MinimumBlockingByteCount;
+        private static readonly int s_BYTE_SIZE_HANDSHAKE = TCSupport.MinimumBlockingByteCount;
 
-        private static readonly int NUM_TRYS = 5;
+        private const int NUM_TRYS = 5;
 
         #region Test Cases
 
@@ -118,12 +118,12 @@ namespace System.IO.Ports.Tests
 
                 try
                 {
-                    com.BaseStream.Write(new byte[BYTE_SIZE_TIMEOUT], 0, BYTE_SIZE_TIMEOUT);
+                    com.BaseStream.Write(new byte[s_BYTE_SIZE_TIMEOUT], 0, s_BYTE_SIZE_TIMEOUT);
                 }
                 catch (TimeoutException)
                 {
                 }
-           
+
                 VerifyTimeout(com);
             }
         }
@@ -160,12 +160,12 @@ namespace System.IO.Ports.Tests
 
                 try
                 {
-                    com1.BaseStream.Write(new byte[BYTE_SIZE_TIMEOUT], 0, BYTE_SIZE_TIMEOUT);
+                    com1.BaseStream.Write(new byte[s_BYTE_SIZE_TIMEOUT], 0, s_BYTE_SIZE_TIMEOUT);
                 }
                 catch (TimeoutException)
                 {
                 }
-          
+
                 asyncEnableRts.Stop();
 
                 while (t.IsAlive)
@@ -180,7 +180,7 @@ namespace System.IO.Ports.Tests
         {
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
-                var asyncWriteRndByteArray = new AsyncWriteRndByteArray(com, BYTE_SIZE_BYTES_TO_WRITE);
+                var asyncWriteRndByteArray = new AsyncWriteRndByteArray(com, s_BYTE_SIZE_BYTES_TO_WRITE);
                 var t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
 
                 Debug.WriteLine("Verifying BytesToWrite with one call to Write");
@@ -200,12 +200,11 @@ namespace System.IO.Ports.Tests
                     waitTime += 50;
                 }
 
-                TCSupport.WaitForWriteBufferToLoad(com, BYTE_SIZE_BYTES_TO_WRITE);
+                TCSupport.WaitForWriteBufferToLoad(com, s_BYTE_SIZE_BYTES_TO_WRITE);
 
                 // Wait for write method to timeout
                 while (t.IsAlive)
                     Thread.Sleep(100);
-
             }
         }
 
@@ -215,7 +214,7 @@ namespace System.IO.Ports.Tests
         {
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
-                var asyncWriteRndByteArray = new AsyncWriteRndByteArray(com, BYTE_SIZE_BYTES_TO_WRITE);
+                var asyncWriteRndByteArray = new AsyncWriteRndByteArray(com, s_BYTE_SIZE_BYTES_TO_WRITE);
                 var t1 = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
                 var t2 = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
 
@@ -236,7 +235,7 @@ namespace System.IO.Ports.Tests
                     waitTime += 50;
                 }
 
-                TCSupport.WaitForExactWriteBufferLoad(com, BYTE_SIZE_BYTES_TO_WRITE);
+                TCSupport.WaitForExactWriteBufferLoad(com, s_BYTE_SIZE_BYTES_TO_WRITE);
 
                 // Write a random byte[] asynchronously so we can verify some things while the write call is blocking
                 t2.Start();
@@ -249,7 +248,7 @@ namespace System.IO.Ports.Tests
                     waitTime += 50;
                 }
 
-                TCSupport.WaitForExactWriteBufferLoad(com, BYTE_SIZE_BYTES_TO_WRITE * 2);
+                TCSupport.WaitForExactWriteBufferLoad(com, s_BYTE_SIZE_BYTES_TO_WRITE * 2);
 
                 // Wait for both write methods to timeout
                 while (t1.IsAlive || t2.IsAlive)
@@ -262,7 +261,7 @@ namespace System.IO.Ports.Tests
         {
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
-                var asyncWriteRndByteArray = new AsyncWriteRndByteArray(com, BYTE_SIZE_HANDSHAKE);
+                var asyncWriteRndByteArray = new AsyncWriteRndByteArray(com, s_BYTE_SIZE_HANDSHAKE);
                 var t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
 
                 // Write a random byte[] asynchronously so we can verify some things while the write call is blocking
@@ -328,7 +327,6 @@ namespace System.IO.Ports.Tests
                             Monitor.Wait(this);
 
                         com2.RtsEnable = false;
-
                     }
                 }
             }
@@ -396,7 +394,7 @@ namespace System.IO.Ports.Tests
 
             try
             {
-                com.BaseStream.Write(new byte[BYTE_SIZE_TIMEOUT], 0, BYTE_SIZE_TIMEOUT); // Warm up write method
+                com.BaseStream.Write(new byte[s_BYTE_SIZE_TIMEOUT], 0, s_BYTE_SIZE_TIMEOUT); // Warm up write method
             }
             catch (TimeoutException)
             {
@@ -409,7 +407,7 @@ namespace System.IO.Ports.Tests
                 timer.Start();
                 try
                 {
-                    com.BaseStream.Write(new byte[BYTE_SIZE_TIMEOUT], 0, BYTE_SIZE_TIMEOUT);
+                    com.BaseStream.Write(new byte[s_BYTE_SIZE_TIMEOUT], 0, s_BYTE_SIZE_TIMEOUT);
                 }
                 catch (TimeoutException)
                 {
@@ -438,7 +436,7 @@ namespace System.IO.Ports.Tests
             using (var com1 = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             using (var com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
-                var asyncWriteRndByteArray = new AsyncWriteRndByteArray(com1, BYTE_SIZE_HANDSHAKE);
+                var asyncWriteRndByteArray = new AsyncWriteRndByteArray(com1, s_BYTE_SIZE_HANDSHAKE);
                 var t = new Thread(asyncWriteRndByteArray.WriteRndByteArray);
 
                 var XOffBuffer = new byte[1];
@@ -477,7 +475,7 @@ namespace System.IO.Ports.Tests
                     waitTime += 50;
                 }
 
-                TCSupport.WaitForWriteBufferToLoad(com1, BYTE_SIZE_HANDSHAKE);
+                TCSupport.WaitForWriteBufferToLoad(com1, s_BYTE_SIZE_HANDSHAKE);
 
                 // Verify that CtsHolding is false if the RequestToSend or RequestToSendXOnXOff handshake method is used
                 if ((Handshake.RequestToSend == handshake || Handshake.RequestToSendXOnXOff == handshake) &&

--- a/src/System.IO.Ports/tests/SerialStream/Write_byte_int_int_Generic.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Write_byte_int_int_Generic.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Configuration;
 using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
@@ -235,15 +236,7 @@ namespace System.IO.Ports.Tests
                     waitTime += 50;
                 }
 
-                waitTime = 0;
-
-                while (BYTE_SIZE_BYTES_TO_WRITE > com.BytesToWrite && waitTime < 500)
-                {
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                Assert.Equal(BYTE_SIZE_BYTES_TO_WRITE, com.BytesToWrite);
+                TCSupport.WaitForExactWriteBufferLoad(com, BYTE_SIZE_BYTES_TO_WRITE);
 
                 // Write a random byte[] asynchronously so we can verify some things while the write call is blocking
                 t2.Start();
@@ -256,15 +249,7 @@ namespace System.IO.Ports.Tests
                     waitTime += 50;
                 }
 
-                waitTime = 0;
-
-                while (BYTE_SIZE_BYTES_TO_WRITE * 2 > com.BytesToWrite && waitTime < 500)
-                {
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                Assert.Equal(BYTE_SIZE_BYTES_TO_WRITE*2, com.BytesToWrite);
+                TCSupport.WaitForExactWriteBufferLoad(com, BYTE_SIZE_BYTES_TO_WRITE * 2);
 
                 // Wait for both write methods to timeout
                 while (t1.IsAlive || t2.IsAlive)
@@ -492,15 +477,7 @@ namespace System.IO.Ports.Tests
                     waitTime += 50;
                 }
 
-                waitTime = 0;
-                while (BYTE_SIZE_HANDSHAKE > com1.BytesToWrite && waitTime < 500)
-                {
-                    Thread.Sleep(50);
-                    waitTime += 50;
-                }
-
-                // Verify that the correct number of bytes are in the buffer
-                Assert.Equal(BYTE_SIZE_HANDSHAKE, com1.BytesToWrite);
+                TCSupport.WaitForWriteBufferToLoad(com1, BYTE_SIZE_HANDSHAKE);
 
                 // Verify that CtsHolding is false if the RequestToSend or RequestToSendXOnXOff handshake method is used
                 if ((Handshake.RequestToSend == handshake || Handshake.RequestToSendXOnXOff == handshake) &&

--- a/src/System.IO.Ports/tests/Support/FlowControlCapabilities.cs
+++ b/src/System.IO.Ports/tests/Support/FlowControlCapabilities.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Legacy.Support
 {
     public class FlowControlCapabilities

--- a/src/System.IO.Ports/tests/Support/LocalMachineSerialInfo.cs
+++ b/src/System.IO.Ports/tests/Support/LocalMachineSerialInfo.cs
@@ -3,18 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace Legacy.Support
 {
     [Serializable()]
     public class LocalMachineSerialInfo
     {
-        private string _firstAvailablePortName;
-        private string _secondAvailablePortName;
-        private bool _nullModemPresent;
-        private string _loopbackPortName;
+        private readonly string _firstAvailablePortName;
+        private readonly string _secondAvailablePortName;
+        private readonly bool _nullModemPresent;
+        private readonly string _loopbackPortName;
 
         public LocalMachineSerialInfo(string firstAvailablePortName, string secondAvailablePortName, string loopBackPortName, bool nullModemPresent)
         {

--- a/src/System.IO.Ports/tests/Support/LocalMachineSerialInfo.cs
+++ b/src/System.IO.Ports/tests/Support/LocalMachineSerialInfo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Legacy.Support
@@ -21,10 +22,6 @@ namespace Legacy.Support
             _secondAvailablePortName = secondAvailablePortName;
             _loopbackPortName = loopBackPortName;
             _nullModemPresent = nullModemPresent;
-            Debug.WriteLine("First available port name  : " + firstAvailablePortName);
-            Debug.WriteLine("Second available port name : " + secondAvailablePortName);
-            Debug.WriteLine("Loopback port name         : " + loopBackPortName);
-            Debug.WriteLine("NullModem present          : " + nullModemPresent);
         }
 
         public string FirstAvailablePortName

--- a/src/System.IO.Ports/tests/Support/PortHelper.cs
+++ b/src/System.IO.Ports/tests/Support/PortHelper.cs
@@ -74,4 +74,10 @@ namespace Legacy.Support
             return ports.ToArray();
         }
     }
+
+    public static class XOnOff
+    {
+        public const byte XOFF = 19;
+        public const byte XON = 17;
+    }
 }

--- a/src/System.IO.Ports/tests/Support/SerialPortProperties.cs
+++ b/src/System.IO.Ports/tests/Support/SerialPortProperties.cs
@@ -20,22 +20,22 @@ namespace Legacy.Support
         // here then the property can never be set in this class and will never be 
         // used for verification.
 
-        public static readonly int defaultBaudRate = 9600;
+        private const int defaultBaudRate = 9600;
         public static readonly string defaultPortName = "COM1";
-        public static readonly int defaultDataBits = 8;
+        private const int defaultDataBits = 8;
         public static readonly StopBits defaultStopBits = StopBits.One;
         public static readonly Parity defaultParity = Parity.None;
         public static readonly Handshake defaultHandshake = Handshake.None;
         public static readonly Encoding defaultEncoding = new ASCIIEncoding();
         public static readonly bool defaultDtrEnable = false;
         public static readonly bool defaultRtsEnable = false;
-        public static readonly int defaultReadTimeout = -1;
-        public static readonly int defaultWriteTimeout = -1;
+        private const int defaultReadTimeout = -1;
+        private const int defaultWriteTimeout = -1;
         public static readonly Type defaultBytesToRead = typeof(InvalidOperationException);
         public static readonly Type defaultBytesToWrite = typeof(InvalidOperationException);
         public static readonly bool defaultIsOpen = false;
         public static readonly Type defaultBaseStream = typeof(InvalidOperationException);
-        public static readonly int defaultReceivedBytesThreshold = 1;
+        private const int defaultReceivedBytesThreshold = 1;
         public static readonly bool defaultDiscardNull = false;
         public static readonly byte defaultParityReplace = (byte)'?';
         public static readonly Type defaultCDHolding = typeof(InvalidOperationException);
@@ -43,29 +43,29 @@ namespace Legacy.Support
         public static readonly Type defaultDsrHolding = typeof(InvalidOperationException);
         public static readonly string defaultNewLine = "\n";
         public static readonly Type defaultBreakState = typeof(InvalidOperationException);
-        public static readonly int defaultReadBufferSize = 4 * 1024;
-        public static readonly int defaultWriteBufferSize = 2 * 1024;
+        private const int defaultReadBufferSize = 4 * 1024;
+        private const int defaultWriteBufferSize = 2 * 1024;
 
         // All of the following properties are the defualts of SerialPort when the
         // serial port connection is open. The names of the data members here must
         // begin with openDefault followed by the EXACT(case sensitive) name of
         // the property in SerialPort class.
 
-        public static readonly int openDefaultBaudRate = 9600;
+        private const int openDefaultBaudRate = 9600;
         public static readonly string openDefaultPortName = "COM1";
-        public static readonly int openDefaultDataBits = 8;
+        private const int openDefaultDataBits = 8;
         public static readonly StopBits openDefaultStopBits = StopBits.One;
         public static readonly Parity openDefaultParity = Parity.None;
         public static readonly Handshake openDefaultHandshake = Handshake.None;
         public static readonly Encoding openDefaultEncoding = new ASCIIEncoding();
         public static readonly bool openDefaultDtrEnable = false;
         public static readonly bool openDefaultRtsEnable = false;
-        public static readonly int openDefaultReadTimeout = -1;
-        public static readonly int openDefaultWriteTimeout = -1;
-        public static readonly int openDefaultBytesToRead = 0;
-        public static readonly int openDefaultBytesToWrite = 0;
+        private const int openDefaultReadTimeout = -1;
+        private const int openDefaultWriteTimeout = -1;
+        private const int openDefaultBytesToRead = 0;
+        private const int openDefaultBytesToWrite = 0;
         public static readonly bool openDefaultIsOpen = true;
-        public static readonly int openDefaultReceivedBytesThreshold = 1;
+        private const int openDefaultReceivedBytesThreshold = 1;
         public static readonly bool openDefaultDiscardNull = false;
         public static readonly byte openDefaultParityReplace = (byte)'?';
 
@@ -79,8 +79,8 @@ namespace Legacy.Support
 
         public static readonly string openDefaultNewLine = "\n";
         public static readonly bool openDefaultBreakState = false;
-        public static readonly int openReadBufferSize = 4 * 1024;
-        public static readonly int openWriteBufferSize = 2 * 1024;
+        private const int openReadBufferSize = 4 * 1024;
+        private const int openWriteBufferSize = 2 * 1024;
 
         private Hashtable _properties;
         private Hashtable _openDefaultProperties;

--- a/src/System.IO.Ports/tests/Support/TCSupport.cs
+++ b/src/System.IO.Ports/tests/Support/TCSupport.cs
@@ -22,7 +22,7 @@ namespace Legacy.Support
         private static SerialPortRequirements s_localMachineSerialPortRequirements;
 
         // Set this true to display port info to the console rather than Debug.WriteLine
-        private static bool _displayPortInfoOnConsole = false;
+        private static bool s_displayPortInfoOnConsole = false;
 
         static TCSupport()
         {
@@ -63,7 +63,7 @@ namespace Legacy.Support
             // If there is a pair like this, then they take precedence over any other way of identifying two available ports
             for (int firstIndex = 0; firstIndex < openablePortNames.Count && !nullModemPresent; firstIndex++)
             {
-                for (int secondIndex = firstIndex+1; secondIndex < openablePortNames.Count && !nullModemPresent; secondIndex++)
+                for (int secondIndex = firstIndex + 1; secondIndex < openablePortNames.Count && !nullModemPresent; secondIndex++)
                 {
                     string firstPortName = openablePortNames[firstIndex];
                     string secondPortName = openablePortNames[secondIndex];
@@ -126,7 +126,7 @@ namespace Legacy.Support
 
         private static void PrintInfo(string format, params object[] args)
         {
-            if (_displayPortInfoOnConsole)
+            if (s_displayPortInfoOnConsole)
             {
                 Console.WriteLine(format, args);
             }
@@ -290,7 +290,7 @@ namespace Legacy.Support
         private const int MAX_RANDOM_ASCII_CHAR = 127;
 
         private static readonly Random s_random = new Random(-55);
-        private static FlowControlCapabilities s_flowControlCapabilities = new FlowControlCapabilities(0,0,false);
+        private static FlowControlCapabilities s_flowControlCapabilities = new FlowControlCapabilities(0, 0, false);
 
         [Flags]
         public enum CharacterOptions { None, Surrogates, ASCII };
@@ -481,7 +481,7 @@ namespace Legacy.Support
         {
             for (int i = 0; i < count; ++i)
             {
-                bytes[i+index] = (byte)s_random.Next(0, 256);
+                bytes[i + index] = (byte)s_random.Next(0, 256);
             }
         }
 
@@ -510,7 +510,7 @@ namespace Legacy.Support
             return OrdinalIndexOf(input, startIndex, input.Length - startIndex, search);
         }
 
-        public static int OrdinalIndexOf(string input, int startIndex, int count, string search)
+        private static int OrdinalIndexOf(string input, int startIndex, int count, string search)
         {
             int lastSearchIndex = (count + startIndex) - search.Length;
             if (lastSearchIndex >= input.Length)
@@ -660,6 +660,5 @@ namespace Legacy.Support
         {
             Assert.True(task.Wait(5000), "Timeout waiting for task completion");
         }
-
     }
 }

--- a/src/System.IO.Ports/tests/Support/TestDelegate.cs
+++ b/src/System.IO.Ports/tests/Support/TestDelegate.cs
@@ -1,8 +1,0 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-namespace Legacy.Support
-{
-    public delegate bool TestDelegate();
-}

--- a/src/System.IO.Ports/tests/System.IO.Ports.Tests.csproj
+++ b/src/System.IO.Ports/tests/System.IO.Ports.Tests.csproj
@@ -113,7 +113,6 @@
     <Compile Include="Support\SerialPortConnection.cs" />
     <Compile Include="Support\SerialPortProperties.cs" />
     <Compile Include="Support\TCSupport.cs" />
-    <Compile Include="Support\TestDelegate.cs" />
     <Compile Include="Support\PortsTest.cs" />
     <Compile Include="Support\TestEventHandler.cs" />
   </ItemGroup>


### PR DESCRIPTION
There is a widely used pattern within the tests where the test blocks waiting for an expected number of bytes to be held in either the write or read buffers.

There are various implementations of this in the legacy code - some have no timeout (and hence hang the test completely if there's a problem), some have a timeout but don't care if the timeout exceeded or not (which in some cases conceals defects in the test code), and some have a timeout followed by a separate check on buffer content.

This PR refactors a large number of these tests to use simple helper methods which are more consistent in approach.

We still have 100% run & pass where appropriate hardware is available:

System.IO.Ports.Tests  Total: 994, Errors: 0, Failed: 0, Skipped: 0, Time: 1112.919s
