### PR TITLE
Remove check for safewinhttphandles to depend on finalization.

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeSafeWinHttpHandle.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeSafeWinHttpHandle.cs
@@ -13,33 +13,19 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
 {
     internal class FakeSafeWinHttpHandle : Interop.WinHttp.SafeWinHttpHandle
     {
-        private static int s_HandlesOpen = 0;
-
         private Interop.WinHttp.WINHTTP_STATUS_CALLBACK _callback = null;
         private IntPtr _context = IntPtr.Zero;
-        
+
         public FakeSafeWinHttpHandle(bool markAsValid)
         {
             if (markAsValid)
             {
                 SetHandle(Marshal.AllocHGlobal(1));
-                Interlocked.Increment(ref s_HandlesOpen);
-                Debug.WriteLine(
-                    "FakeSafeWinHttpHandle.cctor, handle=#{0}, s_HandlesOpen={1}",
-                    handle.GetHashCode(),
-                    s_HandlesOpen);
+                Debug.WriteLine("FakeSafeWinHttpHandle.cctor, handle=#{0}", handle.GetHashCode());
             }
             else
             {
                 SetHandleAsInvalid();
-            }
-        }
-
-        public static int HandlesOpen
-        {
-            get
-            {
-                return s_HandlesOpen;
             }
         }
 
@@ -49,7 +35,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             {
                 return _callback;
             }
-            
+
             set
             {
                 _callback = value;
@@ -62,7 +48,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             {
                 return _context;
             }
-            
+
             set
             {
                 _context = value;
@@ -75,7 +61,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             {
                 return true;
             }
-            
+
             // Sleep for delay time specified.  Abort if handle becomes closed.
             var sw = new Stopwatch();
             sw.Start();
@@ -86,15 +72,15 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
                     sw.Stop();
                     return false;
                 }
-                
+
                 Thread.Sleep(1);
             }
 
             sw.Stop();
-            
+
             return true;
         }
-        
+
         public void InvokeCallback(uint internetStatus, Interop.WinHttp.WINHTTP_ASYNC_RESULT asyncResult)
         {
             GCHandle pinnedAsyncResult = GCHandle.Alloc(asyncResult, GCHandleType.Pinned);
@@ -113,12 +99,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
 
         protected override bool ReleaseHandle()
         {
-            Interlocked.Decrement(ref s_HandlesOpen);
-            Debug.WriteLine(
-                "FakeSafeWinHttpHandle.ReleaseHandle, handle=#{0}, s_HandlesOpen={1}",
-                handle.GetHashCode(),
-                s_HandlesOpen);
-            
+            Debug.WriteLine("FakeSafeWinHttpHandle.ReleaseHandle, handle=#{0}", handle.GetHashCode());
             return base.ReleaseHandle();
         }
     }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/SafeWinHttpHandleTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/SafeWinHttpHandleTest.cs
@@ -11,7 +11,6 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
 {
     public class SafeWinHttpHandleTest
     {
-        [ActiveIssue(13951)]
         [Fact]
         public void CreateAddRefDispose_HandleIsNotClosed()
         {
@@ -20,15 +19,13 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             safeHandle.DangerousAddRef(ref success);
             Assert.True(success, "DangerousAddRef");
             safeHandle.Dispose();
-            
+
             Assert.False(safeHandle.IsClosed, "closed");
-            Assert.Equal(1, FakeSafeWinHttpHandle.HandlesOpen);
-            
+
             // Clean up safeHandle to keep outstanding handles at zero.
             safeHandle.DangerousRelease();
         }
 
-        [ActiveIssue(13951)]
         [Fact]
         public void CreateAddRefDisposeDispose_HandleIsNotClosed()
         {
@@ -38,15 +35,13 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Assert.True(success, "DangerousAddRef");
             safeHandle.Dispose();
             safeHandle.Dispose();
-            
+
             Assert.False(safeHandle.IsClosed, "closed");
-            Assert.Equal(1, FakeSafeWinHttpHandle.HandlesOpen);
-            
+
             // Clean up safeHandle to keep outstanding handles at zero.
             safeHandle.DangerousRelease();
         }
 
-        [ActiveIssue(13951)]
         [Fact]
         public void CreateAddRefDisposeRelease_HandleIsClosed()
         {
@@ -56,12 +51,10 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Assert.True(success, "DangerousAddRef");
             safeHandle.Dispose();
             safeHandle.DangerousRelease();
-            
+
             Assert.True(safeHandle.IsClosed, "closed");
-            Assert.Equal(0, FakeSafeWinHttpHandle.HandlesOpen);
         }
 
-        [ActiveIssue(13951)]
         [Fact]
         public void CreateAddRefRelease_HandleIsNotClosed()
         {
@@ -70,15 +63,13 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             safeHandle.DangerousAddRef(ref success);
             Assert.True(success, "DangerousAddRef");
             safeHandle.DangerousRelease();
-            
+
             Assert.False(safeHandle.IsClosed, "closed");
-            Assert.Equal(1, FakeSafeWinHttpHandle.HandlesOpen);
-            
+
             // Clean up safeHandle to keep outstanding handles at zero.
             safeHandle.Dispose();
         }
 
-        [ActiveIssue(13951)]
         [Fact]
         public void CreateAddRefReleaseDispose_HandleIsClosed()
         {
@@ -88,22 +79,19 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Assert.True(success, "DangerousAddRef");
             safeHandle.DangerousRelease();
             safeHandle.Dispose();
-            
+
             Assert.True(safeHandle.IsClosed, "closed");
-            Assert.Equal(0, FakeSafeWinHttpHandle.HandlesOpen);
         }
 
-        [ActiveIssue(13951)]
         [Fact]
         public void CreateDispose_HandleIsClosed()
         {
             var safeHandle = new FakeSafeWinHttpHandle(true);
             safeHandle.Dispose();
-            
+
             Assert.True(safeHandle.IsClosed, "closed");
         }
 
-        [ActiveIssue(13951)]
         [Fact]
         public void CreateDisposeDispose_HandleIsClosedAndSecondDisposeIsNoop()
         {
@@ -113,17 +101,15 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Assert.True(safeHandle.IsClosed, "closed");
         }
 
-        [ActiveIssue(13951)]
         [Fact]
         public void CreateDisposeAddRef_ThrowsObjectDisposedException()
         {
             var safeHandle = new FakeSafeWinHttpHandle(true);
             safeHandle.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => 
+            Assert.Throws<ObjectDisposedException>(() =>
                 { bool ignore = false; safeHandle.DangerousAddRef(ref ignore); });
         }
 
-        [ActiveIssue(13951)]
         [Fact]
         public void CreateDisposeRelease_ThrowsObjectDisposedException()
         {
@@ -132,7 +118,6 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             Assert.Throws<ObjectDisposedException>(() => safeHandle.DangerousRelease());
         }
 
-        [ActiveIssue(13951)]
         [Fact]
         public void SetParentHandle_CreateParentCreateChildDisposeParent_ParentNotClosed()
         {
@@ -140,15 +125,13 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             var childHandle = new FakeSafeWinHttpHandle(true);
             childHandle.SetParentHandle(parentHandle);
             parentHandle.Dispose();
-            
+
             Assert.False(parentHandle.IsClosed, "closed");
-            Assert.Equal(2, FakeSafeWinHttpHandle.HandlesOpen);
-            
+
             // Clean up safeHandles to keep outstanding handles at zero.
             childHandle.Dispose();
         }
 
-        [ActiveIssue(13951)]
         [Fact]
         public void SetParentHandle_CreateParentCreateChildDisposeParentDisposeChild_HandlesClosed()
         {
@@ -157,12 +140,11 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             childHandle.SetParentHandle(parentHandle);
             parentHandle.Dispose();
             childHandle.Dispose();
-            
+
             Assert.True(parentHandle.IsClosed, "closed");
             Assert.True(childHandle.IsClosed, "closed");
         }
 
-        [ActiveIssue(13951)]
         [Fact]
         public void SetParentHandle_CreateParentCreateChildDisposeChildDisposeParent_HandlesClosed()
         {
@@ -171,7 +153,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             childHandle.SetParentHandle(parentHandle);
             childHandle.Dispose();
             parentHandle.Dispose();
-            
+
             Assert.True(parentHandle.IsClosed, "closed");
             Assert.True(childHandle.IsClosed, "closed");
         }


### PR DESCRIPTION
Checking for handle count depends on when ReleaseHandle on the safehandle is called. The invocation of ReleaseHandle is dependent on when the finalizer thread executes this object from ReadyToFinalize queue. Since this is not testing the SafeWinHttpHandle, removing this check from the networking test library.

fixes #13951 

cc @jkotas @karelz @steveharter @ianhays 