### PR TITLE
Use lazy initializers in place of double check locks

### DIFF
--- a/src/Common/src/System/Net/NetworkInformation/HostInformationPal.Uap.cs
+++ b/src/Common/src/System/Net/NetworkInformation/HostInformationPal.Uap.cs
@@ -65,17 +65,7 @@ namespace System.Net.NetworkInformation
 
         private static void EnsureFixedInfo()
         {
-            if (!Volatile.Read(ref s_fixedInfoInitialized))
-            {
-                lock (s_syncObject)
-                {
-                    if (!s_fixedInfoInitialized)
-                    {
-                        s_fixedInfo = GetFixedInfo();
-                        Volatile.Write(ref s_fixedInfoInitialized, true);
-                    }
-                }
-            }
+            LazyInitializer.EnsureInitialized(ref s_fixedInfo, ref s_fixedInfoInitialized, ref s_syncObject, () => GetFixedInfo());
         }
     }
 }

--- a/src/Common/src/System/Net/NetworkInformation/HostInformationPal.Windows.cs
+++ b/src/Common/src/System/Net/NetworkInformation/HostInformationPal.Windows.cs
@@ -68,17 +68,7 @@ namespace System.Net.NetworkInformation
 
         private static void EnsureFixedInfo()
         {
-            if (!Volatile.Read(ref s_fixedInfoInitialized))
-            {
-                lock (s_syncObject)
-                {
-                    if (!s_fixedInfoInitialized)
-                    {
-                        s_fixedInfo = GetFixedInfo();
-                        Volatile.Write(ref s_fixedInfoInitialized, true);
-                    }
-                }
-            }
+            LazyInitializer.EnsureInitialized(ref s_fixedInfo, ref s_fixedInfoInitialized, ref s_syncObject, () => GetFixedInfo());
         }
     }
 }

--- a/src/System.Console/src/System/Console.cs
+++ b/src/System.Console/src/System/Console.cs
@@ -14,7 +14,7 @@ namespace System
     public static class Console
     {
         private const int DefaultConsoleBufferSize = 256; // default size of buffer used in stream readers/writers
-        private static readonly object InternalSyncObject = new object(); // for synchronizing changing of Console's static fields
+        private static object InternalSyncObject = new object(); // for synchronizing changing of Console's static fields
         private static TextReader s_in;
         private static TextWriter s_out, s_error;
         private static Encoding s_inputEncoding;
@@ -25,33 +25,16 @@ namespace System
         private static ConsoleCancelEventHandler _cancelCallbacks;
         private static ConsolePal.ControlCHandlerRegistrar _registrar;
 
-        internal static T EnsureInitialized<T>(ref T field, Func<T> initializer) where T : class
-        {
-            lock (InternalSyncObject)
-            {
-                T result = Volatile.Read(ref field);
-                if (result == null)
-                {
-                    result = initializer();
-                    Volatile.Write(ref field, result);
-                }
-                return result;
-            }
-        }
+        internal static T EnsureInitialized<T>(ref T field, Func<T> initializer) where T : class =>
+            LazyInitializer.EnsureInitialized(ref field, ref InternalSyncObject, initializer);
 
-        public static TextReader In
-        {
-            get
-            {
-                return Volatile.Read(ref s_in) ?? EnsureInitialized(ref s_in, () => ConsolePal.GetOrCreateReader());
-            }
-        }
+        public static TextReader In => EnsureInitialized(ref s_in, () => ConsolePal.GetOrCreateReader());
 
         public static Encoding InputEncoding
         {
             get
             {
-                return Volatile.Read(ref s_inputEncoding) ?? EnsureInitialized(ref s_inputEncoding, () => ConsolePal.InputEncoding);
+                return EnsureInitialized(ref s_inputEncoding, () => ConsolePal.InputEncoding);
             }
             set
             {
@@ -75,7 +58,7 @@ namespace System
         {
             get
             {
-                return Volatile.Read(ref s_outputEncoding) ?? EnsureInitialized(ref s_outputEncoding, () => ConsolePal.OutputEncoding);
+                return EnsureInitialized(ref s_outputEncoding, () => ConsolePal.OutputEncoding);
             }
             set
             {
@@ -128,15 +111,9 @@ namespace System
             return ConsolePal.ReadKey(intercept);
         }
 
-        public static TextWriter Out
-        {
-            get { return Volatile.Read(ref s_out) ?? EnsureInitialized(ref s_out, () => CreateOutputWriter(OpenStandardOutput())); }
-        }
+        public static TextWriter Out => EnsureInitialized(ref s_out, () => CreateOutputWriter(OpenStandardOutput()));
 
-        public static TextWriter Error
-        {
-            get { return Volatile.Read(ref s_error) ?? EnsureInitialized(ref s_error, () => CreateOutputWriter(OpenStandardError())); }
-        }
+        public static TextWriter Error => EnsureInitialized(ref s_error, () => CreateOutputWriter(OpenStandardError()));
 
         private static TextWriter CreateOutputWriter(Stream outputStream)
         {
@@ -157,8 +134,7 @@ namespace System
         {
             get
             {
-                StrongBox<bool> redirected = Volatile.Read(ref _isStdInRedirected) ??
-                    EnsureInitialized(ref _isStdInRedirected, () => new StrongBox<bool>(ConsolePal.IsInputRedirectedCore()));
+                StrongBox<bool> redirected = EnsureInitialized(ref _isStdInRedirected, () => new StrongBox<bool>(ConsolePal.IsInputRedirectedCore()));
                 return redirected.Value;
             }
         }
@@ -167,8 +143,7 @@ namespace System
         {
             get
             {
-                StrongBox<bool> redirected = Volatile.Read(ref _isStdOutRedirected) ??
-                    EnsureInitialized(ref _isStdOutRedirected, () => new StrongBox<bool>(ConsolePal.IsOutputRedirectedCore()));
+                StrongBox<bool> redirected = EnsureInitialized(ref _isStdOutRedirected, () => new StrongBox<bool>(ConsolePal.IsOutputRedirectedCore()));
                 return redirected.Value;
             }
         }
@@ -177,8 +152,7 @@ namespace System
         {
             get
             {
-                StrongBox<bool> redirected = Volatile.Read(ref _isStdErrRedirected) ??
-                    EnsureInitialized(ref _isStdErrRedirected, () => new StrongBox<bool>(ConsolePal.IsErrorRedirectedCore()));
+                StrongBox<bool> redirected = EnsureInitialized(ref _isStdErrRedirected, () => new StrongBox<bool>(ConsolePal.IsErrorRedirectedCore()));
                 return redirected.Value;
             }
         }

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -53,8 +53,7 @@ namespace System
             {
                 EnsureInitialized();
 
-                return Volatile.Read(ref s_stdInReader) ??
-                    Console.EnsureInitialized(
+                return Console.EnsureInitialized(
                         ref s_stdInReader,
                         () => SyncTextReader.GetSynchronizedTextReader(
                             new StdInReader(

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -14,29 +14,17 @@ namespace System.Diagnostics
 {
     internal sealed class PerformanceCounterLib
     {
-        private static volatile string s_computerName;
+        private static string s_computerName;
 
         private PerformanceMonitor _performanceMonitor;
         private string _machineName;
         private string _perfLcid;
 
-        private static volatile Dictionary<String, PerformanceCounterLib> s_libraryTable;
+        private static Dictionary<String, PerformanceCounterLib> s_libraryTable;
         private Dictionary<int, string> _nameTable;
         private readonly object _nameTableLock = new Object();
 
         private static Object s_internalSyncObject;
-        private static Object InternalSyncObject
-        {
-            get
-            {
-                if (s_internalSyncObject == null)
-                {
-                    Object o = new Object();
-                    Interlocked.CompareExchange(ref s_internalSyncObject, o, null);
-                }
-                return s_internalSyncObject;
-            }
-        }
 
         internal PerformanceCounterLib(string machineName, string lcid)
         {
@@ -45,24 +33,7 @@ namespace System.Diagnostics
         }
 
         /// <internalonly/>
-        internal static string ComputerName
-        {
-            get
-            {
-                if (s_computerName == null)
-                {
-                    lock (InternalSyncObject)
-                    {
-                        if (s_computerName == null)
-                        {
-                            s_computerName = Interop.Kernel32.GetComputerName();
-                        }
-                    }
-                }
-
-                return s_computerName;
-            }
-        }
+        internal static string ComputerName => LazyInitializer.EnsureInitialized(ref s_computerName, ref s_internalSyncObject, () => Interop.Kernel32.GetComputerName());
 
         internal Dictionary<int, string> NameTable
         {
@@ -95,14 +66,7 @@ namespace System.Diagnostics
             else
                 machineName = machineName.ToLowerInvariant();
 
-            if (PerformanceCounterLib.s_libraryTable == null)
-            {
-                lock (InternalSyncObject)
-                {
-                    if (PerformanceCounterLib.s_libraryTable == null)
-                        PerformanceCounterLib.s_libraryTable = new Dictionary<string, PerformanceCounterLib>();
-                }
-            }
+            LazyInitializer.EnsureInitialized(ref s_libraryTable, ref s_internalSyncObject, () => new Dictionary<string, PerformanceCounterLib>());
 
             string libraryKey = machineName + ":" + lcidString;
             PerformanceCounterLib library;
@@ -118,7 +82,7 @@ namespace System.Diagnostics
         {
             if (_performanceMonitor == null)
             {
-                lock (InternalSyncObject)
+                lock (LazyInitializer.EnsureInitialized(ref s_internalSyncObject))
                 {
                     if (_performanceMonitor == null)
                         _performanceMonitor = new PerformanceMonitor(_machineName);


### PR DESCRIPTION
Next set of changes for Issue 3862 to use lazy initialization constructs in place of double check locks.

@stephentoub @karelz kindly review.