### PR TITLE
Cut GetTypeInfo from ConcurrentDictionary and use switch over if-else

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -93,31 +93,30 @@ namespace System.Collections.Concurrent
             // See http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-335.pdf
             //
             Type valueType = typeof(TValue);
-            if (valueType.IsEnum)
+            if (!valueType.IsValueType)
             {
-                valueType = Enum.GetUnderlyingType(valueType);
-            }
-            bool isAtomic =
-                !valueType.GetTypeInfo().IsValueType ||
-                valueType == typeof(bool) ||
-                valueType == typeof(char) ||
-                valueType == typeof(byte) ||
-                valueType == typeof(sbyte) ||
-                valueType == typeof(short) ||
-                valueType == typeof(ushort) ||
-                valueType == typeof(int) ||
-                valueType == typeof(uint) ||
-                valueType == typeof(float);
-
-            if (!isAtomic && IntPtr.Size == 8)
-            {
-                isAtomic =
-                    valueType == typeof(double) ||
-                    valueType == typeof(long) ||
-                    valueType == typeof(ulong);
+                return true;
             }
 
-            return isAtomic;
+            switch (Type.GetTypeCode(valueType))
+            {
+                case TypeCode.Boolean:
+                case TypeCode.Byte:
+                case TypeCode.Char:
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.SByte:
+                case TypeCode.Single:
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                    return true;
+                case TypeCode.Int64:
+                case TypeCode.Double:
+                case TypeCode.UInt64:
+                    return IntPtr.Size == 8;
+                default:
+                    return false;
+            }
         }
 
         /// <summary>

--- a/src/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionary.Generic.Tests.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionary.Generic.Tests.cs
@@ -42,6 +42,28 @@ namespace System.Collections.Concurrent.Tests
         protected override string CreateTValue(int seed) => CreateTKey(seed);
     }
 
+    public class ConcurrentDictionary_Generic_Tests_ulong_ulong : ConcurrentDictionary_Generic_Tests<ulong, ulong>
+    {
+        protected override bool DefaultValueAllowed => true;
+
+        protected override KeyValuePair<ulong, ulong> CreateT(int seed)
+        {
+            ulong key = CreateTKey(seed);
+            ulong value = CreateTKey(~seed);
+            return new KeyValuePair<ulong, ulong>(key, value);
+        }
+
+        protected override ulong CreateTKey(int seed)
+        {
+            Random rand = new Random(seed);
+            ulong hi = unchecked((ulong)rand.Next());
+            ulong lo = unchecked((ulong)rand.Next());
+            return (hi << 32) | lo;
+        }
+
+        protected override ulong CreateTValue(int seed) => CreateTKey(seed);
+    }
+
     public class ConcurrentDictionary_Generic_Tests_int_int : ConcurrentDictionary_Generic_Tests<int, int>
     {
         protected override bool DefaultValueAllowed => true;


### PR DESCRIPTION
`GetTypeInfo` is no longer a necessary step to get `IsValueType` so remove the call to it (contributes to #16305).

Replace if-else ladder on `== typeof(…)` with switch on `GetTypeCode` so up to a dozen tests becomes at most 3.

This makes it no longer necessary to test for enum types and get underlying type, so don't.

Add a 64-bit type to the types covered in testing.