### PR TITLE
RootFS: Add no-lldb option to fix arm64 build

### DIFF
--- a/cross/arm64/toolchain.cmake
+++ b/cross/arm64/toolchain.cmake
@@ -9,6 +9,8 @@ set(TOOLCHAIN "aarch64-linux-gnu")
 add_compile_options(-target ${TOOLCHAIN})
 add_compile_options(--sysroot=${CROSS_ROOTFS})
 
+include_directories(SYSTEM ${CROSS_ROOTFS}/usr/include/)
+
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -target ${TOOLCHAIN}")
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -B ${CROSS_ROOTFS}/usr/lib/gcc/${TOOLCHAIN}")
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -L${CROSS_ROOTFS}/lib/${TOOLCHAIN}")

--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -5,6 +5,7 @@ usage()
     echo "Usage: $0 [BuildArch] [LinuxCodeName] [--skipunmount]"
     echo "BuildArch can be: arm(default), armel, arm64, x86"
     echo "LinuxCodeName - optional, Code name for Linux, can be: trusty(default), vivid, wily, xenial. If BuildArch is armel, LinuxCodeName is jessie(default) or tizen."
+    echo "lldbx.y - optional, LLDB version, can be: lldb3.6(default), lldb3.8, no-lldb"
     echo "--skipunmount - optional, will skip the unmount of rootfs folder."
     exit 1
 }
@@ -15,6 +16,7 @@ __InitialDir=$PWD
 __BuildArch=arm
 __UbuntuArch=armhf
 __UbuntuRepo="http://ports.ubuntu.com/"
+__LLDB_Package="lldb-3.6-dev"
 __SkipUnmount=0
 
 # base development support
@@ -62,6 +64,15 @@ for i in "$@" ; do
             __UbuntuArch=i386
             __UbuntuRepo="http://archive.ubuntu.com/ubuntu/"
             ;;
+        lldb3.6)
+            __LLDB_Package="lldb-3.6-dev"
+            ;;
+        lldb3.8)
+            __LLDB_Package="lldb-3.8-dev"
+            ;;
+        no-lldb)
+            unset __LLDB_Package
+            ;;
         vivid)
             if [ "$__LinuxCodeName" != "jessie" ]; then
                 __LinuxCodeName=vivid
@@ -99,6 +110,11 @@ for i in "$@" ; do
             ;;
     esac
 done
+
+if [ "$__BuildArch" == "armel" ]; then
+    __LLDB_Package="lldb-3.5-dev"
+fi
+__UbuntuPackages+=" ${__LLDB_Package:-}"
 
 __RootfsDir="$__CrossDir/rootfs/$__BuildArch"
 

--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -15,7 +15,6 @@ __InitialDir=$PWD
 __BuildArch=arm
 __UbuntuArch=armhf
 __UbuntuRepo="http://ports.ubuntu.com/"
-__LLDB_Package="lldb-3.6-dev"
 __SkipUnmount=0
 
 # base development support
@@ -100,11 +99,6 @@ for i in "$@" ; do
             ;;
     esac
 done
-
-if [ "$__BuildArch" == "armel" ]; then
-    __LLDB_Package="lldb-3.5-dev"
-fi
-__UbuntuPackages+=" ${__LLDB_Package:-}"
 
 __RootfsDir="$__CrossDir/rootfs/$__BuildArch"
 


### PR DESCRIPTION
#16182 and #13200 added lldb to the rootfs for CoreFX.

However, CoreFX does not have a dependency on liblldb (CoreCLR does), and this package is not available for ubuntu.16.04-arm64 and earlier, causing the RootFS generation to fail.

This PR adds an option to disable adding the LLDB package for the CoreFX RootFS.