### PR TITLE
Update Debug CrossBuild Pipeline definition to use V2 images

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -539,7 +539,7 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux-Crossbuild",
           "Parameters": {
-            "PB_DockerTag": "ubuntu1404_cross_prereqs_v1",
+            "PB_DockerTag": "ubuntu1404_cross_prereqs_v2",
             "PB_Architecture": "arm"
           },
           "ReportingParameters": {
@@ -552,9 +552,8 @@
         {
           "Name": "DotNet-CoreFx-Trusted-Linux-Crossbuild",
           "Parameters": {
-            "PB_DockerTag": "ubuntu1604_cross_prereqs_v1",
-            "PB_Architecture": "arm",
-            "CrossToolsetVersion": "xenial"
+            "PB_DockerTag": "ubuntu1604_cross_prereqs_v2",
+            "PB_Architecture": "arm"
           },
           "ReportingParameters": {
             "OperatingSystem": "Ubuntu 16.04",


### PR DESCRIPTION
Update debug CrossBuild definitions to use updated Docker images.

@wtgodbe PTAL

CC @weshaggard 