### PR TITLE
Improved Asin and ACos

### DIFF
--- a/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
@@ -27,7 +27,7 @@ namespace System.Numerics
         // This is the largest x for which 2 x^2 will not overflow. It is used for branching inside Asin and Acos.
         private static readonly double s_asinOverflowThreshold = Math.Sqrt(double.MaxValue) / 2.0;
 
-        // This constant is used inside Asin and Acos.
+        // This value is used inside Asin and Acos.
         private static readonly double s_log2 = Math.Log(2.0);
 
         private double _real;
@@ -168,7 +168,7 @@ namespace System.Numerics
             // Compute log(1 + x) without loss of accuracy when x is small.
 
             // Our only use case so far is for positive values, so this isn't coded to handle negative values.
-            Debug.Assert(!(x < 0.0));
+            Debug.Assert((x >= 0.0) || double.IsNaN(x));
 
             double xp1 = 1.0 + x;
             if (xp1 == 1.0)
@@ -418,8 +418,8 @@ namespace System.Numerics
             // to determine u. Compute u = arcsin(beta) or u = arctan(beta') for arcsin, u = arccos(beta)
             // or arctan(1/beta') for arccos.
 
-            Debug.Assert(!(x < 0.0));
-            Debug.Assert(!(y < 0.0));
+            Debug.Assert((x >= 0.0) || double.IsNaN(x));
+            Debug.Assert((y >= 0.0) || double.IsNaN(y));
 
             // For x or y large enough to overflow alpha^2, we can simplify our formulas and avoid overflow.
             if ((x > s_asinOverflowThreshold) || (y > s_asinOverflowThreshold))

--- a/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
@@ -23,6 +23,9 @@ namespace System.Numerics
         // This is the largest x for which (Hypot(x,x) + x) will not overflow. It is used for branching inside Sqrt.
         private static readonly double s_sqrtRescaleThreshold = double.MaxValue / (Math.Sqrt(2.0) + 1.0);
 
+        // This is the largest x for which 2 x^2 will not overflow. It is used for branching inside Asin and Acos.
+        private static readonly double s_asinOverflowThreshold = Math.Sqrt(double.MaxValue) / 2.0;
+
         private double _real;
         private double _imaginary;
         
@@ -155,6 +158,31 @@ namespace System.Numerics
 
         }
 
+
+        private static double Log1P(double x)
+        {
+            // Compute log(1 + x) without loss of accuracy when x is small.
+            // Our only use case so far is for positive values, so this isn't coded to handle negative values.
+
+            double xp1 = 1.0 + x;
+            if (xp1 == 1.0)
+            {
+                return x;
+            }
+            else if (x < 0.75)
+            {
+                // This is accurate to within 5 ulp with any floating-point system that uses a guard digit,
+                // as proven in Theorem 4 of "What Every Computer Scientist Should Know About Floating-Point
+                // Arithmetic" (https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html)
+                return x * Math.Log(xp1) / (xp1 - 1.0);
+            }
+            else
+            {
+                return Math.Log(xp1);
+            }
+
+        }
+
         public static Complex Conjugate(Complex value)
         {
             // Conjugate of a Complex number: the conjugate of x+i*y is x-i*y
@@ -246,11 +274,23 @@ namespace System.Numerics
 
         public static Complex Asin(Complex value)
         {
-            if ((value._imaginary == 0 && value._real < 0) || value._imaginary > 0)
+            double b, bPrime, v;
+            Asin_Internal(Math.Abs(value.Real), Math.Abs(value.Imaginary), out b, out bPrime, out v);
+
+            double u;
+            if (bPrime < 0.0)
             {
-                return -Asin(-value);
+                u = Math.Asin(b);
             }
-            return (-ImaginaryOne) * Log(ImaginaryOne * value + Sqrt(One - value * value));
+            else
+            {
+                u = Math.Atan(bPrime);
+            }
+
+            if (value.Real < 0.0) u = -u;
+            if (value.Imaginary < 0.0) v = -v;
+
+            return new Complex(u, v);
         }
 
         public static Complex Cos(Complex value) {
@@ -270,11 +310,23 @@ namespace System.Numerics
 
         public static Complex Acos(Complex value)
         {
-            if ((value._imaginary == 0 && value._real > 0) || value._imaginary < 0)
+            double b, bPrime, v;
+            Asin_Internal(Math.Abs(value.Real), Math.Abs(value.Imaginary), out b, out bPrime, out v);
+
+            double u;
+            if (bPrime < 0.0)
             {
-                return Math.PI - Acos(-value);
+                u = Math.Acos(b);
             }
-            return (-ImaginaryOne) * Log(value + ImaginaryOne * Sqrt(One - (value * value)));
+            else
+            {
+                u = Math.Atan(1.0 / bPrime);
+            }
+
+            if (value.Real < 0.0) u = Math.PI - u;
+            if (value.Imaginary > 0.0) v = -v;
+
+            return new Complex(u, v);
         }
 
         public static Complex Tan(Complex value)
@@ -319,6 +371,117 @@ namespace System.Numerics
             Complex two = new Complex(2.0, 0.0);
             return (ImaginaryOne / two) * (Log(One - ImaginaryOne * value) - Log(One + ImaginaryOne * value));
         }
+
+        private static void Asin_Internal (double x, double y, out double b, out double bPrime, out double v) {
+
+            // This method for the inverse complex sine (and cosine) is described in
+            // Hull and Tang, "Implementing the Complex Arcsine and Arccosine Functions Using Exception Handling",
+            // ACM Transactions on Mathematical Software (1997)
+            // (https://www.researchgate.net/profile/Ping_Tang3/publication/220493330_Implementing_the_Complex_Arcsine_and_Arccosine_Functions_Using_Exception_Handling/links/55b244b208ae9289a085245d.pdf)
+
+            // First, the basics: start with sin(w) = (e^{iw} - e^{-iw})/(2i) = z. Here z is the input
+            // and w is the output. To solve for w, define t = e^{i w} and multiply through by t to
+            // get the quadratic equation t^2 - 2 i z t - 1 = 0. The solution is t = i z + sqrt(1 - z^2), so
+            //   w = arcsin(z) = - i log( i z + sqrt(1 - z^2) )
+            // Decompose z = x + i y, multiply out i z + sqrt(1 - z^2), use log(s) = |s| + i arg(s), and do a
+            // bunch of algebra to get the components of w = arcsin(z) = u + i v
+            //   u = arcsin(\beta)  v = sign(y) log(\alpha + sqrt(\alpha^2 - 1))
+            // where
+            //   \alpha = (\rho + \sigma)/2  \beta = (\rho - \sigma)/2
+            //   \rho = sqrt((x + 1)^2 + y^2)  \sigma = \sqrt((x - 1)^2 + y^2)
+            // This appears in DLMF section 4.23. (http://dlmf.nist.gov/4.23), along with the analogous
+            //   arccos(w) = arccos(\beta) - i sign(y) log(\alpha + sqrt(\alpha^2 - 1))
+            // So \alpha and \beta together give us arcsin(w) and arccos(w).
+
+            // As written, \alpha is not susceptible to cancelation errors, but \beta is. To avoid cancelation, note
+            //   \beta = (\rho^2 - \sigma^2)/(\rho + \sigma))/2 = (2 x)/(\rho + \sigma) = x / \alpha
+            // which is not subject to cancelation. Note \alpha >= 1 and |\beta| <= 1.
+
+            // For \alpha ~ 1, the argument of the log is near unity, so we compute (\alpha - 1) instead,
+            // and write the argument as 1 + (\alpha - 1) + \sqrt{(\alpha - 1)(\alpha + 1)}.
+            // For \beta ~ 1, arccos does not accurately resolve small angles, so we compute the tangent of the angle
+            // instead. Hull and Tang derive formulas for (\alpha - 1) and \beta' = \tan(u) that do not suffer
+            // cancelation for these cases.
+
+            // For simplicity, we assume all positive inputs and return all positive outputs. The caller should
+            // assign signs appropriate to the desired cut conventions. We return v directly since its magnitude
+            // is the same for both arcsin and arccos. Instead of u, we usually return \beta and sometimes \beta'.
+            // If \beta' is not computed, it is set to -1; if it is computed, it should be used instead of \beta
+            // to determine u. Compute u = \arcsin(\beta) or u = \arctan(\beta') for arcsin, u = \arccos(\beta)
+            // or \arctan(1/\beta') for arccos.
+
+            // For x or y large enough to overflow \alpha^2, we can simplify our formulas and avoid overflow.
+            if ((x > s_asinOverflowThreshold) || (y > s_asinOverflowThreshold))
+            {
+
+                b = -1.0;
+                bPrime = x / y;
+
+                double small, big;
+                if (x < y)
+                {
+                    small = x;
+                    big = y;
+                }
+                else
+                {
+                    small = y;
+                    big = x;
+                }
+                double ratio = small / big;
+                v = Math.Log(2.0) + Math.Log(big) + 0.5 * Log1P(ratio * ratio);
+
+            }
+            else
+            {
+
+                double r = Hypot((x + 1.0), y);
+                double s = Hypot((x - 1.0), y);
+
+                double a = (r + s) / 2.0;
+                b = x / a;
+
+                if (b > 0.75)
+                {
+                    double amx;
+                    if (x <= 1.0)
+                    {
+                        amx = (y * y / (r + (x + 1.0)) + (s + (1.0 - x))) / 2.0;
+                    }
+                    else
+                    {
+                        amx = y * y * (1.0 / (r + (x + 1.0)) + 1.0 / (s + (x - 1.0))) / 2.0;
+                    }
+                    bPrime = x / Math.Sqrt((a + x) * amx);
+                }
+                else
+                {
+                    bPrime = -1.0;
+                }
+
+                if (a < 1.5)
+                {
+                    double am1;
+                    if (x < 1.0)
+                    {
+                        am1 = y * y / 2.0 * (1.0 / (r + (x + 1.0)) + 1.0 / (s + (1.0 - x)));
+                    }
+                    else
+                    {
+                        am1 = (y * y / (r + (x + 1.0)) + (s + (x - 1.0))) / 2.0;
+                    }
+                    v = Log1P(am1 + Math.Sqrt(am1 * (a + 1.0)));
+                }
+                else
+                {
+                    // Because of the test above, we can be sure that a * a will not overflow.
+                    v = Math.Log(a + Math.Sqrt((a - 1.0) * (a + 1.0)));
+                }
+
+            }
+
+        }
+
 
         public static Complex Log(Complex value)
         {

--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -341,9 +341,11 @@ namespace System.Numerics.Tests
             yield return new object[] { double.MinValue, 0, double.NaN, double.NaN };
 
             // Invalid values
-            foreach (double invalidReal in s_invalidDoubleValues) {
+            foreach (double invalidReal in s_invalidDoubleValues)
+            {
                 yield return new object[] { invalidReal, 1, double.NaN, double.NaN }; // Invalid real
-                foreach (double invalidImaginary in s_invalidDoubleValues) {
+                foreach (double invalidImaginary in s_invalidDoubleValues)
+                {
                     yield return new object[] { 1, invalidImaginary, double.NaN, double.NaN }; // Invalid imaginary
                     yield return new object[] { invalidReal, invalidImaginary, double.NaN, double.NaN }; // Invalid real, invalid imaginary
                 }
@@ -352,7 +354,7 @@ namespace System.Numerics.Tests
 
         [Theory, MemberData("ACos_Legacy_TestData")]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
-        public static void ACos_Legacy (double real, double imaginary, double expectedReal, double expectedImaginary)
+        public static void ACos_Legacy(double real, double imaginary, double expectedReal, double expectedImaginary)
         {
             var complex = new Complex(real, imaginary);
             Complex result = Complex.Acos(complex);
@@ -441,7 +443,8 @@ namespace System.Numerics.Tests
         [ActiveIssue(15455)]
         [Theory, MemberData(nameof(ASin_Advanced_TestData))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        public static void ASin_Advanced (double real, double imaginary, double expectedReal, double expectedImaginary) {
+        public static void ASin_Advanced(double real, double imaginary, double expectedReal, double expectedImaginary)
+        {
             var complex = new Complex(real, imaginary);
             Complex result = Complex.Asin(complex);
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
@@ -467,7 +470,8 @@ namespace System.Numerics.Tests
 
         [Theory, MemberData("ASin_Legacy_TestData")]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
-        public static void ASin_Legacy (double real, double imaginary, double expectedReal, double expectedImaginary) {
+        public static void ASin_Legacy(double real, double imaginary, double expectedReal, double expectedImaginary)
+        {
             var complex = new Complex(real, imaginary);
             Complex result = Complex.Asin(complex);
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
@@ -1470,7 +1474,8 @@ namespace System.Numerics.Tests
 
         [Theory, MemberData(nameof(Tan_Legacy_TestData))]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
-        public static void Tan_Legacy (double real, double imaginary, double expectedReal, double expectedImaginary) {
+        public static void Tan_Legacy(double real, double imaginary, double expectedReal, double expectedImaginary)
+        {
             var complex = new Complex(real, imaginary);
             Complex result = Complex.Tan(complex);
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
@@ -1542,7 +1547,8 @@ namespace System.Numerics.Tests
 
         [Theory, MemberData(nameof(Tanh_Legacy_TestData))]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
-        public static void Tanh_Legacy (double real, double imaginary, double expectedReal, double expectedImaginary) {
+        public static void Tanh_Legacy(double real, double imaginary, double expectedReal, double expectedImaginary)
+        {
             var complex = new Complex(real, imaginary);
             Complex result = Complex.Tanh(complex);
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);

--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -334,6 +334,31 @@ namespace System.Numerics.Tests
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
         }
 
+        public static IEnumerable<object[]> ACos_Legacy_TestData ()
+        {
+            // Boundary values
+            yield return new object[] { double.MaxValue, 0, double.NaN, double.NaN };
+            yield return new object[] { double.MinValue, 0, double.NaN, double.NaN };
+
+            // Invalid values
+            foreach (double invalidReal in s_invalidDoubleValues) {
+                yield return new object[] { invalidReal, 1, double.NaN, double.NaN }; // Invalid real
+                foreach (double invalidImaginary in s_invalidDoubleValues) {
+                    yield return new object[] { 1, invalidImaginary, double.NaN, double.NaN }; // Invalid imaginary
+                    yield return new object[] { invalidReal, invalidImaginary, double.NaN, double.NaN }; // Invalid real, invalid imaginary
+                }
+            }
+        }
+
+        [Theory, MemberData("ACos_Legacy_TestData")]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void ACos_Legacy (double real, double imaginary, double expectedReal, double expectedImaginary)
+        {
+            var complex = new Complex(real, imaginary);
+            Complex result = Complex.Acos(complex);
+            VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
+        }
+
         public static IEnumerable<object[]> Add_TestData()
         {
             yield return new object[] { 0, 0, RandomPositiveDouble(), RandomPositiveDouble() }; // 0 + x = x
@@ -394,7 +419,12 @@ namespace System.Numerics.Tests
             yield return new object[] { -1234000000, 0, -1.5707963267948966, 21.62667394298955 }; // Real part is negative, imaginary part is 0
             yield return new object[] { 0, 1234000000, 0, 21.62667394298955 }; // Imaginary part is positive
 
-            // Extreme values
+            // Extremely tiny values
+            yield return new object[] { 1.0 / double.MaxValue, 0.0, 1.0 / double.MaxValue, 0.0 };
+            yield return new object[] { 0.0, -1.0 / double.MaxValue, 0.0, -1.0 / double.MaxValue };
+            yield return new object[] { -1.0 / double.MaxValue, 1.0 / double.MaxValue, -1.0 / double.MaxValue, 1.0 / double.MaxValue };
+
+            // Extremely large values
             yield return new object[] { double.MaxValue, 0.0, Math.PI / 2.0, Math.Log(2.0) + Math.Log(double.MaxValue) };
             yield return new object[] { 0.0, double.MaxValue, 0.0, Math.Log(2.0) + Math.Log(double.MaxValue) };
             yield return new object[] { double.MaxValue, double.MaxValue, Math.PI / 4.0, Math.Log(2.0 * Math.Sqrt(2.0)) + Math.Log(double.MaxValue) };
@@ -411,12 +441,39 @@ namespace System.Numerics.Tests
         [ActiveIssue(15455)]
         [Theory, MemberData(nameof(ASin_Advanced_TestData))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        public static void ASin_Advanced(double real, double imaginary, double expectedReal, double expectedImaginary)
-        {
+        public static void ASin_Advanced (double real, double imaginary, double expectedReal, double expectedImaginary) {
             var complex = new Complex(real, imaginary);
             Complex result = Complex.Asin(complex);
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
         }
+
+        public static IEnumerable<object[]> ASin_Legacy_TestData()
+        {
+            // Boundary values
+            yield return new object[] { double.MaxValue, 0, double.NaN, double.NaN };
+            yield return new object[] { double.MinValue, 0, double.NaN, double.NaN };
+
+            // Invalid values
+            foreach (double invalidReal in s_invalidDoubleValues)
+            {
+                yield return new object[] { invalidReal, 1, double.NaN, double.NaN }; // Invalid real
+                foreach (double invalidImaginary in s_invalidDoubleValues)
+                {
+                    yield return new object[] { 1, invalidImaginary, double.NaN, double.NaN }; // Invalid imaginary
+                    yield return new object[] { invalidReal, invalidImaginary, double.NaN, double.NaN }; // Invalid real, invalid imaginary
+                }
+            }
+        }
+
+        [Theory, MemberData("ASin_Legacy_TestData")]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void ASin_Legacy (double real, double imaginary, double expectedReal, double expectedImaginary) {
+            var complex = new Complex(real, imaginary);
+            Complex result = Complex.Asin(complex);
+            VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
+        }
+
+
 
         [Theory]
         [MemberData(nameof(Primitives_2_TestData))]

--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -301,23 +301,28 @@ namespace System.Numerics.Tests
 
         public static IEnumerable<object[]> ACos_Advanced_TestData()
         {
+            // Simple values
+            yield return new object[] { 0.0, 0.0, Math.PI / 2.0, 0.0 };
+            yield return new object[] { 1.0, 0.0, 0.0, 0.0 };
+            yield return new object[] { -1.0, 0.0, Math.PI, 0.0 };
+            yield return new object[] { 0.0, 1.0, Math.PI / 2.0, -Math.Log(1.0 + Math.Sqrt(2.0)) };
+            yield return new object[] { 0.0, -1.0, Math.PI / 2.0, Math.Log(1.0 + Math.Sqrt(2.0)) };
+
             yield return new object[] { 1234000000, 0, 0, 21.62667394298955 }; // Real part is positive, imaginary part is 0
             yield return new object[] { 0, -1234000000, 1.5707963267948966, 21.62667394298955 }; // Imaginary part is negative
 
-            // Boundary values
-            yield return new object[] { double.MaxValue, 0, double.NaN, double.NaN };
-            yield return new object[] { double.MinValue, 0, double.NaN, double.NaN };
+            // Extreme values
+            yield return new object[] { double.MaxValue, 0.0, 0.0, Math.Log(2.0) + Math.Log(double.MaxValue) };
+            yield return new object[] { 0.0, double.MaxValue, Math.PI / 2.0, -(Math.Log(2.0) + Math.Log(double.MaxValue)) };
+            yield return new object[] { -double.MaxValue, -double.MaxValue, 3.0 / 4.0 * Math.PI, Math.Log(2.0 * Math.Sqrt(2.0)) + Math.Log(double.MaxValue) };
 
-            // Invalid values
-            foreach (double invalidReal in s_invalidDoubleValues)
-            {
-                yield return new object[] { invalidReal, 1, double.NaN, double.NaN }; // Invalid real
-                foreach (double invalidImaginary in s_invalidDoubleValues)
-                {
-                    yield return new object[] { 1, invalidImaginary, double.NaN, double.NaN }; // Invalid imaginary
-                    yield return new object[] { invalidReal, invalidImaginary, double.NaN, double.NaN }; // Invalid real, invalid imaginary
-                }
-            }
+            // NaN values
+            yield return new object[] { double.NaN, double.NaN, double.NaN, double.NaN };
+            yield return new object[] { -1.0, double.NaN, double.NaN, double.NaN };
+            yield return new object[] { double.NegativeInfinity, double.NaN, double.NaN, double.NaN };
+            yield return new object[] { double.NaN, 0.0, double.NaN, double.NaN };
+            yield return new object[] { double.NaN, double.PositiveInfinity, double.NaN, double.NaN };
+
         }
 
         [Theory, MemberData(nameof(ACos_Advanced_TestData))]
@@ -394,16 +399,13 @@ namespace System.Numerics.Tests
             yield return new object[] { 0.0, double.MaxValue, 0.0, Math.Log(2.0) + Math.Log(double.MaxValue) };
             yield return new object[] { double.MaxValue, double.MaxValue, Math.PI / 4.0, Math.Log(2.0 * Math.Sqrt(2.0)) + Math.Log(double.MaxValue) };
 
-            // Invalid values
-            foreach (double invalidReal in s_invalidDoubleValues)
-            {
-                yield return new object[] { invalidReal, 1, double.NaN, double.NaN }; // Invalid real
-                foreach (double invalidImaginary in s_invalidDoubleValues)
-                {
-                    yield return new object[] { 1, invalidImaginary, double.NaN, double.NaN }; // Invalid imaginary
-                    yield return new object[] { invalidReal, invalidImaginary, double.NaN, double.NaN }; // Invalid real, invalid imaginary
-                }
-            }
+            // NaN values
+            yield return new object[] { double.NaN, double.NaN, double.NaN, double.NaN };
+            yield return new object[] { 0.0, double.NaN, double.NaN, double.NaN };
+            yield return new object[] { double.PositiveInfinity, double.NaN, double.NaN, double.NaN };
+            yield return new object[] { double.NaN, 1.0, double.NaN, double.NaN };
+            yield return new object[] { double.NaN, double.NegativeInfinity, double.NaN, double.NaN };
+            
         }
 
         [ActiveIssue(15455)]

--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -322,7 +322,6 @@ namespace System.Numerics.Tests
             yield return new object[] { double.NegativeInfinity, double.NaN, double.NaN, double.NaN };
             yield return new object[] { double.NaN, 0.0, double.NaN, double.NaN };
             yield return new object[] { double.NaN, double.PositiveInfinity, double.NaN, double.NaN };
-
         }
 
         [Theory, MemberData(nameof(ACos_Advanced_TestData))]
@@ -436,8 +435,7 @@ namespace System.Numerics.Tests
             yield return new object[] { 0.0, double.NaN, double.NaN, double.NaN };
             yield return new object[] { double.PositiveInfinity, double.NaN, double.NaN, double.NaN };
             yield return new object[] { double.NaN, 1.0, double.NaN, double.NaN };
-            yield return new object[] { double.NaN, double.NegativeInfinity, double.NaN, double.NaN };
-            
+            yield return new object[] { double.NaN, double.NegativeInfinity, double.NaN, double.NaN };            
         }
 
         [ActiveIssue(15455)]
@@ -476,8 +474,6 @@ namespace System.Numerics.Tests
             Complex result = Complex.Asin(complex);
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
         }
-
-
 
         [Theory]
         [MemberData(nameof(Primitives_2_TestData))]


### PR DESCRIPTION
Previous implementations of Asin and Acos were based on log(i z + sqrt(1 - z^2)), which is subject to overflow and cancellation in large fractions of the space of representable z. The new implementation is based on an article by Hull and Tang that correctly handles essentially the entire representable space. This solves bug #15455, which can be closed after this pull.

Fixes #15455