### PR TITLE
Remove accidental trailing quotes from SerialPort resource strings

### DIFF
--- a/src/System.IO.Ports/src/Resources/Strings.resx
+++ b/src/System.IO.Ports/src/Resources/Strings.resx
@@ -110,7 +110,7 @@
     <value>Non-negative number required.</value>
   </data>
   <data name="ArgumentOutOfRange_NeedPosNum" xml:space="preserve">
-    <value>Positive number required."</value>
+    <value>Positive number required.</value>
   </data>
   <data name="ArgumentOutOfRange_Timeout" xml:space="preserve">
     <value>The timeout must be greater than or equal to -1.</value>
@@ -134,10 +134,10 @@
     <value>Unable to read beyond the end of the stream.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
-    <value>Can not access a closed Stream."</value>
+    <value>Can not access a closed Stream.</value>
   </data>
   <data name="InvalidNullEmptyArgument" xml:space="preserve">
-    <value>Argument {0} cannot be null or zero-length."</value>
+    <value>Argument {0} cannot be null or zero-length.</value>
   </data>
   <data name="Arg_WrongAsyncResult" xml:space="preserve">
     <value>IAsyncResult object did not come from the corresponding async method on this type.</value>
@@ -146,7 +146,7 @@
     <value>EndRead can only be called once for each asynchronous operation.</value>
   </data>
   <data name="InvalidOperation_EndWriteCalledMultiple" xml:space="preserve">
-    <value>EndWrite can only be called once for each asynchronous operation."</value>
+    <value>EndWrite can only be called once for each asynchronous operation.</value>
   </data>
   <data name="IO_PortNotFound" xml:space="preserve">
     <value>The specified port does not exist.</value>
@@ -164,9 +164,9 @@
     <value>The process cannot access the port because it is being used by another process.</value>
   </data>
   <data name="IO_SharingViolation_File" xml:space="preserve">
-    <value>The process cannot access the port '{0}' because it is being used by another process."</value>
+    <value>The process cannot access the port '{0}' because it is being used by another process.</value>
   </data>
   <data name="UnauthorizedAccess_IODenied_Path" xml:space="preserve">
-    <value>Access to the port '{0}' is denied."</value>
+    <value>Access to the port '{0}' is denied.</value>
   </data>
 </root>


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/pull/16326#discussion_r102133442

cc: @danmosemsft, @JeremyKuhne