### PR TITLE
Enable BinaryFormatter on uapaot

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/src/Configurations.props
+++ b/src/System.Runtime.Serialization.Formatters/src/Configurations.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildConfigurations>
+      uapaot-Windows_NT;
       uap-Windows_NT;
       netcoreapp;
     </BuildConfigurations>


### PR DESCRIPTION
Enable building BinaryFormatter for uapaot. Since this assembly builds against contracts, no other CoreFX changes are required at this point (but there will be some CoreRT changes to make it functional).