### PR TITLE
Refactor HTTP DiagnosticSource logging (part1 continued)

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandlerLoggingStrings.cs
+++ b/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandlerLoggingStrings.cs
@@ -12,5 +12,6 @@ namespace System.Net.Http
         public const string DiagnosticListenerName = "HttpHandlerDiagnosticListener";
         public const string RequestWriteName = "System.Net.Http.Request";
         public const string ResponseWriteName = "System.Net.Http.Response";
+        public const string ExceptionWriteName = "System.Net.Http.Exception";
     }
 }


### PR DESCRIPTION
This change addresses post-review comments for PR #15971:

1. new `DiagnosticListener.IsEnabled()` API is used to very efficiently determine if there is a subscriber to HttpDiagnoticListener and enable diagnostics.

2. Exceptions are sent in a separate event `System.Net.Http.Exception`, and `System.Net.Http.Response` is still fired for all requests (successful, faulted and cancelled)

3. Events documentation concerns will be addressed in next part (with Activity implementation)

/cc @stephentoub  @vancem @avanderhoorn @nbilling @cwe1ss @karolz-ms @SergeyKanzhelev @brahmnes 