### PR TITLE
Cleanup disabled tests missing correct issue numbers

### DIFF
--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
@@ -351,14 +351,5 @@ namespace System.Collections.Tests
             Assert.True(comparerSet2.SetEquals(set));
         }
         #endregion
-
-        [Fact]
-        public void IntersectWith_SupersetEnumerableWithDups_ExpectedResultsInCorrectOrder ()
-        {
-            var set = new SortedSet<int> { 1, 3, 5, 7, 9 };
-            set.IntersectWith(new [] { 5, 7, 3, 7, 11, 7, 5, 2 });
-
-            Assert.Equal(new int[] { 3, 5, 7 }, set);
-        }
     }
 }

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.cs
@@ -54,6 +54,15 @@ namespace System.Collections.Tests
             Assert.Equal(5, view.Min);
             Assert.Equal(7, view.Max);
         }
+
+        [Fact]
+        public void SortedSet_Generic_IntersectWith_SupersetEnumerableWithDups()
+        {
+            var set = (SortedSet<int>)CreateSortedSet(new[] { 1, 3, 5, 7, 9 }, 5, 5);
+            set.IntersectWith(new[] { 5, 7, 3, 7, 11, 7, 5, 2 });
+
+            Assert.Equal(new[] { 3, 5, 7 }, set);
+        }
     }
 
     public class SortedSet_Generic_Tests_int_With_NullComparer : SortedSet_Generic_Tests_int

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.indexer.genclass.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.indexer.genclass.cs
@@ -896,7 +896,8 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.indexer.genclas
         private static dynamic s_dy = new MemberClass<string>();
         private static int s_num = 0;
 
-        [Fact(Skip = "870811")]
+        [Fact]
+        [ActiveIssue(16747)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod());

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Simple/VarianceTest.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Simple/VarianceTest.cs
@@ -18,7 +18,8 @@ namespace SampleDynamicTests
     {
         private delegate T Create<out T>();
 
-        [Fact(Skip = "906219")]
+        [Fact]
+        [ActiveIssue(16748)]
         public static void VarianceTest_RunTest()
         {
             dynamic d1 = (Create<Tiger>)(() => new Tiger());

--- a/src/System.Linq.Parallel/tests/QueryOperators/SequenceEqualTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SequenceEqualTests.cs
@@ -169,7 +169,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [ActiveIssue("Cancellation token not shared")]
+        [ActiveIssue(16751)] //Cancellation token not shared
         [MemberData("SequenceEqualData", new int[] { /* Sources.OuterLoopCount */ })]
         public static void SequenceEqual_SharedLeft_Cancellation(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count)
         {
@@ -183,7 +183,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [ActiveIssue("Cancellation token not shared")]
+        [ActiveIssue(16751)] //Cancellation token not shared
         [MemberData("SequenceEqualData", new int[] { /* Sources.OuterLoopCount */ })]
         public static void SequenceEqual_SharedRight_Cancellation(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count)
         {

--- a/src/System.Linq/tests/SelectManyTests.cs
+++ b/src/System.Linq/tests/SelectManyTests.cs
@@ -212,8 +212,8 @@ namespace System.Linq.Tests
             Assert.Equal(source.Last().total, source.SelectMany((e, i) => i == 4 ? e.total : Enumerable.Empty<int?>()));
         }
 
-        [Fact]
-        [ActiveIssue("Valid test but too intensive to enable even in OuterLoop")]
+        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop"]
+        [ActiveIssue(16750)] //Valid test but too intensive to enable even in OuterLoop
         public void IndexOverflow()
         {
             var selected = new FastInfiniteEnumerator<int>().SelectMany((e, i) => Enumerable.Empty<int>());

--- a/src/System.Linq/tests/SelectManyTests.cs
+++ b/src/System.Linq/tests/SelectManyTests.cs
@@ -212,8 +212,7 @@ namespace System.Linq.Tests
             Assert.Equal(source.Last().total, source.SelectMany((e, i) => i == 4 ? e.total : Enumerable.Empty<int?>()));
         }
 
-        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop"]
-        [ActiveIssue(16750)] //Valid test but too intensive to enable even in OuterLoop
+        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop")]
         public void IndexOverflow()
         {
             var selected = new FastInfiniteEnumerator<int>().SelectMany((e, i) => Enumerable.Empty<int>());

--- a/src/System.Linq/tests/SelectTests.cs
+++ b/src/System.Linq/tests/SelectTests.cs
@@ -139,8 +139,7 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.Select((e, i) => i == 5 ? e.name : null));
         }
 
-        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop"]
-        [ActiveIssue(16750)] //Valid test but too intensive to enable even in OuterLoop
+        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop")]
         public void Overflow()
         {
             var selected = new FastInfiniteEnumerator<int>().Select((e, i) => e);

--- a/src/System.Linq/tests/SelectTests.cs
+++ b/src/System.Linq/tests/SelectTests.cs
@@ -139,8 +139,8 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.Select((e, i) => i == 5 ? e.name : null));
         }
 
-        [Fact]
-        [ActiveIssue("Valid test but too intensive to enable even in OuterLoop")]
+        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop"]
+        [ActiveIssue(16750)] //Valid test but too intensive to enable even in OuterLoop
         public void Overflow()
         {
             var selected = new FastInfiniteEnumerator<int>().Select((e, i) => e);

--- a/src/System.Linq/tests/SkipWhileTests.cs
+++ b/src/System.Linq/tests/SkipWhileTests.cs
@@ -141,9 +141,9 @@ namespace System.Linq.Tests
 
             Assert.Equal(expected, source.SkipWhile((element, index) => index < source.Length - 1));
         }
-        
-        [Fact]
-        [ActiveIssue("Valid test but too intensive to enable even in OuterLoop")]
+
+        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop"]
+        [ActiveIssue(16750)] //Valid test but too intensive to enable even in OuterLoop
         public void IndexSkipWhileOverflowBeyondIntMaxValueElements()
         {
             var skipped = new FastInfiniteEnumerator<int>().SkipWhile((e, i) => true);

--- a/src/System.Linq/tests/SkipWhileTests.cs
+++ b/src/System.Linq/tests/SkipWhileTests.cs
@@ -142,8 +142,7 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.SkipWhile((element, index) => index < source.Length - 1));
         }
 
-        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop"]
-        [ActiveIssue(16750)] //Valid test but too intensive to enable even in OuterLoop
+        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop")]
         public void IndexSkipWhileOverflowBeyondIntMaxValueElements()
         {
             var skipped = new FastInfiniteEnumerator<int>().SkipWhile((e, i) => true);

--- a/src/System.Linq/tests/TakeWhileTests.cs
+++ b/src/System.Linq/tests/TakeWhileTests.cs
@@ -117,8 +117,7 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.RunOnce().TakeWhile((element, index) => index < source.Length - 1));
         }
 
-        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop"]
-        [ActiveIssue(16750)] //Valid test but too intensive to enable even in OuterLoop
+        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop")]
         public void IndexTakeWhileOverflowBeyondIntMaxValueElements()
         {
             var taken = new FastInfiniteEnumerator<int>().TakeWhile((e, i) => true);

--- a/src/System.Linq/tests/TakeWhileTests.cs
+++ b/src/System.Linq/tests/TakeWhileTests.cs
@@ -117,8 +117,8 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.RunOnce().TakeWhile((element, index) => index < source.Length - 1));
         }
 
-        [Fact]
-        [ActiveIssue("Valid test but too intensive to enable even in OuterLoop")]
+        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop"]
+        [ActiveIssue(16750)] //Valid test but too intensive to enable even in OuterLoop
         public void IndexTakeWhileOverflowBeyondIntMaxValueElements()
         {
             var taken = new FastInfiniteEnumerator<int>().TakeWhile((e, i) => true);

--- a/src/System.Linq/tests/ToArrayTests.cs
+++ b/src/System.Linq/tests/ToArrayTests.cs
@@ -127,8 +127,7 @@ namespace System.Linq.Tests
             Assert.Equal(1, source.CopyToTouched);
         }
 
-        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop"]
-        [ActiveIssue(16750)] //Valid test but too intensive to enable even in OuterLoop
+        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop")]
         public void ToArray_FailOnExtremelyLargeCollection()
         {
             var largeSeq = new FastInfiniteEnumerator<byte>();

--- a/src/System.Linq/tests/ToArrayTests.cs
+++ b/src/System.Linq/tests/ToArrayTests.cs
@@ -127,8 +127,8 @@ namespace System.Linq.Tests
             Assert.Equal(1, source.CopyToTouched);
         }
 
-        [Fact]
-        [ActiveIssue("Valid test but too intensive to enable even in OuterLoop")]
+        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop"]
+        [ActiveIssue(16750)] //Valid test but too intensive to enable even in OuterLoop
         public void ToArray_FailOnExtremelyLargeCollection()
         {
             var largeSeq = new FastInfiniteEnumerator<byte>();

--- a/src/System.Linq/tests/WhereTests.cs
+++ b/src/System.Linq/tests/WhereTests.cs
@@ -997,8 +997,8 @@ namespace System.Linq.Tests
             Assert.Equal(source.Skip(source.Length - 1), source.Where((e, i) => i == source.Length - 1));
         }
 
-        [Fact]
-        [ActiveIssue("Valid test but too intensive to enable even in OuterLoop")]
+        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop"]
+        [ActiveIssue(16750)] //Valid test but too intensive to enable even in OuterLoop
         public void IndexOverflows()
         {
             var infiniteWhere = new FastInfiniteEnumerator<int>().Where((e, i) => true);

--- a/src/System.Linq/tests/WhereTests.cs
+++ b/src/System.Linq/tests/WhereTests.cs
@@ -997,8 +997,7 @@ namespace System.Linq.Tests
             Assert.Equal(source.Skip(source.Length - 1), source.Where((e, i) => i == source.Length - 1));
         }
 
-        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop"]
-        [ActiveIssue(16750)] //Valid test but too intensive to enable even in OuterLoop
+        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop")]
         public void IndexOverflows()
         {
             var infiniteWhere = new FastInfiniteEnumerator<int>().Where((e, i) => true);

--- a/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -1880,7 +1880,7 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
     }
 
     [Fact]
-    [ActiveIssue("fails when using CodeGen as well")]
+    [ActiveIssue(16752)] //fails when using CodeGen as well
     public static void Xml_BaseClassAndDerivedClass2WithSameProperty()
     {
         var value = new DerivedClassWithSameProperty2() { DateTimeProperty = new DateTime(100, DateTimeKind.Utc), IntProperty = 5, StringProperty = "TestString", ListProperty = new List<string>() };

--- a/src/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
+++ b/src/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
@@ -17,6 +17,7 @@ namespace System.Runtime.Loader.Tests
         private const string TestAssembly = "System.Runtime.Loader.Test.Assembly";
 
         [Fact(Skip = "https://github.com/dotnet/corefx/issues/15101")]
+        [ActiveIssue(15101)]
         public static void GetAssemblyNameTest_ValidAssembly()
         {
             string originalDir = Environment.CurrentDirectory;
@@ -90,6 +91,7 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact(Skip = "https://github.com/dotnet/corefx/issues/15101")]
+        [ActiveIssue(15101)]
         public static void LoadFromAssemblyName_ValidTrustedPlatformAssembly()
         {
             string originalDir = Environment.CurrentDirectory;

--- a/src/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
+++ b/src/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
@@ -16,7 +16,7 @@ namespace System.Runtime.Loader.Tests
     {
         private const string TestAssembly = "System.Runtime.Loader.Test.Assembly";
 
-        [Fact(Skip = "https://github.com/dotnet/corefx/issues/15101")]
+        [Fact]
         [ActiveIssue(15101)]
         public static void GetAssemblyNameTest_ValidAssembly()
         {
@@ -90,7 +90,7 @@ namespace System.Runtime.Loader.Tests
                 () => loadContext.LoadFromAssemblyName(asmName));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/corefx/issues/15101")]
+        [Fact]
         [ActiveIssue(15101)]
         public static void LoadFromAssemblyName_ValidTrustedPlatformAssembly()
         {

--- a/src/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
+++ b/src/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
@@ -117,6 +117,7 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact(Skip = "https://github.com/dotnet/corefx/issues/15101")]
+        [ActiveIssue(15101)]
         public static void LoadInDefaultContext()
         {
             Init();

--- a/src/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
+++ b/src/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
@@ -116,7 +116,7 @@ namespace System.Runtime.Loader.Tests
             File.Copy(targetRenamedPath, targetPath); 
         }
 
-        [Fact(Skip = "https://github.com/dotnet/corefx/issues/15101")]
+        [Fact]
         [ActiveIssue(15101)]
         public static void LoadInDefaultContext()
         {

--- a/src/System.Runtime.Numerics/tests/BigInteger/PerformanceTests.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/PerformanceTests.cs
@@ -21,7 +21,7 @@ namespace System.Numerics.Tests
         }
 
         [Theory]
-        [ActiveIssue("PerformanceTest")]
+        [ActiveIssue(16754)] //PerformanceTest
         [InlineData(1000000, 16, 16)]
         [InlineData(1000000, 64, 64)]
         [InlineData(1000000, 256, 256)]
@@ -35,7 +35,7 @@ namespace System.Numerics.Tests
         }
 
         [Theory]
-        [ActiveIssue("PerformanceTest")]
+        [ActiveIssue(16754)] //PerformanceTest
         [InlineData(1000000, 16, 16)]
         [InlineData(1000000, 64, 64)]
         [InlineData(1000000, 256, 256)]
@@ -49,7 +49,7 @@ namespace System.Numerics.Tests
         }
 
         [Theory]
-        [ActiveIssue("PerformanceTest")]
+        [ActiveIssue(16754)] //PerformanceTest
         [InlineData(1000000, 16, 16)]
         [InlineData(1000000, 64, 64)]
         [InlineData(1000000, 256, 256)]
@@ -63,7 +63,7 @@ namespace System.Numerics.Tests
         }
 
         [Theory]
-        [ActiveIssue("PerformanceTest")]
+        [ActiveIssue(16754)] //PerformanceTest
         [InlineData(1000000, 16)]
         [InlineData(1000000, 64)]
         [InlineData(1000000, 256)]
@@ -77,7 +77,7 @@ namespace System.Numerics.Tests
         }
 
         [Theory]
-        [ActiveIssue("PerformanceTest")]
+        [ActiveIssue(16754)] //PerformanceTest
         [InlineData(1000000, 16, 16)]
         [InlineData(1000000, 64, 16)]
         [InlineData(1000000, 256, 128)]
@@ -91,7 +91,7 @@ namespace System.Numerics.Tests
         }
 
         [Theory]
-        [ActiveIssue("PerformanceTest")]
+        [ActiveIssue(16754)] //PerformanceTest
         [InlineData(1000000, 16, 16)]
         [InlineData(1000000, 64, 16)]
         [InlineData(1000000, 256, 128)]
@@ -105,7 +105,7 @@ namespace System.Numerics.Tests
         }
 
         [Theory]
-        [ActiveIssue("PerformanceTest")]
+        [ActiveIssue(16754)] //PerformanceTest
         [InlineData(1000000, 16, 16)]
         [InlineData(1000000, 64, 64)]
         [InlineData(100000, 256, 256)]
@@ -119,7 +119,7 @@ namespace System.Numerics.Tests
         }
 
         [Theory]
-        [ActiveIssue("PerformanceTest")]
+        [ActiveIssue(16754)] //PerformanceTest
         [InlineData(100000, 16, 16, 16)]
         [InlineData(10000, 64, 64, 64)]
         [InlineData(1000, 256, 256, 256)]

--- a/src/System.Runtime.Numerics/tests/BigInteger/PerformanceTests.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/PerformanceTests.cs
@@ -20,8 +20,7 @@ namespace System.Numerics.Tests
             _output = output;
         }
 
-        [Theory]
-        [ActiveIssue(16754)] //PerformanceTest
+        [Benchmark] //PerformanceTest
         [InlineData(1000000, 16, 16)]
         [InlineData(1000000, 64, 64)]
         [InlineData(1000000, 256, 256)]
@@ -34,8 +33,7 @@ namespace System.Numerics.Tests
             RunBenchmark(count, leftBits, rightBits, (l, r) => BigInteger.Add(l, r));
         }
 
-        [Theory]
-        [ActiveIssue(16754)] //PerformanceTest
+        [Benchmark] //PerformanceTest
         [InlineData(1000000, 16, 16)]
         [InlineData(1000000, 64, 64)]
         [InlineData(1000000, 256, 256)]
@@ -48,8 +46,7 @@ namespace System.Numerics.Tests
             RunBenchmark(count, leftBits, rightBits, (l, r) => BigInteger.Subtract(l, r));
         }
 
-        [Theory]
-        [ActiveIssue(16754)] //PerformanceTest
+        [Benchmark] //PerformanceTest
         [InlineData(1000000, 16, 16)]
         [InlineData(1000000, 64, 64)]
         [InlineData(1000000, 256, 256)]
@@ -62,8 +59,7 @@ namespace System.Numerics.Tests
             RunBenchmark(count, leftBits, rightBits, (l, r) => BigInteger.Multiply(l, r));
         }
 
-        [Theory]
-        [ActiveIssue(16754)] //PerformanceTest
+        [Benchmark] //PerformanceTest
         [InlineData(1000000, 16)]
         [InlineData(1000000, 64)]
         [InlineData(1000000, 256)]
@@ -76,8 +72,7 @@ namespace System.Numerics.Tests
             RunBenchmark(count, bits, v => BigInteger.Multiply(v, v));
         }
 
-        [Theory]
-        [ActiveIssue(16754)] //PerformanceTest
+        [Benchmark] //PerformanceTest
         [InlineData(1000000, 16, 16)]
         [InlineData(1000000, 64, 16)]
         [InlineData(1000000, 256, 128)]
@@ -90,8 +85,7 @@ namespace System.Numerics.Tests
             RunBenchmark(count, leftBits, rightBits, (l, r) => BigInteger.Divide(l, r));
         }
 
-        [Theory]
-        [ActiveIssue(16754)] //PerformanceTest
+        [Benchmark] //PerformanceTest
         [InlineData(1000000, 16, 16)]
         [InlineData(1000000, 64, 16)]
         [InlineData(1000000, 256, 128)]
@@ -104,8 +98,7 @@ namespace System.Numerics.Tests
             RunBenchmark(count, leftBits, rightBits, (l, r) => BigInteger.Remainder(l, r));
         }
 
-        [Theory]
-        [ActiveIssue(16754)] //PerformanceTest
+        [Benchmark] //PerformanceTest
         [InlineData(1000000, 16, 16)]
         [InlineData(1000000, 64, 64)]
         [InlineData(100000, 256, 256)]
@@ -118,8 +111,7 @@ namespace System.Numerics.Tests
             RunBenchmark(count, leftBits, rightBits, (l, r) => BigInteger.GreatestCommonDivisor(l, r));
         }
 
-        [Theory]
-        [ActiveIssue(16754)] //PerformanceTest
+        [Benchmark] //PerformanceTest
         [InlineData(100000, 16, 16, 16)]
         [InlineData(10000, 64, 64, 64)]
         [InlineData(1000, 256, 256, 256)]

--- a/src/System.Runtime.Numerics/tests/BigInteger/PerformanceTests.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/PerformanceTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using Xunit;
+using Microsoft.Xunit.Performance;
 using Xunit.Abstractions;
 
 namespace System.Numerics.Tests

--- a/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -747,7 +747,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
             }
         }
 
-        [ActiveIssue("Fails on desktop and core: 'Unable to cast object of type 'System.UInt32[][*]' to type 'System.Object[]'")]
+        [ActiveIssue(16753)] //Fails on desktop and core: 'Unable to cast object of type 'System.UInt32[][*]' to type 'System.Object[]'
         [Fact]
         public void Roundtrip_ArrayContainingArrayAtNonZeroLowerBound()
         {

--- a/src/System.Runtime/tests/System/StringTests.cs
+++ b/src/System.Runtime/tests/System/StringTests.cs
@@ -816,7 +816,7 @@ namespace System.Tests
         }
 
         [Theory]
-        [ActiveIssue("dotnet/coreclr#2051", TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/coreclr/issues/2051", TestPlatforms.AnyUnix)]
         [InlineData(StringComparison.CurrentCulture)]
         [InlineData(StringComparison.CurrentCultureIgnoreCase)]
         [InlineData(StringComparison.Ordinal)]
@@ -1234,7 +1234,7 @@ namespace System.Tests
         }
 
         [Theory]
-        [ActiveIssue("dotnet/coreclr#2051", TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/coreclr/issues/2051", TestPlatforms.AnyUnix)]
         [InlineData("He\0lo", "He\0lo", 0)]
         [InlineData("He\0lo", "He\0", 0)]
         [InlineData("He\0lo", "\0", 2)]
@@ -1703,7 +1703,7 @@ namespace System.Tests
         }
 
         [Theory]
-        [ActiveIssue("dotnet/coreclr#2051", TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/coreclr/issues/2051", TestPlatforms.AnyUnix)]
         [InlineData("He\0lo", "He\0lo", 0)]
         [InlineData("He\0lo", "He\0", 0)]
         [InlineData("He\0lo", "\0", 2)]
@@ -2097,7 +2097,7 @@ namespace System.Tests
         }
 
         [Theory]
-        [ActiveIssue("dotnet/coreclr#2051", TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/coreclr/issues/2051", TestPlatforms.AnyUnix)]
         [InlineData(StringComparison.CurrentCulture)]
         [InlineData(StringComparison.CurrentCultureIgnoreCase)]
         [InlineData(StringComparison.Ordinal)]

--- a/src/System.Transactions.Local/tests/EnlistTest.cs
+++ b/src/System.Transactions.Local/tests/EnlistTest.cs
@@ -142,7 +142,7 @@ namespace System.Transactions.Tests
         /* We support only 1 durable with 2PC
 		 * On .net, this becomes a distributed transaction
 		 */
-        [ActiveIssue("Distributed transactions are not supported.")]
+        [ActiveIssue(16755)] //Distributed transactions are not supported.
         [Fact]
         public void Vol0_Dur1_2PC()
         {
@@ -447,7 +447,7 @@ namespace System.Transactions.Tests
 		 * > 1 durable, On .net this becomes a distributed transaction
 		 * We don't support this in mono yet. 
 		 */
-        [ActiveIssue("Distributed transactions are not supported.")]
+        [ActiveIssue(16755)] //Distributed transactions are not supported.
         [Fact]
         public void Vol0_Dur2()
         {


### PR DESCRIPTION
1.	[Fact(Skip = "870811")] 
Create a new issue: https://github.com/dotnet/corefx/issues/16747
2.	[Fact(Skip = "906219")]
Create a new issue: https://github.com/dotnet/corefx/issues/16748
Change to [ActiveIssue(issue number)]
3. 	[Fact(Skip = "https://github.com/dotnet/corefx/issues/15101")]
Add Attribute: [ActiveIssue(15101)]
4.   	[ActiveIssue("PerformanceTest")]
Create a new issue: https://github.com/dotnet/corefx/issues/16754 
5.	[ActiveIssue("Valid test but too intensive to enable even in OuterLoop")]
Create a new issue: https://github.com/dotnet/corefx/issues/16750 
6.	[ActiveIssue("Cancellation token not shared")]
Create a new issue: https://github.com/dotnet/corefx/issues/16751 
7.	[ActiveIssue("Fails on desktop and core: 'Unable to cast object of type 'System.UInt32[][*]' to type 'System.Object[]'")]
Create a new issue: https://github.com/dotnet/corefx/issues/16753 
8.	[ActiveIssue("fails when using CodeGen as well")]
Create a new issue: https://github.com/dotnet/corefx/issues/16752 
9.	[ActiveIssue("Distributed transactions are not supported.")]
Create a new issue: https://github.com/dotnet/corefx/issues/16755
10.   [ActiveIssue("dotnet/coreclr#2051", TestPlatforms.AnyUnix)] 
Change to [ActiveIssue("https://github.com/dotnet/coreclr/issues/2051”, TestPlatforms.AnyUnix)].

