### PR TITLE
Fix FormatterServices.GetUninitializedObject allows allocating byref-like objects

### DIFF
--- a/src/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeHelpersTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeHelpersTests.netcoreapp.cs
@@ -46,6 +46,7 @@ namespace System.Runtime.CompilerServices.Tests
             Assert.Throws<MemberAccessException>(() => RuntimeHelpers.GetUninitializedObject(typeof(System.IO.Stream))); // abstract type
             Assert.Throws<MemberAccessException>(() => RuntimeHelpers.GetUninitializedObject(typeof(System.Collections.IEnumerable))); // interface
             Assert.Throws<MemberAccessException>(() => RuntimeHelpers.GetUninitializedObject(typeof(System.Collections.Generic.List<>))); // generic definition
+            Assert.Throws<NotSupportedException>(() => RuntimeHelpers.GetUninitializedObject(typeof(TypedReference))); // byref-like type
         }
 
         [Fact]


### PR DESCRIPTION
Add regression test for https://github.com/dotnet/coreclr/issues/9739