### PR TITLE
Fix behaviour of TreeSubSet Min and Max

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
@@ -131,15 +131,21 @@ namespace System.Collections.Generic
                     Node current = _root;
                     T result = default(T);
 
-                    while (current != null) {
+                    while (current != null)
+                    {
 
                         int comp = _lBoundActive ? Comparer.Compare(_min, current.Item) : -1;
-                        if (comp == 1) {
+                        if (comp == 1)
+                        {
                             current = current.Right;
-                        } else {
+                        }
+                        else
+                        {
                             result = current.Item;
                             if (comp == 0)
+                            {
                                 break;
+                            }
                             current = current.Left;
                         }
                     }
@@ -155,15 +161,20 @@ namespace System.Collections.Generic
                     Node current = _root;
                     T result = default(T);
 
-                    while (current != null) {
-
+                    while (current != null)
+                    {
                         int comp = _uBoundActive ? Comparer.Compare(_max, current.Item) : 1;
-                        if (comp == -1) {
+                        if (comp == -1)
+                        {
                             current = current.Left;
-                        } else {
+                        }
+                        else
+                        {
                             result = current.Item;
                             if (comp == 0)
+                            {
                                 break;
+                            }
                             current = current.Right;
                         }
                     }

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
@@ -124,6 +124,54 @@ namespace System.Collections.Generic
                 return comp >= 0;
             }
 
+            internal override T MinInternal
+            {
+                get
+                {
+                    Node current = _root;
+                    T result = default(T);
+
+                    while (current != null) {
+
+                        int comp = _lBoundActive ? Comparer.Compare(_min, current.Item) : -1;
+                        if (comp == 1) {
+                            current = current.Right;
+                        } else {
+                            result = current.Item;
+                            if (comp == 0)
+                                break;
+                            current = current.Left;
+                        }
+                    }
+
+                    return result;
+                }
+            }
+
+            internal override T MaxInternal
+            {
+                get
+                {
+                    Node current = _root;
+                    T result = default(T);
+
+                    while (current != null) {
+
+                        int comp = _uBoundActive ? Comparer.Compare(_max, current.Item) : 1;
+                        if (comp == -1) {
+                            current = current.Left;
+                        } else {
+                            result = current.Item;
+                            if (comp == 0)
+                                break;
+                            current = current.Right;
+                        }
+                    }
+
+                    return result;
+               }
+            }
+
             internal override bool InOrderTreeWalk(TreeWalkPredicate<T> action)
             {
                 VersionCheck();

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -1575,7 +1575,9 @@ namespace System.Collections.Generic
 
         #region ISorted members
 
-        public T Min
+        public T Min => MinInternal;
+
+        internal virtual T MinInternal
         {
             get
             {
@@ -1594,7 +1596,9 @@ namespace System.Collections.Generic
             }
         }
 
-        public T Max
+        public T Max => MaxInternal;
+        
+        internal virtual T MaxInternal 
         {
             get
             {

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.cs
@@ -29,7 +29,6 @@ namespace System.Collections.Tests
 
         protected override bool DefaultValueAllowed => true;
 
-        [ActiveIssue(16760)]
         [Fact]
         public void SortedSet_Generic_GetViewBetween_MinMax()
         {

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.cs
@@ -62,6 +62,27 @@ namespace System.Collections.Tests
 
             Assert.Equal(new[] { 3, 5, 7 }, set);
         }
+
+        [Fact]
+        public void SortedSet_Generic_GetViewBetween_MinMax_Exhaustive()
+        {
+            var set = (SortedSet<int>)CreateSortedSet(new[] { 7, 11, 3, 1, 5, 9, 13 }, 7, 7);
+            for (int i = 0; i < 14; i++)
+            {
+                for (int j = i; j < 14; j ++)
+                {
+                    SortedSet<int> view = set.GetViewBetween(i, j);
+
+                    if (j < i || (j == i && i % 2 == 0) ){
+                        Assert.Equal(default(int), view.Min);
+                        Assert.Equal(default(int), view.Max);
+                    } else {
+                        Assert.Equal(i + ((i+1) % 2), view.Min);
+                        Assert.Equal(j - ((j+1) % 2), view.Max);
+                    }
+                }
+            }
+        }
     }
 
     public class SortedSet_Generic_Tests_int_With_NullComparer : SortedSet_Generic_Tests_int

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.cs
@@ -73,10 +73,13 @@ namespace System.Collections.Tests
                 {
                     SortedSet<int> view = set.GetViewBetween(i, j);
 
-                    if (j < i || (j == i && i % 2 == 0) ){
+                    if (j < i || (j == i && i % 2 == 0) )
+                    {
                         Assert.Equal(default(int), view.Min);
                         Assert.Equal(default(int), view.Max);
-                    } else {
+                    }
+                    else
+                    {
                         Assert.Equal(i + ((i+1) % 2), view.Min);
                         Assert.Equal(j - ((j+1) % 2), view.Max);
                     }


### PR DESCRIPTION
Fixes #16760.

Provide correct override in TreeSubSet for Min and Max, they now take
account of the range of the subset.

As the root is guaranteed to be in the range, then the code does not
need to check something is in the range, if _root is not null.

This makes Min and Max virtual. Is that an acceptable change?  Previously, they hid the virtual behaviour inside the implementation. 
cc @stephentoub @marek-safar @ianhays 