### PR TITLE
SerialPort: Set write timeouts on loopback tests

### DIFF
--- a/src/System.IO.Ports/tests/Support/SerialPortConnection.cs
+++ b/src/System.IO.Ports/tests/Support/SerialPortConnection.cs
@@ -71,6 +71,8 @@ namespace Legacy.Support
             {
                 com1.ReadTimeout = 1000;
                 com2.ReadTimeout = 1000;
+                com1.WriteTimeout = 1000;
+                com2.WriteTimeout = 1000;
 
                 com1.WriteLine("Ping");
 


### PR DESCRIPTION
 #16359 is suffering a hang on the WriteLine in the loopback/null-modem test which runs once before any tests.  

I suspect this will turn out to be hardware/driver problems, but there's no reason not to set an explicit write timeout during this test.