### PR TITLE
Improve CI: disable WebSocket test ReceiveAsync_Cancel_Success

### DIFF
--- a/src/System.Net.WebSockets.Client/tests/CancelTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CancelTest.cs
@@ -52,6 +52,7 @@ namespace System.Net.WebSockets.Client.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
+        [ActiveIssue(13302)]
         public async Task ReceiveAsync_Cancel_Success(Uri server)
         {
             await TestCancellation(async (cws) =>


### PR DESCRIPTION
Disable test that has been failing every few days: https://github.com/dotnet/corefx/issues/13302

It is failing because the test verifies the exact WebSocketException exception string which does not always match. Recent error messages not accounted for:
- "The WebSocket is in an invalid state ('Aborte···"
- "The remote party closed the WebSocket connect···"

@ianhays 

Pertains to #14519