### PR TITLE
Handle explicit InstructionIndex changes within filters

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -664,8 +664,8 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string InstructionName => "LeaveExceptionFilter";
 
-        // The boolean result is popped from the stack in the filter runner.
-        public override int ConsumedStack => 1;
+        // The exception and the boolean result are popped from the stack in the filter runner.
+        public override int ConsumedStack => 2;
 
         public override int ProducedStack => 0;
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -31,34 +31,26 @@ namespace System.Linq.Expressions.Interpreter
 
     internal sealed class ExceptionHandler
     {
-        public readonly Type ExceptionType;
+        private readonly Type _exceptionType;
         public readonly int LabelIndex;
         public readonly int HandlerStartIndex;
         public readonly int HandlerEndIndex;
         public readonly ExceptionFilter Filter;
 
-        internal TryCatchFinallyHandler Parent = null;
-
         internal ExceptionHandler(int labelIndex, int handlerStartIndex, int handlerEndIndex, Type exceptionType, ExceptionFilter filter)
         {
             Debug.Assert(exceptionType != null);
             LabelIndex = labelIndex;
-            ExceptionType = exceptionType;
+            _exceptionType = exceptionType;
             HandlerStartIndex = handlerStartIndex;
             HandlerEndIndex = handlerEndIndex;
             Filter = filter;
         }
 
-        internal void SetParent(TryCatchFinallyHandler tryHandler)
-        {
-            Debug.Assert(Parent == null);
-            Parent = tryHandler;
-        }
-
-        public bool Matches(Type exceptionType) => ExceptionType.IsAssignableFrom(exceptionType);
+        public bool Matches(Type exceptionType) => _exceptionType.IsAssignableFrom(exceptionType);
 
         public override string ToString() =>
-            string.Format(CultureInfo.InvariantCulture, "catch({0}) [{1}->{2}]", ExceptionType.Name, HandlerStartIndex, HandlerEndIndex);
+            string.Format(CultureInfo.InvariantCulture, "catch({0}) [{1}->{2}]", _exceptionType.Name, HandlerStartIndex, HandlerEndIndex);
     }
 
     internal sealed class TryCatchFinallyHandler
@@ -103,16 +95,7 @@ namespace System.Linq.Expressions.Interpreter
             FinallyStartIndex = finallyStart;
             FinallyEndIndex = finallyEnd;
             GotoEndTargetIndex = gotoEndLabelIndex;
-
             _handlers = handlers;
-
-            if (_handlers != null)
-            {
-                foreach (ExceptionHandler handler in _handlers)
-                {
-                    handler.SetParent(this);
-                }
-            }
         }
 
         internal bool HasHandler(InterpretedFrame frame, Exception exception, out ExceptionHandler handler, out object unwrappedException)

--- a/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -509,7 +509,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(3, Expression.Lambda<Func<int>>(finally2).Compile(useInterpreter)());
         }
 
-        [Theory, InlineData(true)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void FaultNotTriggeredOnNoThrow(bool useInterpreter)
         {
             ParameterExpression variable = Expression.Parameter(typeof(int));
@@ -560,7 +560,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(2, Expression.Lambda<Func<int>>(block).Compile(useInterpreter)());
         }
 
-        [Theory, InlineData(true)]
+        [Theory, ClassData(typeof(CompilationTypes))]
         public void FinallyAndFaultAfterManyLabels(bool useInterpreter)
         {
             // There is a caching optimisation used below a certain number of faults or
@@ -949,6 +949,96 @@ namespace System.Linq.Expressions.Tests
                 );
             Func<int> func = Expression.Lambda<Func<int>>(tryExp).Compile(useInterpreter);
             Assert.Equal(9, func());
+        }
+
+        [Theory, InlineData(true)]
+        public void TryFinallyWithinFilter(bool useInterpreter)
+        {
+            TryExpression tryExp = Expression.TryCatch(
+                Expression.Throw(Expression.Constant(new TestException()), typeof(int)),
+                Expression.Catch(
+                    typeof(TestException),
+                    Expression.Constant(1),
+                    Expression.TryFinally(Expression.Constant(false), Expression.Empty())
+                    ),
+                Expression.Catch(
+                    typeof(TestException),
+                    Expression.Constant(2),
+                    Expression.TryFinally(Expression.Constant(true), Expression.Empty())
+                    ),
+                Expression.Catch(
+                    typeof(TestException),
+                    Expression.Constant(3)
+                    )
+                );
+            Func<int> func = Expression.Lambda<Func<int>>(tryExp).Compile(useInterpreter);
+            Assert.Equal(2, func());
+        }
+
+        [Fact, ActiveIssue(15719)]
+        public void TryFinallyWithinFilterCompiled()
+        {
+            TryFinallyWithinFilter(false);
+        }
+
+        [Theory, InlineData(true)]
+        public void TryCatchWithinFilter(bool useInterpreter)
+        {
+            TryExpression tryExp = Expression.TryCatch(
+                Expression.Throw(Expression.Constant(new TestException()), typeof(int)),
+                Expression.Catch(
+                    typeof(TestException),
+                    Expression.Constant(1),
+                    Expression.TryCatch(Expression.Constant(false), Expression.Catch(typeof(Expression), Expression.Constant(false)))
+                    ),
+                Expression.Catch(
+                    typeof(TestException),
+                    Expression.Constant(2),
+                    Expression.TryCatch(Expression.Constant(true), Expression.Catch(typeof(Expression), Expression.Constant(true)))
+                    ),
+                Expression.Catch(
+                    typeof(TestException),
+                    Expression.Constant(3)
+                    )
+                );
+            Func<int> func = Expression.Lambda<Func<int>>(tryExp).Compile(useInterpreter);
+            Assert.Equal(2, func());
+        }
+
+        [Fact, ActiveIssue(15719)]
+        public void TryCatchWithinFilterCompiled()
+        {
+            TryCatchWithinFilter(false);
+        }
+
+        [Theory, InlineData(true)]
+        public void TryCatchThrowingWithinFilter(bool useInterpreter)
+        {
+            TryExpression tryExp = Expression.TryCatch(
+                Expression.Throw(Expression.Constant(new TestException()), typeof(int)),
+                Expression.Catch(
+                    typeof(TestException),
+                    Expression.Constant(1),
+                    Expression.TryCatch(Expression.Throw(Expression.Constant(new TestException()), typeof(bool)), Expression.Catch(typeof(Exception), Expression.Constant(false)))
+                    ),
+                Expression.Catch(
+                    typeof(TestException),
+                    Expression.Constant(2),
+                    Expression.TryCatch(Expression.Throw(Expression.Constant(new TestException()), typeof(bool)), Expression.Catch(typeof(Exception), Expression.Constant(true)))
+                    ),
+                Expression.Catch(
+                    typeof(TestException),
+                    Expression.Constant(3)
+                    )
+                );
+            Func<int> func = Expression.Lambda<Func<int>>(tryExp).Compile(useInterpreter);
+            Assert.Equal(2, func());
+        }
+
+        [Fact, ActiveIssue(15719)]
+        public void TryCatchThrowingWithinFilterCompiled()
+        {
+            TryCatchThrowingWithinFilter(false);
         }
 
         private bool MethodWithManyArguments(


### PR DESCRIPTION
Fixes #16539 

Also remove unused `ExceptionHandler.Parent` field and make `ExceptionHandler.ExceptionType` field private.