### PR TITLE
Add RIDs for Android

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -559,6 +559,26 @@
             "#import": [ "alpine.3.4.3", "alpine.3-x64" ]
         },
 
+        "android": {
+            "#import": [ "linux" ]
+        },
+        "android-arm": {
+            "#import": [ "android", "linux-arm" ]
+        },
+        "android-arm64": {
+            "#import": [ "android", "linux-arm64" ]
+        },
+
+        "android.21": {
+            "#import": [ "android" ]
+        },
+        "android.21-arm": {
+            "#import": [ "android.21", "android-arm" ]
+        },
+        "android.21-arm64": {
+            "#import": [ "android.21", "android-arm64" ]
+        },
+
         "corert": {
             "#import": [ "any" ]
         },


### PR DESCRIPTION
With the work done in CoreCLR and CoreFX, we now have a "Hello World" up and running on Android.

This PR introduces RIDs for Android.

Some remarks:
- Because Android uses the Linux kernel, I've chosen to make Android import Linux. Just like Alpine Linux, Android uses a different C runtime (bionic), so chances this will always work are slim.
- At the moment, CoreCLR and CoreFX support arm and arm64 Android, so I've left out x86 and x64 Android (although they make make great candidates for testing as they can be virtualized on x64 hardware)
- Android versions by "API levels", so you have API level 1, 2, 3,... . I've chosen to make API level 21 explicit, because it is the first API level that also support arm64. At the same time, the CoreCLR and  CoreFX builds use packages borrowed from Termux (I like to think of Termux as a package management system for Android, similar to brew on macOS). They also target API level 21, so there's some consistency there.