### PR TITLE
Don't use DefaultValueInstruction for nullable types.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DefaultValueInstruction.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DefaultValueInstruction.cs
@@ -2,7 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Reflection;
+using System.Diagnostics;
+using System.Dynamic.Utils;
 
 namespace System.Linq.Expressions.Interpreter
 {
@@ -12,17 +13,18 @@ namespace System.Linq.Expressions.Interpreter
 
         internal DefaultValueInstruction(Type type)
         {
+            Debug.Assert(type.IsValueType);
+            Debug.Assert(!type.IsNullableType());
             _type = type;
         }
 
-        public override int ConsumedStack => 0;
         public override int ProducedStack => 1;
+
         public override string InstructionName => "DefaultValue";
 
         public override int Run(InterpretedFrame frame)
         {
-            object value = _type.IsValueType ? Activator.CreateInstance(_type) : null;
-            frame.Push(value);
+            frame.Push(Activator.CreateInstance(_type));
             return 1;
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -362,7 +362,11 @@ namespace System.Linq.Expressions.Interpreter
         {
             if (type != typeof(void))
             {
-                if (type.IsValueType)
+                if (type.IsNullableOrReferenceType())
+                {
+                    _instructions.EmitLoad(value: null);
+                }
+                else
                 {
                     object value = ScriptingRuntimeHelpers.GetPrimitiveDefaultValue(type);
                     if (value != null)
@@ -373,10 +377,6 @@ namespace System.Linq.Expressions.Interpreter
                     {
                         _instructions.EmitDefaultValue(type);
                     }
-                }
-                else
-                {
-                    _instructions.EmitLoad(value: null);
                 }
             }
         }
@@ -2416,8 +2416,16 @@ namespace System.Linq.Expressions.Interpreter
             }
             else
             {
-                Debug.Assert(node.Type.IsValueType);
-                _instructions.EmitDefaultValue(node.Type);
+                Type type = node.Type;
+                Debug.Assert(type.IsValueType);
+                if (type.IsNullableType())
+                {
+                    _instructions.EmitLoad(value: null);
+                }
+                else
+                {
+                    _instructions.EmitDefaultValue(type);
+                }
             }
         }
 

--- a/src/System.Linq.Expressions/tests/Default/DefaultTests.cs
+++ b/src/System.Linq.Expressions/tests/Default/DefaultTests.cs
@@ -83,5 +83,29 @@ namespace System.Linq.Expressions.Tests
             Func<DBNull> func = lambda.Compile(useInterpreter);
             Assert.Null(func());
         }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void StructType(bool useInterpreter)
+        {
+            Expression<Func<Sp>> lambda = Expression.Lambda<Func<Sp>>(Expression.Default(typeof(Sp)));
+            Func<Sp> func = lambda.Compile(useInterpreter);
+            Sp defaultValue = func();
+            Assert.Equal(0, defaultValue.I);
+            Assert.Equal(0.0, defaultValue.D);
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public void PrivateStructType(bool useInterpreter)
+        {
+            Expression<Func<StPri>> lambda = Expression.Lambda<Func<StPri>>(Expression.Default(typeof(StPri)));
+            Func<StPri> func = lambda.Compile(useInterpreter);
+            StPri defaultValue = func();
+            Assert.Equal(0, defaultValue.IntProperty);
+        }
+
+        private struct StPri
+        {
+            public int IntProperty { get; set; }
+        }
     }
 }


### PR DESCRIPTION
As the result of the call to `Activator.CreateInstance` will be null for nullable types, just load null directly with the singleton `LoadObjectInstruction` for null values.

Since the only test coverage of this instruction was with such a nullable type, add tests for `DefaultExpression` with non-nullable struct types.

`DefaultValueInstruction` takes a different path for reference types, but is only used with value types (and now only non-nullable value types) making one of those paths unreachable, so replace the test for `IsValueType` with an assertion.