### PR TITLE
Re-enable Socket perf test on OSX

### DIFF
--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
@@ -28,7 +28,6 @@ namespace System.Net.Sockets.Performance.Tests
             }
         }
 
-        [ActiveIssue(13349, TestPlatforms.OSX)]
         [OuterLoop]
         [Fact]
         public void SocketPerformance_MultipleSocketClientAsync_LocalHostServerAsync()


### PR DESCRIPTION
With changes from https://github.com/dotnet/corefx/pull/15679/files and comments from @geoffkizer, re-enabling this per issue https://github.com/dotnet/corefx/issues/13349.

Test will be monitored over next few days to see if it fails.