### PR TITLE
rework some Windows p/invoke logic and related code

### DIFF
--- a/src/Common/src/Interop/Windows/Winsock/Interop.TransmitFile.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.TransmitFile.cs
@@ -16,16 +16,16 @@ internal static partial class Interop
             SafeHandle fileHandle,
             int numberOfBytesToWrite,
             int numberOfBytesPerSend,
-            SafeHandle overlapped,
+            SafeNativeOverlapped overlapped,
             TransmitFileBuffers* buffers,
             TransmitFileOptions flags);
 
         [StructLayout(LayoutKind.Sequential)]
-        internal struct TransmitFileBuffers
+        internal unsafe struct TransmitFileBuffers
         {
-            internal IntPtr Head;
+            internal byte* Head;
             internal int HeadLength;
-            internal IntPtr Tail;
+            internal byte* Tail;
             internal int TailLength;
         }
     }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSAConnect.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSAConnect.cs
@@ -12,13 +12,13 @@ internal static partial class Interop
     {
         // This function is always potentially blocking so it uses an IntPtr.
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern SocketError WSAConnect(
-            [In] IntPtr socketHandle,
-            [In] byte[] socketAddress,
-            [In] int socketAddressSize,
-            [In] IntPtr inBuffer,
-            [In] IntPtr outBuffer,
-            [In] IntPtr sQOS,
-            [In] IntPtr gQOS);
+        internal static unsafe extern int WSAConnect(
+            IntPtr socketHandle,
+            byte* socketAddress,
+            int socketAddressSize,
+            void* inBuffer,
+            void* outBuffer,
+            void* sQOS,
+            void* gQOS);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSAGetOverlappedResult.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSAGetOverlappedResult.cs
@@ -11,11 +11,11 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern bool WSAGetOverlappedResult(
-            [In] SafeCloseSocket socketHandle,
-            [In] SafeHandle overlapped,
-            [Out] out uint bytesTransferred,
-            [In] bool wait,
-            [Out] out SocketFlags socketFlags);
+        internal static unsafe extern bool WSAGetOverlappedResult(
+            SafeCloseSocket socketHandle,
+            SafeHandle overlapped,
+            uint* bytesTransferred,
+            bool wait,
+            SocketFlags* socketFlags);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
@@ -11,33 +11,23 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern SocketError WSARecv(
-            [In] SafeCloseSocket socketHandle,
-            [In] ref WSABuffer buffer,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In, Out] ref SocketFlags socketFlags,
-            [In] SafeHandle overlapped,
-            [In] IntPtr completionRoutine);
-
-        [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern SocketError WSARecv(
-            [In] SafeCloseSocket socketHandle,
-            [In, Out] WSABuffer[] buffers,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In, Out] ref SocketFlags socketFlags,
-            [In] SafeHandle overlapped,
-            [In] IntPtr completionRoutine);
+        internal static extern unsafe int WSARecv(
+            SafeCloseSocket socketHandle,
+            WSABuffer* buffers,
+            int bufferCount,
+            int* bytesTransferred,
+            SocketFlags* socketFlags,
+            SafeNativeOverlapped overlapped,
+            void* completionRoutine);
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true, EntryPoint = "WSARecv")]
-        internal static extern SocketError WSARecv_Blocking(
-            [In] IntPtr socketHandle,
-            [In, Out] WSABuffer[] buffers,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In, Out] ref SocketFlags socketFlags,
-            [In] SafeHandle overlapped,
-            [In] IntPtr completionRoutine);
+        internal static extern unsafe int WSARecv_Blocking(
+            IntPtr socketHandle,
+            WSABuffer* buffers,
+            int bufferCount,
+            int* bytesTransferred,
+            SocketFlags* socketFlags,
+            SafeNativeOverlapped overlapped,
+            void* completionRoutine);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSARecvFrom.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSARecvFrom.cs
@@ -11,27 +11,15 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern SocketError WSARecvFrom(
-            [In] SafeCloseSocket socketHandle,
-            [In] ref WSABuffer buffer,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In, Out] ref SocketFlags socketFlags,
-            [In] IntPtr socketAddressPointer,
-            [In] IntPtr socketAddressSizePointer,
-            [In] SafeHandle overlapped,
-            [In] IntPtr completionRoutine);
-
-        [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern SocketError WSARecvFrom(
-            [In] SafeCloseSocket socketHandle,
-            [In, Out] WSABuffer[] buffers,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In, Out] ref SocketFlags socketFlags,
-            [In] IntPtr socketAddressPointer,
-            [In] IntPtr socketAddressSizePointer,
-            [In] SafeNativeOverlapped overlapped,
-            [In] IntPtr completionRoutine);
+        internal static extern unsafe int WSARecvFrom(
+            SafeCloseSocket socketHandle,
+            WSABuffer* buffers,
+            int bufferCount,
+            int* bytesTransferred,
+            SocketFlags* socketFlags,
+            byte* socketAddress,
+            int* socketAddressSize,
+            SafeHandle overlapped,
+            void* completionRoutine);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSASend.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSASend.cs
@@ -11,33 +11,23 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern SocketError WSASend(
-            [In] SafeCloseSocket socketHandle,
-            [In] ref WSABuffer buffer,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In] SocketFlags socketFlags,
-            [In] SafeHandle overlapped,
-            [In] IntPtr completionRoutine);
-
-        [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern SocketError WSASend(
-            [In] SafeCloseSocket socketHandle,
-            [In] WSABuffer[] buffersArray,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In] SocketFlags socketFlags,
-            [In] SafeHandle overlapped,
-            [In] IntPtr completionRoutine);
+        internal static extern unsafe int WSASend(
+            SafeCloseSocket socketHandle,
+            WSABuffer* buffers,
+            int bufferCount,
+            int* bytesTransferred,
+            SocketFlags socketFlags,
+            SafeNativeOverlapped overlapped,
+            void* completionRoutine);
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true, EntryPoint = "WSASend")]
-        internal static extern SocketError WSASend_Blocking(
-            [In] IntPtr socketHandle,
-            [In] WSABuffer[] buffersArray,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In] SocketFlags socketFlags,
-            [In] SafeHandle overlapped,
-            [In] IntPtr completionRoutine);
+        internal static extern unsafe int WSASend_Blocking(
+            IntPtr socketHandle,
+            WSABuffer* buffers,
+            int bufferCount,
+            int* bytesTransferred,
+            SocketFlags socketFlags,
+            SafeNativeOverlapped overlapped,
+            void* completionRoutine);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSASendTo.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSASendTo.cs
@@ -11,27 +11,15 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern SocketError WSASendTo(
-            [In] SafeCloseSocket socketHandle,
-            [In] ref WSABuffer buffer,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In] SocketFlags socketFlags,
-            [In] IntPtr socketAddress,
-            [In] int socketAddressSize,
-            [In] SafeHandle overlapped,
-            [In] IntPtr completionRoutine);
-
-        [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern SocketError WSASendTo(
-            [In] SafeCloseSocket socketHandle,
-            [In] WSABuffer[] buffersArray,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In] SocketFlags socketFlags,
-            [In] IntPtr socketAddress,
-            [In] int socketAddressSize,
-            [In] SafeNativeOverlapped overlapped,
-            [In] IntPtr completionRoutine);
+        internal static extern unsafe int WSASendTo(
+            SafeCloseSocket socketHandle,
+            WSABuffer* buffers,
+            int bufferCount,
+            int* bytesTransferred,
+            SocketFlags socketFlags,
+            byte* socketAddress,
+            int socketAddressSize,
+            SafeNativeOverlapped overlapped,
+            void* completionRoutine);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WinsockAsync.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WinsockAsync.cs
@@ -99,7 +99,7 @@ internal static partial class Interop
         //  };
         // } TRANSMIT_PACKETS_ELEMENT;
         [StructLayout(LayoutKind.Explicit)]
-        internal struct TransmitPacketsElement
+        internal unsafe struct TransmitPacketsElement
         {
             [System.Runtime.InteropServices.FieldOffset(0)]
             internal TransmitPacketsElementFlags flags;
@@ -108,9 +108,13 @@ internal static partial class Interop
             [System.Runtime.InteropServices.FieldOffset(8)]
             internal Int64 fileOffset;
             [System.Runtime.InteropServices.FieldOffset(8)]
-            internal IntPtr buffer;
+            internal byte* buffer;
             [System.Runtime.InteropServices.FieldOffset(16)]
             internal IntPtr fileHandle;
+
+            // This controls how many TransmitPacketsElement structs we will allocate on the stack.
+            // Beyond this, we need to alloc on the heap and pin.
+            internal const int StackAllocLimit = 128;
         }
 
         // WinSock 2 extension -- bit values and indices for FD_XXX network events
@@ -161,14 +165,29 @@ internal static partial class Interop
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal struct WSAMsg
+        internal unsafe struct WSAMsg
         {
-            internal IntPtr socketAddress;
+            internal byte* socketAddress;
             internal uint addressLength;
-            internal IntPtr buffers;
+            internal WSABuffer* buffers;
             internal uint count;
             internal WSABuffer controlBuffer;
             internal SocketFlags flags;
+            internal int pad;
+
+            // NOTE: Even though Win32 docs say the flags arg is a DWORD, and thus 4 bytes long, it seems to actually write 4 bytes past this.
+            // The "pad" field above deals with this.
+
+            internal unsafe WSAMsg(byte* socketAddressBuffer, int socketAddressLen, WSABuffer* wsaBuffers, int bufferCount, WSABuffer controlBuffer, SocketFlags flags)
+            {
+                this.socketAddress = socketAddressBuffer;
+                this.addressLength = (uint)socketAddressLen;
+                this.buffers = wsaBuffers;
+                this.count = (uint)bufferCount;
+                this.controlBuffer = controlBuffer;
+                this.flags = flags;
+                this.pad = 0;
+            }
         }
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.accept.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.accept.cs
@@ -12,9 +12,9 @@ internal static partial class Interop
     {
         // Blocking call - requires IntPtr instead of SafeCloseSocket.
         [DllImport(Interop.Libraries.Ws2_32, ExactSpelling = true, SetLastError = true)]
-        internal static extern SafeCloseSocket.InnerSafeCloseSocket accept(
-            [In] IntPtr socketHandle,
-            [Out] byte[] socketAddress,
-            [In, Out] ref int socketAddressSize);
+        internal static unsafe extern SafeCloseSocket.InnerSafeCloseSocket accept(
+            IntPtr socketHandle,
+            byte* socketAddress,
+            int* socketAddressSize);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.recv.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.recv.cs
@@ -13,9 +13,9 @@ internal static partial class Interop
         // This method is always blocking, so it uses an IntPtr.
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern unsafe int recv(
-            [In] IntPtr socketHandle,
-            [In] byte* pinnedBuffer,
-            [In] int len,
-            [In] SocketFlags socketFlags);
+            IntPtr socketHandle,
+            byte* pinnedBuffer,
+            int len,
+            SocketFlags socketFlags);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.recvfrom.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.recvfrom.cs
@@ -13,11 +13,11 @@ internal static partial class Interop
         // This method is always blocking, so it uses an IntPtr.
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern unsafe int recvfrom(
-            [In] IntPtr socketHandle,
-            [In] byte* pinnedBuffer,
-            [In] int len,
-            [In] SocketFlags socketFlags,
-            [Out] byte[] socketAddress,
-            [In, Out] ref int socketAddressSize);
+            IntPtr socketHandle,
+            byte* pinnedBuffer,
+            int len,
+            SocketFlags socketFlags,
+            byte* socketAddress,
+            int* socketAddressSize);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.send.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.send.cs
@@ -13,9 +13,9 @@ internal static partial class Interop
         // This method is always blocking, so it uses an IntPtr.
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern unsafe int send(
-            [In] IntPtr socketHandle,
-            [In] byte* pinnedBuffer,
-            [In] int len,
-            [In] SocketFlags socketFlags);
+            IntPtr socketHandle,
+            byte* pinnedBuffer,
+            int len,
+            SocketFlags socketFlags);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.sendto.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.sendto.cs
@@ -13,11 +13,11 @@ internal static partial class Interop
         // This method is always blocking, so it uses an IntPtr.
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static extern unsafe int sendto(
-            [In] IntPtr socketHandle,
-            [In] byte* pinnedBuffer,
-            [In] int len,
-            [In] SocketFlags socketFlags,
-            [In] byte[] socketAddress,
-            [In] int socketAddressSize);
+            IntPtr socketHandle,
+            byte* pinnedBuffer,
+            int len,
+            SocketFlags socketFlags,
+            byte* socketAddress,
+            int socketAddressSize);
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/WSABuffer.cs
+++ b/src/Common/src/Interop/Windows/Winsock/WSABuffer.cs
@@ -2,14 +2,26 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 namespace System.Net.Sockets
 {
     [StructLayout(LayoutKind.Sequential)]
-    internal struct WSABuffer
+    internal unsafe struct WSABuffer
     {
-        internal int Length; // Length of Buffer
-        internal IntPtr Pointer;// Pointer to Buffer
+        internal int Length;        // Length of Buffer
+        internal byte* Pointer;     // Pointer to Buffer
+
+        public WSABuffer(byte* pointer, int length)
+        {
+            Pointer = pointer;
+            Length = length;
+        }
+
+        // This controls how many WSABuffer structs we will allocate on the stack
+        // when calling WSARecv, WSASend, etc.
+        // Beyond this, we need to alloc on the heap and pin.
+        internal const int StackAllocLimit = 256;
     }
 }

--- a/src/Common/src/System/Net/SafeCloseSocket.Windows.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Windows.cs
@@ -98,12 +98,12 @@ namespace System.Net.Sockets
             return CreateSocket(InnerSafeCloseSocket.CreateWSASocket(addressFamily, socketType, protocolType));
         }
 
-        internal static SafeCloseSocket Accept(
+        internal static unsafe SafeCloseSocket Accept(
             SafeCloseSocket socketHandle,
-            byte[] socketAddress,
-            ref int socketAddressSize)
+            byte* socketAddress,
+            int* socketAddressSize)
         {
-            return CreateSocket(InnerSafeCloseSocket.Accept(socketHandle, socketAddress, ref socketAddressSize));
+            return CreateSocket(InnerSafeCloseSocket.Accept(socketHandle, socketAddress, socketAddressSize));
         }
 
         private void InnerReleaseHandle()
@@ -248,9 +248,9 @@ namespace System.Net.Sockets
                 return result;
             }
 
-            internal static InnerSafeCloseSocket Accept(SafeCloseSocket socketHandle, byte[] socketAddress, ref int socketAddressSize)
+            internal static unsafe InnerSafeCloseSocket Accept(SafeCloseSocket socketHandle, byte* socketAddress, int* socketAddressSize)
             {
-                InnerSafeCloseSocket result = Interop.Winsock.accept(socketHandle.DangerousGetHandle(), socketAddress, ref socketAddressSize);
+                InnerSafeCloseSocket result = Interop.Winsock.accept(socketHandle.DangerousGetHandle(), socketAddress, socketAddressSize);
                 if (result.IsInvalid)
                 {
                     result.SetHandleAsInvalid();

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
@@ -107,17 +107,16 @@ namespace System.Net.Sockets
                             bool success = Interop.Winsock.WSAGetOverlappedResult(
                                 socket.SafeHandle,
                                 asyncResult._nativeOverlapped,
-                                out numBytes,
+                                &numBytes,
                                 false,
-                                out ignore);
-                            if (!success)
-                            {
-                                socketError = SocketPal.GetLastSocketError();
-                            }
+                                &ignore);
+
                             if (success)
                             {
-                                NetEventSource.Fail(asyncResult, $"Unexpectedly succeeded. errorCode:{errorCode} numBytes:{numBytes}");
+                                NetEventSource.Fail(asyncResult, $"WSAGetOverlappedResult unexpectedly succeeded. errorCode:{errorCode} numBytes:{numBytes}");
                             }
+
+                            socketError = SocketPal.GetLastSocketError();
                         }
                         catch (ObjectDisposedException)
                         {
@@ -143,9 +142,7 @@ namespace System.Net.Sockets
             InvokeCallback(PostCompletion(numBytes));
         }
 
-        // The following property returns the Win32 unsafe pointer to
-        // whichever Overlapped structure we're using for IO.
-        internal SafeHandle OverlappedHandle
+        internal SafeNativeOverlapped OverlappedHandle
         {
             get
             {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
@@ -262,65 +262,64 @@ namespace System.Net.Sockets
         }
     }
 
-    internal delegate bool AcceptExDelegate(
+    internal unsafe delegate bool AcceptExDelegate(
                 SafeCloseSocket listenSocketHandle,
                 SafeCloseSocket acceptSocketHandle,
-                IntPtr buffer,
+                byte* buffer,
                 int len,
                 int localAddressLength,
                 int remoteAddressLength,
-                out int bytesReceived,
-                SafeHandle overlapped);
+                int* bytesReceived,
+                SafeNativeOverlapped overlapped);
 
-    internal delegate void GetAcceptExSockaddrsDelegate(
-                IntPtr buffer,
+    internal unsafe delegate void GetAcceptExSockaddrsDelegate(
+                byte* buffer,
                 int receiveDataLength,
                 int localAddressLength,
                 int remoteAddressLength,
-                out IntPtr localSocketAddress,
-                out int localSocketAddressLength,
-                out IntPtr remoteSocketAddress,
-                out int remoteSocketAddressLength);
+                byte** localSocketAddress,
+                int* localSocketAddressLength,
+                byte** remoteSocketAddress,
+                int* remoteSocketAddressLength);
 
-
-    internal delegate bool ConnectExDelegate(
+    internal unsafe delegate bool ConnectExDelegate(
                 SafeCloseSocket socketHandle,
-                IntPtr socketAddress,
+                byte* socketAddress,
                 int socketAddressSize,
-                IntPtr buffer,
+                byte* buffer,
                 int dataLength,
-                out int bytesSent,
-                SafeHandle overlapped);
+                int* bytesSent,
+                SafeNativeOverlapped overlapped);
 
     internal delegate bool DisconnectExDelegate(
-                SafeCloseSocket socketHandle, 
-                SafeHandle overlapped, 
-                int flags, 
-                int reserved);
-
-    internal delegate bool DisconnectExDelegateBlocking(
-                SafeCloseSocket socketHandle, 
-                IntPtr overlapped, 
-                int flags, 
-                int reserved);
-
-    internal delegate SocketError WSARecvMsgDelegate(
                 SafeCloseSocket socketHandle,
-                IntPtr msg,
-                out int bytesTransferred,
-                SafeHandle overlapped,
-                IntPtr completionRoutine);
+                SafeNativeOverlapped overlapped, 
+                int flags, 
+                int reserved);
 
-    internal delegate SocketError WSARecvMsgDelegateBlocking(
+    internal unsafe delegate bool DisconnectExDelegateBlocking(
+                SafeCloseSocket socketHandle, 
+                void* overlapped, 
+                int flags, 
+                int reserved);
+
+    internal unsafe delegate int WSARecvMsgDelegate(
+                SafeCloseSocket socketHandle,
+                Interop.Winsock.WSAMsg* msg,
+                int* bytesTransferred,
+                SafeNativeOverlapped overlapped,
+                void* completionRoutine);
+
+    internal unsafe delegate int WSARecvMsgDelegateBlocking(
                 IntPtr socketHandle,
-                IntPtr msg,
-                out int bytesTransferred,
-                IntPtr overlapped,
-                IntPtr completionRoutine);
+                Interop.Winsock.WSAMsg* msg,
+                int* bytesTransferred,
+                void* overlapped,
+                void* completionRoutine);
 
-    internal delegate bool TransmitPacketsDelegate(
+    internal unsafe delegate bool TransmitPacketsDelegate(
                 SafeCloseSocket socketHandle,
-                IntPtr packetArray,
+                Interop.Winsock.TransmitPacketsElement* packetArray,
                 int elementCount,
                 int sendSize,
                 SafeNativeOverlapped overlapped,

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -22,14 +22,14 @@ namespace System.Net.Sockets
             }
         }
 
-        internal bool AcceptEx(SafeCloseSocket listenSocketHandle,
+        internal unsafe bool AcceptEx(SafeCloseSocket listenSocketHandle,
             SafeCloseSocket acceptSocketHandle,
-            IntPtr buffer,
+            byte* buffer,
             int len,
             int localAddressLength,
             int remoteAddressLength,
-            out int bytesReceived,
-            SafeHandle overlapped)
+            int* bytesReceived,
+            SafeNativeOverlapped overlapped)
         {
             EnsureDynamicWinsockMethods();
             AcceptExDelegate acceptEx = _dynamicWinsockMethods.GetDelegate<AcceptExDelegate>(listenSocketHandle);
@@ -40,18 +40,18 @@ namespace System.Net.Sockets
                 len,
                 localAddressLength,
                 remoteAddressLength,
-                out bytesReceived,
+                bytesReceived,
                 overlapped);
         }
 
-        internal void GetAcceptExSockaddrs(IntPtr buffer,
+        internal unsafe void GetAcceptExSockaddrs(byte* buffer,
             int receiveDataLength,
             int localAddressLength,
             int remoteAddressLength,
-            out IntPtr localSocketAddress,
-            out int localSocketAddressLength,
-            out IntPtr remoteSocketAddress,
-            out int remoteSocketAddressLength)
+            byte** localSocketAddress,
+            int* localSocketAddressLength,
+            byte** remoteSocketAddress,
+            int* remoteSocketAddressLength)
         {
             EnsureDynamicWinsockMethods();
             GetAcceptExSockaddrsDelegate getAcceptExSockaddrs = _dynamicWinsockMethods.GetDelegate<GetAcceptExSockaddrsDelegate>(_handle);
@@ -60,13 +60,13 @@ namespace System.Net.Sockets
                 receiveDataLength,
                 localAddressLength,
                 remoteAddressLength,
-                out localSocketAddress,
-                out localSocketAddressLength,
-                out remoteSocketAddress,
-                out remoteSocketAddressLength);
+                localSocketAddress,
+                localSocketAddressLength,
+                remoteSocketAddress,
+                remoteSocketAddressLength);
         }
 
-        internal bool DisconnectEx(SafeCloseSocket socketHandle, SafeHandle overlapped, int flags, int reserved)
+        internal bool DisconnectEx(SafeCloseSocket socketHandle, SafeNativeOverlapped overlapped, int flags, int reserved)
         {
             EnsureDynamicWinsockMethods();
             DisconnectExDelegate disconnectEx = _dynamicWinsockMethods.GetDelegate<DisconnectExDelegate>(socketHandle);
@@ -74,7 +74,7 @@ namespace System.Net.Sockets
             return disconnectEx(socketHandle, overlapped, flags, reserved);
         }
 
-        internal bool DisconnectExBlocking(SafeCloseSocket socketHandle, IntPtr overlapped, int flags, int reserved)
+        internal unsafe bool DisconnectExBlocking(SafeCloseSocket socketHandle, void* overlapped, int flags, int reserved)
         {
             EnsureDynamicWinsockMethods();
             DisconnectExDelegateBlocking disconnectEx_Blocking = _dynamicWinsockMethods.GetDelegate<DisconnectExDelegateBlocking>(socketHandle);
@@ -82,37 +82,37 @@ namespace System.Net.Sockets
             return disconnectEx_Blocking(socketHandle, overlapped, flags, reserved);
         }
 
-        internal bool ConnectEx(SafeCloseSocket socketHandle,
-            IntPtr socketAddress,
+        internal unsafe bool ConnectEx(SafeCloseSocket socketHandle,
+            byte* socketAddress,
             int socketAddressSize,
-            IntPtr buffer,
+            byte* buffer,
             int dataLength,
-            out int bytesSent,
-            SafeHandle overlapped)
+            int* bytesSent,
+            SafeNativeOverlapped overlapped)
         {
             EnsureDynamicWinsockMethods();
             ConnectExDelegate connectEx = _dynamicWinsockMethods.GetDelegate<ConnectExDelegate>(socketHandle);
 
-            return connectEx(socketHandle, socketAddress, socketAddressSize, buffer, dataLength, out bytesSent, overlapped);
+            return connectEx(socketHandle, socketAddress, socketAddressSize, buffer, dataLength, bytesSent, overlapped);
         }
 
-        internal SocketError WSARecvMsg(SafeCloseSocket socketHandle, IntPtr msg, out int bytesTransferred, SafeHandle overlapped, IntPtr completionRoutine)
+        internal unsafe int WSARecvMsg(SafeCloseSocket socketHandle, Interop.Winsock.WSAMsg* msg, int* bytesTransferred, SafeNativeOverlapped overlapped, void* completionRoutine)
         {
             EnsureDynamicWinsockMethods();
             WSARecvMsgDelegate recvMsg = _dynamicWinsockMethods.GetDelegate<WSARecvMsgDelegate>(socketHandle);
 
-            return recvMsg(socketHandle, msg, out bytesTransferred, overlapped, completionRoutine);
+            return recvMsg(socketHandle, msg, bytesTransferred, overlapped, completionRoutine);
         }
 
-        internal SocketError WSARecvMsgBlocking(IntPtr socketHandle, IntPtr msg, out int bytesTransferred, IntPtr overlapped, IntPtr completionRoutine)
+        internal unsafe int WSARecvMsgBlocking(IntPtr socketHandle, Interop.Winsock.WSAMsg* msg, int* bytesTransferred, void* overlapped, void* completionRoutine)
         {
             EnsureDynamicWinsockMethods();
             WSARecvMsgDelegateBlocking recvMsg_Blocking = _dynamicWinsockMethods.GetDelegate<WSARecvMsgDelegateBlocking>(_handle);
 
-            return recvMsg_Blocking(socketHandle, msg, out bytesTransferred, overlapped, completionRoutine);
+            return recvMsg_Blocking(socketHandle, msg, bytesTransferred, overlapped, completionRoutine);
         }
 
-        internal bool TransmitPackets(SafeCloseSocket socketHandle, IntPtr packetArray, int elementCount, int sendSize, SafeNativeOverlapped overlapped, TransmitFileOptions flags)
+        internal unsafe bool TransmitPackets(SafeCloseSocket socketHandle, Interop.Winsock.TransmitPacketsElement* packetArray, int elementCount, int sendSize, SafeNativeOverlapped overlapped, TransmitFileOptions flags)
         {
             EnsureDynamicWinsockMethods();
             TransmitPacketsDelegate transmitPackets = _dynamicWinsockMethods.GetDelegate<TransmitPacketsDelegate>(socketHandle);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -4294,13 +4294,12 @@ namespace System.Net.Sockets
             e.StartOperationReceive();
 
             // Local vars for sync completion of native call.
-            SocketFlags flags;
             SocketError socketError;
 
             // Wrap native methods with try/catch so event args object can be cleaned up.
             try
             {
-                socketError = e.DoOperationReceive(_handle, out flags);
+                socketError = e.DoOperationReceive(_handle);
             }
             catch
             {
@@ -4353,12 +4352,11 @@ namespace System.Net.Sockets
             e.StartOperationReceiveFrom();
 
             // Make the native call.
-            SocketFlags flags;
             SocketError socketError;
 
             try
             {
-                socketError = e.DoOperationReceiveFrom(_handle, out flags);
+                socketError = e.DoOperationReceiveFrom(_handle);
             }
             catch
             {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -20,7 +20,7 @@ namespace System.Net.Sockets
             // No-op for *nix.
         }
 
-        private void FreeInternals(bool calledFromFinalizer)
+        private void FreeInternals()
         {
             // No-op for *nix.
         }
@@ -139,9 +139,10 @@ namespace System.Net.Sockets
             _socketAddressSize = 0;
         }
 
-        internal unsafe SocketError DoOperationReceive(SafeCloseSocket handle, out SocketFlags flags)
+        internal unsafe SocketError DoOperationReceive(SafeCloseSocket handle)
         {
             int bytesReceived;
+            SocketFlags flags;
             SocketError errorCode;
             if (_buffer != null)
             {
@@ -167,8 +168,9 @@ namespace System.Net.Sockets
             _socketAddressSize = 0;
         }
 
-        internal unsafe SocketError DoOperationReceiveFrom(SafeCloseSocket handle, out SocketFlags flags)
+        internal unsafe SocketError DoOperationReceiveFrom(SafeCloseSocket handle)
         {
+            SocketFlags flags;
             SocketError errorCode;
             int bytesReceived = 0;
             int socketAddressLen = _socketAddress.Size;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -18,13 +18,13 @@ namespace System.Net.Sockets
     public partial class SocketAsyncEventArgs : EventArgs, IDisposable
     {
         // AcceptSocket property variables.
-        internal Socket _acceptSocket;
+        private Socket _acceptSocket;
         private Socket _connectSocket;
 
         // Buffer,Offset,Count property variables.
-        internal byte[] _buffer;
-        internal int _count;
-        internal int _offset;
+        private byte[] _buffer;
+        private int _count;
+        private int _offset;
 
         // BufferList property variables.
         private IList<ArraySegment<byte>> _bufferList;
@@ -50,27 +50,27 @@ namespace System.Net.Sockets
         private EndPoint _remoteEndPoint;
 
         // SendPacketsSendSize property variable.
-        internal int _sendPacketsSendSize;
+        private int _sendPacketsSendSize;
 
         // SendPacketsElements property variables.
-        internal SendPacketsElement[] _sendPacketsElements;
+        private SendPacketsElement[] _sendPacketsElements;
 
         // SendPacketsFlags property variable.
-        internal TransmitFileOptions _sendPacketsFlags;
+        private TransmitFileOptions _sendPacketsFlags;
 
         // SocketError property variables.
         private SocketError _socketError;
         private Exception _connectByNameError;
 
         // SocketFlags property variables.
-        internal SocketFlags _socketFlags;
+        private SocketFlags _socketFlags;
 
         // UserToken property variables.
         private object _userToken;
 
         // Internal buffer for AcceptEx when Buffer not supplied.
-        internal byte[] _acceptBuffer;
-        internal int _acceptAddressBufferCount;
+        private byte[] _acceptBuffer;
+        private int _acceptAddressBufferCount;
 
         // Internal SocketAddress buffer.
         internal Internals.SocketAddress _socketAddress;
@@ -407,7 +407,7 @@ namespace System.Net.Sockets
             }
 
             // OK to dispose now.
-            FreeInternals(false);
+            FreeInternals();
 
             // Don't bother finalizing later.
             GC.SuppressFinalize(this);
@@ -415,7 +415,7 @@ namespace System.Net.Sockets
 
         ~SocketAsyncEventArgs()
         {
-            FreeInternals(true);
+            FreeInternals();
         }
 
         // NOTE: Use a try/finally to make sure Complete is called when you're done

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -111,73 +111,155 @@ namespace System.Net.Sockets
             return errorCode == SocketError.SocketError ? GetLastSocketError() : SocketError.Success;
         }
 
-        public static SocketError Accept(SafeCloseSocket handle, byte[] buffer, ref int nameLen, out SafeCloseSocket socket)
+        public static unsafe SocketError Accept(SafeCloseSocket handle, byte[] buffer, ref int nameLen, out SafeCloseSocket socket)
         {
-            socket = SafeCloseSocket.Accept(handle, buffer, ref nameLen);
-            return socket.IsInvalid ? GetLastSocketError() : SocketError.Success;
-        }
-
-        public static SocketError Connect(SafeCloseSocket handle, byte[] peerAddress, int peerAddressLen)
-        {
-            SocketError errorCode = Interop.Winsock.WSAConnect(
-                handle.DangerousGetHandle(),
-                peerAddress,
-                peerAddressLen,
-                IntPtr.Zero,
-                IntPtr.Zero,
-                IntPtr.Zero,
-                IntPtr.Zero);
-            return errorCode == SocketError.SocketError ? GetLastSocketError() : SocketError.Success;
-        }
-
-        public static SocketError Send(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, out int bytesTransferred)
-        {
-            int count = buffers.Count;
-            WSABuffer[] WSABuffers = new WSABuffer[count];
-            GCHandle[] objectsToPin = null;
-
-            try
+            int localNameLen = nameLen;
+            fixed (byte* bufferPtr = buffer)
             {
-                objectsToPin = new GCHandle[count];
-                for (int i = 0; i < count; ++i)
-                {
-                    ArraySegment<byte> buffer = buffers[i];
-                    RangeValidationHelpers.ValidateSegment(buffer);
-                    objectsToPin[i] = GCHandle.Alloc(buffer.Array, GCHandleType.Pinned);
-                    WSABuffers[i].Length = buffer.Count;
-                    WSABuffers[i].Pointer = Marshal.UnsafeAddrOfPinnedArrayElement(buffer.Array, buffer.Offset);
-                }
-
-                // This may throw ObjectDisposedException.
-                SocketError errorCode = Interop.Winsock.WSASend_Blocking(
-                    handle.DangerousGetHandle(),
-                    WSABuffers,
-                    count,
-                    out bytesTransferred,
-                    socketFlags,
-                    SafeNativeOverlapped.Zero,
-                    IntPtr.Zero);
-
-                if ((SocketError)errorCode == SocketError.SocketError)
-                {
-                    errorCode = GetLastSocketError();
-                }
-
-                return errorCode;
+                socket = SafeCloseSocket.Accept(handle, bufferPtr, &localNameLen);
             }
-            finally
+
+            if (socket.IsInvalid)
             {
-                if (objectsToPin != null)
+                return GetLastSocketError();
+            }
+
+            nameLen = localNameLen;
+            return SocketError.Success;
+        }
+
+        public static unsafe SocketError Connect(SafeCloseSocket handle, byte[] peerAddress, int peerAddressLen)
+        {
+            int result;
+            fixed (byte* peerAddressPtr = peerAddress)
+            {
+                result = Interop.Winsock.WSAConnect(
+                    handle.DangerousGetHandle(),
+                    peerAddressPtr,
+                    peerAddressLen,
+                    null,
+                    null,
+                    null,
+                    null);
+            }
+
+            return result == 0 ? SocketError.Success : GetLastSocketError();
+        }
+
+        private static unsafe void ClearGCHandleArray(GCHandle* gcHandles, int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                gcHandles[i] = default(GCHandle);
+            }
+        }
+
+        private static unsafe void PinBuffers(IList<ArraySegment<byte>> buffers, GCHandle *gcHandles, int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                gcHandles[i] = GCHandle.Alloc(buffers[i].Array, GCHandleType.Pinned);
+            }
+        }
+
+        private static unsafe void UnpinBuffers(GCHandle *gcHandles, int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                if (gcHandles[i].IsAllocated)
                 {
-                    for (int i = 0; i < objectsToPin.Length; ++i)
+                    gcHandles[i].Free();
+                }
+            }
+        }
+
+        private static unsafe byte* GetPinnedBufferPointer(byte[] buffer, int offset)
+        {
+            return (byte*)Marshal.UnsafeAddrOfPinnedArrayElement(buffer, offset);
+        }
+
+        private static unsafe void PopulateWSABufferArray(WSABuffer* wsaBuffers, IList<ArraySegment<byte>> bufferList)
+        {
+            int bufferCount = bufferList.Count;
+            for (int i = 0; i < bufferCount; i++)
+            {
+                ArraySegment<byte> buffer = bufferList[i];
+                byte* bufferPtr = GetPinnedBufferPointer(buffer.Array, buffer.Offset);
+                wsaBuffers[i] = new WSABuffer(bufferPtr, buffer.Count);
+            }
+        }
+
+        public static unsafe SocketError Send(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, out int bytesTransferred)
+        {
+            int bytesSent;
+            int result;
+
+            int count = buffers.Count;
+
+            if (count < WSABuffer.StackAllocLimit)
+            {
+                WSABuffer* wsaBuffers = stackalloc WSABuffer[count];
+                GCHandle* gcHandles = stackalloc GCHandle[count];
+                ClearGCHandleArray(gcHandles, count);
+
+                try
+                {
+                    PinBuffers(buffers, gcHandles, count);
+                    PopulateWSABufferArray(wsaBuffers, buffers);
+
+                    // This may throw ObjectDisposedException.
+                    result = Interop.Winsock.WSASend_Blocking(
+                        handle.DangerousGetHandle(),
+                        wsaBuffers,
+                        count,
+                        &bytesSent,
+                        socketFlags,
+                        SafeNativeOverlapped.Zero,
+                        null);
+                }
+                finally
+                {
+                    UnpinBuffers(gcHandles, count);
+                }
+            }
+            else
+            {
+                WSABuffer[] wsaBuffersHeap = new WSABuffer[count];
+                GCHandle[] gcHandlesHeap = new GCHandle[count];
+
+                fixed (WSABuffer* wsaBuffers = wsaBuffersHeap)
+                fixed (GCHandle* gcHandles = gcHandlesHeap)
+                {
+                    try
                     {
-                        if (objectsToPin[i].IsAllocated)
-                        {
-                            objectsToPin[i].Free();
-                        }
+                        PinBuffers(buffers, gcHandles, count);
+                        PopulateWSABufferArray(wsaBuffers, buffers);
+
+                        // This may throw ObjectDisposedException.
+                        result = Interop.Winsock.WSASend_Blocking(
+                            handle.DangerousGetHandle(),
+                            wsaBuffers,
+                            count,
+                            &bytesSent,
+                            socketFlags,
+                            SafeNativeOverlapped.Zero,
+                            null);
+                    }
+                    finally
+                    {
+                        UnpinBuffers(gcHandles, count);
                     }
                 }
             }
+
+            if (result != 0)
+            {
+                bytesTransferred = 0;
+                return GetLastSocketError();
+            }
+
+            bytesTransferred = bytesSent;
+            return SocketError.Success;
         }
 
         public static unsafe SocketError Send(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, out int bytesTransferred)
@@ -222,27 +304,30 @@ namespace System.Net.Sockets
         public static unsafe SocketError SendTo(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, byte[] peerAddress, int peerAddressSize, out int bytesTransferred)
         {
             int bytesSent;
-            if (buffer.Length == 0)
+            fixed (byte* peerAddressPtr = peerAddress)
             {
-                bytesSent = Interop.Winsock.sendto(
-                    handle.DangerousGetHandle(),
-                    null,
-                    0,
-                    socketFlags,
-                    peerAddress,
-                    peerAddressSize);
-            }
-            else
-            {
-                fixed (byte* pinnedBuffer = &buffer[0])
+                if (buffer.Length == 0)
                 {
                     bytesSent = Interop.Winsock.sendto(
                         handle.DangerousGetHandle(),
-                        pinnedBuffer + offset,
-                        size,
+                        null,
+                        0,
                         socketFlags,
-                        peerAddress,
+                        peerAddressPtr,
                         peerAddressSize);
+                }
+                else
+                {
+                    fixed (byte* pinnedBuffer = &buffer[0])
+                    {
+                        bytesSent = Interop.Winsock.sendto(
+                            handle.DangerousGetHandle(),
+                            pinnedBuffer + offset,
+                            size,
+                            socketFlags,
+                            peerAddressPtr,
+                            peerAddressSize);
+                    }
                 }
             }
 
@@ -256,54 +341,79 @@ namespace System.Net.Sockets
             return SocketError.Success;
         }
 
-        public static SocketError Receive(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, ref SocketFlags socketFlags, out int bytesTransferred)
+        public static unsafe SocketError Receive(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, ref SocketFlags socketFlags, out int bytesTransferred)
         {
+            int bytesReceived;
+            SocketFlags flags = socketFlags;
+            int result;
+
             int count = buffers.Count;
-            WSABuffer[] WSABuffers = new WSABuffer[count];
-            GCHandle[] objectsToPin = null;
 
-            try
+            if (count < WSABuffer.StackAllocLimit)
             {
-                objectsToPin = new GCHandle[count];
-                for (int i = 0; i < count; ++i)
+                WSABuffer* wsaBuffers = stackalloc WSABuffer[count];
+                GCHandle* gcHandles = stackalloc GCHandle[count];
+                ClearGCHandleArray(gcHandles, count);
+
+                try
                 {
-                    ArraySegment<byte> buffer = buffers[i];
-                    RangeValidationHelpers.ValidateSegment(buffer);
-                    objectsToPin[i] = GCHandle.Alloc(buffer.Array, GCHandleType.Pinned);
-                    WSABuffers[i].Length = buffer.Count;
-                    WSABuffers[i].Pointer = Marshal.UnsafeAddrOfPinnedArrayElement(buffer.Array, buffer.Offset);
+                    PinBuffers(buffers, gcHandles, count);
+                    PopulateWSABufferArray(wsaBuffers, buffers);
+
+                    // This can throw ObjectDisposedException.
+                    result = Interop.Winsock.WSARecv_Blocking(
+                        handle.DangerousGetHandle(),
+                        wsaBuffers,
+                        count,
+                        &bytesReceived,
+                        &flags,
+                        SafeNativeOverlapped.Zero,
+                        null);
                 }
-
-                // This can throw ObjectDisposedException.
-                SocketError errorCode = Interop.Winsock.WSARecv_Blocking(
-                    handle.DangerousGetHandle(),
-                    WSABuffers,
-                    count,
-                    out bytesTransferred,
-                    ref socketFlags,
-                    SafeNativeOverlapped.Zero,
-                    IntPtr.Zero);
-
-                if ((SocketError)errorCode == SocketError.SocketError)
+                finally
                 {
-                    errorCode = GetLastSocketError();
+                    UnpinBuffers(gcHandles, count);
                 }
-
-                return errorCode;
             }
-            finally
+            else
             {
-                if (objectsToPin != null)
+                WSABuffer[] wsaBuffersHeap = new WSABuffer[count];
+                GCHandle[] gcHandlesHeap = new GCHandle[count];
+
+                fixed (WSABuffer* wsaBuffers = wsaBuffersHeap)
+                fixed (GCHandle* gcHandles = gcHandlesHeap)
                 {
-                    for (int i = 0; i < objectsToPin.Length; ++i)
+                    try
                     {
-                        if (objectsToPin[i].IsAllocated)
-                        {
-                            objectsToPin[i].Free();
-                        }
+                        PinBuffers(buffers, gcHandles, count);
+                        PopulateWSABufferArray(wsaBuffers, buffers);
+
+                        // This can throw ObjectDisposedException.
+                        result = Interop.Winsock.WSARecv_Blocking(
+                            handle.DangerousGetHandle(),
+                            wsaBuffers,
+                            count,
+                            &bytesReceived,
+                            &flags,
+                            SafeNativeOverlapped.Zero,
+                            null);
+                    }
+                    finally
+                    {
+                        UnpinBuffers(gcHandles, count);
                     }
                 }
             }
+
+            if (result != 0)
+            {
+                bytesTransferred = 0;
+                return GetLastSocketError();
+            }
+
+            bytesTransferred = bytesReceived;
+            socketFlags = flags;
+            return SocketError.Success;
         }
 
         public static unsafe SocketError Receive(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, out int bytesTransferred)
@@ -350,7 +460,7 @@ namespace System.Net.Sockets
             return new IPPacketInformation(address, (int)controlBuffer->index);
         }
 
-        public static unsafe SocketError ReceiveMessageFrom(Socket socket, SafeCloseSocket handle, byte[] buffer, int offset, int size, ref SocketFlags socketFlags, Internals.SocketAddress socketAddress, out Internals.SocketAddress receiveAddress, out IPPacketInformation ipPacketInformation, out int bytesTransferred)
+        public static unsafe SocketError ReceiveMessageFrom(Socket socket, SafeCloseSocket handle, byte[] buffer, int offset, int count, ref SocketFlags socketFlags, Internals.SocketAddress socketAddress, out Internals.SocketAddress receiveAddress, out IPPacketInformation ipPacketInformation, out int bytesTransferred)
         {
             bool ipv4, ipv6;
             Socket.GetIPProtocolInformation(socket.AddressFamily, socketAddress, out ipv4, out ipv6);
@@ -359,32 +469,33 @@ namespace System.Net.Sockets
             receiveAddress = socketAddress;
             ipPacketInformation = default(IPPacketInformation);
 
-            fixed (byte* ptrBuffer = buffer)
+            int bytesReceived;
+            fixed (byte* ptrBuffer = &buffer[offset])
             fixed (byte* ptrSocketAddress = socketAddress.Buffer)
             {
-                Interop.Winsock.WSAMsg wsaMsg;
-                wsaMsg.socketAddress = (IntPtr)ptrSocketAddress;
-                wsaMsg.addressLength = (uint)socketAddress.Size;
-                wsaMsg.flags = socketFlags;
+                WSABuffer wsaBuffer = new WSABuffer(ptrBuffer, count);
 
-                WSABuffer wsaBuffer;
-                wsaBuffer.Length = size;
-                wsaBuffer.Pointer = (IntPtr)(ptrBuffer + offset);
-                wsaMsg.buffers = (IntPtr)(&wsaBuffer);
-                wsaMsg.count = 1;
+                Interop.Winsock.WSAMsg wsaMsg = new Interop.Winsock.WSAMsg(
+                    ptrSocketAddress,
+                    socketAddress.Size, 
+                    &wsaBuffer, 
+                    1, 
+                    default(WSABuffer),
+                    socketFlags);
 
                 if (ipv4)
                 {
                     Interop.Winsock.ControlData controlBuffer;
-                    wsaMsg.controlBuffer.Pointer = (IntPtr)(&controlBuffer);
-                    wsaMsg.controlBuffer.Length = sizeof(Interop.Winsock.ControlData);
+                    wsaMsg.controlBuffer = new WSABuffer((byte*) &controlBuffer, sizeof(Interop.Winsock.ControlData));
 
-                    if (socket.WSARecvMsgBlocking(
+                    int result = socket.WSARecvMsgBlocking(
                         handle.DangerousGetHandle(),
-                        (IntPtr)(&wsaMsg),
-                        out bytesTransferred,
-                        IntPtr.Zero,
-                        IntPtr.Zero) == SocketError.SocketError)
+                        &wsaMsg,
+                        &bytesReceived,
+                        null,
+                        null);
+                    
+                    if (result != 0)
                     {
                         return GetLastSocketError();
                     }
@@ -394,15 +505,16 @@ namespace System.Net.Sockets
                 else if (ipv6)
                 {
                     Interop.Winsock.ControlDataIPv6 controlBuffer;
-                    wsaMsg.controlBuffer.Pointer = (IntPtr)(&controlBuffer);
-                    wsaMsg.controlBuffer.Length = sizeof(Interop.Winsock.ControlDataIPv6);
+                    wsaMsg.controlBuffer = new WSABuffer((byte*)&controlBuffer, sizeof(Interop.Winsock.ControlDataIPv6));
 
-                    if (socket.WSARecvMsgBlocking(
+                    int result = socket.WSARecvMsgBlocking(
                         handle.DangerousGetHandle(),
-                        (IntPtr)(&wsaMsg),
-                        out bytesTransferred,
-                        IntPtr.Zero,
-                        IntPtr.Zero) == SocketError.SocketError)
+                        &wsaMsg,
+                        &bytesReceived,
+                        null,
+                        null);
+                        
+                    if (result != 0)
                     {
                         return GetLastSocketError();
                     }
@@ -411,21 +523,21 @@ namespace System.Net.Sockets
                 }
                 else
                 {
-                    wsaMsg.controlBuffer.Pointer = IntPtr.Zero;
-                    wsaMsg.controlBuffer.Length = 0;
-
-                    if (socket.WSARecvMsgBlocking(
+                    int result = socket.WSARecvMsgBlocking(
                         handle.DangerousGetHandle(),
-                        (IntPtr)(&wsaMsg),
-                        out bytesTransferred,
-                        IntPtr.Zero,
-                        IntPtr.Zero) == SocketError.SocketError)
+                        &wsaMsg,
+                        &bytesReceived,
+                        null,
+                        null);
+                        
+                    if (result != 0)
                     {
                         return GetLastSocketError();
                     }
                 }
 
                 socketFlags = wsaMsg.flags;
+                bytesTransferred = bytesReceived;
             }
 
             return SocketError.Success;
@@ -434,15 +546,19 @@ namespace System.Net.Sockets
         public static unsafe SocketError ReceiveFrom(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, byte[] socketAddress, ref int addressLength, out int bytesTransferred)
         {
             int bytesReceived;
-            if (buffer.Length == 0)
+            int localAddressLength = addressLength;
+            fixed (byte* socketAddressPtr = socketAddress)
             {
-                bytesReceived = Interop.Winsock.recvfrom(handle.DangerousGetHandle(), null, 0, socketFlags, socketAddress, ref addressLength);
-            }
-            else
-            {
-                fixed (byte* pinnedBuffer = &buffer[0])
+                if (buffer.Length == 0)
                 {
-                    bytesReceived = Interop.Winsock.recvfrom(handle.DangerousGetHandle(), pinnedBuffer + offset, size, socketFlags, socketAddress, ref addressLength);
+                    bytesReceived = Interop.Winsock.recvfrom(handle.DangerousGetHandle(), null, 0, socketFlags, socketAddressPtr, &localAddressLength);
+                }
+                else
+                {
+                    fixed (byte* pinnedBuffer = &buffer[0])
+                    {
+                        bytesReceived = Interop.Winsock.recvfrom(handle.DangerousGetHandle(), pinnedBuffer + offset, size, socketFlags, socketAddressPtr, &localAddressLength);
+                    }
                 }
             }
 
@@ -453,6 +569,7 @@ namespace System.Net.Sockets
             }
 
             bytesTransferred = bytesReceived;
+            addressLength = localAddressLength;
             return SocketError.Success;
         }
 
@@ -805,15 +922,19 @@ namespace System.Net.Sockets
             asyncResult.SetUnmanagedStructures(socketAddress);
             try
             {
-                int ignoreBytesSent;
-                bool success = socket.ConnectEx(
-                    handle,
-                    Marshal.UnsafeAddrOfPinnedArrayElement(socketAddress, 0),
-                    socketAddressLen,
-                    IntPtr.Zero,
-                    0,
-                    out ignoreBytesSent,
-                    asyncResult.OverlappedHandle);
+                bool success;
+                fixed (byte* socketAddressPtr = &socketAddress[0])
+                {
+                    int ignoreBytesSent;
+                    success = socket.ConnectEx(
+                        handle,
+                        socketAddressPtr,
+                        socketAddressLen,
+                        null,
+                        0,
+                        &ignoreBytesSent,
+                        asyncResult.OverlappedHandle);
+                }
 
                 return asyncResult.ProcessOverlappedResult(success, 0);
             }
@@ -827,21 +948,24 @@ namespace System.Net.Sockets
         public static unsafe SocketError SendAsync(SafeCloseSocket handle, byte[] buffer, int offset, int count, SocketFlags socketFlags, OverlappedAsyncResult asyncResult)
         {
             // Set up unmanaged structures for overlapped WSASend.
-            asyncResult.SetUnmanagedStructures(buffer, offset, count, null, false /*don't pin null remoteEP*/);
+            // This will pin the buffer.
+            asyncResult.SetUnmanagedStructures(buffer);
             try
             {
-                // This can throw ObjectDisposedException.
+                WSABuffer wsaBuffer = new WSABuffer(GetPinnedBufferPointer(buffer, offset), count);
                 int bytesTransferred;
-                SocketError errorCode = Interop.Winsock.WSASend(
+
+                // This can throw ObjectDisposedException.
+                int result = Interop.Winsock.WSASend(
                     handle,
-                    ref asyncResult._singleBuffer,
-                    1, // There is only ever 1 buffer being sent.
-                    out bytesTransferred,
+                    &wsaBuffer,
+                    1,
+                    &bytesTransferred,
                     socketFlags,
                     asyncResult.OverlappedHandle,
-                    IntPtr.Zero);
+                    null);
 
-                return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
+                return asyncResult.ProcessOverlappedResult(result == 0, bytesTransferred);
             }
             catch
             {
@@ -853,21 +977,49 @@ namespace System.Net.Sockets
         public static unsafe SocketError SendAsync(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, OverlappedAsyncResult asyncResult)
         {
             // Set up asyncResult for overlapped WSASend.
+            // This will pin the buffers.
             asyncResult.SetUnmanagedStructures(buffers);
             try
             {
-                // This can throw ObjectDisposedException.
+                int result;
                 int bytesTransferred;
-                SocketError errorCode = Interop.Winsock.WSASend(
-                    handle,
-                    asyncResult._wsaBuffers,
-                    asyncResult._wsaBuffers.Length,
-                    out bytesTransferred,
-                    socketFlags,
-                    asyncResult.OverlappedHandle,
-                    IntPtr.Zero);
 
-                return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
+                int bufferCount = buffers.Count;
+                if (bufferCount <= WSABuffer.StackAllocLimit)
+                {
+                    WSABuffer* wsaBuffers = stackalloc WSABuffer[bufferCount];
+                    PopulateWSABufferArray(wsaBuffers, buffers);
+
+                    // This can throw ObjectDisposedException.
+                    result = Interop.Winsock.WSASend(
+                        handle,
+                        wsaBuffers,
+                        bufferCount,
+                        &bytesTransferred,
+                        socketFlags,
+                        asyncResult.OverlappedHandle,
+                        null);
+                }
+                else
+                {
+                    WSABuffer[] wsaHeapBuffers = new WSABuffer[bufferCount];
+                    fixed (WSABuffer* wsaBuffers = wsaHeapBuffers)
+                    {
+                        PopulateWSABufferArray(wsaBuffers, buffers);
+
+                        // This can throw ObjectDisposedException.
+                        result = Interop.Winsock.WSASend(
+                            handle,
+                            wsaBuffers,
+                            bufferCount,
+                            &bytesTransferred,
+                            socketFlags,
+                            asyncResult.OverlappedHandle,
+                            null);
+                    }
+                }
+
+                return asyncResult.ProcessOverlappedResult(result == 0, bytesTransferred);
             }
             catch
             {
@@ -881,7 +1033,7 @@ namespace System.Net.Sockets
         private static unsafe bool TransmitFileHelper(
             SafeHandle socket, 
             SafeHandle fileHandle,
-            SafeHandle overlapped,
+            SafeNativeOverlapped overlapped,
             byte[] preBuffer,
             byte[] postBuffer,
             TransmitFileOptions flags)
@@ -892,14 +1044,14 @@ namespace System.Net.Sockets
             if (preBuffer != null && preBuffer.Length > 0)
             {
                 needTransmitFileBuffers = true;
-                transmitFileBuffers.Head = Marshal.UnsafeAddrOfPinnedArrayElement(preBuffer, 0);
+                transmitFileBuffers.Head = (byte*) Marshal.UnsafeAddrOfPinnedArrayElement(preBuffer, 0);
                 transmitFileBuffers.HeadLength = preBuffer.Length;
             }
 
             if (postBuffer != null && postBuffer.Length > 0)
             {
                 needTransmitFileBuffers = true;
-                transmitFileBuffers.Tail = Marshal.UnsafeAddrOfPinnedArrayElement(postBuffer, 0);
+                transmitFileBuffers.Tail = (byte*) Marshal.UnsafeAddrOfPinnedArrayElement(postBuffer, 0);
                 transmitFileBuffers.TailLength = postBuffer.Length;
             }
 
@@ -934,22 +1086,25 @@ namespace System.Net.Sockets
         public static unsafe SocketError SendToAsync(SafeCloseSocket handle, byte[] buffer, int offset, int count, SocketFlags socketFlags, Internals.SocketAddress socketAddress, OverlappedAsyncResult asyncResult)
         {
             // Set up asyncResult for overlapped WSASendTo.
-            asyncResult.SetUnmanagedStructures(buffer, offset, count, socketAddress, false /* don't pin RemoteEP*/);
+            // This will pin the buffer and the socketAddress.
+            asyncResult.SetUnmanagedStructures(buffer, socketAddress);
             try
             {
+                WSABuffer wsaBuffer = new WSABuffer(GetPinnedBufferPointer(buffer, offset), count);
                 int bytesTransferred;
-                SocketError errorCode = Interop.Winsock.WSASendTo(
+
+                int result = Interop.Winsock.WSASendTo(
                     handle,
-                    ref asyncResult._singleBuffer,
-                    1, // There is only ever 1 buffer being sent.
-                    out bytesTransferred,
+                    &wsaBuffer,
+                    1,
+                    &bytesTransferred,
                     socketFlags,
                     asyncResult.GetSocketAddressPtr(),
                     asyncResult.SocketAddress.Size,
                     asyncResult.OverlappedHandle,
-                    IntPtr.Zero);
+                    null);
 
-                return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
+                return asyncResult.ProcessOverlappedResult(result == 0, bytesTransferred);
             }
             catch
             {
@@ -961,21 +1116,24 @@ namespace System.Net.Sockets
         public static unsafe SocketError ReceiveAsync(SafeCloseSocket handle, byte[] buffer, int offset, int count, SocketFlags socketFlags, OverlappedAsyncResult asyncResult)
         {
             // Set up asyncResult for overlapped WSARecv.
-            asyncResult.SetUnmanagedStructures(buffer, offset, count, null, false /* don't pin null RemoteEP*/);
+            // This will pin the buffer.
+            asyncResult.SetUnmanagedStructures(buffer);
             try
             {
-                // This can throw ObjectDisposedException.
+                WSABuffer wsaBuffer = new WSABuffer(GetPinnedBufferPointer(buffer, offset), count);
                 int bytesTransferred;
-                SocketError errorCode = Interop.Winsock.WSARecv(
+                
+                // This can throw ObjectDisposedException.
+                int result = Interop.Winsock.WSARecv(
                     handle,
-                    ref asyncResult._singleBuffer,
+                    &wsaBuffer,
                     1,
-                    out bytesTransferred,
-                    ref socketFlags,
+                    &bytesTransferred,
+                    &socketFlags,
                     asyncResult.OverlappedHandle,
-                    IntPtr.Zero);
+                    null);
 
-                return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
+                return asyncResult.ProcessOverlappedResult(result == 0, bytesTransferred);
             }
             catch
             {
@@ -986,22 +1144,50 @@ namespace System.Net.Sockets
 
         public static unsafe SocketError ReceiveAsync(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, OverlappedAsyncResult asyncResult)
         {
-            // Set up asyncResult for overlapped WSASend.
+            // Set up asyncResult for overlapped WSARecv.
+            // This will pin the buffers.
             asyncResult.SetUnmanagedStructures(buffers);
             try
             {
-                // This can throw ObjectDisposedException.
+                int result;
                 int bytesTransferred;
-                SocketError errorCode = Interop.Winsock.WSARecv(
-                    handle,
-                    asyncResult._wsaBuffers,
-                    asyncResult._wsaBuffers.Length,
-                    out bytesTransferred,
-                    ref socketFlags,
-                    asyncResult.OverlappedHandle,
-                    IntPtr.Zero);
 
-                return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
+                int bufferCount = buffers.Count;
+                if (bufferCount <= WSABuffer.StackAllocLimit)
+                {
+                    WSABuffer* wsaBuffers = stackalloc WSABuffer[bufferCount];
+                    PopulateWSABufferArray(wsaBuffers, buffers);
+
+                    // This can throw ObjectDisposedException.
+                    result = Interop.Winsock.WSARecv(
+                        handle,
+                        wsaBuffers,
+                        bufferCount,
+                        &bytesTransferred,
+                        &socketFlags,
+                        asyncResult.OverlappedHandle,
+                        null);
+                }
+                else
+                {
+                    WSABuffer[] wsaHeapBuffers = new WSABuffer[bufferCount];
+                    fixed (WSABuffer* wsaBuffers = wsaHeapBuffers)
+                    {
+                        PopulateWSABufferArray(wsaBuffers, buffers);
+
+                        // This can throw ObjectDisposedException.
+                        result = Interop.Winsock.WSARecv(
+                            handle,
+                            wsaBuffers,
+                            bufferCount,
+                            &bytesTransferred,
+                            &socketFlags,
+                            asyncResult.OverlappedHandle,
+                            null);
+                    }
+                }
+
+                return asyncResult.ProcessOverlappedResult(result == 0, bytesTransferred);
             }
             catch
             {
@@ -1013,22 +1199,25 @@ namespace System.Net.Sockets
         public static unsafe SocketError ReceiveFromAsync(SafeCloseSocket handle, byte[] buffer, int offset, int count, SocketFlags socketFlags, Internals.SocketAddress socketAddress, OverlappedAsyncResult asyncResult)
         {
             // Set up asyncResult for overlapped WSARecvFrom.
-            asyncResult.SetUnmanagedStructures(buffer, offset, count, socketAddress, true);
+            // This will pin the buffer and the socketAddress.
+            asyncResult.SetUnmanagedStructures(buffer, socketAddress);
             try
             {
+                WSABuffer wsaBuffer = new WSABuffer(GetPinnedBufferPointer(buffer, offset), count);
                 int bytesTransferred;
-                SocketError errorCode = Interop.Winsock.WSARecvFrom(
+
+                int result = Interop.Winsock.WSARecvFrom(
                     handle,
-                    ref asyncResult._singleBuffer,
+                    &wsaBuffer,
                     1,
-                    out bytesTransferred,
-                    ref socketFlags,
+                    &bytesTransferred,
+                    &socketFlags,
                     asyncResult.GetSocketAddressPtr(),
                     asyncResult.GetSocketAddressSizePtr(),
                     asyncResult.OverlappedHandle,
-                    IntPtr.Zero);
+                    null);
 
-                return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
+                return asyncResult.ProcessOverlappedResult(result == 0, bytesTransferred);
             }
             catch
             {
@@ -1039,18 +1228,30 @@ namespace System.Net.Sockets
 
         public static unsafe SocketError ReceiveMessageFromAsync(Socket socket, SafeCloseSocket handle, byte[] buffer, int offset, int count, SocketFlags socketFlags, Internals.SocketAddress socketAddress, ReceiveMessageOverlappedAsyncResult asyncResult)
         {
-            asyncResult.SetUnmanagedStructures(buffer, offset, count, socketAddress, socketFlags);
+            asyncResult.SetUnmanagedStructures(buffer, socketAddress, socketFlags);
             try
             {
                 int bytesTransfered;
-                SocketError errorCode = (SocketError)socket.WSARecvMsg(
-                    handle,
-                    Marshal.UnsafeAddrOfPinnedArrayElement(asyncResult._messageBuffer, 0),
-                    out bytesTransfered,
-                    asyncResult.OverlappedHandle,
-                    IntPtr.Zero);
 
-                return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransfered);
+                WSABuffer wsaBuffer = new WSABuffer(GetPinnedBufferPointer(buffer, offset), count);
+                WSABuffer wsaControlBuffer = new WSABuffer(asyncResult.GetControlBuffer(), asyncResult.GetControlBufferSize());
+
+                Interop.Winsock.WSAMsg wsaMsg = new Interop.Winsock.WSAMsg(
+                    asyncResult.GetSocketAddressPtr(),
+                    asyncResult.GetSocketAddressSize(),
+                    &wsaBuffer,
+                    1,
+                    wsaControlBuffer,
+                    socketFlags);
+
+                int result = socket.WSARecvMsg(
+                    handle,
+                    &wsaMsg,
+                    &bytesTransfered,
+                    asyncResult.OverlappedHandle,
+                    null);
+
+                return asyncResult.ProcessOverlappedResult(result == 0, bytesTransfered);
             }
             catch
             {
@@ -1076,11 +1277,11 @@ namespace System.Net.Sockets
                 bool success = socket.AcceptEx(
                     handle,
                     acceptHandle,
-                    Marshal.UnsafeAddrOfPinnedArrayElement(asyncResult.Buffer, 0),
+                    (byte*) Marshal.UnsafeAddrOfPinnedArrayElement(asyncResult.Buffer, 0),
                     receiveSize,
                     addressBufferSize,
                     addressBufferSize,
-                    out bytesTransferred,
+                    &bytesTransferred,
                     asyncResult.OverlappedHandle);
 
                 return asyncResult.ProcessOverlappedResult(success, 0);
@@ -1118,12 +1319,12 @@ namespace System.Net.Sockets
             }
         }
 
-        internal static SocketError Disconnect(Socket socket, SafeCloseSocket handle, bool reuseSocket)
+        internal static unsafe SocketError Disconnect(Socket socket, SafeCloseSocket handle, bool reuseSocket)
         {
             SocketError errorCode = SocketError.Success;
 
             // This can throw ObjectDisposedException (handle, and retrieving the delegate).
-            if (!socket.DisconnectExBlocking(handle, IntPtr.Zero, (int)(reuseSocket ? TransmitFileOptions.ReuseSocket : 0), 0))
+            if (!socket.DisconnectExBlocking(handle, null, (int)(reuseSocket ? TransmitFileOptions.ReuseSocket : 0), 0))
             {
                 errorCode = GetLastSocketError();
             }


### PR DESCRIPTION
Rework the p/invoke definitions and related logic, to try to ensure correctness, improve performance, and reduce memory usage.

Several related changes:

- Use explicit native types generally, to avoid unexpected p/invoke marshalling behavior.  Avoid IntPtr.  SafeHandle is fine.
- Most native socket routines return a simple int, not a SocketError; fix this
- Build struct parameters (e.g. WSABuffer, WSAMsg) on the stack where possible
- Use explicit GCHandles in SocketAsyncEventArgs rather than Overlapped to do pinning.
- Avoid reallocating Overlapped structures in SocketAsyncEventArgs
- Try to enforce pinning semantics in SocketAsyncEventArgs using asserts and GCHandles

Fixes #16213, #16306 

@stephentoub @davidsh @cipop @Priya91 