### PR TITLE
Clean-up and optimise Microsoft.CSharp.RuntimeBinder.Semantics.TypeArray

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/UserStringBuilder.cs
@@ -104,25 +104,25 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             if (null == @params)
                 return;
 
-            for (int i = 0; i < @params.size; i++)
+            for (int i = 0; i < @params.Count; i++)
             {
                 if (i > 0)
                 {
                     ErrAppendString(", ");
                 }
 
-                if (isParamArray && i == @params.size - 1)
+                if (isParamArray && i == @params.Count - 1)
                 {
                     ErrAppendString("params ");
                 }
 
                 // parameter type name
-                ErrAppendType(@params.Item(i), null);
+                ErrAppendType(@params[i], null);
             }
 
             if (isVarargs)
             {
-                if (@params.size != 0)
+                if (@params.Count != 0)
                 {
                     ErrAppendString(", ");
                 }
@@ -203,7 +203,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             if (parent == getBSymmgr().GetRootNS())
                 return;
 
-            if (pctx != null && !pctx.FNop() && parent.IsAggregateSymbol() && 0 != parent.AsAggregateSymbol().GetTypeVarsAll().size)
+            if (pctx != null && !pctx.FNop() && parent.IsAggregateSymbol() && 0 != parent.AsAggregateSymbol().GetTypeVarsAll().Count)
             {
                 CType pType = GetTypeManager().SubstType(parent.AsAggregateSymbol().getThisType(), pctx);
                 ErrAppendType(pType, null);
@@ -217,14 +217,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
 
         private void ErrAppendTypeParameters(TypeArray @params, SubstContext pctx, bool forClass)
         {
-            if (@params != null && @params.size != 0)
+            if (@params != null && @params.Count != 0)
             {
                 ErrAppendChar('<');
-                ErrAppendType(@params.Item(0), pctx);
-                for (int i = 1; i < @params.size; i++)
+                ErrAppendType(@params[0], pctx);
+                for (int i = 1; i < @params.Count; i++)
                 {
                     ErrAppendString(",");
-                    ErrAppendType(@params.Item(i), pctx);
+                    ErrAppendType(@params[i], pctx);
                 }
                 ErrAppendChar('>');
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ExpressionTreeCallRewriter.cs
@@ -1017,14 +1017,14 @@ namespace Microsoft.CSharp.RuntimeBinder
                 }
 
                 Debug.Assert((m.Name == methodInfo.Name) &&
-                    (m.GetParameters().Length == genericParams.size) &&
+                    (m.GetParameters().Length == genericParams.Count) &&
                     (TypesAreEqual(m.ReturnType, genericReturn.AssociatedSystemType)));
 
                 bool bMatch = true;
                 ParameterInfo[] parameters = m.GetParameters();
-                for (int i = 0; i < genericParams.size; i++)
+                for (int i = 0; i < genericParams.Count; i++)
                 {
-                    if (!TypesAreEqual(parameters[i].ParameterType, genericParams.Item(i).AssociatedSystemType))
+                    if (!TypesAreEqual(parameters[i].ParameterType, genericParams[i].AssociatedSystemType))
                     {
                         bMatch = false;
                         break;
@@ -1034,11 +1034,11 @@ namespace Microsoft.CSharp.RuntimeBinder
                 {
                     if (m.IsGenericMethod)
                     {
-                        int size = methinfo.Method.TypeArgs?.size ?? 0;
+                        int size = methinfo.Method.TypeArgs?.Count ?? 0;
                         Type[] typeArgs = new Type[size];
                         if (size > 0)
                         {
-                            for (int i = 0; i < methinfo.Method.TypeArgs.size; i++)
+                            for (int i = 0; i < methinfo.Method.TypeArgs.Count; i++)
                             {
                                 typeArgs[i] = methinfo.Method.TypeArgs[i].AssociatedSystemType;
                             }
@@ -1086,13 +1086,13 @@ namespace Microsoft.CSharp.RuntimeBinder
                 {
                     continue;
                 }
-                Debug.Assert(c.GetParameters() == null || c.GetParameters().Length == genericInstanceParams.size);
+                Debug.Assert(c.GetParameters() == null || c.GetParameters().Length == genericInstanceParams.Count);
 
                 bool bMatch = true;
                 ParameterInfo[] parameters = c.GetParameters();
-                for (int i = 0; i < genericInstanceParams.size; i++)
+                for (int i = 0; i < genericInstanceParams.Count; i++)
                 {
-                    if (!TypesAreEqual(parameters[i].ParameterType, genericInstanceParams.Item(i).AssociatedSystemType))
+                    if (!TypesAreEqual(parameters[i].ParameterType, genericInstanceParams[i].AssociatedSystemType))
                     {
                         bMatch = false;
                         break;
@@ -1143,14 +1143,14 @@ namespace Microsoft.CSharp.RuntimeBinder
                     continue;
                 }
                 Debug.Assert((p.Name == propertyInfo.Name) &&
-                    (p.GetIndexParameters() == null || p.GetIndexParameters().Length == genericInstanceParams.size));
+                    (p.GetIndexParameters() == null || p.GetIndexParameters().Length == genericInstanceParams.Count));
 
                 bool bMatch = true;
                 ParameterInfo[] parameters = p.GetSetMethod(true) != null ?
                     p.GetSetMethod(true).GetParameters() : p.GetGetMethod(true).GetParameters();
-                for (int i = 0; i < genericInstanceParams.size; i++)
+                for (int i = 0; i < genericInstanceParams.Count; i++)
                 {
-                    if (!TypesAreEqual(parameters[i].ParameterType, genericInstanceParams.Item(i).AssociatedSystemType))
+                    if (!TypesAreEqual(parameters[i].ParameterType, genericInstanceParams[i].AssociatedSystemType))
                     {
                         bMatch = false;
                         break;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -977,9 +977,9 @@ namespace Microsoft.CSharp.RuntimeBinder
             {
                 TypeArray collectioniFaces = callingType.GetWinRTCollectionIfacesAll(SymbolLoader);
 
-                for (int i = 0; i < collectioniFaces.size; i++)
+                for (int i = 0; i < collectioniFaces.Count; i++)
                 {
-                    CType t = collectioniFaces.Item(i);
+                    CType t = collectioniFaces[i];
                     // Collection interfaces will be aggregates.
                     Debug.Assert(t.IsAggregateType());
 
@@ -1250,8 +1250,8 @@ namespace Microsoft.CSharp.RuntimeBinder
 
             // Check if we have a potential call to an indexed property accessor.
             // If so, we'll flag overload resolution to let us call non-callables.
-            if ((payload.Name.StartsWith("set_", StringComparison.Ordinal) && swt.Sym.AsMethodSymbol().Params.Size > 1) ||
-                (payload.Name.StartsWith("get_", StringComparison.Ordinal) && swt.Sym.AsMethodSymbol().Params.Size > 0))
+            if ((payload.Name.StartsWith("set_", StringComparison.Ordinal) && swt.Sym.AsMethodSymbol().Params.Count > 1) ||
+                (payload.Name.StartsWith("get_", StringComparison.Ordinal) && swt.Sym.AsMethodSymbol().Params.Count > 0))
             {
                 memGroup.flags &= ~EXPRFLAG.EXF_USERCALLABLE;
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/Better.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/Better.cs
@@ -57,14 +57,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             // Non-generic wins.
-            if (mpwi1.TypeArgs.size != 0)
+            if (mpwi1.TypeArgs.Count != 0)
             {
-                if (mpwi2.TypeArgs.size == 0)
+                if (mpwi2.TypeArgs.Count == 0)
                 {
                     return BetterType.Right;
                 }
             }
-            else if (mpwi2.TypeArgs.size != 0)
+            else if (mpwi2.TypeArgs.Count != 0)
             {
                 return BetterType.Left;
             }
@@ -137,20 +137,20 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 #if DEBUG
             // We never have a named argument that is in a position in the argument
             // list past the end of what would be the formal parameter list.
-            for (int i = pta.size; i < args.carg; i++)
+            for (int i = pta.Count; i < args.carg; i++)
             {
                 Debug.Assert(!args.prgexpr[i].isNamedArgumentSpecification());
             }
 #endif
 
             CType type = pTypeThrough != null ? pTypeThrough : mpwi.GetType();
-            CType[] typeList = new CType[pta.size];
+            CType[] typeList = new CType[pta.Count];
             MethodOrPropertySymbol methProp = GroupToArgsBinder.FindMostDerivedMethod(GetSymbolLoader(), mpwi.MethProp(), type);
 
             // We initialize the new type array with the parameters for the method. 
-            for (int iParam = 0; iParam < pta.size; iParam++)
+            for (int iParam = 0; iParam < pta.Count; iParam++)
             {
-                typeList[iParam] = pta.Item(iParam);
+                typeList[iParam] = pta[iParam];
             }
 
             // We then go over the specified arguments and put the type for any named argument in the right position in the array.
@@ -161,7 +161,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     // We find the index of the type of the argument in the method parameter list and store that in a temp
                     int index = FindName(methProp.ParameterNames, arg.asNamedArgumentSpecification().Name);
-                    CType tempType = pta.Item(index);
+                    CType tempType = pta[index];
 
                     // Starting from the current position in the type list up until the location of the type of the optional argument
                     //  We shift types by one:
@@ -177,7 +177,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
             }
 
-            return GetSymbolLoader().getBSymmgr().AllocParams(pta.size, typeList);
+            return GetSymbolLoader().getBSymmgr().AllocParams(pta.Count, typeList);
         }
 
         ////////////////////////////////////////////////////////////////////////////////
@@ -245,9 +245,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             for (int i = 0; i < args.carg; i++)
             {
                 EXPR arg = args.fHasExprs ? args.prgexpr[i] : null;
-                CType argType = args.types.Item(i);
-                CType p1 = pta1.Item(i);
-                CType p2 = pta2.Item(i);
+                CType argType = args.types[i];
+                CType p1 = pta1[i];
+                CType p2 = pta2[i];
 
                 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                 // RUNTIME BINDER ONLY CHANGE
@@ -289,7 +289,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // We may have different sizes if we had optional parameters. If thats the case,
             // the one with fewer parameters wins (ie less optional parameters) unless it is
             // expanded. If so, the one with more parameters wins (ie option beats expanded).
-            if (pta1.size != pta2.size && betterMethod == BetterType.Neither)
+            if (pta1.Count != pta2.Count && betterMethod == BetterType.Neither)
             {
                 if (node1.fExpanded && !node2.fExpanded)
                 {
@@ -304,11 +304,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // then we are ambiguous. Otherwise, take the one that didn't need any 
                 // optionals.
 
-                if (pta1.size == args.carg)
+                if (pta1.Count == args.carg)
                 {
                     return BetterType.Left;
                 }
-                else if (pta2.size == args.carg)
+                else if (pta2.Count == args.carg)
                 {
                     return BetterType.Right;
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
@@ -691,17 +691,17 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             bool isExtensionMethod = false;
             // If the method we have bound to is an extension method and we are using it as an extension and not as a static method
-            if (methInvoke.Params.Size < @params.Size && mwiWrap.Meth().IsExtension())
+            if (methInvoke.Params.Count < @params.Count && mwiWrap.Meth().IsExtension())
             {
                 isExtensionMethod = true;
                 TypeArray extParams = GetTypes().SubstTypeArray(mwiWrap.Meth().Params, mwiWrap.GetType());
                 // The this parameter must be a reference type. 
-                if (extParams.Item(0).IsTypeParameterType() ? !@params.Item(0).IsRefType() : !extParams.Item(0).IsRefType())
+                if (extParams[0].IsTypeParameterType() ? !@params[0].IsRefType() : !extParams[0].IsRefType())
                 {
                     // We should issue a better message here. 
                     // We were only disallowing value types, hence the error message specific to value types.
                     // Now we are issuing the same error message for not-known to be reference types, not just value types.
-                    ErrorContext.Error(ErrorCode.ERR_ValueTypeExtDelegate, mwiWrap, extParams.Item(0).IsTypeParameterType() ? @params.Item(0) : extParams.Item(0));
+                    ErrorContext.Error(ErrorCode.ERR_ValueTypeExtDelegate, mwiWrap, extParams[0].IsTypeParameterType() ? @params[0] : extParams[0]);
                 }
             }
 
@@ -729,10 +729,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             TypeArray paramsReal = GetTypes().SubstTypeArray(mwiWrap.Meth().Params, mwiWrap.Ats, mwiWrap.TypeArgs);
             if (paramsReal != @params)
             {
-                for (int i = 0; i < paramsReal.Size; i++)
+                for (int i = 0; i < paramsReal.Count; i++)
                 {
-                    CType param = @params.Item(i);
-                    CType paramReal = paramsReal.Item(i);
+                    CType param = @params[i];
+                    CType paramReal = paramsReal[i];
 
                     if (param != paramReal && !CConversions.FImpRefConv(GetSymbolLoader(), param, paramReal))
                     {
@@ -754,7 +754,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             obj = isExtensionMethod ? grp.GetOptionalObject() : obj;
             Debug.Assert(mwiWrap.Meth().getKind() == SYMKIND.SK_MethodSymbol);
-            if (mwiWrap.TypeArgs.Size > 0)
+            if (mwiWrap.TypeArgs.Count > 0)
             {
                 // Check method type variable constraints.
                 TypeBind.CheckMethConstraints(GetSemanticChecker(), GetErrorContext(), mwiWrap);
@@ -798,10 +798,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private bool BindGrpConversionCore(out MethPropWithInst pmpwi, BindingFlag bindFlags, EXPRMEMGRP grp, ref TypeArray args, AggregateType atsDelegate, bool fReportErrors, out MethPropWithInst pmpwiAmbig)
         {
             bool retval = false;
-            int carg = args.Size;
+            int carg = args.Count;
 
             ArgInfos argParam = new ArgInfos();
-            argParam.carg = args.Size;
+            argParam.carg = args.Count;
             argParam.types = args;
             argParam.fHasExprs = false;
             GroupToArgsBinder binder = new GroupToArgsBinder(this, bindFlags, grp, argParam, null, false, atsDelegate);
@@ -1032,7 +1032,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                     for (MethodSymbol convCur = aggCur.GetFirstUDConversion(); convCur != null; convCur = convCur.ConvNext())
                     {
-                        if (convCur.Params.Size != 1)
+                        if (convCur.Params.Count != 1)
                         {
                             // If we have a user-defined conversion that 
                             // does not specify the correct number of parameters, we may
@@ -1048,7 +1048,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             continue;
 
                         // Get the substituted src and dst types.
-                        typeFrom = GetTypes().SubstType(convCur.Params.Item(0), atsCur);
+                        typeFrom = GetTypes().SubstType(convCur.Params[0], atsCur);
                         typeTo = GetTypes().SubstType(convCur.RetType, atsCur);
 
                         bool fNeedImplicit = fImplicitOnly;
@@ -1208,7 +1208,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 UdConvInfo uci = prguci[iuci];
 
                 // Get the substituted src and dst types.
-                typeFrom = GetTypes().SubstType(uci.mwt.Meth().Params.Item(0), uci.mwt.GetType());
+                typeFrom = GetTypes().SubstType(uci.mwt.Meth().Params[0], uci.mwt.GetType());
                 typeTo = GetTypes().SubstType(uci.mwt.Meth().RetType, uci.mwt.GetType());
 
                 int ctypeLift = 0;
@@ -1310,7 +1310,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             Debug.Assert(ctypeLiftBest <= 2);
 
-            typeFrom = GetTypes().SubstType(mwiBest.Meth().Params.Item(0), mwiBest.GetType());
+            typeFrom = GetTypes().SubstType(mwiBest.Meth().Params[0], mwiBest.GetType());
             typeTo = GetTypes().SubstType(mwiBest.Meth().RetType, mwiBest.GetType());
 
             EXPR exprDst;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversions.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversions.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 if (typeSrc.IsArrayType())
                 {
                     if (typeSrc.AsArrayType().rank != 1 ||
-                        !typeDst.isInterfaceType() || typeDst.AsAggregateType().GetTypeArgsAll().Size != 1)
+                        !typeDst.isInterfaceType() || typeDst.AsAggregateType().GetTypeArgsAll().Count != 1)
                     {
                         return false;
                     }
@@ -144,7 +144,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         return false;
                     }
 
-                    return FExpRefConv(loader, typeSrc.AsArrayType().GetElementType(), typeDst.AsAggregateType().GetTypeArgsAll().Item(0));
+                    return FExpRefConv(loader, typeSrc.AsArrayType().GetElementType(), typeDst.AsAggregateType().GetTypeArgsAll()[0]);
                 }
 
                 if (typeDst.IsArrayType() && typeSrc.IsAggregateType())
@@ -162,7 +162,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     ArrayType arrayDest = typeDst.AsArrayType();
                     AggregateType aggtypeSrc = typeSrc.AsAggregateType();
                     if (arrayDest.rank != 1 || !typeSrc.isInterfaceType() ||
-                        aggtypeSrc.GetTypeArgsAll().Size != 1)
+                        aggtypeSrc.GetTypeArgsAll().Count != 1)
                     {
                         return false;
                     }
@@ -179,7 +179,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
 
                     CType typeArr = arrayDest.GetElementType();
-                    CType typeLst = aggtypeSrc.GetTypeArgsAll().Item(0);
+                    CType typeLst = aggtypeSrc.GetTypeArgsAll()[0];
 
                     Debug.Assert(!typeArr.IsNeverSameType());
                     return typeArr == typeLst || FExpRefConv(loader, typeArr, typeLst);
@@ -230,13 +230,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             TypeArray pSourceArgs = pSource.AsAggregateType().GetTypeArgsAll();
             TypeArray pTargetArgs = pTarget.AsAggregateType().GetTypeArgsAll();
 
-            Debug.Assert(pTypeParams.size == pSourceArgs.size);
-            Debug.Assert(pTypeParams.size == pTargetArgs.size);
+            Debug.Assert(pTypeParams.Count == pSourceArgs.Count);
+            Debug.Assert(pTypeParams.Count == pTargetArgs.Count);
 
-            for (int iParam = 0; iParam < pTypeParams.size; ++iParam)
+            for (int iParam = 0; iParam < pTypeParams.Count; ++iParam)
             {
-                CType pSourceArg = pSourceArgs.Item(iParam);
-                CType pTargetArg = pTargetArgs.Item(iParam);
+                CType pSourceArg = pSourceArgs[iParam];
+                CType pTargetArg = pTargetArgs[iParam];
 
                 // If they're identical then this one is automatically good, so skip it.
                 // If we have an error type, then we're in some fault tolerance. Let it through.
@@ -244,7 +244,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     continue;
                 }
-                TypeParameterType pParam = pTypeParams.Item(iParam).AsTypeParameterType();
+                TypeParameterType pParam = pTypeParams[iParam].AsTypeParameterType();
                 if (pParam.Invariant)
                 {
                     return false;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExplicitConversion.cs
@@ -235,7 +235,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 Debug.Assert(_typeDest != null);
 
                 if (!_typeSrc.IsArrayType() || _typeSrc.AsArrayType().rank != 1 ||
-                    !_typeDest.isInterfaceType() || _typeDest.AsAggregateType().GetTypeArgsAll().Size != 1)
+                    !_typeDest.isInterfaceType() || _typeDest.AsAggregateType().GetTypeArgsAll().Count != 1)
                 {
                     return false;
                 }
@@ -252,7 +252,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
 
                 CType typeArr = _typeSrc.AsArrayType().GetElementType();
-                CType typeLst = _typeDest.AsAggregateType().GetTypeArgsAll().Item(0);
+                CType typeLst = _typeDest.AsAggregateType().GetTypeArgsAll()[0];
 
                 if (!CConversions.FExpRefConv(GetSymbolLoader(), typeArr, typeLst))
                 {
@@ -320,7 +320,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 //   are the same type or there is an implicit or explicit reference conversion from S to T.
 
                 if (arrayDest.rank != 1 || !_typeSrc.isInterfaceType() ||
-                    _typeSrc.AsAggregateType().GetTypeArgsAll().Size != 1)
+                    _typeSrc.AsAggregateType().GetTypeArgsAll().Count != 1)
                 {
                     return false;
                 }
@@ -337,7 +337,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
 
                 CType typeArr = arrayDest.GetElementType();
-                CType typeLst = _typeSrc.AsAggregateType().GetTypeArgsAll().Item(0);
+                CType typeLst = _typeSrc.AsAggregateType().GetTypeArgsAll()[0];
 
                 Debug.Assert(!typeArr.IsNeverSameType());
                 if (typeArr != typeLst && !CConversions.FExpRefConv(GetSymbolLoader(), typeArr, typeLst))

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -925,7 +925,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     pwt.Sym.IsPropertySymbol() &&
                     pwt.GetType() != null &&
                     pwt.Prop().getClass() == pwt.GetType().getAggregate());
-            Debug.Assert(pwt.Prop().Params.size == 0 || pwt.Prop().isIndexer());
+            Debug.Assert(pwt.Prop().Params.Count == 0 || pwt.Prop().isIndexer());
             Debug.Assert(pOtherType == null ||
                     !pwt.Prop().isIndexer() &&
                     pOtherType.getAggregate() == pwt.Prop().RetType.getAggregate());
@@ -1119,12 +1119,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
 
                 // Only look at operators with 1 args.
-                if (!methCur.isOperator || methCur.Params.size != 1)
+                if (!methCur.isOperator || methCur.Params.Count != 1)
                     continue;
-                Debug.Assert(methCur.typeVars.size == 0);
+                Debug.Assert(methCur.typeVars.Count == 0);
 
                 TypeArray paramsCur = GetTypes().SubstTypeArray(methCur.Params, atsCur);
-                CType typeParam = paramsCur.Item(0);
+                CType typeParam = paramsCur[0];
                 NullableType nubParam;
 
                 if (canConvert(arg, typeParam))
@@ -1179,11 +1179,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (pmethBest.ctypeLift != 0)
             {
-                call = BindLiftedUDUnop(arg, pmethBest.@params.Item(0), pmethBest.mpwi);
+                call = BindLiftedUDUnop(arg, pmethBest.@params[0], pmethBest.mpwi);
             }
             else
             {
-                call = BindUDUnopCall(arg, pmethBest.@params.Item(0), pmethBest.mpwi);
+                call = BindUDUnopCall(arg, pmethBest.@params[0], pmethBest.mpwi);
             }
 
             return GetExprFactory().CreateUserDefinedUnaryOperator(ek, call.type, arg, call, pmethBest.mpwi);
@@ -1600,10 +1600,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // We need to check unsafe on the parameters as well, since we cannot check in conversion.
                 TypeArray pParams = pMWI.Meth().Params;
 
-                for (int i = 0; i < pParams.size; i++)
+                for (int i = 0; i < pParams.Count; i++)
                 {
                     // This is an optimization: don't call this in the vast majority of cases
-                    CType type = pParams.Item(i);
+                    CType type = pParams[i];
 
                     if (type.isUnsafe())
                     {
@@ -1930,7 +1930,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             MethodOrPropertySymbol mostDerivedMethod = GroupToArgsBinder.FindMostDerivedMethod(GetSymbolLoader(), mp, callingObjectType);
 
-            int paramCount = mp.Params.size;
+            int paramCount = mp.Params.Count;
             TypeArray @params = mp.Params;
             int iDst = 0;
             bool markTypeFromExternCall = mp.IsFMETHSYM() && mp.AsFMETHSYM().isExternal;
@@ -1966,7 +1966,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
                 else if (paramCount != 0)
                 {
-                    if (paramCount == 1 && mp.isParamArray && argCount > mp.Params.size)
+                    if (paramCount == 1 && mp.isParamArray && argCount > mp.Params.Count)
                     {
                         // we arrived at the last formal, and we have more than one actual, so
                         // we need to put the rest in an array...
@@ -1987,12 +1987,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             }
                             index++;
                         }
-                        Debug.Assert(index != mp.Params.size);
-                        CType substDestType = GetTypes().SubstType(@params.Item(index), type, pTypeArgs);
+                        Debug.Assert(index != mp.Params.Count);
+                        CType substDestType = GetTypes().SubstType(@params[index], type, pTypeArgs);
 
                         // If we cant convert the argument and we're the param array argument, then deal with it.
                         if (!canConvert(argument.asNamedArgumentSpecification().Value, substDestType) &&
-                            mp.isParamArray && index == mp.Params.size - 1)
+                            mp.isParamArray && index == mp.Params.Count - 1)
                         {
                             // We have a param array, but we're not at the end yet. This will happen
                             // with named arguments when the user specifies a name for the param array,
@@ -2002,7 +2002,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             // void Foo(int y, params int[] x);
                             // ...
                             // Foo(x:1, y:1);
-                            CType arrayType = GetTypes().SubstType(mp.Params.Item(mp.Params.size - 1), type, pTypeArgs);
+                            CType arrayType = GetTypes().SubstType(mp.Params[mp.Params.Count - 1], type, pTypeArgs);
                             CType elemType = arrayType.AsArrayType().GetElementType();
 
                             // Use an EK_ARRINIT even in the empty case so empty param arrays in attributes work.
@@ -2026,7 +2026,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     else
                     {
-                        CType substDestType = GetTypes().SubstType(@params.Item(iDst), type, pTypeArgs);
+                        CType substDestType = GetTypes().SubstType(@params[iDst], type, pTypeArgs);
                         rval = tryConvert(indir, substDestType);
                     }
 
@@ -2034,7 +2034,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     {
                         // the last arg failed to fix up, so it must fixup into the array element
                         // if we have a param array (we will be passing a 1 element array...)
-                        if (mp.isParamArray && paramCount == 1 && argCount >= mp.Params.size)
+                        if (mp.isParamArray && paramCount == 1 && argCount >= mp.Params.Count)
                         {
                             goto FIXUPPARAMLIST;
                         }
@@ -2074,7 +2074,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             // we need to create an array and put it as the last arg...
-            CType substitutedArrayType = GetTypes().SubstType(mp.Params.Item(mp.Params.size - 1), type, pTypeArgs);
+            CType substitutedArrayType = GetTypes().SubstType(mp.Params[mp.Params.Count - 1], type, pTypeArgs);
             if (!substitutedArrayType.IsArrayType() || substitutedArrayType.AsArrayType().rank != 1)
             {
                 // Invalid type for params array parameter. Happens in LAF scenarios, e.g.
@@ -2242,21 +2242,21 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private bool TryGetExpandedParams(TypeArray @params, int count, out TypeArray ppExpandedParams)
         {
             CType[] prgtype;
-            if (count < @params.size - 1)
+            if (count < @params.Count - 1)
             {
                 // The user has specified less arguments than our parameters, but we still
                 // need to return our set of types without the param array. This is in the 
                 // case that all the parameters are optional.
-                prgtype = new CType[@params.size - 1];
-                @params.CopyItems(0, @params.size - 1, prgtype);
-                ppExpandedParams = GetGlobalSymbols().AllocParams(@params.size - 1, prgtype);
+                prgtype = new CType[@params.Count - 1];
+                @params.CopyItems(0, @params.Count - 1, prgtype);
+                ppExpandedParams = GetGlobalSymbols().AllocParams(@params.Count - 1, prgtype);
                 return true;
             }
 
             prgtype = new CType[count];
-            @params.CopyItems(0, @params.size - 1, prgtype);
+            @params.CopyItems(0, @params.Count - 1, prgtype);
 
-            CType type = @params.Item(@params.size - 1);
+            CType type = @params[@params.Count - 1];
             CType elementType = null;
 
             if (!type.IsArrayType())
@@ -2269,7 +2269,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // At this point, we have an array sym.
             elementType = type.AsArrayType().GetElementType();
 
-            for (int itype = @params.size - 1; itype < count; itype++)
+            for (int itype = @params.Count - 1; itype < count; itype++)
             {
                 prgtype[itype] = elementType;
             }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinder.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 CType pTypeThrough = _pGroup.GetOptionalObject() != null ? _pGroup.GetOptionalObject().type : null;
                 CMemberLookupResults.CMethodIterator iterator = _pGroup.GetMemberLookupResults().GetMethodIterator(GetSemanticChecker(), GetSymbolLoader(), pTypeThrough, GetTypeQualifier(_pGroup), _pExprBinder.ContextForMemberLookup(), true, // AllowBogusAndInaccessible
-                    false, _pGroup.typeArgs.size, _pGroup.flags, mask);
+                    false, _pGroup.typeArgs.Count, _pGroup.flags, mask);
                 while (true)
                 {
                     bool bFoundExpanded;
@@ -240,10 +240,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                         // If we have the wrong number of arguments and still have room in our cache of 20,
                         // then store it in our cache and go to the next sym.
-                        if (_pCurrentParameters.size != _pArguments.carg)
+                        if (_pCurrentParameters.Count != _pArguments.carg)
                         {
                             if (_nWrongCount < cswtMaxWrongCount &&
-                                    (!_pCurrentSym.isParamArray || _pArguments.carg < _pCurrentParameters.size - 1))
+                                    (!_pCurrentSym.isParamArray || _pArguments.carg < _pCurrentParameters.Count - 1))
                             {
                                 _swtWrongCount[_nWrongCount++] = new SymWithType(_pCurrentSym, _pCurrentType);
                             }
@@ -323,9 +323,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         if (_pCurrentType.isInterfaceType())
                         {
                             TypeArray ifaces = _pCurrentType.GetIfacesAll();
-                            for (int i = 0; i < ifaces.size; i++)
+                            for (int i = 0; i < ifaces.Count; i++)
                             {
-                                AggregateType type = ifaces.Item(i).AsAggregateType();
+                                AggregateType type = ifaces[i].AsAggregateType();
 
                                 Debug.Assert(type.isInterfaceType());
                                 _HiddenTypes.Add(type);
@@ -395,7 +395,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             if (bReportErrors)
                             {
                                 if (pAmbig1.@params != pAmbig2.@params ||
-                                    pAmbig1.mpwi.MethProp().Params.size != pAmbig2.mpwi.MethProp().Params.size ||
+                                    pAmbig1.mpwi.MethProp().Params.Count != pAmbig2.mpwi.MethProp().Params.Count ||
                                     pAmbig1.mpwi.TypeArgs != pAmbig2.mpwi.TypeArgs ||
                                     pAmbig1.mpwi.GetType() != pAmbig2.mpwi.GetType() ||
                                     pAmbig1.mpwi.MethProp().Params == pAmbig2.mpwi.MethProp().Params)
@@ -445,7 +445,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return false;
                 }
 
-                int numParameters = _pCurrentParameters.size;
+                int numParameters = _pCurrentParameters.Count;
 
                 // If we have no parameters, or fewer parameters than we have arguments, bail.
                 if (numParameters == 0 || numParameters < _pArguments.carg)
@@ -483,7 +483,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 // We use the param count from pCurrentParameters because they may have been resized 
                 // for param arrays.
-                int numParameters = pCurrentParameters.size;
+                int numParameters = pCurrentParameters.Count;
 
                 EXPR[] pExprArguments = new EXPR[numParameters];
 
@@ -498,7 +498,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 foreach (Name name in methprop.ParameterNames)
                 {
                     // This can happen if we had expanded our param array to size 0.
-                    if (index >= pCurrentParameters.size)
+                    if (index >= pCurrentParameters.Count)
                     {
                         break;
                     }
@@ -530,7 +530,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     {
                         if (methprop.IsParameterOptional(index))
                         {
-                            pNewArg = GenerateOptionalArgument(symbolLoader, exprFactory, methprop, @params.Item(index), index);
+                            pNewArg = GenerateOptionalArgument(symbolLoader, exprFactory, methprop, @params[index], index);
                         }
                         else if (paramArrayArgument != null && index == methprop.Params.Count - 1)
                         {
@@ -547,7 +547,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
 
                 // Here we've found all the arguments, or have default values for them.
-                CType[] prgTypes = new CType[pCurrentParameters.size];
+                CType[] prgTypes = new CType[pCurrentParameters.Count];
                 for (int i = 0; i < numParameters; i++)
                 {
                     if (i < pArguments.prgexpr.Count)
@@ -560,8 +560,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     prgTypes[i] = pArguments.prgexpr[i].type;
                 }
-                pArguments.carg = pCurrentParameters.size;
-                pArguments.types = symbolLoader.getBSymmgr().AllocParams(pCurrentParameters.size, prgTypes);
+                pArguments.carg = pCurrentParameters.Count;
+                pArguments.types = symbolLoader.getBSymmgr().AllocParams(pCurrentParameters.Count, prgTypes);
                 return true;
             }
 
@@ -782,7 +782,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             private bool AddArgumentsForOptionalParameters()
             {
-                if (_pCurrentParameters.size <= _pArguments.carg)
+                if (_pCurrentParameters.Count <= _pArguments.carg)
                 {
                     // If we have enough arguments, or too many, no need to add any optionals here.
                     return true;
@@ -803,8 +803,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     _pCurrentParameters,
                     _pCurrentType,
                     _pGroup.typeArgs);
-                EXPR[] pArguments = new EXPR[_pCurrentParameters.size - i];
-                for (; i < @params.size; i++, index++)
+                EXPR[] pArguments = new EXPR[_pCurrentParameters.Count - i];
+                for (; i < @params.Count; i++, index++)
                 {
                     if (!methprop.IsParameterOptional(i))
                     {
@@ -812,7 +812,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         return false;
                     }
 
-                    pArguments[index] = GenerateOptionalArgument(GetSymbolLoader(), _pExprBinder.GetExprFactory(), methprop, @params.Item(i), i);
+                    pArguments[index] = GenerateOptionalArgument(GetSymbolLoader(), _pExprBinder.GetExprFactory(), methprop, @params[i], i);
                 }
 
                 // Success. Lets copy them in now.
@@ -820,13 +820,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     _pArguments.prgexpr.Add(pArguments[n]);
                 }
-                CType[] prgTypes = new CType[@params.size];
-                for (int n = 0; n < @params.size; n++)
+                CType[] prgTypes = new CType[@params.Count];
+                for (int n = 0; n < @params.Count; n++)
                 {
                     prgTypes[n] = _pArguments.prgexpr[n].type;
                 }
-                _pArguments.types = GetSymbolLoader().getBSymmgr().AllocParams(@params.size, prgTypes);
-                _pArguments.carg = @params.size;
+                _pArguments.types = GetSymbolLoader().getBSymmgr().AllocParams(@params.Count, prgTypes);
+                _pArguments.carg = @params.Count;
                 _bArgumentsChangedForNamedOrOptionalArguments = true;
                 return true;
             }
@@ -976,14 +976,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // and actual arguments, then proceed.
                 {
                     int numOptionals = 0;
-                    for (int i = _pArguments.carg; i < _pCurrentSym.Params.size; i++)
+                    for (int i = _pArguments.carg; i < _pCurrentSym.Params.Count; i++)
                     {
                         if (_pCurrentSym.IsParameterOptional(i))
                         {
                             numOptionals++;
                         }
                     }
-                    if (_pArguments.carg + numOptionals < _pCurrentParameters.size - 1)
+                    if (_pArguments.carg + numOptionals < _pCurrentParameters.Count - 1)
                     {
                         return false;
                     }
@@ -999,11 +999,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 TypeArray typeArgs = _pGroup.typeArgs;
 
                 // Get the type args.
-                if (_pCurrentSym.IsMethodSymbol() && _pCurrentSym.AsMethodSymbol().typeVars.size != typeArgs.size)
+                if (_pCurrentSym.IsMethodSymbol() && _pCurrentSym.AsMethodSymbol().typeVars.Count != typeArgs.Count)
                 {
                     MethodSymbol methSym = _pCurrentSym.AsMethodSymbol();
                     // Can't infer if some type args are specified.
-                    if (typeArgs.size > 0)
+                    if (typeArgs.Count > 0)
                     {
                         if (!_mwtBadArity)
                         {
@@ -1011,7 +1011,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         }
                         return Result.Failure_NoSearchForExpanded;
                     }
-                    Debug.Assert(methSym.typeVars.size > 0);
+                    Debug.Assert(methSym.typeVars.Count > 0);
 
                     // Try to infer. If we have an errorsym in the type arguments, we know we cant infer,
                     // but we want to attempt it anyway. We'll mark this as "cant infer" so that we can
@@ -1030,7 +1030,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         if (_results.IsBetterUninferableResult(_pCurrentTypeArgs))
                         {
                             TypeArray pTypeVars = methSym.typeVars;
-                            if (pTypeVars != null && _pCurrentTypeArgs != null && pTypeVars.size == _pCurrentTypeArgs.size)
+                            if (pTypeVars != null && _pCurrentTypeArgs != null && pTypeVars.Count == _pCurrentTypeArgs.Count)
                             {
                                 _mpwiCantInferInstArg.Set(_pCurrentSym.AsMethodSymbol(), _pCurrentType, _pCurrentTypeArgs);
                             }
@@ -1058,7 +1058,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     UpdateArguments();
                     for (int ivar = 0; ivar < _pArguments.carg; ivar++)
                     {
-                        CType var = _pCurrentParameters.Item(ivar);
+                        CType var = _pCurrentParameters[ivar];
                         bool constraintErrors = !TypeBind.CheckConstraints(GetSemanticChecker(), GetErrorContext(), var, CheckConstraintsFlags.NoErrors);
                         if (constraintErrors && !DoesTypeArgumentsContainErrorSym(var))
                         {
@@ -1069,7 +1069,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                     for (int ivar = 0; ivar < _pArguments.carg; ivar++)
                     {
-                        CType var = _pCurrentParameters.Item(ivar);
+                        CType var = _pCurrentParameters[ivar];
                         containsErrorSym |= DoesTypeArgumentsContainErrorSym(var);
                         bool fresult;
 
@@ -1087,7 +1087,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         }
                         else
                         {
-                            fresult = _pExprBinder.canConvert(_pArguments.types.Item(ivar), var);
+                            fresult = _pExprBinder.canConvert(_pArguments.types[ivar], var);
                         }
 
                         // Mark this as a legitimate error if we didn't have any error syms.
@@ -1104,13 +1104,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                                     _pBestParameters = _pCurrentParameters;
                                 }
                             }
-                            else if (ivar == _nArgBest && _pArguments.types.Item(ivar) != var)
+                            else if (ivar == _nArgBest && _pArguments.types[ivar] != var)
                             {
                                 // this is to eliminate the paranoid case of types that are equal but can't convert 
                                 // (think ErrorType != ErrorType)
                                 // See if they just differ in out / ref.
-                                CType argStripped = _pArguments.types.Item(ivar).IsParameterModifierType() ?
-                                    _pArguments.types.Item(ivar).AsParameterModifierType().GetParameterType() : _pArguments.types.Item(ivar);
+                                CType argStripped = _pArguments.types[ivar].IsParameterModifierType() ?
+                                    _pArguments.types[ivar].AsParameterModifierType().GetParameterType() : _pArguments.types[ivar];
                                 CType varStripped = var.IsParameterModifierType() ? var.AsParameterModifierType().GetParameterType() : var;
 
                                 if (argStripped == varStripped)
@@ -1150,7 +1150,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         // then mark us down. Note that the extension may not need to infer type args,
                         // so check if we have any type variables at all to begin with.
                         if (!_pCurrentSym.AsMethodSymbol().IsExtension() ||
-                            _pCurrentSym.AsMethodSymbol().typeVars.size == 0 ||
+                            _pCurrentSym.AsMethodSymbol().typeVars.Count == 0 ||
                                 MethodTypeInferrer.CanObjectOfExtensionBeInferred(
                                     _pExprBinder,
                                     GetSymbolLoader(),
@@ -1207,14 +1207,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
 
                 MethodOrPropertySymbol pMethod = null;
-                for (int iParam = 0; iParam < _pCurrentParameters.size; ++iParam)
+                for (int iParam = 0; iParam < _pCurrentParameters.Count; ++iParam)
                 {
                     EXPR pArgument = _pArguments.prgexpr[iParam];
                     if (!pArgument.IsOptionalArgument)
                     {
                         continue;
                     }
-                    CType pType = _pCurrentParameters.Item(iParam);
+                    CType pType = _pCurrentParameters[iParam];
 
                     if (pType == pArgument.type)
                     {
@@ -1241,9 +1241,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
 
                 TypeArray typeVars = var.AsAggregateType().GetTypeArgsAll();
-                for (int i = 0; i < typeVars.size; i++)
+                for (int i = 0; i < typeVars.Count; i++)
                 {
-                    CType type = typeVars.Item(i);
+                    CType type = typeVars[i];
                     if (type.IsErrorType())
                     {
                         return true;
@@ -1266,7 +1266,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 // used for Methods and Indexers
                 Debug.Assert(_pGroup.sk == SYMKIND.SK_MethodSymbol || _pGroup.sk == SYMKIND.SK_PropertySymbol && 0 != (_pGroup.flags & EXPRFLAG.EXF_INDEXER));
-                Debug.Assert(_pGroup.typeArgs.size == 0 || _pGroup.sk == SYMKIND.SK_MethodSymbol);
+                Debug.Assert(_pGroup.typeArgs.Count == 0 || _pGroup.sk == SYMKIND.SK_MethodSymbol);
 
                 // if this is a binding to finalize on object, then complain:
                 if (_results.GetBestResult().MethProp().name == GetSymbolLoader().GetNameManager().GetPredefName(PredefinedName.PN_DTOR) &&
@@ -1288,7 +1288,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     Debug.Assert(_results.GetBestResult().MethProp().IsMethodSymbol());
 
-                    if (_results.GetBestResult().TypeArgs.size > 0)
+                    if (_results.GetBestResult().TypeArgs.Count > 0)
                     {
                         // Check method type variable constraints.
                         TypeBind.CheckMethConstraints(GetSemanticChecker(), GetErrorContext(), new MethWithInst(_results.GetBestResult()));
@@ -1371,7 +1371,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
                 else if (_mwtBadArity)
                 {
-                    int cvar = _mwtBadArity.Meth().typeVars.size;
+                    int cvar = _mwtBadArity.Meth().typeVars.Count;
                     GetErrorContext().ErrorRef(cvar > 0 ? ErrorCode.ERR_BadArity : ErrorCode.ERR_HasNoTypeVars, _mwtBadArity, new ErrArgSymKind(_mwtBadArity.Meth()), _pArguments.carg);
                 }
                 else if (_mpwiParamTypeConstraints)
@@ -1489,13 +1489,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // Argument X: cannot convert type 'Y' to type 'Z'
                 for (int ivar = 0; ivar < _pArguments.carg; ivar++)
                 {
-                    CType var = _pBestParameters.Item(ivar);
+                    CType var = _pBestParameters[ivar];
 
                     if (!_pExprBinder.canConvert(_pArguments.prgexpr[ivar], var))
                     {
                         // See if they just differ in out / ref.
-                        CType argStripped = _pArguments.types.Item(ivar).IsParameterModifierType() ?
-                            _pArguments.types.Item(ivar).AsParameterModifierType().GetParameterType() : _pArguments.types.Item(ivar);
+                        CType argStripped = _pArguments.types[ivar].IsParameterModifierType() ?
+                            _pArguments.types[ivar].AsParameterModifierType().GetParameterType() : _pArguments.types[ivar];
                         CType varStripped = var.IsParameterModifierType() ? var.AsParameterModifierType().GetParameterType() : var;
                         if (argStripped == varStripped)
                         {
@@ -1506,7 +1506,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             }
                             else
                             {
-                                CType argument = _pArguments.types.Item(ivar);
+                                CType argument = _pArguments.types[ivar];
 
                                 // the argument is decorated, but doesn't needs a 'ref' or 'out'
                                 GetErrorContext().Error(ErrorCode.ERR_BadArgExtraRef, ivar + 1, (argument.IsParameterModifierType() && argument.AsParameterModifierType().isOut) ? "out" : "ref");
@@ -1518,7 +1518,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             // on the type at all. 
                             Symbol sym = _results.GetBestResult().Sym;
                             if (ivar == 0 && sym.IsMethodSymbol() && sym.AsMethodSymbol().IsExtension() && _pGroup.GetOptionalObject() != null &&
-                                !_pExprBinder.canConvertInstanceParamForExtension(_pGroup.GetOptionalObject(), sym.AsMethodSymbol().Params.Item(0)))
+                                !_pExprBinder.canConvertInstanceParamForExtension(_pGroup.GetOptionalObject(), sym.AsMethodSymbol().Params[0]))
                             {
                                 if (!_pGroup.GetOptionalObject().type.getBogus())
                                 {
@@ -1527,7 +1527,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                             }
                             else
                             {
-                                GetErrorContext().Error(ErrorCode.ERR_BadArgType, ivar + 1, new ErrArg(_pArguments.types.Item(ivar), ErrArgFlags.Unique), new ErrArg(var, ErrArgFlags.Unique));
+                                GetErrorContext().Error(ErrorCode.ERR_BadArgType, ivar + 1, new ErrArg(_pArguments.types[ivar], ErrArgFlags.Unique), new ErrArg(var, ErrArgFlags.Unique));
                             }
                         }
                     }
@@ -1538,7 +1538,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 for (int ivar = 0; ivar < _pArguments.carg; ivar++)
                 {
-                    CType var = _pBestParameters.Item(ivar);
+                    CType var = _pBestParameters[ivar];
                     if (var.IsParameterModifierType())
                     {
                         GetErrorContext().ErrorRef(ErrorCode.ERR_InitializerAddHasParamModifiers, _results.GetBestResult());

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinderResult.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/GroupToArgsBinderResult.cs
@@ -56,9 +56,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             private static int NumberOfErrorTypes(TypeArray pTypeArgs)
             {
                 int nCount = 0;
-                for (int i = 0; i < pTypeArgs.Size; i++)
+                for (int i = 0; i < pTypeArgs.Count; i++)
                 {
-                    if (pTypeArgs.Item(i).IsErrorType())
+                    if (pTypeArgs[i].IsErrorType())
                     {
                         nCount++;
                     }
@@ -73,18 +73,18 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 if (leftErrors == rightErrors)
                 {
-                    int max = pTypeArgs1.Size > pTypeArgs2.Size ? pTypeArgs2.Size : pTypeArgs1.Size;
+                    int max = pTypeArgs1.Count > pTypeArgs2.Count ? pTypeArgs2.Count : pTypeArgs1.Count;
 
                     // If we don't have a winner yet, go through each element's type args.
                     for (int i = 0; i < max; i++)
                     {
-                        if (pTypeArgs1.Item(i).IsAggregateType())
+                        if (pTypeArgs1[i].IsAggregateType())
                         {
-                            leftErrors += NumberOfErrorTypes(pTypeArgs1.Item(i).AsAggregateType().GetTypeArgsAll());
+                            leftErrors += NumberOfErrorTypes(pTypeArgs1[i].AsAggregateType().GetTypeArgsAll());
                         }
-                        if (pTypeArgs2.Item(i).IsAggregateType())
+                        if (pTypeArgs2[i].IsAggregateType())
                         {
-                            rightErrors += NumberOfErrorTypes(pTypeArgs2.Item(i).AsAggregateType().GetTypeArgsAll());
+                            rightErrors += NumberOfErrorTypes(pTypeArgs2[i].AsAggregateType().GetTypeArgsAll());
                         }
                     }
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ImplicitConversion.cs
@@ -557,8 +557,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 if ((_typeDest.IsArrayType() ||
                      (_typeDest.isInterfaceType() &&
-                      _typeDest.AsAggregateType().GetTypeArgsAll().Size == 1 &&
-                      ((_typeDest.AsAggregateType().GetTypeArgsAll().Item(0) != _typeSrc.AsArrayType().GetElementType()) ||
+                      _typeDest.AsAggregateType().GetTypeArgsAll().Count == 1 &&
+                      ((_typeDest.AsAggregateType().GetTypeArgsAll()[0] != _typeSrc.AsArrayType().GetElementType()) ||
                        0 != (_flags & CONVERTTYPE.FORCECAST))))
                     &&
                     (0 != (_flags & CONVERTTYPE.FORCECAST) ||
@@ -868,11 +868,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
                     do
                     {
-                        if (++itype >= bnds.Size)
+                        if (++itype >= bnds.Count)
                         {
                             return false;
                         }
-                        typeTmp = bnds.Item(itype);
+                        typeTmp = bnds[itype];
                     }
                     while (!typeTmp.isInterfaceType() && !typeTmp.IsTypeParameterType());
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         // For non-zero arity, only methods of the correct arity are considered.
                         // For zero arity, don't filter out any methods since we do type argument
                         // inferencing.
-                        if (_arity > 0 && symCur.AsMethodSymbol().typeVars.size != _arity)
+                        if (_arity > 0 && symCur.AsMethodSymbol().typeVars.Count != _arity)
                         {
                             if (!_swtBadArity)
                                 _swtBadArity.Set(symCur, typeCur);
@@ -155,7 +155,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                     case SYMKIND.SK_AggregateSymbol:
                         // For types, always filter on arity.
-                        if (symCur.AsAggregateSymbol().GetTypeVars().size != _arity)
+                        if (symCur.AsAggregateSymbol().GetTypeVars().Count != _arity)
                         {
                             if (!_swtBadArity)
                                 _swtBadArity.Set(symCur, typeCur);
@@ -200,8 +200,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     // If its an indexed property method symbol, let it through.
                     if (symCur.IsMethodSymbol() &&
                         symCur.AsMethodSymbol().isPropertyAccessor() &&
-                        ((symCur.name.Text.StartsWith("set_", StringComparison.Ordinal) && symCur.AsMethodSymbol().Params.size > 1) ||
-                        (symCur.name.Text.StartsWith("get_", StringComparison.Ordinal) && symCur.AsMethodSymbol().Params.size > 0)))
+                        ((symCur.name.Text.StartsWith("set_", StringComparison.Ordinal) && symCur.AsMethodSymbol().Params.Count > 1) ||
+                        (symCur.name.Text.StartsWith("get_", StringComparison.Ordinal) && symCur.AsMethodSymbol().Params.Count > 0)))
                     {
                         bIsIndexedProperty = true;
                     }
@@ -466,7 +466,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(!_swtFirst || _fMulti);
             Debug.Assert(typeStart == null || typeStart.isInterfaceType());
-            Debug.Assert(typeStart != null || types.size != 0);
+            Debug.Assert(typeStart != null || types.Count != 0);
 
             // Clear all the hidden flags. Anything found in a class hides any other
             // kind of member in all the interfaces.
@@ -476,9 +476,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 typeStart.fDiffHidden = (_swtFirst != null);
             }
 
-            for (int i = 0; i < types.size; i++)
+            for (int i = 0; i < types.Count; i++)
             {
-                AggregateType type = types.Item(i).AsAggregateType();
+                AggregateType type = types[i].AsAggregateType();
                 Debug.Assert(type.isInterfaceType());
                 type.fAllHidden = false;
                 type.fDiffHidden = !!_swtFirst;
@@ -490,7 +490,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (typeCur == null)
             {
-                typeCur = types.Item(itypeNext++).AsAggregateType();
+                typeCur = types[itypeNext++].AsAggregateType();
             }
             Debug.Assert(typeCur != null);
 
@@ -507,9 +507,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                     // Mark base interfaces appropriately.
                     TypeArray ifaces = typeCur.GetIfacesAll();
-                    for (int i = 0; i < ifaces.size; i++)
+                    for (int i = 0; i < ifaces.Count; i++)
                     {
-                        AggregateType type = ifaces.Item(i).AsAggregateType();
+                        AggregateType type = ifaces[i].AsAggregateType();
                         Debug.Assert(type.isInterfaceType());
                         if (fHideByName)
                             type.fAllHidden = true;
@@ -522,11 +522,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
                 _flags &= ~MemLookFlags.TypeVarsAllowed;
 
-                if (itypeNext >= types.size)
+                if (itypeNext >= types.Count)
                     return !fHideObject;
 
                 // Substitution has already been done.
-                typeCur = types.Item(itypeNext++).AsAggregateType();
+                typeCur = types[itypeNext++].AsAggregateType();
             }
         }
 
@@ -663,7 +663,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 _flags &= ~MemLookFlags.TypeVarsAllowed;
                 ifaces = typeSrc.AsTypeParameterType().GetInterfaceBounds();
                 typeCls1 = typeSrc.AsTypeParameterType().GetEffectiveBaseClass();
-                if (ifaces.size > 0 && typeCls1.isPredefType(PredefinedType.PT_OBJECT))
+                if (ifaces.Count > 0 && typeCls1.isPredefType(PredefinedType.PT_OBJECT))
                     typeCls1 = null;
             }
             else if (!typeSrc.isInterfaceType())
@@ -683,14 +683,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 ifaces = typeIface.GetIfacesAll();
             }
 
-            if (typeIface != null || ifaces.size > 0)
+            if (typeIface != null || ifaces.Count > 0)
                 typeCls2 = GetSymbolLoader().GetReqPredefType(PredefinedType.PT_OBJECT);
 
             // Search the class first (except possibly object).
             if (typeCls1 == null || LookupInClass(typeCls1, ref typeCls2))
             {
                 // Search the interfaces.
-                if ((typeIface != null || ifaces.size > 0) && LookupInInterfaces(typeIface, ifaces) && typeCls2 != null)
+                if ((typeIface != null || ifaces.Count > 0) && LookupInInterfaces(typeIface, ifaces) && typeCls2 != null)
                 {
                     // Search object last.
                     Debug.Assert(typeCls2 != null && typeCls2.isPredefType(PredefinedType.PT_OBJECT));
@@ -810,11 +810,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     case SYMKIND.SK_MethodSymbol:
                         Debug.Assert(_arity != 0);
-                        cvar = _swtBadArity.Sym.AsMethodSymbol().typeVars.size;
+                        cvar = _swtBadArity.Sym.AsMethodSymbol().typeVars.Count;
                         GetErrorContext().ErrorRef(cvar > 0 ? ErrorCode.ERR_BadArity : ErrorCode.ERR_HasNoTypeVars, _swtBadArity, new ErrArgSymKind(_swtBadArity.Sym), cvar);
                         break;
                     case SYMKIND.SK_AggregateSymbol:
-                        cvar = _swtBadArity.Sym.AsAggregateSymbol().GetTypeVars().size;
+                        cvar = _swtBadArity.Sym.AsAggregateSymbol().GetTypeVars().Count;
                         GetErrorContext().ErrorRef(cvar > 0 ? ErrorCode.ERR_BadArity : ErrorCode.ERR_HasNoTypeVars, _swtBadArity, new ErrArgSymKind(_swtBadArity.Sym), cvar);
                         break;
                     default:

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodIterator.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 if (_pCurrentType == null) // First guy.
                 {
-                    if (_pContainingTypes.size == 0)
+                    if (_pContainingTypes.Count == 0)
                     {
                         // No instance methods, only extensions.
                         _bIsCheckingInstanceMethods = false;
@@ -154,7 +154,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // If our arity is non-0, we must match arity with this symbol.
                 if (_nArity > 0)
                 {
-                    if (_mask == symbmask_t.MASK_MethodSymbol && _pCurrentSym.AsMethodSymbol().typeVars.size != _nArity)
+                    if (_mask == symbmask_t.MASK_MethodSymbol && _pCurrentSym.AsMethodSymbol().typeVars.Count != _nArity)
                     {
                         return false;
                     }
@@ -260,16 +260,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             private bool FindNextTypeForInstanceMethods()
             {
                 // Otherwise, search through other types listed as well as our base class.
-                if (_pContainingTypes.size > 0)
+                if (_pContainingTypes.Count > 0)
                 {
-                    if (_nCurrentTypeCount >= _pContainingTypes.size)
+                    if (_nCurrentTypeCount >= _pContainingTypes.Count)
                     {
                         // No more types to check.
                         _pCurrentType = null;
                     }
                     else
                     {
-                        _pCurrentType = _pContainingTypes.Item(_nCurrentTypeCount++).AsAggregateType();
+                        _pCurrentType = _pContainingTypes[_nCurrentTypeCount++].AsAggregateType();
                     }
                 }
                 else

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MethodTypeInferrer.cs
@@ -88,16 +88,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             out TypeArray ppInferredTypeArguments)
         {
             Debug.Assert(pMethod != null);
-            Debug.Assert(pMethod.typeVars.size > 0);
+            Debug.Assert(pMethod.typeVars.Count > 0);
             Debug.Assert(pMethod.isParamArray || pMethod.Params == pMethodFormalParameterTypes);
             ppInferredTypeArguments = null;
-            if (pMethodFormalParameterTypes.size == 0 || pMethod.InferenceMustFail())
+            if (pMethodFormalParameterTypes.Count == 0 || pMethod.InferenceMustFail())
             {
                 return false;
             }
             Debug.Assert(pMethodArguments != null);
             Debug.Assert(pMethodFormalParameterTypes != null);
-            Debug.Assert(pMethodArguments.carg <= pMethodFormalParameterTypes.size);
+            Debug.Assert(pMethodArguments.carg <= pMethodFormalParameterTypes.Count);
 
             var inferrer = new MethodTypeInferrer(binder, symbolLoader,
                 pMethodFormalParameterTypes, pMethodArguments,
@@ -136,11 +136,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             _pMethodArguments = pMethodArguments;
             _pMethodTypeParameters = pMethodTypeParameters;
             _pClassTypeArguments = pClassTypeArguments;
-            _pFixedResults = new CType[pMethodTypeParameters.size];
-            _pLowerBounds = new List<CType>[pMethodTypeParameters.size];
-            _pUpperBounds = new List<CType>[pMethodTypeParameters.size];
-            _pExactBounds = new List<CType>[pMethodTypeParameters.size];
-            for (int iBound = 0; iBound < pMethodTypeParameters.size; ++iBound)
+            _pFixedResults = new CType[pMethodTypeParameters.Count];
+            _pLowerBounds = new List<CType>[pMethodTypeParameters.Count];
+            _pUpperBounds = new List<CType>[pMethodTypeParameters.Count];
+            _pExactBounds = new List<CType>[pMethodTypeParameters.Count];
+            for (int iBound = 0; iBound < pMethodTypeParameters.Count; ++iBound)
             {
                 _pLowerBounds[iBound] = new List<CType>();
                 _pUpperBounds[iBound] = new List<CType>();
@@ -169,7 +169,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // This is nice and concise.  However, it falls down if there are multiple
             // CType params that we have left.
 
-            for (int iParam = 0; iParam < _pMethodTypeParameters.size; iParam++)
+            for (int iParam = 0; iParam < _pMethodTypeParameters.Count; iParam++)
             {
                 // We iterate through the resultant types and replace any that are
                 // null, or an error CType that has less information (e.g null name or
@@ -195,10 +195,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 _pFixedResults[iParam] = GetTypeManager().GetErrorType(
                                         null/*pParentType*/,
                                         null,
-                                        _pMethodTypeParameters.ItemAsTypeParameterType(iParam).GetName(),
+                                        (_pMethodTypeParameters.ItemAsTypeParameterType(iParam)).GetName(),
                                         BSYMMGR.EmptyTypeArray());
             }
-            return GetGlobalSymbols().AllocParams(_pMethodTypeParameters.size, _pFixedResults);
+            return GetGlobalSymbols().AllocParams(_pMethodTypeParameters.Count, _pFixedResults);
         }
 
         ////////////////////////////////////////////////////////////////////////////////
@@ -206,7 +206,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private bool IsUnfixed(int iParam)
         {
             Debug.Assert(0 <= iParam);
-            Debug.Assert(iParam < _pMethodTypeParameters.size);
+            Debug.Assert(iParam < _pMethodTypeParameters.Count);
             return _pFixedResults[iParam] == null;
         }
 
@@ -225,7 +225,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private bool AllFixed()
         {
-            for (int iParam = 0; iParam < _pMethodTypeParameters.size; ++iParam)
+            for (int iParam = 0; iParam < _pMethodTypeParameters.Count; ++iParam)
             {
                 if (IsUnfixed(iParam))
                 {
@@ -276,7 +276,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private bool HasBound(int iParam)
         {
             Debug.Assert(0 <= iParam);
-            Debug.Assert(iParam < _pMethodTypeParameters.size);
+            Debug.Assert(iParam < _pMethodTypeParameters.Count);
             return !_pLowerBounds[iParam].IsEmpty() ||
                 !_pExactBounds[iParam].IsEmpty() ||
                 !_pUpperBounds[iParam].IsEmpty();
@@ -294,14 +294,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // or there may be input parameters fixed to _unfixed_ method CType variables.
             // Both of those scenarios are legal.)
 
-            CType[] ppMethodParameters = new CType[_pMethodTypeParameters.size];
-            for (int iParam = 0; iParam < _pMethodTypeParameters.size; iParam++)
+            CType[] ppMethodParameters = new CType[_pMethodTypeParameters.Count];
+            for (int iParam = 0; iParam < _pMethodTypeParameters.Count; iParam++)
             {
                 TypeParameterType pParam = _pMethodTypeParameters.ItemAsTypeParameterType(iParam);
                 ppMethodParameters[iParam] = IsUnfixed(iParam) ? pParam : _pFixedResults[iParam];
             }
-            SubstContext subsctx = new SubstContext(_pClassTypeArguments.ToArray(), _pClassTypeArguments.size,
-                ppMethodParameters, _pMethodTypeParameters.size);
+            SubstContext subsctx = new SubstContext(_pClassTypeArguments.Items, _pClassTypeArguments.Count,
+                ppMethodParameters, _pMethodTypeParameters.Count);
             AggregateType pFixedDelegateType =
                 GetTypeManager().SubstType(pDelegateType, subsctx).AsAggregateType();
             TypeArray pFixedDelegateParams =
@@ -347,7 +347,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(_pMethodFormalParameterTypes != null);
             Debug.Assert(_pMethodArguments != null);
-            Debug.Assert(_pMethodArguments.carg <= _pMethodFormalParameterTypes.size);
+            Debug.Assert(_pMethodArguments.carg <= _pMethodFormalParameterTypes.Count);
 
             // SPEC: For each of the method arguments Ei:
             for (int iArg = 0; iArg < _pMethodArguments.carg; iArg++)
@@ -367,7 +367,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     continue;
                 }
 
-                CType pDest = _pMethodFormalParameterTypes.Item(iArg);
+                CType pDest = _pMethodFormalParameterTypes[iArg];
 
                 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                 // RUNTIME BINDER ONLY CHANGE
@@ -380,7 +380,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 CType pSource = pExpr.RuntimeObjectActualType != null
                     ? pExpr.RuntimeObjectActualType
-                    : _pMethodArguments.types.Item(iArg);
+                    : _pMethodArguments.types[iArg];
 
                 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                 // END RUNTIME BINDER ONLY CHANGE
@@ -561,7 +561,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             for (int iArg = 0; iArg < _pMethodArguments.carg; iArg++)
             {
-                CType pDest = _pMethodFormalParameterTypes.Item(iArg);
+                CType pDest = _pMethodFormalParameterTypes[iArg];
                 if (pDest.IsParameterModifierType())
                 {
                     pDest = pDest.AsParameterModifierType().GetParameterType();
@@ -570,7 +570,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 if (HasUnfixedParamInOutputType(pExpr, pDest) &&
                     !HasUnfixedParamInInputType(pExpr, pDest))
                 {
-                    CType pSource = _pMethodArguments.types.Item(iArg);
+                    CType pSource = _pMethodArguments.types[iArg];
                     if (pSource.IsParameterModifierType())
                     {
                         pSource = pSource.AsParameterModifierType().GetParameterType();
@@ -595,10 +595,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // dependent on anything. We need to first determine which parameters need to be 
             // fixed, and then fix them all at once.
 
-            bool[] pNeedsFixing = new bool[_pMethodTypeParameters.size];
+            bool[] pNeedsFixing = new bool[_pMethodTypeParameters.Count];
             int iParam;
             NewInferenceResult res = NewInferenceResult.NoProgress;
-            for (iParam = 0; iParam < _pMethodTypeParameters.size; iParam++)
+            for (iParam = 0; iParam < _pMethodTypeParameters.Count; iParam++)
             {
                 if (IsUnfixed(iParam) && HasBound(iParam) && !DependsOnAny(iParam))
                 {
@@ -606,7 +606,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     res = NewInferenceResult.MadeProgress;
                 }
             }
-            for (iParam = 0; iParam < _pMethodTypeParameters.size; iParam++)
+            for (iParam = 0; iParam < _pMethodTypeParameters.Count; iParam++)
             {
                 // Fix as much as you can, even if there are errors.  That will
                 // help with intellisense.
@@ -632,10 +632,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // As above, we must collect up everything that needs fixing first,
             // and then fix them.
 
-            bool[] pNeedsFixing = new bool[_pMethodTypeParameters.size];
+            bool[] pNeedsFixing = new bool[_pMethodTypeParameters.Count];
             int iParam;
             NewInferenceResult res = NewInferenceResult.NoProgress;
-            for (iParam = 0; iParam < _pMethodTypeParameters.size; iParam++)
+            for (iParam = 0; iParam < _pMethodTypeParameters.Count; iParam++)
             {
                 if (IsUnfixed(iParam) && HasBound(iParam) && AnyDependsOn(iParam))
                 {
@@ -643,7 +643,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     res = NewInferenceResult.MadeProgress;
                 }
             }
-            for (iParam = 0; iParam < _pMethodTypeParameters.size; iParam++)
+            for (iParam = 0; iParam < _pMethodTypeParameters.Count; iParam++)
             {
                 // Fix as much as you can, even if there are errors.  That will
                 // help with intellisense.
@@ -693,7 +693,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private bool HasUnfixedParamInInputType(EXPR pSource, CType pDest)
         {
-            for (int iParam = 0; iParam < _pMethodTypeParameters.size; iParam++)
+            for (int iParam = 0; iParam < _pMethodTypeParameters.Count; iParam++)
             {
                 if (IsUnfixed(iParam))
                 {
@@ -741,7 +741,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private bool HasUnfixedParamInOutputType(EXPR pSource, CType pDest)
         {
-            for (int iParam = 0; iParam < _pMethodTypeParameters.size; iParam++)
+            for (int iParam = 0; iParam < _pMethodTypeParameters.Count; iParam++)
             {
                 if (IsUnfixed(iParam))
                 {
@@ -762,8 +762,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private bool DependsDirectlyOn(int iParam, int jParam)
         {
-            Debug.Assert(0 <= iParam && iParam < _pMethodTypeParameters.size);
-            Debug.Assert(0 <= jParam && jParam < _pMethodTypeParameters.size);
+            Debug.Assert(0 <= iParam && iParam < _pMethodTypeParameters.Count);
+            Debug.Assert(0 <= jParam && jParam < _pMethodTypeParameters.Count);
 
             // SPEC: An unfixed CType parameter Xi depends directly on an unfixed CType
             // SPEC: parameter Xj if for some argument Ek with CType Tk, Xj occurs
@@ -780,7 +780,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             for (int iArg = 0; iArg < _pMethodArguments.carg; iArg++)
             {
-                CType pDest = _pMethodFormalParameterTypes.Item(iArg);
+                CType pDest = _pMethodFormalParameterTypes[iArg];
                 if (pDest.IsParameterModifierType())
                 {
                     pDest = pDest.AsParameterModifierType().GetParameterType();
@@ -839,11 +839,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // be an O(n^2) algorithm in practice.
 
             Debug.Assert(_ppDependencies == null);
-            _ppDependencies = new Dependency[_pMethodTypeParameters.size][];
-            for (int iParam = 0; iParam < _pMethodTypeParameters.size; ++iParam)
+            _ppDependencies = new Dependency[_pMethodTypeParameters.Count][];
+            for (int iParam = 0; iParam < _pMethodTypeParameters.Count; ++iParam)
             {
-                _ppDependencies[iParam] = new Dependency[_pMethodTypeParameters.size];
-                for (int jParam = 0; jParam < _pMethodTypeParameters.size; ++jParam)
+                _ppDependencies[iParam] = new Dependency[_pMethodTypeParameters.Count];
+                for (int jParam = 0; jParam < _pMethodTypeParameters.Count; ++jParam)
                 {
                     if (DependsDirectlyOn(iParam, jParam))
                     {
@@ -865,8 +865,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // SPEC: directly on Xk and Xk depends on Xj. Thus "depends on" is the
             // SPEC: transitive but not reflexive closure of "depends directly on".
 
-            Debug.Assert(0 <= iParam && iParam < _pMethodTypeParameters.size);
-            Debug.Assert(0 <= jParam && jParam < _pMethodTypeParameters.size);
+            Debug.Assert(0 <= iParam && iParam < _pMethodTypeParameters.Count);
+            Debug.Assert(0 <= jParam && jParam < _pMethodTypeParameters.Count);
 
             if (_dependenciesDirty)
             {
@@ -881,8 +881,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private bool DependsTransitivelyOn(int iParam, int jParam)
         {
             Debug.Assert(_ppDependencies != null);
-            Debug.Assert(0 <= iParam && iParam < _pMethodTypeParameters.size);
-            Debug.Assert(0 <= jParam && jParam < _pMethodTypeParameters.size);
+            Debug.Assert(0 <= iParam && iParam < _pMethodTypeParameters.Count);
+            Debug.Assert(0 <= jParam && jParam < _pMethodTypeParameters.Count);
 
             // Can we find Xk such that Xi depends on Xk and Xk depends on Xj?
             // If so, then Xi depends indirectly on Xj.  (Note that there is
@@ -892,7 +892,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // directly OR indirectly on Xk and Xk depends on Xj, then that's
             // good enough.)
 
-            for (int kParam = 0; kParam < _pMethodTypeParameters.size; ++kParam)
+            for (int kParam = 0; kParam < _pMethodTypeParameters.Count; ++kParam)
             {
                 if (0 != ((_ppDependencies[iParam][kParam]) & Dependency.DependsMask) &&
                     0 != ((_ppDependencies[kParam][jParam]) & Dependency.DependsMask))
@@ -922,9 +922,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(_ppDependencies != null);
             bool madeProgress = false;
-            for (int iParam = 0; iParam < _pMethodTypeParameters.size; ++iParam)
+            for (int iParam = 0; iParam < _pMethodTypeParameters.Count; ++iParam)
             {
-                for (int jParam = 0; jParam < _pMethodTypeParameters.size; ++jParam)
+                for (int jParam = 0; jParam < _pMethodTypeParameters.Count; ++jParam)
                 {
                     if (_ppDependencies[iParam][jParam] == Dependency.Unknown)
                     {
@@ -944,9 +944,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private void SetUnknownsToNotDependent()
         {
             Debug.Assert(_ppDependencies != null);
-            for (int iParam = 0; iParam < _pMethodTypeParameters.size; ++iParam)
+            for (int iParam = 0; iParam < _pMethodTypeParameters.Count; ++iParam)
             {
-                for (int jParam = 0; jParam < _pMethodTypeParameters.size; ++jParam)
+                for (int jParam = 0; jParam < _pMethodTypeParameters.Count; ++jParam)
                 {
                     if (_ppDependencies[iParam][jParam] == Dependency.Unknown)
                     {
@@ -961,9 +961,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private void SetIndirectsToUnknown()
         {
             Debug.Assert(_ppDependencies != null);
-            for (int iParam = 0; iParam < _pMethodTypeParameters.size; ++iParam)
+            for (int iParam = 0; iParam < _pMethodTypeParameters.Count; ++iParam)
             {
-                for (int jParam = 0; jParam < _pMethodTypeParameters.size; ++jParam)
+                for (int jParam = 0; jParam < _pMethodTypeParameters.Count; ++jParam)
                 {
                     if (_ppDependencies[iParam][jParam] == Dependency.Indirect)
                     {
@@ -982,7 +982,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 return;
             }
-            for (int jParam = 0; jParam < _pMethodTypeParameters.size; ++jParam)
+            for (int jParam = 0; jParam < _pMethodTypeParameters.Count; ++jParam)
             {
                 _ppDependencies[iParam][jParam] = Dependency.NotDependent;
                 _ppDependencies[jParam][iParam] = Dependency.NotDependent;
@@ -994,8 +994,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private bool DependsOnAny(int iParam)
         {
-            Debug.Assert(0 <= iParam && iParam < _pMethodTypeParameters.size);
-            for (int jParam = 0; jParam < _pMethodTypeParameters.size; ++jParam)
+            Debug.Assert(0 <= iParam && iParam < _pMethodTypeParameters.Count);
+            for (int jParam = 0; jParam < _pMethodTypeParameters.Count; ++jParam)
             {
                 if (DependsOn(iParam, jParam))
                 {
@@ -1009,8 +1009,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private bool AnyDependsOn(int iParam)
         {
-            Debug.Assert(0 <= iParam && iParam < _pMethodTypeParameters.size);
-            for (int jParam = 0; jParam < _pMethodTypeParameters.size; ++jParam)
+            Debug.Assert(0 <= iParam && iParam < _pMethodTypeParameters.Count);
+            for (int jParam = 0; jParam < _pMethodTypeParameters.Count; ++jParam)
             {
                 if (DependsOn(jParam, iParam))
                 {
@@ -1094,7 +1094,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return false;
             }
 
-            ArgInfos argInfo = new ArgInfos() { carg = pDelegateParameters.size, types = pDelegateParameters, fHasExprs = false, prgexpr = null };
+            ArgInfos argInfo = new ArgInfos() { carg = pDelegateParameters.Count, types = pDelegateParameters, fHasExprs = false, prgexpr = null };
 
             var argsBinder = new ExpressionBinder.GroupToArgsBinder(_binder, 0/* flags */, pSource.asMEMGRP(), argInfo, null, false, pDelegateType);
 
@@ -1247,11 +1247,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             Debug.Assert(pSourceArgs != null);
             Debug.Assert(pDestArgs != null);
-            Debug.Assert(pSourceArgs.size == pDestArgs.size);
+            Debug.Assert(pSourceArgs.Count == pDestArgs.Count);
 
-            for (int arg = 0; arg < pSourceArgs.size; ++arg)
+            for (int arg = 0; arg < pSourceArgs.Count; ++arg)
             {
-                ExactInference(pSourceArgs.Item(arg), pDestArgs.Item(arg));
+                ExactInference(pSourceArgs[arg], pDestArgs[arg]);
             }
         }
 
@@ -1398,7 +1398,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return false;
                 }
                 AggregateType pAggregateDest = pDest.AsAggregateType();
-                pElementDest = pAggregateDest.GetTypeArgsThis().Item(0);
+                pElementDest = pAggregateDest.GetTypeArgsThis()[0];
             }
             else
             {
@@ -1448,7 +1448,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             AggregateType pConstructedDest = pDest.AsAggregateType();
             TypeArray pDestArgs = pConstructedDest.GetTypeArgsAll();
-            if (pDestArgs.size == 0)
+            if (pDestArgs.Count == 0)
             {
                 return false;
             }
@@ -1618,14 +1618,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(pSourceArgs != null);
             Debug.Assert(pDestArgs != null);
 
-            Debug.Assert(pTypeParams.size == pSourceArgs.size);
-            Debug.Assert(pTypeParams.size == pDestArgs.size);
+            Debug.Assert(pTypeParams.Count == pSourceArgs.Count);
+            Debug.Assert(pTypeParams.Count == pDestArgs.Count);
 
-            for (int arg = 0; arg < pSourceArgs.size; ++arg)
+            for (int arg = 0; arg < pSourceArgs.Count; ++arg)
             {
                 TypeParameterType pTypeParam = pTypeParams.ItemAsTypeParameterType(arg);
-                CType pSourceArg = pSourceArgs.Item(arg);
-                CType pDestArg = pDestArgs.Item(arg);
+                CType pSourceArg = pSourceArgs[arg];
+                CType pDestArg = pDestArgs[arg];
 
                 if (pSourceArg.IsRefType() && pTypeParam.Covariant)
                 {
@@ -1633,11 +1633,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
                 else if (pSourceArg.IsRefType() && pTypeParam.Contravariant)
                 {
-                    UpperBoundInference(pSourceArgs.Item(arg), pDestArgs.Item(arg));
+                    UpperBoundInference(pSourceArgs[arg], pDestArgs[arg]);
                 }
                 else
                 {
-                    ExactInference(pSourceArgs.Item(arg), pDestArgs.Item(arg));
+                    ExactInference(pSourceArgs[arg], pDestArgs[arg]);
                 }
             }
         }
@@ -1746,7 +1746,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return false;
                 }
                 AggregateType pAggregateSource = pSource.AsAggregateType();
-                pElementSource = pAggregateSource.GetTypeArgsThis().Item(0);
+                pElementSource = pAggregateSource.GetTypeArgsThis()[0];
             }
             else
             {
@@ -1775,7 +1775,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             AggregateType pConstructedSource = pSource.AsAggregateType();
             TypeArray pSourceArgs = pConstructedSource.GetTypeArgsAll();
-            if (pSourceArgs.size == 0)
+            if (pSourceArgs.Count == 0)
             {
                 return false;
             }
@@ -1918,14 +1918,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(pSourceArgs != null);
             Debug.Assert(pDestArgs != null);
 
-            Debug.Assert(pTypeParams.size == pSourceArgs.size);
-            Debug.Assert(pTypeParams.size == pDestArgs.size);
+            Debug.Assert(pTypeParams.Count == pSourceArgs.Count);
+            Debug.Assert(pTypeParams.Count == pDestArgs.Count);
 
-            for (int arg = 0; arg < pSourceArgs.size; ++arg)
+            for (int arg = 0; arg < pSourceArgs.Count; ++arg)
             {
                 TypeParameterType pTypeParam = pTypeParams.ItemAsTypeParameterType(arg);
-                CType pSourceArg = pSourceArgs.Item(arg);
-                CType pDestArg = pDestArgs.Item(arg);
+                CType pSourceArg = pSourceArgs[arg];
+                CType pDestArg = pDestArgs[arg];
 
                 if (pSourceArg.IsRefType() && pTypeParam.Covariant)
                 {
@@ -1933,11 +1933,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
                 else if (pSourceArg.IsRefType() && pTypeParam.Contravariant)
                 {
-                    LowerBoundInference(pSourceArgs.Item(arg), pDestArgs.Item(arg));
+                    LowerBoundInference(pSourceArgs[arg], pDestArgs[arg]);
                 }
                 else
                 {
-                    ExactInference(pSourceArgs.Item(arg), pDestArgs.Item(arg));
+                    ExactInference(pSourceArgs[arg], pDestArgs[arg]);
                 }
             }
         }
@@ -2132,12 +2132,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             Debug.Assert(_pMethodFormalParameterTypes != null);
             Debug.Assert(_pMethodArguments != null);
-            Debug.Assert(_pMethodArguments.carg <= _pMethodFormalParameterTypes.size);
+            Debug.Assert(_pMethodArguments.carg <= _pMethodFormalParameterTypes.Count);
 
             for (int iArg = 0; iArg < _pMethodArguments.carg; iArg++)
             {
-                CType pDest = _pMethodFormalParameterTypes.Item(iArg);
-                CType pSource = _pMethodArguments.types.Item(iArg);
+                CType pDest = _pMethodFormalParameterTypes[iArg];
+                CType pSource = _pMethodArguments.types[iArg];
                 if (pDest.IsParameterModifierType())
                 {
                     pDest = pDest.AsParameterModifierType().GetParameterType();
@@ -2155,7 +2155,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // In the event of failure we still want to fix as much as we can, so
             // that intellisense gives the best possible result.
 
-            for (int iParam = 0; iParam < _pMethodTypeParameters.size; iParam++)
+            for (int iParam = 0; iParam < _pMethodTypeParameters.Count; iParam++)
             {
                 if (!HasBound(iParam) || !Fix(iParam))
                 {
@@ -2221,16 +2221,16 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             ArgInfos pMethodArguments)
         {
             Debug.Assert(pMethod != null);
-            Debug.Assert(pMethod.typeVars.size > 0);
+            Debug.Assert(pMethod.typeVars.Count > 0);
             Debug.Assert(pMethodFormalParameterTypes != null);
             Debug.Assert(pMethod.isParamArray || pMethod.Params == pMethodFormalParameterTypes);
             // We need at least one formal parameter type and at least one argument.
-            if (pMethodFormalParameterTypes.size < 1 || pMethod.InferenceMustFail())
+            if (pMethodFormalParameterTypes.Count < 1 || pMethod.InferenceMustFail())
             {
                 return false;
             }
             Debug.Assert(pMethodArguments != null);
-            Debug.Assert(pMethodArguments.carg <= pMethodFormalParameterTypes.size);
+            Debug.Assert(pMethodArguments.carg <= pMethodFormalParameterTypes.Count);
             if (pMethodArguments.carg < 1)
             {
                 return false;
@@ -2245,11 +2245,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private bool CanInferExtensionObject()
         {
             Debug.Assert(_pMethodFormalParameterTypes != null);
-            Debug.Assert(_pMethodFormalParameterTypes.size >= 1);
+            Debug.Assert(_pMethodFormalParameterTypes.Count >= 1);
             Debug.Assert(_pMethodArguments != null);
             Debug.Assert(_pMethodArguments.carg >= 1);
-            CType pDest = _pMethodFormalParameterTypes.Item(0);
-            CType pSource = _pMethodArguments.types.Item(0);
+            CType pDest = _pMethodFormalParameterTypes[0];
+            CType pSource = _pMethodArguments.types[0];
             if (pDest.IsParameterModifierType())
             {
                 pDest = pDest.AsParameterModifierType().GetParameterType();
@@ -2268,7 +2268,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             LowerBoundInference(pSource, pDest);
             // Now check to see that every CType parameter used by the first
             // formal parameter CType was successfully inferred.
-            for (int iParam = 0; iParam < _pMethodTypeParameters.size; ++iParam)
+            for (int iParam = 0; iParam < _pMethodTypeParameters.Count; ++iParam)
             {
                 TypeParameterType pParam = _pMethodTypeParameters.ItemAsTypeParameterType(iParam);
                 if (!TypeManager.TypeContainsType(pDest, pParam))

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -2537,9 +2537,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             CType typeRet = pCall.type;
 
-            Debug.Assert(pCall.mwi.Meth().Params.size == 2);
-            if (!GetTypes().SubstEqualTypes(typeRet, pCall.mwi.Meth().Params.Item(0), typeRet) ||
-                !GetTypes().SubstEqualTypes(typeRet, pCall.mwi.Meth().Params.Item(1), typeRet))
+            Debug.Assert(pCall.mwi.Meth().Params.Count == 2);
+            if (!GetTypes().SubstEqualTypes(typeRet, pCall.mwi.Meth().Params[0], typeRet) ||
+                !GetTypes().SubstEqualTypes(typeRet, pCall.mwi.Meth().Params[1], typeRet))
             {
                 MethWithInst mwi = new MethWithInst(null, null);
                 EXPRMEMGRP pMemGroup = GetExprFactory().CreateMemGroup(null, mwi);
@@ -2628,11 +2628,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private bool UserDefinedBinaryOperatorCanBeLifted(ExpressionKind ek, MethodSymbol method, AggregateType ats,
             TypeArray Params)
         {
-            if (!Params.Item(0).IsNonNubValType())
+            if (!Params[0].IsNonNubValType())
             {
                 return false;
             }
-            if (!Params.Item(1).IsNonNubValType())
+            if (!Params[1].IsNonNubValType())
             {
                 return false;
             }
@@ -2649,7 +2649,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     {
                         return false;
                     }
-                    if (Params.Item(0) != Params.Item(1))
+                    if (Params[0] != Params[1])
                     {
                         return false;
                     }
@@ -2673,13 +2673,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         private bool UserDefinedBinaryOperatorIsApplicable(List<CandidateFunctionMember> candidateList,
             ExpressionKind ek, MethodSymbol method, AggregateType ats, EXPR arg1, EXPR arg2, bool fDontLift)
         {
-            if (!method.isOperator || method.Params.size != 2)
+            if (!method.isOperator || method.Params.Count != 2)
             {
                 return false;
             }
-            Debug.Assert(method.typeVars.size == 0);
+            Debug.Assert(method.typeVars.Count == 0);
             TypeArray paramsCur = GetTypes().SubstTypeArray(method.Params, ats);
-            if (canConvert(arg1, paramsCur.Item(0)) && canConvert(arg2, paramsCur.Item(1)))
+            if (canConvert(arg1, paramsCur[0]) && canConvert(arg2, paramsCur[1]))
             {
                 candidateList.Add(new CandidateFunctionMember(
                     new MethPropWithInst(method, ats, BSYMMGR.EmptyTypeArray()),
@@ -2694,8 +2694,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return false;
             }
             CType[] rgtype = new CType[2];
-            rgtype[0] = GetTypes().GetNullable(paramsCur.Item(0));
-            rgtype[1] = GetTypes().GetNullable(paramsCur.Item(1));
+            rgtype[0] = GetTypes().GetNullable(paramsCur[0]);
+            rgtype[1] = GetTypes().GetNullable(paramsCur[1]);
             if (!canConvert(arg1, rgtype[0]) || !canConvert(arg2, rgtype[1]))
             {
                 return false;
@@ -2816,8 +2816,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private EXPRCALL BindUDBinopCall(EXPR arg1, EXPR arg2, TypeArray Params, CType typeRet, MethPropWithInst mpwi)
         {
-            arg1 = mustConvert(arg1, Params.Item(0));
-            arg2 = mustConvert(arg2, Params.Item(1));
+            arg1 = mustConvert(arg1, Params[0]);
+            arg2 = mustConvert(arg2, Params[1]);
             EXPRLIST args = GetExprFactory().CreateList(arg1, arg2);
 
             checkUnsafe(arg1.type); // added to the binder so we don't bind to pointer ops
@@ -2851,19 +2851,19 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             TypeArray paramsRaw = GetTypes().SubstTypeArray(mpwi.Meth().Params, mpwi.GetType());
             Debug.Assert(Params != paramsRaw);
-            Debug.Assert(paramsRaw.Item(0) == Params.Item(0).GetBaseOrParameterOrElementType());
-            Debug.Assert(paramsRaw.Item(1) == Params.Item(1).GetBaseOrParameterOrElementType());
+            Debug.Assert(paramsRaw[0] == Params[0].GetBaseOrParameterOrElementType());
+            Debug.Assert(paramsRaw[1] == Params[1].GetBaseOrParameterOrElementType());
 
-            if (!canConvert(arg1.type.StripNubs(), paramsRaw.Item(0), CONVERTTYPE.NOUDC))
+            if (!canConvert(arg1.type.StripNubs(), paramsRaw[0], CONVERTTYPE.NOUDC))
             {
-                exprVal1 = mustConvert(arg1, Params.Item(0));
+                exprVal1 = mustConvert(arg1, Params[0]);
             }
-            if (!canConvert(arg2.type.StripNubs(), paramsRaw.Item(1), CONVERTTYPE.NOUDC))
+            if (!canConvert(arg2.type.StripNubs(), paramsRaw[1], CONVERTTYPE.NOUDC))
             {
-                exprVal2 = mustConvert(arg2, Params.Item(1));
+                exprVal2 = mustConvert(arg2, Params[1]);
             }
-            EXPR nonLiftedArg1 = mustCast(exprVal1, paramsRaw.Item(0));
-            EXPR nonLiftedArg2 = mustCast(exprVal2, paramsRaw.Item(1));
+            EXPR nonLiftedArg1 = mustCast(exprVal1, paramsRaw[0]);
+            EXPR nonLiftedArg2 = mustCast(exprVal2, paramsRaw[1]);
             switch (ek)
             {
                 default:
@@ -2871,7 +2871,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     break;
                 case ExpressionKind.EK_EQ:
                 case ExpressionKind.EK_NE:
-                    Debug.Assert(paramsRaw.Item(0) == paramsRaw.Item(1));
+                    Debug.Assert(paramsRaw[0] == paramsRaw[1]);
                     Debug.Assert(typeRetRaw.isPredefType(PredefinedType.PT_BOOL));
                     // These ones don't lift the return type. Instead, if either side is null, the result is false.
                     typeRet = typeRetRaw;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/PredefinedMembers.cs
@@ -460,7 +460,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     {
                         int index = signature[indexIntoSignatures];
                         indexIntoSignatures++;
-                        return classTyVars.Item(index);
+                        return classTyVars[index];
                     }
                 case (MethodSignatureEnum)PredefinedType.PT_VOID:
                     return GetTypeManager().GetVoid();
@@ -470,8 +470,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         AggregateSymbol agg = GetOptPredefAgg((PredefinedType)current);
                         if (agg != null)
                         {
-                            CType[] typeArgs = new CType[agg.GetTypeVars().size];
-                            for (int iTypeArg = 0; iTypeArg < agg.GetTypeVars().size; iTypeArg++)
+                            CType[] typeArgs = new CType[agg.GetTypeVars().Count];
+                            for (int iTypeArg = 0; iTypeArg < agg.GetTypeVars().Count; iTypeArg++)
                             {
                                 typeArgs[iTypeArg] = LoadTypeFromSignature(signature, ref indexIntoSignatures, classTyVars);
                                 if (typeArgs[iTypeArg] == null)
@@ -479,7 +479,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                                     return null;
                                 }
                             }
-                            AggregateType type = GetTypeManager().GetAggregate(agg, getBSymmgr().AllocParams(agg.GetTypeVars().size, typeArgs));
+                            AggregateType type = GetTypeManager().GetAggregate(agg, getBSymmgr().AllocParams(agg.GetTypeVars().Count, typeArgs));
                             if (type.isPredefType(PredefinedType.PT_G_OPTIONAL))
                             {
                                 return GetTypeManager().GetNubFromNullable(type);
@@ -627,7 +627,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     if ((methsym.GetAccess() == methodAccess || methodAccess == ACCESS.ACC_UNKNOWN) &&
                         methsym.isStatic == isStatic &&
                         methsym.isVirtual == isVirtual &&
-                        methsym.typeVars.size == cMethodTyVars &&
+                        methsym.typeVars.Count == cMethodTyVars &&
                         GetTypeManager().SubstEqualTypes(methsym.RetType, returnType, null, methsym.typeVars, SubstTypeFlags.DenormMeth) &&
                         GetTypeManager().SubstEqualTypeArrays(methsym.Params, argumentTypes, (TypeArray)null,
                             methsym.typeVars, SubstTypeFlags.DenormMeth) &&

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SemanticChecker.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             // Substitute on the CType.
-            if (atsCheck.GetTypeArgsAll().size > 0)
+            if (atsCheck.GetTypeArgsAll().Count > 0)
             {
                 CType = SymbolLoader.GetTypeManager().SubstType(CType, atsCheck);
             }
@@ -112,9 +112,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             TypeArray typeArgs = type.AsAggregateType().GetTypeArgsAll();
-            for (int i = 0; i < typeArgs.size; i++)
+            for (int i = 0; i < typeArgs.Count; i++)
             {
-                if (!CheckTypeAccess(typeArgs.Item(i), symWhere))
+                if (!CheckTypeAccess(typeArgs[i], symWhere))
                     return false;
             }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/SubstitutionContext.cs
@@ -72,11 +72,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             if (typeArgsCls != null)
             {
-#if DEBUG
                 typeArgsCls.AssertValid();
-#endif
-                ctypeCls = typeArgsCls.size;
-                prgtypeCls = typeArgsCls.ToArray();
+                ctypeCls = typeArgsCls.Count;
+                prgtypeCls = typeArgsCls.Items;
             }
             else
             {
@@ -86,12 +84,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             if (typeArgsMeth != null)
             {
-#if DEBUG
                 typeArgsMeth.AssertValid();
-#endif
-
-                ctypeMeth = typeArgsMeth.size;
-                prgtypeMeth = typeArgsMeth.ToArray();
+                ctypeMeth = typeArgsMeth.Count;
+                prgtypeMeth = typeArgsMeth.Items;
             }
             else
             {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodOrPropertySymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodOrPropertySymbol.cs
@@ -63,12 +63,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 // Should only be set once!
                 _Params = value;
-                _optionalParameterIndex = new bool[_Params.size];
-                _defaultParameterIndex = new bool[_Params.size];
-                _defaultParameters = new CONSTVAL[_Params.size];
-                _defaultParameterConstValTypes = new CType[_Params.size];
-                _marshalAsIndex = new bool[_Params.size];
-                _marshalAsBuffer = new UnmanagedType[_Params.size];
+                _optionalParameterIndex = new bool[_Params.Count];
+                _defaultParameterIndex = new bool[_Params.Count];
+                _defaultParameters = new CONSTVAL[_Params.Count];
+                _defaultParameterConstValTypes = new CType[_Params.Count];
+                _marshalAsIndex = new bool[_Params.Count];
+                _marshalAsBuffer = new UnmanagedType[_Params.Count];
             }
         }             // array of cParams parameter types.
         public AggregateDeclaration declaration;       // containing declaration
@@ -82,7 +82,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public bool IsParameterOptional(int index)
         {
-            Debug.Assert(index < Params.size);
+            Debug.Assert(index < Params.Count);
 
             if (_optionalParameterIndex == null)
             {
@@ -115,7 +115,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public bool HasDefaultParameterValue(int index)
         {
-            Debug.Assert(index < Params.size);
+            Debug.Assert(index < Params.Count);
             Debug.Assert(_defaultParameterIndex != null);
             return _defaultParameterIndex[index];
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodSymbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/MethodSymbol.cs
@@ -44,19 +44,19 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             Debug.Assert(!_inferenceMustFail);
             _checkedInfMustFail = true;
-            for (int ivar = 0; ivar < typeVars.Size; ivar++)
+            for (int ivar = 0; ivar < typeVars.Count; ivar++)
             {
                 TypeParameterType var = typeVars.ItemAsTypeParameterType(ivar);
                 // See if type var is used in a parameter.
                 for (int ipar = 0; ; ipar++)
                 {
-                    if (ipar >= Params.Size)
+                    if (ipar >= Params.Count)
                     {
                         // This type variable is not in any parameter.
                         _inferenceMustFail = true;
                         return true;
                     }
-                    if (TypeManager.TypeContainsType(Params.Item(ipar), var))
+                    if (TypeManager.TypeContainsType(Params[ipar], var))
                     {
                         break;
                     }
@@ -84,8 +84,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public bool IsNullableConstructor()
         {
             return getClass().isPredefAgg(PredefinedType.PT_G_OPTIONAL) &&
-                Params.Size == 1 &&
-                Params.Item(0).IsGenericParameter &&
+                Params.Count == 1 &&
+                Params[0].IsGenericParameter &&
                 IsConstructor();
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/Symbol.cs
@@ -176,9 +176,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         }
                         if (meth.Params != null)
                         {
-                            for (int i = 0; !fBogus && i < meth.Params.Size; i++)
+                            for (int i = 0; !fBogus && i < meth.Params.Count; i++)
                             {
-                                fBogus |= meth.Params.Item(i).computeCurrentBogusState();
+                                fBogus |= meth.Params[i].computeCurrentBogusState();
                             }
                         }
                     }
@@ -221,7 +221,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     fBogus = this.AsAggregateType().getAggregate().computeCurrentBogusState();
                     for (int i = 0; !fBogus && i < this.AsAggregateType().GetTypeArgsAll().size; i++)
                     {
-                        fBogus |= this.AsAggregateType().GetTypeArgsAll().Item(i).computeCurrentBogusState();
+                        fBogus |= this.AsAggregateType().GetTypeArgsAll()[i].computeCurrentBogusState();
                     }
                     break;
                  */

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolLoader.cs
@@ -205,9 +205,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             while (atsDer != null)
             {
                 TypeArray ifacesAll = atsDer.GetIfacesAll();
-                for (int i = 0; i < ifacesAll.Size; i++)
+                for (int i = 0; i < ifacesAll.Count; i++)
                 {
-                    if (AreTypesEqualForConversion(ifacesAll.Item(i), pBase))
+                    if (AreTypesEqualForConversion(ifacesAll[i], pBase))
                     {
                         return true;
                     }
@@ -337,10 +337,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return false;
             }
 
-            Debug.Assert(atsDest.GetTypeArgsAll().Size == 1);
+            Debug.Assert(atsDest.GetTypeArgsAll().Count == 1);
 
             CType pSourceElement = pSource.GetElementType();
-            CType pDestTypeArgument = atsDest.GetTypeArgsAll().Item(0);
+            CType pDestTypeArgument = atsDest.GetTypeArgsAll()[0];
             return HasIdentityOrImplicitReferenceConversion(pSourceElement, pDestTypeArgument);
         }
 
@@ -505,9 +505,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // * From T to any interface type I in T's effective interface set, and
             //   from T to any base interface of I.
             TypeArray pInterfaces = pSource.GetInterfaceBounds();
-            for (int i = 0; i < pInterfaces.Size; ++i)
+            for (int i = 0; i < pInterfaces.Count; ++i)
             {
-                if (pInterfaces.Item(i) == pDest)
+                if (pInterfaces[i] == pDest)
                 {
                     return true;
                 }
@@ -534,9 +534,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             while (atsDer != null)
             {
                 TypeArray ifacesAll = atsDer.GetIfacesAll();
-                for (int i = 0; i < ifacesAll.size; i++)
+                for (int i = 0; i < ifacesAll.Count; i++)
                 {
-                    if (HasInterfaceConversion(ifacesAll.Item(i).AsAggregateType(), pBase.AsAggregateType()))
+                    if (HasInterfaceConversion(ifacesAll[i].AsAggregateType(), pBase.AsAggregateType()))
                     {
                         return true;
                     }
@@ -595,19 +595,19 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             TypeArray pSourceArgs = pSource.GetTypeArgsAll();
             TypeArray pDestArgs = pDest.GetTypeArgsAll();
 
-            Debug.Assert(pTypeParams.size == pSourceArgs.size);
-            Debug.Assert(pTypeParams.size == pDestArgs.size);
+            Debug.Assert(pTypeParams.Count == pSourceArgs.Count);
+            Debug.Assert(pTypeParams.Count == pDestArgs.Count);
 
-            for (int iParam = 0; iParam < pTypeParams.size; ++iParam)
+            for (int iParam = 0; iParam < pTypeParams.Count; ++iParam)
             {
-                CType pSourceArg = pSourceArgs.Item(iParam);
-                CType pDestArg = pDestArgs.Item(iParam);
+                CType pSourceArg = pSourceArgs[iParam];
+                CType pDestArg = pDestArgs[iParam];
                 // If they're identical then this one is automatically good, so skip it.
                 if (pSourceArg == pDestArg)
                 {
                     continue;
                 }
-                TypeParameterType pParam = pTypeParams.Item(iParam).AsTypeParameterType();
+                TypeParameterType pParam = pTypeParams[iParam].AsTypeParameterType();
                 if (pParam.Invariant)
                 {
                     return false;
@@ -664,9 +664,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             // * From T to any interface type I in T's effective interface set, and
             //   from T to any base interface of I.
             TypeArray pInterfaces = pSource.GetInterfaceBounds();
-            for (int i = 0; i < pInterfaces.Size; ++i)
+            for (int i = 0; i < pInterfaces.Count; ++i)
             {
-                if (pInterfaces.Item(i) == pDest)
+                if (pInterfaces[i] == pDest)
                 {
                     return true;
                 }
@@ -824,9 +824,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 while (derived != null)
                 {
-                    for (int i = 0; i < derived.GetIfacesAll().Size; i++)
+                    for (int i = 0; i < derived.GetIfacesAll().Count; i++)
                     {
-                        AggregateType iface = derived.GetIfacesAll().Item(i).AsAggregateType();
+                        AggregateType iface = derived.GetIfacesAll()[i].AsAggregateType();
                         if (iface.getAggregate() == @base)
                             return true;
                     }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
@@ -139,18 +139,18 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 return BetterType.Same;
             }
-            if (ta1.Size != ta2.Size)
+            if (ta1.Count != ta2.Count)
             {
                 // The one with more parameters is more specific.
-                return ta1.Size > ta2.Size ? BetterType.Left : BetterType.Right;
+                return ta1.Count > ta2.Count ? BetterType.Left : BetterType.Right;
             }
 
             BetterType nTot = BetterType.Neither;
 
-            for (int i = 0; i < ta1.Size; i++)
+            for (int i = 0; i < ta1.Count; i++)
             {
-                CType type1 = ta1.Item(i);
-                CType type2 = ta2.Item(i);
+                CType type1 = ta1[i];
+                CType type2 = ta2[i];
                 BetterType nParam = BetterType.Neither;
 
             LAgain:
@@ -372,7 +372,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public TypeArray AllocParams(int ctype, TypeArray array, int offset)
         {
-            CType[] types = array.ToArray();
+            CType[] types = array.Items;
             CType[] newTypes = new CType[ctype];
             Array.ConstrainedCopy(types, offset, newTypes, 0, ctype);
             return AllocParams(newTypes);
@@ -404,7 +404,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public TypeArray ConcatParams(TypeArray pta1, TypeArray pta2)
         {
-            return ConcatParams(pta1.ToArray(), pta2.ToArray());
+            return ConcatParams(pta1.Items, pta2.Items);
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Visitors/ExpressionTreeRewriter.cs
@@ -1221,8 +1221,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Debug.Assert(orig1 != null && orig2 != null);
             EXPR new1 = pp1;
             EXPR new2 = pp2;
-            CType fptype1 = method.Params.Item(0);
-            CType fptype2 = method.Params.Item(1);
+            CType fptype1 = method.Params[0];
+            CType fptype2 = method.Params[1];
             CType aatype1 = orig1.type;
             CType aatype2 = orig2.type;
             // Is the operator even a candidate for lifting?

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/TypeBind.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             AggregateType ats = type.AsAggregateType();
 
-            if (ats.GetTypeArgsAll().size == 0)
+            if (ats.GetTypeArgsAll().Count == 0)
             {
                 // Common case: there are no type vars, so there are no constraints.
                 ats.fConstraintsChecked = true;
@@ -72,7 +72,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             TypeArray typeArgsThis = ats.GetTypeArgsThis();
             TypeArray typeArgsAll = ats.GetTypeArgsAll();
 
-            Debug.Assert(typeVars.size == typeArgsThis.size);
+            Debug.Assert(typeVars.Count == typeArgsThis.Count);
 
             if (!ats.fConstraintsChecked)
             {
@@ -88,13 +88,13 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 ats.fConstraintError |= ats.outerType.fConstraintError;
             }
 
-            if (typeVars.size > 0)
+            if (typeVars.Count > 0)
                 ats.fConstraintError |= !CheckConstraintsCore(checker, errHandling, ats.getAggregate(), typeVars, typeArgsThis, typeArgsAll, null, (flags & CheckConstraintsFlags.NoErrors));
 
             // Now check type args themselves.
-            for (int i = 0; i < typeArgsThis.size; i++)
+            for (int i = 0; i < typeArgsThis.Count; i++)
             {
-                CType arg = typeArgsThis.Item(i).GetNakedType(true);
+                CType arg = typeArgsThis[i].GetNakedType(true);
                 if (arg.IsAggregateType() && !arg.AsAggregateType().fConstraintsChecked)
                 {
                     CheckConstraints(checker, errHandling, arg.AsAggregateType(), flags | CheckConstraintsFlags.Outer);
@@ -110,10 +110,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public static void CheckMethConstraints(CSemanticChecker checker, ErrorHandling errCtx, MethWithInst mwi)
         {
             Debug.Assert(mwi.Meth() != null && mwi.GetType() != null && mwi.TypeArgs != null);
-            Debug.Assert(mwi.Meth().typeVars.size == mwi.TypeArgs.size);
+            Debug.Assert(mwi.Meth().typeVars.Count == mwi.TypeArgs.Count);
             Debug.Assert(mwi.GetType().getAggregate() == mwi.Meth().getClass());
 
-            if (mwi.TypeArgs.size > 0)
+            if (mwi.TypeArgs.Count > 0)
             {
                 CheckConstraintsCore(checker, errCtx, mwi.Meth(), mwi.Meth().typeVars, mwi.TypeArgs, mwi.GetType().GetTypeArgsAll(), mwi.TypeArgs, CheckConstraintsFlags.None);
             }
@@ -125,17 +125,17 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private static bool CheckConstraintsCore(CSemanticChecker checker, ErrorHandling errHandling, Symbol symErr, TypeArray typeVars, TypeArray typeArgs, TypeArray typeArgsCls, TypeArray typeArgsMeth, CheckConstraintsFlags flags)
         {
-            Debug.Assert(typeVars.size == typeArgs.size);
-            Debug.Assert(typeVars.size > 0);
+            Debug.Assert(typeVars.Count == typeArgs.Count);
+            Debug.Assert(typeVars.Count > 0);
             Debug.Assert(flags == CheckConstraintsFlags.None || flags == CheckConstraintsFlags.NoErrors);
 
             bool fError = false;
 
-            for (int i = 0; i < typeVars.size; i++)
+            for (int i = 0; i < typeVars.Count; i++)
             {
                 // Empty bounds should be set to object.
                 TypeParameterType var = typeVars.ItemAsTypeParameterType(i);
-                CType arg = typeArgs.Item(i);
+                CType arg = typeArgs[i];
 
                 bool fOK = CheckSingleConstraint(checker, errHandling, symErr, var, arg, typeArgsCls, typeArgsMeth, flags);
                 fError |= !fOK;
@@ -218,9 +218,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 if (bIsValueType && arg.IsTypeParameterType())
                 {
                     TypeArray pArgBnds = arg.AsTypeParameterType().GetBounds();
-                    if (pArgBnds.size > 0)
+                    if (pArgBnds.Count > 0)
                     {
-                        bIsNullable = pArgBnds.Item(0).IsNullableType();
+                        bIsNullable = pArgBnds[0].IsNullableType();
                     }
                 }
 
@@ -235,15 +235,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
 
                 // Since FValCon() is set it is redundant to check System.ValueType as well.
-                if (bnds.size != 0 && bnds.Item(0).isPredefType(PredefinedType.PT_VALUE))
+                if (bnds.Count != 0 && bnds[0].isPredefType(PredefinedType.PT_VALUE))
                 {
                     itypeMin = 1;
                 }
             }
 
-            for (int j = itypeMin; j < bnds.size; j++)
+            for (int j = itypeMin; j < bnds.Count; j++)
             {
-                CType typeBnd = bnds.Item(j);
+                CType typeBnd = bnds[j];
                 if (!SatisfiesBound(checker, arg, typeBnd))
                 {
                     if (fReportErrors)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/AggregateType.cs
@@ -122,12 +122,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             TypeArray pCheckedOuterTypeArgs = outerTypeArgs;
             TypeManager pTypeManager = getAggregate().GetTypeManager();
 
-            if (_pTypeArgsThis.Size > 0 && AreAllTypeArgumentsUnitTypes(_pTypeArgsThis))
+            if (_pTypeArgsThis.Count > 0 && AreAllTypeArgumentsUnitTypes(_pTypeArgsThis))
             {
-                if (outerTypeArgs.Size > 0 && !AreAllTypeArgumentsUnitTypes(outerTypeArgs))
+                if (outerTypeArgs.Count > 0 && !AreAllTypeArgumentsUnitTypes(outerTypeArgs))
                 {
                     // We have open placeholder types in our type, but not the parent.
-                    pCheckedOuterTypeArgs = pTypeManager.CreateArrayOfUnitTypes(outerTypeArgs.Size);
+                    pCheckedOuterTypeArgs = pTypeManager.CreateArrayOfUnitTypes(outerTypeArgs.Count);
                 }
             }
             _pTypeArgsAll = pTypeManager.ConcatenateTypeArrays(pCheckedOuterTypeArgs, _pTypeArgsThis);
@@ -135,15 +135,15 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         private bool AreAllTypeArgumentsUnitTypes(TypeArray typeArray)
         {
-            if (typeArray.Size == 0)
+            if (typeArray.Count == 0)
             {
                 return true;
             }
 
-            for (int i = 0; i < typeArray.size; i++)
+            for (int i = 0; i < typeArray.Count; i++)
             {
-                Debug.Assert(typeArray.Item(i) != null);
-                if (!typeArray.Item(i).IsOpenTypePlaceholderType())
+                Debug.Assert(typeArray[i] != null);
+                if (!typeArray[i].IsOpenTypePlaceholderType())
                 {
                     return false;
                 }
@@ -177,9 +177,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 TypeArray ifaces = GetIfacesAll();
                 System.Collections.Generic.List<CType> typeList = new System.Collections.Generic.List<CType>();
 
-                for (int i = 0; i < ifaces.size; i++)
+                for (int i = 0; i < ifaces.Count; i++)
                 {
-                    AggregateType type = ifaces.Item(i).AsAggregateType();
+                    AggregateType type = ifaces[i].AsAggregateType();
                     Debug.Assert(type.isInterfaceType());
 
                     if (type.IsCollectionType())

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/PredefinedTypes.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/PredefinedTypes.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                  aggCur != null;
                  aggCur = BSYMMGR.LookupNextSym(aggCur, bag, symbmask_t.MASK_AggregateSymbol).AsAggregateSymbol())
             {
-                if (!aggCur.InAlias(aid) || aggCur.GetTypeVarsAll().size != arity)
+                if (!aggCur.InAlias(aid) || aggCur.GetTypeVarsAll().Count != arity)
                 {
                     continue;
                 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -169,14 +169,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             List<Type> list = new List<Type>();
 
             // Get each type arg.
-            for (int i = 0; i < typeArgs.size; i++)
+            for (int i = 0; i < typeArgs.Count; i++)
             {
                 // Unnamed type parameter types are just placeholders.
-                if (typeArgs.Item(i).IsTypeParameterType() && typeArgs.Item(i).AsTypeParameterType().GetTypeParameterSymbol().name == null)
+                if (typeArgs[i].IsTypeParameterType() && typeArgs[i].AsTypeParameterType().GetTypeParameterSymbol().name == null)
                 {
                     return null;
                 }
-                list.Add(typeArgs.Item(i).AssociatedSystemType);
+                list.Add(typeArgs[i].AssociatedSystemType);
             }
 
             Type[] systemTypeArgs = list.ToArray();
@@ -244,9 +244,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 case TypeKind.TK_AggregateType:
                     fBogus = AsAggregateType().getAggregate().computeCurrentBogusState();
-                    for (int i = 0; !fBogus && i < AsAggregateType().GetTypeArgsAll().size; i++)
+                    for (int i = 0; !fBogus && i < AsAggregateType().GetTypeArgsAll().Count; i++)
                     {
-                        fBogus |= AsAggregateType().GetTypeArgsAll().Item(i).computeCurrentBogusState();
+                        fBogus |= AsAggregateType().GetTypeArgsAll()[i].computeCurrentBogusState();
                     }
                     break;
 
@@ -655,7 +655,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         }
 
                         // Generics are always managed.
-                        if (aggT.GetTypeVarsAll().size > 0)
+                        if (aggT.GetTypeVarsAll().Count > 0)
                         {
                             aggT.SetManagedStruct(true);
                             return true;
@@ -698,7 +698,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             if (isPredefType(PredefinedType.PT_G_EXPRESSION))
             {
-                return AsAggregateType().GetTypeArgsThis().Item(0);
+                return AsAggregateType().GetTypeArgsThis()[0];
             }
 
             return this;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeArray.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeArray.cs
@@ -9,58 +9,31 @@ using System.Linq;
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     /////////////////////////////////////////////////////////////////////////////////
-    // Encapsulates a type list, including its size and metadata token.
+    // Encapsulates a type list, including its size.
 
     internal sealed class TypeArray
     {
-        private readonly CType[] _items;
-
         public TypeArray(CType[] types)
         {
-            _items = types;
-            if (_items == null)
-            {
-                _items = Array.Empty<CType>();
-            }
+            Debug.Assert(types != null);
+            Items = types;
         }
 
-        public int Size { get { return _items.Length; } }
-        public int size { get { return Size; } }
+        public int Count => Items.Length;
 
-        public bool HasErrors() { return false; }
-        public CType Item(int i) { return _items[i]; }
-        public TypeParameterType ItemAsTypeParameterType(int i) { return _items[i].AsTypeParameterType(); }
+        public TypeParameterType ItemAsTypeParameterType(int i) => Items[i].AsTypeParameterType();
 
-        public CType[] ToArray() { return _items.ToArray(); }
+        public CType[] Items { get; }
 
-        [System.Runtime.CompilerServices.IndexerName("EyeTim")]
-        public CType this[int i]
-        {
-            get { return _items[i]; }
-        }
+        public CType this[int i] => Items[i];
 
-        public int Count
-        {
-            get { return _items.Length; }
-        }
-
-#if DEBUG
+        [Conditional("DEBUG")]
         public void AssertValid()
         {
-            Debug.Assert(size >= 0);
-            for (int i = 0; i < size; i++)
-            {
-                Debug.Assert(_items[i] != null);
-            }
+            Debug.Assert(Count >= 0);
+            Debug.Assert(Items.All(item => item != null));
         }
-#endif
 
-        public void CopyItems(int i, int c, CType[] dest)
-        {
-            for (int j = 0; j < c; ++j)
-            {
-                dest[j] = _items[i + j];
-            }
-        }
+        public void CopyItems(int i, int c, CType[] dest) => Array.Copy(Items, i, dest, 0, c);
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -105,9 +105,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     }
 
                     TypeArray typeArgsAll = ctype.AsAggregateType().GetTypeArgsAll();
-                    for (int i = 0; i < typeArgsAll.size; i++)
+                    for (int i = 0; i < typeArgsAll.Count; i++)
                     {
-                        CType typeArg = typeArgsAll.Item(i);
+                        CType typeArg = typeArgsAll[i];
 
                         if (TypeContainsAnonymousTypes(typeArg))
                         {
@@ -219,7 +219,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 typeArgs = BSYMMGR.EmptyTypeArray();
             }
 
-            Debug.Assert(agg.GetTypeVars().Size == typeArgs.Size);
+            Debug.Assert(agg.GetTypeVars().Count == typeArgs.Count);
 
             Name name = _BSymmgr.GetNameFromPtrs(typeArgs, atsOuter);
             Debug.Assert(name != null);
@@ -236,7 +236,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
                 Debug.Assert(!pAggregate.fConstraintsChecked && !pAggregate.fConstraintError);
 
-                pAggregate.SetErrors(pAggregate.GetTypeArgsAll().HasErrors());
+                pAggregate.SetErrors(false);
 #if CSEE
 
                 SpecializedSymbolCreationEE* pSymCreate = static_cast<SpecializedSymbolCreationEE*>(m_BSymmgr.GetSymFactory().m_pSpecializedSymbolCreation);
@@ -281,7 +281,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
             else
             {
-                Debug.Assert(pAggregate.HasErrors() == pAggregate.GetTypeArgsAll().HasErrors());
+                Debug.Assert(!pAggregate.HasErrors());
             }
 
             Debug.Assert(pAggregate.getAggregate() == agg);
@@ -293,9 +293,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public AggregateType GetAggregate(AggregateSymbol agg, TypeArray typeArgsAll)
         {
-            Debug.Assert(typeArgsAll != null && typeArgsAll.Size == agg.GetTypeVarsAll().Size);
+            Debug.Assert(typeArgsAll != null && typeArgsAll.Count == agg.GetTypeVarsAll().Count);
 
-            if (typeArgsAll.size == 0)
+            if (typeArgsAll.Count == 0)
                 return agg.getThisType();
 
             AggregateSymbol aggOuter = agg.GetOuterAgg();
@@ -303,11 +303,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             if (aggOuter == null)
                 return GetAggregate(agg, null, typeArgsAll);
 
-            int cvarOuter = aggOuter.GetTypeVarsAll().Size;
-            Debug.Assert(cvarOuter <= typeArgsAll.Size);
+            int cvarOuter = aggOuter.GetTypeVarsAll().Count;
+            Debug.Assert(cvarOuter <= typeArgsAll.Count);
 
             TypeArray typeArgsOuter = _BSymmgr.AllocParams(cvarOuter, typeArgsAll, 0);
-            TypeArray typeArgsInner = _BSymmgr.AllocParams(agg.GetTypeVars().Size, typeArgsAll, cvarOuter);
+            TypeArray typeArgsInner = _BSymmgr.AllocParams(agg.GetTypeVars().Count, typeArgsAll, cvarOuter);
             AggregateType atsOuter = GetAggregate(aggOuter, typeArgsOuter);
 
             return GetAggregate(agg, atsOuter, typeArgsInner);
@@ -356,7 +356,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public NullableType GetNubFromNullable(AggregateType ats)
         {
             Debug.Assert(ats.isPredefType(PredefinedType.PT_G_OPTIONAL));
-            return GetNullable(ats.GetTypeArgsAll().Item(0));
+            return GetNullable(ats.GetTypeArgsAll()[0]);
         }
 
         public ParameterModifierType GetParameterModifier(CType paramType, bool isOut)
@@ -502,20 +502,20 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public TypeArray SubstTypeArray(TypeArray taSrc, SubstContext pctx)
         {
-            if (taSrc == null || taSrc.Size == 0 || pctx == null || pctx.FNop())
+            if (taSrc == null || taSrc.Count == 0 || pctx == null || pctx.FNop())
                 return taSrc;
 
-            CType[] prgpts = new CType[taSrc.Size];
-            for (int ipts = 0; ipts < taSrc.Size; ipts++)
+            CType[] prgpts = new CType[taSrc.Count];
+            for (int ipts = 0; ipts < taSrc.Count; ipts++)
             {
-                prgpts[ipts] = this.SubstTypeCore(taSrc.Item(ipts), pctx);
+                prgpts[ipts] = this.SubstTypeCore(taSrc[ipts], pctx);
             }
-            return _BSymmgr.AllocParams(taSrc.size, prgpts);
+            return _BSymmgr.AllocParams(taSrc.Count, prgpts);
         }
 
         private TypeArray SubstTypeArray(TypeArray taSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth, SubstTypeFlags grfst)
         {
-            if (taSrc == null || taSrc.Size == 0)
+            if (taSrc == null || taSrc.Count == 0)
                 return taSrc;
 
             var ctx = new SubstContext(typeArgsCls, typeArgsMeth, grfst);
@@ -523,12 +523,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             if (ctx.FNop())
                 return taSrc;
 
-            CType[] prgpts = new CType[taSrc.Size];
-            for (int ipts = 0; ipts < taSrc.Size; ipts++)
+            CType[] prgpts = new CType[taSrc.Count];
+            for (int ipts = 0; ipts < taSrc.Count; ipts++)
             {
-                prgpts[ipts] = SubstTypeCore(taSrc.Item(ipts), ctx);
+                prgpts[ipts] = SubstTypeCore(taSrc[ipts], ctx);
             }
-            return _BSymmgr.AllocParams(taSrc.Size, prgpts);
+            return _BSymmgr.AllocParams(taSrc.Count, prgpts);
         }
 
         public TypeArray SubstTypeArray(TypeArray taSrc, TypeArray typeArgsCls, TypeArray typeArgsMeth)
@@ -579,7 +579,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return (typeDst == typeSrc) ? type : GetNullable(typeDst);
 
                 case TypeKind.TK_AggregateType:
-                    if (type.AsAggregateType().GetTypeArgsAll().size > 0)
+                    if (type.AsAggregateType().GetTypeArgsAll().Count > 0)
                     {
                         AggregateType ats = type.AsAggregateType();
 
@@ -662,9 +662,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 // Debug.Assert(taDst == SubstTypeArray(taSrc, typeArgsCls, typeArgsMeth, grfst));
                 return true;
             }
-            if (taDst.Size != taSrc.Size)
+            if (taDst.Count != taSrc.Count)
                 return false;
-            if (taDst.Size == 0)
+            if (taDst.Count == 0)
                 return true;
 
             var ctx = new SubstContext(typeArgsCls, typeArgsMeth, grfst);
@@ -672,9 +672,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             if (ctx.FNop())
                 return false;
 
-            for (int i = 0; i < taDst.size; i++)
+            for (int i = 0; i < taDst.Count; i++)
             {
-                if (!SubstEqualTypesCore(taDst.Item(i), taSrc.Item(i), ctx))
+                if (!SubstEqualTypesCore(taDst[i], taSrc[i], ctx))
                     return false;
             }
 
@@ -734,12 +734,12 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         if (atsSrc.getAggregate() != atsDst.getAggregate())
                             return false;
 
-                        Debug.Assert(atsSrc.GetTypeArgsAll().Size == atsDst.GetTypeArgsAll().Size);
+                        Debug.Assert(atsSrc.GetTypeArgsAll().Count == atsDst.GetTypeArgsAll().Count);
 
                         // All the args must unify.
-                        for (int i = 0; i < atsSrc.GetTypeArgsAll().Size; i++)
+                        for (int i = 0; i < atsSrc.GetTypeArgsAll().Count; i++)
                         {
-                            if (!SubstEqualTypesCore(atsDst.GetTypeArgsAll().Item(i), atsSrc.GetTypeArgsAll().Item(i), pctx))
+                            if (!SubstEqualTypesCore(atsDst.GetTypeArgsAll()[i], atsSrc.GetTypeArgsAll()[i], pctx))
                                 return false;
                         }
                     }
@@ -754,7 +754,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         Debug.Assert(errSrc.nameText != null && errSrc.typeArgs != null);
                         Debug.Assert(errDst.nameText != null && errDst.typeArgs != null);
 
-                        if (errSrc.nameText != errDst.nameText || errSrc.typeArgs.Size != errDst.typeArgs.Size)
+                        if (errSrc.nameText != errDst.nameText || errSrc.typeArgs.Count != errDst.typeArgs.Count)
                             return false;
 
                         if (errSrc.HasTypeParent() != errDst.HasTypeParent())
@@ -781,9 +781,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         }
 
                         // All the args must unify.
-                        for (int i = 0; i < errSrc.typeArgs.Size; i++)
+                        for (int i = 0; i < errSrc.typeArgs.Count; i++)
                         {
-                            if (!SubstEqualTypesCore(errDst.typeArgs.Item(i), errSrc.typeArgs.Item(i), pctx))
+                            if (!SubstEqualTypesCore(errDst.typeArgs[i], errSrc.typeArgs[i], pctx))
                                 return false;
                         }
                     }
@@ -868,9 +868,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     { // BLOCK
                         AggregateType ats = type.AsAggregateType();
 
-                        for (int i = 0; i < ats.GetTypeArgsAll().Size; i++)
+                        for (int i = 0; i < ats.GetTypeArgsAll().Count; i++)
                         {
-                            if (TypeContainsType(ats.GetTypeArgsAll().Item(i), typeFind))
+                            if (TypeContainsType(ats.GetTypeArgsAll()[i], typeFind))
                                 return true;
                         }
                     }
@@ -882,9 +882,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         ErrorType err = type.AsErrorType();
                         Debug.Assert(err.nameText != null && err.typeArgs != null);
 
-                        for (int i = 0; i < err.typeArgs.Size; i++)
+                        for (int i = 0; i < err.typeArgs.Count; i++)
                         {
-                            if (TypeContainsType(err.typeArgs.Item(i), typeFind))
+                            if (TypeContainsType(err.typeArgs[i], typeFind))
                                 return true;
                         }
                         if (err.HasTypeParent())
@@ -928,9 +928,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     { // BLOCK
                         AggregateType ats = type.AsAggregateType();
 
-                        for (int i = 0; i < ats.GetTypeArgsAll().Size; i++)
+                        for (int i = 0; i < ats.GetTypeArgsAll().Count; i++)
                         {
-                            if (TypeContainsTyVars(ats.GetTypeArgsAll().Item(i), typeVars))
+                            if (TypeContainsTyVars(ats.GetTypeArgsAll()[i], typeVars))
                             {
                                 return true;
                             }
@@ -944,9 +944,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                         ErrorType err = type.AsErrorType();
                         Debug.Assert(err.nameText != null && err.typeArgs != null);
 
-                        for (int i = 0; i < err.typeArgs.Size; i++)
+                        for (int i = 0; i < err.typeArgs.Count; i++)
                         {
-                            if (TypeContainsTyVars(err.typeArgs.Item(i), typeVars))
+                            if (TypeContainsTyVars(err.typeArgs[i], typeVars))
                             {
                                 return true;
                             }
@@ -960,10 +960,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     return false;
 
                 case TypeKind.TK_TypeParameterType:
-                    if (typeVars != null && typeVars.Size > 0)
+                    if (typeVars != null && typeVars.Count > 0)
                     {
                         int ivar = type.AsTypeParameterType().GetIndexInTotalParameters();
-                        return ivar < typeVars.Size && type == typeVars.Item(ivar);
+                        return ivar < typeVars.Count && type == typeVars[ivar];
                     }
                     return true;
             }
@@ -973,7 +973,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(@params != null);
             Debug.Assert(typeFind != null);
-            for (int p = 0; p < @params.size; p++)
+            for (int p = 0; p < @params.Count; p++)
             {
                 CType sym = @params[p];
                 if (TypeContainsType(sym, typeFind))
@@ -1214,25 +1214,25 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
             TypeArray typeArgs = typeSrc.GetTypeArgsThis();
             TypeArray typeParams = aggOpenType.GetTypeArgsThis();
-            CType[] newTypeArgsTemp = new CType[typeArgs.size];
+            CType[] newTypeArgsTemp = new CType[typeArgs.Count];
 
-            for (int i = 0; i < typeArgs.size; i++)
+            for (int i = 0; i < typeArgs.Count; i++)
             {
-                if (semanticChecker.CheckTypeAccess(typeArgs.Item(i), bindingContext.ContextForMemberLookup()))
+                if (semanticChecker.CheckTypeAccess(typeArgs[i], bindingContext.ContextForMemberLookup()))
                 {
                     // we have an accessible argument, this position is not a problem.
-                    newTypeArgsTemp[i] = typeArgs.Item(i);
+                    newTypeArgsTemp[i] = typeArgs[i];
                     continue;
                 }
 
-                if (!typeArgs.Item(i).IsRefType() || !typeParams.Item(i).AsTypeParameterType().Covariant)
+                if (!typeArgs[i].IsRefType() || !typeParams[i].AsTypeParameterType().Covariant)
                 {
                     // This guy is inaccessible, and we are not going to be able to vary him, so we need to fail.
                     return false;
                 }
 
                 CType intermediateTypeArg;
-                if (GetBestAccessibleType(semanticChecker, bindingContext, typeArgs.Item(i), out intermediateTypeArg))
+                if (GetBestAccessibleType(semanticChecker, bindingContext, typeArgs[i], out intermediateTypeArg))
                 {
                     // now we either have a value type (which must be accessible due to the above
                     // check, OR we have an inaccessible type (which must be a ref type). In either
@@ -1247,7 +1247,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
             }
 
-            TypeArray newTypeArgs = semanticChecker.getBSymmgr().AllocParams(typeArgs.size, newTypeArgsTemp);
+            TypeArray newTypeArgs = semanticChecker.getBSymmgr().AllocParams(typeArgs.Count, newTypeArgsTemp);
             CType intermediateType = this.GetAggregate(aggSym, typeSrc.outerType, newTypeArgs);
 
             // All type arguments were varied successfully, which means now we must be accessible. But we could

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeParameterType.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeParameterType.cs
@@ -26,9 +26,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             //   U then S depends on U.
 
             TypeArray pConstraints = GetBounds();
-            for (int iConstraint = 0; iConstraint < pConstraints.size; ++iConstraint)
+            for (int iConstraint = 0; iConstraint < pConstraints.Count; ++iConstraint)
             {
-                CType pConstraint = pConstraints.Item(iConstraint);
+                CType pConstraint = pConstraints[iConstraint];
                 if (pConstraint == pType)
                 {
                     return true;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/UtilityTypeExtensions.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/UtilityTypeExtensions.cs
@@ -13,14 +13,14 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(type != null);
             yield return type;
-            foreach (AggregateType t in type.GetIfacesAll().ToArray())
+            foreach (AggregateType t in type.GetIfacesAll().Items)
                 yield return t;
         }
 
         private static IEnumerable<AggregateType> AllConstraintInterfaces(this TypeArray constraints)
         {
             Debug.Assert(constraints != null);
-            foreach (AggregateType c in constraints.ToArray())
+            foreach (AggregateType c in constraints.Items)
                 foreach (AggregateType t in c.InterfaceAndBases())
                     yield return t;
         }
@@ -40,7 +40,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         {
             Debug.Assert(type != null);
             foreach (AggregateType b in type.TypeAndBaseClasses())
-                foreach (AggregateType t in b.GetIfacesAll().ToArray())
+                foreach (AggregateType t in b.GetIfacesAll().Items)
                     yield return t;
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -320,9 +320,9 @@ namespace Microsoft.CSharp.RuntimeBinder
             {
                 TypeArray collectioniFaces = ctype.AsAggregateType().GetWinRTCollectionIfacesAll(_semanticChecker.GetSymbolLoader());
 
-                for (int i = 0; i < collectioniFaces.size; i++)
+                for (int i = 0; i < collectioniFaces.Count; i++)
                 {
-                    CType collectionType = collectioniFaces.Item(i);
+                    CType collectionType = collectioniFaces[i];
                     Debug.Assert(collectionType.isInterfaceType());
 
                     // Insert into our list of Types.
@@ -408,7 +408,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 Type genericDefinition = type.GetGenericTypeDefinition();
                 Type[] genericArguments = genericDefinition.GetGenericArguments();
                 List<CType> ctypes = new List<CType>();
-                int outerParameters = agg.isNested() ? agg.GetOuterAgg().GetTypeVarsAll().size : 0;
+                int outerParameters = agg.isNested() ? agg.GetOuterAgg().GetTypeVarsAll().Count : 0;
 
                 for (int i = 0; i < genericArguments.Length; i++)
                 {
@@ -940,7 +940,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 agg != null;
                 agg = BSYMMGR.LookupNextSym(agg, agg.Parent, symbmask_t.MASK_AggregateSymbol) as AggregateSymbol)
             {
-                if (agg.GetTypeVarsAll().size == type.GetGenericArguments().Length)
+                if (agg.GetTypeVarsAll().Count == type.GetGenericArguments().Length)
                 {
                     return agg;
                 }
@@ -1093,12 +1093,12 @@ namespace Microsoft.CSharp.RuntimeBinder
                 Type[] genericArguments = genericDefinition.GetGenericArguments();
 
                 // After we load the type parameters, we need to resolve their bounds.
-                for (int i = 0; i < agg.GetTypeVars().size; i++)
+                for (int i = 0; i < agg.GetTypeVars().Count; i++)
                 {
                     Type t = genericArguments[i];
-                    if (agg.GetTypeVars().Item(i).IsTypeParameterType())
+                    if (agg.GetTypeVars()[i].IsTypeParameterType())
                     {
-                        agg.GetTypeVars().Item(i).AsTypeParameterType().GetTypeParameterSymbol().SetBounds(
+                        agg.GetTypeVars()[i].AsTypeParameterType().GetTypeParameterSymbol().SetBounds(
                             _bsymmgr.AllocParams(
                             GetCTypeArrayFromTypes(t.GetGenericParameterConstraints())));
                     }
@@ -1312,7 +1312,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             Type eventRegistrationTokenType = EventRegistrationTokenType;
             if ((object)eventRegistrationTokenType != null && (object)WindowsRuntimeMarshalType != null &&
                 ev.methAdd.RetType.AssociatedSystemType == eventRegistrationTokenType &&
-                ev.methRemove.Params.Item(0).AssociatedSystemType == eventRegistrationTokenType)
+                ev.methRemove.Params[0].AssociatedSystemType == eventRegistrationTokenType)
             {
                 ev.IsWindowsRuntimeEvent = true;
             }
@@ -1464,7 +1464,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
                 // If we have an indexed property, leave the method as a method we can call,
                 // and mark the property as bogus.
-                if (isIndexer || prop.methGet.Params.size == 0)
+                if (isIndexer || prop.methGet.Params.Count == 0)
                 {
                     prop.methGet.SetProperty(prop);
                 }
@@ -1485,7 +1485,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
                 // If we have an indexed property, leave the method as a method we can call,
                 // and mark the property as bogus.
-                if (isIndexer || prop.methSet.Params.size == 1)
+                if (isIndexer || prop.methSet.Params.Count == 1)
                 {
                     prop.methSet.SetProperty(prop);
                 }
@@ -2066,7 +2066,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             if (t.IsTypeParameterType())
             {
                 // Add conversions for the bounds.
-                foreach (CType bound in t.AsTypeParameterType().GetBounds().ToArray())
+                foreach (CType bound in t.AsTypeParameterType().GetBounds().Items)
                 {
                     AddConversionsForType(bound.AssociatedSystemType);
                 }


### PR DESCRIPTION
Clean-up:

Has `Size`, `size` and `Count` properties all doing the same thing. Consolidate into a single property. While `size` is the most heavily used and `Count` the least, `Count` is the most .NET idiomatic, so leave it as the sole property.

Has both `Item()` method and indexer. Replace use of `Item()` with use of indexer, and remove `Item()` method.

Debug-only `AssertValid()` method can be made conditional rather than wrapped in `#if`/`#endif` for cleaner use. While this means it will be compiled to the release build rewriting the assertion within it to be a single linq operation means it will be compiled as an empty method for those so the cost in IL size is much less than the savings made above.

Optimise:

`HasErrors` property is hard-coded to return false and therefore of not really checking anything. Remove.

All uses of `ToArray()` do not mutate the resultant array so exposing the `_items` field as a public `Items` property is safe, and avoids many allocations and copies.

Constructor is never called with null, so remove null path, but assert that null isn't passed.