### PR TITLE
Bring back paths blocked by UNSUPPORTEDAPI in Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
@@ -1007,11 +1007,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             // We need to find the associated methodinfo on the instantiated type.
             foreach (MethodInfo m in type.GetRuntimeMethods())
             {
-#if UNSUPPORTEDAPI
-                if ((m.MetadataToken != methodInfo.MetadataToken) || (m.Module != methodInfo.Module))
-#else
                 if (!m.HasSameMetadataDefinitionAs(methodInfo))
-#endif
                 {
                     continue;
                 }
@@ -1078,11 +1074,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
             foreach (ConstructorInfo c in type.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
             {
-#if UNSUPPORTEDAPI
-                if ((c.MetadataToken != ctorInfo.MetadataToken) || (c.Module != ctorInfo.Module))
-#else
                 if (!c.HasSameMetadataDefinitionAs(ctorInfo))
-#endif
                 {
                     continue;
                 }
@@ -1134,12 +1126,8 @@ namespace Microsoft.CSharp.RuntimeBinder
 
             foreach (PropertyInfo p in type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
             {
-#if UNSUPPORTEDAPI
-                if ((p.MetadataToken != propertyInfo.MetadataToken) || (p.Module != propertyInfo.Module))
-#else
                 if (!p.HasSameMetadataDefinitionAs(propertyInfo))
                 {
-#endif
                     continue;
                 }
                 Debug.Assert((p.Name == propertyInfo.Name) &&

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -898,11 +898,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                     ParameterInfo[] parameters = methodBase.GetParameters();
 
                     bool bAdded = false;
-#if UNSUPPORTEDAPI
-                    foreach (MethodInfo methinfo in Enumerable.Where(t.DeclaringType.GetRuntimeMethods(), m => m.MetadataToken == methodBase.MetadataToken))
-#else
                     foreach (MethodInfo methinfo in Enumerable.Where(t.DeclaringType.GetRuntimeMethods(), m => m.HasSameMetadataDefinitionAs(methodBase)))
-#endif
                     {
                         if (!methinfo.IsGenericMethod)
                         {
@@ -1553,9 +1549,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             ConstructorInfo ctor = member as ConstructorInfo;
 
             Debug.Assert(method != null || ctor != null);
-#if UNSUPPORTEDAPI
             Debug.Assert(member.DeclaringType == member.ReflectedType);
-#endif
             // If we are trying to add an actual method via MethodKindEnum.Actual, and 
             // the memberinfo is a special name, and its not static, then return null. 
             // We'll re-add the thing later with some other method kind.
@@ -1772,15 +1766,9 @@ namespace Microsoft.CSharp.RuntimeBinder
                 CType cvType = _semanticChecker.GetSymbolLoader().GetReqPredefType(PredefinedType.PT_OBJECT);
 
                 // We need to use RawDefaultValue, because DefaultValue is too clever.
-#if UNSUPPORTEDAPI
                 if (parameters[i].RawDefaultValue != null)
                 {
                     object defValue = parameters[i].RawDefaultValue;
-#else
-                if (parameters[i].DefaultValue != null)
-                {
-                    object defValue = parameters[i].DefaultValue;
-#endif
                     Type defType = defValue.GetType();
 
                     if (defType == typeof(Byte))
@@ -1881,7 +1869,6 @@ namespace Microsoft.CSharp.RuntimeBinder
         private uint GetCountOfModOpts(ParameterInfo[] parameters)
         {
             uint count = 0;
-#if UNSUPPORTEDAPI
             foreach (ParameterInfo p in parameters)
             {
                 if (p.GetOptionalCustomModifiers() != null)
@@ -1889,7 +1876,6 @@ namespace Microsoft.CSharp.RuntimeBinder
                     count += (uint)p.GetOptionalCustomModifiers().Length;
                 }
             }
-#endif
             return count;
         }
 


### PR DESCRIPTION
The methods these paths use are all available again, and all have coverage from tests between the three test projects that hit MS.CSharp

Fixes #16041

Bring them back except…

Since this makes `HasSameMetadataDefinitionAs` calls now equivalent to the `UNSUPPORTEDAPI` code it is a substitute for, just keep it and remove the `UNSUPPORTEDAPI` code at those locations.

`s_MemberEquivalence` delegate is now dead code. Remove it.