### PR TITLE
[ARM/CI] Fix CI failure for ubuntu arm

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -455,8 +455,8 @@ def buildArchConfiguration = ['Debug': 'x86',
 [true, false].each { isPR ->
     ['netcoreapp'].each { targetGroup ->
         ['Debug', 'Release'].each { configurationGroup ->
-            ['Ubuntu', 'Ubuntu16.04', 'Tizen'].each { osName ->
-                if (osName == "Ubuntu") {
+            ['Ubuntu14.04', 'Ubuntu16.04', 'Tizen'].each { osName ->
+                if (osName == "Ubuntu14.04") {
                     linuxCodeName="trusty"
                     abi = "arm"
                 }


### PR DESCRIPTION
This PR fixes two failing arm CI jobs which can be found in CI report of this PR.

[ARM/CI]  Use correct Ubuntu name for arm
Let's use "Ubuntu14.04" instead of "Ubuntu" for arm,
because "Ubuntu14.04" is defined and is being used for other architectures.

**Before:**
Following two CI jobs are failed when archiving binary files, because `Ubuntu` is not defined in `osGroupMap` of netci.groovy.
```
test innerloop Ubuntu arm Debug
test innerloop Ubuntu arm Release
```

**After:**
Following two CI jobs replace above two jobs and expected to work well after merging this PR.
```
test innerloop Ubuntu14.04 arm Debug
test innerloop Ubuntu14.04 arm Release
```