### PR TITLE
Fix in src\System.Memory\ref\System.Memory.csproj

### DIFF
--- a/src/System.Memory/ref/System.Memory.csproj
+++ b/src/System.Memory/ref/System.Memory.csproj
@@ -14,7 +14,7 @@
     <Compile Include="System.Memory.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.0'">
-    <Reference Include="System.Runtime" />
+    <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Use `<ProjectReference>` instead of `<Reference>` for `System.Runtime` in src\System.Memory\ref\System.Memory.csproj, else the build fails unless System.Runtime.dll already exists.