### PR TITLE
Fix overflow exception in SystemNetworkInterface

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
@@ -150,7 +150,7 @@ namespace System.Net.NetworkInformation
 
             _type = ipAdapterAddresses.type;
             _operStatus = ipAdapterAddresses.operStatus;
-            _speed = (long)ipAdapterAddresses.receiveLinkSpeed;
+            _speed = unchecked((long)ipAdapterAddresses.receiveLinkSpeed);
 
             // API specific info.
             _ipv6Index = ipAdapterAddresses.ipv6Index;


### PR DESCRIPTION
This problem occured after we enabled the overflow/underflow check in corefx debug builds.

Fixes #16340