### PR TITLE
Use RuntimeHelpers.IsReferenceOrContainsReferences in System.Collections

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
 namespace System.Collections.Generic
@@ -309,7 +310,10 @@ namespace System.Collections.Generic
                             _slots[last].next = _slots[i].next;
                         }
                         _slots[i].hashCode = -1;
-                        _slots[i].value = default(T);
+                        if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+                        {
+                            _slots[i].value = default(T);
+                        }
                         _slots[i].next = _freeList;
 
                         _count--;

--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -12,6 +12,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
 {
@@ -89,12 +90,17 @@ namespace System.Collections.Generic
         {
             if (_size != 0)
             {
-                if (_head < _tail)
-                    Array.Clear(_array, _head, _size);
-                else
+                if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
                 {
-                    Array.Clear(_array, _head, _array.Length - _head);
-                    Array.Clear(_array, 0, _tail);
+                    if (_head < _tail)
+                    {
+                        Array.Clear(_array, _head, _size);
+                    }
+                    else
+                    {
+                        Array.Clear(_array, _head, _array.Length - _head);
+                        Array.Clear(_array, 0, _tail);
+                    }
                 }
 
                 _size = 0;
@@ -233,7 +239,10 @@ namespace System.Collections.Generic
             }
 
             T removed = _array[_head];
-            _array[_head] = default(T);
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                _array[_head] = default(T);
+            }
             MoveNext(ref _head);
             _size--;
             _version++;
@@ -249,7 +258,10 @@ namespace System.Collections.Generic
             }
 
             result = _array[_head];
-            _array[_head] = default(T);
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                _array[_head] = default(T);
+            }
             MoveNext(ref _head);
             _size--;
             _version++;

--- a/src/System.Collections/src/System/Collections/Generic/SortedList.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedList.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
 {
@@ -415,8 +416,14 @@ namespace System.Collections.Generic
             // clear does not change the capacity
             _version++;
             // Don't need to doc this but we clear the elements so that the gc can reclaim the references.
-            Array.Clear(_keys, 0, _size);
-            Array.Clear(_values, 0, _size);
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
+            {
+                Array.Clear(_keys, 0, _size);
+            }
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
+            {
+                Array.Clear(_values, 0, _size);
+            }
             _size = 0;
         }
 
@@ -590,7 +597,6 @@ namespace System.Collections.Generic
                     return _values[i];
 
                 throw new KeyNotFoundException();
-                // return default(TValue);
             }
             set
             {
@@ -707,8 +713,14 @@ namespace System.Collections.Generic
                 Array.Copy(_keys, index + 1, _keys, index, _size - index);
                 Array.Copy(_values, index + 1, _values, index, _size - index);
             }
-            _keys[_size] = default(TKey);
-            _values[_size] = default(TValue);
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
+            {
+                _keys[_size] = default(TKey);
+            }
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
+            {
+                _values[_size] = default(TValue);
+            }
             _version++;
         }
 

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -12,6 +12,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
 {
@@ -81,7 +82,10 @@ namespace System.Collections.Generic
         // Removes all Objects from the Stack.
         public void Clear()
         {
-            Array.Clear(_array, 0, _size); // Don't need to doc this but we clear the elements so that the gc can reclaim the references.
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                Array.Clear(_array, 0, _size); // Don't need to doc this but we clear the elements so that the gc can reclaim the references.
+            }
             _size = 0;
             _version++;
         }
@@ -225,7 +229,10 @@ namespace System.Collections.Generic
             
             _version++;
             T item = _array[--_size];
-            _array[_size] = default(T);     // Free memory quicker.
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                _array[_size] = default(T);     // Free memory quicker.
+            }
             return item;
         }
 
@@ -239,7 +246,10 @@ namespace System.Collections.Generic
 
             _version++;
             result = _array[--_size];
-            _array[_size] = default(T);     // Free memory quicker.
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                _array[_size] = default(T);     // Free memory quicker.
+            }
             return true;
         }
 


### PR DESCRIPTION
Avoid clearing arrays and array slots unless necessary based on T being a reference or containing references.

cc: @jkotas 