### PR TITLE
Remove CoreCLR pull 7966 from SerializeDeserialize_Roundtrips() under System.Collections.ObjectModel.Tests

### DIFF
--- a/src/System.ObjectModel/tests/KeyedCollection/Serialization.netstandard.cs
+++ b/src/System.ObjectModel/tests/KeyedCollection/Serialization.netstandard.cs
@@ -17,7 +17,6 @@ namespace System.Collections.ObjectModel.Tests
             yield return new object[] { new TestCollection() { "hello", "world" } };
         }
 
-        [ActiveIssue("https://github.com/dotnet/coreclr/pull/7966")]
         [Theory]
         [MemberData(nameof(SerializeDeserialize_Roundtrips_MemberData))]
         public void SerializeDeserialize_Roundtrips(TestCollection c)


### PR DESCRIPTION
Remove CoreCLR pull 7966 from SerializeDeserialize_Roundtrips() under System.Collections.ObjectModel.Tests in Serialization.netstandard.cs

Run >msbuild System.ObjectModel.Tests.csproj /t:BuildAndTest 
--> Succeeded