### PR TITLE
Fix tests that assumed GC refs could become collectable in the middle of a method.

### DIFF
--- a/src/System.Diagnostics.TraceSource/tests/SwitchClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/SwitchClassTests.cs
@@ -37,11 +37,17 @@ namespace System.Diagnostics.TraceSourceTests
             Assert.Equal("", item.Description);
         }
 
+        [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static WeakReference PruneMakeRef()
+        {
+            return new WeakReference(new TestSwitch());
+        }
+
         [Fact]
         public void PruneTest()
         {
             var strongSwitch = new TestSwitch();
-            var weakSwitch = new WeakReference(new TestSwitch());
+            var weakSwitch = PruneMakeRef();
             Assert.True(weakSwitch.IsAlive);
             GC.Collect(2);
             Trace.Refresh();

--- a/src/System.Diagnostics.TraceSource/tests/TraceSourceClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TraceSourceClassTests.cs
@@ -64,11 +64,17 @@ namespace System.Diagnostics.TraceSourceTests
             trace.TraceEvent(TraceEventType.Critical, 0);
         }
 
+        [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static WeakReference PruneMakeRef()
+        {
+            return new WeakReference(new TraceSource("TestTraceSource"));
+        }
+
         [Fact]
         public void PruneTest()
         {
             var strongTrace = new TraceSource("TestTraceSource");
-            var traceRef = new WeakReference(new TraceSource("TestTraceSource"));
+            var traceRef = PruneMakeRef();
             Assert.True(traceRef.IsAlive);
             GC.Collect(2);
             Trace.Refresh();

--- a/src/System.Runtime/tests/System/GCTests.cs
+++ b/src/System.Runtime/tests/System/GCTests.cs
@@ -81,10 +81,17 @@ namespace System.Tests
 
         private class FinalizerTest
         {
-            public static void Run()
+            [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+            private static void MakeAndDropTest()
             {
                 var obj = new TestObject();
                 obj = null;
+            }
+
+            public static void Run()
+            {
+                MakeAndDropTest();
+
                 GC.Collect();
 
                 // Make sure Finalize() is called
@@ -112,12 +119,17 @@ namespace System.Tests
 
         private class KeepAliveTest
         {
+            [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+            private static void MakeAndDropDNKA()
+            {
+                new DoNotKeepAliveObject();
+            }
+
             public static void Run()
             {
                 var keepAlive = new KeepAliveObject();
 
-                var doNotKeepAlive = new DoNotKeepAliveObject();
-                doNotKeepAlive = null;
+                MakeAndDropDNKA();
 
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
@@ -157,14 +169,19 @@ namespace System.Tests
 
         private class KeepAliveNullTest
         {
-            public static void Run()
+            [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+            private static void MakeAndNull()
             {
                 var obj = new TestObject();
                 obj = null;
+            }
+
+            public static void Run()
+            {
+                MakeAndNull();
 
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                GC.KeepAlive(obj);
 
                 Assert.True(TestObject.Finalized);
             }

--- a/src/System.Runtime/tests/System/GCTests.cs
+++ b/src/System.Runtime/tests/System/GCTests.cs
@@ -84,8 +84,7 @@ namespace System.Tests
             [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
             private static void MakeAndDropTest()
             {
-                var obj = new TestObject();
-                obj = null;
+                new TestObject();
             }
 
             public static void Run()

--- a/src/System.Runtime/tests/System/Runtime/CompilerServices/ConditionalWeakTableTests.cs
+++ b/src/System.Runtime/tests/System/Runtime/CompilerServices/ConditionalWeakTableTests.cs
@@ -183,8 +183,8 @@ namespace System.Runtime.CompilerServices.Tests
             });
         }
 
-        [Fact]
-        public static void AddRemove_DropValue()
+        [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static WeakReference GetWeakCondTabRef(out ConditionalWeakTable<object, object> cwt_out, out object key_out)
         {
             var key = new object();
             var value = new object();
@@ -194,9 +194,20 @@ namespace System.Runtime.CompilerServices.Tests
             cwt.Add(key, value);
             cwt.Remove(key);
 
+            // Return 3 values to the caller, drop everything else on the floor.
+            cwt_out = cwt;
+            key_out = key;
+            return new WeakReference(value);
+        }
+
+        [Fact]
+        public static void AddRemove_DropValue()
+        {
             // Verify that the removed entry is not keeping the value alive
-            var wrValue = new WeakReference(value);
-            value = null;
+            ConditionalWeakTable<object, object> cwt;
+            object key;
+
+            var wrValue = GetWeakCondTabRef(out cwt, out key);
 
             GC.Collect();
             Assert.False(wrValue.IsAlive);
@@ -205,52 +216,68 @@ namespace System.Runtime.CompilerServices.Tests
             GC.KeepAlive(key);
         }
 
-        [Fact]
-        public static void GetOrCreateValue()
+        [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static void GetWeakRefPair(out WeakReference<object> key_out, out WeakReference<object> val_out)
         {
             var cwt = new ConditionalWeakTable<object, object>();
             var key = new object();
-            object obj = null;
 
             object value = cwt.GetOrCreateValue(key);
 
             Assert.True(cwt.TryGetValue(key, out value));
             Assert.Equal(value, cwt.GetValue(key, k => new object()));
 
-            var wrValue = new WeakReference<object>(value, false);
-            var wrkey = new WeakReference<object>(key, false);
-            key = null;
-            value = null;
+            val_out = new WeakReference<object>(value, false);
+            key_out = new WeakReference<object>(key, false);
+        }
+
+        [Fact]
+        public static void GetOrCreateValue()
+        {
+            object obj = null;
+
+            WeakReference<object> wrValue;
+            WeakReference<object> wrKey;
+
+            GetWeakRefPair(out wrKey, out wrValue);
 
             GC.Collect();
 
             // key and value must be collected
             Assert.False(wrValue.TryGetTarget(out obj));
-            Assert.False(wrkey.TryGetTarget(out obj));
+            Assert.False(wrKey.TryGetTarget(out obj));
         }
 
-        [Fact]
-        public static void GetValue()
+        [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static void GetWeakRefValPair(out WeakReference<object> key_out, out WeakReference<object> val_out)
         {
             var cwt = new ConditionalWeakTable<object, object>();
             var key = new object();
-            object obj = null;
 
             object value = cwt.GetValue(key, k => new object());
 
             Assert.True(cwt.TryGetValue(key, out value));
             Assert.Equal(value, cwt.GetOrCreateValue(key));
 
-            WeakReference<object> wrValue = new WeakReference<object>(value, false);
-            WeakReference<object> wrkey = new WeakReference<object>(key, false);
-            key = null;
-            value = null;
+            val_out = new WeakReference<object>(value, false);
+            key_out = new WeakReference<object>(key, false);
+        }
+
+        [Fact]
+        public static void GetValue()
+        {
+            object obj = null;
+
+            WeakReference<object> wrValue;
+            WeakReference<object> wrKey;
+
+            GetWeakRefValPair(out wrKey, out wrValue);
 
             GC.Collect();
 
             // key and value must be collected
             Assert.False(wrValue.TryGetTarget(out obj));
-            Assert.False(wrkey.TryGetTarget(out obj));
+            Assert.False(wrKey.TryGetTarget(out obj));
         }
 
         [Theory]

--- a/src/System.Runtime/tests/System/Runtime/CompilerServices/ConditionalWeakTableTests.cs
+++ b/src/System.Runtime/tests/System/Runtime/CompilerServices/ConditionalWeakTableTests.cs
@@ -234,8 +234,6 @@ namespace System.Runtime.CompilerServices.Tests
         [Fact]
         public static void GetOrCreateValue()
         {
-            object obj = null;
-
             WeakReference<object> wrValue;
             WeakReference<object> wrKey;
 
@@ -244,6 +242,7 @@ namespace System.Runtime.CompilerServices.Tests
             GC.Collect();
 
             // key and value must be collected
+            object obj;
             Assert.False(wrValue.TryGetTarget(out obj));
             Assert.False(wrKey.TryGetTarget(out obj));
         }
@@ -266,8 +265,6 @@ namespace System.Runtime.CompilerServices.Tests
         [Fact]
         public static void GetValue()
         {
-            object obj = null;
-
             WeakReference<object> wrValue;
             WeakReference<object> wrKey;
 
@@ -276,6 +273,7 @@ namespace System.Runtime.CompilerServices.Tests
             GC.Collect();
 
             // key and value must be collected
+            object obj;
             Assert.False(wrValue.TryGetTarget(out obj));
             Assert.False(wrKey.TryGetTarget(out obj));
         }

--- a/src/System.Threading.Tasks/tests/CancellationTokenTests.cs
+++ b/src/System.Threading.Tasks/tests/CancellationTokenTests.cs
@@ -817,6 +817,12 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static void FinalizeHelper(DisposeTracker disposeTracker)
+        {
+            new DerivedCTS(disposeTracker);
+        }
+
         // Several tests for deriving custom user types from CancellationTokenSource
         [Fact]
         public static void DerivedCancellationTokenSource()
@@ -873,9 +879,7 @@ namespace System.Threading.Tasks.Tests
             {
                 var disposeTracker = new DisposeTracker();
 
-                // Since the object is not assigned into a variable, it can be GC'd before the current method terminates.
-                // (This is only an issue in the Debug build)
-                new DerivedCTS(disposeTracker);
+                FinalizeHelper(disposeTracker);
 
                 // Wait until the DerivedCTS object is finalized
                 SpinWait.SpinUntil(() =>


### PR DESCRIPTION
Some tests have been assuming that when a local reference (e.g. a local variable) is last used in a method, it is immediately available to be collected by the GC, but this was never guaranteed (it just happened to work that way most of the time) and with upcoming CoreCLR changes this assumption will break tests. This change moves such references into their own method bodies - this is still not 100% guaranteed to work but it's very hard to see it ever breaking in the real world.