### PR TITLE
Improve CI: disable socket tests on Unix which may fail due to port being in-use

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -843,6 +843,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // Binds to a specific port on 'connectTo' which on Unix may already be in use
         public void BeginAcceptV6BoundToSpecificV4_CantConnect()
         {
             Assert.Throws<SocketException>(() =>
@@ -852,6 +853,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // Binds to a specific port on 'connectTo' which on Unix may already be in use
         public void BeginAcceptV4BoundToSpecificV6_CantConnect()
         {
             Assert.Throws<SocketException>(() =>
@@ -861,6 +863,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // Binds to a specific port on 'connectTo' which on Unix may already be in use
         public void BeginAcceptV6BoundToAnyV4_CantConnect()
         {
             Assert.Throws<SocketException>(() =>
@@ -947,6 +950,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // Binds to a specific port on 'connectTo' which on Unix may already be in use
         public void AcceptAsyncV6BoundToSpecificV4_CantConnect()
         {
             Assert.Throws<SocketException>(() =>
@@ -956,6 +960,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // Binds to a specific port on 'connectTo' which on Unix may already be in use
         public void AcceptAsyncV4BoundToSpecificV6_CantConnect()
         {
             Assert.Throws<SocketException>(() =>
@@ -964,8 +969,8 @@ namespace System.Net.Sockets.Tests
             });
         }
 
-        [ActiveIssue(13213)]
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // Binds to a specific port on 'connectTo' which on Unix may already be in use
         public void AcceptAsyncV6BoundToAnyV4_CantConnect()
         {
             Assert.Throws<SocketException>(() =>
@@ -1097,6 +1102,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // Binds to a specific port on 'connectTo' which on Unix may already be in use
         public void SendToV4IPEndPointToV6Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1106,6 +1112,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // Binds to a specific port on 'connectTo' which on Unix may already be in use
         public void SendToV6IPEndPointToV4Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1316,6 +1323,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // Binds to a specific port on 'connectTo' which on Unix may already be in use
         public void SendToAsyncV4IPEndPointToV6Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1325,6 +1333,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // Binds to a specific port on 'connectTo' which on Unix may already be in use
         public void SendToAsyncV6IPEndPointToV4Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>


### PR DESCRIPTION
Several Socket tests bind to an open port (returned from the OS), and then connect to that same port but on a different IPV4 or IPV6 loopback address. On Windows that seems to work fine (that other loopback port is never in use), but on Unix (and OSX) port #'s are random (not incremental as in Windows) and it treats IPV4 and IPV6 as separate addresses thus the expected unused port will occasionally be in use causing that test, or related test to fail.

Most likely it is the 'mirror' test that is using the other protocol+port, meaning the test just before or after the current test that for example tests (IPV6, IPV4) while the original tests (IPV4, IPV6). I have repro'd the failures fairly consistently on Ubuntu by adding a 'for' loop to both tests so they execute 1,000 times or so. I have also written a small POSIX example that shows given a bound IPV6 loopback port, the OS can return an IPV4 address with the same port.

This PR just disables these tests for non-Windows cases. Note that these are also the 'failure' tests, meaning the happy path tests (IPV6, IPV6) or (IPV4, IPV4) are not changed here.

Addresses https://github.com/dotnet/corefx/issues/9017, https://github.com/dotnet/corefx/issues/13213 
Also https://github.com/dotnet/corefx/issues/14519

cc @stephentoub , @CIPop, @davidsh 
