### PR TITLE
Fix ActivityCurrentFlowsWithAsyncComplex test

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -369,12 +369,12 @@ namespace System.Diagnostics.Tests
             Activity activity1 = new Activity("activity1").Start();
             Assert.Same(activity1, Activity.Current);
 
-            SemaphoreSlim semaphore = new SemaphoreSlim(initialCount: 1);
+            SemaphoreSlim semaphore = new SemaphoreSlim(initialCount: 0);
             Task task = Task.Run(async () =>
             {
                 // Wait until the semaphore is signaled.
                 await semaphore.WaitAsync();
-                Assert.Equal(activity1, Activity.Current);
+                Assert.Same(activity1, Activity.Current);
             });
 
             Activity activity2 = new Activity("activity2").Start();


### PR DESCRIPTION
The test was passing, but not as intended. A semaphore was created with an initial count of 1 when in fact it was supposed to be 0 (i.e. block until someone calls Release)