### PR TITLE
Add symmetric and asymmetric XML encryption samples

### DIFF
--- a/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
+++ b/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
@@ -95,7 +95,7 @@ namespace System.Security.Cryptography.Xml.Tests
                 XmlDocument xmlDocToDecrypt = LoadXmlFromString(xmlDocToEncrypt.OuterXml);
                 Decrypt(xmlDocToDecrypt, key, "rsaKey");
 
-                Assert.Equal(ExampleXml, xmlDocToDecrypt.OuterXml);
+                Assert.Equal(ExampleXml.Replace("\r\n", "\n"), xmlDocToDecrypt.OuterXml.Replace("\r\n", "\n"));
             }
         }
     }

--- a/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
+++ b/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
@@ -1,0 +1,102 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using Xunit;
+
+namespace System.Security.Cryptography.Xml.Tests
+{
+    // Simplified implementation of MSDN sample:
+    // https://msdn.microsoft.com/en-us/library/ms229746(v=vs.110).aspx
+    public class EncryptingAndDecryptingAsymmetric
+    {
+        const string ExampleXmlRootElement = "example";
+        const string ExampleXml = @"<?xml version=""1.0""?>
+<example>
+<test>some text node</test>
+</example>";
+
+        private static XmlDocument LoadXmlFromString(string xml)
+        {
+            var doc = new XmlDocument();
+            doc.PreserveWhitespace = true;
+            doc.LoadXml(xml);
+            return doc;
+        }
+
+        private static void Encrypt(XmlDocument doc, string elementName, string encryptionElementID, RSA rsaKey, string keyName)
+        {
+            var elementToEncrypt = (XmlElement)doc.GetElementsByTagName(elementName)[0];
+
+            using (var sessionKey = new RijndaelManaged())
+            {
+                sessionKey.KeySize = 256;
+
+                // Encrypt the session key and add it to an EncryptedKey element.
+                var encryptedKey = new EncryptedKey()
+                {
+                    CipherData = new CipherData(EncryptedXml.EncryptKey(sessionKey.Key, rsaKey, false)),
+                    EncryptionMethod = new EncryptionMethod(EncryptedXml.XmlEncRSA15Url)
+                };
+
+                // Specify which EncryptedData
+                // uses this key. An XML document can have
+                // multiple EncryptedData elements that use
+                // different keys.
+                encryptedKey.AddReference(new DataReference()
+                {
+                    Uri = "#" + encryptionElementID
+                });
+
+                var encryptedData = new EncryptedData()
+                {
+                    Type = EncryptedXml.XmlEncElementUrl,
+                    Id = encryptionElementID,
+
+                    // Create an EncryptionMethod element so that the
+                    // receiver knows which algorithm to use for decryption.
+                    EncryptionMethod = new EncryptionMethod(EncryptedXml.XmlEncAES256Url)
+                };
+
+                encryptedData.KeyInfo.AddClause(new KeyInfoEncryptedKey(encryptedKey));
+                encryptedKey.KeyInfo.AddClause(new KeyInfoName()
+                {
+                    Value = keyName
+                });
+
+                var encryptedXml = new EncryptedXml();
+                encryptedData.CipherData.CipherValue = encryptedXml.EncryptData(elementToEncrypt, sessionKey, false);
+
+                EncryptedXml.ReplaceElement(elementToEncrypt, encryptedData, false);
+            }
+        }
+
+        public static void Decrypt(XmlDocument doc, RSA rsaKey, string keyName)
+        {
+            var encrypted = new EncryptedXml(doc);
+            encrypted.AddKeyNameMapping(keyName, rsaKey);
+            encrypted.DecryptDocument();
+        }
+
+        [Fact]
+        public void AsymmetricEncryptionRoundtrip()
+        {
+            using (var key = RSA.Create())
+            {
+                XmlDocument xmlDocToEncrypt = LoadXmlFromString(ExampleXml);
+                Encrypt(xmlDocToEncrypt, ExampleXmlRootElement, "EncryptedElement1", key, "rsaKey");
+
+                XmlDocument xmlDocToDecrypt = LoadXmlFromString(xmlDocToEncrypt.OuterXml);
+                Decrypt(xmlDocToDecrypt, key, "rsaKey");
+
+                Assert.Equal(ExampleXml, xmlDocToDecrypt.OuterXml);
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
+++ b/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
@@ -34,7 +34,7 @@ namespace System.Security.Cryptography.Xml.Tests
         {
             var elementToEncrypt = (XmlElement)doc.GetElementsByTagName(elementName)[0];
 
-            using (var sessionKey = new RijndaelManaged())
+            using (var sessionKey = Aes.Create())
             {
                 sessionKey.KeySize = 256;
 

--- a/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
+++ b/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
@@ -92,6 +92,7 @@ namespace System.Security.Cryptography.Xml.Tests
                 XmlDocument xmlDocToEncrypt = LoadXmlFromString(ExampleXml);
                 Encrypt(xmlDocToEncrypt, ExampleXmlRootElement, "EncryptedElement1", key, "rsaKey");
 
+                Assert.DoesNotContain("some text node", xmlDocToEncrypt.OuterXml);
                 XmlDocument xmlDocToDecrypt = LoadXmlFromString(xmlDocToEncrypt.OuterXml);
                 Decrypt(xmlDocToDecrypt, key, "rsaKey");
 

--- a/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
+++ b/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
@@ -16,12 +16,6 @@ namespace System.Security.Cryptography.Xml.Tests
     // https://msdn.microsoft.com/en-us/library/ms229746(v=vs.110).aspx
     public class EncryptingAndDecryptingAsymmetric
     {
-        const string ExampleXmlRootElement = "example";
-        const string ExampleXml = @"<?xml version=""1.0""?>
-<example>
-<test>some text node</test>
-</example>";
-
         private static XmlDocument LoadXmlFromString(string xml)
         {
             var doc = new XmlDocument();
@@ -87,16 +81,24 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void AsymmetricEncryptionRoundtrip()
         {
+            const string testString = "some text node";
+            const string exampleXmlRootElement = "example";
+            const string exampleXml = @"<?xml version=""1.0""?>
+<example>
+<test>some text node</test>
+</example>";
+
             using (RSA key = RSA.Create())
             {
-                XmlDocument xmlDocToEncrypt = LoadXmlFromString(ExampleXml);
-                Encrypt(xmlDocToEncrypt, ExampleXmlRootElement, "EncryptedElement1", key, "rsaKey");
+                XmlDocument xmlDocToEncrypt = LoadXmlFromString(exampleXml);
+                Assert.Contains(testString, xmlDocToEncrypt.OuterXml);
+                Encrypt(xmlDocToEncrypt, exampleXmlRootElement, "EncryptedElement1", key, "rsaKey");
 
-                Assert.DoesNotContain("some text node", xmlDocToEncrypt.OuterXml);
+                Assert.DoesNotContain(testString, xmlDocToEncrypt.OuterXml);
                 XmlDocument xmlDocToDecrypt = LoadXmlFromString(xmlDocToEncrypt.OuterXml);
                 Decrypt(xmlDocToDecrypt, key, "rsaKey");
 
-                Assert.Equal(ExampleXml.Replace("\r\n", "\n"), xmlDocToDecrypt.OuterXml.Replace("\r\n", "\n"));
+                Assert.Equal(exampleXml.Replace("\r\n", "\n"), xmlDocToDecrypt.OuterXml.Replace("\r\n", "\n"));
             }
         }
     }

--- a/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
+++ b/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
@@ -87,7 +87,7 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void AsymmetricEncryptionRoundtrip()
         {
-            using (var key = RSA.Create())
+            using (RSA key = RSA.Create())
             {
                 XmlDocument xmlDocToEncrypt = LoadXmlFromString(ExampleXml);
                 Encrypt(xmlDocToEncrypt, ExampleXmlRootElement, "EncryptedElement1", key, "rsaKey");

--- a/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingSymmetric.cs
+++ b/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingSymmetric.cs
@@ -56,7 +56,7 @@ namespace System.Security.Cryptography.Xml.Tests
             {
                 return EncryptedXml.XmlEncDESUrl;
             }
-            else if (key is Rijndael)
+            else if (key is Rijndael || key is Aes)
             {
                 switch (key.KeySize)
                 {
@@ -89,7 +89,7 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void SymmetricEncryptionRoundtrip()
         {
-            using (var key = new RijndaelManaged())
+            using (var key = Aes.Create())
             {
                 XmlDocument xmlDocToEncrypt = LoadXmlFromString(ExampleXml);
                 EncryptElement(xmlDocToEncrypt, ExampleXmlRootElement, key);

--- a/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingSymmetric.cs
+++ b/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingSymmetric.cs
@@ -16,12 +16,6 @@ namespace System.Security.Cryptography.Xml.Tests
     // https://msdn.microsoft.com/en-us/library/sb7w85t6(v=vs.110).aspx
     public class EncryptingAndDecryptingSymmetric
     {
-        const string ExampleXmlRootElement = "example";
-        const string ExampleXml = @"<?xml version=""1.0""?>
-<example>
-<test>some text node</test>
-</example>";
-
         private static XmlDocument LoadXmlFromString(string xml)
         {
             var doc = new XmlDocument();
@@ -89,12 +83,20 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void SymmetricEncryptionRoundtrip()
         {
+            const string testString = "some text node";
+            const string ExampleXmlRootElement = "example";
+            const string ExampleXml = @"<?xml version=""1.0""?>
+<example>
+<test>some text node</test>
+</example>";
+
             using (var key = Aes.Create())
             {
                 XmlDocument xmlDocToEncrypt = LoadXmlFromString(ExampleXml);
+                Assert.Contains(testString, xmlDocToEncrypt.OuterXml);
                 EncryptElement(xmlDocToEncrypt, ExampleXmlRootElement, key);
 
-                Assert.DoesNotContain("some text node", xmlDocToEncrypt.OuterXml);
+                Assert.DoesNotContain(testString, xmlDocToEncrypt.OuterXml);
                 XmlDocument xmlDocToDecrypt = LoadXmlFromString(xmlDocToEncrypt.OuterXml);
                 Decrypt(xmlDocToDecrypt, key);
 

--- a/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingSymmetric.cs
+++ b/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingSymmetric.cs
@@ -97,7 +97,7 @@ namespace System.Security.Cryptography.Xml.Tests
                 XmlDocument xmlDocToDecrypt = LoadXmlFromString(xmlDocToEncrypt.OuterXml);
                 Decrypt(xmlDocToDecrypt, key);
 
-                Assert.Equal(ExampleXml, xmlDocToDecrypt.OuterXml);
+                Assert.Equal(ExampleXml.Replace("\r\n", "\n"), xmlDocToDecrypt.OuterXml.Replace("\r\n", "\n"));
             }
         }
     }

--- a/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingSymmetric.cs
+++ b/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingSymmetric.cs
@@ -94,6 +94,7 @@ namespace System.Security.Cryptography.Xml.Tests
                 XmlDocument xmlDocToEncrypt = LoadXmlFromString(ExampleXml);
                 EncryptElement(xmlDocToEncrypt, ExampleXmlRootElement, key);
 
+                Assert.DoesNotContain("some text node", xmlDocToEncrypt.OuterXml);
                 XmlDocument xmlDocToDecrypt = LoadXmlFromString(xmlDocToEncrypt.OuterXml);
                 Decrypt(xmlDocToDecrypt, key);
 

--- a/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingSymmetric.cs
+++ b/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingSymmetric.cs
@@ -1,0 +1,104 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using Xunit;
+
+namespace System.Security.Cryptography.Xml.Tests
+{
+    // Simplified implementation of MSDN sample:
+    // https://msdn.microsoft.com/en-us/library/sb7w85t6(v=vs.110).aspx
+    public class EncryptingAndDecryptingSymmetric
+    {
+        const string ExampleXmlRootElement = "example";
+        const string ExampleXml = @"<?xml version=""1.0""?>
+<example>
+<test>some text node</test>
+</example>";
+
+        private static XmlDocument LoadXmlFromString(string xml)
+        {
+            var doc = new XmlDocument();
+            doc.PreserveWhitespace = true;
+            doc.LoadXml(xml);
+            return doc;
+        }
+
+        private static void EncryptElement(XmlDocument doc, string elementName, SymmetricAlgorithm key)
+        {
+            var elementToEncrypt = (XmlElement)doc.GetElementsByTagName(elementName)[0];
+
+            var encryptedXml = new EncryptedXml();
+            var encryptedData = new EncryptedData()
+            {
+                Type = EncryptedXml.XmlEncElementUrl,
+                EncryptionMethod = new EncryptionMethod(GetEncryptionMethodName(key))
+            };
+
+            encryptedData.CipherData.CipherValue = encryptedXml.EncryptData(elementToEncrypt, key, false);
+
+            EncryptedXml.ReplaceElement(elementToEncrypt, encryptedData, false);
+        }
+
+        private static string GetEncryptionMethodName(SymmetricAlgorithm key)
+        {
+            if (key is TripleDES)
+            {
+                return EncryptedXml.XmlEncTripleDESUrl;
+            }
+            else if (key is DES)
+            {
+                return EncryptedXml.XmlEncDESUrl;
+            }
+            else if (key is Rijndael)
+            {
+                switch (key.KeySize)
+                {
+                    case 128:
+                        return EncryptedXml.XmlEncAES128Url;
+                    case 192:
+                        return EncryptedXml.XmlEncAES192Url;
+                    case 256:
+                        return EncryptedXml.XmlEncAES256Url;
+                }
+            }
+
+            throw new CryptographicException("The specified algorithm is not supported for XML Encryption.");
+        }
+
+        private static void Decrypt(XmlDocument doc, SymmetricAlgorithm key)
+        {
+            var encryptedElement = (XmlElement)doc.GetElementsByTagName("EncryptedData")[0];
+
+            var encryptedData = new EncryptedData();
+            encryptedData.LoadXml(encryptedElement);
+
+            var encryptedXml = new EncryptedXml();
+
+            byte[] rgbOutput = encryptedXml.DecryptData(encryptedData, key);
+
+            encryptedXml.ReplaceData(encryptedElement, rgbOutput);
+        }
+
+        [Fact]
+        public void SymmetricEncryptionRoundtrip()
+        {
+            using (var key = new RijndaelManaged())
+            {
+                XmlDocument xmlDocToEncrypt = LoadXmlFromString(ExampleXml);
+                EncryptElement(xmlDocToEncrypt, ExampleXmlRootElement, key);
+
+                XmlDocument xmlDocToDecrypt = LoadXmlFromString(xmlDocToEncrypt.OuterXml);
+                Decrypt(xmlDocToDecrypt, key);
+
+                Assert.Equal(ExampleXml, xmlDocToDecrypt.OuterXml);
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Xml/tests/Samples/SigningVerifying.cs
+++ b/src/System.Security.Cryptography.Xml/tests/Samples/SigningVerifying.cs
@@ -56,7 +56,7 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void SignedXmlHasVerifiableSignature()
         {
-            using (var key = RSA.Create())
+            using (RSA key = RSA.Create())
             {
                 var xmlDoc = new XmlDocument();
                 xmlDoc.PreserveWhitespace = true;

--- a/src/System.Security.Cryptography.Xml/tests/Samples/SigningVerifying.cs
+++ b/src/System.Security.Cryptography.Xml/tests/Samples/SigningVerifying.cs
@@ -12,7 +12,10 @@ using Xunit;
 
 namespace System.Security.Cryptography.Xml.Tests
 {
-    public class Samples
+    // Implementation of MSDN samples:
+    // Signing: https://msdn.microsoft.com/en-us/library/ms229745(v=vs.110).aspx
+    // Verifying: https://msdn.microsoft.com/en-us/library/ms229745(v=vs.110).aspx
+    public class SigningAndVerifying
     {
         const string ExampleXml = @"<?xml version=""1.0""?>
 <example>
@@ -50,9 +53,6 @@ namespace System.Security.Cryptography.Xml.Tests
             return signedXml.CheckSignature(key);
         }
 
-        // Implementation of MSDN samples:
-        // Signing: https://msdn.microsoft.com/en-us/library/ms229745(v=vs.110).aspx
-        // Verifying: https://msdn.microsoft.com/en-us/library/ms229745(v=vs.110).aspx
         [Fact]
         public void SignedXmlHasVerifiableSignature()
         {

--- a/src/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
+++ b/src/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
@@ -25,6 +25,9 @@
     <Compile Include="KeyInfoX509DataTest.cs" />
     <Compile Include="ReferenceTest.cs" />
     <Compile Include="RSAKeyValueTest.cs" />
+    <Compile Include="Samples\EncryptingDecryptingAsymmetric.cs" />
+    <Compile Include="Samples\SigningVerifying.cs" />
+    <Compile Include="Samples\EncryptingDecryptingSymmetric.cs" />
     <Compile Include="SignatureTest.cs" />
     <Compile Include="SignedInfoTest.cs" />
     <Compile Include="SignedXmlTest.cs" />
@@ -53,8 +56,5 @@
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Release|AnyCPU'" />
-  <ItemGroup>
-    <Compile Include="Samples\Samples.cs" />
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Add significantly simplified MSDN samples.

This was building and passing correctly on Windows but it is possible it will fail on Linux

cc: @bartonjs @morganbr on MSDN they were using `try .. finally { key.Clear(); }` pattern - I have changed that to `using (var key = ...) { }` - is that correct or was Clear doing something more?

FYI @tintoy @anthonylangsworth @peterwurzinger