### PR TITLE
Fix SqlClient diagnostic test failures

### DIFF
--- a/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -21,10 +21,11 @@ namespace System.Diagnostics
         protected static string HostRunner => Process.GetCurrentProcess().MainModule.FileName;
 
         /// <summary>A timeout (milliseconds) after which a wait on a remote operation should be considered a failure.</summary>
-        public const int FailWaitTimeoutMilliseconds = 30 * 1000;
+        public const int FailWaitTimeoutMilliseconds = 60 * 1000;
         /// <summary>The exit code returned when the test process exits successfully.</summary>
         internal const int SuccessExitCode = 42;
 
+        /// <summary>Determines if we're running on the .NET Framework (rather than .NET Core).</summary>
         internal static bool IsFullFramework => RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
 
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
@@ -172,9 +173,13 @@ namespace System.Diagnostics
                     // needing to do this in every derived test and keep each test much simpler.
                     try
                     {
-                        Assert.True(Process.WaitForExit(Options.TimeOut));
+                        Assert.True(Process.WaitForExit(Options.TimeOut),
+                            $"Timed out after {Options.TimeOut}ms waiting for remote process {Process.Id}");
+
                         if (Options.CheckExitCode)
+                        {
                             Assert.Equal(SuccessExitCode, Process.ExitCode);
+                        }
                     }
                     finally
                     {

--- a/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
@@ -383,7 +383,7 @@ namespace System.Data.SqlClient.Tests
             }, s_tcpConnStr).Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsConnectionStringConfigured))]
         public void ExecuteXmlReaderAsyncErrorTest()
         {
             RemoteInvoke(cs =>

--- a/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
@@ -2,403 +2,477 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Xunit;
-using System.Reflection;
-using System.Diagnostics;
 using System.Collections;
-using System.Xml;
+using System.Diagnostics;
+using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.SqlServer.TDS.Servers;
+using System.Xml;
 using Microsoft.SqlServer.TDS;
-using Microsoft.SqlServer.TDS.EndPoint;
-using Microsoft.SqlServer.TDS.SQLBatch;
-using Microsoft.SqlServer.TDS.Error;
 using Microsoft.SqlServer.TDS.Done;
+using Microsoft.SqlServer.TDS.EndPoint;
+using Microsoft.SqlServer.TDS.Error;
+using Microsoft.SqlServer.TDS.Servers;
+using Microsoft.SqlServer.TDS.SQLBatch;
+using Xunit;
 
 namespace System.Data.SqlClient.Tests
 {
-    public class DiagnosticTest : IDisposable
+    public class DiagnosticTest : RemoteExecutorTestBase
     {
-        private string _connectionString;
-        private string _badConnectionString = "data source = bad; initial catalog = bad; uid = bad; password = bad; connection timeout = 1;";
+        private const string BadConnectionString = "data source = bad; initial catalog = bad; uid = bad; password = bad; connection timeout = 1;";
+        private static readonly string s_tcpConnStr = $"\"{Environment.GetEnvironmentVariable("TEST_TCP_CONN_STR")}\"";
         
-        private TestTdsServer _server;
-        private static readonly string s_tcpConnStr = Environment.GetEnvironmentVariable("TEST_TCP_CONN_STR");
-
-        public static bool IsConnectionStringConfigured() => !string.IsNullOrEmpty(s_tcpConnStr);
-
-        public DiagnosticTest()
-        {
-            QueryEngine engine = new DiagnosticsQueryEngine();
-            _server = TestTdsServer.StartServerWithQueryEngine(engine);
-            _connectionString = _server.ConnectionString;
-        }
+        public static bool IsConnectionStringConfigured() => s_tcpConnStr != "\"\"";
 
         [Fact]
         public void ExecuteScalarTest()
         {
-            CollectStatisticsDiagnostics(() =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection conn = new SqlConnection(_connectionString))
-                using (SqlCommand cmd = new SqlCommand())
+                CollectStatisticsDiagnostics(connectionString =>
                 {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "SELECT [name], [state] FROM [sys].[databases] WHERE [name] = db_name();";
+                    using (SqlConnection conn = new SqlConnection(connectionString))
+                    using (SqlCommand cmd = new SqlCommand())
+                    {
+                        cmd.Connection = conn;
+                        cmd.CommandText = "SELECT [name], [state] FROM [sys].[databases] WHERE [name] = db_name();";
 
-                    conn.Open();
-                    var output = cmd.ExecuteScalar();
-                }
-            });
+                        conn.Open();
+                        var output = cmd.ExecuteScalar();
+                    }
+                });
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
         public void ExecuteScalarErrorTest()
         {
-            CollectStatisticsDiagnostics(() =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection conn = new SqlConnection(_connectionString))
-                using (SqlCommand cmd = new SqlCommand())
+                CollectStatisticsDiagnostics(connectionString =>
                 {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "select 1 / 0;";
+                    using (SqlConnection conn = new SqlConnection(connectionString))
+                    using (SqlCommand cmd = new SqlCommand())
+                    {
+                        cmd.Connection = conn;
+                        cmd.CommandText = "select 1 / 0;";
 
-                    conn.Open();
+                        conn.Open();
 
-                    try { var output = cmd.ExecuteScalar(); }
-                    catch { }
-                }
-            });
+                        try { var output = cmd.ExecuteScalar(); }
+                        catch { }
+                    }
+                });
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
         public void ExecuteNonQueryTest()
         {
-            CollectStatisticsDiagnostics(() =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection conn = new SqlConnection(_connectionString))
-                using (SqlCommand cmd = new SqlCommand())
+                CollectStatisticsDiagnostics(connectionString =>
                 {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "SELECT [name], [state] FROM [sys].[databases] WHERE [name] = db_name();";
+                    using (SqlConnection conn = new SqlConnection(connectionString))
+                    using (SqlCommand cmd = new SqlCommand())
+                    {
+                        cmd.Connection = conn;
+                        cmd.CommandText = "SELECT [name], [state] FROM [sys].[databases] WHERE [name] = db_name();";
 
-                    conn.Open();
-                    var output = cmd.ExecuteNonQuery();
-                }
-            });
+                        conn.Open();
+                        var output = cmd.ExecuteNonQuery();
+                    }
+                });
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
         public void ExecuteNonQueryErrorTest()
         {
-            CollectStatisticsDiagnostics(() =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection conn = new SqlConnection(_connectionString))
-                using (SqlCommand cmd = new SqlCommand())
+                CollectStatisticsDiagnostics(connectionString =>
                 {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "select 1 / 0;";
+                    using (SqlConnection conn = new SqlConnection(connectionString))
+                    using (SqlCommand cmd = new SqlCommand())
+                    {
+                        cmd.Connection = conn;
+                        cmd.CommandText = "select 1 / 0;";
 
-                    conn.Open();
-                    try { var output = cmd.ExecuteNonQuery(); }
-                    catch { }
-                }
-            });
+                        conn.Open();
+                        try { var output = cmd.ExecuteNonQuery(); }
+                        catch { }
+                    }
+                });
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
         public void ExecuteReaderTest()
         {
-            CollectStatisticsDiagnostics(() =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection conn = new SqlConnection(_connectionString))
-                using (SqlCommand cmd = new SqlCommand())
+                CollectStatisticsDiagnostics(connectionString =>
                 {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "SELECT [name], [state] FROM [sys].[databases] WHERE [name] = db_name();";
+                    using (SqlConnection conn = new SqlConnection(connectionString))
+                    using (SqlCommand cmd = new SqlCommand())
+                    {
+                        cmd.Connection = conn;
+                        cmd.CommandText = "SELECT [name], [state] FROM [sys].[databases] WHERE [name] = db_name();";
 
-                    conn.Open();
-                    SqlDataReader reader = cmd.ExecuteReader();
-                    while (reader.Read()) { }
-                }
-            });
+                        conn.Open();
+                        SqlDataReader reader = cmd.ExecuteReader();
+                        while (reader.Read()) { }
+                    }
+                });
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
         public void ExecuteReaderErrorTest()
         {
-            CollectStatisticsDiagnostics(() =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection conn = new SqlConnection(_connectionString))
-                using (SqlCommand cmd = new SqlCommand())
+                CollectStatisticsDiagnostics(connectionString =>
                 {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "select 1 / 0;";
-
-                    try
+                    using (SqlConnection conn = new SqlConnection(connectionString))
+                    using (SqlCommand cmd = new SqlCommand())
                     {
-                        SqlDataReader reader = cmd.ExecuteReader();
-                        while (reader.Read()) { }
+                        cmd.Connection = conn;
+                        cmd.CommandText = "select 1 / 0;";
+
+                        try
+                        {
+                            SqlDataReader reader = cmd.ExecuteReader();
+                            while (reader.Read()) { }
+                        }
+                        catch { }
                     }
-                    catch { }
-                }
-            });
+                });
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
         public void ExecuteReaderWithCommandBehaviorTest()
         {
-            CollectStatisticsDiagnostics(() =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection conn = new SqlConnection(_connectionString))
-                using (SqlCommand cmd = new SqlCommand())
+                CollectStatisticsDiagnostics(connectionString =>
                 {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "SELECT [name], [state] FROM [sys].[databases] WHERE [name] = db_name();";
+                    using (SqlConnection conn = new SqlConnection(connectionString))
+                    using (SqlCommand cmd = new SqlCommand())
+                    {
+                        cmd.Connection = conn;
+                        cmd.CommandText = "SELECT [name], [state] FROM [sys].[databases] WHERE [name] = db_name();";
 
-                    conn.Open();
-                    SqlDataReader reader = cmd.ExecuteReader(CommandBehavior.Default);
-                    while (reader.Read()) { }
-                }
-            });
+                        conn.Open();
+                        SqlDataReader reader = cmd.ExecuteReader(CommandBehavior.Default);
+                        while (reader.Read()) { }
+                    }
+                });
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [ConditionalFact(nameof(IsConnectionStringConfigured))]
         public void ExecuteXmlReaderTest()
         {
-            CollectStatisticsDiagnostics(() =>
+            RemoteInvoke(cs =>
             {
-                using (SqlConnection conn = new SqlConnection(s_tcpConnStr))
-                using (SqlCommand cmd = new SqlCommand())
+                CollectStatisticsDiagnostics(_ =>
                 {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "select * from sys.objects for xml auto, xmldata;";
+                    using (SqlConnection conn = new SqlConnection(cs))
+                    using (SqlCommand cmd = new SqlCommand())
+                    {
+                        cmd.Connection = conn;
+                        cmd.CommandText = "select * from sys.objects for xml auto, xmldata;";
 
-                    conn.Open();
-                    XmlReader reader = cmd.ExecuteXmlReader();
-                    while (reader.Read()) { }
-                }
-            });
+                        conn.Open();
+                        XmlReader reader = cmd.ExecuteXmlReader();
+                        while (reader.Read()) { }
+                    }
+                });
+                return SuccessExitCode;
+            }, s_tcpConnStr).Dispose();
         }
 
         [Fact]
         public void ExecuteXmlReaderErrorTest()
         {
-            CollectStatisticsDiagnostics(() =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection conn = new SqlConnection(_connectionString))
-                using (SqlCommand cmd = new SqlCommand())
+                CollectStatisticsDiagnostics(connectionString =>
                 {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "select *, baddata = 1 / 0 from sys.objects for xml auto, xmldata;";
-
-                    try
+                    using (SqlConnection conn = new SqlConnection(connectionString))
+                    using (SqlCommand cmd = new SqlCommand())
                     {
-                        XmlReader reader = cmd.ExecuteXmlReader();
-                        while (reader.Read()) { }
+                        cmd.Connection = conn;
+                        cmd.CommandText = "select *, baddata = 1 / 0 from sys.objects for xml auto, xmldata;";
+
+                        try
+                        {
+                            XmlReader reader = cmd.ExecuteXmlReader();
+                            while (reader.Read()) { }
+                        }
+                        catch { }
                     }
-                    catch { }
-                }
-            });
+                });
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
         public void ExecuteScalarAsyncTest()
         {
-            CollectStatisticsDiagnosticsAsync(async () =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection conn = new SqlConnection(_connectionString))
-                using (SqlCommand cmd = new SqlCommand())
+                CollectStatisticsDiagnosticsAsync(async connectionString =>
                 {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "SELECT [name], [state] FROM [sys].[databases] WHERE [name] = db_name();";
+                    using (SqlConnection conn = new SqlConnection(connectionString))
+                    using (SqlCommand cmd = new SqlCommand())
+                    {
+                        cmd.Connection = conn;
+                        cmd.CommandText = "SELECT [name], [state] FROM [sys].[databases] WHERE [name] = db_name();";
 
-                    conn.Open();
-                    var output = await cmd.ExecuteScalarAsync();
-                }
-            });
+                        conn.Open();
+                        var output = await cmd.ExecuteScalarAsync();
+                    }
+                }).GetAwaiter().GetResult();
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
         public void ExecuteScalarAsyncErrorTest()
         {
-            CollectStatisticsDiagnosticsAsync(async () =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection conn = new SqlConnection(_connectionString))
-                using (SqlCommand cmd = new SqlCommand())
+                CollectStatisticsDiagnosticsAsync(async connectionString =>
                 {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "select 1 / 0;";
+                    using (SqlConnection conn = new SqlConnection(connectionString))
+                    using (SqlCommand cmd = new SqlCommand())
+                    {
+                        cmd.Connection = conn;
+                        cmd.CommandText = "select 1 / 0;";
 
-                    conn.Open();
+                        conn.Open();
 
-                    try { var output = await cmd.ExecuteScalarAsync(); }
-                    catch { }
-                }
-            });
+                        try { var output = await cmd.ExecuteScalarAsync(); }
+                        catch { }
+                    }
+                }).GetAwaiter().GetResult();
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
         public void ExecuteNonQueryAsyncTest()
         {
-            CollectStatisticsDiagnosticsAsync(async () =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection conn = new SqlConnection(_connectionString))
-                using (SqlCommand cmd = new SqlCommand())
+                CollectStatisticsDiagnosticsAsync(async connectionString =>
                 {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "SELECT [name], [state] FROM [sys].[databases] WHERE [name] = db_name();";
+                    using (SqlConnection conn = new SqlConnection(connectionString))
+                    using (SqlCommand cmd = new SqlCommand())
+                    {
+                        cmd.Connection = conn;
+                        cmd.CommandText = "SELECT [name], [state] FROM [sys].[databases] WHERE [name] = db_name();";
 
-                    conn.Open();
-                    var output = await cmd.ExecuteNonQueryAsync();
-                }
-            });
+                        conn.Open();
+                        var output = await cmd.ExecuteNonQueryAsync();
+                    }
+                }).GetAwaiter().GetResult();
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
         public void ExecuteNonQueryAsyncErrorTest()
         {
-            CollectStatisticsDiagnosticsAsync(async () =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection conn = new SqlConnection(_connectionString))
-                using (SqlCommand cmd = new SqlCommand())
+                CollectStatisticsDiagnosticsAsync(async connectionString =>
                 {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "select 1 / 0;";
+                    using (SqlConnection conn = new SqlConnection(connectionString))
+                    using (SqlCommand cmd = new SqlCommand())
+                    {
+                        cmd.Connection = conn;
+                        cmd.CommandText = "select 1 / 0;";
 
-                    conn.Open();
-                    try { var output = await cmd.ExecuteNonQueryAsync(); }
-                    catch { }
-                }
-            });
+                        conn.Open();
+                        try { var output = await cmd.ExecuteNonQueryAsync(); }
+                        catch { }
+                    }
+                }).GetAwaiter().GetResult();
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
         public void ExecuteReaderAsyncTest()
         {
-            CollectStatisticsDiagnosticsAsync(async () =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection conn = new SqlConnection(_connectionString))
-                using (SqlCommand cmd = new SqlCommand())
+                CollectStatisticsDiagnosticsAsync(async connectionString =>
                 {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "SELECT [name], [state] FROM [sys].[databases] WHERE [name] = db_name();";
+                    using (SqlConnection conn = new SqlConnection(connectionString))
+                    using (SqlCommand cmd = new SqlCommand())
+                    {
+                        cmd.Connection = conn;
+                        cmd.CommandText = "SELECT [name], [state] FROM [sys].[databases] WHERE [name] = db_name();";
 
-                    conn.Open();
-                    SqlDataReader reader = await cmd.ExecuteReaderAsync();
-                    while (reader.Read()) { }
-                }
-            });
+                        conn.Open();
+                        SqlDataReader reader = await cmd.ExecuteReaderAsync();
+                        while (reader.Read()) { }
+                    }
+                }).GetAwaiter().GetResult();
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
         public void ExecuteReaderAsyncErrorTest()
         {
-            CollectStatisticsDiagnosticsAsync(async () =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection conn = new SqlConnection(_connectionString))
-                using (SqlCommand cmd = new SqlCommand())
+                CollectStatisticsDiagnosticsAsync(async connectionString =>
                 {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "select 1 / 0;";
-
-                    try
+                    using (SqlConnection conn = new SqlConnection(connectionString))
+                    using (SqlCommand cmd = new SqlCommand())
                     {
-                        SqlDataReader reader = await cmd.ExecuteReaderAsync();
-                        while (reader.Read()) { }
+                        cmd.Connection = conn;
+                        cmd.CommandText = "select 1 / 0;";
+
+                        try
+                        {
+                            SqlDataReader reader = await cmd.ExecuteReaderAsync();
+                            while (reader.Read()) { }
+                        }
+                        catch { }
                     }
-                    catch { }
-                }
-            });
+                }).GetAwaiter().GetResult();
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [ConditionalFact(nameof(IsConnectionStringConfigured))]
         public void ExecuteXmlReaderAsyncTest()
         {
-            CollectStatisticsDiagnosticsAsync(async () =>
+            RemoteInvoke(cs =>
             {
-                using (SqlConnection conn = new SqlConnection(s_tcpConnStr))
-                using (SqlCommand cmd = new SqlCommand())
+                CollectStatisticsDiagnosticsAsync(async _ =>
                 {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "select * from sys.objects for xml auto, xmldata;";
+                    using (SqlConnection conn = new SqlConnection(cs))
+                    using (SqlCommand cmd = new SqlCommand())
+                    {
+                        cmd.Connection = conn;
+                        cmd.CommandText = "select * from sys.objects for xml auto, xmldata;";
 
-                    conn.Open();
-                    XmlReader reader = await cmd.ExecuteXmlReaderAsync();
-                    while (reader.Read()) { }
-                }
-            });
+                        conn.Open();
+                        XmlReader reader = await cmd.ExecuteXmlReaderAsync();
+                        while (reader.Read()) { }
+                    }
+                }).GetAwaiter().GetResult();
+                return SuccessExitCode;
+            }, s_tcpConnStr).Dispose();
         }
 
         [Fact]
         public void ExecuteXmlReaderAsyncErrorTest()
         {
-            CollectStatisticsDiagnosticsAsync(async () =>
+            RemoteInvoke(cs =>
             {
-                using (SqlConnection conn = new SqlConnection(_connectionString))
-                using (SqlCommand cmd = new SqlCommand())
+                CollectStatisticsDiagnosticsAsync(async _ =>
                 {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "select *, baddata = 1 / 0 from sys.objects for xml auto, xmldata;";
-
-                    try
+                    using (SqlConnection conn = new SqlConnection(cs))
+                    using (SqlCommand cmd = new SqlCommand())
                     {
-                        XmlReader reader = await cmd.ExecuteXmlReaderAsync();
-                        while (reader.Read()) { }
+                        cmd.Connection = conn;
+                        cmd.CommandText = "select *, baddata = 1 / 0 from sys.objects for xml auto, xmldata;";
+
+                        try
+                        {
+                            XmlReader reader = await cmd.ExecuteXmlReaderAsync();
+                            while (reader.Read()) { }
+                        }
+                        catch { }
                     }
-                    catch { }
-                }
-            });
+                }).GetAwaiter().GetResult();
+                return SuccessExitCode;
+            }, s_tcpConnStr).Dispose();
         }
 
         [Fact]
         public void ConnectionOpenTest()
         {
-            CollectStatisticsDiagnostics(() =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection sqlConnection = new SqlConnection(_connectionString))
+                CollectStatisticsDiagnostics(connectionString =>
                 {
-                    sqlConnection.Open();
-                }
-            });
+                    using (SqlConnection sqlConnection = new SqlConnection(connectionString))
+                    {
+                        sqlConnection.Open();
+                    }
+                });
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
         public void ConnectionOpenErrorTest()
         {
-            CollectStatisticsDiagnostics(() =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection sqlConnection = new SqlConnection(_badConnectionString))
+                CollectStatisticsDiagnostics(_ =>
                 {
-                    try { sqlConnection.Open(); } catch { }
-                }
-            });
+                    using (SqlConnection sqlConnection = new SqlConnection(BadConnectionString))
+                    {
+                        try { sqlConnection.Open(); } catch { }
+                    }
+                });
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
         public void ConnectionOpenAsyncTest()
         {
-            CollectStatisticsDiagnosticsAsync(async () =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection sqlConnection = new SqlConnection(_connectionString))
+                CollectStatisticsDiagnosticsAsync(async connectionString =>
                 {
-                    await sqlConnection.OpenAsync();
-                }
-            });
+                    using (SqlConnection sqlConnection = new SqlConnection(connectionString))
+                    {
+                        await sqlConnection.OpenAsync();
+                    }
+                }).GetAwaiter().GetResult();
+                return SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
         public void ConnectionOpenAsyncErrorTest()
         {
-            CollectStatisticsDiagnosticsAsync(async () =>
+            RemoteInvoke(() =>
             {
-                using (SqlConnection sqlConnection = new SqlConnection(_badConnectionString))
+                CollectStatisticsDiagnosticsAsync(async _ =>
                 {
-                    try { await sqlConnection.OpenAsync(); } catch { }
-                }
-            });
+                    using (SqlConnection sqlConnection = new SqlConnection(BadConnectionString))
+                    {
+                        try { await sqlConnection.OpenAsync(); } catch { }
+                    }
+                }).GetAwaiter().GetResult();
+                return SuccessExitCode;
+            }).Dispose();
         }
-        
-        private void CollectStatisticsDiagnostics(Action sqlOperation)
+
+        private static void CollectStatisticsDiagnostics(Action<string> sqlOperation)
         {
             bool statsLogged = false;
             bool operationHasError = false;
@@ -582,15 +656,16 @@ namespace System.Data.SqlClient.Tests
 
             diagnosticListenerObserver.Enable();
             using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
+            using (var server = TestTdsServer.StartServerWithQueryEngine(new DiagnosticsQueryEngine()))
             { 
-                sqlOperation();
+                sqlOperation(server.ConnectionString);
 
                 Assert.True(statsLogged);
 
                 diagnosticListenerObserver.Disable();
             }
         }
-        private async void CollectStatisticsDiagnosticsAsync(Func<Task> sqlOperation)
+        private static async Task CollectStatisticsDiagnosticsAsync(Func<string, Task> sqlOperation)
         {
             bool statsLogged = false;
             bool operationHasError = false;
@@ -759,8 +834,9 @@ namespace System.Data.SqlClient.Tests
 
             diagnosticListenerObserver.Enable();
             using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
-            { 
-                await sqlOperation();
+            using (var server = TestTdsServer.StartServerWithQueryEngine(new DiagnosticsQueryEngine()))
+            {
+                await sqlOperation(server.ConnectionString);
 
                 Assert.True(statsLogged);
 
@@ -768,7 +844,7 @@ namespace System.Data.SqlClient.Tests
             }
         }
         
-        private T GetPropertyValueFromType<T>(object obj, string propName)
+        private static T GetPropertyValueFromType<T>(object obj, string propName)
         {
             Type type = obj.GetType();
             PropertyInfo pi = type.GetRuntimeProperty(propName);
@@ -776,9 +852,6 @@ namespace System.Data.SqlClient.Tests
             var propertyValue = pi.GetValue(obj);
             return (T)propertyValue;
         }
-
-        public void Dispose() => _server?.Dispose();
-
     }
 
     public class DiagnosticsQueryEngine : QueryEngine

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -16,6 +16,12 @@
     <Compile Include="TcpDefaultForAzureTest.cs" />
     <Compile Include="SqlConnectionTest.cs" />
     <Compile Include="TestTdsServer.cs" />
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorTestBase.cs">
+      <Link>Common\System\Diagnostics\RemoteExecutorTestBase.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
+      <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tools\TDS\TDS.Servers\TDS.Servers.csproj">
@@ -26,6 +32,10 @@
     </ProjectReference>
     <ProjectReference Include="..\Tools\TDS\TDS\TDS.csproj">
       <Name>TDS</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>RemoteExecutorConsoleApp</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
Two issues:
- Tests from the DiagnosticTests class might run concurrently with tests from other test classes.  This could cause interference between the tests.
- The CollectStatisticsDiagnosticsAsync method was void returning, which meant the test harness would not wait for its completion before processing other tests.  This could both cause interference between the tests (including other diagnostics tests) and cause unhandled exceptions to tear down the test process.

Fixes:
- Use RemoteInvoke to launch each diagnostic test in its own process so that it doesn't experience or cause interference with other tests.
- Ensure that all operations are appropriately waited for.

Fixes https://github.com/dotnet/corefx/issues/15383
cc: @saurabh500, @danmosemsft 

(I suggest reviewing while ignoring whitespace: https://github.com/dotnet/corefx/pull/16349/files?w=1)