### PR TITLE
Fix a 512 vs 521 typo in ECDSA keysize assert.

### DIFF
--- a/src/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
@@ -281,7 +281,7 @@ namespace System.Security.Cryptography
                     {
                         long size = Interop.AppleCrypto.EccGetKeySizeInBits(newKeyPair.PublicKey);
 
-                        Debug.Assert(size == 256 || size == 384 || size == 512, $"Unknown keysize ({size})");
+                        Debug.Assert(size == 256 || size == 384 || size == 521, $"Unknown keysize ({size})");
                         KeySizeValue = (int)size;
                     }
                 }


### PR DESCRIPTION
Once Keychain enumeration was working locally it was observed that a
NIST-P521 certificate calling GetECDsaPublicKey() was asserting.

This should already have been caught by the tests, but key generation was
disabled due to perf and keychain contamination.