### PR TITLE
Improve Uri.UnescapeDataString codepath

### DIFF
--- a/src/System.Private.Uri/System.Private.Uri.sln
+++ b/src/System.Private.Uri/System.Private.Uri.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Private.Uri.ExtendedFunctional.Tests", "tests\ExtendedFunctionalTests\System.Private.Uri.ExtendedFunctional.Tests.csproj", "{0febe054-68ac-446f-b999-9068736d3cec}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Private.Uri.ExtendedFunctional.Tests", "tests\ExtendedFunctionalTests\System.Private.Uri.ExtendedFunctional.Tests.csproj", "{0FEBE054-68AC-446F-B999-9068736D3CEC}"
 	ProjectSection(ProjectDependencies) = postProject
 		{4AC5343E-6E31-4BA5-A795-0493AE7E9008} = {4AC5343E-6E31-4BA5-A795-0493AE7E9008}
 	EndProjectSection
@@ -29,10 +29,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{0febe054-68ac-446f-b999-9068736d3cec}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0febe054-68ac-446f-b999-9068736d3cec}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0febe054-68ac-446f-b999-9068736d3cec}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0febe054-68ac-446f-b999-9068736d3cec}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0FEBE054-68AC-446F-B999-9068736D3CEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0FEBE054-68AC-446F-B999-9068736D3CEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0FEBE054-68AC-446F-B999-9068736D3CEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0FEBE054-68AC-446F-B999-9068736D3CEC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -50,7 +50,7 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{0febe054-68ac-446f-b999-9068736d3cec} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{0FEBE054-68AC-446F-B999-9068736D3CEC} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{96AF3242-A368-4F13-B006-A722CC3B8517} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{4AC5343E-6E31-4BA5-A795-0493AE7E9008} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}

--- a/src/System.Private.Uri/src/System.Private.Uri.csproj
+++ b/src/System.Private.Uri/src/System.Private.Uri.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{4AC5343E-6E31-4BA5-A795-0493AE7E9008}</ProjectGuid>
     <AssemblyName>System.Private.Uri</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />

--- a/src/System.Private.Uri/src/System.Private.Uri.csproj
+++ b/src/System.Private.Uri/src/System.Private.Uri.csproj
@@ -5,6 +5,7 @@
     <ProjectGuid>{4AC5343E-6E31-4BA5-A795-0493AE7E9008}</ProjectGuid>
     <AssemblyName>System.Private.Uri</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
@@ -47,6 +48,7 @@
     <Compile Include="System\UriPartial.cs" />
     <Compile Include="System\UriScheme.cs" />
     <Compile Include="System\UriSyntax.cs" />
+    <Compile Include="System\PooledCharArray.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' and ('$(TargetGroup)'=='netcoreapp' OR '$(TargetGroup)'=='uap')">
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">

--- a/src/System.Private.Uri/src/System/IriHelper.cs
+++ b/src/System.Private.Uri/src/System/IriHelper.cs
@@ -133,12 +133,8 @@ namespace System
         //
         internal static unsafe string EscapeUnescapeIri(char* pInput, int start, int end, UriComponents component)
         {
-            char[] dest = new char[end - start];
+            PooledCharArray dest = new PooledCharArray(end - start);
             byte[] bytes = null;
-
-            // Pin the array to do pointer accesses
-            GCHandle destHandle = GCHandle.Alloc(dest, GCHandleType.Pinned);
-            char* pDest = (char*)destHandle.AddrOfPinnedObject();
 
             const int percentEncodingLen = 3; // Escaped UTF-8 will take 3 chars: %AB.
             const int bufferCapacityIncrease = 30 * percentEncodingLen;
@@ -166,11 +162,11 @@ namespace System
                         {
                             // keep as is
                             Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
-                            pDest[destOffset++] = pInput[next++];
+                            dest[destOffset++] = pInput[next++];
                             Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
-                            pDest[destOffset++] = pInput[next++];
+                            dest[destOffset++] = pInput[next++];
                             Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
-                            pDest[destOffset++] = pInput[next];
+                            dest[destOffset++] = pInput[next];
                             continue;
                         }
                         else if (ch <= '\x7F')
@@ -178,7 +174,7 @@ namespace System
                             Debug.Assert(ch < 0xFF, "Expecting ASCII character.");
                             Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
                             //ASCII
-                            pDest[destOffset++] = ch;
+                            dest[destOffset++] = ch;
                             next += 2;
                             continue;
                         }
@@ -241,7 +237,7 @@ namespace System
                                 // copy the escaped versions of those sequences.
                                 // Decoded Unicode values will be kept only when they are allowed by the URI/IRI RFC
                                 // rules.
-                                UriHelper.MatchUTF8Sequence(pDest, dest, ref destOffset, unescapedChars, charCount, bytes,
+                                UriHelper.MatchUTF8Sequence(ref dest, ref destOffset, unescapedChars, charCount, bytes,
                                     byteCount, component == UriComponents.Query, true);
                             }
                             else
@@ -250,7 +246,7 @@ namespace System
                                 for (int i = startSeq; i <= next; ++i)
                                 {
                                     Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
-                                    pDest[destOffset++] = pInput[i];
+                                    dest[destOffset++] = pInput[i];
                                 }
                             }
                         }
@@ -258,7 +254,7 @@ namespace System
                     else
                     {
                         Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
-                        pDest[destOffset++] = pInput[next];
+                        dest[destOffset++] = pInput[next];
                     }
                 }
                 else if (ch > '\x7f')
@@ -275,9 +271,9 @@ namespace System
                         {
                             // copy the two chars
                             Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
-                            pDest[destOffset++] = pInput[next++];
+                            dest[destOffset++] = pInput[next++];
                             Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
-                            pDest[destOffset++] = pInput[next];
+                            dest[destOffset++] = pInput[next];
                         }
                     }
                     else
@@ -288,7 +284,7 @@ namespace System
                             {
                                 // copy it
                                 Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
-                                pDest[destOffset++] = pInput[next];
+                                dest[destOffset++] = pInput[next];
                             }
                         }
                         else
@@ -302,7 +298,7 @@ namespace System
                 {
                     // just copy the character
                     Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
-                    pDest[destOffset++] = pInput[next];
+                    dest[destOffset++] = pInput[next];
                 }
 
                 if (escape)
@@ -311,32 +307,13 @@ namespace System
 
                     if (bufferRemaining < MaxNumberOfBytesEncoded * percentEncodingLen)
                     {
-                        int newBufferLength = 0;
-
                         checked
                         {
                             // may need more memory since we didn't anticipate escaping
-                            newBufferLength = dest.Length + bufferCapacityIncrease;
                             bufferRemaining += bufferCapacityIncrease;
                         }
 
-                        char[] newDest = new char[newBufferLength];
-
-                        fixed (char* pNewDest = newDest)
-                        {
-                            Buffer.MemoryCopy((byte*)pDest, (byte*)pNewDest, newBufferLength * sizeof(char), destOffset * sizeof(char));
-                        }
-
-                        if (destHandle.IsAllocated)
-                        {
-                            destHandle.Free();
-                        }
-
-                        dest = newDest;
-
-                        // re-pin new dest[] array
-                        destHandle = GCHandle.Alloc(dest, GCHandleType.Pinned);
-                        pDest = (char*)destHandle.AddrOfPinnedObject();
+                        dest.GrowAndCopy(bufferCapacityIncrease);
                     }
 
                     byte[] encodedBytes = new byte[MaxNumberOfBytesEncoded];
@@ -349,17 +326,13 @@ namespace System
 
                         for (int count = 0; count < encodedBytesCount; ++count)
                         {
-                            UriHelper.EscapeAsciiChar((char)encodedBytes[count], dest, ref destOffset);
+                            UriHelper.EscapeAsciiChar((char)encodedBytes[count], ref dest, ref destOffset);
                         }
                     }
                 }
             }
 
-            if (destHandle.IsAllocated)
-                destHandle.Free();
-
-            Debug.Assert(destOffset <= dest.Length, "Destination length met or exceeded destination offset.");
-            return new string(dest, 0, destOffset);
+            return dest.GetStringAndRelease(destOffset);
         }
     }
 }

--- a/src/System.Private.Uri/src/System/PooledCharArray.cs
+++ b/src/System.Private.Uri/src/System/PooledCharArray.cs
@@ -46,6 +46,19 @@ namespace System
     		}
     	}
 
+        public unsafe bool IsSameString(char* ptrStr, int start, int end)
+        {
+            while (start <= end)
+            {
+                if (ptrStr[start] != _buffer[start])
+                {
+                    return false;
+                }
+                start++;
+            }
+            return true;
+        }
+
     	public void GrowAndCopy(int extraSpace)
     	{
     		char[] oldBuffer = _buffer;

--- a/src/System.Private.Uri/src/System/PooledCharArray.cs
+++ b/src/System.Private.Uri/src/System/PooledCharArray.cs
@@ -16,6 +16,15 @@ namespace System
     		_buffer = ArrayPool<char>.Shared.Rent(size);
     	}
 
+		public PooledCharArray(char[] fromArray)
+		{
+			_buffer = ArrayPool<char>.Shared.Rent(fromArray.Length);
+			for (int i = 0; i < fromArray.Length; i++)
+			{
+				_buffer[i] = fromArray[i];
+			}
+		}
+
     	public void Release()
     	{
     		if (_buffer != null)
@@ -27,12 +36,24 @@ namespace System
 
     	public int Length => _buffer.Length;
 
+		public char[] Array => _buffer;
+
     	public string GetStringAndRelease(int stringLength)
     	{
     		string ret = new string(_buffer, 0, stringLength);
     		Release();
     		return ret;
     	}
+
+		public void CopyAndRelease(char[] dest, int offset, int count)
+		{
+			while (count > 0)
+			{
+				dest[offset] = _buffer[offset++];
+				count--;
+			}
+			Release();
+		}
 
     	public char this[int index]
     	{

--- a/src/System.Private.Uri/src/System/PooledCharArray.cs
+++ b/src/System.Private.Uri/src/System/PooledCharArray.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Buffers;
+
+namespace System
+{
+    internal struct PooledCharArray
+    {
+    	private char[] _buffer;
+
+    	public PooledCharArray(int size)
+    	{
+    		_buffer = ArrayPool<char>.Shared.Rent(size);
+    	}
+
+    	public void Release()
+    	{
+    		if (_buffer != null)
+    		{
+    			ArrayPool<char>.Shared.Return(_buffer);
+    			_buffer = null;
+    		}
+    	}
+
+    	public int Length => _buffer.Length;
+
+    	public string GetStringAndRelease(int stringLength)
+    	{
+    		string ret = new string(_buffer, 0, stringLength);
+    		Release();
+    		return ret;
+    	}
+
+    	public char this[int index]
+    	{
+    		get
+    		{
+    			return _buffer[index];
+    		}
+    		set
+    		{
+    			_buffer[index] = value;
+    		}
+    	}
+
+    	public void GrowAndCopy(int extraSpace)
+    	{
+    		char[] oldBuffer = _buffer;
+    		char[] newBuffer = ArrayPool<char>.Shared.Rent(_buffer.Length + extraSpace);
+    		Buffer.BlockCopy(oldBuffer, 0, newBuffer, 0, _buffer.Length);
+    		_buffer = newBuffer;
+    		ArrayPool<char>.Shared.Return(oldBuffer);
+    	}
+    }
+}

--- a/src/System.Private.Uri/src/System/UriExt.cs
+++ b/src/System.Private.Uri/src/System/UriExt.cs
@@ -518,10 +518,15 @@ namespace System
 
                     UnescapeMode unescapeMode = UnescapeMode.Unescape | UnescapeMode.UnescapeAll;
                     position = 0;
-                    char[] dest = new char[stringToUnescape.Length];
-                    dest = UriHelper.UnescapeString(stringToUnescape, 0, stringToUnescape.Length, dest, ref position,
+                    #if netcoreapp
+                        return UriHelper.UnescapeString(stringToUnescape, 0, stringToUnescape.Length, ref position,
                         c_DummyChar, c_DummyChar, c_DummyChar, unescapeMode, null, false);
-                    return new string(dest, 0, position);
+                    #else
+                        char[] dest = new char[stringToUnescape.Length];
+                        dest = UriHelper.UnescapeString(stringToUnescape, 0, stringToUnescape.Length, dest, ref position,
+                        c_DummyChar, c_DummyChar, c_DummyChar, unescapeMode, null, false);
+                        return new string(dest, 0, position);
+                    #endif
                 }
             }
         }

--- a/src/System.Private.Uri/src/System/UriExt.cs
+++ b/src/System.Private.Uri/src/System/UriExt.cs
@@ -529,7 +529,7 @@ namespace System
                     UnescapeMode unescapeMode = UnescapeMode.Unescape | UnescapeMode.UnescapeAll;
                     position = 0;
                     PooledCharArray pooledArray = new PooledCharArray(stringToUnescape.Length);
-                    UriHelper.UnescapeString(stringToUnescape, 0, stringToUnescape.Length, pooledArray, ref position,
+                    UriHelper.UnescapeString(stringToUnescape, 0, stringToUnescape.Length, ref pooledArray, ref position,
                     c_DummyChar, c_DummyChar, c_DummyChar, unescapeMode, null, false);
 
                     if(pooledArray.IsSameString(pStr, 0, position))

--- a/src/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/System.Private.Uri/src/System/UriHelper.cs
@@ -248,7 +248,6 @@ namespace System
             return dest;
         }
 
-#region OldCode
         internal static unsafe char[] UnescapeString(string input, int start, int end, char[] dest,
             ref int destPosition, char rsvd1, char rsvd2, char rsvd3, UnescapeMode unescapeMode, UriParser syntax,
             bool isQuery)
@@ -263,349 +262,19 @@ namespace System
         internal static unsafe char[] UnescapeString(char* pStr, int start, int end, char[] dest, ref int destPosition,
             char rsvd1, char rsvd2, char rsvd3, UnescapeMode unescapeMode, UriParser syntax, bool isQuery)
         {
-            byte[] bytes = null;
-            byte escapedReallocations = 0;
-            bool escapeReserved = false;
-            int next = start;
-            bool iriParsing = Uri.IriParsingStatic(syntax)
-                                && ((unescapeMode & UnescapeMode.EscapeUnescape) == UnescapeMode.EscapeUnescape);
+            PooledCharArray pooledArray = new PooledCharArray(dest);
 
-            while (true)
+            UnescapeString(pStr, start, end, ref pooledArray, ref destPosition, rsvd1, rsvd2, rsvd3, unescapeMode,
+                    syntax, isQuery);
+
+            if (destPosition > dest.Length)
             {
-                // we may need to re-pin dest[]
-                fixed (char* pDest = dest)
-                {
-                    if ((unescapeMode & UnescapeMode.EscapeUnescape) == UnescapeMode.CopyOnly)
-                    {
-                        while (start < end)
-                            pDest[destPosition++] = pStr[start++];
-                        return dest;
-                    }
-
-                    while (true)
-                    {
-                        char ch = (char)0;
-
-                        for (; next < end; ++next)
-                        {
-                            if ((ch = pStr[next]) == '%')
-                            {
-                                if ((unescapeMode & UnescapeMode.Unescape) == 0)
-                                {
-                                    // re-escape, don't check anything else
-                                    escapeReserved = true;
-                                }
-                                else if (next + 2 < end)
-                                {
-                                    ch = EscapedAscii(pStr[next + 1], pStr[next + 2]);
-                                    // Unescape a good sequence if full unescape is requested
-                                    if (unescapeMode >= UnescapeMode.UnescapeAll)
-                                    {
-                                        if (ch == Uri.c_DummyChar)
-                                        {
-                                            if (unescapeMode >= UnescapeMode.UnescapeAllOrThrow)
-                                            {
-                                                // Should be a rare case where the app tries to feed an invalid escaped sequence
-                                                throw new UriFormatException(SR.net_uri_BadString);
-                                            }
-                                            continue;
-                                        }
-                                    }
-                                    // re-escape % from an invalid sequence
-                                    else if (ch == Uri.c_DummyChar)
-                                    {
-                                        if ((unescapeMode & UnescapeMode.Escape) != 0)
-                                            escapeReserved = true;
-                                        else
-                                            continue;   // we should throw instead but since v1.0 would just print '%'
-                                    }
-                                    // Do not unescape '%' itself unless full unescape is requested
-                                    else if (ch == '%')
-                                    {
-                                        next += 2;
-                                        continue;
-                                    }
-                                    // Do not unescape a reserved char unless full unescape is requested
-                                    else if (ch == rsvd1 || ch == rsvd2 || ch == rsvd3)
-                                    {
-                                        next += 2;
-                                        continue;
-                                    }
-                                    // Do not unescape a dangerous char unless it's V1ToStringFlags mode
-                                    else if ((unescapeMode & UnescapeMode.V1ToStringFlag) == 0 && IsNotSafeForUnescape(ch))
-                                    {
-                                        next += 2;
-                                        continue;
-                                    }
-                                    else if (iriParsing && ((ch <= '\x9F' && IsNotSafeForUnescape(ch)) ||
-                                                            (ch > '\x9F' && !IriHelper.CheckIriUnicodeRange(ch, isQuery))))
-                                    {
-                                        // check if unenscaping gives a char outside iri range 
-                                        // if it does then keep it escaped
-                                        next += 2;
-                                        continue;
-                                    }
-                                    // unescape escaped char or escape %
-                                    break;
-                                }
-                                else if (unescapeMode >= UnescapeMode.UnescapeAll)
-                                {
-                                    if (unescapeMode >= UnescapeMode.UnescapeAllOrThrow)
-                                    {
-                                        // Should be a rare case where the app tries to feed an invalid escaped sequence
-                                        throw new UriFormatException(SR.net_uri_BadString);
-                                    }
-                                    // keep a '%' as part of a bogus sequence 
-                                    continue;
-                                }
-                                else
-                                {
-                                    escapeReserved = true;
-                                }
-                                // escape (escapeReserved==true) or otherwise unescape the sequence
-                                break;
-                            }
-                            else if ((unescapeMode & (UnescapeMode.Unescape | UnescapeMode.UnescapeAll))
-                                == (UnescapeMode.Unescape | UnescapeMode.UnescapeAll))
-                            {
-                                continue;
-                            }
-                            else if ((unescapeMode & UnescapeMode.Escape) != 0)
-                            {
-                                // Could actually escape some of the characters
-                                if (ch == rsvd1 || ch == rsvd2 || ch == rsvd3)
-                                {
-                                    // found an unescaped reserved character -> escape it
-                                    escapeReserved = true;
-                                    break;
-                                }
-                                else if ((unescapeMode & UnescapeMode.V1ToStringFlag) == 0
-                                    && (ch <= '\x1F' || (ch >= '\x7F' && ch <= '\x9F')))
-                                {
-                                    // found an unescaped reserved character -> escape it
-                                    escapeReserved = true;
-                                    break;
-                                }
-                            }
-                        }
-
-                        //copy off previous characters from input
-                        while (start < next)
-                            pDest[destPosition++] = pStr[start++];
-
-                        if (next != end)
-                        {
-                            if (escapeReserved)
-                            {
-                                //escape that char
-                                // Since this should be _really_ rare case, reallocate with constant size increase of 30 rsvd-type characters.
-                                if (escapedReallocations == 0)
-                                {
-                                    escapedReallocations = 30;
-                                    char[] newDest = new char[dest.Length + escapedReallocations * 3];
-                                    fixed (char* pNewDest = &newDest[0])
-                                    {
-                                        for (int i = 0; i < destPosition; ++i)
-                                            pNewDest[i] = pDest[i];
-                                    }
-                                    dest = newDest;
-                                    // re-pin new dest[] array
-                                    goto dest_fixed_loop_break;
-                                }
-                                else
-                                {
-                                    --escapedReallocations;
-                                    EscapeAsciiChar(pStr[next], dest, ref destPosition);
-                                    escapeReserved = false;
-                                    start = ++next;
-                                    continue;
-                                }
-                            }
-
-                            // unescaping either one Ascii or possibly multiple Unicode
-
-                            if (ch <= '\x7F')
-                            {
-                                //ASCII
-                                dest[destPosition++] = ch;
-                                next += 3;
-                                start = next;
-                                continue;
-                            }
-
-                            // Unicode
-
-                            int byteCount = 1;
-                            // lazy initialization of max size, will reuse the array for next sequences
-                            if ((object)bytes == null)
-                                bytes = new byte[end - next];
-
-                            bytes[0] = (byte)ch;
-                            next += 3;
-                            while (next < end)
-                            {
-                                // Check on exit criterion
-                                if ((ch = pStr[next]) != '%' || next + 2 >= end)
-                                    break;
-
-                                // already made sure we have 3 characters in str
-                                ch = EscapedAscii(pStr[next + 1], pStr[next + 2]);
-
-                                //invalid hex sequence ?
-                                if (ch == Uri.c_DummyChar)
-                                    break;
-                                // character is not part of a UTF-8 sequence ?
-                                else if (ch < '\x80')
-                                    break;
-                                else
-                                {
-                                    //a UTF-8 sequence
-                                    bytes[byteCount++] = (byte)ch;
-                                    next += 3;
-                                }
-                            }
-
-                            Encoding noFallbackCharUTF8 = Encoding.GetEncoding(
-                                                                                Encoding.UTF8.CodePage,
-                                                                                new EncoderReplacementFallback(""),
-                                                                                new DecoderReplacementFallback(""));
-
-                            char[] unescapedChars = new char[bytes.Length];
-                            int charCount = noFallbackCharUTF8.GetChars(bytes, 0, byteCount, unescapedChars, 0);
-
-                            start = next;
-
-                            // match exact bytes
-                            // Do not unescape chars not allowed by Iri
-                            // need to check for invalid utf sequences that may not have given any chars
-
-                            MatchUTF8Sequence(pDest, dest, ref destPosition, unescapedChars, charCount, bytes,
-                                byteCount, isQuery, iriParsing);
-                        }
-
-                        if (next == end)
-                            goto done;
-                    }
-                dest_fixed_loop_break:;
-                }
+                dest = new char[destPosition];
             }
 
-        done: return dest;
+            pooledArray.CopyAndRelease(dest, 0, destPosition);
+            return dest;
         }
-
-        internal static unsafe void MatchUTF8Sequence(char* pDest, char[] dest, ref int destOffset, char[] unescapedChars,
-            int charCount, byte[] bytes, int byteCount, bool isQuery, bool iriParsing)
-        {
-            int count = 0;
-            fixed (char* unescapedCharsPtr = unescapedChars)
-            {
-                for (int j = 0; j < charCount; ++j)
-                {
-                    bool isHighSurr = char.IsHighSurrogate(unescapedCharsPtr[j]);
-
-                    byte[] encodedBytes = Encoding.UTF8.GetBytes(unescapedChars, j, isHighSurr ? 2 : 1);
-                    int encodedBytesLength = encodedBytes.Length;
-
-                    // we have to keep unicode chars outside Iri range escaped
-                    bool inIriRange = false;
-                    if (iriParsing)
-                    {
-                        if (!isHighSurr)
-                            inIriRange = IriHelper.CheckIriUnicodeRange(unescapedChars[j], isQuery);
-                        else
-                        {
-                            bool surrPair = false;
-                            inIriRange = IriHelper.CheckIriUnicodeRange(unescapedChars[j], unescapedChars[j + 1],
-                                                                   ref surrPair, isQuery);
-                        }
-                    }
-
-                    while (true)
-                    {
-                        // Escape any invalid bytes that were before this character
-                        while (bytes[count] != encodedBytes[0])
-                        {
-                            Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
-                            EscapeAsciiChar((char)bytes[count++], dest, ref destOffset);
-                        }
-
-                        // check if all bytes match
-                        bool allBytesMatch = true;
-                        int k = 0;
-                        for (; k < encodedBytesLength; ++k)
-                        {
-                            if (bytes[count + k] != encodedBytes[k])
-                            {
-                                allBytesMatch = false;
-                                break;
-                            }
-                        }
-
-                        if (allBytesMatch)
-                        {
-                            count += encodedBytesLength;
-                            if (iriParsing)
-                            {
-                                if (!inIriRange)
-                                {
-                                    // need to keep chars not allowed as escaped
-                                    for (int l = 0; l < encodedBytes.Length; ++l)
-                                    {
-                                        Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
-                                        EscapeAsciiChar((char)encodedBytes[l], dest, ref destOffset);
-                                    }
-                                }
-                                else if (!UriHelper.IsBidiControlCharacter(unescapedCharsPtr[j]))
-                                {
-                                    //copy chars
-                                    Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
-                                    pDest[destOffset++] = unescapedCharsPtr[j];
-                                    if (isHighSurr)
-                                    {
-                                        Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
-                                        pDest[destOffset++] = unescapedCharsPtr[j + 1];
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                //copy chars
-                                Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
-                                pDest[destOffset++] = unescapedCharsPtr[j];
-
-                                if (isHighSurr)
-                                {
-                                    Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
-                                    pDest[destOffset++] = unescapedCharsPtr[j + 1];
-                                }
-                            }
-
-                            break; // break out of while (true) since we've matched this char bytes
-                        }
-                        else
-                        {
-                            // copy bytes till place where bytes don't match
-                            for (int l = 0; l < k; ++l)
-                            {
-                                Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
-                                EscapeAsciiChar((char)bytes[count++], dest, ref destOffset);
-                            }
-                        }
-                    }
-
-                    if (isHighSurr) j++;
-                }
-            }
-
-            // Include any trailing invalid sequences
-            while (count < byteCount)
-            {
-                Debug.Assert(dest.Length > destOffset, "Destination length exceeded destination offset.");
-                EscapeAsciiChar((char)bytes[count++], dest, ref destOffset);
-            }
-        }
-
-#endregion
 
         //
         // This method will assume that any good Escaped Sequence will be unescaped in the output
@@ -645,7 +314,11 @@ namespace System
                 if ((unescapeMode & UnescapeMode.EscapeUnescape) == UnescapeMode.CopyOnly)
                 {
                     while (start < end)
+                    {
                         pooledArray[destPosition++] = pStr[start++];
+                    }
+
+                    return;
                 }
 
                 while (true)
@@ -838,7 +511,7 @@ namespace System
                         // Do not unescape chars not allowed by Iri
                         // need to check for invalid utf sequences that may not have given any chars
 
-                        MatchUTF8SequenceFastPath(ref pooledArray, ref destPosition, unescapedChars, charCount, bytes,
+                        MatchUTF8Sequence(ref pooledArray, ref destPosition, unescapedChars, charCount, bytes,
                             byteCount, isQuery, iriParsing);
                     }
 
@@ -854,7 +527,7 @@ namespace System
         // We got the unescaped chars, we then re-encode them and match off the bytes
         // to get the invalid sequence bytes that we just copy off
         //
-        internal static unsafe void MatchUTF8SequenceFastPath(ref PooledCharArray dest, ref int destOffset, char[] unescapedChars,
+        internal static unsafe void MatchUTF8Sequence(ref PooledCharArray dest, ref int destOffset, char[] unescapedChars,
             int charCount, byte[] bytes, int byteCount, bool isQuery, bool iriParsing)
         {
             int count = 0;

--- a/src/System.Private.Uri/tests/UnitTests/System.Private.Uri.Unit.Tests.csproj
+++ b/src/System.Private.Uri/tests/UnitTests/System.Private.Uri.Unit.Tests.csproj
@@ -24,6 +24,7 @@
     <Compile Include="..\..\src\System\UriHelper.cs" />
     <Compile Include="..\..\src\System\IriHelper.cs" />
     <Compile Include="..\..\src\System\UriEnumTypes.cs" />
+    <Compile Include="..\..\src\System\PooledCharArray.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Work for #16040 

This improvement is an initial proposal to avoid char[] allocations done in Uri.UnescapeDataString codepath specifically under UriHelper.UnescapeString. This as well reflects to be faster in a local mini-test I wrote [source code here](https://github.com/safern/mini-test/) -- and also saw some improvements in inclusive and exclusive time in an asp.net test scenario which you can find [here](https://github.com/aspnet/Performance/tree/dev/testapp/BigModelBinding).

The main improvements is that now I'm not seeing any char[] allocations in the GC Heap in any of the scenarios coming from the Uri.UnescapeDataString codepath and a little improvement in execution time. 

## Here is the mini-test I wrote PerfView traces result:

### CPU Stacks

> Before My Changes

![image](https://cloud.githubusercontent.com/assets/22899328/23326754/5de2b656-fab6-11e6-9552-fc0118bacc84.png)

> After My Changes

![image](https://cloud.githubusercontent.com/assets/22899328/23326750/46e19846-fab6-11e6-966b-c30743aa4688.png)

In this test scenario we can see that there is a bigger difference inclusive and exclusive time spent in `Uri.UnescapeDataString`

### GC Heap

> Before My Changes

![image](https://cloud.githubusercontent.com/assets/22899328/23326793/00b5f7bc-fab7-11e6-8584-b7294d7b393c.png)

* Callers to `Char[]`

![image](https://cloud.githubusercontent.com/assets/22899328/23326797/214fbb0c-fab7-11e6-954e-b60ad2d2d7e4.png)

> After My Changes

![image](https://cloud.githubusercontent.com/assets/22899328/23326780/cfbfad1a-fab6-11e6-9387-0c757d18c381.png)

* Callers to `Char[]`

![image](https://cloud.githubusercontent.com/assets/22899328/23326805/3b30d240-fab7-11e6-8c66-a0dc08247d77.png)

As we can see in this scenarios `Uri.UnescapeDataString` is allocating 0 `Char[]` and it reduced the allocations by 50% from 34,000 to 17,000.

## Here are the results for the asp.net test scenario:

### CPU Stacks

> Before My Changes

![image](https://cloud.githubusercontent.com/assets/22899328/23326631/6e1c4fb6-fab4-11e6-817e-ae2ee1e57d87.png)

> After My Changes

![image](https://cloud.githubusercontent.com/assets/22899328/23326605/29e8b1b8-fab4-11e6-8ac6-84e84d67d2d8.png)

As we can see after the changes `Uri.UnescapeDataString` went down on both exclusive (0.4%) and inclusive (0.1%) time.

### GC Heap

> Before My Changes

![image](https://cloud.githubusercontent.com/assets/22899328/23326694/527cbe52-fab5-11e6-985e-281f3b6db36d.png)

* Callers to `Char[]`

![image](https://cloud.githubusercontent.com/assets/22899328/23326703/664af5fc-fab5-11e6-90f5-d8ceb188c5fb.png)

> After My Changes

![image](https://cloud.githubusercontent.com/assets/22899328/23326654/c925cd9c-fab4-11e6-9d1b-c5a779ae208c.png)

* Callers to `Char[]`

![image](https://cloud.githubusercontent.com/assets/22899328/23326673/0c223f7c-fab5-11e6-90da-b27b29db8de2.png)

As we can see `Char[]` allocations went down 0.4% and in this particular scenario is around 7,500 less allocations when using `ArrayPool`. Also we can see on the callers that are creating this objects that if we use `ArrayPool` there is 0 `Char[]` allocations in `Uri.UnescapeDataString`


Now I'm keeping the old `UriHelper.UnescapeString` code and its dependencies around because in order to delete it there is a lot of work required because it is used a lot from internal APIs.

/cc @stephentoub @jkotas @danmosemsft 
