### PR TITLE
Add test for using LINQ to enumerate Environment.GetEnvironmentVariables

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -162,6 +164,25 @@ namespace System.Tests
             else
             {
                 Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(EnvironmentVariableTarget.User)]
+        [InlineData(EnvironmentVariableTarget.Process)]
+        [InlineData(EnvironmentVariableTarget.Machine)]
+        public void GetEnumerator_LinqOverDictionaryEntries_Success(EnvironmentVariableTarget? target)
+        {
+            IDictionary envVars = target != null ?
+                Environment.GetEnvironmentVariables(target.Value) :
+                Environment.GetEnvironmentVariables();
+
+            Assert.IsType<Hashtable>(envVars);
+
+            foreach (KeyValuePair<string, string> envVar in envVars.Cast<DictionaryEntry>().Select(de => new KeyValuePair<string, string>((string)de.Key, (string)de.Value)))
+            {
+                Assert.NotNull(envVar.Key);
             }
         }
 


### PR DESCRIPTION
cc: @JeremyKuhne, @benaadams 