### PR TITLE
Clean up unused SupportsKeyGeneration properties

### DIFF
--- a/src/System.Security.Cryptography.Cng/tests/ECDsaCngProvider.cs
+++ b/src/System.Security.Cryptography.Cng/tests/ECDsaCngProvider.cs
@@ -52,8 +52,6 @@ namespace System.Security.Cryptography.EcDsa.Tests
                 return false;
             }
         }
-
-        public bool SupportsKeyGeneration => true;
     }
 
     public partial class ECDsaFactory

--- a/src/System.Security.Cryptography.Cng/tests/RSACngProvider.cs
+++ b/src/System.Security.Cryptography.Cng/tests/RSACngProvider.cs
@@ -39,8 +39,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             get { return true; }
         }
-
-        public bool SupportsKeyGeneration => true;
     }
 
     public partial class RSAFactory

--- a/src/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderProvider.cs
+++ b/src/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderProvider.cs
@@ -25,8 +25,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             get { return false; }
         }
-
-        public bool SupportsKeyGeneration => true;
     }
 
     public partial class RSAFactory

--- a/src/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslProvider.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslProvider.cs
@@ -54,8 +54,6 @@ namespace System.Security.Cryptography.EcDsa.Tests
                 return true;
             }
         }
-
-        public bool SupportsKeyGeneration => true;
     }
 
     public partial class ECDsaFactory

--- a/src/System.Security.Cryptography.OpenSsl/tests/RSAOpenSslProvider.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/RSAOpenSslProvider.cs
@@ -25,8 +25,6 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             get { return false; }
         }
-
-        public bool SupportsKeyGeneration => true;
     }
 
     public partial class RSAFactory


### PR DESCRIPTION
The platform-specific interop type providers for RSA and ECDSA still had the
SupportsKeyGeneration properties defined.  Nothing calls them anymore, so
delete them before they make it to master.