### PR TITLE
Cleanup SerialPort.GetPortNames

### DIFF
--- a/src/System.IO.Ports/src/System/IO/Ports/SerialPort.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialPort.cs
@@ -558,43 +558,27 @@ namespace System.IO.Ports
         public static string[] GetPortNames()
         {
             // Hitting the registry for this isn't the only way to get the ports.
-            // 
+            //
             // WMI: https://msdn.microsoft.com/en-us/library/aa394413.aspx
             // QueryDosDevice: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365461.aspx
             //
             // QueryDosDevice involves finding any ports that map to \Device\Serialx (call with null to get all, then iterate to get the actual device name)
 
-            RegistryKey baseKey = null;
-            RegistryKey serialKey = null;
-
-            String[] portNames = null;
-
-            try
+            using (RegistryKey serialKey = Registry.LocalMachine.OpenSubKey(@"HARDWARE\DEVICEMAP\SERIALCOMM"))
             {
-                baseKey = Registry.LocalMachine;
-                serialKey = baseKey.OpenSubKey(@"HARDWARE\DEVICEMAP\SERIALCOMM", false);
-
                 if (serialKey != null)
                 {
-
-                    string[] deviceNames = serialKey.GetValueNames();
-                    portNames = new String[deviceNames.Length];
-
-                    for (int i = 0; i < deviceNames.Length; i++)
-                        portNames[i] = (string)serialKey.GetValue(deviceNames[i]);
+                    string[] result = serialKey.GetValueNames();
+                    for (int i = 0; i < result.Length; i++)
+                    {
+                        // Replace the name in the array with its value.
+                        result[i] = (string)serialKey.GetValue(result[i]);
+                    }
+                    return result;
                 }
             }
-            finally
-            {
-                baseKey?.Dispose();
-                serialKey?.Dispose();
-            }
 
-            // If serialKey didn't exist for some reason
-            if (portNames == null)
-                portNames = new String[0];
-
-            return portNames;
+            return Array.Empty<string>();
         }
 
         // SerialPort is open <=> SerialPort has an associated SerialStream.


### PR DESCRIPTION
Instead of allocating a new `string[]` array to return, reuse the array returned from `RegistryKey.GetValueNames`.

cc: @JeremyKuhne, @willdean