### PR TITLE
Delete unnecessary [In, Out] annotations on Stream Read methods

### DIFF
--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.cs
@@ -1041,12 +1041,12 @@ namespace System.IO.Ports
 
         // Blocking read operation, returning the number of bytes read from the stream.
 
-        public override int Read([In, Out] byte[] array, int offset, int count)
+        public override int Read(byte[] array, int offset, int count)
         {
             return Read(array, offset, count, ReadTimeout);
         }
 
-        internal unsafe int Read([In, Out] byte[] array, int offset, int count, int timeout)
+        internal unsafe int Read(byte[] array, int offset, int count, int timeout)
         {
             if (array == null)
                 throw new ArgumentNullException(nameof(array), SR.ArgumentNull_Buffer);

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpRequestStream.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpRequestStream.Managed.cs
@@ -123,7 +123,7 @@ namespace System.Net
             return size;
         }
 
-        public override int Read([In, Out] byte[] buffer, int offset, int count)
+        public override int Read(byte[] buffer, int offset, int count)
         {
             if (_disposed)
                 throw new ObjectDisposedException(typeof(HttpRequestStream).ToString());

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpResponseStream.Managed.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpResponseStream.Managed.cs
@@ -277,7 +277,7 @@ namespace System.Net
             }
         }
 
-        public override int Read([In, Out] byte[] buffer, int offset, int count)
+        public override int Read(byte[] buffer, int offset, int count)
         {
             throw new NotSupportedException(SR.net_writeonlystream);
         }

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpRequestStream.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpRequestStream.Windows.cs
@@ -114,7 +114,7 @@ namespace System.Net
             throw new NotSupportedException(SR.net_noseek);
         }
 
-        public override int Read([In, Out] byte[] buffer, int offset, int size)
+        public override int Read(byte[] buffer, int offset, int size)
         {
             if (NetEventSource.IsEnabled)
             {

--- a/src/System.Net.HttpListener/src/System/Net/Windows/HttpResponseStream.Windows.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/HttpResponseStream.Windows.cs
@@ -97,7 +97,7 @@ namespace System.Net
             throw new NotSupportedException(SR.net_noseek);
         }
 
-        public override int Read([In, Out] byte[] buffer, int offset, int size)
+        public override int Read(byte[] buffer, int offset, int size)
         {
             throw new InvalidOperationException(SR.net_writeonlystream);
         }


### PR DESCRIPTION
This annotation has no effect, the base Stream class does not have it, and most stream implementations in corefx do not have it either.

Follow-up of #11972