### PR TITLE
Remove CoreCLR pull 6423 from NegativeValueNotFound() under System.Runtime.Serialization.Formatters.Tests

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/tests/SerializationInfoTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/SerializationInfoTests.cs
@@ -82,7 +82,6 @@ namespace System.Runtime.Serialization.Formatters.Tests
             Assert.Throws<SerializationException>(() => si.AddValue("bool", true));
         }
 
-        [ActiveIssue("https://github.com/dotnet/coreclr/pull/6423")]
         [Fact]
         public void NegativeValueNotFound()
         {


### PR DESCRIPTION
Remove ActiveIssue 6423 from NegativeValueNotFound() under System.Runtime.Serialization.Formatters.Tests in SerializationInfoTests.cs

Run msbuild System.Runtime.Serialization.Formatters.Tests.csproj /t:BuildAndTest
--> Succeeded