### PR TITLE
SerialPort: Cleanup ArgumentException paramNames/messages

### DIFF
--- a/src/System.IO.Ports/src/Resources/Strings.resx
+++ b/src/System.IO.Ports/src/Resources/Strings.resx
@@ -100,12 +100,6 @@
   <data name="Argument_InvalidOffLen" xml:space="preserve">
     <value>Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.</value>
   </data>
-  <data name="ArgumentNull_Array" xml:space="preserve">
-    <value>Array cannot be null.</value>
-  </data>
-  <data name="ArgumentNull_Buffer" xml:space="preserve">
-    <value>Buffer cannot be null.</value>
-  </data>
   <data name="ArgumentOutOfRange_Bounds_Lower_Upper" xml:space="preserve">
     <value>Argument must be between {0} and {1}.</value>
   </data>
@@ -123,9 +117,6 @@
   </data>
   <data name="ArgumentOutOfRange_WriteTimeout" xml:space="preserve">
     <value>The timeout must be either a positive number or -1.</value>
-  </data>
-  <data name="ArgumentOutOfRange_OffsetOut" xml:space="preserve">
-    <value>Either offset did not refer to a position in the string, or there is an insufficient length of destination character array."</value>
   </data>
   <data name="IndexOutOfRange_IORaceCondition" xml:space="preserve">
     <value>Probable I/O race condition detected while copying memory.  The I/O package is not thread safe by default.  In multithreaded applications, a stream must be accessed in a thread-safe way, such as a thread-safe wrapper returned by TextReader's or TextWriter's Synchronized methods.  This also applies to classes like StreamWriter and StreamReader.</value>

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialPort.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialPort.cs
@@ -287,9 +287,9 @@ namespace System.IO.Ports
             set
             {
                 if (value == null)
-                    throw new ArgumentNullException();
+                    throw new ArgumentNullException(nameof(NewLine));
                 if (value.Length == 0)
-                    throw new ArgumentException(string.Format(SR.InvalidNullEmptyArgument, nameof(NewLine)));
+                    throw new ArgumentException(string.Format(SR.InvalidNullEmptyArgument, nameof(NewLine)), nameof(NewLine));
 
                 _newLine = value;
             }
@@ -630,11 +630,11 @@ namespace System.IO.Ports
             if (!IsOpen)
                 throw new InvalidOperationException(SR.Port_not_open);
             if (buffer == null)
-                throw new ArgumentNullException("buffer", SR.ArgumentNull_Buffer);
+                throw new ArgumentNullException(nameof(buffer));
             if (offset < 0)
-                throw new ArgumentOutOfRangeException("offset", SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+                throw new ArgumentOutOfRangeException(nameof(offset), SR.ArgumentOutOfRange_NeedNonNegNumRequired);
             if (count < 0)
-                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNumRequired);
             if (buffer.Length - offset < count)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
             int bytesReadToBuffer = 0;
@@ -771,11 +771,11 @@ namespace System.IO.Ports
             if (!IsOpen)
                 throw new InvalidOperationException(SR.Port_not_open);
             if (buffer == null)
-                throw new ArgumentNullException("buffer", SR.ArgumentNull_Buffer);
+                throw new ArgumentNullException(nameof(buffer));
             if (offset < 0)
-                throw new ArgumentOutOfRangeException("offset", SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+                throw new ArgumentOutOfRangeException(nameof(offset), SR.ArgumentOutOfRange_NeedNonNegNumRequired);
             if (count < 0)
-                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_NeedNonNegNumRequired);
+                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNumRequired);
             if (buffer.Length - offset < count)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
 
@@ -1016,7 +1016,7 @@ namespace System.IO.Ports
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
             if (value.Length == 0)
-                throw new ArgumentException(string.Format(SR.InvalidNullEmptyArgument, nameof(value)));
+                throw new ArgumentException(string.Format(SR.InvalidNullEmptyArgument, nameof(value)), nameof(value));
 
             int startTicks = Environment.TickCount;
             int numCharsRead;
@@ -1173,7 +1173,7 @@ namespace System.IO.Ports
             if (!IsOpen)
                 throw new InvalidOperationException(SR.Port_not_open);
             if (buffer == null)
-                throw new ArgumentNullException(nameof(buffer), SR.ArgumentNull_Buffer);
+                throw new ArgumentNullException(nameof(buffer));
             if (offset < 0)
                 throw new ArgumentOutOfRangeException(nameof(offset), SR.ArgumentOutOfRange_NeedNonNegNumRequired);
             if (count < 0)

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.cs
@@ -499,7 +499,7 @@ namespace System.IO.Ports
             set
             {
                 if (value <= 0 && value != SerialPort.InfiniteTimeout)
-                    throw new ArgumentOutOfRangeException("WriteTimeout", SR.ArgumentOutOfRange_WriteTimeout);
+                    throw new ArgumentOutOfRangeException(nameof(WriteTimeout), SR.ArgumentOutOfRange_WriteTimeout);
                 if (_handle == null) InternalResources.FileNotOpen();
 
                 int oldWriteConstant = _commTimeouts.WriteTotalTimeoutConstant;
@@ -1049,7 +1049,7 @@ namespace System.IO.Ports
         internal unsafe int Read([In, Out] byte[] array, int offset, int count, int timeout)
         {
             if (array == null)
-                throw new ArgumentNullException(nameof(array), SR.ArgumentNull_Buffer);
+                throw new ArgumentNullException(nameof(array));
             if (offset < 0)
                 throw new ArgumentOutOfRangeException(nameof(offset), SR.ArgumentOutOfRange_NeedNonNegNumRequired);
             if (count < 0)
@@ -1145,14 +1145,14 @@ namespace System.IO.Ports
             if (_inBreak)
                 throw new InvalidOperationException(SR.In_Break_State);
             if (array == null)
-                throw new ArgumentNullException(nameof(array), SR.ArgumentNull_Array);
+                throw new ArgumentNullException(nameof(array));
             if (offset < 0)
                 throw new ArgumentOutOfRangeException(nameof(offset), SR.ArgumentOutOfRange_NeedPosNum);
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedPosNum);
             if (count == 0) return; // no need to expend overhead in creating asyncResult, etc.
             if (array.Length - offset < count)
-                throw new ArgumentException(nameof(count), SR.ArgumentOutOfRange_OffsetOut);
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
             Debug.Assert(timeout == SerialPort.InfiniteTimeout || timeout >= 0, "Serial Stream Write - write timeout is " + timeout);
 
             // check for open handle, though the port is always supposed to be open


### PR DESCRIPTION
Use `nameof`, specify the `paramName` where appropriate, and remove some unnecessary resources.