### PR TITLE
Temporary fix for dotnet/corefx#16654

### DIFF
--- a/src/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
+++ b/src/System.Security.Cryptography.Xml/tests/System.Security.Cryptography.Xml.Tests.csproj
@@ -29,6 +29,7 @@
     <Compile Include="SignedInfoTest.cs" />
     <Compile Include="SignedXmlTest.cs" />
     <Compile Include="SignedXmlTests.cs" />
+    <Compile Include="TestHelpers.cs" />
     <Compile Include="TransformChainTest.cs" />
     <Compile Include="TransformTest.cs" />
     <Compile Include="XmlDecryptionTransformTest.cs" />
@@ -41,6 +42,9 @@
     <Compile Include="XmlDsigXPathTransformTest.cs" />
     <Compile Include="XmlDsigXsltTransformTest.cs" />
     <Compile Include="XmlLicenseTransformTest.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\Common\tests\System\IO\TempFile.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="EncryptedXmlSample3.xml" />

--- a/src/System.Security.Cryptography.Xml/tests/TestHelpers.cs
+++ b/src/System.Security.Cryptography.Xml/tests/TestHelpers.cs
@@ -17,6 +17,8 @@ namespace System.Security.Cryptography.Xml.Tests
                 Path.Combine(Directory.GetCurrentDirectory(), testName + ".dtd")
             );
 
+            File.WriteAllText(file.Path, "<!-- presence, not content, required -->");
+
             return file;
         }
 

--- a/src/System.Security.Cryptography.Xml/tests/TestHelpers.cs
+++ b/src/System.Security.Cryptography.Xml/tests/TestHelpers.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+
+namespace System.Security.Cryptography.Xml.Tests
+{
+    internal static class TestHelpers
+    {
+        public static TempFile CreateTestDtdFile(string testName)
+        {
+            if (testName == null)
+                throw new ArgumentNullException(nameof(testName));
+
+            var file = new TempFile(
+                Path.Combine(Directory.GetCurrentDirectory(), testName + ".dtd")
+            );
+
+            return file;
+        }
+
+        public static TempFile CreateTestTextFile(string testName, string content)
+        {
+            if (testName == null)
+                throw new ArgumentNullException(nameof(testName));
+
+            if (content == null)
+                throw new ArgumentNullException(nameof(content));
+
+            var file = new TempFile(
+                Path.Combine(Directory.GetCurrentDirectory(), testName + ".txt")
+            );
+
+            File.WriteAllText(file.Path, content);
+
+            return file;
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NTransformTest.cs
@@ -39,7 +39,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
     }
 
-    public class XmlDsigC14NTransformTest : IDisposable
+    public class XmlDsigC14NTransformTest
     {
 
         protected UnprotectedXmlDsigC14NTransform transform;
@@ -47,18 +47,6 @@ namespace System.Security.Cryptography.Xml.Tests
         public XmlDsigC14NTransformTest()
         {
             transform = new UnprotectedXmlDsigC14NTransform();
-        }
-
-        public void Dispose()
-        {
-            try
-            {
-                if (File.Exists("doc.dtd"))
-                    File.Delete("doc.dtd");
-                if (File.Exists("world.txt"))
-                    File.Delete("world.txt");
-            }
-            catch { }
         }
 
         [Fact] // ctor ()
@@ -214,13 +202,11 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void C14NSpecExample1()
         {
-            using (StreamWriter sw = new StreamWriter("doc.dtd", false, Encoding.ASCII))
+            using (TestHelpers.CreateTestDtdFile(GetType().Name + "." + nameof(C14NSpecExample1)))
             {
-                sw.Write("<!-- presence, not content, required -->");
-                sw.Close();
+                string res = ExecuteXmlDSigC14NTransform(C14NSpecExample1Input);
+                Assert.Equal(C14NSpecExample1Output, res);
             }
-            string res = ExecuteXmlDSigC14NTransform(C14NSpecExample1Input);
-            Assert.Equal(C14NSpecExample1Output, res);
         }
 
         [Fact]
@@ -248,13 +234,12 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact(Skip = "TODO: fix me")]
         public void C14NSpecExample5()
         {
-            using (StreamWriter sw = new StreamWriter("world.txt", false, Encoding.ASCII))
+            string testName = GetType().Name + "." + nameof(C14NSpecExample5);
+            using (TestHelpers.CreateTestTextFile(testName, "world"))
             {
-                sw.Write("world");
-                sw.Close();
+                string res = ExecuteXmlDSigC14NTransform(C14NSpecExample5Input(testName));
+                Assert.Equal(C14NSpecExample5Output, res);
             }
-            string res = ExecuteXmlDSigC14NTransform(C14NSpecExample5Input);
-            Assert.Equal(C14NSpecExample5Output, res);
         }
 
         [Fact]
@@ -416,11 +401,11 @@ namespace System.Security.Cryptography.Xml.Tests
         // Example 5 from C14N spec - Entity References: 
         // http://www.w3.org/TR/xml-c14n#Example-Entities
         //
-        static string C14NSpecExample5Input =
+        static string C14NSpecExample5Input(string worldName) =>
                 "<!DOCTYPE doc [\n" +
                 "<!ATTLIST doc attrExtEnt ENTITY #IMPLIED>\n" +
                 "<!ENTITY ent1 \"Hello\">\n" +
-                "<!ENTITY ent2 SYSTEM \"world.txt\">\n" +
+                $"<!ENTITY ent2 SYSTEM \"{worldName}.txt\">\n" +
                 "<!ENTITY entExt SYSTEM \"earth.gif\" NDATA gif>\n" +
                 "<!NOTATION gif SYSTEM \"viewgif.exe\">\n" +
                 "]>\n" +
@@ -429,6 +414,7 @@ namespace System.Security.Cryptography.Xml.Tests
                 "</doc>\n" +
                 "\n" +
                 "<!-- Let world.txt contain \"world\" (excluding the quotes) -->\n";
+
         static string C14NSpecExample5Output =
                 "<doc attrExtEnt=\"entExt\">\n" +
                 "   Hello, world!\n" +

--- a/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NWithCommentsTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NWithCommentsTransformTest.cs
@@ -30,7 +30,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
     }
 
-    public class XmlDsigC14NWithCommentsTransformTest : IDisposable
+    public class XmlDsigC14NWithCommentsTransformTest
     {
 
         protected UnprotectedXmlDsigC14NWithCommentsTransform transform;
@@ -38,22 +38,6 @@ namespace System.Security.Cryptography.Xml.Tests
         public XmlDsigC14NWithCommentsTransformTest()
         {
             transform = new UnprotectedXmlDsigC14NWithCommentsTransform();
-        }
-
-        public void Dispose()
-        {
-            try
-            {
-                if (File.Exists("doc.dtd"))
-                    File.Delete("doc.dtd");
-                if (File.Exists("world.txt"))
-                    File.Delete("world.txt");
-            }
-            catch { }
-            if (File.Exists("doc.dtd"))
-                throw new Exception("File.Delete() is not working.");
-            if (File.Exists("world.txt"))
-                throw new Exception("File.Delete() is not working.");
         }
 
         [Fact]
@@ -114,29 +98,27 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Throws<ArgumentException>(() => transform.GetOutput(doc.GetType()));
         }
 
-        [Fact]
+        [Fact()]
         public void C14NSpecExample1()
         {
-            using (StreamWriter sw = new StreamWriter("doc.dtd", false, Encoding.ASCII))
+            string testName = GetType().Name + "." + nameof(C14NSpecExample1);
+            using (TestHelpers.CreateTestDtdFile(testName))
             {
-                sw.Write("<!-- presence, not content, required -->");
-                sw.Close();
+                string res = ExecuteXmlDSigC14NTransform(C14NSpecExample1Input, true);
+                Assert.Equal(C14NSpecExample1Output, res);
             }
-            string res = ExecuteXmlDSigC14NTransform(C14NSpecExample1Input, true);
-            Assert.Equal(C14NSpecExample1Output, res);
         }
 
-        [Fact]
+        [Fact()]
         // [ExpectedException (typeof (SecurityException))]
         public void C14NSpecExample1_WithoutResolver()
         {
-            using (StreamWriter sw = new StreamWriter("doc.dtd", false, Encoding.ASCII))
+            string testName = GetType().Name + "." + nameof(C14NSpecExample1_WithoutResolver);
+            using (TestHelpers.CreateTestDtdFile(testName))
             {
-                sw.Write("<!-- presence, not content, required -->");
-                sw.Close();
+                string res = ExecuteXmlDSigC14NTransform(C14NSpecExample1Input, false);
+                Assert.Equal(C14NSpecExample1Output, res);
             }
-            string res = ExecuteXmlDSigC14NTransform(C14NSpecExample1Input, false);
-            Assert.Equal(C14NSpecExample1Output, res);
         }
 
         [Fact]
@@ -160,19 +142,15 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Equal(C14NSpecExample4Output, res);
         }
 
-        [Fact(Skip = "TODO: fix me")]
+        [Fact()]
         public void C14NSpecExample5()
         {
-            if (!File.Exists("world.txt"))
+            string testName = GetType().Name + "." + nameof(C14NSpecExample5);
+            using (TestHelpers.CreateTestTextFile(testName, "world"))
             {
-                using (StreamWriter sw = new StreamWriter("world.txt", false, Encoding.ASCII))
-                {
-                    sw.Write("world");
-                    sw.Close();
-                }
+                string res = ExecuteXmlDSigC14NTransform(C14NSpecExample5Input(testName), false);
+                Assert.Equal(C14NSpecExample5Output, res);
             }
-            string res = ExecuteXmlDSigC14NTransform(C14NSpecExample5Input, false);
-            Assert.Equal(C14NSpecExample5Output, res);
         }
 
         [Fact]
@@ -345,11 +323,11 @@ namespace System.Security.Cryptography.Xml.Tests
         // Example 5 from C14N spec - Entity References: 
         // http://www.w3.org/TR/xml-c14n#Example-Entities
         //
-        static string C14NSpecExample5Input =
+        static string C14NSpecExample5Input(string worldName) =>
                 "<!DOCTYPE doc [\n" +
                 "<!ATTLIST doc attrExtEnt ENTITY #IMPLIED>\n" +
                 "<!ENTITY ent1 \"Hello\">\n" +
-                "<!ENTITY ent2 SYSTEM \"world.txt\">\n" +
+                $"<!ENTITY ent2 SYSTEM \"{worldName}.txt\">\n" +
                 "<!ENTITY entExt SYSTEM \"earth.gif\" NDATA gif>\n" +
                 "<!NOTATION gif SYSTEM \"viewgif.exe\">\n" +
                 "]>\n" +
@@ -357,7 +335,7 @@ namespace System.Security.Cryptography.Xml.Tests
                 "   &ent1;, &ent2;!\n" +
                 "</doc>\n" +
                 "\n" +
-                "<!-- Let world.txt contain \"world\" (excluding the quotes) -->\n";
+                $"<!-- Let {worldName}.txt contain \"world\" (excluding the quotes) -->\n";
         static string C14NSpecExample5Output =
                 "<doc attrExtEnt=\"entExt\">\n" +
                 "   Hello, world!\n" +

--- a/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NWithCommentsTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NWithCommentsTransformTest.cs
@@ -142,14 +142,14 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Equal(C14NSpecExample4Output, res);
         }
 
-        [Fact]
+        [Fact(Skip = "TODO: Broken because entity is not resolved from text file content - fixme")]
         public void C14NSpecExample5()
         {
             string testName = GetType().Name + "." + nameof(C14NSpecExample5);
             using (TestHelpers.CreateTestTextFile(testName, "world"))
             {
                 string res = ExecuteXmlDSigC14NTransform(C14NSpecExample5Input(testName), false);
-                Assert.Equal(C14NSpecExample5Output, res);
+                Assert.Equal(C14NSpecExample5Output(testName), res);
             }
         }
 
@@ -327,7 +327,7 @@ namespace System.Security.Cryptography.Xml.Tests
                 "<!DOCTYPE doc [\n" +
                 "<!ATTLIST doc attrExtEnt ENTITY #IMPLIED>\n" +
                 "<!ENTITY ent1 \"Hello\">\n" +
-                $"<!ENTITY ent2 SYSTEM \"{worldName}.txt\">\n" +
+                $"<!ENTITY ent2 SYSTEM \"{Path.GetFullPath(worldName + ".txt")}\">\n" +
                 "<!ENTITY entExt SYSTEM \"earth.gif\" NDATA gif>\n" +
                 "<!NOTATION gif SYSTEM \"viewgif.exe\">\n" +
                 "]>\n" +
@@ -336,11 +336,11 @@ namespace System.Security.Cryptography.Xml.Tests
                 "</doc>\n" +
                 "\n" +
                 $"<!-- Let {worldName}.txt contain \"world\" (excluding the quotes) -->\n";
-        static string C14NSpecExample5Output =
+        static string C14NSpecExample5Output(string worldName) =>
                 "<doc attrExtEnt=\"entExt\">\n" +
                 "   Hello, world!\n" +
                 "</doc>\n" +
-                "<!-- Let world.txt contain \"world\" (excluding the quotes) -->";
+                $"<!-- Let {worldName}.txt contain \"world\" (excluding the quotes) -->";
 
         //
         // Example 6 from C14N spec - UTF-8 Encoding: 

--- a/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NWithCommentsTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NWithCommentsTransformTest.cs
@@ -98,7 +98,7 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Throws<ArgumentException>(() => transform.GetOutput(doc.GetType()));
         }
 
-        [Fact()]
+        [Fact]
         public void C14NSpecExample1()
         {
             string testName = GetType().Name + "." + nameof(C14NSpecExample1);
@@ -109,7 +109,7 @@ namespace System.Security.Cryptography.Xml.Tests
             }
         }
 
-        [Fact()]
+        [Fact]
         // [ExpectedException (typeof (SecurityException))]
         public void C14NSpecExample1_WithoutResolver()
         {
@@ -142,7 +142,7 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Equal(C14NSpecExample4Output, res);
         }
 
-        [Fact()]
+        [Fact]
         public void C14NSpecExample5()
         {
             string testName = GetType().Name + "." + nameof(C14NSpecExample5);

--- a/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NWithCommentsTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDsigC14NWithCommentsTransformTest.cs
@@ -23,7 +23,6 @@ namespace System.Security.Cryptography.Xml.Tests
     // making it difficult to test properly. This class "open it up" :-)
     public class UnprotectedXmlDsigC14NWithCommentsTransform : XmlDsigC14NWithCommentsTransform
     {
-
         public XmlNodeList UnprotectedGetInnerXml()
         {
             return base.GetInnerXml();
@@ -32,70 +31,40 @@ namespace System.Security.Cryptography.Xml.Tests
 
     public class XmlDsigC14NWithCommentsTransformTest
     {
-
-        protected UnprotectedXmlDsigC14NWithCommentsTransform transform;
-
-        public XmlDsigC14NWithCommentsTransformTest()
-        {
-            transform = new UnprotectedXmlDsigC14NWithCommentsTransform();
-        }
-
         [Fact]
-        public void Properties()
+        public void Constructor()
         {
-            Assert.Equal("http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments", transform.Algorithm);
-
-            Type[] input = transform.InputTypes;
-            Assert.True((input.Length == 3), "Input #");
-            // check presence of every supported input types
-            bool istream = false;
-            bool ixmldoc = false;
-            bool ixmlnl = false;
-            foreach (Type t in input)
-            {
-                if (t.ToString() == "System.IO.Stream")
-                    istream = true;
-                if (t.ToString() == "System.Xml.XmlDocument")
-                    ixmldoc = true;
-                if (t.ToString() == "System.Xml.XmlNodeList")
-                    ixmlnl = true;
-            }
-            Assert.True(istream, "Input Stream");
-            Assert.True(ixmldoc, "Input XmlDocument");
-            Assert.True(ixmlnl, "Input XmlNodeList");
-
-            Type[] output = transform.OutputTypes;
-            Assert.True((output.Length == 1), "Output #");
-            // check presence of every supported output types
-            bool ostream = false;
-            foreach (Type t in output)
-            {
-                if (t.ToString() == "System.IO.Stream")
-                    ostream = true;
-            }
-            Assert.True(ostream, "Output Stream");
+            XmlDsigC14NWithCommentsTransform xmlDsigC14NWithCommentsTransform = new XmlDsigC14NWithCommentsTransform();
+            Assert.Null(xmlDsigC14NWithCommentsTransform.Context);
+            Assert.Equal("http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments", xmlDsigC14NWithCommentsTransform.Algorithm);
+            Assert.Equal(new[] { typeof(Stream), typeof(XmlDocument), typeof(XmlNodeList) }, xmlDsigC14NWithCommentsTransform.InputTypes);
+            Assert.Equal(new[] { typeof(Stream) }, xmlDsigC14NWithCommentsTransform.OutputTypes);
         }
 
         [Fact]
         public void GetInnerXml()
         {
+            UnprotectedXmlDsigC14NWithCommentsTransform transform = new UnprotectedXmlDsigC14NWithCommentsTransform();
             XmlNodeList xnl = transform.UnprotectedGetInnerXml();
-            Assert.Equal(null, xnl);
+            Assert.Null(xnl);
         }
 
-        [Fact]
-        public void LoadInputWithUnsupportedType()
+        [Theory]
+        [InlineData("")]
+        [InlineData(new byte[] { 0xBA, 0xD })]
+        public void LoadInput_UnsupportedType(object input)
         {
-            byte[] bad = { 0xBA, 0xD };
-            // LAMESPEC: input MUST be one of InputType - but no exception is thrown (not documented)
-            Assert.Throws<ArgumentException>(() => transform.LoadInput(bad));
+            XmlDsigC14NWithCommentsTransform xmlDsigC14NWithCommentsTransform = new XmlDsigC14NWithCommentsTransform();
+            Assert.Throws<ArgumentException>(() => xmlDsigC14NWithCommentsTransform.LoadInput(input));
         }
 
-        [Fact]
-        public void UnsupportedOutput()
+        [Theory]
+        [InlineData(typeof(XmlDocument))]
+        [InlineData(typeof(XmlNodeList))]
+        public void GetOutput_UnsupportedType(Type type)
         {
-            XmlDocument doc = new XmlDocument();
-            Assert.Throws<ArgumentException>(() => transform.GetOutput(doc.GetType()));
+            XmlDsigC14NWithCommentsTransform xmlDsigC14NWithCommentsTransform = new XmlDsigC14NWithCommentsTransform();
+            Assert.Throws<ArgumentException>(() => xmlDsigC14NWithCommentsTransform.GetOutput(type));
         }
 
         [Fact]
@@ -161,8 +130,9 @@ namespace System.Security.Cryptography.Xml.Tests
             using (XmlReader reader = XmlReader.Create(stream, new XmlReaderSettings { ValidationType = ValidationType.None, DtdProcessing = DtdProcessing.Parse, XmlResolver = resolver }))
             {
                 doc.Load(reader);
+                XmlDsigC14NWithCommentsTransform transform = new XmlDsigC14NWithCommentsTransform();
                 transform.LoadInput(doc);
-                return Stream2String((Stream)transform.GetOutput(), actualEncoding);
+                return Stream2String((Stream) transform.GetOutput(), actualEncoding);
             }
         }
 

--- a/src/System.Security.Cryptography.Xml/tests/XmlDsigExcC14NTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlDsigExcC14NTransformTest.cs
@@ -53,7 +53,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
     }
 
-    public class XmlDsigExcC14NTransformTest : IDisposable
+    public class XmlDsigExcC14NTransformTest
     {
 
         protected UnprotectedXmlDsigExcC14NTransform transform;
@@ -61,18 +61,6 @@ namespace System.Security.Cryptography.Xml.Tests
         public XmlDsigExcC14NTransformTest()
         {
             transform = new UnprotectedXmlDsigExcC14NTransform();
-        }
-
-        public void Dispose()
-        {
-            try
-            {
-                if (File.Exists("doc.dtd"))
-                    File.Delete("doc.dtd");
-                if (File.Exists("world.txt"))
-                    File.Delete("world.txt");
-            }
-            catch { }
         }
 
         [Fact] // ctor ()
@@ -304,13 +292,12 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void ExcC14NSpecExample1()
         {
-            using (StreamWriter sw = new StreamWriter("doc.dtd", false, Encoding.ASCII))
+            string testName = GetType().Name + "." + nameof(ExcC14NSpecExample1);
+            using (TestHelpers.CreateTestDtdFile(testName))
             {
-                sw.Write("<!-- presence, not content, required -->");
-                sw.Close();
+                string res = ExecuteXmlDSigExcC14NTransform(ExcC14NSpecExample1Input);
+                Assert.Equal(ExcC14NSpecExample1Output, res);
             }
-            string res = ExecuteXmlDSigExcC14NTransform(ExcC14NSpecExample1Input);
-            Assert.Equal(ExcC14NSpecExample1Output, res);
         }
 
         [Fact]
@@ -338,13 +325,12 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact(Skip = "TODO: fix me")]
         public void ExcC14NSpecExample5()
         {
-            using (StreamWriter sw = new StreamWriter("world.txt", false, Encoding.ASCII))
+            string testName = GetType().Name + "." + nameof(ExcC14NSpecExample5);
+            using (TestHelpers.CreateTestTextFile(testName, "world"))
             {
-                sw.Write("world");
-                sw.Close();
+                string res = ExecuteXmlDSigExcC14NTransform(ExcC14NSpecExample5Input(testName));
+                Assert.Equal(ExcC14NSpecExample5Output, res);
             }
-            string res = ExecuteXmlDSigExcC14NTransform(ExcC14NSpecExample5Input);
-            Assert.Equal(ExcC14NSpecExample5Output, res);
         }
 
         [Fact]
@@ -505,11 +491,11 @@ namespace System.Security.Cryptography.Xml.Tests
         // Example 5 from ExcC14N spec - Entity References: 
         // http://www.w3.org/TR/xml-c14n#Example-Entities
         //
-        static string ExcC14NSpecExample5Input =
+        static string ExcC14NSpecExample5Input(string worldName) =>
                 "<!DOCTYPE doc [\n" +
                 "<!ATTLIST doc attrExtEnt ENTITY #IMPLIED>\n" +
                 "<!ENTITY ent1 \"Hello\">\n" +
-                "<!ENTITY ent2 SYSTEM \"world.txt\">\n" +
+                $"<!ENTITY ent2 SYSTEM \"{worldName}.txt\">\n" +
                 "<!ENTITY entExt SYSTEM \"earth.gif\" NDATA gif>\n" +
                 "<!NOTATION gif SYSTEM \"viewgif.exe\">\n" +
                 "]>\n" +
@@ -517,7 +503,7 @@ namespace System.Security.Cryptography.Xml.Tests
                 "   &ent1;, &ent2;!\n" +
                 "</doc>\n" +
                 "\n" +
-                "<!-- Let world.txt contain \"world\" (excluding the quotes) -->\n";
+                $"<!-- Let {worldName}.txt contain \"world\" (excluding the quotes) -->\n";
         static string ExcC14NSpecExample5Output =
                 "<doc attrExtEnt=\"entExt\">\n" +
                 "   Hello, world!\n" +


### PR DESCRIPTION
As noted in dotnet/corefx#16654, some of the tests ported from mono were not designed to be run concurrently. I've modified them so they use the test name as a prefix for the `.dtd` / `.txt` files used in the tests.

cc: @danmosemsft @krwq