### PR TITLE
Fix leak in DbCommand's use of CancellationToken

### DIFF
--- a/src/System.Data.Common/src/System/Data/Common/DbCommand.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbCommand.cs
@@ -128,7 +128,7 @@ namespace System.Data.Common
                 CancellationTokenRegistration registration = new CancellationTokenRegistration();
                 if (cancellationToken.CanBeCanceled)
                 {
-                    registration = cancellationToken.Register(CancelIgnoreFailure);
+                    registration = cancellationToken.Register(s => ((DbCommand)s).CancelIgnoreFailure(), this);
                 }
 
                 try
@@ -137,8 +137,11 @@ namespace System.Data.Common
                 }
                 catch (Exception e)
                 {
-                    registration.Dispose();
                     return Task.FromException<int>(e);
+                }
+                finally
+                {
+                    registration.Dispose();
                 }
             }
         }
@@ -166,7 +169,7 @@ namespace System.Data.Common
                 CancellationTokenRegistration registration = new CancellationTokenRegistration();
                 if (cancellationToken.CanBeCanceled)
                 {
-                    registration = cancellationToken.Register(CancelIgnoreFailure);
+                    registration = cancellationToken.Register(s => ((DbCommand)s).CancelIgnoreFailure(), this);
                 }
 
                 try
@@ -175,8 +178,11 @@ namespace System.Data.Common
                 }
                 catch (Exception e)
                 {
-                    registration.Dispose();
                     return Task.FromException<DbDataReader>(e);
+                }
+                finally
+                {
+                    registration.Dispose();
                 }
             }
         }
@@ -195,7 +201,7 @@ namespace System.Data.Common
                 CancellationTokenRegistration registration = new CancellationTokenRegistration();
                 if (cancellationToken.CanBeCanceled)
                 {
-                    registration = cancellationToken.Register(CancelIgnoreFailure);
+                    registration = cancellationToken.Register(s => ((DbCommand)s).CancelIgnoreFailure(), this);
                 }
 
                 try
@@ -204,8 +210,11 @@ namespace System.Data.Common
                 }
                 catch (Exception e)
                 {
-                    registration.Dispose();
                     return Task.FromException<object>(e);
+                }
+                finally
+                {
+                    registration.Dispose();
                 }
             }
         }


### PR DESCRIPTION
We're only disposing of the registration on error; we should also dispose of it on success. While doing this, I've also avoided a delegate allocation per operation.

Fixes https://github.com/dotnet/corefx/issues/16439
cc: @saurabh500 