### PR TITLE
Add tests for debugger displays for some collections

### DIFF
--- a/src/System.Collections.NonGeneric/tests/QueueTests.cs
+++ b/src/System.Collections.NonGeneric/tests/QueueTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -101,8 +102,17 @@ namespace System.Collections.Tests
             testQueue.Enqueue(1);
             testQueue.Enqueue("b");
             testQueue.Enqueue(2);
-            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(testQueue);
 
+            DebuggerAttributeInfo debuggerAttribute = DebuggerAttributes.ValidateDebuggerTypeProxyProperties(testQueue);
+            PropertyInfo infoProperty = debuggerAttribute.Properties.Single(property => property.Name == "Items");
+            object[] items = (object[])infoProperty.GetValue(debuggerAttribute.Instance);
+
+            Assert.Equal(testQueue.ToArray(), items);
+        }
+
+        [Fact]
+        public static void DebuggerAttribute_NullQueue_ThrowsArgumentNullException()
+        {
             bool threwNull = false;
             try
             {

--- a/src/System.Collections.NonGeneric/tests/SortedListTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedListTests.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
@@ -211,15 +212,54 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void DebuggerAttribute()
+        public static void DebuggerAttribute_Empty()
+        {
+            Assert.Equal("Count = 0", DebuggerAttributes.ValidateDebuggerDisplayReferences(new SortedList()));
+        }
+
+        [Fact]
+        public static void DebuggerAttribute_NormalList()
         {
             var list = new SortedList() { { "a", 1 }, { "b", 2 } };
+            DebuggerAttributeInfo debuggerAttribute = DebuggerAttributes.ValidateDebuggerTypeProxyProperties(list);
+            PropertyInfo infoProperty = debuggerAttribute.Properties.Single(property => property.Name == "Items");
+            object[] items = (object[])infoProperty.GetValue(debuggerAttribute.Instance);
 
-            DebuggerAttributes.ValidateDebuggerDisplayReferences(new SortedList());
+            Assert.Equal(list.Count, items.Length);
+            for (int i = 0; i < list.Count; i++)
+            {
+                object item = items[i];
+                object key = item.GetType().GetField("_key", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(item);
+                object value = item.GetType().GetField("_value", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(item);
 
-            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(list);
-            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(typeof(SortedList), SortedList.Synchronized(list));
+                Assert.Equal(i, list.IndexOfKey(key));
+                Assert.Equal(i, list.IndexOfValue(value));
+            }
+        }
 
+        [Fact]
+        public static void DebuggerAttribute_SynchronizedList()
+        {
+            var list = SortedList.Synchronized(new SortedList() { { "a", 1 }, { "b", 2 } });
+            DebuggerAttributeInfo debuggerAttribute = DebuggerAttributes.ValidateDebuggerTypeProxyProperties(typeof(SortedList), list);
+            PropertyInfo infoProperty = debuggerAttribute.Properties.Single(property => property.Name == "Items");
+            object[] items = (object[])infoProperty.GetValue(debuggerAttribute.Instance);
+
+            Assert.Equal(list.Count, items.Length);
+            for (int i = 0; i < list.Count; i++)
+            {
+                object item = items[i];
+                object key = item.GetType().GetField("_key", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(item);
+                object value = item.GetType().GetField("_value", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(item);
+
+                Assert.Equal(i, list.IndexOfKey(key));
+                Assert.Equal(i, list.IndexOfValue(value));
+            }
+        }
+
+        [Fact]
+        public static void DebuggerAttribute_NullSortedList_ThrowsArgumentNullException()
+        {
             bool threwNull = false;
             try
             {

--- a/src/System.Collections.NonGeneric/tests/SortedListTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedListTests.cs
@@ -224,17 +224,7 @@ namespace System.Collections.Tests
             DebuggerAttributeInfo debuggerAttribute = DebuggerAttributes.ValidateDebuggerTypeProxyProperties(list);
             PropertyInfo infoProperty = debuggerAttribute.Properties.Single(property => property.Name == "Items");
             object[] items = (object[])infoProperty.GetValue(debuggerAttribute.Instance);
-
             Assert.Equal(list.Count, items.Length);
-            for (int i = 0; i < list.Count; i++)
-            {
-                object item = items[i];
-                object key = item.GetType().GetField("_key", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(item);
-                object value = item.GetType().GetField("_value", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(item);
-
-                Assert.Equal(i, list.IndexOfKey(key));
-                Assert.Equal(i, list.IndexOfValue(value));
-            }
         }
 
         [Fact]
@@ -244,17 +234,7 @@ namespace System.Collections.Tests
             DebuggerAttributeInfo debuggerAttribute = DebuggerAttributes.ValidateDebuggerTypeProxyProperties(typeof(SortedList), list);
             PropertyInfo infoProperty = debuggerAttribute.Properties.Single(property => property.Name == "Items");
             object[] items = (object[])infoProperty.GetValue(debuggerAttribute.Instance);
-
             Assert.Equal(list.Count, items.Length);
-            for (int i = 0; i < list.Count; i++)
-            {
-                object item = items[i];
-                object key = item.GetType().GetField("_key", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(item);
-                object value = item.GetType().GetField("_value", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(item);
-
-                Assert.Equal(i, list.IndexOfKey(key));
-                Assert.Equal(i, list.IndexOfValue(value));
-            }
         }
 
         [Fact]

--- a/src/System.Collections.NonGeneric/tests/StackTests.cs
+++ b/src/System.Collections.NonGeneric/tests/StackTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
@@ -79,8 +80,17 @@ namespace System.Collections.Tests
             stack.Push(1);
             stack.Push("b");
             stack.Push(2);
-            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(stack);
 
+            DebuggerAttributeInfo debuggerAttribute = DebuggerAttributes.ValidateDebuggerTypeProxyProperties(stack);
+            PropertyInfo infoProperty = debuggerAttribute.Properties.Single(property => property.Name == "Items");
+            object[] items = (object[])infoProperty.GetValue(debuggerAttribute.Instance);
+
+            Assert.Equal(stack.ToArray(), items);
+        }
+
+        [Fact]
+        public static void DebuggerAttribute_NullStack_ThrowsArgumentNullException()
+        {
             bool threwNull = false;
             try
             {

--- a/src/System.Linq/tests/GroupByTests.cs
+++ b/src/System.Linq/tests/GroupByTests.cs
@@ -875,18 +875,18 @@ namespace System.Linq.Tests
             object proxyObject = DebuggerAttributes.GetProxyObject(grouping);
             
             // Validate proxy fields
-            Assert.Empty(DebuggerAttributes.GetDebuggerVisibleFields(proxyObject));
+            Assert.Empty(DebuggerAttributes.GetDebuggerVisibleFields(proxyObject.GetType()));
 
             // Validate proxy properties
-            IDictionary<string, PropertyInfo> properties = DebuggerAttributes.GetDebuggerVisibleProperties(proxyObject);
-            Assert.Equal(2, properties.Count);
+            IEnumerable<PropertyInfo> properties = DebuggerAttributes.GetDebuggerVisibleProperties(proxyObject.GetType());
+            Assert.Equal(2, properties.Count());
             
             // Key
-            TKey key = (TKey)properties["Key"].GetValue(proxyObject);
+            TKey key = (TKey)properties.Single(property => property.Name == "Key").GetValue(proxyObject);
             Assert.Equal(grouping.Key, key);
 
             // Values
-            PropertyInfo valuesProperty = properties["Values"];
+            PropertyInfo valuesProperty = properties.Single(property => property.Name == "Values");
             Assert.Equal(DebuggerBrowsableState.RootHidden, DebuggerAttributes.GetDebuggerBrowsableState(valuesProperty));
             TElement[] values = (TElement[])valuesProperty.GetValue(proxyObject);
             Assert.IsType<TElement[]>(values); // Arrays can be covariant / of assignment-compatible types

--- a/src/System.Linq/tests/ToLookupTests.cs
+++ b/src/System.Linq/tests/ToLookupTests.cs
@@ -300,14 +300,14 @@ namespace System.Linq.Tests
             object proxyObject = DebuggerAttributes.GetProxyObject(lookup);
 
             // Validate proxy fields
-            Assert.Empty(DebuggerAttributes.GetDebuggerVisibleFields(proxyObject));
+            Assert.Empty(DebuggerAttributes.GetDebuggerVisibleFields(proxyObject.GetType()));
 
             // Validate proxy properties
-            IDictionary<string, PropertyInfo> properties = DebuggerAttributes.GetDebuggerVisibleProperties(proxyObject);
-            Assert.Equal(1, properties.Count);
+            IEnumerable<PropertyInfo> properties = DebuggerAttributes.GetDebuggerVisibleProperties(proxyObject.GetType());
+            Assert.Equal(1, properties.Count());
 
             // Groupings
-            PropertyInfo groupingsProperty = properties["Groupings"];
+            PropertyInfo groupingsProperty = properties.Single(property => property.Name == "Groupings");
             Assert.Equal(DebuggerBrowsableState.RootHidden, DebuggerAttributes.GetDebuggerBrowsableState(groupingsProperty));
             var groupings = (IGrouping<TKey, TElement>[])groupingsProperty.GetValue(proxyObject);
             Assert.IsType<IGrouping<TKey, TElement>[]>(groupings); // Arrays can be covariant / of assignment-compatible types


### PR DESCRIPTION
Increases code coverage for these types

Also requires a bit of refactoring of the existing DebuggerAttributes helpers to return useful information that tests can expand on