### PR TITLE
Avoid non-trivial marshaling in System.ReadKey

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.ReadConsoleInput.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.ReadConsoleInput.cs
@@ -13,7 +13,7 @@ internal partial class Interop
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     internal struct KeyEventRecord
     {
-        internal bool keyDown;
+        internal BOOL keyDown;
         internal short repeatCount;
         internal short virtualKeyCode;
         internal short virtualScanCode;

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -51,13 +51,16 @@
       <Link>Common\System\Text\DBCSDecoder.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.Encoding.Constants.cs">
-      <Link>Common\Interop\Windows\kernel32\Interop.Encoding.Constants.cs</Link>
+      <Link>Common\Interop\Windows\Interop.Encoding.Constants.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetCPInfoEx.cs">
-      <Link>Common\Interop\Windows\kernel32\Interop.GetCPInfoEx.cs</Link>
+      <Link>Common\Interop\Windows\Interop.GetCPInfoEx.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.BOOL.cs">
+      <Link>Common\Interop\Windows\Interop.BOOL.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.Beep.cs">
       <Link>Common\Interop\Windows\Interop.Beep.cs</Link>

--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -197,7 +197,7 @@ namespace System
         [System.Security.SecurityCritical]  // auto-generated
         private static bool IsKeyDownEvent(Interop.InputRecord ir)
         {
-            return (ir.eventType == Interop.KEY_EVENT && ir.keyEvent.keyDown);
+            return (ir.eventType == Interop.KEY_EVENT && ir.keyEvent.keyDown != Interop.BOOL.FALSE);
         }
 
         [System.Security.SecurityCritical]  // auto-generated

--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -186,7 +186,6 @@ namespace System
         // we will lose repeated keystrokes when someone switches from
         // calling ReadKey to calling Read or ReadLine.  Those methods should 
         // ideally flush this cache as well.
-        [System.Security.SecurityCritical] // auto-generated
         private static Interop.InputRecord _cachedInputRecord;
 
         // Skip non key events. Generally we want to surface only KeyDown event 
@@ -194,13 +193,11 @@ namespace System
         // where the assumption of KeyDown-KeyUp pairing for a given key press 
         // is invalid. For example in IME Unicode keyboard input, we often see
         // only KeyUp until the key is released.  
-        [System.Security.SecurityCritical]  // auto-generated
         private static bool IsKeyDownEvent(Interop.InputRecord ir)
         {
             return (ir.eventType == Interop.KEY_EVENT && ir.keyEvent.keyDown != Interop.BOOL.FALSE);
         }
 
-        [System.Security.SecurityCritical]  // auto-generated
         private static bool IsModKey(Interop.InputRecord ir)
         {
             // We should also skip over Shift, Control, and Alt, as well as caps lock.
@@ -230,7 +227,6 @@ namespace System
         // desired effect is to translate the sequence into one Unicode KeyPress. 
         // We need to keep track of the Alt+NumPad sequence and surface the final
         // unicode char alone when the Alt key is released. 
-        [System.Security.SecurityCritical]  // auto-generated
         private static bool IsAltKeyDown(Interop.InputRecord ir)
         {
             return (((ControlKeyState)ir.keyEvent.controlKeyState)
@@ -613,7 +609,6 @@ namespace System
 
         public static string Title
         {
-            [System.Security.SecuritySafeCritical]  // auto-generated
             get
             {
                 string title = null;
@@ -632,7 +627,6 @@ namespace System
                 return title;
             }
 
-            [System.Security.SecuritySafeCritical]  // auto-generated
             set
             {
                 if (value == null)
@@ -825,7 +819,6 @@ namespace System
 
         public static int BufferWidth
         {
-            [System.Security.SecuritySafeCritical]  // auto-generated
             get
             {
                 Interop.Kernel32.CONSOLE_SCREEN_BUFFER_INFO csbi = GetBufferInfo();
@@ -839,7 +832,6 @@ namespace System
 
         public static int BufferHeight
         {
-            [System.Security.SecuritySafeCritical]  // auto-generated
             get
             {
                 Interop.Kernel32.CONSOLE_SCREEN_BUFFER_INFO csbi = GetBufferInfo();
@@ -851,7 +843,6 @@ namespace System
             }
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static void SetBufferSize(int width, int height)
         {
             // Ensure the new size is not smaller than the console window
@@ -873,7 +864,6 @@ namespace System
 
         public static int LargestWindowWidth
         {
-            [System.Security.SecuritySafeCritical]  // auto-generated
             get
             {
                 // Note this varies based on current screen resolution and 
@@ -885,7 +875,6 @@ namespace System
 
         public static int LargestWindowHeight
         {
-            [System.Security.SecuritySafeCritical]  // auto-generated
             get
             {
                 // Note this varies based on current screen resolution and 


### PR DESCRIPTION
- Change KeyEventRecord to be blittable structure. It is better for perf and workarounds dotnet/corert#2852
- Stripped security annotations from System.Console.PAL while I was on it