### PR TITLE
ApplyPreReleaseSuffix to static dependencies

### DIFF
--- a/pkg/dir.targets
+++ b/pkg/dir.targets
@@ -12,9 +12,18 @@
                    Apply="$(BaseLinePackageDependencies)">
       <Output TaskParameter="BaseLinedDependencies" ItemName="_BaseLinedStaticDependencies" />
     </ApplyBaseLine>
+
+    <ApplyPreReleaseSuffix Condition="'@(_BaseLinedStaticDependencies)' != ''" 
+                           OriginalPackages="@(_BaseLinedStaticDependencies)" 
+                           StablePackages="@(StablePackage)"
+                           PackageIndexes="@(PackageIndex)"
+                           PreReleaseSuffix="$(VersionSuffix)">
+      <Output TaskParameter="UpdatedPackages" ItemName="_SuffixedStaticDependencies"/>
+    </ApplyPreReleaseSuffix>
+    
     <ItemGroup>
       <Dependency Remove="@(Dependency)" />
-      <Dependency Include="@(_BaseLinedStaticDependencies)" />
+      <Dependency Include="@(_SuffixedStaticDependencies)" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
I was applying the baseline but neglecting to append
pre-release.  As a result we were getting dependencies
to stable packages which didn't exist.

Follow up to https://github.com/dotnet/corefx/pull/16573

/cc @chcosta 