### PR TITLE
Expose and test (I)Dictionary.GetValueOrDefault

### DIFF
--- a/src/System.Collections/ref/System.Collections.cs
+++ b/src/System.Collections/ref/System.Collections.cs
@@ -42,6 +42,14 @@ namespace System.Collections
 }
 namespace System.Collections.Generic
 {
+    public static class CollectionExtensions
+    {
+        public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
+        public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
+        public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
+    }
     public abstract partial class Comparer<T> : System.Collections.Generic.IComparer<T>, System.Collections.IComparer
     {
         protected Comparer() { }
@@ -98,6 +106,8 @@ namespace System.Collections.Generic
         void System.Collections.IDictionary.Remove(object key) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
+        public TValue GetValueOrDefault(TKey key) { throw null; }
+        public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IDictionaryEnumerator, System.Collections.IEnumerator, System.IDisposable
         {

--- a/src/System.Collections/src/ApiCompatBaseline.uapaot.txt
+++ b/src/System.Collections/src/ApiCompatBaseline.uapaot.txt
@@ -1,0 +1,4 @@
+Compat issues with assembly System.Collections:
+MembersMustExist : Member 'System.Collections.Generic.Dictionary<TKey, TValue>.GetValueOrDefault(TKey)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'System.Collections.Generic.Dictionary<TKey, TValue>.GetValueOrDefault(TKey, TValue)' does not exist in the implementation but it does exist in the contract.
+Total Issues: 2

--- a/src/System.Collections/src/System.Collections.csproj
+++ b/src/System.Collections/src/System.Collections.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <Compile Include="System\Collections\BitArray.cs" />
     <Compile Include="System\Collections\Generic\BitHelper.cs" />
+    <Compile Include="System\Collections\Generic\CollectionExtensions.cs" />
     <Compile Include="System\Collections\Generic\ICollectionDebugView.cs" />
     <Compile Include="System\Collections\Generic\IDictionaryDebugView.cs" />
     <Compile Include="System\Collections\Generic\HashSet.cs" />

--- a/src/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
+++ b/src/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Collections.Generic
+{
+    public static class CollectionExtensions
+    {
+        public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
+        {
+            return dictionary.GetValueOrDefault(key, default(TValue));
+        }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)
+        {
+            if (dictionary == null)
+            {
+                throw new ArgumentNullException(nameof(dictionary));
+            }
+
+            TValue value;
+            if(dictionary.TryGetValue(key, out value))
+            {
+                return value;
+            }
+
+            return defaultValue;
+        }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)
+        {
+            return dictionary.GetValueOrDefault(key, default(TValue));
+        }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)
+        {
+            if (dictionary == null)
+            {
+                throw new ArgumentNullException(nameof(dictionary));
+            }
+
+            TValue value;
+            if(dictionary.TryGetValue(key, out value))
+            {
+                return value;
+            }
+
+            return defaultValue;
+        }
+    }
+}

--- a/src/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
+++ b/src/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
@@ -19,12 +19,7 @@ namespace System.Collections.Generic
             }
 
             TValue value;
-            if(dictionary.TryGetValue(key, out value))
-            {
-                return value;
-            }
-
-            return defaultValue;
+            return dictionary.TryGetValue(key, out value) ? value : defaultValue;
         }
 
         public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)
@@ -39,13 +34,8 @@ namespace System.Collections.Generic
                 throw new ArgumentNullException(nameof(dictionary));
             }
 
-            TValue value;
-            if(dictionary.TryGetValue(key, out value))
-            {
-                return value;
-            }
-
-            return defaultValue;
+            TValue value;            
+            return dictionary.TryGetValue(key, out value) ? value : defaultValue;
         }
     }
 }

--- a/src/System.Collections/tests/Generic/CollectionExtensionsTests.cs
+++ b/src/System.Collections/tests/Generic/CollectionExtensionsTests.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    public class CollectionExtensionsTests
+    {
+        [Fact]
+        public void GetValueOrDefault_KeyExistsInIDictionary_ReturnsValue()
+        {
+            IDictionary<string, string> dictionary = new Dictionary<string, string>() { { "key", "value" } };
+            Assert.Equal("value", dictionary.GetValueOrDefault("key"));
+            Assert.Equal("value", dictionary.GetValueOrDefault("key", null));
+        }
+
+        [Fact]
+        public void GetValueOrDefault_KeyDoesntExistInIDictionary_ReturnsDefaultValue()
+        {
+            IDictionary<string, string> dictionary = new Dictionary<string, string>() { { "key", "value" } };
+            Assert.Null(dictionary.GetValueOrDefault("anotherKey"));
+            Assert.Equal("anotherValue", dictionary.GetValueOrDefault("anotherKey", "anotherValue"));
+        }
+
+        [Fact]
+        public void GetValueOrDefault_NullKeyIDictionary_ThrowsArgumentNullException()
+        {
+            IDictionary<string, string> dictionary = new Dictionary<string, string>() { { "key", "value" } };
+            Assert.Throws<ArgumentNullException>("key", () => dictionary.GetValueOrDefault(null));
+            Assert.Throws<ArgumentNullException>("key", () => dictionary.GetValueOrDefault(null, "anotherValue"));
+        }
+
+        [Fact]
+        public void GetValueOrDefault_NullIDictionary_ThrowsArgumentNullException()
+        {
+            IDictionary<string, string> dictionary = null;
+            Assert.Throws<ArgumentNullException>("dictionary", () => dictionary.GetValueOrDefault("key"));
+            Assert.Throws<ArgumentNullException>("dictionary", () => dictionary.GetValueOrDefault("key", "value"));
+        }
+
+        [Fact]
+        public void GetValueOrDefault_KeyExistsInIReadOnlyDictionary_ReturnsValue()
+        {
+            IReadOnlyDictionary<string, string> dictionary = new Dictionary<string, string>() { { "key", "value" } };
+            Assert.Equal("value", dictionary.GetValueOrDefault("key"));
+            Assert.Equal("value", dictionary.GetValueOrDefault("key", null));
+        }
+
+        [Fact]
+        public void GetValueOrDefault_KeyDoesntExistInIReadOnlyDictionary_ReturnsDefaultValue()
+        {
+            IReadOnlyDictionary<string, string> dictionary = new Dictionary<string, string>() { { "key", "value" } };
+            Assert.Null(dictionary.GetValueOrDefault("anotherKey"));
+            Assert.Equal("anotherValue", dictionary.GetValueOrDefault("anotherKey", "anotherValue"));
+        }
+
+        [Fact]
+        public void GetValueOrDefault_NullKeyIReadOnlyDictionary_ThrowsArgumentNullException()
+        {
+            IReadOnlyDictionary<string, string> dictionary = new Dictionary<string, string>() { { "key", "value" } };
+            Assert.Throws<ArgumentNullException>("key", () => dictionary.GetValueOrDefault(null));
+            Assert.Throws<ArgumentNullException>("key", () => dictionary.GetValueOrDefault(null, "anotherValue"));
+        }
+
+        [Fact]
+        public void GetValueOrDefault_NullIReadOnlyDictionary_ThrowsArgumentNullException()
+        {
+            IReadOnlyDictionary<string, string> dictionary = null;
+            Assert.Throws<ArgumentNullException>("dictionary", () => dictionary.GetValueOrDefault("key"));
+            Assert.Throws<ArgumentNullException>("dictionary", () => dictionary.GetValueOrDefault("key", "value"));
+        }
+    }
+}

--- a/src/System.Collections/tests/Generic/CollectionExtensionsTests.cs
+++ b/src/System.Collections/tests/Generic/CollectionExtensionsTests.cs
@@ -12,7 +12,7 @@ namespace System.Collections.Tests
         [Fact]
         public void GetValueOrDefault_KeyExistsInIDictionary_ReturnsValue()
         {
-            IDictionary<string, string> dictionary = new Dictionary<string, string>() { { "key", "value" } };
+            IDictionary<string, string> dictionary = new SortedDictionary<string, string>() { { "key", "value" } };
             Assert.Equal("value", dictionary.GetValueOrDefault("key"));
             Assert.Equal("value", dictionary.GetValueOrDefault("key", null));
         }
@@ -20,7 +20,7 @@ namespace System.Collections.Tests
         [Fact]
         public void GetValueOrDefault_KeyDoesntExistInIDictionary_ReturnsDefaultValue()
         {
-            IDictionary<string, string> dictionary = new Dictionary<string, string>() { { "key", "value" } };
+            IDictionary<string, string> dictionary = new SortedDictionary<string, string>() { { "key", "value" } };
             Assert.Null(dictionary.GetValueOrDefault("anotherKey"));
             Assert.Equal("anotherValue", dictionary.GetValueOrDefault("anotherKey", "anotherValue"));
         }
@@ -28,7 +28,7 @@ namespace System.Collections.Tests
         [Fact]
         public void GetValueOrDefault_NullKeyIDictionary_ThrowsArgumentNullException()
         {
-            IDictionary<string, string> dictionary = new Dictionary<string, string>() { { "key", "value" } };
+            IDictionary<string, string> dictionary = new SortedDictionary<string, string>() { { "key", "value" } };
             Assert.Throws<ArgumentNullException>("key", () => dictionary.GetValueOrDefault(null));
             Assert.Throws<ArgumentNullException>("key", () => dictionary.GetValueOrDefault(null, "anotherValue"));
         }
@@ -44,7 +44,7 @@ namespace System.Collections.Tests
         [Fact]
         public void GetValueOrDefault_KeyExistsInIReadOnlyDictionary_ReturnsValue()
         {
-            IReadOnlyDictionary<string, string> dictionary = new Dictionary<string, string>() { { "key", "value" } };
+            IReadOnlyDictionary<string, string> dictionary = new SortedDictionary<string, string>() { { "key", "value" } };
             Assert.Equal("value", dictionary.GetValueOrDefault("key"));
             Assert.Equal("value", dictionary.GetValueOrDefault("key", null));
         }
@@ -52,7 +52,7 @@ namespace System.Collections.Tests
         [Fact]
         public void GetValueOrDefault_KeyDoesntExistInIReadOnlyDictionary_ReturnsDefaultValue()
         {
-            IReadOnlyDictionary<string, string> dictionary = new Dictionary<string, string>() { { "key", "value" } };
+            IReadOnlyDictionary<string, string> dictionary = new SortedDictionary<string, string>() { { "key", "value" } };
             Assert.Null(dictionary.GetValueOrDefault("anotherKey"));
             Assert.Equal("anotherValue", dictionary.GetValueOrDefault("anotherKey", "anotherValue"));
         }
@@ -60,7 +60,7 @@ namespace System.Collections.Tests
         [Fact]
         public void GetValueOrDefault_NullKeyIReadOnlyDictionary_ThrowsArgumentNullException()
         {
-            IReadOnlyDictionary<string, string> dictionary = new Dictionary<string, string>() { { "key", "value" } };
+            IReadOnlyDictionary<string, string> dictionary = new SortedDictionary<string, string>() { { "key", "value" } };
             Assert.Throws<ArgumentNullException>("key", () => dictionary.GetValueOrDefault(null));
             Assert.Throws<ArgumentNullException>("key", () => dictionary.GetValueOrDefault(null, "anotherValue"));
         }

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.netcoreapp.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.netcoreapp.cs
@@ -32,6 +32,28 @@ namespace System.Collections.Tests
             var copied = new Dictionary<TKey, TValue>(collection, comparer);
             Assert.Equal(collection, copied);
         }
-    }
 
+        [Fact]
+        public void GetValueOrDefault_KeyExistsInIDictionary_ReturnsValue()
+        {
+            int seed = 9600;
+            TKey key = CreateTKey(seed++);
+            TValue value = CreateTValue(seed++);
+            Dictionary<TKey, TValue> dictionary = new Dictionary<TKey, TValue>() { { key, value } };
+
+            Assert.Equal(value, dictionary.GetValueOrDefault(key));
+            Assert.Equal(value, dictionary.GetValueOrDefault(key, CreateTValue(seed++)));
+        }
+
+        [Fact]
+        public void GetValueOrDefault_KeyDoesntExistInIDictionary_ReturnsDefaultValue()
+        {
+            int seed = 9600;
+            TKey key = CreateTKey(seed++);
+            TValue defaultValue = CreateTValue(seed++);
+            Dictionary<TKey, TValue> dictionary = new Dictionary<TKey, TValue>() { { CreateTKey(seed++), CreateTValue(seed++) } };
+            Assert.Equal(default(TValue), dictionary.GetValueOrDefault(key));
+            Assert.Equal(defaultValue, dictionary.GetValueOrDefault(key, defaultValue));
+        }
+    }
 }

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.netcoreapp.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.netcoreapp.cs
@@ -34,7 +34,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public void GetValueOrDefault_KeyExistsInIDictionary_ReturnsValue()
+        public void GetValueOrDefault_KeyExists_ReturnsValue()
         {
             int seed = 9600;
             TKey key = CreateTKey(seed++);
@@ -46,7 +46,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public void GetValueOrDefault_KeyDoesntExistInIDictionary_ReturnsDefaultValue()
+        public void GetValueOrDefault_KeyDoesntExist_ReturnsDefaultValue()
         {
             int seed = 9600;
             TKey key = CreateTKey(seed++);

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="BitArray\BitArray_GetSetTests.cs" />
     <Compile Include="BitArray\BitArray_OperatorsTests.cs" />
     <Compile Include="BitArray\BitArray_OperatorsTests.netcoreapp.cs" Condition="'$(TargetGroup)'=='netcoreapp'" />
+    <Compile Include="Generic\CollectionExtensionsTests.cs" Condition="'$(TargetGroup)'=='netcoreapp'" />
     <Compile Include="Generic\Comparers\Comparer.Generic.Tests.cs" />
     <Compile Include="Generic\Comparers\Comparer.Tests.cs" />
     <Compile Include="Generic\Comparers\Comparers.Generic.cs" />


### PR DESCRIPTION
Running `msbuild src\System.Collections\src\System.Collections.csproj /p:TargetGroup=uapaot /p:BaselineAllApiCompatError=true` doesn't seem to change anything but I hope this passes CI

Fixes #3482