### PR TITLE
small changes to unix SocketAsyncContext

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -367,6 +367,7 @@ namespace System.Net.Sockets
 
             public void Init()
             {
+                Debug.Assert(_queueLock == null);
                 _queueLock = new object();
             }
 


### PR DESCRIPTION
This is a bit of cleanup/reorganization in preparation for upcoming perf enhancements.

- When we retry an async operation and it then succeeds, complete it synchronously rather than queuing a completion to the thread pool.
- Align operations and queues with OS readiness notifications (i.e. read/write)
- Move the queue locks to the queue structure, and partially encapsulate access to the lock (in anticipation of fully encapsulating this in subsequent changes)

