### PR TITLE
Reenable MyGet package publishing

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -140,7 +140,7 @@
       }
     },
     {
-      "enabled": false,
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "packages -> dotnet.myget.org",


### PR DESCRIPTION
In https://github.com/dotnet/corefx/pull/16388, I accidentally disabled package publishing to MyGet. It was hard to spot because adding the `Submit symbol server request` step made the diff unclear.

This hasn't affected a build yet, because none has made it to this point in the build since I merged that PR.