### PR TITLE
Disable overflow checks by default

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -176,7 +176,6 @@
         <Optimize Condition="'$(Optimize)' == ''">false</Optimize>
         <DebugType Condition="'$(DebugType)' == ''">full</DebugType>
         <DefineConstants>$(DefineConstants),DEBUG,TRACE</DefineConstants>
-        <CheckForOverflowUnderflow Condition="'$(CheckForOverflowUnderflow)' == ''">true</CheckForOverflowUnderflow>
       </PropertyGroup>
     </When>
     <When Condition="'$(ConfigurationGroup)' == 'Release'">


### PR DESCRIPTION
Do the first step in pulling the annotations by undoing the change that disabled the overflow checks to stop the damage.

E.g. @marek-safar and I had to do 3 rounds of adding unchecked annotations in https://github.com/dotnet/corefx/pull/16583 to make the debug build work with the overflow checks.