### PR TITLE
Enable Server Logging for ConnectionOpenTest

### DIFF
--- a/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
@@ -418,8 +418,9 @@ namespace System.Data.SqlClient.Tests
                     using (SqlConnection sqlConnection = new SqlConnection(connectionString))
                     {
                         sqlConnection.Open();
+                        Console.WriteLine("SqlClient.DiagnosticsTest.ConnectionOpenTest:: Connection Opened ");
                     }
-                });
+                }, true);
                 return SuccessExitCode;
             }).Dispose();
         }
@@ -472,7 +473,7 @@ namespace System.Data.SqlClient.Tests
             }).Dispose();
         }
 
-        private static void CollectStatisticsDiagnostics(Action<string> sqlOperation)
+        private static void CollectStatisticsDiagnostics(Action<string> sqlOperation, bool enableServerLogging = false)
         {
             bool statsLogged = false;
             bool operationHasError = false;
@@ -656,8 +657,8 @@ namespace System.Data.SqlClient.Tests
 
             diagnosticListenerObserver.Enable();
             using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
-            using (var server = TestTdsServer.StartServerWithQueryEngine(new DiagnosticsQueryEngine()))
-            { 
+            using (var server = TestTdsServer.StartServerWithQueryEngine(new DiagnosticsQueryEngine(), enableLog:enableServerLogging))
+            {
                 sqlOperation(server.ConnectionString);
 
                 Assert.True(statsLogged);


### PR DESCRIPTION
Enabling logging for the ConnectionOpenTest
Adding a Console Statement after connection open to see if the client completed login.

I have only covered ConnectionOpenTest to avoid any noise so that we diagnose this particular test in isolation.

cc @stephentoub @danmosemsft 