### PR TITLE
OverflowException in System.Security.AccessControl

### DIFF
--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/ACE.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/ACE.cs
@@ -149,7 +149,7 @@ nameof(binaryForm),
 
             binaryForm[offset + 0] = (byte)AceType;
             binaryForm[offset + 1] = (byte)AceFlags;
-            binaryForm[offset + 2] = (byte)(Length >> 0);
+            binaryForm[offset + 2] = unchecked((byte)(Length >> 0));
             binaryForm[offset + 3] = (byte)(Length >> 8);
         }
 
@@ -987,11 +987,11 @@ nameof(opaque),
             //
 
             accessMask =
-                (int)(
+                unchecked((int)(
                 (((uint)binaryForm[baseOffset + 0]) << 0) +
                 (((uint)binaryForm[baseOffset + 1]) << 8) +
                 (((uint)binaryForm[baseOffset + 2]) << 16) +
-                (((uint)binaryForm[baseOffset + 3]) << 24));
+                (((uint)binaryForm[baseOffset + 3]) << 24)));
 
             offsetLocal += AccessMaskLength;
 
@@ -1067,11 +1067,13 @@ nameof(opaque),
             //
             // Store the access mask in the big-endian format
             //
-
-            binaryForm[baseOffset + 0] = (byte)(AccessMask >> 0);
-            binaryForm[baseOffset + 1] = (byte)(AccessMask >> 8);
-            binaryForm[baseOffset + 2] = (byte)(AccessMask >> 16);
-            binaryForm[baseOffset + 3] = (byte)(AccessMask >> 24);
+            unchecked
+            {
+                binaryForm[baseOffset + 0] = (byte)(AccessMask >> 0);
+                binaryForm[baseOffset + 1] = (byte)(AccessMask >> 8);
+                binaryForm[baseOffset + 2] = (byte)(AccessMask >> 16);
+                binaryForm[baseOffset + 3] = (byte)(AccessMask >> 24);
+            }
 
             offsetLocal += AccessMaskLength;
 
@@ -1953,11 +1955,11 @@ nameof(qualifier),
             int offsetLocal = 0;
 
             accessMask =
-                (int)(
+                unchecked((int)(
                 (((uint)binaryForm[baseOffset + 0]) << 0) +
                 (((uint)binaryForm[baseOffset + 1]) << 8) +
                 (((uint)binaryForm[baseOffset + 2]) << 16) +
-                (((uint)binaryForm[baseOffset + 3]) << 24));
+                (((uint)binaryForm[baseOffset + 3]) << 24)));
 
             offsetLocal += AccessMaskLength;
 
@@ -2162,11 +2164,13 @@ nameof(qualifier),
             //
             // Store the access mask in the big-endian format
             //
-
-            binaryForm[baseOffset + 0] = (byte)(AccessMask >> 0);
-            binaryForm[baseOffset + 1] = (byte)(AccessMask >> 8);
-            binaryForm[baseOffset + 2] = (byte)(AccessMask >> 16);
-            binaryForm[baseOffset + 3] = (byte)(AccessMask >> 24);
+            unchecked
+            {
+                binaryForm[baseOffset + 0] = (byte)(AccessMask >> 0);
+                binaryForm[baseOffset + 1] = (byte)(AccessMask >> 8);
+                binaryForm[baseOffset + 2] = (byte)(AccessMask >> 16);
+                binaryForm[baseOffset + 3] = (byte)(AccessMask >> 24);
+            }
 
             offsetLocal += AccessMaskLength;
 

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/ACL.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/ACL.cs
@@ -323,9 +323,9 @@ nameof(binaryForm),
 
             binaryForm[offset + 0] = Revision;
             binaryForm[offset + 1] = 0;
-            binaryForm[offset + 2] = ( byte )( BinaryLength >> 0 );
+            binaryForm[offset + 2] = unchecked(( byte )( BinaryLength >> 0 ));
             binaryForm[offset + 3] = ( byte )( BinaryLength >> 8 );
-            binaryForm[offset + 4] = ( byte )( Count >> 0 );
+            binaryForm[offset + 4] = unchecked(( byte )( Count >> 0 ));
             binaryForm[offset + 5] = ( byte )( Count >> 8 );
             binaryForm[offset + 6] = 0;
             binaryForm[offset + 7] = 0;

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/SecurityDescriptor.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/SecurityDescriptor.cs
@@ -305,7 +305,7 @@ nameof(binaryForm),
 
             binaryForm[offset + 0] = Revision;
             binaryForm[offset + 1] = rmControl;
-            binaryForm[offset + 2] = (byte)((int)materializedControlFlags >> 0);
+            binaryForm[offset + 2] = unchecked((byte)((int)materializedControlFlags >> 0));
             binaryForm[offset + 3] = (byte)((int)materializedControlFlags >> 8);
 
             //

--- a/src/System.Security.AccessControl/tests/Ace/Ace.Compound.Tests.cs
+++ b/src/System.Security.AccessControl/tests/Ace/Ace.Compound.Tests.cs
@@ -36,10 +36,13 @@ namespace System.Security.AccessControl.Tests
             int baseOffset = offset + 4;
             int offsetLocal = 0;
 
-            binaryForm[baseOffset + 0] = (byte)(accessMask >> 0);
-            binaryForm[baseOffset + 1] = (byte)(accessMask >> 8);
-            binaryForm[baseOffset + 2] = (byte)(accessMask >> 16);
-            binaryForm[baseOffset + 3] = (byte)(accessMask >> 24);
+            unchecked
+            {
+                binaryForm[baseOffset + 0] = (byte)(accessMask >> 0);
+                binaryForm[baseOffset + 1] = (byte)(accessMask >> 8);
+                binaryForm[baseOffset + 2] = (byte)(accessMask >> 16);
+                binaryForm[baseOffset + 3] = (byte)(accessMask >> 24);
+            }
             offsetLocal += 4;
 
             binaryForm[baseOffset + offsetLocal + 0] = (byte)((ushort)compoundAceType >> 0);

--- a/src/System.Security.AccessControl/tests/Ace/Ace.Object.Tests.cs
+++ b/src/System.Security.AccessControl/tests/Ace/Ace.Object.Tests.cs
@@ -61,10 +61,13 @@ namespace System.Security.AccessControl.Tests
             int baseOffset = offset + 4;
             int offsetLocal = 0;
 
-            binaryForm[baseOffset + 0] = (byte)(accessMask >> 0);
-            binaryForm[baseOffset + 1] = (byte)(accessMask >> 8);
-            binaryForm[baseOffset + 2] = (byte)(accessMask >> 16);
-            binaryForm[baseOffset + 3] = (byte)(accessMask >> 24);
+            unchecked
+            {
+                binaryForm[baseOffset + 0] = (byte)(accessMask >> 0);
+                binaryForm[baseOffset + 1] = (byte)(accessMask >> 8);
+                binaryForm[baseOffset + 2] = (byte)(accessMask >> 16);
+                binaryForm[baseOffset + 3] = (byte)(accessMask >> 24);
+            }
             offsetLocal += 4;
 
             binaryForm[baseOffset + offsetLocal + 0] = (byte)(((uint)flags) >> 0);


### PR DESCRIPTION
Fixed several overflow exceptions in both product and test code of
System.Security.AccessControl. Note that there could be more overflows
masked by issue #15041.

Fix #16315