### PR TITLE
Remove unnecessary GetTypeInfo calls from Microsoft.VisualBasic

### DIFF
--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/ConversionResolution.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/ConversionResolution.vb
@@ -389,9 +389,9 @@ Namespace Microsoft.VisualBasic.CompilerServices
             Dim sourceElementType As Type = sourceArrayType.GetElementType
             Dim conversion As ConversionClass = ConversionClass.None
 
-            If (targetInterface.GetTypeInfo().IsGenericType AndAlso Not targetInterface.GetTypeInfo().IsGenericTypeDefinition) Then
+            If (targetInterface.IsGenericType AndAlso Not targetInterface.IsGenericTypeDefinition) Then
 
-                Dim rawTargetInterface As Type = targetInterface.GetTypeInfo().GetGenericTypeDefinition()
+                Dim rawTargetInterface As Type = targetInterface.GetGenericTypeDefinition()
 
                 If (rawTargetInterface Is GetType(System.Collections.Generic.IList(Of )) OrElse
                     rawTargetInterface Is GetType(System.Collections.Generic.ICollection(Of )) OrElse

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Conversions.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Conversions.vb
@@ -1284,8 +1284,8 @@ GetSpecialValue:
                         'is harmless, but ClassifyPredefinedConversion hasn't been updated to consider Nullable conversions,
                         'and updating this across the entire runtime would be significant feature work.
 
-                        If Not (targetType.GetTypeInfo().IsGenericType AndAlso
-                                Not targetType.GetTypeInfo().IsGenericTypeDefinition AndAlso
+                        If Not (targetType.IsGenericType AndAlso
+                                Not targetType.IsGenericTypeDefinition AndAlso
                                 targetType.GetGenericTypeDefinition().Equals(GetType(Nullable(Of ))) AndAlso
                                 targetType.GetGenericArguments().Length > 0 AndAlso
                                 invocationResult.GetType().Equals(targetType.GetGenericArguments()(0))) Then

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/ObjectFlowControl.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/ObjectFlowControl.vb
@@ -21,7 +21,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         End Sub
 
         Public Shared Sub CheckForSyncLockOnValueType(ByVal expression As Object)
-            If expression IsNot Nothing AndAlso expression.GetType.GetTypeInfo().IsValueType() Then
+            If expression IsNot Nothing AndAlso expression.GetType.IsValueType() Then
                 Throw New ArgumentException(
                     GetResourceString(SR.SyncLockRequiresReferenceType1, VBFriendlyName(expression.GetType)))
             End If
@@ -50,7 +50,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
             Private Shared Function GetWidestType(ByVal type1 As System.Type, ByVal type2 As System.Type) As Type
                 If type1 Is Nothing OrElse type2 Is Nothing Then Return Nothing
 
-                If Not type1.GetTypeInfo().IsEnum AndAlso Not type2.GetTypeInfo().IsEnum Then
+                If Not type1.IsEnum AndAlso Not type2.IsEnum Then
                     Dim tc1 As TypeCode = GetTypeCode(type1)
                     Dim tc2 As TypeCode = GetTypeCode(type2)
 
@@ -173,11 +173,11 @@ Namespace Microsoft.VisualBasic.CompilerServices
                 ' of the loop the enum.
                 Dim currentEnumType As Type = Nothing
 
-                If (startTypeCode = widestTypeCode) AndAlso startType.GetTypeInfo().IsEnum Then
+                If (startTypeCode = widestTypeCode) AndAlso startType.IsEnum Then
                     currentEnumType = startType
                 End If
 
-                If (limitTypeCode = widestTypeCode) AndAlso limitType.GetTypeInfo().IsEnum Then
+                If (limitTypeCode = widestTypeCode) AndAlso limitType.IsEnum Then
                     If (Not currentEnumType Is Nothing) AndAlso
                        (Not currentEnumType Is limitType) Then
                         currentEnumType = Nothing
@@ -187,7 +187,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
                     currentEnumType = limitType
                 End If
 
-                If (stepTypeCode = widestTypeCode) AndAlso stepType.GetTypeInfo().IsEnum Then
+                If (stepTypeCode = widestTypeCode) AndAlso stepType.IsEnum Then
                     If (Not currentEnumType Is Nothing) AndAlso
                        (Not currentEnumType Is stepType) Then
                         currentEnumType = Nothing

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Operators.Resolution.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Operators.Resolution.vb
@@ -65,7 +65,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
                     If IsOrInheritsFrom(type2, commonAncestor) Then
                         Exit While
                     End If
-                    commonAncestor = commonAncestor.GetTypeInfo().BaseType
+                    commonAncestor = commonAncestor.BaseType
                 End While
 
                 Dim container As Container = New Container(type2)

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Operators.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Operators.vb
@@ -1211,7 +1211,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         Private Shared Function NotSByte(ByVal operand As SByte, ByVal operandType As Type) As Object
             Dim result As SByte = Not operand
 
-            If operandType.GetTypeInfo.IsEnum Then
+            If operandType.IsEnum Then
                 Return System.Enum.ToObject(operandType, result)
             End If
             Return result
@@ -1220,7 +1220,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         Private Shared Function NotByte(ByVal operand As Byte, ByVal operandType As Type) As Object
             Dim result As Byte = Not operand
 
-            If operandType.GetTypeInfo.IsEnum Then
+            If operandType.IsEnum Then
                 Return System.Enum.ToObject(operandType, result)
             End If
             Return result
@@ -1229,7 +1229,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         Private Shared Function NotInt16(ByVal operand As Int16, ByVal operandType As Type) As Object
             Dim result As Int16 = Not operand
 
-            If operandType.GetTypeInfo.IsEnum Then
+            If operandType.IsEnum Then
                 Return System.Enum.ToObject(operandType, result)
             End If
             Return result
@@ -1238,7 +1238,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         Private Shared Function NotUInt16(ByVal operand As UInt16, ByVal operandType As Type) As Object
             Dim result As UInt16 = Not operand
 
-            If operandType.GetTypeInfo.IsEnum Then
+            If operandType.IsEnum Then
                 Return System.Enum.ToObject(operandType, result)
             End If
             Return result
@@ -1247,7 +1247,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         Private Shared Function NotInt32(ByVal operand As Int32, ByVal operandType As Type) As Object
             Dim result As Int32 = Not operand
 
-            If operandType.GetTypeInfo.IsEnum Then
+            If operandType.IsEnum Then
                 Return System.Enum.ToObject(operandType, result)
             End If
             Return result
@@ -1256,7 +1256,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         Private Shared Function NotUInt32(ByVal operand As UInt32, ByVal operandType As Type) As Object
             Dim result As UInt32 = Not operand
 
-            If operandType.GetTypeInfo.IsEnum Then
+            If operandType.IsEnum Then
                 Return System.Enum.ToObject(operandType, result)
             End If
             Return result
@@ -1269,7 +1269,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         Private Shared Function NotInt64(ByVal operand As Int64, ByVal operandType As Type) As Object
             Dim result As Int64 = Not operand
 
-            If operandType.GetTypeInfo.IsEnum Then
+            If operandType.IsEnum Then
                 Return System.Enum.ToObject(operandType, result)
             End If
             Return result
@@ -1278,7 +1278,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         Private Shared Function NotUInt64(ByVal operand As UInt64, ByVal operandType As Type) As Object
             Dim result As UInt64 = Not operand
 
-            If operandType.GetTypeInfo.IsEnum Then
+            If operandType.IsEnum Then
                 Return System.Enum.ToObject(operandType, result)
             End If
             Return result

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/OverloadResolution.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/OverloadResolution.vb
@@ -995,7 +995,7 @@ nextcandidate:
             If (inferred OrElse
                 Not digThroughToBasesAndImplements OrElse
                 Not IsInstantiatedGeneric(parameterType) OrElse
-                (Not parameterType.GetTypeInfo.IsClass AndAlso Not parameterType.GetTypeInfo.IsInterface)) Then
+                (Not parameterType.IsClass AndAlso Not parameterType.IsInterface)) Then
 
                 'can only inherit from classes or interfaces.
                 'can ignore generic parameters here because it
@@ -1016,7 +1016,7 @@ nextcandidate:
                 '   array is possible.
                 '
                 If (argumentType.GetArrayRank > 1 OrElse
-                    parameterType.GetTypeInfo.IsClass) Then
+                    parameterType.IsClass) Then
 
                     Return False
                 End If
@@ -1029,8 +1029,8 @@ nextcandidate:
                     GoTo RetryInference
                 End If
 
-            ElseIf (Not argumentType.GetTypeInfo.IsClass AndAlso
-                     Not argumentType.GetTypeInfo.IsInterface) Then
+            ElseIf (Not argumentType.IsClass AndAlso
+                     Not argumentType.IsInterface) Then
 
                 Debug.Assert(Not IsGenericParameter(argumentType), "Generic parameter unexpected!!!")
 
@@ -1043,13 +1043,13 @@ nextcandidate:
             End If
 
 
-            If (parameterType.GetTypeInfo.IsClass) Then
+            If (parameterType.IsClass) Then
 
-                If (Not argumentType.GetTypeInfo.IsClass) Then
+                If (Not argumentType.IsClass) Then
                     Return False
                 End If
 
-                Dim base As Type = argumentType.GetTypeInfo.BaseType
+                Dim base As Type = argumentType.BaseType
 
                 While (base IsNot Nothing)
 
@@ -1059,7 +1059,7 @@ nextcandidate:
                         Exit While
                     End If
 
-                    base = base.GetTypeInfo.BaseType
+                    base = base.BaseType
                 End While
 
                 argumentType = base
@@ -1123,7 +1123,7 @@ RetryInference:
             '  -- If P is Array Of T, and A is Array Of X, then infer X for T
 
             If IsGenericParameter(parameterType) Then
-                If AreGenericMethodDefsEqual(parameterType.GetTypeInfo.DeclaringMethod, targetProcedure) Then
+                If AreGenericMethodDefsEqual(parameterType.DeclaringMethod, targetProcedure) Then
                     Dim parameterIndex As Integer = parameterType.GenericParameterPosition
                     If typeInferenceArguments(parameterIndex) Is Nothing Then
                         typeInferenceArguments(parameterIndex) = argumentType

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Symbols.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Symbols.vb
@@ -223,6 +223,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
                 Case TypeCode.Char : Return GetType(Char)
                 Case TypeCode.String : Return GetType(String)
                 Case TypeCode.Object : Return GetType(Object)
+                Case TypeCode.DBNull : Return GetType(DBNull)
 
                 Case TypeCode.Empty
                     'fall through
@@ -241,11 +242,11 @@ Namespace Microsoft.VisualBasic.CompilerServices
         End Function
 
         Friend Shared Function IsValueType(ByVal type As System.Type) As Boolean
-            Return type.GetTypeInfo.IsValueType
+            Return type.IsValueType
         End Function
 
         Friend Shared Function IsEnum(ByVal type As System.Type) As Boolean
-            Return type.GetTypeInfo.IsEnum
+            Return type.IsEnum
         End Function
 
         Friend Shared Function IsArrayType(ByVal type As System.Type) As Boolean
@@ -358,7 +359,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
 
 
         Friend Shared Function IsClass(ByVal type As System.Type) As Boolean
-            Return type.GetTypeInfo.IsClass OrElse IsRootEnumType(type)
+            Return type.IsClass OrElse IsRootEnumType(type)
         End Function
 
         Friend Shared Function IsClassOrValueType(ByVal type As System.Type) As Boolean
@@ -366,7 +367,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         End Function
 
         Friend Shared Function IsInterface(ByVal type As System.Type) As Boolean
-            Return type.GetTypeInfo.IsInterface
+            Return type.IsInterface
         End Function
 
         Friend Shared Function IsClassOrInterface(ByVal type As System.Type) As Boolean
@@ -383,14 +384,14 @@ Namespace Microsoft.VisualBasic.CompilerServices
 
 #If LATEBINDING Then
         Friend Shared Function IsCollectionInterface(ByVal type As System.Type) As Boolean
-            If type.GetTypeInfo.IsInterface AndAlso
-               ((type.GetTypeInfo.IsGenericType AndAlso
-                   (type.GetTypeInfo.GetGenericTypeDefinition() Is GetType(System.Collections.Generic.IList(Of )) OrElse
-                    type.GetTypeInfo.GetGenericTypeDefinition() Is GetType(System.Collections.Generic.ICollection(Of )) OrElse
-                    type.GetTypeInfo.GetGenericTypeDefinition() Is GetType(System.Collections.Generic.IEnumerable(Of )) OrElse
-                    type.GetTypeInfo.GetGenericTypeDefinition() Is GetType(System.Collections.Generic.IReadOnlyList(Of )) OrElse
-                    type.GetTypeInfo.GetGenericTypeDefinition() Is GetType(System.Collections.Generic.IReadOnlyCollection(Of )) OrElse
-                    type.GetTypeInfo.GetGenericTypeDefinition() Is GetType(System.Collections.Generic.IDictionary(Of ,)) OrElse
+            If type.IsInterface AndAlso
+               ((type.IsGenericType AndAlso
+                   (type.GetGenericTypeDefinition() Is GetType(System.Collections.Generic.IList(Of )) OrElse
+                    type.GetGenericTypeDefinition() Is GetType(System.Collections.Generic.ICollection(Of )) OrElse
+                    type.GetGenericTypeDefinition() Is GetType(System.Collections.Generic.IEnumerable(Of )) OrElse
+                    type.GetGenericTypeDefinition() Is GetType(System.Collections.Generic.IReadOnlyList(Of )) OrElse
+                    type.GetGenericTypeDefinition() Is GetType(System.Collections.Generic.IReadOnlyCollection(Of )) OrElse
+                    type.GetGenericTypeDefinition() Is GetType(System.Collections.Generic.IDictionary(Of ,)) OrElse
                     type.GetGenericTypeDefinition() Is GetType(System.Collections.Generic.IReadOnlyDictionary(Of ,)))) OrElse
                 type Is GetType(System.Collections.IList) OrElse
                 type Is GetType(System.Collections.ICollection) OrElse
@@ -447,12 +448,12 @@ Namespace Microsoft.VisualBasic.CompilerServices
 
             If derived.IsGenericParameter() Then
                 If IsClass(base) AndAlso
-                   (CBool(derived.GetTypeInfo.GenericParameterAttributes() And GenericParameterAttributes.NotNullableValueTypeConstraint)) AndAlso
+                   (CBool(derived.GenericParameterAttributes() And GenericParameterAttributes.NotNullableValueTypeConstraint)) AndAlso
                    IsOrInheritsFrom(GetType(System.ValueType), base) Then
                     Return True
                 End If
 
-                For Each typeConstraint As Type In derived.GetTypeInfo.GetGenericParameterConstraints
+                For Each typeConstraint As Type In derived.GetGenericParameterConstraints
                     If IsOrInheritsFrom(typeConstraint, base) Then
                         Return True
                     End If
@@ -475,11 +476,11 @@ Namespace Microsoft.VisualBasic.CompilerServices
         End Function
 
         Friend Shared Function IsGeneric(ByVal type As Type) As Boolean
-            Return type.GetTypeInfo.IsGenericType
+            Return type.IsGenericType
         End Function
 
         Friend Shared Function IsInstantiatedGeneric(ByVal type As Type) As Boolean
-            Return type.GetTypeInfo.IsGenericType AndAlso (Not type.GetTypeInfo.IsGenericTypeDefinition)
+            Return type.IsGenericType AndAlso (Not type.IsGenericTypeDefinition)
         End Function
 
         Friend Shared Function IsGeneric(ByVal method As MethodBase) As Boolean
@@ -531,7 +532,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
             Debug.Assert(IsGenericParameter(genericParameter), "expected type parameter")
 
             'Type parameters with no class constraint have System.Object as their base type.
-            Dim classConstraint As Type = genericParameter.GetTypeInfo.BaseType
+            Dim classConstraint As Type = genericParameter.BaseType
             If IsRootObjectType(classConstraint) Then Return Nothing
             Return classConstraint
         End Function
@@ -543,8 +544,8 @@ Namespace Microsoft.VisualBasic.CompilerServices
             Debug.Assert(genericMethodDef IsNot Nothing AndAlso IsRawGeneric(genericMethodDef), "Uninstantiated generic expected!!!")
 
             If IsGenericParameter(possibleGenericParameter) AndAlso
-               possibleGenericParameter.GetTypeInfo.DeclaringMethod IsNot Nothing AndAlso
-               AreGenericMethodDefsEqual(possibleGenericParameter.GetTypeInfo.DeclaringMethod, genericMethodDef) Then
+               possibleGenericParameter.DeclaringMethod IsNot Nothing AndAlso
+               AreGenericMethodDefsEqual(possibleGenericParameter.DeclaringMethod, genericMethodDef) Then
                 Return possibleGenericParameter.GenericParameterPosition
             End If
             Return -1
@@ -561,9 +562,9 @@ Namespace Microsoft.VisualBasic.CompilerServices
             If IsGenericParameter(referringType) Then
                 'Is T a generic parameter of Method?
 
-                Debug.Assert(referringType.GetTypeInfo.DeclaringMethod.IsGenericMethodDefinition, "Unexpected generic method instantiation!!!")
+                Debug.Assert(referringType.DeclaringMethod.IsGenericMethodDefinition, "Unexpected generic method instantiation!!!")
 
-                If AreGenericMethodDefsEqual(referringType.GetTypeInfo.DeclaringMethod, method) Then
+                If AreGenericMethodDefsEqual(referringType.DeclaringMethod, method) Then
                     Return True
                 End If
 
@@ -738,7 +739,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
             ' in the runtime library. Read the reflection documentation and test with
             ' nested types before changing this code.
 
-            Return Not declaringType.GetTypeInfo.IsPublic AndAlso declaringType.GetTypeInfo.Assembly Is Utils.VBRuntimeAssembly
+            Return Not declaringType.IsPublic AndAlso declaringType.Assembly Is Utils.VBRuntimeAssembly
 
         End Function
 
@@ -805,15 +806,15 @@ Namespace Microsoft.VisualBasic.CompilerServices
                 Get
                     Dim curType As Type = _type
                     While curType IsNot Nothing
-                        If (curType.GetTypeInfo.Attributes And TypeAttributes.WindowsRuntime) = TypeAttributes.WindowsRuntime Then
+                        If (curType.Attributes And TypeAttributes.WindowsRuntime) = TypeAttributes.WindowsRuntime Then
                             ' Found a WinRT COM object
                             Return True
-                        ElseIf (curType.GetTypeInfo.Attributes And TypeAttributes.Import) = TypeAttributes.Import Then
+                        ElseIf (curType.Attributes And TypeAttributes.Import) = TypeAttributes.Import Then
                             ' Found a class that is actually imported from COM but not WinRT
                             ' this is definitely a non-WinRT COM object
                             Return False
                         End If
-                        curType = curType.GetTypeInfo.BaseType
+                        curType = curType.BaseType
                     End While
                     Return False
 
@@ -1009,13 +1010,13 @@ Namespace Microsoft.VisualBasic.CompilerServices
                 'Find the default member name.
                 Dim current As Type = searchType
                 Do
-                    Dim attributes As Object() = Enumerable.ToArray(current.GetTypeInfo.GetCustomAttributes(GetType(DefaultMemberAttribute), False))
+                    Dim attributes As Object() = Enumerable.ToArray(current.GetCustomAttributes(GetType(DefaultMemberAttribute), False))
 
                     If attributes IsNot Nothing AndAlso attributes.Length > 0 Then
                         potentialDefaultMemberName = DirectCast(attributes(0), DefaultMemberAttribute).MemberName
                         Exit Do
                     End If
-                    current = current.GetTypeInfo.BaseType
+                    current = current.BaseType
 
                 Loop While current IsNot Nothing AndAlso Not IsRootObjectType(current)
 

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Utils.LateBinder.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Utils.LateBinder.vb
@@ -101,7 +101,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
                 End If
 
                 ' if the cached assembly ref has not been set, then set it here
-                s_VBRuntimeAssembly = GetType(Utils).GetTypeInfo.Assembly
+                s_VBRuntimeAssembly = GetType(Utils).Assembly
                 Return s_VBRuntimeAssembly
             End Get
         End Property
@@ -214,7 +214,7 @@ GetSpecialValue:
 
 
             Dim tc As TypeCode
-            If typ.GetTypeInfo.IsEnum Then
+            If typ.IsEnum Then
                 tc = TypeCode.Object
             Else
                 tc = typ.GetTypeCode
@@ -317,7 +317,7 @@ GetSpecialValue:
 
         Private Shared Function GetGenericArgsSuffix(ByVal typ As Type) As String
 
-            If Not typ.GetTypeInfo.IsGenericType Then
+            If Not typ.IsGenericType Then
                 Return Nothing
             End If
 
@@ -325,7 +325,7 @@ GetSpecialValue:
             Dim totalTypeArgsCount As Integer = typeArgs.Length
             Dim typeArgsCount As Integer = totalTypeArgsCount
 
-            If typ.DeclaringType IsNot Nothing AndAlso typ.DeclaringType.GetTypeInfo.IsGenericType Then
+            If typ.DeclaringType IsNot Nothing AndAlso typ.DeclaringType.IsGenericType Then
                 typeArgsCount = typeArgsCount - typ.DeclaringType.GetGenericArguments().Length
             End If
 
@@ -408,7 +408,7 @@ GetSpecialValue:
             End If
 
             If (method.Attributes And System.Reflection.MethodAttributes.Virtual) <> 0 Then
-                If Not method.DeclaringType.GetTypeInfo.IsInterface Then
+                If Not method.DeclaringType.IsInterface Then
                     MethodToString &= "Overrides "
                 End If
             ElseIf IsShared(method) Then
@@ -514,7 +514,7 @@ GetSpecialValue:
             resultString &= "Public "
 
             If (accessor.Attributes And MethodAttributes.Virtual) <> 0 Then
-                If Not prop.DeclaringType.GetTypeInfo.IsInterface Then
+                If Not prop.DeclaringType.IsInterface Then
                     resultString &= "Overrides "
                 End If
             ElseIf IsShared(accessor) Then

--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Utils.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/Utils.vb
@@ -77,49 +77,12 @@ Namespace Global.Microsoft.VisualBasic.CompilerServices
 
         <System.Runtime.CompilerServices.ExtensionAttribute()>
         Public Function GetTypeCode(type As Type) As TypeCode
-
-            If type Is Nothing Then
-                Return TypeCode.Empty
-            ElseIf GetType(Boolean).Equals(type) Then
-                Return TypeCode.Boolean
-            ElseIf GetType(Char).Equals(type) Then
-                Return TypeCode.Char
-            ElseIf GetType(SByte).Equals(type) Then
-                Return TypeCode.SByte
-            ElseIf GetType(Byte).Equals(type) Then
-                Return TypeCode.Byte
-            ElseIf GetType(Short).Equals(type) Then
-                Return TypeCode.Int16
-            ElseIf GetType(UShort).Equals(type) Then
-                Return TypeCode.UInt16
-            ElseIf GetType(Int32).Equals(type) Then
-                Return TypeCode.Int32
-            ElseIf GetType(UInt32).Equals(type) Then
-                Return TypeCode.UInt32
-            ElseIf GetType(Long).Equals(type) Then
-                Return TypeCode.Int64
-            ElseIf GetType(ULong).Equals(type) Then
-                Return TypeCode.UInt64
-            ElseIf GetType(Single).Equals(type) Then
-                Return TypeCode.Single
-            ElseIf GetType(Double).Equals(type) Then
-                Return TypeCode.Double
-            ElseIf GetType(Decimal).Equals(type) Then
-                Return TypeCode.Decimal
-            ElseIf GetType(DateTime).Equals(type) Then
-                Return TypeCode.DateTime
-            ElseIf GetType(String).Equals(type) Then
-                Return TypeCode.String
-            ElseIf type.GetTypeInfo().IsEnum Then
-                Return GetTypeCode([Enum].GetUnderlyingType(type))
-            Else
-                Return TypeCode.Object
-            End If
+            Return Type.GetTypeCode(type)
         End Function
 
         <System.Runtime.CompilerServices.ExtensionAttribute()>
         Public Function IsSubclassOf(source As Type, other As Type) As Boolean
-            Return source.GetTypeInfo().IsSubclassOf(other)
+            Return source.IsSubclassOf(other)
         End Function
 
         Public ReadOnly Property BindingFlagsInvokeMethod As BindingFlags
@@ -268,11 +231,11 @@ Namespace Global.Microsoft.VisualBasic.CompilerServices
             If t1.IsGenericParameter Then
                 If t2.IsGenericParameter Then
                     ' If member's declaring type is not type parameter's declaring type, we assume that it is used as a type argument
-                    If t1.GetTypeInfo().DeclaringMethod Is Nothing AndAlso member1.DeclaringType.Equals(t1.GetTypeInfo().DeclaringType) Then
-                        If Not (t2.GetTypeInfo().DeclaringMethod Is Nothing AndAlso member2.DeclaringType.Equals(t2.GetTypeInfo().DeclaringType)) Then
+                    If t1.DeclaringMethod Is Nothing AndAlso member1.DeclaringType.Equals(t1.DeclaringType) Then
+                        If Not (t2.DeclaringMethod Is Nothing AndAlso member2.DeclaringType.Equals(t2.DeclaringType)) Then
                             Return t1.IsTypeParameterEquivalentToTypeInst(t2, member2)
                         End If
-                    ElseIf t2.GetTypeInfo().DeclaringMethod Is Nothing AndAlso member2.DeclaringType.Equals(t2.GetTypeInfo().DeclaringType) Then
+                    ElseIf t2.DeclaringMethod Is Nothing AndAlso member2.DeclaringType.Equals(t2.DeclaringType) Then
                         Return t2.IsTypeParameterEquivalentToTypeInst(t1, member1)
                     End If
 
@@ -288,7 +251,7 @@ Namespace Global.Microsoft.VisualBasic.CompilerServices
             End If
 
             ' Recurse in for generic types arrays, byref and pointer types.
-            If t1.GetTypeInfo().IsGenericType AndAlso t2.GetTypeInfo().IsGenericType Then
+            If t1.IsGenericType AndAlso t2.IsGenericType Then
                 Dim args1 As Type() = t1.GetGenericArguments()
                 Dim args2 As Type() = t2.GetGenericArguments()
 
@@ -319,7 +282,7 @@ Namespace Global.Microsoft.VisualBasic.CompilerServices
 
             Debug.Assert(typeParam.IsGenericParameter)
 
-            If typeParam.GetTypeInfo().DeclaringMethod IsNot Nothing Then
+            If typeParam.DeclaringMethod IsNot Nothing Then
                 ' The type param is from a generic method. Since only methods can be generic, anything else
                 ' here means they are not equivalent.
                 If Not (TypeOf member Is MethodBase) Then
@@ -327,14 +290,14 @@ Namespace Global.Microsoft.VisualBasic.CompilerServices
                 End If
 
                 Dim method As MethodBase = DirectCast(member, MethodBase)
-                Dim position As Integer = typeParam.GetTypeInfo().GenericParameterPosition
+                Dim position As Integer = typeParam.GenericParameterPosition
                 Dim args As Type() = If(method.IsGenericMethod, method.GetGenericArguments(), Nothing)
 
                 Return args IsNot Nothing AndAlso
                        args.Length > position AndAlso
                        args(position).Equals(typeInst)
             Else
-                Return member.DeclaringType.GetGenericArguments()(typeParam.GetTypeInfo().GenericParameterPosition).Equals(typeInst)
+                Return member.DeclaringType.GetGenericArguments()(typeParam.GenericParameterPosition).Equals(typeInst)
             End If
         End Function
 


### PR DESCRIPTION
Just one left that uses `GetDeclaredMethods` method.

Contributes to #16305

Also have `GetTypeCode` extension call into `Type.GetTypeCode` as that is now available.