### PR TITLE
Fix test for child process inheriting environment variables

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -183,7 +183,6 @@ namespace System.Diagnostics.Tests
             });
         }
 
-        [ActiveIssue(14417)]
         [Fact]
         public void TestEnvironmentOfChildProcess()
         {
@@ -196,7 +195,7 @@ namespace System.Diagnostics.Tests
                 // to its output stream so we can read them.
                 Process p = CreateProcess(() =>
                 {
-                    Console.Write(string.Join(ItemSeparator, Environment.GetEnvironmentVariables().Cast<DictionaryEntry>().Select(e => e.Key + "=" + e.Value)));
+                    Console.Write(string.Join(ItemSeparator, Environment.GetEnvironmentVariables().Cast<DictionaryEntry>().Select(e => Convert.ToBase64String(Encoding.UTF8.GetBytes(e.Key + "=" + e.Value)))));
                     return SuccessExitCode;
                 });
                 p.StartInfo.StandardOutputEncoding = Encoding.UTF8;
@@ -206,7 +205,7 @@ namespace System.Diagnostics.Tests
                 Assert.True(p.WaitForExit(WaitInMS));
 
                 // Parse the env vars from the child process
-                var actualEnv = new HashSet<string>(output.Split(new[] { ItemSeparator }, StringSplitOptions.None));
+                var actualEnv = new HashSet<string>(output.Split(new[] { ItemSeparator }, StringSplitOptions.None).Select(s => Encoding.UTF8.GetString(Convert.FromBase64String(s))));
 
                 // Validate against StartInfo.Environment.
                 var startInfoEnv = new HashSet<string>(p.StartInfo.Environment.Select(e => e.Key + "=" + e.Value));


### PR DESCRIPTION
The test was initially disabled for one issue that was fixed.  But it
was then suffering from an issue related to encodings rather than to
environment variables, not the purpose of the test.

Fixes https://github.com/dotnet/corefx/issues/14417
cc: @JeremyKuhne, @Priya91 