### PR TITLE
fix p/invoke marshalling of WSABuffers

### DIFF
--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Net.Sockets;
 
@@ -39,6 +40,9 @@ internal static partial class Interop
             SafeNativeOverlapped overlapped,
             IntPtr completionRoutine)
         {
+            // We intentionally do NOT copy this back after the function completes:
+            // We don't want to cause a race in async scenarios.
+            // The WSABuffer struct should be unchanged anyway.
             WSABuffer localBuffer = buffer;
             return WSARecv(socketHandle, &localBuffer, bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
         }
@@ -52,6 +56,7 @@ internal static partial class Interop
             SafeNativeOverlapped overlapped,
             IntPtr completionRoutine)
         {
+            Debug.Assert(buffers != null);
             fixed (WSABuffer* buffersPtr = &buffers[0])
             { 
                 return WSARecv(socketHandle, buffersPtr, bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
@@ -67,6 +72,7 @@ internal static partial class Interop
             SafeNativeOverlapped overlapped,
             IntPtr completionRoutine)
         {
+            Debug.Assert(buffers != null);
             fixed (WSABuffer* buffersPtr = &buffers[0])
             {
                 return WSARecv(socketHandle, buffersPtr, bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSARecv.cs
@@ -11,33 +11,66 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern SocketError WSARecv(
-            [In] SafeCloseSocket socketHandle,
-            [In] ref WSABuffer buffer,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In, Out] ref SocketFlags socketFlags,
-            [In] SafeHandle overlapped,
-            [In] IntPtr completionRoutine);
+        internal static unsafe extern SocketError WSARecv(
+            SafeCloseSocket socketHandle,
+            WSABuffer* buffer,
+            int bufferCount,
+            out int bytesTransferred,
+            ref SocketFlags socketFlags,
+            SafeNativeOverlapped overlapped,
+            IntPtr completionRoutine);
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern SocketError WSARecv(
-            [In] SafeCloseSocket socketHandle,
-            [In, Out] WSABuffer[] buffers,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In, Out] ref SocketFlags socketFlags,
-            [In] SafeHandle overlapped,
-            [In] IntPtr completionRoutine);
+        internal static unsafe extern SocketError WSARecv(
+            IntPtr socketHandle,
+            WSABuffer* buffer,
+            int bufferCount,
+            out int bytesTransferred,
+            ref SocketFlags socketFlags,
+            SafeNativeOverlapped overlapped,
+            IntPtr completionRoutine);
 
-        [DllImport(Interop.Libraries.Ws2_32, SetLastError = true, EntryPoint = "WSARecv")]
-        internal static extern SocketError WSARecv_Blocking(
-            [In] IntPtr socketHandle,
-            [In, Out] WSABuffer[] buffers,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In, Out] ref SocketFlags socketFlags,
-            [In] SafeHandle overlapped,
-            [In] IntPtr completionRoutine);
+        internal static unsafe SocketError WSARecv(
+            SafeCloseSocket socketHandle,
+            ref WSABuffer buffer,
+            int bufferCount,
+            out int bytesTransferred,
+            ref SocketFlags socketFlags,
+            SafeNativeOverlapped overlapped,
+            IntPtr completionRoutine)
+        {
+            WSABuffer localBuffer = buffer;
+            return WSARecv(socketHandle, &localBuffer, bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
+        }
+
+        internal static unsafe SocketError WSARecv(
+            SafeCloseSocket socketHandle,
+            WSABuffer[] buffers,
+            int bufferCount,
+            out int bytesTransferred,
+            ref SocketFlags socketFlags,
+            SafeNativeOverlapped overlapped,
+            IntPtr completionRoutine)
+        {
+            fixed (WSABuffer* buffersPtr = &buffers[0])
+            { 
+                return WSARecv(socketHandle, buffersPtr, bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
+            }
+        }
+
+        internal static unsafe SocketError WSARecv(
+            IntPtr socketHandle,
+            WSABuffer[] buffers,
+            int bufferCount,
+            out int bytesTransferred,
+            ref SocketFlags socketFlags,
+            SafeNativeOverlapped overlapped,
+            IntPtr completionRoutine)
+        {
+            fixed (WSABuffer* buffersPtr = &buffers[0])
+            {
+                return WSARecv(socketHandle, buffersPtr, bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSARecvFrom.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSARecvFrom.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Net.Sockets;
 
@@ -34,6 +35,9 @@ internal static partial class Interop
             SafeNativeOverlapped overlapped,
             IntPtr completionRoutine)
         {
+            // We intentionally do NOT copy this back after the function completes:
+            // We don't want to cause a race in async scenarios.
+            // The WSABuffer struct should be unchanged anyway.
             WSABuffer localBuffer = buffer;
             return WSARecvFrom(socketHandle, &localBuffer, bufferCount, out bytesTransferred, ref socketFlags, socketAddressPointer, socketAddressSizePointer, overlapped, completionRoutine);
         }
@@ -49,6 +53,7 @@ internal static partial class Interop
             SafeNativeOverlapped overlapped,
             IntPtr completionRoutine)
         {
+            Debug.Assert(buffers != null);
             fixed (WSABuffer* buffersPtr = &buffers[0])
             {
                 return WSARecvFrom(socketHandle, buffersPtr, bufferCount, out bytesTransferred, ref socketFlags, socketAddressPointer, socketAddressSizePointer, overlapped, completionRoutine);

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSARecvFrom.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSARecvFrom.cs
@@ -10,28 +10,49 @@ internal static partial class Interop
 {
     internal static partial class Winsock
     {
-        [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern SocketError WSARecvFrom(
-            [In] SafeCloseSocket socketHandle,
-            [In] ref WSABuffer buffer,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In, Out] ref SocketFlags socketFlags,
-            [In] IntPtr socketAddressPointer,
-            [In] IntPtr socketAddressSizePointer,
-            [In] SafeHandle overlapped,
-            [In] IntPtr completionRoutine);
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern SocketError WSARecvFrom(
-            [In] SafeCloseSocket socketHandle,
-            [In, Out] WSABuffer[] buffers,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In, Out] ref SocketFlags socketFlags,
-            [In] IntPtr socketAddressPointer,
-            [In] IntPtr socketAddressSizePointer,
-            [In] SafeNativeOverlapped overlapped,
-            [In] IntPtr completionRoutine);
+        internal static unsafe extern SocketError WSARecvFrom(
+            SafeCloseSocket socketHandle,
+            WSABuffer* buffers,
+            int bufferCount,
+            out int bytesTransferred,
+            ref SocketFlags socketFlags,
+            IntPtr socketAddressPointer,
+            IntPtr socketAddressSizePointer,
+            SafeNativeOverlapped overlapped,
+            IntPtr completionRoutine);
+
+        internal static unsafe SocketError WSARecvFrom(
+            SafeCloseSocket socketHandle,
+            ref WSABuffer buffer,
+            int bufferCount,
+            out int bytesTransferred,
+            ref SocketFlags socketFlags,
+            IntPtr socketAddressPointer,
+            IntPtr socketAddressSizePointer,
+            SafeNativeOverlapped overlapped,
+            IntPtr completionRoutine)
+        {
+            WSABuffer localBuffer = buffer;
+            return WSARecvFrom(socketHandle, &localBuffer, bufferCount, out bytesTransferred, ref socketFlags, socketAddressPointer, socketAddressSizePointer, overlapped, completionRoutine);
+        }
+
+        internal static unsafe SocketError WSARecvFrom(
+            SafeCloseSocket socketHandle,
+            WSABuffer[] buffers,
+            int bufferCount,
+            out int bytesTransferred,
+            ref SocketFlags socketFlags,
+            IntPtr socketAddressPointer,
+            IntPtr socketAddressSizePointer,
+            SafeNativeOverlapped overlapped,
+            IntPtr completionRoutine)
+        {
+            fixed (WSABuffer* buffersPtr = &buffers[0])
+            {
+                return WSARecvFrom(socketHandle, buffersPtr, bufferCount, out bytesTransferred, ref socketFlags, socketAddressPointer, socketAddressSizePointer, overlapped, completionRoutine);
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSASend.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSASend.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Net.Sockets;
 
@@ -39,6 +40,9 @@ internal static partial class Interop
             SafeNativeOverlapped overlapped,
             IntPtr completionRoutine)
         {
+            // We intentionally do NOT copy this back after the function completes:
+            // We don't want to cause a race in async scenarios.
+            // The WSABuffer struct should be unchanged anyway.
             WSABuffer localBuffer = buffer;
             return WSASend(socketHandle, &localBuffer, bufferCount, out bytesTransferred, socketFlags, overlapped, completionRoutine);
         }
@@ -52,6 +56,7 @@ internal static partial class Interop
             SafeNativeOverlapped overlapped,
             IntPtr completionRoutine)
         {
+            Debug.Assert(buffers != null);
             fixed (WSABuffer* buffersPtr = &buffers[0])
             {
                 return WSASend(socketHandle, buffersPtr, bufferCount, out bytesTransferred, socketFlags, overlapped, completionRoutine);
@@ -67,6 +72,7 @@ internal static partial class Interop
             SafeNativeOverlapped overlapped,
             IntPtr completionRoutine)
         {
+            Debug.Assert(buffers != null);
             fixed (WSABuffer* buffersPtr = &buffers[0])
             {
                 return WSASend(socketHandle, buffersPtr, bufferCount, out bytesTransferred, socketFlags, overlapped, completionRoutine);

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSASend.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSASend.cs
@@ -11,33 +11,66 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern SocketError WSASend(
-            [In] SafeCloseSocket socketHandle,
-            [In] ref WSABuffer buffer,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In] SocketFlags socketFlags,
-            [In] SafeHandle overlapped,
-            [In] IntPtr completionRoutine);
+        internal static extern unsafe SocketError WSASend(
+            SafeCloseSocket socketHandle,
+            WSABuffer* buffers,
+            int bufferCount,
+            out int bytesTransferred,
+            SocketFlags socketFlags,
+            SafeNativeOverlapped overlapped,
+            IntPtr completionRoutine);
 
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern SocketError WSASend(
-            [In] SafeCloseSocket socketHandle,
-            [In] WSABuffer[] buffersArray,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In] SocketFlags socketFlags,
-            [In] SafeHandle overlapped,
-            [In] IntPtr completionRoutine);
+        internal static extern unsafe SocketError WSASend(
+            IntPtr socketHandle,
+            WSABuffer* buffers,
+            int bufferCount,
+            out int bytesTransferred,
+            SocketFlags socketFlags,
+            SafeNativeOverlapped overlapped,
+            IntPtr completionRoutine);
 
-        [DllImport(Interop.Libraries.Ws2_32, SetLastError = true, EntryPoint = "WSASend")]
-        internal static extern SocketError WSASend_Blocking(
-            [In] IntPtr socketHandle,
-            [In] WSABuffer[] buffersArray,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In] SocketFlags socketFlags,
-            [In] SafeHandle overlapped,
-            [In] IntPtr completionRoutine);
+        internal static unsafe SocketError WSASend(
+            SafeCloseSocket socketHandle,
+            ref WSABuffer buffer,
+            int bufferCount,
+            out int bytesTransferred,
+            SocketFlags socketFlags,
+            SafeNativeOverlapped overlapped,
+            IntPtr completionRoutine)
+        {
+            WSABuffer localBuffer = buffer;
+            return WSASend(socketHandle, &localBuffer, bufferCount, out bytesTransferred, socketFlags, overlapped, completionRoutine);
+        }
+
+        internal static unsafe SocketError WSASend(
+            SafeCloseSocket socketHandle,
+            WSABuffer[] buffers,
+            int bufferCount,
+            out int bytesTransferred,
+            SocketFlags socketFlags,
+            SafeNativeOverlapped overlapped,
+            IntPtr completionRoutine)
+        {
+            fixed (WSABuffer* buffersPtr = &buffers[0])
+            {
+                return WSASend(socketHandle, buffersPtr, bufferCount, out bytesTransferred, socketFlags, overlapped, completionRoutine);
+            }
+        }
+
+        internal static unsafe SocketError WSASend(
+            IntPtr socketHandle,
+            WSABuffer[] buffers,
+            int bufferCount,
+            out int bytesTransferred,
+            SocketFlags socketFlags,
+            SafeNativeOverlapped overlapped,
+            IntPtr completionRoutine)
+        {
+            fixed (WSABuffer* buffersPtr = &buffers[0])
+            {
+                return WSASend(socketHandle, buffersPtr, bufferCount, out bytesTransferred, socketFlags, overlapped, completionRoutine);
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSASendTo.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSASendTo.cs
@@ -11,27 +11,47 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern SocketError WSASendTo(
-            [In] SafeCloseSocket socketHandle,
-            [In] ref WSABuffer buffer,
-            [In] int bufferCount,
-            [Out] out int bytesTransferred,
-            [In] SocketFlags socketFlags,
-            [In] IntPtr socketAddress,
-            [In] int socketAddressSize,
-            [In] SafeHandle overlapped,
-            [In] IntPtr completionRoutine);
+        internal static unsafe extern SocketError WSASendTo(
+            SafeCloseSocket socketHandle,
+            WSABuffer* buffers,
+            int bufferCount,
+            out int bytesTransferred,
+            SocketFlags socketFlags,
+            IntPtr socketAddress,
+            int socketAddressSize,
+            SafeNativeOverlapped overlapped,
+            IntPtr completionRoutine);
 
-        [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static extern SocketError WSASendTo(
-            [In] SafeCloseSocket socketHandle,
-            [In] WSABuffer[] buffersArray,
-            [In] int bufferCount,
+        internal static unsafe SocketError WSASendTo(
+            SafeCloseSocket socketHandle,
+            ref WSABuffer buffer,
+            int bufferCount,
+            out int bytesTransferred,
+            SocketFlags socketFlags,
+            IntPtr socketAddress,
+            int socketAddressSize,
+            SafeNativeOverlapped overlapped,
+            IntPtr completionRoutine)
+        {
+            WSABuffer localBuffer = buffer;
+            return WSASendTo(socketHandle, &localBuffer, bufferCount, out bytesTransferred, socketFlags, socketAddress, socketAddressSize, overlapped, completionRoutine);
+        }
+
+        internal static unsafe SocketError WSASendTo(
+            SafeCloseSocket socketHandle,
+            WSABuffer[] buffers,
+            int bufferCount,
             [Out] out int bytesTransferred,
-            [In] SocketFlags socketFlags,
-            [In] IntPtr socketAddress,
-            [In] int socketAddressSize,
-            [In] SafeNativeOverlapped overlapped,
-            [In] IntPtr completionRoutine);
+            SocketFlags socketFlags,
+            IntPtr socketAddress,
+            int socketAddressSize,
+            SafeNativeOverlapped overlapped,
+            IntPtr completionRoutine)
+        {
+            fixed (WSABuffer* buffersPtr = &buffers[0])
+            {
+                return WSASendTo(socketHandle, buffersPtr, bufferCount, out bytesTransferred, socketFlags, socketAddress, socketAddressSize, overlapped, completionRoutine);
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Windows/Winsock/Interop.WSASendTo.cs
+++ b/src/Common/src/Interop/Windows/Winsock/Interop.WSASendTo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Net.Sockets;
 
@@ -33,6 +34,9 @@ internal static partial class Interop
             SafeNativeOverlapped overlapped,
             IntPtr completionRoutine)
         {
+            // We intentionally do NOT copy this back after the function completes:
+            // We don't want to cause a race in async scenarios.
+            // The WSABuffer struct should be unchanged anyway.
             WSABuffer localBuffer = buffer;
             return WSASendTo(socketHandle, &localBuffer, bufferCount, out bytesTransferred, socketFlags, socketAddress, socketAddressSize, overlapped, completionRoutine);
         }
@@ -48,6 +52,7 @@ internal static partial class Interop
             SafeNativeOverlapped overlapped,
             IntPtr completionRoutine)
         {
+            Debug.Assert(buffers != null);
             fixed (WSABuffer* buffersPtr = &buffers[0])
             {
                 return WSASendTo(socketHandle, buffersPtr, bufferCount, out bytesTransferred, socketFlags, socketAddress, socketAddressSize, overlapped, completionRoutine);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
@@ -145,7 +145,7 @@ namespace System.Net.Sockets
 
         // The following property returns the Win32 unsafe pointer to
         // whichever Overlapped structure we're using for IO.
-        internal SafeHandle OverlappedHandle
+        internal SafeNativeOverlapped OverlappedHandle
         {
             get
             {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -149,7 +149,7 @@ namespace System.Net.Sockets
                 }
 
                 // This may throw ObjectDisposedException.
-                SocketError errorCode = Interop.Winsock.WSASend_Blocking(
+                SocketError errorCode = Interop.Winsock.WSASend(
                     handle.DangerousGetHandle(),
                     WSABuffers,
                     count,
@@ -275,7 +275,7 @@ namespace System.Net.Sockets
                 }
 
                 // This can throw ObjectDisposedException.
-                SocketError errorCode = Interop.Winsock.WSARecv_Blocking(
+                SocketError errorCode = Interop.Winsock.WSARecv(
                     handle.DangerousGetHandle(),
                     WSABuffers,
                     count,


### PR DESCRIPTION
Our p/invoke definitions of WSARecv etc were defined to take a WSABuffer[].  This caused copy-in/copy-out marshalling, which caused timing issues because the WSABuffers should not be touched after the WSARecv call returns IOPending.

Fix this by changing the p/invoke definitions to take WSABuffer*.

Fixes #16213 