### PR TITLE
Stabilize custom OrderBy implementation

### DIFF
--- a/src/System.Private.Reflection.Metadata.Ecma335/src/Shims/Environment.cs
+++ b/src/System.Private.Reflection.Metadata.Ecma335/src/Shims/Environment.cs
@@ -6,12 +6,6 @@ namespace System
 {
     internal static class Environment
     {
-        public static int ProcessorCount
-        {
-            get
-            {
-                return 1;
-            }
-        }
+        public static int ProcessorCount => 1;
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/EnumerableExtensions.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/EnumerableExtensions.cs
@@ -40,11 +40,34 @@ namespace System.Reflection.Internal
             return source[source.Count - 1];
         }
 
-        public static List<T> OrderBy<T>(this List<T> source, Comparison<T> comparison)
+        public static IEnumerable<T> OrderBy<T>(this List<T> source, Comparison<T> comparison)
         {
-            var list = new List<T>(source);
-            list.Sort(comparison);
-            return list;
+            // Produce an iterator that represents a stable sort of source.
+            // Implement by creating an int array that represents the initial ordering of elements in
+            // the source list, then sort those integers with a sort function that sorts by the values
+            // in source, but for cases where the values are equivalent, sort by initial index in
+            // the source array
+            int[] map = new int[source.Count];
+            for (int i = 0; i < map.Length; i++)
+                map[i] = i;
+
+            Array.Sort(map, (int left, int right) => 
+            {
+                if (left == right)
+                    return 0;
+
+                int result = comparison(source[left], source[right]);
+                if (result == 0)
+                {
+                    return left - right;
+                }
+                return result;
+            });
+
+            foreach (int index in map)
+            {
+                yield return source[index];
+            }
         }
     }
 }

--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Utilities\CompressedIntegerTests.cs" />
     <Compile Include="Utilities\ImmutableByteArrayInteropTest.cs" />
     <Compile Include="Utilities\MemoryBlockTests.cs" />
+    <Compile Include="Utilities\OrderByTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\Namespace\NamespaceForwardedCS.cs" />

--- a/src/System.Reflection.Metadata/tests/Utilities/OrderByTests.cs
+++ b/src/System.Reflection.Metadata/tests/Utilities/OrderByTests.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Reflection.Internal;
+using System.Text;
+using Xunit;
+
+namespace System.Reflection.Metadata.Tests
+{
+    public class OrderByTests
+    {
+        [Fact]
+        public void ElementsAllSameKey()
+        {
+            List<int> source = new List<int>(new int[] { 9, 9, 9, 9, 9, 9 });
+            int[] expected = { 9, 9, 9, 9, 9, 9 };
+
+            Assert.Equal(expected, source.OrderBy((int x, int y) => { return Comparer<int>.Default.Compare(x, y); }));
+        }
+
+        [Fact]
+        public void FirstAndLastAreDuplicatesCustomComparer()
+        {
+            List<string> source = new List<string>(new string[] { "prakash", "Alpha", "dan", "DAN", "Prakash" });
+            string[] expected = { "Alpha", "dan", "DAN", "prakash", "Prakash" };
+
+            Assert.Equal(expected, source.OrderBy((string left, string right) => { return StringComparer.OrdinalIgnoreCase.Compare(left, right); }));
+        }
+    }
+}


### PR DESCRIPTION
- Changes for System.Private.Reflection.Metadata.Ecma335 broke stability of the OrderBy helper method
- Replace with a stable sort based on Array.Sort
- Also, minor tweak to the Environment.ProcessorCount property to be more concise