### PR TITLE
Move a System.Collections test

### DIFF
--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
@@ -351,14 +351,5 @@ namespace System.Collections.Tests
             Assert.True(comparerSet2.SetEquals(set));
         }
         #endregion
-
-        [Fact]
-        public void IntersectWith_SupersetEnumerableWithDups_ExpectedResultsInCorrectOrder ()
-        {
-            var set = new SortedSet<int> { 1, 3, 5, 7, 9 };
-            set.IntersectWith(new [] { 5, 7, 3, 7, 11, 7, 5, 2 });
-
-            Assert.Equal(new int[] { 3, 5, 7 }, set);
-        }
     }
 }

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.cs
@@ -54,6 +54,15 @@ namespace System.Collections.Tests
             Assert.Equal(5, view.Min);
             Assert.Equal(7, view.Max);
         }
+
+        [Fact]
+        public void SortedSet_Generic_IntersectWith_SupersetEnumerableWithDups()
+        {
+            var set = (SortedSet<int>)CreateSortedSet(new[] { 1, 3, 5, 7, 9 }, 5, 5);
+            set.IntersectWith(new[] { 5, 7, 3, 7, 11, 7, 5, 2 });
+
+            Assert.Equal(new[] { 3, 5, 7 }, set);
+        }
     }
 
     public class SortedSet_Generic_Tests_int_With_NullComparer : SortedSet_Generic_Tests_int


### PR DESCRIPTION
Just moves the test to a more derived test class.  In its current location, it's unnecessarily getting run multiple times but without any variation.

Addressing my remaining comments in https://github.com/dotnet/corefx/pull/16758
cc: @safern