### PR TITLE
Allow native images to resolve for ReferenceFromRuntime references

### DIFF
--- a/referenceFromRuntime.targets
+++ b/referenceFromRuntime.targets
@@ -36,13 +36,23 @@
       <_filteredReferencePathFromRuntimeByFileName Include="@(_referencePathFromRuntimeByFileName)"
           Condition="'@(_referencePathFromRuntimeByFileName)' == '@(ReferenceFromRuntime)' AND '%(Identity)' != ''" />
 
-      <_missingReferenceFromRuntime Include="@(ReferenceFromRuntime)" Exclude="@(_referencePathFromRuntimeByFileName)" />
+      <_remainingReferenceFromRuntime Include="@(ReferenceFromRuntime)" Exclude="@(_filteredReferencePathFromRuntimeByFileName)" />
+
+      <!-- Fallback and check for native images for the references as well -->
+      <_remainingReferenceFromRuntimeWithNI Include="@(_remainingReferenceFromRuntime->'%(Identity).ni')">
+        <OriginalReferenceFromRuntime>%(Identity)</OriginalReferenceFromRuntime>
+      </_remainingReferenceFromRuntimeWithNI>
+
+      <_filteredReferencePathFromRuntimeByFileName Include="@(_referencePathFromRuntimeByFileName)"
+          Condition="'@(_referencePathFromRuntimeByFileName)' == '@(_remainingReferenceFromRuntimeWithNI)' AND '%(Identity)' != ''" />
+
+      <_missingReferenceFromRuntime Include="@(_remainingReferenceFromRuntimeWithNI)" Exclude="@(_filteredReferencePathFromRuntimeByFileName)" />
 
       <!-- transform back to path -->
       <ReferencePath Include="@(_filteredReferencePathFromRuntimeByFileName->'%(ReferencePath)')" />
     </ItemGroup>
 
     <Error Condition="'@(_missingReferenceFromRuntime)' != ''"
-           Text="Could not resolve ReferenceFromRuntime item(s) '@(_missingReferenceFromRuntime)' from '$(RuntimeProjectFile)'." />
+           Text="Could not resolve ReferenceFromRuntime item(s) '%(_missingReferenceFromRuntime.OriginalReferenceFromRuntime)' from '$(RuntimeProjectFile)'." />
   </Target>
 </Project>


### PR DESCRIPTION
We will likely be removing the System.Private.CoreLib.dll and only
having System.Private.CoreLib.ni.dll so we need our ReferenceFromRuntime
infrastructure to support falling back to the ni if that is the only
thing present.

cc @ericstj @gkhanna79 