### PR TITLE
Replace 'int' with 'int32_t' and reformat source.

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_digest.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_digest.cpp
@@ -74,7 +74,7 @@ extern "C" DigestCtx* AppleCryptoNative_DigestCreate(PAL_HashAlgorithm algorithm
     return digestCtx;
 }
 
-extern "C" int AppleCryptoNative_DigestUpdate(DigestCtx* ctx, uint8_t* pBuf, int32_t cbBuf)
+extern "C" int32_t AppleCryptoNative_DigestUpdate(DigestCtx* ctx, uint8_t* pBuf, int32_t cbBuf)
 {
     if (cbBuf == 0)
         return 1;
@@ -100,12 +100,12 @@ extern "C" int AppleCryptoNative_DigestUpdate(DigestCtx* ctx, uint8_t* pBuf, int
     }
 }
 
-extern "C" int AppleCryptoNative_DigestFinal(DigestCtx* ctx, uint8_t* pOutput, int32_t cbOutput)
+extern "C" int32_t AppleCryptoNative_DigestFinal(DigestCtx* ctx, uint8_t* pOutput, int32_t cbOutput)
 {
     if (ctx == nullptr || pOutput == nullptr || cbOutput < ctx->cbDigest)
         return -1;
 
-    int ret = 0;
+    int32_t ret = 0;
 
     switch (ctx->algorithm)
     {

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_digest.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_digest.h
@@ -41,11 +41,11 @@ Apply cbBuf bytes of data from pBuf to the ongoing digest represented in ctx.
 
 Returns 1 on success, 0 on failure, any other value on invalid inputs/state.
 */
-extern "C" int AppleCryptoNative_DigestUpdate(DigestCtx* ctx, uint8_t* pBuf, int32_t cbBuf);
+extern "C" int32_t AppleCryptoNative_DigestUpdate(DigestCtx* ctx, uint8_t* pBuf, int32_t cbBuf);
 
 /*
 Complete the digest in ctx, copying the results to pOutput, and reset ctx for a new digest.
 
 Returns 1 on success, 0 on failure, any other value on invalid inputs/state.
 */
-extern "C" int AppleCryptoNative_DigestFinal(DigestCtx* ctx, uint8_t* pOutput, int32_t cbOutput);
+extern "C" int32_t AppleCryptoNative_DigestFinal(DigestCtx* ctx, uint8_t* pOutput, int32_t cbOutput);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_hmac.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_hmac.cpp
@@ -38,7 +38,7 @@ static CCHmacAlgorithm PalAlgorithmToAppleAlgorithm(PAL_HashAlgorithm algorithm)
     }
 }
 
-static int GetHmacOutputSize(PAL_HashAlgorithm algorithm)
+static int32_t GetHmacOutputSize(PAL_HashAlgorithm algorithm)
 {
     switch (algorithm)
     {
@@ -79,7 +79,7 @@ extern "C" HmacCtx* AppleCryptoNative_HmacCreate(PAL_HashAlgorithm algorithm, in
     return hmacCtx;
 }
 
-extern "C" int AppleCryptoNative_HmacInit(HmacCtx* ctx, uint8_t* pbKey, int32_t cbKey)
+extern "C" int32_t AppleCryptoNative_HmacInit(HmacCtx* ctx, uint8_t* pbKey, int32_t cbKey)
 {
     if (ctx == nullptr || cbKey < 0)
         return 0;
@@ -91,7 +91,7 @@ extern "C" int AppleCryptoNative_HmacInit(HmacCtx* ctx, uint8_t* pbKey, int32_t 
     return 1;
 }
 
-extern "C" int AppleCryptoNative_HmacUpdate(HmacCtx* ctx, uint8_t* pbData, int32_t cbData)
+extern "C" int32_t AppleCryptoNative_HmacUpdate(HmacCtx* ctx, uint8_t* pbData, int32_t cbData)
 {
     if (cbData == 0)
         return 1;
@@ -103,7 +103,7 @@ extern "C" int AppleCryptoNative_HmacUpdate(HmacCtx* ctx, uint8_t* pbData, int32
     return 1;
 }
 
-extern "C" int AppleCryptoNative_HmacFinal(HmacCtx* ctx, uint8_t* pbOutput)
+extern "C" int32_t AppleCryptoNative_HmacFinal(HmacCtx* ctx, uint8_t* pbOutput)
 {
     if (ctx == nullptr || pbOutput == nullptr)
         return 0;

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_hmac.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_hmac.h
@@ -29,18 +29,18 @@ Initialize an HMAC to the correct key and start state.
 
 Returns 1 on success, 0 on error.
 */
-extern "C" int AppleCryptoNative_HmacInit(HmacCtx* ctx, uint8_t* pbKey, int32_t cbKey);
+extern "C" int32_t AppleCryptoNative_HmacInit(HmacCtx* ctx, uint8_t* pbKey, int32_t cbKey);
 
 /*
 Add data into the HMAC
 
 Returns 1 on success, 0 on error.
 */
-extern "C" int AppleCryptoNative_HmacUpdate(HmacCtx* ctx, uint8_t* pbData, int32_t cbData);
+extern "C" int32_t AppleCryptoNative_HmacUpdate(HmacCtx* ctx, uint8_t* pbData, int32_t cbData);
 
 /*
 Complete the HMAC and copy the result into pbOutput.
 
 Returns 1 on success, 0 on error.
 */
-extern "C" int AppleCryptoNative_HmacFinal(HmacCtx* ctx, uint8_t* pbOutput);
+extern "C" int32_t AppleCryptoNative_HmacFinal(HmacCtx* ctx, uint8_t* pbOutput);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.cpp
@@ -86,7 +86,7 @@ EnumerateKeychain(SecKeychainRef keychain, CFStringRef matchType, CFArrayRef* pC
     if (query == nullptr)
         return -2;
 
-    int ret = 0;
+    int32_t ret = 0;
     CFTypeRef result = nullptr;
     CFArrayRef searchList = CFArrayCreate(
         nullptr, const_cast<const void**>(reinterpret_cast<void**>(&keychain)), 1, &kCFTypeArrayCallBacks);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_random.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_random.cpp
@@ -7,7 +7,7 @@
 #include <CommonCrypto/CommonCrypto.h>
 #include <CommonCrypto/CommonRandom.h>
 
-extern "C" int AppleCryptoNative_GetRandomBytes(uint8_t* pBuf, uint32_t cbBuf, int32_t* pkCCStatus)
+extern "C" int32_t AppleCryptoNative_GetRandomBytes(uint8_t* pBuf, uint32_t cbBuf, int32_t* pkCCStatus)
 {
     if (pBuf == nullptr || pkCCStatus == nullptr)
         return -1;

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_random.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_random.h
@@ -11,4 +11,4 @@ Shims CCRandomGenerateBytes, putting the resulting CCRNGStatus value in pkCCStat
 
 Returns 1 on success, 0 on system error (see pkCCStatus), -1 on input error.
 */
-extern "C" int AppleCryptoNative_GetRandomBytes(uint8_t* pBuf, uint32_t cbBuf, int32_t* pkCCStatus);
+extern "C" int32_t AppleCryptoNative_GetRandomBytes(uint8_t* pBuf, uint32_t cbBuf, int32_t* pkCCStatus);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.cpp
@@ -97,7 +97,7 @@ extern "C" int32_t AppleCryptoNative_RsaDecryptOaep(SecKeyRef privateKey,
         return kErrorBadInput;
     }
 
-    int ret = kErrorSeeError;
+    int32_t ret = kErrorSeeError;
     SecTransformRef decryptor = SecDecryptTransformCreate(privateKey, pErrorOut);
 
     if (decryptor != nullptr)
@@ -126,7 +126,7 @@ extern "C" int32_t AppleCryptoNative_RsaDecryptPkcs(
         return kErrorBadInput;
     }
 
-    int ret = kErrorSeeError;
+    int32_t ret = kErrorSeeError;
     SecTransformRef decryptor = SecDecryptTransformCreate(privateKey, pErrorOut);
 
     if (decryptor != nullptr)
@@ -159,7 +159,7 @@ extern "C" int32_t AppleCryptoNative_RsaEncryptOaep(SecKeyRef publicKey,
         return kErrorBadInput;
     }
 
-    int ret = kErrorSeeError;
+    int32_t ret = kErrorSeeError;
     SecTransformRef encryptor = SecEncryptTransformCreate(publicKey, pErrorOut);
 
     if (encryptor != nullptr)
@@ -188,7 +188,7 @@ extern "C" int32_t AppleCryptoNative_RsaEncryptPkcs(
         return kErrorBadInput;
     }
 
-    int ret = kErrorSeeError;
+    int32_t ret = kErrorSeeError;
     SecTransformRef encryptor = SecEncryptTransformCreate(publicKey, pErrorOut);
 
     if (encryptor != nullptr)
@@ -217,7 +217,7 @@ static int32_t ExecuteCFDataTransform(
 
     CFTypeRef xformOutput = nullptr;
     CFDataRef cfData = nullptr;
-    int ret = INT_MIN;
+    int32_t ret = INT_MIN;
 
     cfData = CFDataCreateWithBytesNoCopy(nullptr, pbData, cbData, kCFAllocatorNull);
 

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_seckey.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_seckey.h
@@ -11,10 +11,10 @@
 // Unless another interpretation is "obvious", pal_seckey functions return 1 on success.
 // functions which represent a boolean return 0 on "successful false"
 // otherwise functions will return one of the following return values:
-static const int kErrorBadInput = -1;
-static const int kErrorSeeError = -2;
-static const int kErrorUnknownAlgorithm = -3;
-static const int kErrorUnknownState = -4;
+static const int32_t kErrorBadInput = -1;
+static const int32_t kErrorSeeError = -2;
+static const int32_t kErrorUnknownAlgorithm = -3;
+static const int32_t kErrorUnknownState = -4;
 
 /*
 Export a key object.

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_signverify.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_signverify.cpp
@@ -4,19 +4,19 @@
 
 #include "pal_signverify.h"
 
-static int ExecuteSignTransform(SecTransformRef signer, CFDataRef* pSignatureOut, CFErrorRef* pErrorOut);
-static int ExecuteVerifyTransform(SecTransformRef verifier, CFErrorRef* pErrorOut);
+static int32_t ExecuteSignTransform(SecTransformRef signer, CFDataRef* pSignatureOut, CFErrorRef* pErrorOut);
+static int32_t ExecuteVerifyTransform(SecTransformRef verifier, CFErrorRef* pErrorOut);
 
-static int ConfigureSignVerifyTransform(
+static int32_t ConfigureSignVerifyTransform(
     SecTransformRef xform, CFDataRef cfDataHash, PAL_HashAlgorithm, bool useDigestAlgorithm, CFErrorRef* pErrorOut);
 
-static int GenerateSignature(SecKeyRef privateKey,
-                             uint8_t* pbDataHash,
-                             int32_t cbDataHash,
-                             PAL_HashAlgorithm hashAlgorithm,
-                             bool useHashAlgorithm,
-                             CFDataRef* pSignatureOut,
-                             CFErrorRef* pErrorOut)
+static int32_t GenerateSignature(SecKeyRef privateKey,
+                                 uint8_t* pbDataHash,
+                                 int32_t cbDataHash,
+                                 PAL_HashAlgorithm hashAlgorithm,
+                                 bool useHashAlgorithm,
+                                 CFDataRef* pSignatureOut,
+                                 CFErrorRef* pErrorOut)
 {
     if (pSignatureOut != nullptr)
         *pSignatureOut = nullptr;
@@ -36,7 +36,7 @@ static int GenerateSignature(SecKeyRef privateKey,
         return kErrorUnknownState;
     }
 
-    int ret = kErrorSeeError;
+    int32_t ret = kErrorSeeError;
     SecTransformRef signer = SecSignTransformCreate(privateKey, pErrorOut);
 
     if (signer != nullptr)
@@ -56,30 +56,30 @@ static int GenerateSignature(SecKeyRef privateKey,
     return ret;
 }
 
-extern "C" int AppleCryptoNative_GenerateSignature(
+extern "C" int32_t AppleCryptoNative_GenerateSignature(
     SecKeyRef privateKey, uint8_t* pbDataHash, int32_t cbDataHash, CFDataRef* pSignatureOut, CFErrorRef* pErrorOut)
 {
     return GenerateSignature(privateKey, pbDataHash, cbDataHash, PAL_Unknown, false, pSignatureOut, pErrorOut);
 }
 
-extern "C" int AppleCryptoNative_GenerateSignatureWithHashAlgorithm(SecKeyRef privateKey,
-                                                                    uint8_t* pbDataHash,
-                                                                    int32_t cbDataHash,
-                                                                    PAL_HashAlgorithm hashAlgorithm,
-                                                                    CFDataRef* pSignatureOut,
-                                                                    CFErrorRef* pErrorOut)
+extern "C" int32_t AppleCryptoNative_GenerateSignatureWithHashAlgorithm(SecKeyRef privateKey,
+                                                                        uint8_t* pbDataHash,
+                                                                        int32_t cbDataHash,
+                                                                        PAL_HashAlgorithm hashAlgorithm,
+                                                                        CFDataRef* pSignatureOut,
+                                                                        CFErrorRef* pErrorOut)
 {
     return GenerateSignature(privateKey, pbDataHash, cbDataHash, hashAlgorithm, true, pSignatureOut, pErrorOut);
 }
 
-static int VerifySignature(SecKeyRef publicKey,
-                           uint8_t* pbDataHash,
-                           int32_t cbDataHash,
-                           uint8_t* pbSignature,
-                           int32_t cbSignature,
-                           PAL_HashAlgorithm hashAlgorithm,
-                           bool useHashAlgorithm,
-                           CFErrorRef* pErrorOut)
+static int32_t VerifySignature(SecKeyRef publicKey,
+                               uint8_t* pbDataHash,
+                               int32_t cbDataHash,
+                               uint8_t* pbSignature,
+                               int32_t cbSignature,
+                               PAL_HashAlgorithm hashAlgorithm,
+                               bool useHashAlgorithm,
+                               CFErrorRef* pErrorOut)
 {
     if (pErrorOut != nullptr)
         *pErrorOut = nullptr;
@@ -103,7 +103,7 @@ static int VerifySignature(SecKeyRef publicKey,
         return kErrorUnknownState;
     }
 
-    int ret = kErrorSeeError;
+    int32_t ret = kErrorSeeError;
     SecTransformRef verifier = SecVerifyTransformCreate(publicKey, signature, pErrorOut);
 
     if (verifier != nullptr)
@@ -125,34 +125,34 @@ static int VerifySignature(SecKeyRef publicKey,
     return ret;
 }
 
-extern "C" int AppleCryptoNative_VerifySignatureWithHashAlgorithm(SecKeyRef publicKey,
-                                                                  uint8_t* pbDataHash,
-                                                                  int32_t cbDataHash,
-                                                                  uint8_t* pbSignature,
-                                                                  int32_t cbSignature,
-                                                                  PAL_HashAlgorithm hashAlgorithm,
-                                                                  CFErrorRef* pErrorOut)
+extern "C" int32_t AppleCryptoNative_VerifySignatureWithHashAlgorithm(SecKeyRef publicKey,
+                                                                      uint8_t* pbDataHash,
+                                                                      int32_t cbDataHash,
+                                                                      uint8_t* pbSignature,
+                                                                      int32_t cbSignature,
+                                                                      PAL_HashAlgorithm hashAlgorithm,
+                                                                      CFErrorRef* pErrorOut)
 {
     return VerifySignature(publicKey, pbDataHash, cbDataHash, pbSignature, cbSignature, hashAlgorithm, true, pErrorOut);
 }
 
-extern "C" int AppleCryptoNative_VerifySignature(SecKeyRef publicKey,
-                                                 uint8_t* pbDataHash,
-                                                 int32_t cbDataHash,
-                                                 uint8_t* pbSignature,
-                                                 int32_t cbSignature,
-                                                 CFErrorRef* pErrorOut)
+extern "C" int32_t AppleCryptoNative_VerifySignature(SecKeyRef publicKey,
+                                                     uint8_t* pbDataHash,
+                                                     int32_t cbDataHash,
+                                                     uint8_t* pbSignature,
+                                                     int32_t cbSignature,
+                                                     CFErrorRef* pErrorOut)
 {
     return VerifySignature(publicKey, pbDataHash, cbDataHash, pbSignature, cbSignature, PAL_Unknown, false, pErrorOut);
 }
 
-static int ExecuteSignTransform(SecTransformRef signer, CFDataRef* pSignatureOut, CFErrorRef* pErrorOut)
+static int32_t ExecuteSignTransform(SecTransformRef signer, CFDataRef* pSignatureOut, CFErrorRef* pErrorOut)
 {
     assert(signer != nullptr);
     assert(pSignatureOut != nullptr);
     assert(pErrorOut != nullptr);
 
-    int ret = INT_MIN;
+    int32_t ret = INT_MIN;
     CFTypeRef signerResponse = SecTransformExecute(signer, pErrorOut);
     CFDataRef signature = nullptr;
 
@@ -193,12 +193,12 @@ cleanup:
     return ret;
 }
 
-static int ExecuteVerifyTransform(SecTransformRef verifier, CFErrorRef* pErrorOut)
+static int32_t ExecuteVerifyTransform(SecTransformRef verifier, CFErrorRef* pErrorOut)
 {
     assert(verifier != nullptr);
     assert(pErrorOut != nullptr);
 
-    int ret = kErrorSeeError;
+    int32_t ret = kErrorSeeError;
     CFTypeRef verifierResponse = SecTransformExecute(verifier, pErrorOut);
 
     if (verifierResponse != nullptr)
@@ -214,11 +214,11 @@ static int ExecuteVerifyTransform(SecTransformRef verifier, CFErrorRef* pErrorOu
     return ret;
 }
 
-static int ConfigureSignVerifyTransform(SecTransformRef xform,
-                                        CFDataRef cfDataHash,
-                                        PAL_HashAlgorithm hashAlgorithm,
-                                        bool includeHashAlgorithm,
-                                        CFErrorRef* pErrorOut)
+static int32_t ConfigureSignVerifyTransform(SecTransformRef xform,
+                                            CFDataRef cfDataHash,
+                                            PAL_HashAlgorithm hashAlgorithm,
+                                            bool includeHashAlgorithm,
+                                            CFErrorRef* pErrorOut)
 {
     if (!SecTransformSetAttribute(xform, kSecInputIsAttributeName, kSecInputIsDigest, pErrorOut))
     {
@@ -233,7 +233,7 @@ static int ConfigureSignVerifyTransform(SecTransformRef xform,
     if (includeHashAlgorithm)
     {
         CFStringRef cfHashName = nullptr;
-        int hashSize = 0;
+        int32_t hashSize = 0;
 
         switch (hashAlgorithm)
         {

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_signverify.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_signverify.h
@@ -14,7 +14,7 @@ Generate a signature for algorithms which require only the data hash blob, like 
 
 Follows pal_seckey return conventions.
 */
-extern "C" int AppleCryptoNative_GenerateSignature(
+extern "C" int32_t AppleCryptoNative_GenerateSignature(
     SecKeyRef privateKey, uint8_t* pbDataHash, int32_t cbDataHash, CFDataRef* pSignatureOut, CFErrorRef* pErrorOut);
 
 /*
@@ -22,12 +22,12 @@ Generate a signature for algorithms which require the pair of (dataHash, algorit
 
 Follows pal_seckey return conventions.
 */
-extern "C" int AppleCryptoNative_GenerateSignatureWithHashAlgorithm(SecKeyRef privateKey,
-                                                                    uint8_t* pbDataHash,
-                                                                    int32_t cbDataHash,
-                                                                    PAL_HashAlgorithm hashAlgorithm,
-                                                                    CFDataRef* pSignatureOut,
-                                                                    CFErrorRef* pErrorOut);
+extern "C" int32_t AppleCryptoNative_GenerateSignatureWithHashAlgorithm(SecKeyRef privateKey,
+                                                                        uint8_t* pbDataHash,
+                                                                        int32_t cbDataHash,
+                                                                        PAL_HashAlgorithm hashAlgorithm,
+                                                                        CFDataRef* pSignatureOut,
+                                                                        CFErrorRef* pErrorOut);
 
 /*
 Verify a signature for algorithms which only require the data hash blob, like DSA and ECDSA.
@@ -35,13 +35,13 @@ Verify a signature for algorithms which only require the data hash blob, like DS
 Returns 1 when the signature is correct, 0 when it is incorrect, and otherwise
 follows pal_seckey return conventions.
 */
-extern "C" int AppleCryptoNative_VerifySignatureWithHashAlgorithm(SecKeyRef publicKey,
-                                                                  uint8_t* pbDataHash,
-                                                                  int32_t cbDataHash,
-                                                                  uint8_t* pbSignature,
-                                                                  int32_t cbSignature,
-                                                                  PAL_HashAlgorithm hashAlgorithm,
-                                                                  CFErrorRef* pErrorOut);
+extern "C" int32_t AppleCryptoNative_VerifySignatureWithHashAlgorithm(SecKeyRef publicKey,
+                                                                      uint8_t* pbDataHash,
+                                                                      int32_t cbDataHash,
+                                                                      uint8_t* pbSignature,
+                                                                      int32_t cbSignature,
+                                                                      PAL_HashAlgorithm hashAlgorithm,
+                                                                      CFErrorRef* pErrorOut);
 
 /*
 Verify a signature for algorithms which require the pair of (dataHash, algorithmId), like RSA.
@@ -49,9 +49,9 @@ Verify a signature for algorithms which require the pair of (dataHash, algorithm
 Returns 1 when the signature is correct, 0 when it is incorrect, and otherwise
 follows pal_seckey return conventions.
 */
-extern "C" int AppleCryptoNative_VerifySignature(SecKeyRef publicKey,
-                                                 uint8_t* pbDataHash,
-                                                 int32_t cbDataHash,
-                                                 uint8_t* pbSignature,
-                                                 int32_t cbSignature,
-                                                 CFErrorRef* pErrorOut);
+extern "C" int32_t AppleCryptoNative_VerifySignature(SecKeyRef publicKey,
+                                                     uint8_t* pbDataHash,
+                                                     int32_t cbDataHash,
+                                                     uint8_t* pbSignature,
+                                                     int32_t cbSignature,
+                                                     CFErrorRef* pErrorOut);

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.cpp
@@ -300,7 +300,7 @@ AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringRef cfHos
 
     SecTrustRef trust = nullptr;
     osStatus = SecTrustCreateWithCertificates(certs, sslPolicy, &trust);
-    int ret = INT_MIN;
+    int32_t ret = INT_MIN;
 
     if (osStatus == noErr)
     {
@@ -363,7 +363,7 @@ extern "C" int32_t AppleCryptoNative_SslGetProtocolVersion(SSLContextRef sslCont
         return errSecParam;
 
     SSLProtocol protocol = kSSLProtocolUnknown;
-    int osStatus = SSLGetNegotiatedProtocolVersion(sslContext, &protocol);
+    OSStatus osStatus = SSLGetNegotiatedProtocolVersion(sslContext, &protocol);
 
     if (osStatus == noErr)
     {

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.cpp
@@ -30,16 +30,16 @@ extern "C" void AppleCryptoNative_CryptorFree(CCCryptorRef cryptor)
     }
 }
 
-extern "C" int AppleCryptoNative_CryptorCreate(PAL_SymmetricOperation operation,
-                                               PAL_SymmetricAlgorithm algorithm,
-                                               PAL_ChainingMode chainingMode,
-                                               PAL_PaddingMode paddingMode,
-                                               const uint8_t* pbKey,
-                                               int32_t cbKey,
-                                               const uint8_t* pbIv,
-                                               PAL_SymmetricOptions options,
-                                               CCCryptorRef* ppCryptorOut,
-                                               int32_t* pccStatus)
+extern "C" int32_t AppleCryptoNative_CryptorCreate(PAL_SymmetricOperation operation,
+                                                   PAL_SymmetricAlgorithm algorithm,
+                                                   PAL_ChainingMode chainingMode,
+                                                   PAL_PaddingMode paddingMode,
+                                                   const uint8_t* pbKey,
+                                                   int32_t cbKey,
+                                                   const uint8_t* pbIv,
+                                                   PAL_SymmetricOptions options,
+                                                   CCCryptorRef* ppCryptorOut,
+                                                   int32_t* pccStatus)
 {
     if (pccStatus == nullptr)
         return -1;
@@ -76,13 +76,13 @@ extern "C" int AppleCryptoNative_CryptorCreate(PAL_SymmetricOperation operation,
     return status == kCCSuccess;
 }
 
-extern "C" int AppleCryptoNative_CryptorUpdate(CCCryptorRef cryptor,
-                                               const uint8_t* pbData,
-                                               int32_t cbData,
-                                               uint32_t* pbOutput,
-                                               int32_t cbOutput,
-                                               int32_t* pcbWritten,
-                                               int32_t* pccStatus)
+extern "C" int32_t AppleCryptoNative_CryptorUpdate(CCCryptorRef cryptor,
+                                                   const uint8_t* pbData,
+                                                   int32_t cbData,
+                                                   uint32_t* pbOutput,
+                                                   int32_t cbOutput,
+                                                   int32_t* pcbWritten,
+                                                   int32_t* pccStatus)
 {
     if (pccStatus == nullptr)
         return -1;
@@ -103,7 +103,7 @@ extern "C" int AppleCryptoNative_CryptorUpdate(CCCryptorRef cryptor,
     return status == kCCSuccess;
 }
 
-extern "C" int AppleCryptoNative_CryptorFinal(
+extern "C" int32_t AppleCryptoNative_CryptorFinal(
     CCCryptorRef cryptor, uint8_t* pbOutput, int32_t cbOutput, int32_t* pcbWritten, int32_t* pccStatus)
 {
     if (pccStatus == nullptr)
@@ -121,7 +121,7 @@ extern "C" int AppleCryptoNative_CryptorFinal(
     return status == kCCSuccess;
 }
 
-extern "C" int AppleCryptoNative_CryptorReset(CCCryptorRef cryptor, const uint8_t* pbIv, int32_t* pccStatus)
+extern "C" int32_t AppleCryptoNative_CryptorReset(CCCryptorRef cryptor, const uint8_t* pbIv, int32_t* pccStatus)
 {
     if (pccStatus == nullptr)
         return -1;

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_symmetric.h
@@ -65,36 +65,36 @@ algorithm and assumed valid. pbIv is only allowed to be NULL for PAL_ChainingMod
 
 Returns 1 on success, 0 on system error, -1 on input error.
 */
-extern "C" int AppleCryptoNative_CryptorCreate(PAL_SymmetricOperation operation,
-                                               PAL_SymmetricAlgorithm algorithm,
-                                               PAL_ChainingMode chainingMode,
-                                               PAL_PaddingMode paddingMode,
-                                               const uint8_t* pbKey,
-                                               int32_t cbKey,
-                                               const uint8_t* pbIv,
-                                               PAL_SymmetricOptions options,
-                                               CCCryptorRef* ppCryptorOut,
-                                               int32_t* pkCCStatus);
+extern "C" int32_t AppleCryptoNative_CryptorCreate(PAL_SymmetricOperation operation,
+                                                   PAL_SymmetricAlgorithm algorithm,
+                                                   PAL_ChainingMode chainingMode,
+                                                   PAL_PaddingMode paddingMode,
+                                                   const uint8_t* pbKey,
+                                                   int32_t cbKey,
+                                                   const uint8_t* pbIv,
+                                                   PAL_SymmetricOptions options,
+                                                   CCCryptorRef* ppCryptorOut,
+                                                   int32_t* pkCCStatus);
 
 /*
 Shims CCCryptorUpdate, updating *pkCCStatus as its output.
 
 Returns 1 on success, 0 on system error, -1 on input error.
 */
-extern "C" int AppleCryptoNative_CryptorUpdate(CCCryptorRef cryptor,
-                                               const uint8_t* pbData,
-                                               int32_t cbData,
-                                               uint32_t* pbOutput,
-                                               int32_t cbOutput,
-                                               int32_t* pcbWritten,
-                                               int32_t* pkCCStatus);
+extern "C" int32_t AppleCryptoNative_CryptorUpdate(CCCryptorRef cryptor,
+                                                   const uint8_t* pbData,
+                                                   int32_t cbData,
+                                                   uint32_t* pbOutput,
+                                                   int32_t cbOutput,
+                                                   int32_t* pcbWritten,
+                                                   int32_t* pkCCStatus);
 
 /*
 Shims CCCryptorFinal, updating *pkCCStatus as its output.
 
 Returns 1 on success, 0 on system error, -1 on input error.
 */
-extern "C" int AppleCryptoNative_CryptorFinal(
+extern "C" int32_t AppleCryptoNative_CryptorFinal(
     CCCryptorRef cryptor, uint8_t* pbOutput, int32_t cbOutput, int32_t* pcbWritten, int32_t* pkCCStatus);
 
 /*
@@ -102,4 +102,4 @@ Shims CCCryptorReset, updating *pkCCStatus as its output.
 
 Returns 1 on success, 0 on system error, -1 on input error.
 */
-extern "C" int AppleCryptoNative_CryptorReset(CCCryptorRef cryptor, const uint8_t* pbIv, int32_t* pkCCStatus);
+extern "C" int32_t AppleCryptoNative_CryptorReset(CCCryptorRef cryptor, const uint8_t* pbIv, int32_t* pkCCStatus);


### PR DESCRIPTION
There weren't very many that weren't part of method signatures, so all of the usages of int
were replaced with int32_t.

`char` (the other common not-always-right type) was checked and all instances are for strings,
none were being used when uint8_t was meant instead.