### PR TITLE
Set correct RID in private package runtime.json

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
@@ -51,10 +51,12 @@
     <!-- force a missing file if ref build is absent -->
     <File Include="$(RefBinDir)/MISSING_REF_BUILD" Condition="'@(FileToPackage)' == ''" />
 
-    <Dependency Include="@(BuildRID->'runtime.%(Identity).$(Id)')">
+    <_buildRIDWithMetadata Include="@(BuildRID)">
       <TargetRuntime>%(Identity)</TargetRuntime>
       <Version>$(PackageVersion)</Version>
-    </Dependency>
+    </_buildRIDWithMetadata>
+    <Dependency Include="@(_buildRIDWithMetadata->'runtime.%(Identity).$(Id)')" />
+
     <Dependency Include="Microsoft.NETCore.Platforms">
       <Version>$(PlatformPackageVersion)</Version>
     </Dependency>

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
@@ -29,10 +29,12 @@
     <!-- force a missing file if ref build is absent -->
     <File Include="$(RefBinDir)/MISSING_REF_BUILD" Condition="'@(FileToPackage)' == ''" />
 
-    <Dependency Include="@(BuildRID->'runtime.%(Identity).$(Id)')">
+    <_buildRIDWithMetadata Include="@(BuildRID)">
       <TargetRuntime>%(Identity)</TargetRuntime>
       <Version>$(PackageVersion)</Version>
-    </Dependency>
+    </_buildRIDWithMetadata>
+    <Dependency Include="@(_buildRIDWithMetadata->'runtime.%(Identity).$(Id)')" />
+
     <Dependency Include="Microsoft.NETCore.Platforms">
       <Version>$(PlatformPackageVersion)</Version>
     </Dependency>


### PR DESCRIPTION
My previous change https://github.com/dotnet/corefx/commit/83ecd322e3c6190870f4855fa7104ab3ac0a6404
broke the runtime.json by putting the wrong target runtime string (it
was getting runtime package ID instead).  This was happening because
MSBuild does the transform first then applies metadata and ended up
using the transformed value.  Fix this by breaking it up into to steps
so that applying metadata happens before the transform.

Thanks @chcosta for pointing this out.