### PR TITLE
Add RIDless build configuration for S.R.IS.RuntimeInformation

### DIFF
--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/Configurations.props
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/Configurations.props
@@ -8,6 +8,7 @@
       netfx-Windows_NT;
       uap-Windows_NT;
       uapaot-Windows_NT;
+      netstandard1.1-AnyOS;
       netstandard1.1-Unix;
       netstandard1.1-Windows_NT;
       netcoreapp-Unix;

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.csproj
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.csproj
@@ -11,7 +11,7 @@
     <DefineConstants Condition="'$(TargetGroup)'=='win8'">win8</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='uap'">uap</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='uapaot'">uap;uapaot;netcore50</DefineConstants>
-    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetGroup)'=='NOTAREALTARGETGROUP'">true</GeneratePlatformNotSupportedAssembly>
+    <GeneratePlatformNotSupportedAssembly Condition="'$(TargetGroup)'=='netstandard1.1' AND '$(OSGroup)'=='AnyOS'">true</GeneratePlatformNotSupportedAssembly>
     <!-- use netstandard1.1 refs for win8 and wpa81 -->
     <RefPath Condition="'$(TargetGroup)'=='wpa81' OR '$(TargetGroup)'=='win8'">$(RefRootPath)/netstandard1.1</RefPath>
     <!-- Clear runtime for wpa81 & win8: these project types don't use project.json and need to resolve without a runtime -->


### PR DESCRIPTION
This AnyOS netstandard1.1 configuration is for PCL support so we
ensure we have an asset that isn't in a runtime folder in the package
which PCL's and packages.config don't support.

Fixes https://github.com/dotnet/corefx/issues/15288.

cc @ericstj 