### PR TITLE
Case insensitivity for TargetGroup

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -3,7 +3,7 @@
   <Import Condition="Exists('..\dir.props')" Project="..\dir.props" />
 
   <!-- We shipped assembly file version 4.6.x up until the end of rc3.  Version assembly as
-        4.6.x to ensure compatability in Visual Studio for an in-place update. -->
+        4.6.x to ensure compatibility in Visual Studio for an in-place update. -->
   <PropertyGroup>
     <MajorVersion>4</MajorVersion>
     <MinorVersion>6</MinorVersion>
@@ -151,8 +151,12 @@
     <ConfigurationGroup Condition="'$(ConfigurationGroup)' == ''">Debug</ConfigurationGroup>
     <ArchGroup Condition="'$(ArchGroup)' == ''">x64</ArchGroup>
 
+    <!-- If a TargetGroup is defined, ToLower() it to match how it's defined.  Prevents build errors -->
+    <TargetGroup Condition="'$(TargetGroup)' != '' ">$(TargetGroup.ToLowerInvariant())</TargetGroup>
+
     <!-- Initialize BuildConfiguration from the individual properties if it wasn't already explicitly set -->
-    <BuildConfiguration Condition="'$(BuildConfiguration)' == ''">$(TargetGroup)-$(OSGroup)-$(ConfigurationGroup)-$(ArchGroup)</BuildConfiguration>
+    <!-- Additionally, ToLower() the TargetGroup here as well since this will be used for matching against lower case values -->
+    <BuildConfiguration Condition="'$(BuildConfiguration)' == ''">$(TargetGroup.ToLowerInvariant())-$(OSGroup)-$(ConfigurationGroup)-$(ArchGroup)</BuildConfiguration>
     <BuildConfigurationImportFile>$(ToolsDir)/configuration/configuration.props</BuildConfigurationImportFile>
 
     <!-- if PKGPROJ doesn't set BuildConfigurations, make sure it only builds for TargetGroup=package or BuildAllConfigurations -->

--- a/src/Tools/CoreFx.Tools/Configuration/ConfigurationFactory.cs
+++ b/src/Tools/CoreFx.Tools/Configuration/ConfigurationFactory.cs
@@ -194,7 +194,8 @@ namespace Microsoft.DotNet.Build.Tasks
 
                 PropertyValue propertyValue;
 
-                if (!AllPropertyValues.TryGetValue(value, out propertyValue))
+                if (!AllPropertyValues.TryGetValue(value, out propertyValue) && 
+                    !AllPropertyValues.TryGetValue(value.ToLowerInvariant(), out propertyValue))
                 {
                     if (permitUnknownValues)
                     {


### PR DESCRIPTION
I have a bad habit of passing in upper and mixed-case characters when building, like:
`build.cmd -Framework:UAP
`
... since UAP is an acronym.   By allowing configurations to fall back to lower-case key comparison and ToLower()-ing when generating build configuration, this can be worked around.

Alternately, if we'd rather not go this way, a concise error early in build could save folks time.
(Note the change to line 155 only does anything if it's not passed on the command line)

@joperezr @weshaggard 