### PR TITLE
Update shim bin-placing to use binplace.targets

### DIFF
--- a/src/shims/ApiCompat.proj
+++ b/src/shims/ApiCompat.proj
@@ -8,11 +8,15 @@
     <ApiCompatNSBaselineFile>$(MSBuildThisFileDirectory)ApiCompatBaseline.$(TargetGroup).netstandard20.txt</ApiCompatNSBaselineFile>
     <ApiCompatImplementationDirs>$(RefPath),$(GenFacadesOutputPath)</ApiCompatImplementationDirs>
     <!-- If we are targeting uap or uapaot run ApiCompat against the implementation assemblies instead since they don't match the reference assemblies -->
-    <ApiCompatImplementationDirs Condition="'$(TargetGroup)'=='uap' or '$(TargetGroup)'=='uapaot'">$(RuntimePath),$(GenFacadesOutputPath)</ApiCompatImplementationDirs>
+    <ApiCompatImplementationDirs Condition="$(TargetGroup.StartsWith('uap'))">$(RuntimePath),$(GenFacadesOutputPath)</ApiCompatImplementationDirs>
+    <_RunApiCompat>true</_RunApiCompat>
+    <!-- Disable running apicompat for uap scenarios because the RuntimePath is not correctly setup in BuildAllConfigurations mode -->
+    <_RunApiCompat Condition="'$(BuildAllConfigurations)' == 'true' and $(TargetGroup.StartsWith('uap'))">false</_RunApiCompat>
   </PropertyGroup>
 
   <!-- Run ApiCompat -->
   <Target Name="RunApiCompat"
+          Condition="'$(_RunApiCompat)' == 'true'"
           Inputs="$(ApiCompatResponseFile);@(GenFacadesContracts)"
           Outputs="$(ApiCompatBaselineFile);$(ApiCompatNSBaselineFile)"
   >

--- a/src/shims/dir.props
+++ b/src/shims/dir.props
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\dir.props" />
-    <PropertyGroup>
+  <PropertyGroup>
     <BuildConfigurations>
       netcoreapp;
       uap;
       uapaot;
     </BuildConfigurations>
   </PropertyGroup>
+
+  <Import Project="..\dir.props" />
 
   <ItemGroup>
     <NetFxReference Include="mscorlib" />
@@ -25,6 +26,12 @@
   </ItemGroup>
 
   <PropertyGroup>
-  	<GenFacadesOutputPath>$(BaseIntermediateOutputPath)/shims/facades/</GenFacadesOutputPath>
+    <IsNETCoreApp>true</IsNETCoreApp>
+    <IsUAP>true</IsUAP>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)shims/$(TargetGroup)/</IntermediateOutputPath>
+    <GenFacadesOutputPath>$(BaseIntermediateOutputPath)shims/$(TargetGroup)/facades/</GenFacadesOutputPath>
   </PropertyGroup>
 </Project>

--- a/src/shims/shims.proj
+++ b/src/shims/shims.proj
@@ -12,9 +12,8 @@
   </Target>
 
   <PropertyGroup>
-    <GenFacadesInputPath>$(IntermediateOutputPath)PreGenFacades/</GenFacadesInputPath>
-    <GenFacadesResponseFile>$(GenFacadesInputPath)genfacades.rsp</GenFacadesResponseFile>
-    <GenFacadesSemaphoreFile>$(GenFacadesInputPath)genfacades.sempahore</GenFacadesSemaphoreFile>
+    <GenFacadesResponseFile>$(IntermediateOutputPath)genfacades.rsp</GenFacadesResponseFile>
+    <GenFacadesSemaphoreFile>$(IntermediateOutputPath)genfacades.sempahore</GenFacadesSemaphoreFile>
   </PropertyGroup>
 
   <!-- Generate Facades -->
@@ -32,7 +31,7 @@
       <GenFacadesArgs>$(GenFacadesArgs) -ignoreMissingTypes</GenFacadesArgs>
     </PropertyGroup>
 
-    <MakeDir Directories="$(GenFacadesInputPath)" />
+    <MakeDir Directories="$(IntermediateOutputPath)" />
     <WriteLinesToFile File="$(GenFacadesResponseFile)" Lines="$(GenFacadesArgs)" Overwrite="true" />
 
     <PropertyGroup>
@@ -43,31 +42,23 @@
 
     <Exec Command="$(GenFacadesCmd) -contracts:&quot;@(NETStandardContracts)&quot; @&quot;$(GenFacadesResponseFile)&quot;" WorkingDirectory="$(ToolRuntimePath)" />
 
-    <!-- Copy the facades to the package ref and lib folders to be included in the packages -->
-    <!-- TODO: replace with BinPlacing targets -->
-    <ItemGroup>
-      <PackageOutputPaths Include="$(BinDir)pkg/$(TargetGroup)/ref" Condition="'$(_bc_TargetGroup)'!='uapaot'"/>
-      <PackageOutputPaths Include="$(BinDir)pkg/uap/ref" Condition="'$(_bc_TargetGroup)'=='uapaot'"/>
-      <PackageOutputPaths Include="$(BinDir)pkg/$(TargetGroup)/lib" />
-      <PackageOutputPaths Include="$(RefPath)" />
-      <PackageOutputPaths Include="$(RuntimePath)" />
-      <PackageOutputPaths Condition="'$(BinplaceTestSharedFramework)' == 'true'" Include="$(NETCoreAppTestSharedFrameworkPath)" />
-      <ProducedFacades Include="$(GenFacadesOutputPath)*.dll" />
-      <FileWrites Include="@(ProducedFacades)" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(ProducedFacades)" DestinationFolder="%(PackageOutputPaths.Identity)" >
-      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
-    </Copy>
-
     <Touch Files="$(GenFacadesSemaphoreFile)" AlwaysCreate="true" />
   </Target>
 
-  <Target Name="Build" DependsOnTargets="RunGenFacades" />
+  <Target Name="Build" DependsOnTargets="RunGenFacades;BinPlaceReferenceAssembly;BinPlaceRuntimeAssembly" />
   <Target Name="Clean">
     <RemoveDir Directories="$(IntermediateOutputPath);$(GenFacadesOutputPath)" />
   </Target>
   <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+
+  <Target Name="GetBinplaceItems">
+    <ItemGroup>
+      <BinplaceItem Include="$(GenFacadesOutputPath)*.dll" />
+      <FileWrites Include="@(BinplaceItem)" />
+    </ItemGroup>
+  </Target>
 </Project>
+
+


### PR DESCRIPTION
Also disable apicompat checks for uap* when in BuildAllConfigurations
mode because it doesn't have a RuntimePath correctly setup for those
configurations.

cc @joperezr @ericstj 