### PR TITLE
Add SendReceive tests for Task-based operations

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -936,6 +936,7 @@ namespace System.Net.Sockets.Tests
         public void BeginAccept_NotBound_Throws_InvalidOperation()
         {
             Assert.Throws<InvalidOperationException>(() => GetSocket().BeginAccept(TheAsyncCallback, null));
+            Assert.Throws<InvalidOperationException>(() => { GetSocket().AcceptAsync(); });
         }
 
         [Fact]
@@ -946,6 +947,7 @@ namespace System.Net.Sockets.Tests
                 socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
 
                 Assert.Throws<InvalidOperationException>(() => socket.BeginAccept(TheAsyncCallback, null));
+                Assert.Throws<InvalidOperationException>(() => { socket.AcceptAsync(); });
             }
         }
 
@@ -959,6 +961,7 @@ namespace System.Net.Sockets.Tests
         public void BeginConnect_EndPoint_NullEndPoint_Throws_ArgumentNull()
         {
             Assert.Throws<ArgumentNullException>(() => GetSocket().BeginConnect((EndPoint)null, TheAsyncCallback, null));
+            Assert.Throws<ArgumentNullException>(() => { GetSocket().ConnectAsync((EndPoint)null); });
         }
 
         [Fact]
@@ -969,26 +972,33 @@ namespace System.Net.Sockets.Tests
                 socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
                 socket.Listen(1);
                 Assert.Throws<InvalidOperationException>(() => socket.BeginConnect(new IPEndPoint(IPAddress.Loopback, 1), TheAsyncCallback, null));
+                Assert.Throws<InvalidOperationException>(() => { socket.ConnectAsync(new IPEndPoint(IPAddress.Loopback, 1)); });
             }
         }
 
         [Fact]
         public void BeginConnect_EndPoint_AddressFamily_Throws_NotSupported()
         {
-            Assert.Throws<NotSupportedException>(() => GetSocket(AddressFamily.InterNetwork).BeginConnect(new DnsEndPoint("localhost", 1, AddressFamily.InterNetworkV6), TheAsyncCallback, null));
+            Assert.Throws<NotSupportedException>(() => GetSocket(AddressFamily.InterNetwork).BeginConnect(
+                new DnsEndPoint("localhost", 1, AddressFamily.InterNetworkV6), TheAsyncCallback, null));
+            Assert.Throws<NotSupportedException>(() => { GetSocket(AddressFamily.InterNetwork).ConnectAsync(
+                new DnsEndPoint("localhost", 1, AddressFamily.InterNetworkV6)); });
         }
 
         [Fact]
         public void BeginConnect_Host_NullHost_Throws_ArgumentNull()
         {
             Assert.Throws<ArgumentNullException>(() => GetSocket().BeginConnect((string)null, 1, TheAsyncCallback, null));
+            Assert.Throws<ArgumentNullException>(() => { GetSocket().ConnectAsync((string)null, 1); });
         }
 
-        [Fact]
-        public void BeginConnect_Host_InvalidPort_Throws_ArgumentOutOfRange()
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(65536)]
+        public void BeginConnect_Host_InvalidPort_Throws_ArgumentOutOfRange(int port)
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginConnect("localhost", -1, TheAsyncCallback, null));
-            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginConnect("localhost", 65536, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginConnect("localhost", port, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => { GetSocket().ConnectAsync("localhost", port); });
         }
 
         [Fact]
@@ -999,6 +1009,7 @@ namespace System.Net.Sockets.Tests
                 socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
                 socket.Listen(1);
                 Assert.Throws<InvalidOperationException>(() => socket.BeginConnect("localhost", 1, TheAsyncCallback, null));
+                Assert.Throws<InvalidOperationException>(() => { socket.ConnectAsync("localhost", 1); });
             }
         }
 
@@ -1006,38 +1017,46 @@ namespace System.Net.Sockets.Tests
         public void BeginConnect_IPAddress_NullIPAddress_Throws_ArgumentNull()
         {
             Assert.Throws<ArgumentNullException>(() => GetSocket().BeginConnect((IPAddress)null, 1, TheAsyncCallback, null));
+            Assert.Throws<ArgumentNullException>(() => { GetSocket().ConnectAsync((IPAddress)null, 1); });
         }
 
-        [Fact]
-        public void BeginConnect_IPAddress_InvalidPort_Throws_ArgumentOutOfRange()
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(65536)]
+        public void BeginConnect_IPAddress_InvalidPort_Throws_ArgumentOutOfRange(int port)
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginConnect(IPAddress.Loopback, -1, TheAsyncCallback, null));
-            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginConnect(IPAddress.Loopback, 65536, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginConnect(IPAddress.Loopback, port, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => { GetSocket().ConnectAsync(IPAddress.Loopback, 65536); });
         }
 
         [Fact]
         public void BeginConnect_IPAddress_AddressFamily_Throws_NotSupported()
         {
             Assert.Throws<NotSupportedException>(() => GetSocket(AddressFamily.InterNetwork).BeginConnect(IPAddress.IPv6Loopback, 1, TheAsyncCallback, null));
+            Assert.Throws<NotSupportedException>(() => { GetSocket(AddressFamily.InterNetwork).ConnectAsync(IPAddress.IPv6Loopback, 1); });
         }
 
         [Fact]
         public void BeginConnect_IPAddresses_NullIPAddresses_Throws_ArgumentNull()
         {
             Assert.Throws<ArgumentNullException>(() => GetSocket().BeginConnect((IPAddress[])null, 1, TheAsyncCallback, null));
+            Assert.Throws<ArgumentNullException>(() => { GetSocket().ConnectAsync((IPAddress[])null, 1); });
         }
 
         [Fact]
         public void BeginConnect_IPAddresses_EmptyIPAddresses_Throws_Argument()
         {
             Assert.Throws<ArgumentException>(() => GetSocket().BeginConnect(new IPAddress[0], 1, TheAsyncCallback, null));
+            Assert.Throws<ArgumentException>(() => { GetSocket().ConnectAsync(new IPAddress[0], 1); });
         }
 
-        [Fact]
-        public void BeginConnect_IPAddresses_InvalidPort_Throws_ArgumentOutOfRange()
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(65536)]
+        public void BeginConnect_IPAddresses_InvalidPort_Throws_ArgumentOutOfRange(int port)
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginConnect(new[] { IPAddress.Loopback }, -1, TheAsyncCallback, null));
-            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginConnect(new[] { IPAddress.Loopback }, 65536, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginConnect(new[] { IPAddress.Loopback }, port, TheAsyncCallback, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => { GetSocket().ConnectAsync(new[] { IPAddress.Loopback }, port); });
         }
 
         [Fact]
@@ -1048,6 +1067,13 @@ namespace System.Net.Sockets.Tests
                 socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
                 socket.Listen(1);
                 Assert.Throws<InvalidOperationException>(() => socket.BeginConnect(new[] { IPAddress.Loopback }, 1, TheAsyncCallback, null));
+            }
+
+            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                socket.Listen(1);
+                Assert.Throws<InvalidOperationException>(() => { socket.ConnectAsync(new[] { IPAddress.Loopback }, 1); });
             }
         }
 
@@ -1061,6 +1087,7 @@ namespace System.Net.Sockets.Tests
         public void BeginSend_Buffer_NullBuffer_Throws_ArgumentNull()
         {
             Assert.Throws<ArgumentNullException>(() => GetSocket().BeginSend(null, 0, 0, SocketFlags.None, TheAsyncCallback, null));
+            Assert.Throws<ArgumentNullException>(() => { GetSocket().SendAsync(new ArraySegment<byte>(null, 0, 0), SocketFlags.None); });
         }
 
         [Fact]
@@ -1068,6 +1095,9 @@ namespace System.Net.Sockets.Tests
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSend(s_buffer, -1, 0, SocketFlags.None, TheAsyncCallback, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSend(s_buffer, s_buffer.Length + 1, 0, SocketFlags.None, TheAsyncCallback, null));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { GetSocket().SendAsync(new ArraySegment<byte>(s_buffer, -1, 0), SocketFlags.None); });
+            Assert.ThrowsAny<ArgumentException>(() => { GetSocket().SendAsync(new ArraySegment<byte>(s_buffer, s_buffer.Length + 1, 0), SocketFlags.None); });
         }
 
         [Fact]
@@ -1076,18 +1106,24 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSend(s_buffer, 0, -1, SocketFlags.None, TheAsyncCallback, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSend(s_buffer, 0, s_buffer.Length + 1, SocketFlags.None, TheAsyncCallback, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSend(s_buffer, s_buffer.Length, 1, SocketFlags.None, TheAsyncCallback, null));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { GetSocket().SendAsync(new ArraySegment<byte>(s_buffer, 0, -1), SocketFlags.None); });
+            Assert.ThrowsAny<ArgumentException>(() => { GetSocket().SendAsync(new ArraySegment<byte>(s_buffer, 0, s_buffer.Length + 1), SocketFlags.None); });
+            Assert.ThrowsAny<ArgumentException>(() => { GetSocket().SendAsync(new ArraySegment<byte>(s_buffer, s_buffer.Length, 1), SocketFlags.None); });
         }
 
         [Fact]
         public void BeginSend_Buffers_NullBuffers_Throws_ArgumentNull()
         {
             Assert.Throws<ArgumentNullException>(() => GetSocket().BeginSend(null, SocketFlags.None, TheAsyncCallback, null));
+            Assert.Throws<ArgumentNullException>(() => { GetSocket().SendAsync(null, SocketFlags.None); });
         }
 
         [Fact]
         public void BeginSend_Buffers_EmptyBuffers_Throws_Argument()
         {
             Assert.Throws<ArgumentException>(() => GetSocket().BeginSend(new List<ArraySegment<byte>>(), SocketFlags.None, TheAsyncCallback, null));
+            Assert.Throws<ArgumentException>(() => { GetSocket().SendAsync(new List<ArraySegment<byte>>(), SocketFlags.None); });
         }
 
         [Fact]
@@ -1100,29 +1136,40 @@ namespace System.Net.Sockets.Tests
         public void BeginSendTo_NullBuffer_Throws_ArgumentNull()
         {
             Assert.Throws<ArgumentNullException>(() => GetSocket().BeginSendTo(null, 0, 0, SocketFlags.None, new IPEndPoint(IPAddress.Loopback, 1), TheAsyncCallback, null));
+            Assert.Throws<ArgumentNullException>(() => { GetSocket().SendToAsync(new ArraySegment<byte>(null, 0, 0), SocketFlags.None, new IPEndPoint(IPAddress.Loopback, 1)); });
         }
 
         [Fact]
         public void BeginSendTo_NullEndPoint_Throws_ArgumentNull()
         {
             Assert.Throws<ArgumentNullException>(() => GetSocket().BeginSendTo(s_buffer, 0, 0, SocketFlags.None, null, TheAsyncCallback, null));
+            Assert.Throws<ArgumentNullException>(() => { GetSocket().SendToAsync(new ArraySegment<byte>(s_buffer, 0, 0), SocketFlags.None, null); });
         }
 
         [Fact]
         public void BeginSendTo_InvalidOffset_Throws_ArgumentOutOfRange()
         {
             EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
+
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSendTo(s_buffer, -1, s_buffer.Length, SocketFlags.None, endpoint, TheAsyncCallback, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSendTo(s_buffer, s_buffer.Length + 1, s_buffer.Length, SocketFlags.None, endpoint, TheAsyncCallback, null));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { GetSocket().SendToAsync(new ArraySegment<byte>(s_buffer, -1, s_buffer.Length), SocketFlags.None, endpoint); });
+            Assert.ThrowsAny<ArgumentException>(() => { GetSocket().SendToAsync(new ArraySegment<byte>(s_buffer, s_buffer.Length + 1, s_buffer.Length), SocketFlags.None, endpoint); });
         }
 
         [Fact]
         public void BeginSendTo_InvalidSize_Throws_ArgumentOutOfRange()
         {
             EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
+
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSendTo(s_buffer, 0, -1, SocketFlags.None, endpoint, TheAsyncCallback, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSendTo(s_buffer, 0, s_buffer.Length + 1, SocketFlags.None, endpoint, TheAsyncCallback, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginSendTo(s_buffer, s_buffer.Length, 1, SocketFlags.None, endpoint, TheAsyncCallback, null));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { GetSocket().SendToAsync(new ArraySegment<byte>(s_buffer, 0, -1), SocketFlags.None, endpoint); });
+            Assert.ThrowsAny<ArgumentException>(() => { GetSocket().SendToAsync(new ArraySegment<byte>(s_buffer, 0, s_buffer.Length + 1), SocketFlags.None, endpoint); });
+            Assert.ThrowsAny<ArgumentException>(() => { GetSocket().SendToAsync(new ArraySegment<byte>(s_buffer, s_buffer.Length, 1), SocketFlags.None, endpoint); });
         }
 
         [Fact]
@@ -1135,6 +1182,7 @@ namespace System.Net.Sockets.Tests
         public void BeginReceive_Buffer_NullBuffer_Throws_ArgumentNull()
         {
             Assert.Throws<ArgumentNullException>(() => GetSocket().BeginReceive(null, 0, 0, SocketFlags.None, TheAsyncCallback, null));
+            Assert.Throws<ArgumentNullException>(() => { GetSocket().ReceiveAsync(new ArraySegment<byte>(null, 0, 0), SocketFlags.None); });
         }
 
         [Fact]
@@ -1142,6 +1190,9 @@ namespace System.Net.Sockets.Tests
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceive(s_buffer, -1, 0, SocketFlags.None, TheAsyncCallback, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceive(s_buffer, s_buffer.Length + 1, 0, SocketFlags.None, TheAsyncCallback, null));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { GetSocket().ReceiveAsync(new ArraySegment<byte>(s_buffer, -1, 0), SocketFlags.None); });
+            Assert.ThrowsAny<ArgumentException>(() => { GetSocket().ReceiveAsync(new ArraySegment<byte>(s_buffer, s_buffer.Length + 1, 0), SocketFlags.None); });
         }
 
         [Fact]
@@ -1150,18 +1201,24 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceive(s_buffer, 0, -1, SocketFlags.None, TheAsyncCallback, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceive(s_buffer, 0, s_buffer.Length + 1, SocketFlags.None, TheAsyncCallback, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceive(s_buffer, s_buffer.Length, 1, SocketFlags.None, TheAsyncCallback, null));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { GetSocket().ReceiveAsync(new ArraySegment<byte>(s_buffer, 0, -1), SocketFlags.None); });
+            Assert.ThrowsAny<ArgumentException>(() => { GetSocket().ReceiveAsync(new ArraySegment<byte>(s_buffer, 0, s_buffer.Length + 1), SocketFlags.None); });
+            Assert.ThrowsAny<ArgumentException>(() => { GetSocket().ReceiveAsync(new ArraySegment<byte>(s_buffer, s_buffer.Length, 1), SocketFlags.None); });
         }
 
         [Fact]
         public void BeginReceive_Buffers_NullBuffers_Throws_ArgumentNull()
         {
             Assert.Throws<ArgumentNullException>(() => GetSocket().BeginReceive(null, SocketFlags.None, TheAsyncCallback, null));
+            Assert.Throws<ArgumentNullException>(() => { GetSocket().ReceiveAsync(null, SocketFlags.None); });
         }
 
         [Fact]
         public void BeginReceive_Buffers_EmptyBuffers_Throws_Argument()
         {
             Assert.Throws<ArgumentException>(() => GetSocket().BeginReceive(new List<ArraySegment<byte>>(), SocketFlags.None, TheAsyncCallback, null));
+            Assert.Throws<ArgumentException>(() => { GetSocket().ReceiveAsync(new List<ArraySegment<byte>>(), SocketFlags.None); });
         }
 
         [Fact]
@@ -1175,6 +1232,7 @@ namespace System.Net.Sockets.Tests
         {
             EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
             Assert.Throws<ArgumentNullException>(() => GetSocket().BeginReceiveFrom(null, 0, 0, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
+            Assert.Throws<ArgumentNullException>(() => { GetSocket().ReceiveFromAsync(new ArraySegment<byte>(null, 0, 0), SocketFlags.None, endpoint); });
         }
 
         [Fact]
@@ -1182,6 +1240,7 @@ namespace System.Net.Sockets.Tests
         {
             EndPoint endpoint = null;
             Assert.Throws<ArgumentNullException>(() => GetSocket().BeginReceiveFrom(s_buffer, 0, 0, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
+            Assert.Throws<ArgumentNullException>(() => { GetSocket().ReceiveFromAsync(new ArraySegment<byte>(s_buffer, 0, 0), SocketFlags.None, endpoint); });
         }
 
         [Fact]
@@ -1189,23 +1248,33 @@ namespace System.Net.Sockets.Tests
         {
             EndPoint endpoint = new IPEndPoint(IPAddress.IPv6Loopback, 1);
             Assert.Throws<ArgumentException>(() => GetSocket(AddressFamily.InterNetwork).BeginReceiveFrom(s_buffer, 0, 0, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
+            Assert.Throws<ArgumentException>(() => { GetSocket(AddressFamily.InterNetwork).ReceiveFromAsync(new ArraySegment<byte>(s_buffer, 0, 0), SocketFlags.None, endpoint); });
         }
 
         [Fact]
         public void BeginReceiveFrom_InvalidOffset_Throws_ArgumentOutOfRange()
         {
             EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
+
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveFrom(s_buffer, -1, s_buffer.Length, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveFrom(s_buffer, s_buffer.Length + 1, s_buffer.Length, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { GetSocket().ReceiveFromAsync(new ArraySegment<byte>(s_buffer, -1, s_buffer.Length), SocketFlags.None, endpoint); });
+            Assert.ThrowsAny<ArgumentException>(() => { GetSocket().ReceiveFromAsync(new ArraySegment<byte>(s_buffer, s_buffer.Length + 1, s_buffer.Length), SocketFlags.None, endpoint); });
         }
 
         [Fact]
         public void BeginReceiveFrom_InvalidSize_Throws_ArgumentOutOfRange()
         {
             EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
+
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveFrom(s_buffer, 0, -1, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveFrom(s_buffer, 0, s_buffer.Length + 1, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveFrom(s_buffer, s_buffer.Length, 1, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { GetSocket().ReceiveFromAsync(new ArraySegment<byte>(s_buffer, 0, -1), SocketFlags.None, endpoint); });
+            Assert.ThrowsAny<ArgumentException>(() => { GetSocket().ReceiveFromAsync(new ArraySegment<byte>(s_buffer, 0, s_buffer.Length + 1), SocketFlags.None, endpoint); });
+            Assert.ThrowsAny<ArgumentException>(() => { GetSocket().ReceiveFromAsync(new ArraySegment<byte>(s_buffer, s_buffer.Length, 1), SocketFlags.None, endpoint); });
         }
 
         [Fact]
@@ -1213,6 +1282,7 @@ namespace System.Net.Sockets.Tests
         {
             EndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 1);
             Assert.Throws<InvalidOperationException>(() => GetSocket().BeginReceiveFrom(s_buffer, 0, 0, SocketFlags.None, ref endpoint, TheAsyncCallback, null));
+            Assert.Throws<InvalidOperationException>(() => { GetSocket().ReceiveFromAsync(new ArraySegment<byte>(s_buffer, 0, 0), SocketFlags.None, endpoint); });
         }
 
         [Fact]
@@ -1228,6 +1298,7 @@ namespace System.Net.Sockets.Tests
             EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
 
             Assert.Throws<ArgumentNullException>(() => GetSocket().BeginReceiveMessageFrom(null, 0, 0, SocketFlags.None, ref remote, TheAsyncCallback, null));
+            Assert.Throws<ArgumentNullException>(() => { GetSocket().ReceiveMessageFromAsync(new ArraySegment<byte>(null, 0, 0), SocketFlags.None, remote); });
         }
 
         [Fact]
@@ -1236,6 +1307,7 @@ namespace System.Net.Sockets.Tests
             EndPoint remote = null;
 
             Assert.Throws<ArgumentNullException>(() => GetSocket().BeginReceiveMessageFrom(s_buffer, 0, 0, SocketFlags.None, ref remote, TheAsyncCallback, null));
+            Assert.Throws<ArgumentNullException>(() => { GetSocket().ReceiveMessageFromAsync(new ArraySegment<byte>(s_buffer, 0, 0), SocketFlags.None, remote); });
         }
 
         [Fact]
@@ -1244,6 +1316,7 @@ namespace System.Net.Sockets.Tests
             EndPoint remote = new IPEndPoint(IPAddress.IPv6Loopback, 1);
 
             Assert.Throws<ArgumentException>(() => GetSocket(AddressFamily.InterNetwork).BeginReceiveMessageFrom(s_buffer, 0, 0, SocketFlags.None, ref remote, TheAsyncCallback, null));
+            Assert.Throws<ArgumentException>(() => { GetSocket(AddressFamily.InterNetwork).ReceiveMessageFromAsync(new ArraySegment<byte>(s_buffer, 0, 0), SocketFlags.None, remote); });
         }
 
         [Fact]
@@ -1253,6 +1326,9 @@ namespace System.Net.Sockets.Tests
 
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveMessageFrom(s_buffer, -1, s_buffer.Length, SocketFlags.None, ref remote, TheAsyncCallback, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveMessageFrom(s_buffer, s_buffer.Length + 1, s_buffer.Length, SocketFlags.None, ref remote, TheAsyncCallback, null));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { GetSocket().ReceiveMessageFromAsync(new ArraySegment<byte>(s_buffer, -1, s_buffer.Length), SocketFlags.None, remote); });
+            Assert.ThrowsAny<ArgumentException>(() => { GetSocket().ReceiveMessageFromAsync(new ArraySegment<byte>(s_buffer, s_buffer.Length + 1, s_buffer.Length), SocketFlags.None, remote); });
         }
 
         [Fact]
@@ -1263,6 +1339,10 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveMessageFrom(s_buffer, 0, -1, SocketFlags.None, ref remote, TheAsyncCallback, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveMessageFrom(s_buffer, 0, s_buffer.Length + 1, SocketFlags.None, ref remote, TheAsyncCallback, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().BeginReceiveMessageFrom(s_buffer, s_buffer.Length, 1, SocketFlags.None, ref remote, TheAsyncCallback, null));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { GetSocket().ReceiveMessageFromAsync(new ArraySegment<byte>(s_buffer, 0, -1), SocketFlags.None, remote); });
+            Assert.ThrowsAny<ArgumentException>(() => { GetSocket().ReceiveMessageFromAsync(new ArraySegment<byte>(s_buffer, 0, s_buffer.Length + 1), SocketFlags.None, remote); });
+            Assert.ThrowsAny<ArgumentException>(() => { GetSocket().ReceiveMessageFromAsync(new ArraySegment<byte>(s_buffer, s_buffer.Length, 1), SocketFlags.None, remote); });
         }
 
         [Fact]
@@ -1271,6 +1351,7 @@ namespace System.Net.Sockets.Tests
             EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
 
             Assert.Throws<InvalidOperationException>(() => GetSocket().BeginReceiveMessageFrom(s_buffer, 0, 0, SocketFlags.None, ref remote, TheAsyncCallback, null));
+            Assert.Throws<InvalidOperationException>(() => { GetSocket().ReceiveMessageFromAsync(new ArraySegment<byte>(s_buffer, 0, 0), SocketFlags.None, remote); });
         }
 
         [Fact]

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -20,7 +20,10 @@ namespace System.Net.Sockets.Tests
             _log = output;
         }
 
-        private static void SendToRecvFrom_Datagram_UDP(IPAddress leftAddress, IPAddress rightAddress)
+        [OuterLoop] // TODO: Issue #11345
+        [Theory]
+        [MemberData(nameof(LoopbacksToSameLoopback))]
+        public static void SendToRecvFrom_Datagram_UDP(IPAddress leftAddress, IPAddress rightAddress)
         {
             // TODO #5185: Harden against packet loss
             const int DatagramSize = 256;
@@ -95,7 +98,10 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        private static void SendToRecvFromAPM_Datagram_UDP(IPAddress leftAddress, IPAddress rightAddress)
+        [OuterLoop] // TODO: Issue #11345
+        [Theory]
+        [MemberData(nameof(LoopbacksToSameLoopback))]
+        public static void SendToRecvFromAPM_Datagram_UDP(IPAddress leftAddress, IPAddress rightAddress)
         {
             // TODO #5185: Harden against packet loss
             const int DatagramSize = 256;
@@ -217,7 +223,10 @@ namespace System.Net.Sockets.Tests
             }
         }
 		
-        private static void SendRecv_Stream_TCP(IPAddress listenAt, bool useMultipleBuffers)
+        [OuterLoop] // TODO: Issue #11345
+        [Theory]
+        [MemberData(nameof(LoopbacksAndBuffers))]
+        public static void SendRecv_Stream_TCP(IPAddress listenAt, bool useMultipleBuffers)
         {
             const int BytesToSend = 123456;
             const int ListenBacklog = 1;
@@ -347,7 +356,10 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
         }
 
-        private static void SendRecvAPM_Stream_TCP(IPAddress listenAt, bool useMultipleBuffers)
+        [OuterLoop] // TODO: Issue #11345
+        [Theory]
+        [MemberData(nameof(LoopbacksAndBuffers))]
+        public static void SendRecvAPM_Stream_TCP(IPAddress listenAt, bool useMultipleBuffers)
         {
             const int BytesToSend = 123456;
             const int ListenBacklog = 1;
@@ -529,98 +541,8 @@ namespace System.Net.Sockets.Tests
         }
 
         [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        public void SendToRecvFrom_Single_Datagram_UDP_IPv6()
-        {
-            SendToRecvFrom_Datagram_UDP(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        public void SendToRecvFromAPM_Single_Datagram_UDP_IPv6()
-        {
-            SendToRecvFromAPM_Datagram_UDP(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        public void SendToRecvFrom_Single_Datagram_UDP_IPv4()
-        {
-            SendToRecvFrom_Datagram_UDP(IPAddress.Loopback, IPAddress.Loopback);
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        public void SendToRecvFromAPM_Single_Datagram_UDP_IPv4()
-        {
-            SendToRecvFromAPM_Datagram_UDP(IPAddress.Loopback, IPAddress.Loopback);
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        public void SendRecv_Multiple_Stream_TCP_IPv6()
-        {
-            SendRecv_Stream_TCP(IPAddress.IPv6Loopback, useMultipleBuffers: true);
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        public void SendRecvAPM_Multiple_Stream_TCP_IPv6()
-        {
-            SendRecvAPM_Stream_TCP(IPAddress.IPv6Loopback, useMultipleBuffers: true);
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        public void SendRecv_Single_Stream_TCP_IPv6()
-        {
-            SendRecv_Stream_TCP(IPAddress.IPv6Loopback, useMultipleBuffers: false);
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        public void SendRecvAPM_Single_Stream_TCP_IPv6()
-        {
-            SendRecvAPM_Stream_TCP(IPAddress.IPv6Loopback, useMultipleBuffers: false);
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        public void SendRecv_Multiple_Stream_TCP_IPv4()
-        {
-            SendRecv_Stream_TCP(IPAddress.Loopback, useMultipleBuffers: true);
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        public void SendRecvAPM_Multiple_Stream_TCP_IPv4()
-        {
-            SendRecvAPM_Stream_TCP(IPAddress.Loopback, useMultipleBuffers: true);
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        public void SendRecv_Single_Stream_TCP_IPv4()
-        {
-            SendRecv_Stream_TCP(IPAddress.Loopback, useMultipleBuffers: false);
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [Fact]
-        public void SendRecvAPM_Single_Stream_TCP_IPv4()
-        {
-            SendRecvAPM_Stream_TCP(IPAddress.Loopback, useMultipleBuffers: false);
-        }
-
-        public static readonly object[][] SendToRecvFromAsync_Datagram_UDP_Socket_MemberData = new object[][]
-        {
-            new object[] { IPAddress.IPv6Loopback, IPAddress.IPv6Loopback },
-            new object[] { IPAddress.Loopback, IPAddress.Loopback }
-        };
-
-        [OuterLoop] // TODO: Issue #11345
         [Theory]
-        [MemberData(nameof(SendToRecvFromAsync_Datagram_UDP_Socket_MemberData))]
+        [MemberData(nameof(LoopbacksToSameLoopback))]
         public void SendToRecvFromAsync_Datagram_UDP(IPAddress leftAddress, IPAddress rightAddress)
         {
             // TODO #5185: harden against packet loss
@@ -746,15 +668,9 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        public static readonly object[][] SendToRecvFromAsync_Datagram_UDP_UdpClient_MemberData = new object[][]
-        {
-            new object[] { IPAddress.IPv6Loopback, IPAddress.IPv6Loopback },
-            new object[] { IPAddress.Loopback, IPAddress.Loopback }
-        };
-
         [OuterLoop] // TODO: Issue #11345
         [Theory]
-        [MemberData(nameof(SendToRecvFromAsync_Datagram_UDP_Socket_MemberData))]
+        [MemberData(nameof(LoopbacksToSameLoopback))]
         public void SendToRecvFromAsync_Datagram_UDP_UdpClient(IPAddress leftAddress, IPAddress rightAddress)
         {
             // TODO #5185: harden against packet loss
@@ -828,17 +744,9 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        public static readonly object[][] SendRecvAsync_Stream_TCP_MemberData = new object[][]
-        {
-            new object[] { IPAddress.IPv6Loopback, true },
-            new object[] { IPAddress.IPv6Loopback, false },
-            new object[] { IPAddress.Loopback, true },
-            new object[] { IPAddress.Loopback, false },
-        };
-
         [OuterLoop] // TODO: Issue #11345
         [Theory]
-        [MemberData(nameof(SendRecvAsync_Stream_TCP_MemberData))]
+        [MemberData(nameof(LoopbacksAndBuffers))]
         public void SendRecvAsync_Stream_TCP(IPAddress listenAt, bool useMultipleBuffers)
         {
             const int BytesToSend = 123456;
@@ -1024,15 +932,9 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
         }
 
-        public static readonly object[][] SendRecvAsync_TcpListener_TcpClient_MemberData = new[]
-        {
-            new object[] { IPAddress.Loopback },
-            new object[] { IPAddress.IPv6Loopback },
-        };
-
         [OuterLoop] // TODO: Issue #11345
         [Theory]
-        [MemberData(nameof(SendRecvAsync_TcpListener_TcpClient_MemberData))]
+        [MemberData(nameof(Loopbacks))]
         public void SendRecvAsync_TcpListener_TcpClient(IPAddress listenAt)
         {
             const int BytesToSend = 123456;
@@ -1101,17 +1003,9 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
         }
 
-        public static readonly object[][] SendRecvPollSync_TcpListener_TcpClient_MemberData = new[]
-        {
-            new object[] { IPAddress.Loopback, true },
-            new object[] { IPAddress.Loopback, false },
-            new object[] { IPAddress.IPv6Loopback, true },
-            new object[] { IPAddress.IPv6Loopback, false },
-        };
-
         [OuterLoop] // TODO: Issue #11345
         [Theory]
-        [MemberData(nameof(SendRecvPollSync_TcpListener_TcpClient_MemberData))]
+        [MemberData(nameof(LoopbacksAndBuffers))]
         public void SendRecvPollSync_TcpListener_Socket(IPAddress listenAt, bool pollBeforeOperation)
         {
             const int BytesToSend = 123456;
@@ -1239,5 +1133,25 @@ namespace System.Net.Sockets.Tests
                 }
             }
         }
+
+        public static readonly object[][] Loopbacks = new[]
+        {
+            new object[] { IPAddress.Loopback },
+            new object[] { IPAddress.IPv6Loopback },
+        };
+
+        public static readonly object[][] LoopbacksAndBuffers = new object[][]
+        {
+            new object[] { IPAddress.IPv6Loopback, true },
+            new object[] { IPAddress.IPv6Loopback, false },
+            new object[] { IPAddress.Loopback, true },
+            new object[] { IPAddress.Loopback, false },
+        };
+
+        public static readonly object[][] LoopbacksToSameLoopback = new object[][]
+        {
+            new object[] { IPAddress.IPv6Loopback, IPAddress.IPv6Loopback },
+            new object[] { IPAddress.Loopback, IPAddress.Loopback }
+        };
     }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -11,7 +11,7 @@ using Xunit.Abstractions;
 
 namespace System.Net.Sockets.Tests
 {
-    public class SendReceive
+    public abstract class SendReceive : MemberDatas
     {
         private readonly ITestOutputHelper _log;
 
@@ -20,11 +20,23 @@ namespace System.Net.Sockets.Tests
             _log = output;
         }
 
+        public abstract Task<Socket> AcceptAsync(Socket s);
+        public abstract Task ConnectAsync(Socket s, EndPoint endPoint);
+        public abstract Task<int> ReceiveAsync(Socket s, ArraySegment<byte> buffer);
+        public abstract Task<SocketReceiveFromResult> ReceiveFromAsync(
+            Socket s, ArraySegment<byte> buffer, EndPoint endPoint);
+        public abstract Task<int> ReceiveAsync(Socket s, IList<ArraySegment<byte>> bufferList);
+        public abstract Task<int> SendAsync(Socket s, ArraySegment<byte> buffer);
+        public abstract Task<int> SendAsync(Socket s, IList<ArraySegment<byte>> bufferList);
+        public abstract Task<int> SendToAsync(Socket s, ArraySegment<byte> buffer, EndPoint endpoint);
+
         [OuterLoop] // TODO: Issue #11345
         [Theory]
-        [MemberData(nameof(LoopbacksToSameLoopback))]
-        public static void SendToRecvFrom_Datagram_UDP(IPAddress leftAddress, IPAddress rightAddress)
+        [MemberData(nameof(Loopbacks))]
+        public async Task SendToRecvFrom_Datagram_UDP(IPAddress loopbackAddress)
         {
+            IPAddress leftAddress = loopbackAddress, rightAddress = loopbackAddress;
+
             // TODO #5185: Harden against packet loss
             const int DatagramSize = 256;
             const int DatagramsToSend = 256;
@@ -40,11 +52,11 @@ namespace System.Net.Sockets.Tests
             var leftEndpoint = (IPEndPoint)left.LocalEndPoint;
             var rightEndpoint = (IPEndPoint)right.LocalEndPoint;
 
-            var receiverAck = new ManualResetEventSlim();
-            var senderAck = new ManualResetEventSlim();
+            var receiverAck = new SemaphoreSlim(0);
+            var senderAck = new SemaphoreSlim(0);
 
             var receivedChecksums = new uint?[DatagramsToSend];
-            var leftThread = new Thread(() =>
+            Task leftThread = Task.Run(async () =>
             {
                 using (left)
                 {
@@ -52,22 +64,20 @@ namespace System.Net.Sockets.Tests
                     var recvBuffer = new byte[DatagramSize];
                     for (int i = 0; i < DatagramsToSend; i++)
                     {
-                        int received = left.ReceiveFrom(recvBuffer, SocketFlags.None, ref remote);
-                        Assert.Equal(DatagramSize, received);
-                        Assert.Equal(rightEndpoint, remote);
+                        SocketReceiveFromResult result = await ReceiveFromAsync(
+                            left, new ArraySegment<byte>(recvBuffer), remote);
+                        Assert.Equal(DatagramSize, result.ReceivedBytes);
+                        Assert.Equal(rightEndpoint, result.RemoteEndPoint);
 
-                        int datagramId = (int)recvBuffer[0];
+                        int datagramId = recvBuffer[0];
                         Assert.Null(receivedChecksums[datagramId]);
-                        receivedChecksums[datagramId] = Fletcher32.Checksum(recvBuffer, 0, received);
+                        receivedChecksums[datagramId] = Fletcher32.Checksum(recvBuffer, 0, result.ReceivedBytes);
 
-                        receiverAck.Set();
-                        Assert.True(senderAck.Wait(AckTimeout));
-                        senderAck.Reset();
+                        receiverAck.Release();
+                        Assert.True(await senderAck.WaitAsync(TestTimeout));
                     }
                 }
             });
-
-            leftThread.Start();
 
             var sentChecksums = new uint[DatagramsToSend];
             using (right)
@@ -79,18 +89,17 @@ namespace System.Net.Sockets.Tests
                     random.NextBytes(sendBuffer);
                     sendBuffer[0] = (byte)i;
 
-                    int sent = right.SendTo(sendBuffer, SocketFlags.None, leftEndpoint);
+                    int sent = await SendToAsync(right, new ArraySegment<byte>(sendBuffer), leftEndpoint);
 
-                    Assert.True(receiverAck.Wait(AckTimeout));
-                    receiverAck.Reset();
-                    senderAck.Set();
+                    Assert.True(await receiverAck.WaitAsync(AckTimeout));
+                    senderAck.Release();
 
                     Assert.Equal(DatagramSize, sent);
                     sentChecksums[i] = Fletcher32.Checksum(sendBuffer, 0, sent);
                 }
             }
 
-            Assert.True(leftThread.Join(TestTimeout));
+            await leftThread;
             for (int i = 0; i < DatagramsToSend; i++)
             {
                 Assert.NotNull(receivedChecksums[i]);
@@ -98,163 +107,30 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
-        [Theory]
-        [MemberData(nameof(LoopbacksToSameLoopback))]
-        public static void SendToRecvFromAPM_Datagram_UDP(IPAddress leftAddress, IPAddress rightAddress)
-        {
-            // TODO #5185: Harden against packet loss
-            const int DatagramSize = 256;
-            const int DatagramsToSend = 256;
-            const int AckTimeout = 1000;
-            const int TestTimeout = 30000;
-
-            var left = new Socket(leftAddress.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
-            left.BindToAnonymousPort(leftAddress);
-
-            var right = new Socket(rightAddress.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
-            right.BindToAnonymousPort(rightAddress);
-
-            var leftEndpoint = (IPEndPoint)left.LocalEndPoint;
-            var rightEndpoint = (IPEndPoint)right.LocalEndPoint;
-
-            var receiverAck = new ManualResetEventSlim();
-            var senderAck = new ManualResetEventSlim();
-
-            EndPoint receiveRemote = leftEndpoint.Create(leftEndpoint.Serialize());
-            var receiverFinished = new TaskCompletionSource<bool>();
-            var receivedChecksums = new uint?[DatagramsToSend];
-            var receiveBuffer = new byte[DatagramSize];
-            int receivedDatagrams = -1;
-
-            Action<int, EndPoint> receiveHandler = null;
-            receiveHandler = (received, remote) =>
-            {
-                try
-                {
-                    if (receivedDatagrams != -1)
-                    {
-                        Assert.Equal(DatagramSize, received);
-                        Assert.Equal(rightEndpoint, remote);
-
-                        int datagramId = (int)receiveBuffer[0];
-                        Assert.Null(receivedChecksums[datagramId]);
-                        receivedChecksums[datagramId] = Fletcher32.Checksum(receiveBuffer, 0, received);
-
-                        receiverAck.Set();
-                        Assert.True(senderAck.Wait(AckTimeout));
-                        senderAck.Reset();
-
-                        receivedDatagrams++;
-                        if (receivedDatagrams == DatagramsToSend)
-                        {
-                            left.Dispose();
-                            receiverFinished.SetResult(true);
-                            return;
-                        }
-                    }
-                    else
-                    {
-                        receivedDatagrams = 0;
-                    }
-
-                    left.ReceiveFromAPM(receiveBuffer, 0, receiveBuffer.Length, SocketFlags.None, receiveRemote, receiveHandler);
-                }
-                catch (Exception ex)
-                {
-                    receiverFinished.SetException(ex);
-                }
-            };
-
-            receiveHandler(0, null);
-
-            var random = new Random();
-            var senderFinished = new TaskCompletionSource<bool>();
-            var sentChecksums = new uint[DatagramsToSend];
-            var sendBuffer = new byte[DatagramSize];
-            int sentDatagrams = -1;
-
-            Action<int> sendHandler = null;
-            sendHandler = sent =>
-            {
-                try
-                {
-                    if (sentDatagrams != -1)
-                    {
-                        Assert.True(receiverAck.Wait(AckTimeout));
-                        receiverAck.Reset();
-                        senderAck.Set();
-
-                        Assert.Equal(DatagramSize, sent);
-                        sentChecksums[sentDatagrams] = Fletcher32.Checksum(sendBuffer, 0, sent);
-
-                        sentDatagrams++;
-                        if (sentDatagrams == DatagramsToSend)
-                        {
-                            right.Dispose();
-                            senderFinished.SetResult(true);
-                            return;
-                        }
-                    }
-                    else
-                    {
-                        sentDatagrams = 0;
-                    }
-
-                    random.NextBytes(sendBuffer);
-                    sendBuffer[0] = (byte)sentDatagrams;
-                    right.SendToAPM(sendBuffer, 0, sendBuffer.Length, SocketFlags.None, leftEndpoint, sendHandler);
-                }
-                catch (Exception ex)
-                {
-                    senderFinished.SetException(ex);
-                }
-            };
-
-            sendHandler(0);
-
-            Assert.True(receiverFinished.Task.Wait(TestTimeout));
-            Assert.True(senderFinished.Task.Wait(TestTimeout));
-
-            for (int i = 0; i < DatagramsToSend; i++)
-            {
-                Assert.NotNull(receivedChecksums[i]);
-                Assert.Equal(sentChecksums[i], (uint)receivedChecksums[i]);
-            }
-        }
-		
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(LoopbacksAndBuffers))]
-        public static void SendRecv_Stream_TCP(IPAddress listenAt, bool useMultipleBuffers)
+        public async Task SendRecv_Stream_TCP(IPAddress listenAt, bool useMultipleBuffers)
         {
-            const int BytesToSend = 123456;
-            const int ListenBacklog = 1;
-            const int LingerTime = 10;
-            const int TestTimeout = 30000;
+            const int BytesToSend = 123456, ListenBacklog = 1, LingerTime = 1;
+            int bytesReceived = 0, bytesSent = 0;
+            Fletcher32 receivedChecksum = new Fletcher32(), sentChecksum = new Fletcher32();
 
-            var server = new Socket(listenAt.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            server.BindToAnonymousPort(listenAt);
-
-            server.Listen(ListenBacklog);
-
-            int bytesReceived = 0;
-            var receivedChecksum = new Fletcher32();
-            var serverThread = new Thread(() =>
+            using (var server = new Socket(listenAt.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
             {
-                using (server)
-                {
-                    Socket remote = server.Accept();
-                    Assert.NotNull(remote);
+                server.BindToAnonymousPort(listenAt);
+                server.Listen(ListenBacklog);
 
-                    using (remote)
+                Task serverProcessingTask = Task.Run(async () =>
+                {
+                    using (Socket remote = await AcceptAsync(server))
                     {
                         if (!useMultipleBuffers)
                         {
                             var recvBuffer = new byte[256];
                             for (;;)
                             {
-                                int received = remote.Receive(recvBuffer, 0, recvBuffer.Length, SocketFlags.None);
+                                int received = await ReceiveAsync(remote, new ArraySegment<byte>(recvBuffer));
                                 if (received == 0)
                                 {
                                     break;
@@ -270,12 +146,10 @@ namespace System.Net.Sockets.Tests
                                 new ArraySegment<byte>(new byte[123]),
                                 new ArraySegment<byte>(new byte[256], 2, 100),
                                 new ArraySegment<byte>(new byte[1], 0, 0),
-                                new ArraySegment<byte>(new byte[64], 9, 33)
-                            };
-
+                                new ArraySegment<byte>(new byte[64], 9, 33)};
                             for (;;)
                             {
-                                int received = remote.Receive(recvBuffers, SocketFlags.None);
+                                int received = await ReceiveAsync(remote, recvBuffers);
                                 if (received == 0)
                                 {
                                     break;
@@ -290,717 +164,63 @@ namespace System.Net.Sockets.Tests
                                     remaining -= toAdd;
                                 }
                             }
+
                         }
-                    }
-                }
-            });
-            serverThread.Start();
-
-            EndPoint clientEndpoint = server.LocalEndPoint;
-            var client = new Socket(clientEndpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            client.Connect(clientEndpoint);
-
-            int bytesSent = 0;
-            var sentChecksum = new Fletcher32();
-            using (client)
-            {
-                var random = new Random();
-
-                if (!useMultipleBuffers)
-                {
-                    var sendBuffer = new byte[512];
-                    for (int sent = 0, remaining = BytesToSend; remaining > 0; remaining -= sent)
-                    {
-                        random.NextBytes(sendBuffer);
-
-                        sent = client.Send(sendBuffer, 0, Math.Min(sendBuffer.Length, remaining), SocketFlags.None);
-                        bytesSent += sent;
-                        sentChecksum.Add(sendBuffer, 0, sent);
-                    }
-                }
-                else
-                {
-                    var sendBuffers = new List<ArraySegment<byte>> {
-                        new ArraySegment<byte>(new byte[23]),
-                        new ArraySegment<byte>(new byte[256], 2, 100),
-                        new ArraySegment<byte>(new byte[1], 0, 0),
-                        new ArraySegment<byte>(new byte[64], 9, 9)
-                    };
-
-                    for (int sent = 0, toSend = BytesToSend; toSend > 0; toSend -= sent)
-                    {
-                        for (int i = 0; i < sendBuffers.Count; i++)
-                        {
-                            random.NextBytes(sendBuffers[i].Array);
-                        }
-
-                        sent = client.Send(sendBuffers, SocketFlags.None);
-
-                        bytesSent += sent;
-                        for (int i = 0, remaining = sent; i < sendBuffers.Count && remaining > 0; i++)
-                        {
-                            ArraySegment<byte> buffer = sendBuffers[i];
-                            int toAdd = Math.Min(buffer.Count, remaining);
-                            sentChecksum.Add(buffer.Array, buffer.Offset, toAdd);
-                            remaining -= toAdd;
-                        }
-                    }
-                }
-
-                client.LingerState = new LingerOption(true, LingerTime);
-            }
-
-            Assert.True(serverThread.Join(TestTimeout), "Completed within allowed time");
-
-            Assert.Equal(bytesSent, bytesReceived);
-            Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [Theory]
-        [MemberData(nameof(LoopbacksAndBuffers))]
-        public static void SendRecvAPM_Stream_TCP(IPAddress listenAt, bool useMultipleBuffers)
-        {
-            const int BytesToSend = 123456;
-            const int ListenBacklog = 1;
-            const int LingerTime = 10;
-            const int TestTimeout = 30000;
-
-            var server = new Socket(listenAt.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            server.BindToAnonymousPort(listenAt);
-
-            server.Listen(ListenBacklog);
-
-            var serverFinished = new TaskCompletionSource<bool>();
-            int bytesReceived = 0;
-            var receivedChecksum = new Fletcher32();
-
-            server.AcceptAPM(remote =>
-            {
-                Action<int> recvHandler = null;
-                bool first = true;
-
-                if (!useMultipleBuffers)
-                {
-                    var recvBuffer = new byte[256];
-                    recvHandler = received => 
-                    {
-                        if (!first)
-                        {
-                            if (received == 0)
-                            {
-                                remote.Dispose();
-                                server.Dispose();
-                                serverFinished.SetResult(true);
-                                return;
-                            }
-
-                            bytesReceived += received;
-                            receivedChecksum.Add(recvBuffer, 0, received);
-                        }
-                        else
-                        {
-                            first = false;
-                        }
-
-                        remote.ReceiveAPM(recvBuffer, 0, recvBuffer.Length, SocketFlags.None, recvHandler);
-                    };
-                }
-                else
-                {
-                    var recvBuffers = new List<ArraySegment<byte>> {
-                        new ArraySegment<byte>(new byte[123]),
-                        new ArraySegment<byte>(new byte[256], 2, 100),
-                        new ArraySegment<byte>(new byte[1], 0, 0),
-                        new ArraySegment<byte>(new byte[64], 9, 33)
-                    };
-
-                    recvHandler = received =>
-                    {
-                        if (!first)
-                        {
-                            if (received == 0)
-                            {
-                                remote.Dispose();
-                                server.Dispose();
-                                serverFinished.SetResult(true);
-                                return;
-                            }
-
-                            bytesReceived += received;
-                            for (int i = 0, remaining = received; i < recvBuffers.Count && remaining > 0; i++)
-                            {
-                                ArraySegment<byte> buffer = recvBuffers[i];
-                                int toAdd = Math.Min(buffer.Count, remaining);
-                                receivedChecksum.Add(buffer.Array, buffer.Offset, toAdd);
-                                remaining -= toAdd;
-                            }
-                        }
-                        else
-                        {
-                            first = false;
-                        }
-
-                        remote.ReceiveAPM(recvBuffers, SocketFlags.None, recvHandler);
-                    };
-                }
-
-                recvHandler(0);
-            });
-
-            EndPoint clientEndpoint = server.LocalEndPoint;
-            var client = new Socket(clientEndpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-
-            int bytesSent = 0;
-            var sentChecksum = new Fletcher32();
-
-            client.ConnectAPM(clientEndpoint, () =>
-            {
-                Action<int> sendHandler = null;
-                var random = new Random();
-                var remaining = BytesToSend;
-                bool first = true;
-
-                if (!useMultipleBuffers)
-                {
-                    var sendBuffer = new byte[512];
-                    sendHandler = sent =>
-                    {
-                        if (!first)
-                        {
-                            bytesSent += sent;
-                            sentChecksum.Add(sendBuffer, 0, sent);
-
-                            remaining -= sent;
-                            if (remaining <= 0)
-                            {
-                                client.LingerState = new LingerOption(true, LingerTime);
-                                client.Dispose();
-                                return;
-                            }
-                        }
-                        else
-                        {
-                            first = false;
-                        }
-
-                        random.NextBytes(sendBuffer);
-                        client.SendAPM(sendBuffer, 0, Math.Min(sendBuffer.Length, remaining), SocketFlags.None, sendHandler);
-                    };
-                }
-                else
-                {
-                     var sendBuffers = new List<ArraySegment<byte>> {
-                        new ArraySegment<byte>(new byte[23]),
-                        new ArraySegment<byte>(new byte[256], 2, 100),
-                        new ArraySegment<byte>(new byte[1], 0, 0),
-                        new ArraySegment<byte>(new byte[64], 9, 9)
-                    };
-
-                    sendHandler = sent =>
-                    {
-                        if (!first)
-                        {
-                            bytesSent += sent;
-                            for (int i = 0, r = sent; i < sendBuffers.Count && r > 0; i++)
-                            {
-                                ArraySegment<byte> buffer = sendBuffers[i];
-                                int toAdd = Math.Min(buffer.Count, r);
-                                sentChecksum.Add(buffer.Array, buffer.Offset, toAdd);
-                                r -= toAdd;
-                            }
-
-                            remaining -= sent;
-                            if (remaining <= 0)
-                            {
-                                client.LingerState = new LingerOption(true, LingerTime);
-                                client.Dispose();
-                                return;
-                            }
-                        }
-                        else
-                        {
-                            first = false;
-                        }
-
-                        for (int i = 0; i < sendBuffers.Count; i++)
-                        {
-                            random.NextBytes(sendBuffers[i].Array);
-                        }
-                        client.SendAPM(sendBuffers, SocketFlags.None, sendHandler);
-                    };
-                }
-
-                sendHandler(0);
-            });
-
-            Assert.True(serverFinished.Task.Wait(TestTimeout), "Completed within allowed time");
-
-            Assert.Equal(bytesSent, bytesReceived);
-            Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [Theory]
-        [MemberData(nameof(LoopbacksToSameLoopback))]
-        public void SendToRecvFromAsync_Datagram_UDP(IPAddress leftAddress, IPAddress rightAddress)
-        {
-            // TODO #5185: harden against packet loss
-            const int DatagramSize = 256;
-            const int DatagramsToSend = 256;
-            const int AckTimeout = 1000;
-            const int TestTimeout = 30000;
-
-            var left = new Socket(leftAddress.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
-            var leftEventArgs = new SocketAsyncEventArgs();
-            left.BindToAnonymousPort(leftAddress);
-
-            var right = new Socket(rightAddress.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
-            var rightEventArgs = new SocketAsyncEventArgs();
-            right.BindToAnonymousPort(rightAddress);
-
-            var leftEndpoint = (IPEndPoint)left.LocalEndPoint;
-            var rightEndpoint = (IPEndPoint)right.LocalEndPoint;
-
-            var receiverAck = new ManualResetEventSlim();
-            var senderAck = new ManualResetEventSlim();
-
-            EndPoint receiveRemote = leftEndpoint.Create(leftEndpoint.Serialize());
-            var receiverFinished = new TaskCompletionSource<bool>();
-            var receivedChecksums = new uint?[DatagramsToSend];
-            var receiveBuffer = new byte[DatagramSize];
-            int receivedDatagrams = -1;
-
-            Action<int, EndPoint> receiveHandler = null;
-            receiveHandler = (received, remote) =>
-            {
-                try
-                {
-                    if (receivedDatagrams != -1)
-                    {
-                        Assert.Equal(DatagramSize, received);
-                        Assert.Equal(rightEndpoint, remote);
-
-                        int datagramId = (int)receiveBuffer[0];
-                        Assert.Null(receivedChecksums[datagramId]);
-
-                        receivedChecksums[datagramId] = Fletcher32.Checksum(receiveBuffer, 0, received);
-
-                        receiverAck.Set();
-                        Assert.True(senderAck.Wait(AckTimeout));
-                        senderAck.Reset();
-
-                        receivedDatagrams++;
-                        if (receivedDatagrams == DatagramsToSend)
-                        {
-                            left.Dispose();
-                            receiverFinished.SetResult(true);
-                            return;
-                        }
-                    }
-                    else
-                    {
-                        receivedDatagrams = 0;
-                    }
-
-                    left.ReceiveFromAsync(leftEventArgs, receiveBuffer, 0, receiveBuffer.Length, SocketFlags.None, receiveRemote, receiveHandler);
-                }
-                catch (Exception ex)
-                {
-                    receiverFinished.SetException(ex);
-                }
-            };
-
-            receiveHandler(0, null);
-
-            var random = new Random();
-            var senderFinished = new TaskCompletionSource<bool>();
-            var sentChecksums = new uint[DatagramsToSend];
-            var sendBuffer = new byte[DatagramSize];
-            int sentDatagrams = -1;
-
-            Action<int> sendHandler = null;
-            sendHandler = sent =>
-            {
-                try
-                {
-                    if (sentDatagrams != -1)
-                    {
-                        Assert.True(receiverAck.Wait(AckTimeout));
-                        receiverAck.Reset();
-                        senderAck.Set();
-
-                        Assert.Equal(DatagramSize, sent);
-                        sentChecksums[sentDatagrams] = Fletcher32.Checksum(sendBuffer, 0, sent);
-
-                        sentDatagrams++;
-                        if (sentDatagrams == DatagramsToSend)
-                        {
-                            right.Dispose();
-                            senderFinished.SetResult(true);
-                            return;
-                        }
-                    }
-                    else
-                    {
-                        sentDatagrams = 0;
-                    }
-
-                    random.NextBytes(sendBuffer);
-                    sendBuffer[0] = (byte)sentDatagrams;
-                    right.SendToAsync(rightEventArgs, sendBuffer, 0, sendBuffer.Length, SocketFlags.None, leftEndpoint, sendHandler);
-                }
-                catch (Exception ex)
-                {
-                    senderFinished.SetException(ex);
-                }
-            };
-
-            sendHandler(0);
-
-            Assert.True(receiverFinished.Task.Wait(TestTimeout));
-            Assert.True(senderFinished.Task.Wait(TestTimeout));
-
-            for (int i = 0; i < DatagramsToSend; i++)
-            {
-                Assert.NotNull(receivedChecksums[i]);
-                Assert.Equal(sentChecksums[i], (uint)receivedChecksums[i]);
-            }
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [Theory]
-        [MemberData(nameof(LoopbacksToSameLoopback))]
-        public void SendToRecvFromAsync_Datagram_UDP_UdpClient(IPAddress leftAddress, IPAddress rightAddress)
-        {
-            // TODO #5185: harden against packet loss
-            const int DatagramSize = 256;
-            const int DatagramsToSend = 256;
-            const int AckTimeout = 1000;
-            const int TestTimeout = 30000;
-
-            using (var left = new UdpClient(new IPEndPoint(leftAddress, 0)))
-            using (var right = new UdpClient(new IPEndPoint(rightAddress, 0)))
-            {
-                var leftEndpoint = (IPEndPoint)left.Client.LocalEndPoint;
-                var rightEndpoint = (IPEndPoint)right.Client.LocalEndPoint;
-
-                var receiverAck = new ManualResetEventSlim();
-                var senderAck = new ManualResetEventSlim();
-
-                var receivedChecksums = new uint?[DatagramsToSend];
-                int receivedDatagrams = 0;
-
-                Task receiverTask = Task.Run(async () =>
-                {
-                    for (; receivedDatagrams < DatagramsToSend; receivedDatagrams++)
-                    {
-                        UdpReceiveResult result = await left.ReceiveAsync();
-
-                        receiverAck.Set();
-                        Assert.True(senderAck.Wait(AckTimeout));
-                        senderAck.Reset();
-
-                        Assert.Equal(DatagramSize, result.Buffer.Length);
-                        Assert.Equal(rightEndpoint, result.RemoteEndPoint);
-
-                        int datagramId = (int)result.Buffer[0];
-                        Assert.Null(receivedChecksums[datagramId]);
-
-                        receivedChecksums[datagramId] = Fletcher32.Checksum(result.Buffer, 0, result.Buffer.Length);
                     }
                 });
 
-                var sentChecksums = new uint[DatagramsToSend];
-                int sentDatagrams = 0;
-
-                Task senderTask = Task.Run(async () =>
+                EndPoint clientEndpoint = server.LocalEndPoint;
+                using (var client = new Socket(clientEndpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
                 {
+                    await ConnectAsync(client, clientEndpoint);
+
                     var random = new Random();
-                    var sendBuffer = new byte[DatagramSize];
-
-                    for (; sentDatagrams < DatagramsToSend; sentDatagrams++)
+                    if (!useMultipleBuffers)
                     {
-                        random.NextBytes(sendBuffer);
-                        sendBuffer[0] = (byte)sentDatagrams;
-
-                        int sent = await right.SendAsync(sendBuffer, DatagramSize, leftEndpoint);
-
-                        Assert.True(receiverAck.Wait(AckTimeout));
-                        receiverAck.Reset();
-                        senderAck.Set();
-
-                        Assert.Equal(DatagramSize, sent);
-                        sentChecksums[sentDatagrams] = Fletcher32.Checksum(sendBuffer, 0, sent);
-                    }
-                });
-
-                Assert.True(Task.WaitAll(new[] { receiverTask, senderTask }, TestTimeout));
-                for (int i = 0; i < DatagramsToSend; i++)
-                {
-                    Assert.NotNull(receivedChecksums[i]);
-                    Assert.Equal(sentChecksums[i], (uint)receivedChecksums[i]);
-                }
-            }
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [Theory]
-        [MemberData(nameof(LoopbacksAndBuffers))]
-        public void SendRecvAsync_Stream_TCP(IPAddress listenAt, bool useMultipleBuffers)
-        {
-            const int BytesToSend = 123456;
-            const int ListenBacklog = 1;
-            const int LingerTime = 60;
-            const int TestTimeout = 30000;
-
-            var server = new Socket(listenAt.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            server.BindToAnonymousPort(listenAt);
-
-            server.Listen(ListenBacklog);
-
-            var serverFinished = new TaskCompletionSource<bool>();
-            int bytesReceived = 0;
-            var receivedChecksum = new Fletcher32();
-
-            var serverEventArgs = new SocketAsyncEventArgs();
-            server.AcceptAsync(serverEventArgs, remote =>
-            {
-                Action<int> recvHandler = null;
-                bool first = true;
-
-                if (!useMultipleBuffers)
-                {
-                    var recvBuffer = new byte[256];
-                    recvHandler = received => 
-                    {
-                        if (!first)
-                        {
-                            if (received == 0)
-                            {
-                                remote.Dispose();
-                                server.Dispose();
-                                serverFinished.SetResult(true);
-                                return;
-                            }
-
-                            bytesReceived += received;
-                            receivedChecksum.Add(recvBuffer, 0, received);
-                        }
-                        else
-                        {
-                            first = false;
-                        }
-
-                        remote.ReceiveAsync(serverEventArgs, recvBuffer, 0, recvBuffer.Length, SocketFlags.None, recvHandler);
-                    };
-                }
-                else
-                {
-                    var recvBuffers = new List<ArraySegment<byte>> {
-                        new ArraySegment<byte>(new byte[123]),
-                        new ArraySegment<byte>(new byte[256], 2, 100),
-                        new ArraySegment<byte>(new byte[1], 0, 0),
-                        new ArraySegment<byte>(new byte[64], 9, 33)
-                    };
-
-                    recvHandler = received =>
-                    {
-                        if (!first)
-                        {
-                            if (received == 0)
-                            {
-                                remote.Dispose();
-                                server.Dispose();
-                                serverFinished.SetResult(true);
-                                return;
-                            }
-
-                            bytesReceived += received;
-                            for (int i = 0, remaining = received; i < recvBuffers.Count && remaining > 0; i++)
-                            {
-                                ArraySegment<byte> buffer = recvBuffers[i];
-                                int toAdd = Math.Min(buffer.Count, remaining);
-                                receivedChecksum.Add(buffer.Array, buffer.Offset, toAdd);
-                                remaining -= toAdd;
-                            }
-                        }
-                        else
-                        {
-                            first = false;
-                        }
-
-                        remote.ReceiveAsync(serverEventArgs, recvBuffers, SocketFlags.None, recvHandler);
-                    };
-                }
-
-                recvHandler(0);
-            });
-
-            EndPoint clientEndpoint = server.LocalEndPoint;
-            var client = new Socket(clientEndpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-
-            int bytesSent = 0;
-            var sentChecksum = new Fletcher32();
-
-            var clientEventArgs = new SocketAsyncEventArgs();
-            client.ConnectAsync(clientEventArgs, clientEndpoint, () =>
-            {
-                Action<int> sendHandler = null;
-                var random = new Random();
-                var remaining = BytesToSend;
-                bool first = true;
-
-                if (!useMultipleBuffers)
-                {
-                    var sendBuffer = new byte[512];
-                    sendHandler = sent =>
-                    {
-                        if (!first)
-                        {
-                            bytesSent += sent;
-                            sentChecksum.Add(sendBuffer, 0, sent);
-
-                            remaining -= sent;
-                            Assert.True(remaining >= 0);
-                            if (remaining == 0)
-                            {
-                                client.LingerState = new LingerOption(true, LingerTime);
-                                client.Dispose();
-                                return;
-                            }
-                        }
-                        else
-                        {
-                            first = false;
-                        }
-
-                        random.NextBytes(sendBuffer);
-                        client.SendAsync(clientEventArgs, sendBuffer, 0, Math.Min(sendBuffer.Length, remaining), SocketFlags.None, sendHandler);
-                    };
-                }
-                else
-                {
-                    var sendBuffers = new List<ArraySegment<byte>> {
-                        new ArraySegment<byte>(new byte[23]),
-                        new ArraySegment<byte>(new byte[256], 2, 100),
-                        new ArraySegment<byte>(new byte[1], 0, 0),
-                        new ArraySegment<byte>(new byte[64], 9, 9)
-                    };
-
-                    sendHandler = sent =>
-                    {
-                        if (!first)
-                        {
-                            bytesSent += sent;
-                            for (int i = 0, r = sent; i < sendBuffers.Count && r > 0; i++)
-                            {
-                                ArraySegment<byte> buffer = sendBuffers[i];
-                                int toAdd = Math.Min(buffer.Count, r);
-                                sentChecksum.Add(buffer.Array, buffer.Offset, toAdd);
-                                r -= toAdd;
-                            }
-
-                            remaining -= sent;
-                            if (remaining <= 0)
-                            {
-                                client.LingerState = new LingerOption(true, LingerTime);
-                                client.Dispose();
-                                return;
-                            }
-                        }
-                        else
-                        {
-                            first = false;
-                        }
-
-                        for (int i = 0; i < sendBuffers.Count; i++)
-                        {
-                            random.NextBytes(sendBuffers[i].Array);
-                        }
-
-                        client.SendAsync(clientEventArgs, sendBuffers, SocketFlags.None, sendHandler);
-                    };
-                }
-
-                sendHandler(0);
-            });
-
-            Assert.True(serverFinished.Task.Wait(TestTimeout), "Completed within allowed time");
-
-            Assert.Equal(bytesSent, bytesReceived);
-            Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
-        }
-
-        [OuterLoop] // TODO: Issue #11345
-        [Theory]
-        [MemberData(nameof(Loopbacks))]
-        public void SendRecvAsync_TcpListener_TcpClient(IPAddress listenAt)
-        {
-            const int BytesToSend = 123456;
-            const int ListenBacklog = 1;
-            const int LingerTime = 10;
-            const int TestTimeout = 30000;
-
-            var listener = new TcpListener(listenAt, 0);
-            listener.Start(ListenBacklog);
-
-            int bytesReceived = 0;
-            var receivedChecksum = new Fletcher32();
-            Task serverTask = Task.Run(async () =>
-            {
-                using (TcpClient remote = await listener.AcceptTcpClientAsync())
-                using (NetworkStream stream = remote.GetStream())
-                {
-                    var recvBuffer = new byte[256];
-                    for (;;)
-                    {
-                        int received = await stream.ReadAsync(recvBuffer, 0, recvBuffer.Length);
-                        if (received == 0)
-                        {
-                            break;
-                        }
-
-                        bytesReceived += received;
-                        receivedChecksum.Add(recvBuffer, 0, received);
-                    }
-                }
-            });
-
-            int bytesSent = 0;
-            var sentChecksum = new Fletcher32();
-            Task clientTask = Task.Run(async () =>
-            {
-                var clientEndpoint = (IPEndPoint)listener.LocalEndpoint;
-
-                using (var client = new TcpClient(clientEndpoint.AddressFamily))
-                {
-                    await client.ConnectAsync(clientEndpoint.Address, clientEndpoint.Port);
-
-                    using (NetworkStream stream = client.GetStream())
-                    {
-                        var random = new Random();
                         var sendBuffer = new byte[512];
-                        for (int remaining = BytesToSend, sent = 0; remaining > 0; remaining -= sent)
+                        for (int sent = 0, remaining = BytesToSend; remaining > 0; remaining -= sent)
                         {
                             random.NextBytes(sendBuffer);
-
-                            sent = Math.Min(sendBuffer.Length, remaining);
-                            await stream.WriteAsync(sendBuffer, 0, sent);
-
+                            sent = await SendAsync(client, new ArraySegment<byte>(sendBuffer, 0, Math.Min(sendBuffer.Length, remaining)));
                             bytesSent += sent;
                             sentChecksum.Add(sendBuffer, 0, sent);
                         }
-
-                        client.LingerState = new LingerOption(true, LingerTime);
                     }
+                    else
+                    {
+                        var sendBuffers = new List<ArraySegment<byte>> {
+                        new ArraySegment<byte>(new byte[23]),
+                        new ArraySegment<byte>(new byte[256], 2, 100),
+                        new ArraySegment<byte>(new byte[1], 0, 0),
+                        new ArraySegment<byte>(new byte[64], 9, 9)};
+                        for (int sent = 0, toSend = BytesToSend; toSend > 0; toSend -= sent)
+                        {
+                            for (int i = 0; i < sendBuffers.Count; i++)
+                            {
+                                random.NextBytes(sendBuffers[i].Array);
+                            }
+
+                            sent = await SendAsync(client, sendBuffers);
+
+                            bytesSent += sent;
+                            for (int i = 0, remaining = sent; i < sendBuffers.Count && remaining > 0; i++)
+                            {
+                                ArraySegment<byte> buffer = sendBuffers[i];
+                                int toAdd = Math.Min(buffer.Count, remaining);
+                                sentChecksum.Add(buffer.Array, buffer.Offset, toAdd);
+                                remaining -= toAdd;
+                            }
+                        }
+                    }
+
+                    client.LingerState = new LingerOption(true, LingerTime);
+                    client.Shutdown(SocketShutdown.Both);
+                    await serverProcessingTask;
                 }
-            });
 
-            Assert.True(Task.WaitAll(new[] { serverTask, clientTask }, TestTimeout));
-
-            Assert.Equal(bytesSent, bytesReceived);
-            Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
+                Assert.Equal(bytesSent, bytesReceived);
+                Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
+            }
         }
 
         [OuterLoop] // TODO: Issue #11345
@@ -1088,7 +308,7 @@ namespace System.Net.Sockets.Tests
 
         [ActiveIssue(13778, TestPlatforms.OSX)]
         [Fact]
-        public static async Task SendRecvAsync_0ByteReceive_Success()
+        public async Task SendRecv_0ByteReceive_Success()
         {
             using (Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
@@ -1096,44 +316,355 @@ namespace System.Net.Sockets.Tests
                 listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
                 listener.Listen(1);
 
-                Task<Socket> acceptTask = listener.AcceptAsync();
+                Task<Socket> acceptTask = AcceptAsync(listener);
                 await Task.WhenAll(
                     acceptTask, 
-                    client.ConnectAsync(new IPEndPoint(IPAddress.Loopback, ((IPEndPoint)listener.LocalEndPoint).Port)));
+                    ConnectAsync(client, new IPEndPoint(IPAddress.Loopback, ((IPEndPoint)listener.LocalEndPoint).Port)));
 
                 using (Socket server = await acceptTask)
                 {
-                    TaskCompletionSource<bool> tcs = null;
-
-                    var ea = new SocketAsyncEventArgs();
-                    ea.SetBuffer(Array.Empty<byte>(), 0, 0);
-                    ea.Completed += delegate { tcs.SetResult(true); };
-
                     for (int i = 0; i < 3; i++)
                     {
-                        tcs = new TaskCompletionSource<bool>();
-
                         // Have the client do a 0-byte receive.  No data is available, so this should pend.
-                        Assert.True(client.ReceiveAsync(ea));
+                        Task<int> receive = ReceiveAsync(client, new ArraySegment<byte>(Array.Empty<byte>()));
+                        Assert.False(receive.IsCompleted);
                         Assert.Equal(0, client.Available);
 
                         // Have the server send 1 byte to the client.
                         Assert.Equal(1, server.Send(new byte[1], 0, 1, SocketFlags.None));
 
                         // The client should now wake up, getting 0 bytes with 1 byte available.
-                        await tcs.Task;
-                        Assert.Equal(0, ea.BytesTransferred);
-                        Assert.Equal(SocketError.Success, ea.SocketError);
+                        Assert.Equal(0, await receive);
                         Assert.Equal(1, client.Available); // Due to #13778, this sometimes fails on macOS
 
                         // Receive that byte
-                        Assert.Equal(1, client.Receive(new byte[1]));
+                        Assert.Equal(1, await ReceiveAsync(client, new ArraySegment<byte>(new byte[1])));
                         Assert.Equal(0, client.Available);
                     }
                 }
             }
         }
+    }
 
+    public sealed class SendReceiveUdpClient : MemberDatas
+    {
+        [OuterLoop] // TODO: Issue #11345
+        [Theory]
+        [MemberData(nameof(Loopbacks))]
+        public void SendToRecvFromAsync_Datagram_UDP_UdpClient(IPAddress loopbackAddress)
+        {
+            IPAddress leftAddress = loopbackAddress, rightAddress = loopbackAddress;
+
+            // TODO #5185: harden against packet loss
+            const int DatagramSize = 256;
+            const int DatagramsToSend = 256;
+            const int AckTimeout = 1000;
+            const int TestTimeout = 30000;
+
+            using (var left = new UdpClient(new IPEndPoint(leftAddress, 0)))
+            using (var right = new UdpClient(new IPEndPoint(rightAddress, 0)))
+            {
+                var leftEndpoint = (IPEndPoint)left.Client.LocalEndPoint;
+                var rightEndpoint = (IPEndPoint)right.Client.LocalEndPoint;
+
+                var receiverAck = new ManualResetEventSlim();
+                var senderAck = new ManualResetEventSlim();
+
+                var receivedChecksums = new uint?[DatagramsToSend];
+                int receivedDatagrams = 0;
+
+                Task receiverTask = Task.Run(async () =>
+                {
+                    for (; receivedDatagrams < DatagramsToSend; receivedDatagrams++)
+                    {
+                        UdpReceiveResult result = await left.ReceiveAsync();
+
+                        receiverAck.Set();
+                        Assert.True(senderAck.Wait(AckTimeout));
+                        senderAck.Reset();
+
+                        Assert.Equal(DatagramSize, result.Buffer.Length);
+                        Assert.Equal(rightEndpoint, result.RemoteEndPoint);
+
+                        int datagramId = (int)result.Buffer[0];
+                        Assert.Null(receivedChecksums[datagramId]);
+
+                        receivedChecksums[datagramId] = Fletcher32.Checksum(result.Buffer, 0, result.Buffer.Length);
+                    }
+                });
+
+                var sentChecksums = new uint[DatagramsToSend];
+                int sentDatagrams = 0;
+
+                Task senderTask = Task.Run(async () =>
+                {
+                    var random = new Random();
+                    var sendBuffer = new byte[DatagramSize];
+
+                    for (; sentDatagrams < DatagramsToSend; sentDatagrams++)
+                    {
+                        random.NextBytes(sendBuffer);
+                        sendBuffer[0] = (byte)sentDatagrams;
+
+                        int sent = await right.SendAsync(sendBuffer, DatagramSize, leftEndpoint);
+
+                        Assert.True(receiverAck.Wait(AckTimeout));
+                        receiverAck.Reset();
+                        senderAck.Set();
+
+                        Assert.Equal(DatagramSize, sent);
+                        sentChecksums[sentDatagrams] = Fletcher32.Checksum(sendBuffer, 0, sent);
+                    }
+                });
+
+                Assert.True(Task.WaitAll(new[] { receiverTask, senderTask }, TestTimeout));
+                for (int i = 0; i < DatagramsToSend; i++)
+                {
+                    Assert.NotNull(receivedChecksums[i]);
+                    Assert.Equal(sentChecksums[i], (uint)receivedChecksums[i]);
+                }
+            }
+        }
+    }
+
+    public sealed class SendReceiveListener : MemberDatas
+    {
+        [OuterLoop] // TODO: Issue #11345
+        [Theory]
+        [MemberData(nameof(Loopbacks))]
+        public void SendRecvAsync_TcpListener_TcpClient(IPAddress listenAt)
+        {
+            const int BytesToSend = 123456;
+            const int ListenBacklog = 1;
+            const int LingerTime = 10;
+            const int TestTimeout = 30000;
+
+            var listener = new TcpListener(listenAt, 0);
+            listener.Start(ListenBacklog);
+
+            int bytesReceived = 0;
+            var receivedChecksum = new Fletcher32();
+            Task serverTask = Task.Run(async () =>
+            {
+                using (TcpClient remote = await listener.AcceptTcpClientAsync())
+                using (NetworkStream stream = remote.GetStream())
+                {
+                    var recvBuffer = new byte[256];
+                    for (;;)
+                    {
+                        int received = await stream.ReadAsync(recvBuffer, 0, recvBuffer.Length);
+                        if (received == 0)
+                        {
+                            break;
+                        }
+
+                        bytesReceived += received;
+                        receivedChecksum.Add(recvBuffer, 0, received);
+                    }
+                }
+            });
+
+            int bytesSent = 0;
+            var sentChecksum = new Fletcher32();
+            Task clientTask = Task.Run(async () =>
+            {
+                var clientEndpoint = (IPEndPoint)listener.LocalEndpoint;
+
+                using (var client = new TcpClient(clientEndpoint.AddressFamily))
+                {
+                    await client.ConnectAsync(clientEndpoint.Address, clientEndpoint.Port);
+
+                    using (NetworkStream stream = client.GetStream())
+                    {
+                        var random = new Random();
+                        var sendBuffer = new byte[512];
+                        for (int remaining = BytesToSend, sent = 0; remaining > 0; remaining -= sent)
+                        {
+                            random.NextBytes(sendBuffer);
+
+                            sent = Math.Min(sendBuffer.Length, remaining);
+                            await stream.WriteAsync(sendBuffer, 0, sent);
+
+                            bytesSent += sent;
+                            sentChecksum.Add(sendBuffer, 0, sent);
+                        }
+
+                        client.LingerState = new LingerOption(true, LingerTime);
+                    }
+                }
+            });
+
+            Assert.True(Task.WaitAll(new[] { serverTask, clientTask }, TestTimeout));
+
+            Assert.Equal(bytesSent, bytesReceived);
+            Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
+        }
+    }
+
+    public sealed class SendReceiveSync : SendReceive
+    {
+        public SendReceiveSync(ITestOutputHelper output) : base(output) { }
+        public override Task<Socket> AcceptAsync(Socket s) =>
+            Task.Run(() => s.Accept());
+        public override Task ConnectAsync(Socket s, EndPoint endPoint) =>
+            Task.Run(() => s.Connect(endPoint));
+        public override Task<int> ReceiveAsync(Socket s, ArraySegment<byte> buffer) =>
+            Task.Run(() => s.Receive(buffer.Array, buffer.Offset, buffer.Count, SocketFlags.None));
+        public override Task<int> ReceiveAsync(Socket s, IList<ArraySegment<byte>> bufferList) =>
+            Task.Run(() => s.Receive(bufferList, SocketFlags.None));
+        public override Task<SocketReceiveFromResult> ReceiveFromAsync(Socket s, ArraySegment<byte> buffer, EndPoint endPoint) =>
+            Task.Run(() =>
+            {
+                int received = s.ReceiveFrom(buffer.Array, buffer.Offset, buffer.Count, SocketFlags.None, ref endPoint);
+                return new SocketReceiveFromResult
+                {
+                    ReceivedBytes = received,
+                    RemoteEndPoint = endPoint
+                };
+            });
+        public override Task<int> SendAsync(Socket s, ArraySegment<byte> buffer) =>
+            Task.Run(() => s.Send(buffer.Array, buffer.Offset, buffer.Count, SocketFlags.None));
+        public override Task<int> SendAsync(Socket s, IList<ArraySegment<byte>> bufferList) =>
+            Task.Run(() => s.Send(bufferList, SocketFlags.None));
+        public override Task<int> SendToAsync(Socket s, ArraySegment<byte> buffer, EndPoint endPoint) =>
+            Task.Run(() => s.SendTo(buffer.Array, buffer.Offset, buffer.Count, SocketFlags.None, endPoint));
+    }
+
+    public sealed class SendReceiveApm : SendReceive
+    {
+        public SendReceiveApm(ITestOutputHelper output) : base(output) { }
+        public override Task<Socket> AcceptAsync(Socket s) =>
+            Task.Factory.FromAsync(s.BeginAccept, s.EndAccept, null);
+        public override Task ConnectAsync(Socket s, EndPoint endPoint) =>
+            Task.Factory.FromAsync(s.BeginConnect, s.EndConnect, endPoint, null);
+        public override Task<int> ReceiveAsync(Socket s, ArraySegment<byte> buffer) =>
+            Task.Factory.FromAsync((callback, state) =>
+                s.BeginReceive(buffer.Array, buffer.Offset, buffer.Count, SocketFlags.None, callback, state),
+                s.EndReceive, null);
+        public override Task<int> ReceiveAsync(Socket s, IList<ArraySegment<byte>> bufferList) =>
+            Task.Factory.FromAsync(s.BeginReceive, s.EndReceive, bufferList, SocketFlags.None, null);
+        public override Task<SocketReceiveFromResult> ReceiveFromAsync(Socket s, ArraySegment<byte> buffer, EndPoint endPoint)
+        {
+            var tcs = new TaskCompletionSource<SocketReceiveFromResult>();
+            s.BeginReceiveFrom(buffer.Array, buffer.Offset, buffer.Count, SocketFlags.None, ref endPoint, iar =>
+            {
+                try
+                {
+                    int receivedBytes = s.EndReceiveFrom(iar, ref endPoint);
+                    tcs.TrySetResult(new SocketReceiveFromResult
+                    {
+                        ReceivedBytes = receivedBytes,
+                        RemoteEndPoint = endPoint
+                    });
+                }
+                catch (Exception e) { tcs.TrySetException(e); }
+            }, null);
+            return tcs.Task;
+        }
+        public override Task<int> SendAsync(Socket s, ArraySegment<byte> buffer) =>
+            Task.Factory.FromAsync((callback, state) =>
+                s.BeginSend(buffer.Array, buffer.Offset, buffer.Count, SocketFlags.None, callback, state),
+                s.EndSend, null);
+        public override Task<int> SendAsync(Socket s, IList<ArraySegment<byte>> bufferList) =>
+            Task.Factory.FromAsync(s.BeginSend, s.EndSend, bufferList, SocketFlags.None, null);
+        public override Task<int> SendToAsync(Socket s, ArraySegment<byte> buffer, EndPoint endPoint) =>
+            Task.Factory.FromAsync(
+                (callback, state) => s.BeginSendTo(buffer.Array, buffer.Offset, buffer.Count, SocketFlags.None, endPoint, callback, state),
+                s.EndSendTo, null);
+    }
+
+    public sealed class SendReceiveTask : SendReceive
+    {
+        public SendReceiveTask(ITestOutputHelper output) : base(output) { }
+        public override Task<Socket> AcceptAsync(Socket s) =>
+            s.AcceptAsync();
+        public override Task ConnectAsync(Socket s, EndPoint endPoint) =>
+            s.ConnectAsync(endPoint);
+        public override Task<int> ReceiveAsync(Socket s, ArraySegment<byte> buffer) =>
+            s.ReceiveAsync(buffer, SocketFlags.None);
+        public override Task<int> ReceiveAsync(Socket s, IList<ArraySegment<byte>> bufferList) =>
+            s.ReceiveAsync(bufferList, SocketFlags.None);
+        public override Task<SocketReceiveFromResult> ReceiveFromAsync(Socket s, ArraySegment<byte> buffer, EndPoint endPoint) =>
+            s.ReceiveFromAsync(buffer, SocketFlags.None, endPoint);
+        public override Task<int> SendAsync(Socket s, ArraySegment<byte> buffer) =>
+            s.SendAsync(buffer, SocketFlags.None);
+        public override Task<int> SendAsync(Socket s, IList<ArraySegment<byte>> bufferList) =>
+            s.SendAsync(bufferList, SocketFlags.None);
+        public override Task<int> SendToAsync(Socket s, ArraySegment<byte> buffer, EndPoint endPoint) =>
+            s.SendToAsync(buffer, SocketFlags.None, endPoint);
+    }
+
+    public sealed class SendReceiveEap : SendReceive
+    {
+        public SendReceiveEap(ITestOutputHelper output) : base(output) { }
+        public override Task<Socket> AcceptAsync(Socket s) =>
+            InvokeAsync(s, e => e.AcceptSocket, e => s.AcceptAsync(e));
+        public override Task ConnectAsync(Socket s, EndPoint endPoint) =>
+            InvokeAsync(s, e => true, e =>
+            {
+                e.RemoteEndPoint = endPoint;
+                return s.ConnectAsync(e);
+            });
+        public override Task<int> ReceiveAsync(Socket s, ArraySegment<byte> buffer) =>
+            InvokeAsync(s, e => e.BytesTransferred, e =>
+            {
+                e.SetBuffer(buffer.Array, buffer.Offset, buffer.Count);
+                return s.ReceiveAsync(e);
+            });
+        public override Task<int> ReceiveAsync(Socket s, IList<ArraySegment<byte>> bufferList) =>
+            InvokeAsync(s, e => e.BytesTransferred, e =>
+            {
+                e.BufferList = bufferList;
+                return s.ReceiveAsync(e);
+            });
+        public override Task<SocketReceiveFromResult> ReceiveFromAsync(Socket s, ArraySegment<byte> buffer, EndPoint endPoint) =>
+            InvokeAsync(s, e => new SocketReceiveFromResult { ReceivedBytes = e.BytesTransferred, RemoteEndPoint = e.RemoteEndPoint }, e =>
+            {
+                e.SetBuffer(buffer.Array, buffer.Offset, buffer.Count);
+                e.RemoteEndPoint = endPoint;
+                return s.ReceiveFromAsync(e);
+            });
+        public override Task<int> SendAsync(Socket s, ArraySegment<byte> buffer) =>
+            InvokeAsync(s, e => e.BytesTransferred, e =>
+            {
+                e.SetBuffer(buffer.Array, buffer.Offset, buffer.Count);
+                return s.SendAsync(e);
+            });
+        public override Task<int> SendAsync(Socket s, IList<ArraySegment<byte>> bufferList) =>
+            InvokeAsync(s, e => e.BytesTransferred, e =>
+            {
+                e.BufferList = bufferList;
+                return s.SendAsync(e);
+            });
+        public override Task<int> SendToAsync(Socket s, ArraySegment<byte> buffer, EndPoint endPoint) =>
+            InvokeAsync(s, e => e.BytesTransferred, e =>
+            {
+                e.SetBuffer(buffer.Array, buffer.Offset, buffer.Count);
+                e.RemoteEndPoint = endPoint;
+                return s.SendToAsync(e);
+            });
+
+        private static Task<TResult> InvokeAsync<TResult>(
+            Socket s,
+            Func<SocketAsyncEventArgs, TResult> getResult,
+            Func<SocketAsyncEventArgs, bool> invoke)
+        {
+            var tcs = new TaskCompletionSource<TResult>();
+            var saea = new SocketAsyncEventArgs();
+            EventHandler<SocketAsyncEventArgs> handler = (_, e) =>
+            {
+                if (e.SocketError == SocketError.Success) tcs.SetResult(getResult(e));
+                else tcs.SetException(new SocketException((int)e.SocketError));
+                saea.Dispose();
+            };
+            saea.Completed += handler;
+            if (!invoke(saea)) handler(s, saea);
+            return tcs.Task;
+        }
+    }
+
+    public abstract class MemberDatas
+    {
         public static readonly object[][] Loopbacks = new[]
         {
             new object[] { IPAddress.Loopback },
@@ -1146,12 +677,6 @@ namespace System.Net.Sockets.Tests
             new object[] { IPAddress.IPv6Loopback, false },
             new object[] { IPAddress.Loopback, true },
             new object[] { IPAddress.Loopback, false },
-        };
-
-        public static readonly object[][] LoopbacksToSameLoopback = new object[][]
-        {
-            new object[] { IPAddress.IPv6Loopback, IPAddress.IPv6Loopback },
-            new object[] { IPAddress.Loopback, IPAddress.Loopback }
         };
     }
 }


### PR DESCRIPTION
We have very little coverage of the Socket Task-based async methods.  This adds some basic tests, essentially just copying the existing synchronous test we already had in the SendReceive suite.  I also cleaned up some of the duplication in the file by using theories.

cc: @geoffkizer 