### PR TITLE
Pass -stripSymbols to Linux Crossbuild

### DIFF
--- a/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreFx-Trusted-Linux-Crossbuild.json
@@ -209,7 +209,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/build.sh -buildArch=$(PB_Architecture) -$(PB_ConfigurationGroup)",
+        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/build.sh -buildArch=$(PB_Architecture) -$(PB_ConfigurationGroup) $(PB_BuildArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -419,6 +419,9 @@
     },
     "PB_Architecture": {
       "value": "arm"
+    },
+    "PB_BuildArguments": {
+      "value": ""
     },
     "SourceVersion": {
       "value": "HEAD",

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -150,7 +150,8 @@
         "TreatWarningsAsErrors": "false"
       },
       "BuildParameters": {
-        "PB_ConfigurationGroup": "Release"
+        "PB_ConfigurationGroup": "Release",
+        "PB_BuildArguments": "-stripSymbols"
      },
       "Definitions": [
         {


### PR DESCRIPTION
Passes `-stripSymbols` from https://github.com/dotnet/corefx/pull/15440 to the Linux Crossbuild. This should make it start producing symbol packages. (And not include symbol info in the main package.)

@wtgodbe Is there a reason not to strip symbols in this build leg?

@chcosta @gkhanna79 