### PR TITLE
Should only look at .dll files for ReferenceFromRuntime resolution

### DIFF
--- a/referenceFromRuntime.targets
+++ b/referenceFromRuntime.targets
@@ -28,7 +28,7 @@
           Condition="'$(IsTestProject)'!='true' AND '@(ReferenceFromRuntime)' != ''">
     <ItemGroup>
       <!-- transform to filename in order to intersect -->
-      <_referencePathFromRuntimeByFileName Include="@(_referencePathFromRuntime->'%(FileName)')" >
+      <_referencePathFromRuntimeByFileName Include="@(_referencePathFromRuntime->'%(FileName)')" Condition="'%(_referencePathFromRuntime.Extension)' == '.dll'" >
         <ReferencePath>%(Identity)</ReferencePath>
       </_referencePathFromRuntimeByFileName>
 


### PR DESCRIPTION
When we added the override folks would sometimes also get pdbs and
when they did the ReferenceFromRuntime logic was broken. To fix this
we make sure we only look at .dll files for the ReferenceFromRuntime
resolution logic.

cc @ericstj 

@AndyAyersMS @RussKeldorph this should fix the issue we are seeing in https://github.com/dotnet/corefx/pull/16552 for the CoreCLROverridePath stuff. 