### PR TITLE
Update CoreClr, CoreFx, Standard to beta-25106-02, beta-25106-01, beta-25106-01, respectively (master)

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -1,4 +1,4 @@
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+1.0.1-prerelease-01401-04<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. -->
 
   <!-- There are situations where the live .Net Native targeting pack wouldn't be suitable to pick up.
@@ -17,21 +17,21 @@
        These ref versions are pulled from https://github.com/dotnet/versions.
   -->
   <PropertyGroup>
-    <CoreFxCurrentRef>0f63ef5a159c7cd37724ae17b05bf956dfb79b52</CoreFxCurrentRef>
-    <CoreClrCurrentRef>1c4a59f686ba747727efcddb87b0322b9c48261b</CoreClrCurrentRef>
+    <CoreFxCurrentRef>955fc73c2b773ed2377d020107a2c79524c2cdee</CoreFxCurrentRef>
+    <CoreClrCurrentRef>955fc73c2b773ed2377d020107a2c79524c2cdee</CoreClrCurrentRef>
     <ExternalCurrentRef>3b8a99621d89ad9877f053ba8af25e0f25dcd9d8</ExternalCurrentRef>
     <ProjectNTfsCurrentRef>d9076a006edfd716b4b54d702703fcb1f5575619</ProjectNTfsCurrentRef>
     <SniCurrentRef>05650e53f2aa4497f74cd6e9b053d3f69f64b0bd</SniCurrentRef>
-    <StandardCurrentRef>1fcc52093fa372901c516f23293e8b8350c54027</StandardCurrentRef>
+    <StandardCurrentRef>955fc73c2b773ed2377d020107a2c79524c2cdee</StandardCurrentRef>
   </PropertyGroup>
 
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
-    <CoreFxExpectedPrerelease>stable</CoreFxExpectedPrerelease>
-    <CoreClrExpectedPrerelease>beta-25103-01</CoreClrExpectedPrerelease>
+    <CoreFxExpectedPrerelease>beta-25106-01</CoreFxExpectedPrerelease>
+    <CoreClrExpectedPrerelease>beta-25106-02</CoreClrExpectedPrerelease>
     <ExternalExpectedPrerelease>beta-25016-01</ExternalExpectedPrerelease>
     <ProjectNTfsExpectedPrerelease>beta-25028-00</ProjectNTfsExpectedPrerelease>
-    <NETStandardPackageVersion>2.0.0-beta-25102-01</NETStandardPackageVersion>
+    <NETStandardPackageVersion>2.0.0-beta-25106-01</NETStandardPackageVersion>
     <NETStandardPackageId>NETStandard.Library</NETStandardPackageId>
     <!-- Use the SNI runtime package -->
     <SniPackageVersion>4.4.0-beta-25007-02</SniPackageVersion>

--- a/dependencies.props
+++ b/dependencies.props
@@ -1,4 +1,4 @@
-1.0.1-prerelease-01401-04<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. -->
 
   <!-- There are situations where the live .Net Native targeting pack wouldn't be suitable to pick up.

--- a/external/ilasm/project.json.template
+++ b/external/ilasm/project.json.template
@@ -2,9 +2,9 @@
   "frameworks": {
     "{TFM}": {
       "dependencies": {
-        "Microsoft.NETCore.Platforms": "2.0.0-beta-25022-02",
-        "Microsoft.NETCore.Runtime.CoreCLR": "2.0.0-beta-25103-01",
-        "Microsoft.NETCore.ILAsm": "2.0.0-beta-25103-01"
+        "Microsoft.NETCore.Platforms": "2.0.0-beta-25106-01",
+        "Microsoft.NETCore.Runtime.CoreCLR": "2.0.0-beta-25106-02",
+        "Microsoft.NETCore.ILAsm": "2.0.0-beta-25106-02"
       }
     }
   },

--- a/external/netstandard/netstandard1.x/project.json.template
+++ b/external/netstandard/netstandard1.x/project.json.template
@@ -2,7 +2,7 @@
   "frameworks": {
     "{TFM}": {
       "dependencies": {
-        "NETStandard.Library": "2.0.0-beta-25102-01",
+        "NETStandard.Library": "2.0.0-beta-25106-01",
         "System.Diagnostics.Contracts": "4.3.0",
         "System.Diagnostics.Debug": "4.3.0",
         "System.Dynamic.Runtime": "4.3.0",

--- a/external/netstandard/project.json.template
+++ b/external/netstandard/project.json.template
@@ -2,7 +2,7 @@
   "frameworks": {
     "{TFM}": {
       "dependencies": {
-        "NETStandard.Library": "2.0.0-beta-25102-01"
+        "NETStandard.Library": "2.0.0-beta-25106-01"
       }
     }
   }

--- a/external/runtime/project.json.template
+++ b/external/runtime/project.json.template
@@ -2,9 +2,9 @@
   "frameworks": {
     "{TFM}": {
       "dependencies": {
-        "Microsoft.NETCore.Platforms": "2.0.0-beta-25022-02",
-        "Microsoft.NETCore.Runtime.CoreCLR": "2.0.0-beta-25103-01",
-        "Microsoft.NETCore.TestHost": "2.0.0-beta-25103-01",
+        "Microsoft.NETCore.Platforms": "2.0.0-beta-25106-01",
+        "Microsoft.NETCore.Runtime.CoreCLR": "2.0.0-beta-25106-02",
+        "Microsoft.NETCore.TestHost": "2.0.0-beta-25106-02",
         "runtime.native.System.Data.SqlClient.sni": "4.4.0-beta-24913-02",
         "Microsoft.NETCore.DotNetHost": "1.2.0-beta-001259-00",
         "Microsoft.NETCore.DotNetHostPolicy": "1.2.0-beta-001259-00"

--- a/external/test-runtime/project.json
+++ b/external/test-runtime/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "xunit.console.netcore": "1.0.3-prerelease-00921-01",
-    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01001-04",
+    "Microsoft.DotNet.BuildTools.TestSuite": "1.0.1-prerelease-01401-04",
     "Microsoft.xunit.netcore.extensions": "1.0.1-prerelease-01401-04",
     "xunit.performance.api": "1.0.0-alpha-build0047",
     "xunit.performance.core": "1.0.0-alpha-build0047",


### PR DESCRIPTION
Also updates `Microsoft.DotNet.BuildTools.TestSuite`. A resubmit of https://github.com/dotnet/corefx/pull/16667 to fix an issue that happens when BuildTools attempts to auto-update a static dependency. (https://github.com/dotnet/buildtools/issues/1374)

@weshaggard @safern @stephentoub 