### PR TITLE
Re-enable asymmetric key generation on macOS.

### DIFF
--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ecc.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ecc.cs
@@ -2,21 +2,63 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Security.Cryptography.Apple;
 
 internal static partial class Interop
 {
     internal static partial class AppleCrypto
     {
-        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_EccGenerateKey")]
-        internal static extern int EccGenerateKey(
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static extern int AppleCryptoNative_EccGenerateKey(
             int keySizeInBits,
+            SafeKeychainHandle tempKeychain,
             out SafeSecKeyRefHandle pPublicKey,
             out SafeSecKeyRefHandle pPrivateKey,
             out int pOSStatus);
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_EccGetKeySizeInBits")]
         internal static extern long EccGetKeySizeInBits(SafeSecKeyRefHandle publicKey);
+
+        internal static void EccGenerateKey(
+            int keySizeInBits,
+            out SafeSecKeyRefHandle pPublicKey,
+            out SafeSecKeyRefHandle pPrivateKey)
+        {
+            using (SafeTemporaryKeychainHandle tempKeychain = CreateTemporaryKeychain())
+            {
+                SafeSecKeyRefHandle keychainPublic;
+                SafeSecKeyRefHandle keychainPrivate;
+                int osStatus;
+
+                int result = AppleCryptoNative_EccGenerateKey(
+                    keySizeInBits,
+                    tempKeychain,
+                    out keychainPublic,
+                    out keychainPrivate,
+                    out osStatus);
+
+                if (result == 1)
+                {
+                    pPublicKey = keychainPublic;
+                    pPrivateKey = keychainPrivate;
+                    return;
+                }
+
+                using (keychainPrivate)
+                using (keychainPublic)
+                {
+                    if (result == 0)
+                    {
+                        throw CreateExceptionForOSStatus(osStatus);
+                    }
+
+                    Debug.Fail($"Unexpected result from AppleCryptoNative_EccGenerateKey: {result}");
+                    throw new CryptographicException();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
+++ b/src/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
@@ -14,8 +14,9 @@ internal static partial class Interop
     internal static partial class AppleCrypto
     {
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaGenerateKey")]
-        internal static extern int RsaGenerateKey(
+        private static extern int AppleCryptoNative_RsaGenerateKey(
             int keySizeInBits,
+            SafeKeychainHandle keychain,
             out SafeSecKeyRefHandle pPublicKey,
             out SafeSecKeyRefHandle pPrivateKey,
             out int pOSStatus);
@@ -53,6 +54,45 @@ internal static partial class Interop
             int cbData,
             out SafeCFDataHandle pEncryptedOut,
             out SafeCFErrorHandle pErrorOut);
+
+        internal static void RsaGenerateKey(
+            int keySizeInBits,
+            out SafeSecKeyRefHandle pPublicKey,
+            out SafeSecKeyRefHandle pPrivateKey)
+        {
+            using (SafeTemporaryKeychainHandle tempKeychain = CreateTemporaryKeychain())
+            {
+                SafeSecKeyRefHandle keychainPublic;
+                SafeSecKeyRefHandle keychainPrivate;
+                int osStatus;
+
+                int result = AppleCryptoNative_RsaGenerateKey(
+                    keySizeInBits,
+                    tempKeychain,
+                    out keychainPublic,
+                    out keychainPrivate,
+                    out osStatus);
+
+                if (result == 1)
+                {
+                    pPublicKey = keychainPublic;
+                    pPrivateKey = keychainPrivate;
+                    return;
+                }
+
+                using (keychainPrivate)
+                using (keychainPublic)
+                {
+                    if (result == 0)
+                    {
+                        throw CreateExceptionForOSStatus(osStatus);
+                    }
+
+                    Debug.Fail($"Unexpected result from AppleCryptoNative_RsaGenerateKey: {result}");
+                    throw new CryptographicException();
+                }
+            }
+        }
 
         internal static byte[] RsaEncrypt(
             SafeSecKeyRefHandle publicKey,

--- a/src/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
@@ -305,24 +305,14 @@ namespace System.Security.Cryptography
                         return current;
                     }
 
-#if APPLE_ASYMMETRIC_GENERATION
                     SafeSecKeyRefHandle publicKey;
                     SafeSecKeyRefHandle privateKey;
-                    int osStatus;
 
-                    int gen = Interop.AppleCrypto.EccGenerateKey(KeySizeValue, out publicKey, out privateKey, out osStatus);
-
-                    if (gen != 1)
-                    {
-                        throw Interop.AppleCrypto.CreateExceptionForCCError(osStatus, Interop.AppleCrypto.OSStatus);
-                    }
+                    Interop.AppleCrypto.EccGenerateKey(KeySizeValue, out publicKey, out privateKey);
 
                     current = SecKeyPair.PublicPrivatePair(publicKey, privateKey);
                     _keys = current;
                     return current;
-#else
-                    throw new CryptographicException("ECDSA Key Generation is temporarily disabled");
-#endif
                 }
             }
         }

--- a/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
@@ -260,25 +260,14 @@ namespace System.Security.Cryptography
                     return current;
                 }
 
-#if APPLE_ASYMMETRIC_GENERATION
                 SafeSecKeyRefHandle publicKey;
                 SafeSecKeyRefHandle privateKey;
-                int osStatus;
 
-                int gen = Interop.AppleCrypto.RsaGenerateKey(KeySizeValue, out publicKey, out privateKey, out osStatus);
-
-                if (gen != 1)
-                {
-                    Debug.Assert(gen == 0, $"Expected gen=0, got gen={gen}");
-                    throw Interop.AppleCrypto.CreateExceptionForCCError(osStatus, Interop.AppleCrypto.OSStatus);
-                }
+                Interop.AppleCrypto.RsaGenerateKey(KeySizeValue, out publicKey, out privateKey);
 
                 current = SecKeyPair.PublicPrivatePair(publicKey, privateKey);
                 _keys = current;
                 return current;
-#else
-                throw new CryptographicException("RSA Key Generation is temporarily disabled");
-#endif
             }
 
             private void SetKey(SecKeyPair newKeyPair)

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaFactory.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaFactory.cs
@@ -11,7 +11,6 @@ namespace System.Security.Cryptography.EcDsa.Tests
         ECDsa Create(ECCurve curve);
         bool IsCurveValid(Oid oid);
         bool ExplicitCurvesSupported { get; }
-        bool SupportsKeyGeneration { get; }
     }
 
     public static partial class ECDsaFactory
@@ -37,6 +36,5 @@ namespace System.Security.Cryptography.EcDsa.Tests
         }
 
         public static bool ExplicitCurvesSupported => s_provider.ExplicitCurvesSupported;
-        public static bool SupportsKeyGeneration => s_provider.SupportsKeyGeneration;
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
@@ -9,7 +9,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
 {
     public class ECDsaImportExportTests : ECDsaTestsBase
     {
-        [ConditionalTheory(nameof(SupportsKeyGeneration))]
+        [Theory]
         [MemberData(nameof(TestCurvesFull))]
         public static void TestNamedCurves(CurveDef curveDef)
         {
@@ -115,7 +115,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
             Assert.Throws<ArgumentException>(() => ECCurve.CreateFromOid(new Oid("", "")));
         }
 
-        [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [Fact]
         public static void TestKeySizeCreateKey()
         {
             using (ECDsa ec = ECDsaFactory.Create(ECCurve.NamedCurves.nistP256))

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
 {
     public partial class ECDsaTests : ECDsaTestsBase
     {
-        [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [Fact]
         public void KeySizeProp()
         {
             using (ECDsa e = ECDsaFactory.Create())
@@ -134,7 +134,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
             }
         }
 
-        [ConditionalTheory(nameof(SupportsKeyGeneration))]
+        [Theory]
         [MemberData(nameof(TestCurves))]
         public void TestRegenKeyNamed(CurveDef curveDef)
         {
@@ -179,7 +179,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
             }
         }
 
-        [ConditionalTheory(nameof(SupportsKeyGeneration))]
+        [Theory]
         [MemberData(nameof(TestCurves))]
         public void TestChangeFromNamedCurveToKeySize(CurveDef curveDef)
         {
@@ -213,7 +213,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
             }
         }
 
-        [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [Fact]
         public void TestNegative256WithRandomKey()
         {
             using (ECDsa ecdsa = ECDsaFactory.Create(ECCurve.NamedCurves.nistP256))
@@ -478,7 +478,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-        [ConditionalTheory(nameof(SupportsKeyGeneration))]
+        [Theory]
         [MemberData(nameof(RealImplementations))]
         public void SignData_MaxOffset_ZeroLength_NoThrow(ECDsa ecdsa)
         {
@@ -489,7 +489,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
             Assert.True(ecdsa.VerifyData(Array.Empty<byte>(), signature, HashAlgorithmName.SHA256));
         }
 
-        [ConditionalTheory(nameof(SupportsKeyGeneration))]
+        [Theory]
         [MemberData(nameof(RealImplementations))]
         public void VerifyData_MaxOffset_ZeroLength_NoThrow(ECDsa ecdsa)
         {
@@ -500,7 +500,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
             Assert.True(ecdsa.VerifyData(data, data.Length, 0, signature, HashAlgorithmName.SHA256));
         }
 
-        [ConditionalTheory(nameof(SupportsKeyGeneration))]
+        [Theory]
         [MemberData(nameof(RealImplementations))]
         public void Roundtrip_WithOffset(ECDsa ecdsa)
         {
@@ -517,7 +517,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
 
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-        [ConditionalTheory(nameof(SupportsKeyGeneration))]
+        [Theory]
         [InlineData(256)]
         [InlineData(384)]
         [InlineData(521)]
@@ -548,7 +548,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
             }
         }
 
-        [ConditionalTheory(nameof(SupportsKeyGeneration))]
+        [Theory]
         [MemberData(nameof(InteroperableSignatureConfigurations))]
         public void SignVerify_InteroperableSameKeys_RoundTripsUnlessTampered(ECDsa ecdsa, HashAlgorithmName hashAlgorithm)
         {

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTestsBase.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTestsBase.cs
@@ -247,8 +247,6 @@ namespace System.Security.Cryptography.EcDsa.Tests
                 return ECDsaFactory.ExplicitCurvesSupported;
             }
         }
-
-        internal static bool SupportsKeyGeneration => ECDsaFactory.SupportsKeyGeneration ;
     }
 
     internal static class EcDsaTestExtensions

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
@@ -8,8 +8,6 @@ namespace System.Security.Cryptography.Rsa.Tests
 {
     public class EncryptDecrypt
     {
-        public static bool SupportsKeyGeneration => RSAFactory.SupportsKeyGeneration;
-
         [Fact]
         public static void DecryptSavedAnswer()
         {
@@ -139,7 +137,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             Assert.Equal(TestData.HelloBytes, output);
         }
 
-        [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [Fact]
         public static void RsaCryptRoundtrip()
         {
             byte[] crypt;
@@ -155,7 +153,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             Assert.Equal(TestData.HelloBytes, output);
         }
 
-        [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [Fact]
         public static void RsaDecryptAfterExport()
         {
             byte[] output;

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -10,9 +10,7 @@ namespace System.Security.Cryptography.Rsa.Tests
 {
     public partial class ImportExport
     {
-        public static bool SupportsKeyGeneration => RSAFactory.SupportsKeyGeneration;
-
-        [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [Fact]
         public static void ExportAutoKey()
         {
             RSAParameters privateParams;
@@ -122,7 +120,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             AssertKeyEquals(ref unusualExponentParameters, ref exported);
         }
 
-        [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [Fact]
         public static void ImportReset()
         {
             using (RSA rsa = RSAFactory.Create())

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/KeyGeneration.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/KeyGeneration.cs
@@ -8,15 +8,13 @@ namespace System.Security.Cryptography.Rsa.Tests
 {
     public class KeyGeneration
     {
-        public static bool SupportsKeyGeneration => RSAFactory.SupportsKeyGeneration;
-
-        [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [Fact]
         public static void GenerateMinKey()
         {
             GenerateKey(rsa => GetMin(rsa.LegalKeySizes));
         }
 
-        [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [Fact]
         public static void GenerateSecondMinKey()
         {
             GenerateKey(rsa => GetSecondMin(rsa.LegalKeySizes));
@@ -28,13 +26,13 @@ namespace System.Security.Cryptography.Rsa.Tests
             GenerateKey(rsa => GetMax(rsa.LegalKeySizes));
         }
 
-        [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [Fact]
         public static void GenerateKey_2048()
         {
             GenerateKey(2048);
         }
 
-        [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [Fact]
         public static void GenerateKey_4096()
         {
             GenerateKey(4096);

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
@@ -10,7 +10,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         RSA Create(int keySize);
         bool Supports384PrivateKey { get; }
         bool SupportsSha2Oaep { get; }
-        bool SupportsKeyGeneration { get; }
     }
 
     public static partial class RSAFactory
@@ -28,7 +27,5 @@ namespace System.Security.Cryptography.Rsa.Tests
         public static bool Supports384PrivateKey => s_provider.Supports384PrivateKey;
 
         public static bool SupportsSha2Oaep => s_provider.SupportsSha2Oaep;
-
-        public static bool SupportsKeyGeneration => s_provider.SupportsKeyGeneration;
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
@@ -10,9 +10,7 @@ namespace System.Security.Cryptography.Rsa.Tests
 {
     public class SignVerify
     {
-        public static bool SupportsKeyGeneration => RSAFactory.SupportsKeyGeneration;
-
-        [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [Fact]
         public static void InvalidKeySize_DoesNotInvalidateKey()
         {
             using (RSA rsa = RSAFactory.Create())

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.cpp
@@ -4,7 +4,7 @@
 
 #include "pal_ecc.h"
 
-extern "C" int AppleCryptoNative_EccGenerateKey(
+extern "C" int32_t AppleCryptoNative_EccGenerateKey(
     int32_t keySizeBits, SecKeychainRef tempKeychain, SecKeyRef* pPublicKey, SecKeyRef* pPrivateKey, int32_t* pOSStatus)
 {
     if (pPublicKey != nullptr)

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.h
@@ -14,6 +14,7 @@ Generate an ECC keypair of the specified size.
 Returns 1 on success, 0 on failure. On failure, *pOSStatus should carry the OS failure code.
 */
 extern "C" int AppleCryptoNative_EccGenerateKey(int32_t keySizeBits,
+                                                SecKeychainRef tempKeychain,
                                                 SecKeyRef* pPublicKey,
                                                 SecKeyRef* pPrivateKey,
                                                 int32_t* pOSStatus);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.h
@@ -13,11 +13,11 @@ Generate an ECC keypair of the specified size.
 
 Returns 1 on success, 0 on failure. On failure, *pOSStatus should carry the OS failure code.
 */
-extern "C" int AppleCryptoNative_EccGenerateKey(int32_t keySizeBits,
-                                                SecKeychainRef tempKeychain,
-                                                SecKeyRef* pPublicKey,
-                                                SecKeyRef* pPrivateKey,
-                                                int32_t* pOSStatus);
+extern "C" int32_t AppleCryptoNative_EccGenerateKey(int32_t keySizeBits,
+                                                    SecKeychainRef tempKeychain,
+                                                    SecKeyRef* pPublicKey,
+                                                    SecKeyRef* pPrivateKey,
+                                                    int32_t* pOSStatus);
 
 /*
 Get the keysize, in bits, of an ECC key.

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.cpp
@@ -7,8 +7,8 @@
 static int32_t ExecuteCFDataTransform(
     SecTransformRef xform, uint8_t* pbData, int32_t cbData, CFDataRef* pDataOut, CFErrorRef* pErrorOut);
 
-extern "C" int
-AppleCryptoNative_RsaGenerateKey(int32_t keySizeBits, SecKeyRef* pPublicKey, SecKeyRef* pPrivateKey, int32_t* pOSStatus)
+extern "C" int AppleCryptoNative_RsaGenerateKey(
+    int32_t keySizeBits, SecKeychainRef tempKeychain, SecKeyRef* pPublicKey, SecKeyRef* pPrivateKey, int32_t* pOSStatus)
 {
     if (pPublicKey != nullptr)
         *pPublicKey = nullptr;
@@ -29,8 +29,19 @@ AppleCryptoNative_RsaGenerateKey(int32_t keySizeBits, SecKeyRef* pPublicKey, Sec
     {
         CFDictionaryAddValue(attributes, kSecAttrKeyType, kSecAttrKeyTypeRSA);
         CFDictionaryAddValue(attributes, kSecAttrKeySizeInBits, cfKeySizeValue);
+        CFDictionaryAddValue(attributes, kSecUseKeychain, tempKeychain);
 
         status = SecKeyGeneratePair(attributes, pPublicKey, pPrivateKey);
+
+        if (status == noErr)
+        {
+            status = ExportImportKey(pPublicKey, kSecItemTypePublicKey);
+        }
+
+        if (status == noErr)
+        {
+            status = ExportImportKey(pPrivateKey, kSecItemTypePrivateKey);
+        }
     }
     else
     {

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.cpp
@@ -7,7 +7,7 @@
 static int32_t ExecuteCFDataTransform(
     SecTransformRef xform, uint8_t* pbData, int32_t cbData, CFDataRef* pDataOut, CFErrorRef* pErrorOut);
 
-extern "C" int AppleCryptoNative_RsaGenerateKey(
+extern "C" int32_t AppleCryptoNative_RsaGenerateKey(
     int32_t keySizeBits, SecKeychainRef tempKeychain, SecKeyRef* pPublicKey, SecKeyRef* pPrivateKey, int32_t* pOSStatus)
 {
     if (pPublicKey != nullptr)

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.h
@@ -15,6 +15,7 @@ Generate a new RSA keypair with the specified key size, in bits.
 Returns 1 on success, 0 on failure.  On failure, *pOSStatus should contain the OS reported error.
 */
 extern "C" int AppleCryptoNative_RsaGenerateKey(int32_t keySizeBits,
+                                                SecKeychainRef tempKeychain,
                                                 SecKeyRef* pPublicKey,
                                                 SecKeyRef* pPrivateKey,
                                                 int32_t* pOSStatus);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.h
@@ -14,11 +14,11 @@ Generate a new RSA keypair with the specified key size, in bits.
 
 Returns 1 on success, 0 on failure.  On failure, *pOSStatus should contain the OS reported error.
 */
-extern "C" int AppleCryptoNative_RsaGenerateKey(int32_t keySizeBits,
-                                                SecKeychainRef tempKeychain,
-                                                SecKeyRef* pPublicKey,
-                                                SecKeyRef* pPrivateKey,
-                                                int32_t* pOSStatus);
+extern "C" int32_t AppleCryptoNative_RsaGenerateKey(int32_t keySizeBits,
+                                                    SecKeychainRef tempKeychain,
+                                                    SecKeyRef* pPublicKey,
+                                                    SecKeyRef* pPrivateKey,
+                                                    int32_t* pOSStatus);
 
 /*
 Decrypt the contents of pbData using the provided privateKey under OAEP padding.

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_seckey.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_seckey.cpp
@@ -158,6 +158,12 @@ OSStatus ExportImportKey(SecKeyRef* key, SecExternalItemType type)
         status = SecItemImport(exportData, nullptr, &actualFormat, &actualType, 0, nullptr, nullptr, &outItems);
     }
 
+    CFRelease(exportData);
+    exportData = nullptr;
+
+    CFRelease(keyParams.passphrase);
+    keyParams.passphrase = nullptr;
+
     if (status == noErr && outItems != nullptr)
     {
         CFIndex count = CFArrayGetCount(outItems);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_seckey.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_seckey.h
@@ -57,3 +57,10 @@ For ECC the value should not be used.
 0 is returned for invalid inputs.
 */
 extern "C" uint64_t AppleCryptoNative_SecKeyGetSimpleKeySizeInBytes(SecKeyRef publicKey);
+
+/*
+Export a key and re-import it to the NULL keychain.
+
+Only internal callers are expected.
+*/
+OSStatus ExportImportKey(SecKeyRef* key, SecExternalItemType type);

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.cs
@@ -96,7 +96,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
             return false;
         }
 
-        public bool SupportsKeyGeneration => !RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        public bool SupportsKeyGeneration => true;
     }
 
     public partial class ECDsaFactory

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.cs
@@ -95,8 +95,6 @@ namespace System.Security.Cryptography.EcDsa.Tests
             }
             return false;
         }
-
-        public bool SupportsKeyGeneration => true;
     }
 
     public partial class ECDsaFactory

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
@@ -43,7 +43,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             get { return RuntimeInformation.IsOSPlatform(OSPlatform.Windows); }
         }
 
-        public bool SupportsKeyGeneration => !RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        public bool SupportsKeyGeneration => true;
     }
 
     public partial class RSAFactory

--- a/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/DefaultRSAProvider.cs
@@ -42,8 +42,6 @@ namespace System.Security.Cryptography.Rsa.Tests
             // Currently only RSACng does, which is the default provider on Windows.
             get { return RuntimeInformation.IsOSPlatform(OSPlatform.Windows); }
         }
-
-        public bool SupportsKeyGeneration => true;
     }
 
     public partial class RSAFactory


### PR DESCRIPTION
Generate RSA and ECDSA keys via a temporary keychain.

When no keychain is given, SecKeyGeneratePair will generate the keys into the
default/login keychain.  Since the keys were not expected to have been in the
keychain, they permanently leak out and the keychain grows over time.

Instead, have the managed code provide a temporary keychain into which the keys
will be created. Then, export them and re-import them to the NULL keychain. The
temporary keychain can then be deleted, and the hard problem of delayed cleanup is
avoided.

Files on disk will still leak if the process terminates during the key generation
phase, but that is a much smaller window than other 'temporary file on disk' solutions.