### PR TITLE
Fix parsing of regex alternation construct with named options

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -910,7 +910,9 @@ namespace System.Text.RegularExpressions
                         MoveLeft();
 
                         NodeType = RegexNode.Group;
-                        ScanOptions();
+                        // Disallow options in the children of a testgroup node
+                        if (_group._type != RegexNode.Testgroup)
+                            ScanOptions();
                         if (CharsRight() == 0)
                             goto BreakRecognize;
 

--- a/src/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Xunit;
 
@@ -239,9 +240,45 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("[a-f-[]]+", RegexOptions.None)]
         // Not character class substraction
         [InlineData("[A-[]+", RegexOptions.None)]
+        // Invalid testgroup
+        [InlineData("(?(?m))", RegexOptions.None)]
+        [InlineData("(?(?m)", RegexOptions.None)]
+        [InlineData("(?(?", RegexOptions.None)]
+        [InlineData("(?(", RegexOptions.None)]
+        [InlineData("?(a:b)", RegexOptions.None)]
+        [InlineData("?(a)", RegexOptions.None)]
+        [InlineData("?(a|b)", RegexOptions.None)]
+        [InlineData("?((a)", RegexOptions.None)]
+        [InlineData("?((a)a", RegexOptions.None)]
+        [InlineData("?((a)a|", RegexOptions.None)]
+        [InlineData("?((a)a|b", RegexOptions.None)]
         public void Ctor_InvalidPattern(string pattern, RegexOptions options)
         {
             Assert.Throws<ArgumentException>(() => new Regex(pattern, options));
+        }
+
+        [Theory]
+        // Testgroup with options
+        [InlineData("(?(?i))", RegexOptions.None, typeof(NullReferenceException))]
+        [InlineData("(?(?I))", RegexOptions.None, typeof(NullReferenceException))]
+        [InlineData("(?(?m))", RegexOptions.None, typeof(NullReferenceException))]
+        [InlineData("(?(?M))", RegexOptions.None, typeof(NullReferenceException))]
+        [InlineData("(?(?s))", RegexOptions.None, typeof(NullReferenceException))]
+        [InlineData("(?(?S))", RegexOptions.None, typeof(NullReferenceException))]
+        [InlineData("(?(?x))", RegexOptions.None, typeof(NullReferenceException))]
+        [InlineData("(?(?X))", RegexOptions.None, typeof(NullReferenceException))]
+        [InlineData("(?(?e))", RegexOptions.None, typeof(NullReferenceException))]
+        [InlineData(" (?(?e))", RegexOptions.None, typeof(OutOfMemoryException))]
+        public void Ctor_InvalidPattern_NetCore(string pattern, RegexOptions options, Type exceptionType)
+        {
+            if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework"))
+            {
+                Assert.Throws(exceptionType, () => new Regex(pattern, options));
+            }
+            else
+            {
+                Ctor_InvalidPattern(pattern, options);
+            }
         }
     }
 }

--- a/src/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
@@ -241,8 +241,8 @@ namespace System.Text.RegularExpressions.Tests
         // Not character class substraction
         [InlineData("[A-[]+", RegexOptions.None)]
         // Invalid testgroup
-        [InlineData("(?(?m))", RegexOptions.None)]
-        [InlineData("(?(?m)", RegexOptions.None)]
+        [InlineData("(?(?e))", RegexOptions.None)]
+        [InlineData("(?(?a)", RegexOptions.None)]
         [InlineData("(?(?", RegexOptions.None)]
         [InlineData("(?(", RegexOptions.None)]
         [InlineData("?(a:b)", RegexOptions.None)]
@@ -267,9 +267,10 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("(?(?S))", RegexOptions.None, typeof(NullReferenceException))]
         [InlineData("(?(?x))", RegexOptions.None, typeof(NullReferenceException))]
         [InlineData("(?(?X))", RegexOptions.None, typeof(NullReferenceException))]
-        [InlineData("(?(?e))", RegexOptions.None, typeof(NullReferenceException))]
-        [InlineData(" (?(?e))", RegexOptions.None, typeof(OutOfMemoryException))]
-        public void Ctor_InvalidPattern_NetCore(string pattern, RegexOptions options, Type exceptionType)
+        [InlineData("(?(?n))", RegexOptions.None, typeof(NullReferenceException))]
+        [InlineData("(?(?N))", RegexOptions.None, typeof(NullReferenceException))]
+        [InlineData(" (?(?n))", RegexOptions.None, typeof(OutOfMemoryException))]
+        public void Ctor_InvalidPattern(string pattern, RegexOptions options, Type exceptionType)
         {
             if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework"))
             {

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -177,7 +177,15 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { "(?<!)", "(?<!)cat", RegexOptions.None, 0, 8, false, string.Empty };
 
             // Alternation construct
+            yield return new object[] { "(?(cat)|dog)", "cat", RegexOptions.None, 0, 3, true, string.Empty };
+            yield return new object[] { "(?(cat)|dog)", "catdog", RegexOptions.None, 0, 6, true, string.Empty };
+            yield return new object[] { "(?(cat)dog1|dog2)", "catdog1", RegexOptions.None, 0, 7, false, string.Empty };
+            yield return new object[] { "(?(cat)dog1|dog2)", "catdog2", RegexOptions.None, 0, 7, true, "dog2" };
+            yield return new object[] { "(?(cat)dog1|dog2)", "catdog1dog2", RegexOptions.None, 0, 11, true, "dog2" };
+            yield return new object[] { "(?(dog2))", "dog2", RegexOptions.None, 0, 4, true, string.Empty };
             yield return new object[] { "(?(cat)|dog)", "oof", RegexOptions.None, 0, 3, false, string.Empty };
+            yield return new object[] { "(?(a:b))", "a", RegexOptions.None, 0, 1, true, string.Empty };
+            yield return new object[] { "(?(a:))", "a", RegexOptions.None, 0, 1, true, string.Empty };
 
             // No Negation
             yield return new object[] { "[abcd-[abcd]]+", "abcxyzABCXYZ`!@#$%^&*()_-+= \t\n", RegexOptions.None, 0, 30, false, string.Empty };

--- a/src/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
@@ -119,6 +119,27 @@ namespace System.Text.RegularExpressions.Tests
                     new CaptureData("c", 3, 1)
                 }
             };
+
+            // Alternation construct
+            yield return new object[]
+            {
+                "(?(A)A123|C789)", "A123 B456 C789", RegexOptions.None,
+                new CaptureData[]
+                {
+                    new CaptureData("A123", 0, 4),
+                    new CaptureData("C789", 10, 4),
+                }
+            };
+
+            yield return new object[]
+            {
+                "(?(A)A123|C789)", "A123 B456 C789", RegexOptions.None,
+                new CaptureData[]
+                {
+                    new CaptureData("A123", 0, 4),
+                    new CaptureData("C789", 10, 4),
+                }
+            };
         }
 
         [Theory]


### PR DESCRIPTION
Fixes #1476

I've tried to add a bunch of targetted tests as well as a bunch of fuzzer-style tests. Let me know if you have any suggestions for others.