### PR TITLE
[1.1] Update AspNetCoreHosting keyword

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -991,7 +991,8 @@
       "BaselineVersion": "4.3.0",
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
-        "4.0.1.0": "4.3.0"
+        "4.0.1.0": "4.3.0",
+        "4.0.1.1": "4.3.1"
       }
     },
     "System.Diagnostics.FileVersionInfo": {

--- a/src/System.Diagnostics.DiagnosticSource/dir.props
+++ b/src/System.Diagnostics.DiagnosticSource/dir.props
@@ -1,7 +1,8 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.1</AssemblyVersion>
+    <PackageVersion>4.3.1</PackageVersion>
   </PropertyGroup>
 </Project>
 

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -164,7 +164,9 @@ namespace System.Diagnostics
                 "httpContext.Request.Path;" +
                 "httpContext.Request.QueryString" +
             "\n" +
-            "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.EndRequest@Activity1Stop:-";
+            "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.EndRequest@Activity1Stop:-" +
+                "httpContext.TraceIdentifier;" +
+                "httpContext.Response.StatusCode";
 
         // Setting EntityFrameworkCoreCommands is like having this in the FilterAndPayloadSpecs string
         // It turns on basic SQL commands.

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -586,11 +586,25 @@ namespace System.Diagnostics.Tests
                 eventSourceListener.ResetEventCountAndLastEvent();
 
                 // Stop the ASP.NET reqeust.  
-                aspNetCoreSource.Write("Microsoft.AspNetCore.Hosting.EndRequest", null);
+                aspNetCoreSource.Write("Microsoft.AspNetCore.Hosting.EndRequest",
+                    new
+                    {
+                        httpContext = new
+                        {
+                            Response = new
+                            {
+                                StatusCode = "200"
+                            },
+                            TraceIdentifier = "MyTraceId"
+                        }
+                    });
                 Assert.Equal(1, eventSourceListener.EventCount); // Exactly one more event has been emitted.
                 Assert.Equal("Activity1Stop", eventSourceListener.LastEvent.EventSourceEventName);
                 Assert.Equal("Microsoft.AspNetCore", eventSourceListener.LastEvent.SourceName);
                 Assert.Equal("Microsoft.AspNetCore.Hosting.EndRequest", eventSourceListener.LastEvent.EventName);
+                Assert.True(2 <= eventSourceListener.LastEvent.Arguments.Count);
+                Assert.Equal("MyTraceId", eventSourceListener.LastEvent.Arguments["TraceIdentifier"]);
+                Assert.Equal("200", eventSourceListener.LastEvent.Arguments["StatusCode"]);
                 eventSourceListener.ResetEventCountAndLastEvent();
             }
         }

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -25,6 +25,9 @@
     <Project Include="..\pkg\Microsoft.Private.PackageBaseline\Microsoft.Private.PackageBaseline.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="System.Diagnostics.DiagnosticSource\pkg\System.Diagnostics.DiagnosticSource.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>       
     <!-- add specific builds / pkgproj's here to include in servicing builds -->
   </ItemGroup>
 


### PR DESCRIPTION
The change is to unblock using Application Insights Profiler on .NET Core scenarios.

The change adds httpContext.TraceIdentifier and httpContext.Response.StatusCode keywords which allow Application Insights Profiler to correlate the profiling trace with the corresponding AI request telemetry event.

@vancem 

Note: It's redoing the reverted pr #16199.

