### PR TITLE
Add SortedList.EnsureCapacity tests

### DIFF
--- a/src/System.Collections.NonGeneric/tests/SortedListTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedListTests.cs
@@ -252,31 +252,6 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        [OuterLoop("Takes a long time (~10s) as the test creates a very large SortedList")]
-        public static void GrowthTest()
-        {
-            // A situation like this occurs for very large lengths of SortedList.
-            // To avoid having to actually add all the elements to the list, which would take a long
-            // time, we can use reflection to invoke SortedList's growth method manually.
-            // This is relatively brittle, as it relies on accessing a private method via reflection
-            // that isn't guaranteed to be stable.
-            const int InitialCapacity = 0X7FEFFFFF / 2 + 1;
-            const int MinCapacity = int.MaxValue;
-            var sortedList = new SortedList(InitialCapacity);
-
-            MethodInfo ensureCapacity = sortedList.GetType().GetMethod("EnsureCapacity", BindingFlags.NonPublic | BindingFlags.Instance);
-            try
-            {
-                ensureCapacity.Invoke(sortedList, new object[] { MinCapacity });
-                Assert.Equal(MinCapacity, sortedList.Capacity);
-            }
-            catch (TargetInvocationException ex) when(ex.InnerException is OutOfMemoryException) 
-            {
-                Assert.Equal(InitialCapacity, sortedList.Capacity);
-            }
-        }
-
-        [Fact]
         public static void Add()
         {
             var sortList1 = new SortedList();


### PR DESCRIPTION
Cases where length is very large or length overflows to below min value.

I initially went for the "reserve large capacity and then add items until we reach the point at which this scenario is hit" technique, which would have avoided the need to use reflection here to test things, but this took time and would OOM most of the time!

Thus, we use a semi-hacky reflection tactic to test this.

Along with my other changes to System.Collections.NonGeneric tests, this increases CC to 100% across the whole library!
