### PR TITLE
Disable Test DCS_TypeWithTypeProperty on Uapaot.

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1680,6 +1680,7 @@ public static partial class DataContractSerializerTests
         Assert.StrictEqual<TypeWithCommonTypeProperties>(value, deserializedValue);
     }
 
+#if NET_NATIVE
     [Fact]
     public static void DCS_TypeWithTypeProperty()
     {
@@ -1689,6 +1690,7 @@ public static partial class DataContractSerializerTests
         Assert.StrictEqual(value.Name, deserializedValue.Name);
         Assert.StrictEqual(value.Type, deserializedValue.Type);
     }
+#endif
 
     [Fact]
     public static void DCS_TypeWithExplicitIEnumerableImplementation()

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -1885,12 +1885,14 @@ namespace SerializationTypes
         public ICollection<int> Member1;
     }
 
+#if NET_NATIVE
     public class TypeWithTypeProperty
     {
         public int Id { get; set; }
         public Type Type { get; set; }
         public string Name { get; set; }
     }
+#endif
 
     [DataContract(Namespace = "SerializationTypes.GenericTypeWithPrivateSetter")]
     public class GenericTypeWithPrivateSetter<T>

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.settings.targets
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.settings.targets
@@ -8,6 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <NugetTargetMoniker>.NETStandard,Version=v1.7</NugetTargetMoniker>
     <TestSourceFolder>$(MSBuildThisFileDirectory)\</TestSourceFolder>
+    <DefineConstants Condition="'$(TargetGroup)'=='uapaot'">$(DefineConstants);NET_NATIVE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceFolder)..\..\System.Private.DataContractSerialization\pkg\System.Private.DataContractSerialization.pkgproj">


### PR DESCRIPTION
The test is failing on uapaot. I'm disabling the test so that the tests for DCS can be built.

Fix #16772