### PR TITLE
Fix RIDS for UAP metapackage

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.props
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.props
@@ -23,18 +23,18 @@
   </Choose>
 
   <ItemGroup>
-    <OfficialBuildRID Include="win7-x86">
+    <OfficialBuildRID Include="win10-x86">
       <Platform>x86</Platform>
     </OfficialBuildRID>
-    <OfficialBuildRID Include="win7-x64" />
-    <OfficialBuildRID Include="win8-arm">
+    <OfficialBuildRID Include="win10-x64" />
+    <OfficialBuildRID Include="win10-arm">
       <Platform>arm</Platform>
     </OfficialBuildRID>
-    <OfficialBuildRID Include="win7-x86-aot">
+    <OfficialBuildRID Include="win10-x86-aot">
       <Platform>x86</Platform>
     </OfficialBuildRID>
-    <OfficialBuildRID Include="win7-x64-aot" />
-    <OfficialBuildRID Include="win8-arm-aot">
+    <OfficialBuildRID Include="win10-x64-aot" />
+    <OfficialBuildRID Include="win10-arm-aot">
       <Platform>arm</Platform>
     </OfficialBuildRID>
 


### PR DESCRIPTION
cc: @ericstj 

As @davidwrighton pointed out, the UAP package rids should all be win10. This change fixes that.

FYI: @AntonLapounov @davidwrighton 