### PR TITLE
Change base class of OperationAbortedException to SystemException

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/OperationAbortedException.cs
+++ b/src/System.Data.SqlClient/src/System/Data/OperationAbortedException.cs
@@ -11,7 +11,7 @@ using System.Runtime.Serialization;
 namespace System.Data
 {
     [Serializable]
-    public sealed class OperationAbortedException : Exception
+    public sealed class OperationAbortedException : SystemException
     {
         private OperationAbortedException(string message, Exception innerException) : base(message, innerException)
         {


### PR DESCRIPTION
https://github.com/dotnet/corefx/pull/12351 changed lots of Exceptions to be derived from SystemException instead of Exception but looks like System.Data.OperationAbortedException was forgotten.

From our referencesource dump - it uses SystemException: https://github.com/mono/mono/blob/master/mcs/class/referencesource/System.Data/System/Data/OperationAbortedException.cs#L19

PS:
Also, I am wondering why https://github.com/dotnet/corefx/blob/master/src/System.Data.SqlClient/src/System/Data/OperationAbortedException.cs#L18 is not replaced with https://github.com/dotnet/corefx/blob/master/src/System.Data.Common/src/System/HResults.cs#L26
(I see HResults is internal so SqlClient can not use it, but that magic number doesn't look good).